### PR TITLE
llb: add more features to client package

### DIFF
--- a/client/llb/meta.go
+++ b/client/llb/meta.go
@@ -21,7 +21,10 @@ type Meta struct {
 	cwd  string
 }
 
-func AddEnv(key, value string, v ...interface{}) RunOption {
+func AddEnv(key, value string) RunOption {
+	return AddEnvf(key, value)
+}
+func AddEnvf(key, value string, v ...interface{}) RunOption {
 	return func(m Meta) (Meta, error) {
 		m.env = m.env.AddOrReplace(key, fmt.Sprintf(value, v...))
 		return m, nil
@@ -49,7 +52,10 @@ func Args(args ...string) RunOption {
 	}
 }
 
-func Dir(str string, v ...interface{}) RunOption {
+func Dir(str string) RunOption {
+	return Dirf(str)
+}
+func Dirf(str string, v ...interface{}) RunOption {
 	return func(m Meta) (Meta, error) {
 		m.cwd = fmt.Sprintf(str, v...)
 		return m, nil
@@ -77,7 +83,11 @@ func (m Meta) Args() []string {
 	return append([]string{}, m.args...)
 }
 
-func Shlex(str string, v ...interface{}) RunOption {
+func Shlex(str string) RunOption {
+	return Shlexf(str)
+}
+
+func Shlexf(str string, v ...interface{}) RunOption {
 	return func(m Meta) (Meta, error) {
 		args, err := shlex.Split(fmt.Sprintf(str, v...))
 		if err != nil {

--- a/client/llb/meta.go
+++ b/client/llb/meta.go
@@ -1,0 +1,133 @@
+package llb
+
+import (
+	"fmt"
+
+	"github.com/google/shlex"
+	"github.com/moby/buildkit/util/system"
+)
+
+func NewMeta(args ...string) Meta {
+	m := Meta{}
+	m, _ = AddEnv("PATH", system.DefaultPathEnv)(m)
+	m, _ = Args(args...)(m)
+	m, _ = Dir("/")(m)
+	return m
+}
+
+type Meta struct {
+	args []string
+	env  envList
+	cwd  string
+}
+
+func AddEnv(key, value string, v ...interface{}) RunOption {
+	return func(m Meta) (Meta, error) {
+		m.env = m.env.AddOrReplace(key, fmt.Sprintf(value, v...))
+		return m, nil
+	}
+}
+
+func ClearEnv() RunOption {
+	return func(m Meta) (Meta, error) {
+		m.env = NewMeta().env
+		return m, nil
+	}
+}
+
+func DelEnv(key string) RunOption {
+	return func(m Meta) (Meta, error) {
+		m.env = m.env.Delete(key)
+		return m, nil
+	}
+}
+
+func Args(args ...string) RunOption {
+	return func(m Meta) (Meta, error) {
+		m.args = args
+		return m, nil
+	}
+}
+
+func Dir(str string, v ...interface{}) RunOption {
+	return func(m Meta) (Meta, error) {
+		m.cwd = fmt.Sprintf(str, v...)
+		return m, nil
+	}
+}
+
+func Reset(s *State) RunOption {
+	return func(m Meta) (Meta, error) {
+		if s == nil {
+			return NewMeta(), nil
+		}
+		return s.metaNext, nil
+	}
+}
+
+func (m Meta) Env(key string) (string, bool) {
+	return m.env.Get(key)
+}
+
+func (m Meta) Dir() string {
+	return m.cwd
+}
+
+func (m Meta) Args() []string {
+	return append([]string{}, m.args...)
+}
+
+func Shlex(str string, v ...interface{}) RunOption {
+	return func(m Meta) (Meta, error) {
+		args, err := shlex.Split(fmt.Sprintf(str, v...))
+		if err != nil {
+			return m, err
+		}
+		return Args(args...)(m)
+	}
+}
+
+type envList []keyValue
+
+type keyValue struct {
+	key   string
+	value string
+}
+
+func (e envList) AddOrReplace(k, v string) envList {
+	e = e.Delete(k)
+	e = append(e, keyValue{key: k, value: v})
+	return e
+}
+
+func (e envList) Delete(k string) envList {
+	e = append([]keyValue(nil), e...)
+	if i, ok := e.index(k); ok {
+		return append(e[:i], e[i+1:]...)
+	}
+	return e
+}
+
+func (e envList) Get(k string) (string, bool) {
+	if index, ok := e.index(k); ok {
+		return e[index].value, true
+	}
+	return "", false
+}
+
+func (e envList) index(k string) (int, bool) {
+	for i, kv := range e {
+		if kv.key == k {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+func (e envList) ToArray() []string {
+	out := make([]string, 0, len(e))
+	for _, kv := range e {
+		out = append(out, kv.key+"="+kv.value)
+	}
+	return out
+}

--- a/client/llb/meta_test.go
+++ b/client/llb/meta_test.go
@@ -1,0 +1,61 @@
+package llb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultMeta(t *testing.T) {
+	m := NewMeta()
+	path, ok := m.Env("PATH")
+	assert.True(t, ok)
+	assert.NotEmpty(t, path)
+
+	cwd := m.Dir()
+	assert.NotEmpty(t, cwd)
+}
+
+func TestReset(t *testing.T) {
+	m := NewMeta()
+	wd := m.Dir()
+	path, _ := m.Env("PATH")
+	m, _ = Dir("/foo")(m)
+	m, _ = AddEnv("FOO", "bar")(m)
+
+	m, _ = Reset(nil)(m)
+	assert.Equal(t, wd, m.Dir())
+	path2, _ := m.Env("PATH")
+	assert.Equal(t, path, path2)
+}
+
+func TestEnv(t *testing.T) {
+	m := NewMeta()
+	m, _ = AddEnv("FOO", "bar")(m)
+	m2, _ := AddEnv("FOO", "baz")(m)
+	m2, _ = AddEnv("BAR", "abc")(m2)
+
+	v, ok := m.Env("FOO")
+	assert.True(t, ok)
+	assert.Equal(t, "bar", v)
+
+	_, ok = m.Env("BAR")
+	assert.False(t, ok)
+
+	v, ok = m2.Env("FOO")
+	assert.True(t, ok)
+	assert.Equal(t, "baz", v)
+
+	v, ok = m2.Env("BAR")
+	assert.True(t, ok)
+	assert.Equal(t, "abc", v)
+}
+
+func TestShlex(t *testing.T) {
+	m, err := Shlex("echo foo")(Meta{})
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"echo", "foo"}, m.Args())
+
+	m, err = Shlex("echo \"foo")(Meta{})
+	assert.Error(t, err)
+}

--- a/client/llb/state.go
+++ b/client/llb/state.go
@@ -1,0 +1,162 @@
+package llb
+
+import (
+	_ "crypto/sha256"
+
+	digest "github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
+)
+
+type StateOption func(s *State) *State
+
+// State represents modifiable llb state
+type State struct {
+	source   *source
+	exec     *exec
+	meta     Meta
+	mount    *mount
+	metaNext Meta // this meta will be used for the next Run()
+	err      error
+}
+
+// TODO: add state.Reset() state.Save() state.Restore()
+
+// Validate checks that every node has been set up properly
+func (s *State) Validate() error {
+	if s.source != nil {
+		if err := s.source.Validate(); err != nil {
+			return err
+		}
+	}
+	if s.exec != nil {
+		if err := s.exec.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *State) Run(opts ...RunOption) *ExecState {
+	var es ExecState
+	meta := s.metaNext
+	var err error
+	for _, o := range opts {
+		meta, err = o(meta)
+	}
+
+	exec := &exec{
+		meta:   meta,
+		mounts: []*mount{},
+		root: &mount{
+			dest:      "/",
+			source:    s.source,
+			parent:    s.mount,
+			hasOutput: true,
+		},
+	}
+	exec.root.execState = &es
+	exec.mounts = append(exec.mounts, exec.root)
+
+	es.exec = exec
+	es.mount = exec.root
+	es.metaNext = meta
+	es.meta = meta
+	es.err = err
+	return &es
+}
+
+func (s *State) AddEnv(key, value string, v ...interface{}) *State {
+	s.metaNext, _ = AddEnv(key, value, v...)(s.metaNext)
+	return s
+}
+func (s *State) DelEnv(key string) *State {
+	s.metaNext, _ = DelEnv(key)(s.metaNext)
+	return s
+}
+func (s *State) ClearEnv() *State {
+	s.metaNext, _ = ClearEnv()(s.metaNext)
+	return s
+}
+func (s *State) GetEnv(key string) (string, bool) {
+	return s.metaNext.Env(key)
+}
+
+func (s *State) Dir(str string, v ...interface{}) *State {
+	s.metaNext, _ = Dir(str, v...)(s.metaNext)
+	return s
+}
+func (s *State) GetDir() string {
+	return s.metaNext.Dir()
+}
+
+func (s *State) Args(args ...string) *State {
+	s.metaNext, _ = Args(args...)(s.metaNext)
+	return s
+}
+
+func (s *State) Reset(src *State) *State {
+	copy := *s
+	copy.metaNext, _ = Reset(src)(s.metaNext)
+	return &copy
+}
+
+func (s *State) With(so ...StateOption) *State {
+	for _, o := range so {
+		s = o(s)
+	}
+	return s
+}
+
+func (s *State) Marshal() (list [][]byte, err error) {
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+	cache := make(map[digest.Digest]struct{})
+	if s.source != nil {
+		_, list, err = s.source.marshalTo(nil, cache)
+	} else if s.exec != nil {
+		_, list, err = s.exec.root.marshalTo(nil, cache)
+	} else {
+		_, list, err = s.mount.marshalTo(nil, cache)
+	}
+	return
+}
+
+// ExecState is a state with a active leaf pointing to a run exec command.
+// Mounts can be added only to this state.
+type ExecState struct {
+	State
+}
+
+func (s *ExecState) AddMount(dest string, mountState *State) *State {
+	m := &mount{
+		dest:      dest,
+		source:    mountState.source,
+		parent:    mountState.mount,
+		execState: s,
+		hasOutput: true, // TODO: should be set only if something inherits
+	}
+	var newState State
+	newState.meta = s.meta
+	newState.metaNext = s.metaNext
+	newState.mount = m
+	s.exec.mounts = append(s.exec.mounts, m)
+	return &newState
+}
+
+func (s *ExecState) Root() *State {
+	return &s.State
+}
+
+func (s *ExecState) GetMount(target string) (*State, error) {
+	for _, m := range s.exec.mounts {
+		if m.dest == target {
+			var newState State
+			newState.meta = m.execState.meta
+			newState.metaNext = m.execState.metaNext
+			newState.mount = m
+			return &newState, nil
+		}
+	}
+	return nil, errors.WithStack(errNotFound)
+}

--- a/client/llb/state.go
+++ b/client/llb/state.go
@@ -65,10 +65,14 @@ func (s *State) Run(opts ...RunOption) *ExecState {
 	return &es
 }
 
-func (s *State) AddEnv(key, value string, v ...interface{}) *State {
-	s.metaNext, _ = AddEnv(key, value, v...)(s.metaNext)
+func (s *State) AddEnv(key, value string) *State {
+	return s.AddEnvf(key, value)
+}
+func (s *State) AddEnvf(key, value string, v ...interface{}) *State {
+	s.metaNext, _ = AddEnvf(key, value, v...)(s.metaNext)
 	return s
 }
+
 func (s *State) DelEnv(key string) *State {
 	s.metaNext, _ = DelEnv(key)(s.metaNext)
 	return s
@@ -81,10 +85,14 @@ func (s *State) GetEnv(key string) (string, bool) {
 	return s.metaNext.Env(key)
 }
 
-func (s *State) Dir(str string, v ...interface{}) *State {
-	s.metaNext, _ = Dir(str, v...)(s.metaNext)
+func (s *State) Dir(str string) *State {
+	return s.Dirf(str)
+}
+func (s *State) Dirf(str string, v ...interface{}) *State {
+	s.metaNext, _ = Dirf(str, v...)(s.metaNext)
 	return s
 }
+
 func (s *State) GetDir() string {
 	return s.metaNext.Dir()
 }

--- a/client/llb/state_test.go
+++ b/client/llb/state_test.go
@@ -1,0 +1,28 @@
+package llb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStateMeta(t *testing.T) {
+	s := Source("foo")
+	s = s.AddEnv("BAR", "abc").Dir("/foo/bar")
+
+	v, ok := s.GetEnv("BAR")
+	assert.True(t, ok)
+	assert.Equal(t, "abc", v)
+
+	assert.Equal(t, "/foo/bar", s.GetDir())
+
+	s2 := Source("foo2")
+	s2 = s2.AddEnv("BAZ", "def").Reset(s)
+
+	_, ok = s2.GetEnv("BAZ")
+	assert.False(t, ok)
+
+	v, ok = s2.GetEnv("BAR")
+	assert.True(t, ok)
+	assert.Equal(t, "abc", v)
+}

--- a/examples/buildkit/buildkit.go
+++ b/examples/buildkit/buildkit.go
@@ -75,9 +75,9 @@ func buildkit(withContainerd bool) *llb.State {
 func goFromGit(repo, tag string) llb.StateOption {
 	src := llb.Image("docker.io/library/alpine:latest").
 		Run(llb.Shlex("apk add --no-cache git")).
-		Run(llb.Shlex("git clone https://%[1]s.git /go/src/%[1]s", repo)).
-		Dir("/go/src/%s", repo).
-		Run(llb.Shlex("git checkout -q %s", tag)).Root()
+		Run(llb.Shlexf("git clone https://%[1]s.git /go/src/%[1]s", repo)).
+		Dirf("/go/src/%s", repo).
+		Run(llb.Shlexf("git checkout -q %s", tag)).Root()
 	return func(s *llb.State) *llb.State {
 		return s.With(copyFrom(src, "/go", "/")).Reset(s).Dir(src.GetDir())
 	}
@@ -93,7 +93,7 @@ func copyFrom(src *llb.State, srcPath, destPath string) llb.StateOption {
 // copy copies files between 2 states using cp until there is no copyOp
 func copy(src *llb.State, srcPath string, dest *llb.State, destPath string) *llb.State {
 	cpImage := llb.Image("docker.io/library/alpine:latest")
-	cp := cpImage.Run(llb.Shlex("cp -a /src%s /dest%s", srcPath, destPath))
+	cp := cpImage.Run(llb.Shlexf("cp -a /src%s /dest%s", srcPath, destPath))
 	cp.AddMount("/src", src)
 	return cp.AddMount("/dest", dest)
 }


### PR DESCRIPTION
This is a refactoring of the `llb` package internals.

Introduces new functions for controlling the metadata and mounts of `llb` states. The functions can be now used to modify both state and a single execution operation.

New functions:

`AddEnv`
`DelEnv`
`ClearEnv`
`Dir`
`Args`
`Reset` - replaces all metadata to the one from separate stage

`With` method is added for users to define their own pipelines of modification steps.

example:
```
s.AddEnv("FOO", "bar").
  Run(llb.Args("ls", "-l"), llb.Dir("/proc")).
  Reset(someotherState).
  With(collectionOfSteps).
  Run(llb.Shlex("ls -l"))
```

todo:
- `state.Save() / state.Restore()`
- better error reporting for `Validate()`
- tests that validate marshalled protobuf


I also modified the buildkit example to do the git clone step in parallel with the added features. It's bit of an overkill atm but that is probably good for an example. There is no meaningful speed benefit as there is an extra step for downloading `git`.

@AkihiroSuda @dnephin 