### PR TITLE
.gitignore and .dockerignore: add .buildstate

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 bin
+.buildstate

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bin
+.buildstate


### PR DESCRIPTION
`docker build` was failing with `EPERM` if `sudo ./bin/buildd` was executed with the repo dir as wd.

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>