### PR TITLE
buildd: graceful shutdown on termination signals

### DIFF
--- a/cmd/buildctl/build.go
+++ b/cmd/buildctl/build.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/util/appcontext"
 	"github.com/moby/buildkit/util/progress/progressui"
 	"github.com/urfave/cli"
 	"golang.org/x/sync/errgroup"
@@ -36,7 +37,7 @@ func build(clicontext *cli.Context) error {
 
 	ch := make(chan *client.SolveStatus)
 	displayCh := make(chan *client.SolveStatus)
-	eg, ctx := errgroup.WithContext(appContext())
+	eg, ctx := errgroup.WithContext(appcontext.Context())
 
 	eg.Go(func() error {
 		return c.Solve(ctx, os.Stdin, ch)

--- a/vendor.conf
+++ b/vendor.conf
@@ -20,7 +20,7 @@ github.com/opencontainers/runc 429a5387123625040bacfbb60d96b1cbd02293ab
 github.com/Microsoft/go-winio v0.4.1
 github.com/containerd/fifo 69b99525e472735860a5269b75af1970142b3062
 github.com/opencontainers/runtime-spec 198f23f827eea397d4331d7eb048d9d4c7ff7bee
-github.com/containerd/go-runc 5d38580d03f4fbf2f09b2b0065deeeaf8d21aac2
+github.com/containerd/go-runc df573a0e124617148f49720e1447061131675694 https://github.com/tonistiigi/go-runc.git
 github.com/containerd/console e0a2cdcf03d4d99c3bc061635a66cf92336c6c82
 github.com/Azure/go-ansiterm fa152c58bc15761d0200cb75fe958b89a9d4888e
 google.golang.org/genproto d80a6e20e776b0b17a324d0ba1ab50a39c8e8944

--- a/vendor/github.com/containerd/go-runc/command_linux.go
+++ b/vendor/github.com/containerd/go-runc/command_linux.go
@@ -12,10 +12,12 @@ func (r *Runc) command(context context.Context, args ...string) *exec.Cmd {
 		command = DefaultCommand
 	}
 	cmd := exec.CommandContext(context, command, append(r.args(), args...)...)
-	if r.PdeathSignal != 0 {
-		cmd.SysProcAttr = &syscall.SysProcAttr{
-			Pdeathsig: r.PdeathSignal,
-		}
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: r.Setpgid,
 	}
+	if r.PdeathSignal != 0 {
+		cmd.SysProcAttr.Pdeathsig = r.PdeathSignal
+	}
+
 	return cmd
 }

--- a/vendor/github.com/containerd/go-runc/runc.go
+++ b/vendor/github.com/containerd/go-runc/runc.go
@@ -39,6 +39,7 @@ type Runc struct {
 	Log           string
 	LogFormat     Format
 	PdeathSignal  syscall.Signal
+	Setpgid       bool
 	Criu          string
 	SystemdCgroup string
 }

--- a/worker/runcworker/worker.go
+++ b/worker/runcworker/worker.go
@@ -44,6 +44,7 @@ func New(root string) (worker.Worker, error) {
 		Log:          filepath.Join(root, "runc-log.json"),
 		LogFormat:    runc.JSON,
 		PdeathSignal: syscall.SIGKILL,
+		Setpgid:      true,
 	}
 
 	w := &runcworker{


### PR DESCRIPTION
Currently shutting down buildd would potentially leak mounts and breaks the output of running clients. This update gracefully shuts down all current handlers before shutting down the process.

~based on #49 (only last commit is new)~

includes fix for `go-runc` https://github.com/containerd/go-runc/pull/19

@AkihiroSuda