### PR TITLE
buildctl debug: dump-{llb,metadata,bolt}

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ The first thing to test could be to try building BuildKit with BuildKit. BuildKi
 
 `examples/buildkit/buildkit.go` is a script that defines how to build different configurations of BuildKit and its dependencies using the `client` package. Running this script generates a protobuf definition of a build graph. Note that the script itself does not execute any steps of the build.
 
-You can use `buildctl debug dump` to see what data is this definition.
+You can use `buildctl debug dump-llb` to see what data is this definition.
 
 ```bash
-go run examples/buildkit/buildkit.go | buildctl debug dump | jq .
+go run examples/buildkit/buildkit.go | buildctl debug dump-llb | jq .
 ```
 
 To start building use `buildctl build` command. The script accepts `--target` flag to choose between `containerd` and `standalone` configurations. In standalone mode BuildKit binaries are built together with `runc`. In containerd mode, the `containerd` binary is built as well from the upstream repo.

--- a/cmd/buildctl/debug.go
+++ b/cmd/buildctl/debug.go
@@ -9,6 +9,8 @@ var debugCommand = cli.Command{
 	Name:  "debug",
 	Usage: "debug utilities",
 	Subcommands: []cli.Command{
-		debug.DumpCommand,
+		debug.DumpLLBCommand,
+		debug.DumpMetadataCommand,
+		debug.DumpBoltCommand,
 	},
 }

--- a/cmd/buildctl/debug/dumpbolt.go
+++ b/cmd/buildctl/debug/dumpbolt.go
@@ -1,0 +1,56 @@
+package debug
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/boltdb/bolt"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
+)
+
+var DumpBoltCommand = cli.Command{
+	Name:  "dump-bolt",
+	Usage: "dump an arbitrary bolt db file in human-readable format.  This command does not need the daemon to be running.",
+	// unlike dumpLLB(), dumpBolt() does not support reading from stdin
+	ArgsUsage: "<dbfile>",
+	Action: func(clicontext *cli.Context) error {
+		dbFile := clicontext.Args().First()
+		return dumpBolt(dbFile, func(k, v []byte) string {
+			return fmt.Sprintf("%q: %q", string(k), string(v))
+		})
+	},
+}
+
+func dumpBolt(dbFile string, stringifier func(k, v []byte) string) error {
+	if dbFile == "" {
+		return errors.New("dbfile not specified")
+	}
+	if dbFile == "-" {
+		// user could still specify "/dev/stdin" but unlikely to work
+		return errors.New("stdin unsupported")
+	}
+	db, err := bolt.Open(dbFile, 0400, &bolt.Options{ReadOnly: true, Timeout: 3 * time.Second})
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	return db.View(func(tx *bolt.Tx) error {
+		// TODO: JSON format?
+		return tx.ForEach(func(name []byte, b *bolt.Bucket) error {
+			return dumpBucket(name, b, "", stringifier)
+		})
+	})
+}
+
+func dumpBucket(name []byte, b *bolt.Bucket, indent string, stringifier func(k, v []byte) string) error {
+	fmt.Printf("%sbucket %q:\n", indent, string(name))
+	childrenIndent := indent + "  "
+	return b.ForEach(func(k, v []byte) error {
+		if bb := b.Bucket(k); bb != nil {
+			return dumpBucket(k, bb, childrenIndent, stringifier)
+		}
+		fmt.Printf("%s%s\n", childrenIndent, stringifier(k, v))
+		return nil
+	})
+}

--- a/cmd/buildctl/debug/dumpllb.go
+++ b/cmd/buildctl/debug/dumpllb.go
@@ -12,14 +12,26 @@ import (
 	"github.com/urfave/cli"
 )
 
-var DumpCommand = cli.Command{
-	Name:   "dump",
-	Usage:  "dump LLB in human-readable format. LLB must be passed via stdin. This command does not require the daemon to be running.",
-	Action: dumpLLB,
+var DumpLLBCommand = cli.Command{
+	Name:      "dump-llb",
+	Usage:     "dump LLB in human-readable format. LLB can be also passed via stdin. This command does not require the daemon to be running.",
+	ArgsUsage: "<llbfile>",
+	Action:    dumpLLB,
 }
 
 func dumpLLB(clicontext *cli.Context) error {
-	ops, err := loadLLB(os.Stdin)
+	var r io.Reader
+	if llbFile := clicontext.Args().First(); llbFile != "" && llbFile != "-" {
+		f, err := os.Open(llbFile)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		r = f
+	} else {
+		r = os.Stdin
+	}
+	ops, err := loadLLB(r)
 	if err != nil {
 		return err
 	}

--- a/cmd/buildctl/debug/dumpmetadata.go
+++ b/cmd/buildctl/debug/dumpmetadata.go
@@ -1,0 +1,36 @@
+package debug
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+
+	"github.com/moby/buildkit/cache/metadata"
+	"github.com/urfave/cli"
+)
+
+var DumpMetadataCommand = cli.Command{
+	Name:  "dump-metadata",
+	Usage: "dump the meta in human-readable format.  This command requires the daemon NOT to be running.",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "root",
+			Usage: "path to state directory",
+			Value: ".buildstate",
+		},
+	},
+	Action: func(clicontext *cli.Context) error {
+		dbFile := filepath.Join(clicontext.String("root"), "metadata.db")
+		return dumpBolt(dbFile, func(k, v []byte) string {
+			raw := fmt.Sprintf("%q: %q", string(k), string(v))
+			if len(v) == 0 {
+				return raw
+			}
+			var mv metadata.Value
+			if err := json.Unmarshal(v, &mv); err != nil {
+				return raw
+			}
+			return fmt.Sprintf("%q: {\"Data\":%q, \"Index\":%q}", string(k), string(mv.Data), mv.Index)
+		})
+	},
+}


### PR DESCRIPTION
- dump-llb: renamed from old `dump`. Now supports specifying LLB by filename as well (for consistency with other commands)
- dump-metadata: new command for dumping metadata.db
- dump-bolt: new command for dumping arbitrary boltdb file

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

cc @tonistiigi 