### PR TITLE
solver: remove llb dependency

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -29,7 +29,7 @@ type Controller struct { // TODO: ControlService
 func NewController(opt Opt) (*Controller, error) {
 	c := &Controller{
 		opt: opt,
-		solver: solver.New(solver.Opt{
+		solver: solver.NewLLBSolver(solver.LLBOpt{
 			SourceManager: opt.SourceManager,
 			CacheManager:  opt.CacheManager,
 			Worker:        opt.Worker,
@@ -62,7 +62,7 @@ func (c *Controller) DiskUsage(ctx context.Context, _ *controlapi.DiskUsageReque
 }
 
 func (c *Controller) Solve(ctx context.Context, req *controlapi.SolveRequest) (*controlapi.SolveResponse, error) {
-	v, err := solver.Load(req.Definition)
+	v, err := solver.LoadLLB(req.Definition)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load")
 	}

--- a/solver/source.go
+++ b/solver/source.go
@@ -1,21 +1,31 @@
 package solver
 
 import (
-	"context"
-
-	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/source"
+	"golang.org/x/net/context"
 )
 
-func runSourceOp(ctx context.Context, sm *source.Manager, op *pb.Op_Source) ([]cache.ImmutableRef, error) {
-	id, err := source.FromString(op.Source.Identifier)
+type sourceOp struct {
+	op *pb.Op_Source
+	sm *source.Manager
+}
+
+func newSourceOp(op *pb.Op_Source, sm *source.Manager) (Op, error) {
+	return &sourceOp{
+		op: op,
+		sm: sm,
+	}, nil
+}
+
+func (s *sourceOp) Run(ctx context.Context, _ []Reference) ([]Reference, error) {
+	id, err := source.FromString(s.op.Source.Identifier)
 	if err != nil {
 		return nil, err
 	}
-	ref, err := sm.Pull(ctx, id)
+	ref, err := s.sm.Pull(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	return []cache.ImmutableRef{ref}, nil
+	return []Reference{ref}, nil
 }

--- a/solver/vertex.go
+++ b/solver/vertex.go
@@ -1,0 +1,98 @@
+package solver
+
+import (
+	"sync"
+	"time"
+
+	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/util/progress"
+	digest "github.com/opencontainers/go-digest"
+	"golang.org/x/net/context"
+)
+
+// Vertex is one node in the build graph
+type Vertex interface {
+	// Digest is a content-addressable vertex identifier
+	Digest() digest.Digest
+	// Sys returns an internal value that is used to execute the vertex. Usually
+	// this is capured by the operation resolver method during solve.
+	Sys() interface{}
+	// Array of vertexes current vertex depends on.
+	Inputs() []Input
+	Name() string // change this to general metadata
+}
+
+// Input is an pointer to a single reference from a vertex by an index.
+type Input struct {
+	Index  int
+	Vertex Vertex
+}
+
+type input struct {
+	index  int
+	vertex *vertex
+}
+
+type vertex struct {
+	mu           sync.Mutex
+	sys          interface{}
+	inputs       []*input
+	err          error
+	digest       digest.Digest
+	clientVertex client.Vertex
+	name         string
+}
+
+func (v *vertex) initClientVertex() {
+	inputDigests := make([]digest.Digest, 0, len(v.inputs))
+	for _, inp := range v.inputs {
+		inputDigests = append(inputDigests, inp.vertex.Digest())
+	}
+	v.clientVertex = client.Vertex{
+		Inputs: inputDigests,
+		Name:   v.Name(),
+		Digest: v.digest,
+	}
+}
+
+func (v *vertex) Digest() digest.Digest {
+	return v.digest
+}
+
+func (v *vertex) Sys() interface{} {
+	return v.sys
+}
+
+func (v *vertex) Inputs() (inputs []Input) {
+	for _, i := range v.inputs {
+		inputs = append(inputs, Input{i.index, i.vertex})
+	}
+	return
+}
+
+func (v *vertex) Name() string {
+	return v.name
+}
+
+func (v *vertex) inputRequiresExport(i int) bool {
+	return true // TODO
+}
+
+func (v *vertex) notifyStarted(ctx context.Context) {
+	pw, _, _ := progress.FromContext(ctx)
+	defer pw.Close()
+	now := time.Now()
+	v.clientVertex.Started = &now
+	pw.Write(v.Digest().String(), v.clientVertex)
+}
+
+func (v *vertex) notifyCompleted(ctx context.Context, err error) {
+	pw, _, _ := progress.FromContext(ctx)
+	defer pw.Close()
+	now := time.Now()
+	v.clientVertex.Completed = &now
+	if err != nil {
+		v.clientVertex.Error = err.Error()
+	}
+	pw.Write(v.Digest().String(), v.clientVertex)
+}

--- a/source/manager.go
+++ b/source/manager.go
@@ -13,6 +13,16 @@ type Source interface {
 	Pull(ctx context.Context, id Identifier) (cache.ImmutableRef, error)
 }
 
+// type Source interface {
+// 	ID() string
+// 	Resolve(ctx context.Context, id Identifier) (SourceInstance, error)
+// }
+//
+// type SourceInstance interface {
+// 	GetCacheKey(ctx context.Context) ([]string, error)
+// 	GetSnapshot(ctx context.Context) (cache.ImmutableRef, error)
+// }
+
 type Manager struct {
 	mu      sync.Mutex
 	sources map[string]Source


### PR DESCRIPTION
This PR makes the solver fully self contained, removing dependencies on other packages and llb definition. It makes the solver easily unit-testable and makes it easier to improve its algorithm.

I didn't move the llb definition to a different package yet, in case it turns out that keeping them together help in some test case or feature.

@AkihiroSuda I think I might have made #55 bit more complicated. Having a central concurrency limit should be easier now but as the solver doesn't know what the separate ops are it isn't that easy to assign individual values to them. You can update the `Op` interface if you want to expose more information to the solver, for example, `ConcurrencyGroup() string`

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>