### PR TITLE
buildctl: non-interactive output support

### DIFF
--- a/cmd/buildctl/build.go
+++ b/cmd/buildctl/build.go
@@ -29,6 +29,10 @@ var buildCommand = cli.Command{
 			Name:  "exporter-opt",
 			Usage: "Define custom options for exporter",
 		},
+		cli.BoolFlag{
+			Name:  "no-progress",
+			Usage: "Don't show interactive progress",
+		},
 	},
 }
 
@@ -72,6 +76,20 @@ func build(clicontext *cli.Context) error {
 	})
 
 	eg.Go(func() error {
+		if clicontext.Bool("no-progress") {
+			for s := range displayCh {
+				for _, v := range s.Vertexes {
+					logrus.Debugf("vertex: %s %s %v %v", v.Digest, v.Name, v.Started, v.Completed)
+				}
+				for _, s := range s.Statuses {
+					logrus.Debugf("status: %s %s", s.Vertex, s.ID)
+				}
+				for _, l := range s.Logs {
+					logrus.Debugf("log: %s\n%s", l.Vertex, l.Data)
+				}
+			}
+			return nil
+		}
 		// not using shared context to not disrupt display but let is finish reporting errors
 		return progressui.DisplaySolveStatus(context.TODO(), displayCh)
 	})


### PR DESCRIPTION
Add option for turning off interactive progressbar. The output is far from perfect atm but a starting point. Mostly useful if debug logs are needed from `buildctl`.

`buildctl --debug  build  --no-progress`

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>