### PR TITLE
session: add incremental updates support

### DIFF
--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -33,7 +33,7 @@ func TestManager(t *testing.T) {
 	active, err := cm.New(ctx, nil)
 	require.NoError(t, err)
 
-	m, err := active.Mount(ctx)
+	m, err := active.Mount(ctx, false)
 	require.NoError(t, err)
 
 	lm := snapshot.LocalMounter(m)

--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -12,127 +13,254 @@ import (
 	"github.com/moby/buildkit/cache/metadata"
 	"github.com/moby/buildkit/snapshot"
 	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestManager(t *testing.T) {
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
 	tmpdir, err := ioutil.TempDir("", "cachemanager")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
+	cm := getCacheManager(t, tmpdir)
+
+	_, err = cm.Get(ctx, "foobar")
+	require.Error(t, err)
+
+	checkDiskUsage(t, ctx, cm, 0, 0)
+
+	active, err := cm.New(ctx, nil)
+	require.NoError(t, err)
+
+	m, err := active.Mount(ctx)
+	require.NoError(t, err)
+
+	lm := snapshot.LocalMounter(m)
+	target, err := lm.Mount()
+	require.NoError(t, err)
+
+	fi, err := os.Stat(target)
+	require.NoError(t, err)
+	require.Equal(t, fi.IsDir(), true)
+
+	err = lm.Unmount()
+	require.NoError(t, err)
+
+	_, err = cm.GetMutable(ctx, active.ID())
+	require.Error(t, err)
+	require.Equal(t, errLocked, errors.Cause(err))
+
+	checkDiskUsage(t, ctx, cm, 1, 0)
+
+	snap, err := active.Commit(ctx)
+	require.NoError(t, err)
+
+	checkDiskUsage(t, ctx, cm, 1, 0)
+
+	_, err = cm.GetMutable(ctx, active.ID())
+	require.Error(t, err)
+	require.Equal(t, errLocked, errors.Cause(err))
+
+	err = snap.Release(ctx)
+	require.NoError(t, err)
+
+	checkDiskUsage(t, ctx, cm, 0, 1)
+
+	active, err = cm.GetMutable(ctx, active.ID())
+	require.NoError(t, err)
+
+	checkDiskUsage(t, ctx, cm, 1, 0)
+
+	snap, err = active.Commit(ctx)
+	require.NoError(t, err)
+
+	checkDiskUsage(t, ctx, cm, 1, 0)
+
+	err = snap.Finalize(ctx)
+	require.NoError(t, err)
+
+	err = snap.Release(ctx)
+	require.NoError(t, err)
+
+	_, err = cm.GetMutable(ctx, active.ID())
+	require.Error(t, err)
+	require.Equal(t, errNotFound, errors.Cause(err))
+
+	_, err = cm.GetMutable(ctx, snap.ID())
+	require.Error(t, err)
+	require.Equal(t, errInvalid, errors.Cause(err))
+
+	snap, err = cm.Get(ctx, snap.ID())
+	require.NoError(t, err)
+
+	snap2, err := cm.Get(ctx, snap.ID())
+	require.NoError(t, err)
+
+	checkDiskUsage(t, ctx, cm, 1, 0)
+
+	err = snap.Release(ctx)
+	require.NoError(t, err)
+
+	active2, err := cm.New(ctx, snap2)
+	require.NoError(t, err)
+
+	checkDiskUsage(t, ctx, cm, 2, 0)
+
+	snap3, err := active2.Commit(ctx)
+	require.NoError(t, err)
+
+	err = snap2.Release(ctx)
+	require.NoError(t, err)
+
+	checkDiskUsage(t, ctx, cm, 2, 0)
+
+	err = snap3.Release(ctx)
+	require.NoError(t, err)
+
+	checkDiskUsage(t, ctx, cm, 0, 2)
+
+	err = cm.Close()
+	require.NoError(t, err)
+}
+
+func TestLazyCommit(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+
+	tmpdir, err := ioutil.TempDir("", "cachemanager")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpdir)
+
+	cm := getCacheManager(t, tmpdir)
+
+	active, err := cm.New(ctx, nil)
+	require.NoError(t, err)
+
+	// after commit mutable is locked
+	snap, err := active.Commit(ctx)
+	require.NoError(t, err)
+
+	_, err = cm.GetMutable(ctx, active.ID())
+	require.Error(t, err)
+	require.Equal(t, errLocked, errors.Cause(err))
+
+	// immutable refs still work
+	snap2, err := cm.Get(ctx, snap.ID())
+	require.NoError(t, err)
+	require.Equal(t, snap.ID(), snap2.ID())
+
+	err = snap.Release(ctx)
+	require.NoError(t, err)
+
+	err = snap2.Release(ctx)
+	require.NoError(t, err)
+
+	// immutable work after final release as well
+	snap, err = cm.Get(ctx, snap.ID())
+	require.NoError(t, err)
+	require.Equal(t, snap.ID(), snap2.ID())
+	err = snap.Release(ctx)
+	require.NoError(t, err)
+
+	// after release mutable becomes available again
+	active2, err := cm.GetMutable(ctx, active.ID())
+	require.NoError(t, err)
+	require.Equal(t, active2.ID(), active.ID())
+
+	// because ref was took mutable old immutable are cleared
+	_, err = cm.Get(ctx, snap.ID())
+	require.Error(t, err)
+	require.Equal(t, errNotFound, errors.Cause(err))
+
+	snap, err = active2.Commit(ctx)
+	require.NoError(t, err)
+
+	// this time finalize commit
+	err = snap.Finalize(ctx)
+	require.NoError(t, err)
+
+	err = snap.Release(ctx)
+	require.NoError(t, err)
+
+	// mutable is gone after finalize
+	_, err = cm.GetMutable(ctx, active2.ID())
+	require.Error(t, err)
+	require.Equal(t, errNotFound, errors.Cause(err))
+
+	// immutable still works
+	snap2, err = cm.Get(ctx, snap.ID())
+	require.NoError(t, err)
+	require.Equal(t, snap.ID(), snap2.ID())
+
+	err = snap2.Release(ctx)
+	require.NoError(t, err)
+
+	// test restarting after commit
+	active, err = cm.New(ctx, nil)
+	require.NoError(t, err)
+
+	// after commit mutable is locked
+	snap, err = active.Commit(ctx)
+	require.NoError(t, err)
+
+	err = cm.Close()
+	require.NoError(t, err)
+
+	cm = getCacheManager(t, tmpdir)
+
+	snap2, err = cm.Get(ctx, snap.ID())
+	require.NoError(t, err)
+
+	err = snap2.Release(ctx)
+	require.NoError(t, err)
+
+	active, err = cm.GetMutable(ctx, active.ID())
+	require.NoError(t, err)
+
+	_, err = cm.Get(ctx, snap.ID())
+	require.Error(t, err)
+	require.Equal(t, errNotFound, errors.Cause(err))
+
+	snap, err = active.Commit(ctx)
+	require.NoError(t, err)
+
+	err = cm.Close()
+	require.NoError(t, err)
+
+	cm = getCacheManager(t, tmpdir)
+
+	snap2, err = cm.Get(ctx, snap.ID())
+	require.NoError(t, err)
+
+	err = snap2.Finalize(ctx)
+	require.NoError(t, err)
+
+	err = snap2.Release(ctx)
+	require.NoError(t, err)
+
+	active, err = cm.GetMutable(ctx, active.ID())
+	require.Error(t, err)
+	require.Equal(t, errNotFound, errors.Cause(err))
+}
+
+func getCacheManager(t *testing.T, tmpdir string) Manager {
 	snapshotter, err := naive.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	md, err := metadata.NewStore(filepath.Join(tmpdir, "metadata.db"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	cm, err := NewManager(ManagerOpt{
 		Snapshotter:   snapshotter,
 		MetadataStore: md,
 	})
-	assert.NoError(t, err)
-
-	_, err = cm.Get(ctx, "foobar")
-	assert.Error(t, err)
-
-	checkDiskUsage(t, ctx, cm, 0, 0)
-
-	active, err := cm.New(ctx, nil)
-	assert.NoError(t, err)
-
-	m, err := active.Mount(ctx)
-	assert.NoError(t, err)
-
-	lm := snapshot.LocalMounter(m)
-	target, err := lm.Mount()
-	assert.NoError(t, err)
-
-	fi, err := os.Stat(target)
-	assert.NoError(t, err)
-	assert.Equal(t, fi.IsDir(), true)
-
-	err = lm.Unmount()
-	assert.NoError(t, err)
-
-	_, err = cm.GetMutable(ctx, active.ID())
-	assert.Error(t, err)
-	assert.Equal(t, errLocked, errors.Cause(err))
-
-	checkDiskUsage(t, ctx, cm, 1, 0)
-
-	snap, err := active.Freeze()
-	assert.NoError(t, err)
-
-	checkDiskUsage(t, ctx, cm, 1, 0)
-
-	_, err = cm.GetMutable(ctx, active.ID())
-	assert.Error(t, err)
-	assert.Equal(t, errLocked, errors.Cause(err))
-
-	err = snap.Release(ctx)
-	assert.NoError(t, err)
-
-	checkDiskUsage(t, ctx, cm, 0, 1)
-
-	active, err = cm.GetMutable(ctx, active.ID())
-	assert.NoError(t, err)
-
-	checkDiskUsage(t, ctx, cm, 1, 0)
-
-	snap, err = active.ReleaseAndCommit(ctx)
-	assert.NoError(t, err)
-
-	checkDiskUsage(t, ctx, cm, 1, 0)
-
-	err = snap.Release(ctx)
-	assert.NoError(t, err)
-
-	_, err = cm.GetMutable(ctx, active.ID())
-	assert.Error(t, err)
-	assert.Equal(t, errNotFound, errors.Cause(err))
-
-	_, err = cm.GetMutable(ctx, snap.ID())
-	assert.Error(t, err)
-	assert.Equal(t, errInvalid, errors.Cause(err))
-
-	snap, err = cm.Get(ctx, snap.ID())
-	assert.NoError(t, err)
-
-	snap2, err := cm.Get(ctx, snap.ID())
-	assert.NoError(t, err)
-
-	checkDiskUsage(t, ctx, cm, 1, 0)
-
-	err = snap.Release(ctx)
-	assert.NoError(t, err)
-
-	active2, err := cm.New(ctx, snap2)
-	assert.NoError(t, err)
-
-	checkDiskUsage(t, ctx, cm, 2, 0)
-
-	snap3, err := active2.Freeze()
-	assert.NoError(t, err)
-
-	err = snap2.Release(ctx)
-	assert.NoError(t, err)
-
-	checkDiskUsage(t, ctx, cm, 2, 0)
-
-	err = snap3.Release(ctx)
-	assert.NoError(t, err)
-
-	checkDiskUsage(t, ctx, cm, 0, 2)
-
-	err = cm.Close()
-	assert.NoError(t, err)
+	require.NoError(t, err, fmt.Sprintf("error: %+v", err))
+	return cm
 }
 
 func checkDiskUsage(t *testing.T, ctx context.Context, cm Manager, inuse, unused int) {
 	du, err := cm.DiskUsage(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var inuseActual, unusedActual int
 	for _, r := range du {
 		if r.InUse {
@@ -141,6 +269,6 @@ func checkDiskUsage(t *testing.T, ctx context.Context, cm Manager, inuse, unused
 			unusedActual++
 		}
 	}
-	assert.Equal(t, inuse, inuseActual)
-	assert.Equal(t, unused, unusedActual)
+	require.Equal(t, inuse, inuseActual)
+	require.Equal(t, unused, unusedActual)
 }

--- a/cache/metadata.go
+++ b/cache/metadata.go
@@ -15,6 +15,8 @@ import (
 
 const sizeUnknown int64 = -1
 const keySize = "snapshot.size"
+const keyEqualMutable = "cache.equalMutable"
+const keyEqualImmutable = "cache.equalImmutable"
 
 func setSize(si *metadata.StorageItem, s int64) error {
 	v, err := metadata.NewValue(s)
@@ -22,7 +24,7 @@ func setSize(si *metadata.StorageItem, s int64) error {
 		return errors.Wrap(err, "failed to create size value")
 	}
 	si.Queue(func(b *bolt.Bucket) error {
-		return si.SetValue(b, keySize, *v)
+		return si.SetValue(b, keySize, v)
 	})
 	return nil
 }
@@ -37,4 +39,34 @@ func getSize(si *metadata.StorageItem) int64 {
 		return sizeUnknown
 	}
 	return size
+}
+
+func getEqualMutable(si *metadata.StorageItem) string {
+	v := si.Get(keyEqualMutable)
+	if v == nil {
+		return ""
+	}
+	var str string
+	if err := v.Unmarshal(&str); err != nil {
+		return ""
+	}
+	return str
+}
+
+func setEqualMutable(si *metadata.StorageItem, s string) error {
+	v, err := metadata.NewValue(s)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create %s meta value", keyEqualMutable)
+	}
+	si.Queue(func(b *bolt.Bucket) error {
+		return si.SetValue(b, keyEqualMutable, v)
+	})
+	return nil
+}
+
+func clearEqualMutable(si *metadata.StorageItem) error {
+	si.Queue(func(b *bolt.Bucket) error {
+		return si.SetValue(b, keyEqualMutable, nil)
+	})
+	return nil
 }

--- a/cache/metadata/metadata_test.go
+++ b/cache/metadata/metadata_test.go
@@ -31,7 +31,7 @@ func TestGetSetSearch(t *testing.T) {
 	require.NoError(t, err)
 
 	si.Queue(func(b *bolt.Bucket) error {
-		return si.SetValue(b, "bar", *v)
+		return si.SetValue(b, "bar", v)
 	})
 
 	err = si.Commit()
@@ -72,7 +72,7 @@ func TestGetSetSearch(t *testing.T) {
 	require.NoError(t, err)
 
 	si.Queue(func(b *bolt.Bucket) error {
-		return si.SetValue(b, "bar2", *v)
+		return si.SetValue(b, "bar2", v)
 	})
 
 	err = si.Commit()
@@ -135,7 +135,7 @@ func TestIndexes(t *testing.T) {
 		v.Index = tcase.index
 
 		si.Queue(func(b *bolt.Bucket) error {
-			return si.SetValue(b, tcase.value, *v)
+			return si.SetValue(b, tcase.value, v)
 		})
 
 		err = si.Commit()

--- a/cache/refs.go
+++ b/cache/refs.go
@@ -17,14 +17,15 @@ type ImmutableRef interface {
 	Release(context.Context) error
 	Size(ctx context.Context) (int64, error)
 	Parent() ImmutableRef
+	Finalize(ctx context.Context) error // Make sure reference is flushed to driver
 	// Prepare() / ChainID() / Meta()
 }
 
 type MutableRef interface {
 	Mountable
 	ID() string
-	Freeze() (ImmutableRef, error)
-	ReleaseAndCommit(ctx context.Context) (ImmutableRef, error)
+	Commit(context.Context) (ImmutableRef, error)
+	Release(context.Context) error
 	Size(ctx context.Context) (int64, error)
 }
 
@@ -33,10 +34,8 @@ type Mountable interface {
 }
 
 type cacheRecord struct {
-	mu      sync.Mutex
-	mutable bool
-	frozen  bool
-	// meta   SnapMeta
+	mu        sync.Mutex
+	mutable   bool
 	refs      map[Mountable]struct{}
 	cm        *cacheManager
 	parent    ImmutableRef
@@ -46,6 +45,10 @@ type cacheRecord struct {
 
 	sizeG flightcontrol.Group
 	// size  int64
+
+	// these are filled if multiple refs point to same data
+	equalMutable   *mutableRef
+	equalImmutable *immutableRef
 }
 
 // hold manager lock before calling
@@ -67,11 +70,16 @@ func (cr *cacheRecord) Size(ctx context.Context) (int64, error) {
 	s, err := cr.sizeG.Do(ctx, cr.ID(), func(ctx context.Context) (interface{}, error) {
 		cr.mu.Lock()
 		s := getSize(cr.md)
-		cr.mu.Unlock()
 		if s != sizeUnknown {
+			cr.mu.Unlock()
 			return s, nil
 		}
-		usage, err := cr.cm.ManagerOpt.Snapshotter.Usage(ctx, cr.ID())
+		driverID := cr.ID()
+		if cr.equalMutable != nil {
+			driverID = cr.equalMutable.ID()
+		}
+		cr.mu.Unlock()
+		usage, err := cr.cm.ManagerOpt.Snapshotter.Usage(ctx, driverID)
 		if err != nil {
 			return s, errors.Wrapf(err, "failed to get usage for %s", cr.ID())
 		}
@@ -104,6 +112,9 @@ func (cr *cacheRecord) Mount(ctx context.Context) ([]mount.Mount, error) {
 		}
 		return m, nil
 	}
+	if err := cr.finalize(ctx); err != nil {
+		return nil, err
+	}
 	if cr.viewMount == nil { // TODO: handle this better
 		cr.view = identity.NewID()
 		m, err := cr.cm.Snapshotter.View(ctx, cr.view, cr.ID())
@@ -114,6 +125,18 @@ func (cr *cacheRecord) Mount(ctx context.Context) ([]mount.Mount, error) {
 		cr.viewMount = m
 	}
 	return cr.viewMount, nil
+}
+
+func (cr *cacheRecord) remove(ctx context.Context, removeSnapshot bool) error {
+	if err := cr.cm.md.Clear(cr.ID()); err != nil {
+		return err
+	}
+	if removeSnapshot {
+		if err := cr.cm.Snapshotter.Remove(ctx, cr.ID()); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (cr *cacheRecord) ID() string {
@@ -148,82 +171,100 @@ func (sr *immutableRef) release(ctx context.Context) error {
 	}
 
 	delete(sr.refs, sr)
-	sr.frozen = false
 
 	if len(sr.refs) == 0 {
-		//go sr.cm.GC()
+		if sr.equalMutable != nil {
+			sr.equalMutable.release(ctx)
+		}
+		// go sr.cm.GC()
 	}
 
 	return nil
 }
 
-func (sr *mutableRef) Freeze() (ImmutableRef, error) {
+func (sr *immutableRef) Finalize(ctx context.Context) error {
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+
+	return sr.finalize(ctx)
+}
+
+func (sr *cacheRecord) finalize(ctx context.Context) error {
+	mutable := sr.equalMutable
+	if mutable == nil {
+		return nil
+	}
+	err := sr.cm.Snapshotter.Commit(ctx, sr.ID(), sr.equalMutable.ID())
+	if err != nil {
+		return errors.Wrapf(err, "failed to commit %s", sr.equalMutable.ID())
+	}
+	delete(sr.cm.records, sr.equalMutable.ID())
+	if err := sr.equalMutable.remove(ctx, false); err != nil {
+		return err
+	}
+	sr.equalMutable = nil
+	clearEqualMutable(sr.md)
+	return sr.md.Commit()
+}
+
+func (sr *mutableRef) commit(ctx context.Context) (ImmutableRef, error) {
+	if !sr.mutable || len(sr.refs) == 0 {
+		return nil, errors.Wrapf(errInvalid, "invalid mutable")
+	}
+
+	id := identity.NewID()
+	md, _ := sr.cm.md.Get(id)
+
+	rec := &cacheRecord{
+		cm:           sr.cm,
+		parent:       sr.parent,
+		equalMutable: sr,
+		refs:         make(map[Mountable]struct{}),
+		md:           &md,
+	}
+
+	sr.cm.records[id] = rec
+
+	if err := sr.md.Commit(); err != nil {
+		return nil, err
+	}
+
+	setSize(&md, sizeUnknown)
+	setEqualMutable(&md, sr.ID())
+	if err := md.Commit(); err != nil {
+		return nil, err
+	}
+
+	ref := rec.ref()
+	sr.equalImmutable = ref
+	return ref, nil
+}
+
+func (sr *mutableRef) Commit(ctx context.Context) (ImmutableRef, error) {
 	sr.cm.mu.Lock()
 	defer sr.cm.mu.Unlock()
 
 	sr.mu.Lock()
 	defer sr.mu.Unlock()
 
-	if !sr.mutable || sr.frozen || len(sr.refs) != 1 {
-		return nil, errors.Wrapf(errInvalid, "invalid mutable")
-	}
-
-	if _, ok := sr.refs[sr]; !ok {
-		return nil, errors.Wrapf(errInvalid, "invalid mutable")
-	}
-
-	delete(sr.refs, sr)
-
-	sri := sr.ref()
-
-	sri.frozen = true
-	setSize(sr.md, sizeUnknown)
-	if err := sr.md.Commit(); err != nil {
-		return nil, err
-	}
-
-	return sri, nil
+	return sr.commit(ctx)
 }
 
-func (sr *mutableRef) ReleaseAndCommit(ctx context.Context) (ImmutableRef, error) {
+func (sr *mutableRef) Release(ctx context.Context) error {
 	sr.cm.mu.Lock()
 	defer sr.cm.mu.Unlock()
 
 	sr.mu.Lock()
+	defer sr.mu.Unlock()
 
-	if !sr.mutable || sr.frozen {
-		sr.mu.Unlock()
-		return nil, errors.Wrapf(errInvalid, "invalid mutable")
-	}
-	if len(sr.refs) != 1 {
-		sr.mu.Unlock()
-		return nil, errors.Wrapf(errInvalid, "multiple mutable references")
-	}
+	return sr.release(ctx)
+}
 
-	sr.mu.Unlock()
-
-	id := identity.NewID()
-
-	err := sr.cm.Snapshotter.Commit(ctx, id, sr.ID())
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to commit %s", sr.ID())
-	}
-
-	delete(sr.cm.records, sr.ID())
-
-	if err := sr.cm.md.Clear(sr.ID()); err != nil {
-		return nil, err
-	}
-
-	md, _ := sr.cm.md.Get(id)
-
-	rec := &cacheRecord{
-		cm:     sr.cm,
-		parent: sr.parent,
-		refs:   make(map[Mountable]struct{}),
-		md:     &md,
-	}
-	sr.cm.records[id] = rec // TODO: save to db
-
-	return rec.ref(), nil
+func (sr *mutableRef) release(ctx context.Context) error {
+	delete(sr.refs, sr)
+	// delete(sr.cm.records, sr.ID())
+	// if err := sr.remove(ctx, true); err != nil {
+	// 	return err
+	// }
+	return nil
 }

--- a/client/llb/llb.go
+++ b/client/llb/llb.go
@@ -167,8 +167,9 @@ func (eo *exec) marshalTo(list [][]byte, cache map[digest.Digest]struct{}) (dige
 		}
 
 		pm := &pb.Mount{
-			Input: int64(inputIndex),
-			Dest:  m.dest,
+			Input:    int64(inputIndex),
+			Dest:     m.dest,
+			Readonly: m.readonly,
 		}
 		if m.hasOutput {
 			pm.Output = outputIndex
@@ -186,7 +187,7 @@ func (eo *exec) marshalTo(list [][]byte, cache map[digest.Digest]struct{}) (dige
 type mount struct {
 	execState *ExecState
 	dest      string
-	// ro bool
+	readonly  bool
 	// either parent or source has to be set
 	parent      *mount
 	source      *source

--- a/client/llb/llb.go
+++ b/client/llb/llb.go
@@ -153,7 +153,7 @@ func (eo *exec) marshalTo(list [][]byte, cache map[digest.Digest]struct{}) (dige
 			}
 		}
 		if dgst == "" {
-			inputIndex = -1
+			inputIndex = pb.Empty
 		}
 		if inputIndex == len(pop.Inputs) {
 			var mountIndex int64
@@ -174,7 +174,7 @@ func (eo *exec) marshalTo(list [][]byte, cache map[digest.Digest]struct{}) (dige
 			pm.Output = outputIndex
 			outputIndex++
 		} else {
-			pm.Output = -1
+			pm.Output = pb.SkipOutput
 		}
 		m.outputIndex = outputIndex - 1
 		peo.Mounts = append(peo.Mounts, pm)

--- a/client/llb/state.go
+++ b/client/llb/state.go
@@ -138,13 +138,16 @@ type ExecState struct {
 	State
 }
 
-func (s *ExecState) AddMount(dest string, mountState *State) *State {
+func (s *ExecState) AddMount(dest string, mountState *State, opts ...MountOption) *State {
 	m := &mount{
 		dest:      dest,
 		source:    mountState.source,
 		parent:    mountState.mount,
 		execState: s,
 		hasOutput: true, // TODO: should be set only if something inherits
+	}
+	for _, opt := range opts {
+		opt(m)
 	}
 	var newState State
 	newState.meta = s.meta
@@ -182,9 +185,15 @@ func (s *ExecState) updateMeta(fn metaOption) *ExecState {
 
 type RunOption func(es *ExecState) *ExecState
 
-func AddMount(dest string, mountState *State) RunOption {
+type MountOption func(*mount)
+
+func Readonly(m *mount) {
+	m.readonly = true
+}
+
+func AddMount(dest string, mountState *State, opts ...MountOption) RunOption {
 	return func(es *ExecState) *ExecState {
-		es.AddMount(dest, mountState)
+		es.AddMount(dest, mountState, opts...)
 		return nil
 	}
 }

--- a/client/solve.go
+++ b/client/solve.go
@@ -80,7 +80,7 @@ func (c *Client) Solve(ctx context.Context, r io.Reader, statusChan chan *SolveS
 			Definition:    def,
 			Exporter:      exporter,
 			ExporterAttrs: exporterAttrs,
-			Session:       s.UUID(),
+			Session:       s.ID(),
 		})
 		if err != nil {
 			return errors.Wrap(err, "failed to solve")

--- a/control/control_default.go
+++ b/control/control_default.go
@@ -95,6 +95,7 @@ func defaultControllerOpts(root string, pd pullDeps) (*Opt, error) {
 	ss, err := local.NewSource(local.Opt{
 		SessionManager: sessm,
 		CacheAccessor:  cm,
+		MetadataStore:  md,
 	})
 	if err != nil {
 		return nil, err

--- a/control/control_standalone_test.go
+++ b/control/control_standalone_test.go
@@ -124,7 +124,7 @@ func TestControl(t *testing.T) {
 	err = w.Exec(ctx, meta, root, nil, nil, nil)
 	assert.NoError(t, err)
 
-	rf, err := root.Freeze()
+	rf, err := root.Commit(ctx)
 	assert.NoError(t, err)
 
 	mounts, err = rf.Mount(ctx)

--- a/control/control_standalone_test.go
+++ b/control/control_standalone_test.go
@@ -72,7 +72,7 @@ func TestControl(t *testing.T) {
 	snap, err := src.Snapshot(ctx)
 	assert.NoError(t, err)
 
-	mounts, err := snap.Mount(ctx)
+	mounts, err := snap.Mount(ctx, false)
 	assert.NoError(t, err)
 
 	lm := snapshot.LocalMounter(mounts)
@@ -127,7 +127,7 @@ func TestControl(t *testing.T) {
 	rf, err := root.Commit(ctx)
 	assert.NoError(t, err)
 
-	mounts, err = rf.Mount(ctx)
+	mounts, err = rf.Mount(ctx, false)
 	assert.NoError(t, err)
 
 	lm = snapshot.LocalMounter(mounts)

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -113,12 +113,12 @@ func (e *imageExporter) getBlobs(ctx context.Context, ref cache.ImmutableRef) ([
 			var lower []mount.Mount
 			if parent != nil {
 				defer parent.Release(context.TODO())
-				lower, err = parent.Mount(ctx)
+				lower, err = parent.Mount(ctx, true)
 				if err != nil {
 					return nil, err
 				}
 			}
-			upper, err := ref.Mount(ctx)
+			upper, err := ref.Mount(ctx, true)
 			if err != nil {
 				return nil, err
 			}

--- a/session/context.go
+++ b/session/context.go
@@ -4,11 +4,11 @@ import "context"
 
 type contextKeyT string
 
-var contextKey = contextKeyT("buildkit/session-uuid")
+var contextKey = contextKeyT("buildkit/session-id")
 
-func NewContext(ctx context.Context, uuid string) context.Context {
-	if uuid != "" {
-		return context.WithValue(ctx, contextKey, uuid)
+func NewContext(ctx context.Context, id string) context.Context {
+	if id != "" {
+		return context.WithValue(ctx, contextKey, id)
 	}
 	return ctx
 }

--- a/session/filesync/filesync_test.go
+++ b/session/filesync/filesync_test.go
@@ -44,7 +44,7 @@ func TestFileSyncIncludePatterns(t *testing.T) {
 	})
 
 	g.Go(func() (reterr error) {
-		c, err := m.Get(ctx, s.UUID())
+		c, err := m.Get(ctx, s.ID())
 		if err != nil {
 			return err
 		}

--- a/session/manager.go
+++ b/session/manager.go
@@ -49,14 +49,14 @@ func (sm *Manager) HandleHTTPRequest(ctx context.Context, w http.ResponseWriter,
 		return errors.New("handler does not support hijack")
 	}
 
-	uuid := r.Header.Get(headerSessionUUID)
+	id := r.Header.Get(headerSessionID)
 
 	proto := r.Header.Get("Upgrade")
 
 	sm.mu.Lock()
-	if _, ok := sm.sessions[uuid]; ok {
+	if _, ok := sm.sessions[id]; ok {
 		sm.mu.Unlock()
-		return errors.Errorf("session %s already exists", uuid)
+		return errors.Errorf("session %s already exists", id)
 	}
 
 	if proto == "" {
@@ -105,7 +105,7 @@ func (sm *Manager) handleConn(ctx context.Context, conn net.Conn, opts map[strin
 	opts = canonicalHeaders(opts)
 
 	h := http.Header(opts)
-	uuid := h.Get(headerSessionUUID)
+	id := h.Get(headerSessionID)
 	name := h.Get(headerSessionName)
 	sharedKey := h.Get(headerSessionSharedKey)
 
@@ -117,7 +117,7 @@ func (sm *Manager) handleConn(ctx context.Context, conn net.Conn, opts map[strin
 
 	c := &client{
 		Session: Session{
-			uuid:      uuid,
+			id:        id,
 			name:      name,
 			sharedKey: sharedKey,
 			ctx:       ctx,
@@ -131,13 +131,13 @@ func (sm *Manager) handleConn(ctx context.Context, conn net.Conn, opts map[strin
 	for _, m := range opts[headerSessionMethod] {
 		c.supported[strings.ToLower(m)] = struct{}{}
 	}
-	sm.sessions[uuid] = c
+	sm.sessions[id] = c
 	sm.updateCondition.Broadcast()
 	sm.mu.Unlock()
 
 	defer func() {
 		sm.mu.Lock()
-		delete(sm.sessions, uuid)
+		delete(sm.sessions, id)
 		sm.mu.Unlock()
 	}()
 
@@ -148,8 +148,8 @@ func (sm *Manager) handleConn(ctx context.Context, conn net.Conn, opts map[strin
 	return nil
 }
 
-// Get returns a session by UUID
-func (sm *Manager) Get(ctx context.Context, uuid string) (Caller, error) {
+// Get returns a session by ID
+func (sm *Manager) Get(ctx context.Context, id string) (Caller, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -167,11 +167,11 @@ func (sm *Manager) Get(ctx context.Context, uuid string) (Caller, error) {
 		select {
 		case <-ctx.Done():
 			sm.mu.Unlock()
-			return nil, errors.Wrapf(ctx.Err(), "no active session for %s", uuid)
+			return nil, errors.Wrapf(ctx.Err(), "no active session for %s", id)
 		default:
 		}
 		var ok bool
-		c, ok = sm.sessions[uuid]
+		c, ok = sm.sessions[id]
 		if !ok || c.closed() {
 			sm.updateCondition.Wait()
 			continue

--- a/session/session.go
+++ b/session/session.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	headerSessionUUID      = "X-Docker-Expose-Session-Uuid"
+	headerSessionID        = "X-Docker-Expose-Session-Uuid"
 	headerSessionName      = "X-Docker-Expose-Session-Name"
 	headerSessionSharedKey = "X-Docker-Expose-Session-Sharedkey"
 	headerSessionMethod    = "X-Docker-Expose-Session-Grpc-Method"
@@ -28,7 +28,7 @@ type Attachable interface {
 
 // Session is a long running connection between client and a daemon
 type Session struct {
-	uuid       string
+	id         string
 	name       string
 	sharedKey  string
 	ctx        context.Context
@@ -39,9 +39,9 @@ type Session struct {
 
 // NewSession returns a new long running session
 func NewSession(name, sharedKey string) (*Session, error) {
-	uuid := stringid.GenerateRandomID()
+	id := stringid.GenerateRandomID()
 	s := &Session{
-		uuid:       uuid,
+		id:         id,
 		name:       name,
 		sharedKey:  sharedKey,
 		grpcServer: grpc.NewServer(),
@@ -57,9 +57,9 @@ func (s *Session) Allow(a Attachable) {
 	a.Register(s.grpcServer)
 }
 
-// UUID returns unique identifier for the session
-func (s *Session) UUID() string {
-	return s.uuid
+// ID returns unique identifier for the session
+func (s *Session) ID() string {
+	return s.id
 }
 
 // Run activates the session
@@ -72,7 +72,7 @@ func (s *Session) Run(ctx context.Context, dialer Dialer) error {
 	defer close(s.done)
 
 	meta := make(map[string][]string)
-	meta[headerSessionUUID] = []string{s.uuid}
+	meta[headerSessionID] = []string{s.id}
 	meta[headerSessionName] = []string{s.name}
 	meta[headerSessionSharedKey] = []string{s.sharedKey}
 

--- a/snapshot/blobmapping/snapshotter.go
+++ b/snapshot/blobmapping/snapshotter.go
@@ -114,7 +114,7 @@ func (s *Snapshotter) SetBlob(ctx context.Context, key string, blob digest.Diges
 	v.Index = index(blob)
 
 	return md.Update(func(b *bolt.Bucket) error {
-		return md.SetValue(b, blobKey, *v)
+		return md.SetValue(b, blobKey, v)
 	})
 }
 

--- a/snapshot/localmounter.go
+++ b/snapshot/localmounter.go
@@ -31,7 +31,16 @@ func (lm *localMounter) Mount() (string, error) {
 	defer lm.mu.Unlock()
 
 	if len(lm.m) == 1 && lm.m[0].Type == "bind" {
-		return lm.m[0].Source, nil
+		ro := false
+		for _, opt := range lm.m[0].Options {
+			if opt == "ro" {
+				ro = true
+				break
+			}
+		}
+		if !ro {
+			return lm.m[0].Source, nil
+		}
 	}
 
 	dir, err := ioutil.TempDir("", "buildkit-mount")

--- a/solver/pb/const.go
+++ b/solver/pb/const.go
@@ -1,3 +1,5 @@
 package pb
 
 const RootMount = "/"
+const SkipOutput = -1 // TODO: custom type
+const Empty = -1      // TODO: custom type

--- a/solver/pb/ops.pb.go
+++ b/solver/pb/ops.pb.go
@@ -216,6 +216,7 @@ type Mount struct {
 	Selector string `protobuf:"bytes,2,opt,name=selector,proto3" json:"selector,omitempty"`
 	Dest     string `protobuf:"bytes,3,opt,name=dest,proto3" json:"dest,omitempty"`
 	Output   int64  `protobuf:"varint,4,opt,name=output,proto3" json:"output,omitempty"`
+	Readonly bool   `protobuf:"varint,5,opt,name=readonly,proto3" json:"readonly,omitempty"`
 }
 
 func (m *Mount) Reset()         { *m = Mount{} }
@@ -513,6 +514,16 @@ func (m *Mount) MarshalTo(data []byte) (int, error) {
 		i++
 		i = encodeVarintOps(data, i, uint64(m.Output))
 	}
+	if m.Readonly {
+		data[i] = 0x28
+		i++
+		if m.Readonly {
+			data[i] = 1
+		} else {
+			data[i] = 0
+		}
+		i++
+	}
 	return i, nil
 }
 
@@ -758,6 +769,9 @@ func (m *Mount) Size() (n int) {
 	}
 	if m.Output != 0 {
 		n += 1 + sovOps(uint64(m.Output))
+	}
+	if m.Readonly {
+		n += 2
 	}
 	return n
 }
@@ -1473,6 +1487,26 @@ func (m *Mount) Unmarshal(data []byte) error {
 					break
 				}
 			}
+		case 5:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Readonly", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowOps
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				v |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Readonly = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := skipOps(data[iNdEx:])

--- a/solver/pb/ops.proto
+++ b/solver/pb/ops.proto
@@ -34,6 +34,7 @@ message Mount {
 	string selector = 2;
 	string dest = 3;
 	int64 output = 4;
+	bool readonly = 5;
 }
 
 message CopyOp {

--- a/solver/solver.go
+++ b/solver/solver.go
@@ -309,36 +309,11 @@ func (s *Solver) getRefs(ctx context.Context, j *job, g *vertex) (retRef []Refer
 		}
 		if s.cache != nil {
 			for i, ref := range refs {
-				if ref != nil {
-					if err := s.cache.Set(fmt.Sprintf("%s.%d", cacheKey, i), ref); err != nil {
-						logrus.Errorf("failed to save cache for %s: %v", cacheKey, err)
-					}
+				if err := s.cache.Set(fmt.Sprintf("%s.%d", cacheKey, i), originRef(ref)); err != nil {
+					logrus.Errorf("failed to save cache for %s: %v", cacheKey, err)
 				}
 			}
 		}
 		return refs, nil
 	})
-}
-
-func toImmutableRef(ref Reference) (cache.ImmutableRef, bool) {
-	sysRef := ref
-	if sys, ok := ref.(interface {
-		Sys() Reference
-	}); ok {
-		sysRef = sys.Sys()
-	}
-	immutable, ok := sysRef.(cache.ImmutableRef)
-	if !ok {
-		return nil, false
-	}
-	return &immutableRef{immutable, ref.Release}, true
-}
-
-type immutableRef struct {
-	cache.ImmutableRef
-	release func(context.Context) error
-}
-
-func (ir *immutableRef) Release(ctx context.Context) error {
-	return ir.release(ctx)
 }

--- a/solver/source.go
+++ b/solver/source.go
@@ -58,12 +58,13 @@ func (s *sourceOp) instance(ctx context.Context) (source.SourceInstance, error) 
 	return s.src, nil
 }
 
-func (s *sourceOp) CacheKey(ctx context.Context, _ []string) (string, error) {
+func (s *sourceOp) CacheKey(ctx context.Context, _ []string) (string, int, error) {
 	src, err := s.instance(ctx)
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
-	return src.CacheKey(ctx)
+	k, err := src.CacheKey(ctx)
+	return k, 1, err
 }
 
 func (s *sourceOp) Run(ctx context.Context, _ []Reference) ([]Reference, error) {

--- a/solver/state.go
+++ b/solver/state.go
@@ -24,6 +24,7 @@ type state struct {
 	jobs        map[*job]struct{}
 	refs        []*sharedRef
 	cacheKey    string
+	numRefs     int
 	op          Op
 	progressCtx context.Context
 	cacheCtx    context.Context
@@ -96,7 +97,7 @@ func (s *state) GetRefs(ctx context.Context, cb func(context.Context, Op) ([]Ref
 	return refs, nil
 }
 
-func (s *state) GetCacheKey(ctx context.Context, cb func(context.Context, Op) (string, error)) (string, error) {
+func (s *state) GetCacheKey(ctx context.Context, cb func(context.Context, Op) (string, int, error)) (string, int, error) {
 	_, err := s.Do(ctx, "cache:"+s.key.String(), func(doctx context.Context) (interface{}, error) {
 		if s.cacheKey != "" {
 			if err := writeProgressSnapshot(s.cacheCtx, ctx); err != nil {
@@ -104,18 +105,19 @@ func (s *state) GetCacheKey(ctx context.Context, cb func(context.Context, Op) (s
 			}
 			return nil, nil
 		}
-		cacheKey, err := cb(doctx, s.op)
+		cacheKey, numRefs, err := cb(doctx, s.op)
 		if err != nil {
 			return nil, err
 		}
 		s.cacheKey = cacheKey
+		s.numRefs = numRefs
 		s.cacheCtx = doctx
 		return nil, nil
 	})
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
-	return s.cacheKey, nil
+	return s.cacheKey, s.numRefs, nil
 }
 
 func writeProgressSnapshot(srcCtx, destCtx context.Context) error {

--- a/source/git/gitsource.go
+++ b/source/git/gitsource.go
@@ -95,7 +95,7 @@ func (gs *gitSource) mountRemote(ctx context.Context, remote string) (target str
 		}
 	}()
 
-	mount, err := remoteRef.Mount(ctx)
+	mount, err := remoteRef.Mount(ctx, false)
 	if err != nil {
 		return "", nil, err
 	}
@@ -271,7 +271,7 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context) (out cache.ImmutableRe
 		}
 	}()
 
-	mount, err := checkoutRef.Mount(ctx)
+	mount, err := checkoutRef.Mount(ctx, false)
 	if err != nil {
 		return nil, err
 	}

--- a/source/git/gitsource.go
+++ b/source/git/gitsource.go
@@ -86,10 +86,7 @@ func (gs *gitSource) mountRemote(ctx context.Context, remote string) (target str
 	}
 
 	releaseRemoteRef := func() {
-		s, err := remoteRef.Freeze() // TODO: remove this
-		if err == nil {
-			s.Release(context.TODO())
-		}
+		remoteRef.Release(context.TODO())
 	}
 
 	defer func() {
@@ -133,7 +130,7 @@ func (gs *gitSource) mountRemote(ctx context.Context, remote string) (target str
 		}
 
 		if err := si.Update(func(b *bolt.Bucket) error {
-			return si.SetValue(b, "git-remote", *v)
+			return si.SetValue(b, "git-remote", v)
 		}); err != nil {
 			return "", nil, err
 		}
@@ -270,10 +267,7 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context) (out cache.ImmutableRe
 
 	defer func() {
 		if retErr != nil && checkoutRef != nil {
-			s, err := checkoutRef.Freeze() // TODO: remove this
-			if err != nil {
-				s.Release(context.TODO())
-			}
+			checkoutRef.Release(context.TODO())
 		}
 	}()
 
@@ -326,7 +320,7 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context) (out cache.ImmutableRe
 	lm.Unmount()
 	lm = nil
 
-	snap, err := checkoutRef.ReleaseAndCommit(ctx)
+	snap, err := checkoutRef.Commit(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -345,7 +339,7 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context) (out cache.ImmutableRe
 		return nil, err
 	}
 	if err := si.Update(func(b *bolt.Bucket) error {
-		return si.SetValue(b, "git-snapshot", *v)
+		return si.SetValue(b, "git-snapshot", v)
 	}); err != nil {
 		return nil, err
 	}

--- a/source/git/gitsource_test.go
+++ b/source/git/gitsource_test.go
@@ -55,7 +55,7 @@ func testRepeatedFetch(t *testing.T, keepGitDir bool) {
 	require.NoError(t, err)
 	defer ref1.Release(context.TODO())
 
-	mount, err := ref1.Mount(ctx)
+	mount, err := ref1.Mount(ctx, false)
 	require.NoError(t, err)
 
 	lm := snapshot.LocalMounter(mount)
@@ -102,7 +102,7 @@ func testRepeatedFetch(t *testing.T, keepGitDir bool) {
 	require.NoError(t, err)
 	defer ref3.Release(context.TODO())
 
-	mount, err = ref3.Mount(ctx)
+	mount, err = ref3.Mount(ctx, false)
 	require.NoError(t, err)
 
 	lm = snapshot.LocalMounter(mount)
@@ -161,7 +161,7 @@ func testFetchBySHA(t *testing.T, keepGitDir bool) {
 	require.NoError(t, err)
 	defer ref1.Release(context.TODO())
 
-	mount, err := ref1.Mount(ctx)
+	mount, err := ref1.Mount(ctx, false)
 	require.NoError(t, err)
 
 	lm := snapshot.LocalMounter(mount)
@@ -234,7 +234,7 @@ func testMultipleRepos(t *testing.T, keepGitDir bool) {
 	require.NoError(t, err)
 	defer ref1.Release(context.TODO())
 
-	mount, err := ref1.Mount(ctx)
+	mount, err := ref1.Mount(ctx, false)
 	require.NoError(t, err)
 
 	lm := snapshot.LocalMounter(mount)
@@ -246,7 +246,7 @@ func testMultipleRepos(t *testing.T, keepGitDir bool) {
 	require.NoError(t, err)
 	defer ref2.Release(context.TODO())
 
-	mount, err = ref2.Mount(ctx)
+	mount, err = ref2.Mount(ctx, false)
 	require.NoError(t, err)
 
 	lm = snapshot.LocalMounter(mount)

--- a/source/local/local.go
+++ b/source/local/local.go
@@ -55,11 +55,11 @@ func (ls *localSourceHandler) CacheKey(ctx context.Context) (string, error) {
 	sessionID := ls.src.SessionID
 
 	if sessionID == "" {
-		uuid := session.FromContext(ctx)
-		if uuid == "" {
+		id := session.FromContext(ctx)
+		if id == "" {
 			return "", errors.New("could not access local files without session")
 		}
-		sessionID = uuid
+		sessionID = id
 	}
 
 	return "session:" + ls.src.Name + ":" + sessionID, nil
@@ -67,15 +67,15 @@ func (ls *localSourceHandler) CacheKey(ctx context.Context) (string, error) {
 
 func (ls *localSourceHandler) Snapshot(ctx context.Context) (out cache.ImmutableRef, retErr error) {
 
-	uuid := session.FromContext(ctx)
-	if uuid == "" {
+	id := session.FromContext(ctx)
+	if id == "" {
 		return nil, errors.New("could not access local files without session")
 	}
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	caller, err := ls.sm.Get(timeoutCtx, uuid)
+	caller, err := ls.sm.Get(timeoutCtx, id)
 	if err != nil {
 		return nil, err
 	}

--- a/source/local/local.go
+++ b/source/local/local.go
@@ -118,7 +118,7 @@ func (ls *localSourceHandler) Snapshot(ctx context.Context) (out cache.Immutable
 		}
 	}()
 
-	mount, err := mutable.Mount(ctx)
+	mount, err := mutable.Mount(ctx, false)
 	if err != nil {
 		return nil, err
 	}

--- a/worker/oci/spec_unix.go
+++ b/worker/oci/spec_unix.go
@@ -22,7 +22,7 @@ func GenerateSpec(ctx context.Context, meta worker.Meta, mounts []worker.Mount) 
 	// TODO: User
 
 	for _, m := range mounts {
-		mounts, err := m.Src.Mount(ctx)
+		mounts, err := m.Src.Mount(ctx, m.Readonly)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to mount %s", m.Dest)
 		}

--- a/worker/runcworker/worker.go
+++ b/worker/runcworker/worker.go
@@ -56,7 +56,7 @@ func New(root string) (worker.Worker, error) {
 }
 
 func (w *runcworker) Exec(ctx context.Context, meta worker.Meta, root cache.Mountable, mounts []worker.Mount, stdout, stderr io.WriteCloser) error {
-	rootMount, err := root.Mount(ctx)
+	rootMount, err := root.Mount(ctx, false)
 	if err != nil {
 		return err
 	}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -19,7 +19,7 @@ type Meta struct {
 type Mount struct {
 	Src      cache.Mountable
 	Dest     string
-	ReadOnly bool
+	Readonly bool
 }
 
 type Worker interface {


### PR DESCRIPTION
This adds local sources reuse support. This turned out to be more complicated than expected. In `docker`, local sources are only available to `COPY` commands, so no command can ever change them. `buildkit` allows directly mounting any snapshot.

This means that for a snapshot to become mutable again we have to delay committing it if possible. With the updated interface `mutableRef.Commit()` now works as `mutableRef.Freeze()` before, meaning if all immutable references get released, the original reference can be updated again. Instruction cache interface is also simplified, allowing to delete the unused branches without invalidating cache. If build definition does create files on top of the build context that would invalidate the requirements for build context reuse.

Later this could be possibly improved by writing the changes to build context to a new layer if it was already committed. This does mean though that without a cleanup logic the history chain of a build context would keep growing. So something in the background should periodically flatten it. I think this is reasonable to implement but not a high priority at the moment. It would be good if we could figure out how to do this operation in btrfs without moving any files.


also contains:
- support for readonly mounts in llb
- session: remove confusing uuid variable (asked in 
https://github.com/moby/buildkit/pull/71/files/473619d3000cb6dcc22b4928d1e265edc3544247#diff-928cb614ae092ed4c6f349f4c4c991e4)

@AkihiroSuda 

