### PR TITLE
source: add multiple dir support for local source

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Different versions of the example scripts show different ways of describing the 
 - `./examples/buildkit0` - uses only exec operations, defines a full stage per component.
 - `./examples/buildkit1` - cloning git repositories has been separated for extra concurrency.
 - `./examples/buildkit2` - uses git sources directly instead of running `git clone`, allowing better performance and much safer caching.
+- `./examples/buildkit3` - allows using local source files for separate components eg. `./buildkit3 --runc=local | buildctl build --local runc-src=some/local/path`  
 
 #### Supported runc version
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -106,6 +106,6 @@ func testBuildMultiMount(t *testing.T, address string) {
 	err = llb.WriteTo(dt, buf)
 	assert.Nil(t, err)
 
-	err = c.Solve(context.TODO(), buf, nil, "", nil, "")
+	err = c.Solve(context.TODO(), buf, SolveOpt{}, nil)
 	assert.Nil(t, err)
 }

--- a/cmd/buildctl/build.go
+++ b/cmd/buildctl/build.go
@@ -33,7 +33,7 @@ var buildCommand = cli.Command{
 			Name:  "no-progress",
 			Usage: "Don't show interactive progress",
 		},
-		cli.StringFlag{
+		cli.StringSliceFlag{
 			Name:  "local",
 			Usage: "Allow build access to the local directory",
 		},
@@ -64,8 +64,17 @@ func build(clicontext *cli.Context) error {
 		return errors.Wrap(err, "invalid exporter-opt")
 	}
 
+	localDirs, err := attrMap(clicontext.StringSlice("local"))
+	if err != nil {
+		return errors.Wrap(err, "invalid local")
+	}
+
 	eg.Go(func() error {
-		return c.Solve(ctx, os.Stdin, ch, clicontext.String("exporter"), exporterAttrs, clicontext.String("local"))
+		return c.Solve(ctx, os.Stdin, client.SolveOpt{
+			Exporter:      clicontext.String("exporter"),
+			ExporterAttrs: exporterAttrs,
+			LocalDirs:     localDirs,
+		}, ch)
 	})
 
 	eg.Go(func() error {

--- a/session/filesync/filesync_test.go
+++ b/session/filesync/filesync_test.go
@@ -32,7 +32,7 @@ func TestFileSyncIncludePatterns(t *testing.T) {
 	m, err := session.NewManager()
 	require.NoError(t, err)
 
-	fs := NewFSSyncProvider(tmpDir, nil)
+	fs := NewFSSyncProvider([]SyncedDir{{Name: "test0", Dir: tmpDir}})
 	s.Allow(fs)
 
 	dialer := session.Dialer(testutil.TestStream(testutil.Handler(m.HandleConn)))
@@ -49,6 +49,7 @@ func TestFileSyncIncludePatterns(t *testing.T) {
 			return err
 		}
 		if err := FSSync(ctx, c, FSSendRequestOpt{
+			Name:            "test0",
 			DestDir:         destDir,
 			IncludePatterns: []string{"ba*"},
 		}); err != nil {

--- a/source/local/local.go
+++ b/source/local/local.go
@@ -137,6 +137,7 @@ func (ls *localSourceHandler) Snapshot(ctx context.Context) (out cache.Immutable
 	}()
 
 	opt := filesync.FSSendRequestOpt{
+		Name:             ls.src.Name,
 		IncludePatterns:  nil,
 		OverrideExcludes: false,
 		DestDir:          dest,


### PR DESCRIPTION
This PR adds support for using more than one local sources during build.

```
./buildkit3 --buildkit=local --runc=local | buildctl build --local buildkit-src=. --local runc-src=/path/to/runc
```

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>