### PR TITLE
solver: avoid removing references required for future cache

### DIFF
--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -30,7 +30,7 @@ func TestManager(t *testing.T) {
 
 	checkDiskUsage(t, ctx, cm, 0, 0)
 
-	active, err := cm.New(ctx, nil, CachePolicyKeepMutable)
+	active, err := cm.New(ctx, nil, CachePolicyRetain)
 	require.NoError(t, err)
 
 	m, err := active.Mount(ctx, false)
@@ -102,7 +102,7 @@ func TestManager(t *testing.T) {
 	err = snap.Release(ctx)
 	require.NoError(t, err)
 
-	active2, err := cm.New(ctx, snap2, CachePolicyKeepMutable)
+	active2, err := cm.New(ctx, snap2, CachePolicyRetain)
 	require.NoError(t, err)
 
 	checkDiskUsage(t, ctx, cm, 2, 0)
@@ -133,7 +133,7 @@ func TestLazyCommit(t *testing.T) {
 
 	cm := getCacheManager(t, tmpdir)
 
-	active, err := cm.New(ctx, nil, CachePolicyKeepMutable)
+	active, err := cm.New(ctx, nil, CachePolicyRetain)
 	require.NoError(t, err)
 
 	// after commit mutable is locked
@@ -202,7 +202,7 @@ func TestLazyCommit(t *testing.T) {
 	require.NoError(t, err)
 
 	// test restarting after commit
-	active, err = cm.New(ctx, nil, CachePolicyKeepMutable)
+	active, err = cm.New(ctx, nil, CachePolicyRetain)
 	require.NoError(t, err)
 
 	// after commit mutable is locked

--- a/solver/solver.go
+++ b/solver/solver.go
@@ -256,6 +256,12 @@ func (s *Solver) getRefs(ctx context.Context, j *job, g *vertex) (retRef []Refer
 					for _, r := range r {
 						refs[i] = append(refs[i], newSharedRef(r))
 					}
+					if ref, ok := toImmutableRef(r[index].(Reference)); ok {
+						// make sure input that is required by next step does not get released in case build is cancelled
+						if err := cache.CachePolicyRetain(ref); err != nil {
+							return err
+						}
+					}
 					return nil
 				})
 			}(i, in.vertex, in.index)

--- a/source/git/gitsource.go
+++ b/source/git/gitsource.go
@@ -78,7 +78,7 @@ func (gs *gitSource) mountRemote(ctx context.Context, remote string) (target str
 
 	initializeRepo := false
 	if remoteRef == nil {
-		remoteRef, err = gs.cache.New(ctx, nil, cache.CachePolicyKeepMutable)
+		remoteRef, err = gs.cache.New(ctx, nil, cache.CachePolicyRetain)
 		if err != nil {
 			return "", nil, errors.Wrapf(err, "failed to create new mutable for %s", remote)
 		}

--- a/source/local/local.go
+++ b/source/local/local.go
@@ -104,7 +104,7 @@ func (ls *localSourceHandler) Snapshot(ctx context.Context) (out cache.Immutable
 	}
 
 	if mutable == nil {
-		m, err := ls.cm.New(ctx, nil, cache.CachePolicyKeepMutable)
+		m, err := ls.cm.New(ctx, nil, cache.CachePolicyRetain)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
#76 was bit too agressive . When build was cancelled a snapshot could be removed because the node requiring it didn't complete yet and therefore it became unused. Then on the next invocation data was not found for these vertexes and they needed to be executed again. The solution is to add the retaining cache-policy added to some mutable references in #76 to immutable references as well, as soon as we know that there is a node that would want to use it later.

@AkihiroSuda 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>