### PR TITLE
llb: skip outputs of readonly mounts

### DIFF
--- a/client/llb/state.go
+++ b/client/llb/state.go
@@ -118,7 +118,7 @@ func (s State) Run(ro ...RunOption) ExecState {
 		Env:  getEnv(ei.State),
 	}
 
-	exec := NewExecOp(s.Output(), meta)
+	exec := NewExecOp(s.Output(), meta, ei.ReadonlyRootFS)
 	for _, m := range ei.Mounts {
 		exec.AddMount(m.Target, m.Source, m.Opts...)
 	}

--- a/examples/buildkit3/buildkit.go
+++ b/examples/buildkit3/buildkit.go
@@ -115,7 +115,7 @@ func copyFrom(src llb.State, srcPath, destPath string) llb.StateOption {
 // copy copies files between 2 states using cp until there is no copyOp
 func copy(src llb.State, srcPath string, dest llb.State, destPath string) llb.State {
 	cpImage := llb.Image("docker.io/library/alpine:latest")
-	cp := cpImage.Run(llb.Shlexf("cp -a /src%s /dest%s", srcPath, destPath))
+	cp := cpImage.Run(llb.Shlexf("cp -a /src%s /dest%s", srcPath, destPath), llb.ReadonlyRootFS)
 	cp.AddMount("/src", src, llb.Readonly)
 	return cp.AddMount("/dest", dest)
 }


### PR DESCRIPTION
Disables outputs on readonly mounts and directly links them to parents instead. Currently, these outputs would be committed and later cleaned up.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>