### PR TITLE
imagesource: share config resolver with frontend

### DIFF
--- a/client/llb/source.go
+++ b/client/llb/source.go
@@ -85,7 +85,7 @@ func Image(ref string, opts ...ImageOption) State {
 		opt(&info)
 	}
 	if info.metaResolver != nil {
-		img, err := info.metaResolver.Resolve(context.TODO(), ref)
+		img, err := info.metaResolver.ResolveImageConfig(context.TODO(), ref)
 		if err != nil {
 			src.err = err
 		} else {

--- a/control/control.go
+++ b/control/control.go
@@ -28,6 +28,7 @@ type Opt struct {
 	Exporters        map[string]exporter.Exporter
 	SessionManager   *session.Manager
 	Frontends        map[string]frontend.Frontend
+	ImageSource      source.Source
 }
 
 type Controller struct { // TODO: ControlService
@@ -43,6 +44,7 @@ func NewController(opt Opt) (*Controller, error) {
 			CacheManager:     opt.CacheManager,
 			Worker:           opt.Worker,
 			InstructionCache: opt.InstructionCache,
+			ImageSource:      opt.ImageSource,
 		}),
 	}
 	return c, nil

--- a/control/control_default.go
+++ b/control/control_default.go
@@ -137,5 +137,6 @@ func defaultControllerOpts(root string, pd pullDeps) (*Opt, error) {
 		Exporters:        exporters,
 		SessionManager:   sessm,
 		Frontends:        frontends,
+		ImageSource:      is,
 	}, nil
 }

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -79,7 +79,7 @@ func Dockerfile2LLB(ctx context.Context, dt []byte, opt ConvertOpt) (*llb.State,
 					}
 					d.stage.BaseName = reference.TagNameOnly(ref).String()
 					if opt.MetaResolver != nil {
-						img, err := metaResolver.Resolve(ctx, d.stage.BaseName)
+						img, err := metaResolver.ResolveImageConfig(ctx, d.stage.BaseName)
 						if err != nil {
 							return err
 						}

--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -2,6 +2,7 @@ package frontend
 
 import (
 	"github.com/moby/buildkit/cache"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/net/context"
 )
 
@@ -12,5 +13,5 @@ type Frontend interface {
 
 type FrontendLLBBridge interface {
 	Solve(ctx context.Context, vtx [][]byte) (cache.ImmutableRef, error)
-	// ImageConfigResolver
+	ResolveImageConfig(ctx context.Context, ref string) (*ocispec.Image, error)
 }

--- a/util/imageutil/config.go
+++ b/util/imageutil/config.go
@@ -1,0 +1,115 @@
+package imageutil
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/remotes"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+type IngesterProvider interface {
+	content.Ingester
+	content.Provider
+}
+
+func Config(ctx context.Context, ref string, resolver remotes.Resolver, ingester IngesterProvider) (*ocispec.Image, error) {
+	ref, desc, err := resolver.Resolve(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	fetcher, err := resolver.Fetcher(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	handlers := []images.Handler{
+		remotes.FetchHandler(ingester, fetcher),
+		childrenConfigHandler(ingester),
+	}
+	if err := images.Dispatch(ctx, images.Handlers(handlers...), desc); err != nil {
+		return nil, err
+	}
+	config, err := images.Config(ctx, ingester, desc)
+	if err != nil {
+		return nil, err
+	}
+
+	var ociimage ocispec.Image
+
+	r, err := ingester.ReaderAt(ctx, config.Digest)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	dec := json.NewDecoder(readerAtToReader(r))
+	if err := dec.Decode(&ociimage); err != nil {
+		return nil, err
+	}
+	if dec.More() {
+		return nil, errors.New("invalid image config")
+	}
+
+	return &ociimage, nil
+}
+
+func childrenConfigHandler(provider content.Provider) images.HandlerFunc {
+	return func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		var descs []ocispec.Descriptor
+		switch desc.MediaType {
+		case images.MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest:
+			p, err := content.ReadBlob(ctx, provider, desc.Digest)
+			if err != nil {
+				return nil, err
+			}
+
+			// TODO(stevvooe): We just assume oci manifest, for now. There may be
+			// subtle differences from the docker version.
+			var manifest ocispec.Manifest
+			if err := json.Unmarshal(p, &manifest); err != nil {
+				return nil, err
+			}
+
+			descs = append(descs, manifest.Config)
+		case images.MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
+			p, err := content.ReadBlob(ctx, provider, desc.Digest)
+			if err != nil {
+				return nil, err
+			}
+
+			var index ocispec.Index
+			if err := json.Unmarshal(p, &index); err != nil {
+				return nil, err
+			}
+
+			descs = append(descs, index.Manifests...)
+		case images.MediaTypeDockerSchema2Config, ocispec.MediaTypeImageConfig:
+			// childless data types.
+			return nil, nil
+		default:
+			return nil, errors.Errorf("encountered unknown type %v; children may not be fetched", desc.MediaType)
+		}
+
+		return descs, nil
+	}
+}
+
+func readerAtToReader(r io.ReaderAt) io.Reader {
+	return &reader{ra: r}
+}
+
+type reader struct {
+	ra     io.ReaderAt
+	offset int64
+}
+
+func (r *reader) Read(b []byte) (int, error) {
+	n, err := r.ra.ReadAt(b, r.offset)
+	r.offset += int64(n)
+	return n, err
+}

--- a/vendor.conf
+++ b/vendor.conf
@@ -33,7 +33,7 @@ github.com/google/shlex 6f45313302b9c56850fc17f99e40caebce98c716
 golang.org/x/time 8be79e1e0910c292df4e79c241bb7e8f7e725959
 
 github.com/BurntSushi/locker 392720b78f44e9d0249fcac6c43b111b47a370b8
-github.com/docker/docker 6f723db8c6f0c7f0b252674a9673a25b5978db04 https://github.com/simonferquel/docker.git
+github.com/docker/docker 6f723db8c6f0c7f0b252674a9673a25b5978db04 https://github.com/tonistiigi/docker.git
 github.com/pkg/profile 5b67d428864e92711fcbd2f8629456121a56d91f
 
 github.com/tonistiigi/fsutil d49833a9a6fa5b41f63e7e338038633d10276b57


### PR DESCRIPTION
This makes sure that frontend and llb share the image resolver and makes sure that there are no duplicate calls to the registry. Previously repeated resolves from frontend were also cached because it used `llb.DefaultMetaResolver` but that is not safe for a long-running client like frontend.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>