### PR TITLE
buildctl: allow specifying trace file path

### DIFF
--- a/cmd/buildctl/build.go
+++ b/cmd/buildctl/build.go
@@ -33,11 +33,22 @@ var buildCommand = cli.Command{
 			Name:  "no-progress",
 			Usage: "Don't show interactive progress",
 		},
+		cli.StringFlag{
+			Name:  "trace",
+			Usage: "Path to trace file. e.g. /dev/null. Defaults to /tmp/buildctlXXXXXXXXX.",
+		},
 		cli.StringSliceFlag{
 			Name:  "local",
 			Usage: "Allow build access to the local directory",
 		},
 	},
+}
+
+func openTraceFile(clicontext *cli.Context) (*os.File, error) {
+	if traceFileName := clicontext.String("trace"); traceFileName != "" {
+		return os.OpenFile(traceFileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	}
+	return ioutil.TempFile("", "buildctl")
 }
 
 func build(clicontext *cli.Context) error {
@@ -46,7 +57,7 @@ func build(clicontext *cli.Context) error {
 		return err
 	}
 
-	traceFile, err := ioutil.TempFile("", "buildctl")
+	traceFile, err := openTraceFile(clicontext)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>