### PR TITLE
progressui: fix flicker on printing byte sizes

### DIFF
--- a/cmd/buildctl/diskusage.go
+++ b/cmd/buildctl/diskusage.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"text/tabwriter"
 
-	units "github.com/docker/go-units"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/util/appcontext"
+	"github.com/tonistiigi/units"
 	"github.com/urfave/cli"
 )
 
@@ -67,7 +67,7 @@ func printVerbose(tw *tabwriter.Writer, du []*client.UsageInfo) {
 		printKV(tw, "Created at", di.CreatedAt)
 		printKV(tw, "Mutable", di.Mutable)
 		printKV(tw, "Reclaimable", !di.InUse)
-		printKV(tw, "Size", units.HumanSize(float64(di.Size)))
+		printKV(tw, "Size", fmt.Sprintf("%.2f", units.Bytes(di.Size)))
 		if di.Description != "" {
 			printKV(tw, "Description", di.Description)
 		}
@@ -90,8 +90,7 @@ func printTable(tw *tabwriter.Writer, du []*client.UsageInfo) {
 		if di.Mutable {
 			id += "*"
 		}
-		fmt.Fprintf(tw, "%s\t%v\t%s\t\n", id, !di.InUse, units.HumanSize(float64(di.Size)))
-
+		fmt.Fprintf(tw, "%s\t%v\t%.2f\t\n", id, !di.InUse, units.Bytes(di.Size))
 	}
 
 	tw.Flush()
@@ -111,7 +110,7 @@ func printSummary(tw *tabwriter.Writer, du []*client.UsageInfo) {
 	}
 
 	tw = tabwriter.NewWriter(os.Stdout, 1, 8, 1, '\t', 0)
-	fmt.Fprintf(tw, "Reclaimable:\t%s\n", units.HumanSize(float64(reclaimable)))
-	fmt.Fprintf(tw, "Total:\t%s\n", units.HumanSize(float64(total)))
+	fmt.Fprintf(tw, "Reclaimable:\t%.2f\n", units.Bytes(reclaimable))
+	fmt.Fprintf(tw, "Total:\t%.2f\n", units.Bytes(total))
 	tw.Flush()
 }

--- a/util/progress/progressui/display.go
+++ b/util/progress/progressui/display.go
@@ -8,10 +8,10 @@ import (
 	"time"
 
 	"github.com/containerd/console"
-	"github.com/docker/go-units"
 	"github.com/moby/buildkit/client"
 	"github.com/morikuni/aec"
 	digest "github.com/opencontainers/go-digest"
+	"github.com/tonistiigi/units"
 	"golang.org/x/time/rate"
 )
 
@@ -196,9 +196,9 @@ func (t *trace) displayInfo() (d displayInfo) {
 				name:          v.indent + "=> " + s.ID,
 			}
 			if s.Total != 0 {
-				j.status = units.HumanSize(float64(s.Current)) + " / " + units.HumanSize(float64(s.Total))
+				j.status = fmt.Sprintf("%.2f / %.2f", units.Bytes(s.Current), units.Bytes(s.Total))
 			} else if s.Current != 0 {
-				j.status = units.HumanSize(float64(s.Current))
+				j.status = fmt.Sprintf("%.2f", units.Bytes(s.Current))
 			}
 			d.jobs = append(d.jobs, j)
 		}
@@ -270,7 +270,7 @@ func (disp *display) print(d displayInfo, all bool) {
 			dt = 0
 		}
 		pfx := " => "
-		timer := fmt.Sprintf(" %.1fs\n", dt)
+		timer := fmt.Sprintf(" %3.1fs\n", dt)
 		status := j.status
 		showStatus := false
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -44,3 +44,5 @@ github.com/hashicorp/golang-lru a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
 github.com/mitchellh/hashstructure 2bca23e0e452137f789efbc8610126fd8b94f73b
 github.com/docker/go-connections 3ede32e2033de7505e6500d6c868c2b9ed9f169d
 github.com/docker/distribution 30578ca32960a4d368bf6db67b0a33c2a1f3dc6f
+
+github.com/tonistiigi/units 29de085e9400559bd68aea2e7bc21566e7b8281d

--- a/vendor/github.com/tonistiigi/units/LICENSE
+++ b/vendor/github.com/tonistiigi/units/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Tõnis Tiigi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/tonistiigi/units/bytes.go
+++ b/vendor/github.com/tonistiigi/units/bytes.go
@@ -1,0 +1,117 @@
+/*
+	Simple byte size formatting.
+
+	This package implements types that can be used in stdlib formatting functions
+	like `fmt.Printf` to control the output of the expected printed string.
+
+
+	Floating point flags %f and %g print the value in using the correct unit
+	suffix. Decimal units are default, # switches to binary units. If a value is
+	best represented as full bytes, integer bytes are printed instead.
+
+		Examples:
+			fmt.Printf("%.2f", 123 * B)   => "123B"
+			fmt.Printf("%.2f", 1234 * B)  => "1.23kB"
+			fmt.Printf("%g", 1200 * B)    => "1.2kB"
+			fmt.Printf("%#g", 1024 * B)   => "1KiB"
+
+
+	Integer flag %d always prints the value in bytes. # flag adds an unit prefix.
+
+		Examples:
+			fmt.Printf("%d", 1234 * B)    => "1234"
+			fmt.Printf("%#d", 1234 * B)   => "1234B"
+
+	%v is equal to %g
+
+*/
+package units
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"math/big"
+)
+
+type Bytes int64
+
+const (
+	B Bytes = 1 << (10 * iota)
+	KiB
+	MiB
+	GiB
+	TiB
+	PiB
+	EiB
+
+	KB = 1e3 * B
+	MB = 1e3 * KB
+	GB = 1e3 * MB
+	TB = 1e3 * GB
+	PB = 1e3 * TB
+	EB = 1e3 * PB
+)
+
+var units = map[bool][]string{
+	false: []string{
+		"B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB",
+	},
+	true: []string{
+		"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB",
+	},
+}
+
+func (b Bytes) Format(f fmt.State, c rune) {
+	switch c {
+	case 'f', 'g':
+		fv, unit, ok := b.floatValue(f.Flag('#'))
+		if !ok {
+			b.formatInt(f, 'd', true)
+			return
+		}
+		big.NewFloat(fv).Format(f, c)
+		io.WriteString(f, unit)
+	case 'd':
+		b.formatInt(f, c, f.Flag('#'))
+	default:
+		if f.Flag('#') {
+			fmt.Fprintf(f, "bytes(%d)", int64(b))
+		} else {
+			fmt.Fprintf(f, "%g", b)
+		}
+	}
+}
+
+func (b Bytes) formatInt(f fmt.State, c rune, withUnit bool) {
+	big.NewInt(int64(b)).Format(f, c)
+	if withUnit {
+		io.WriteString(f, "B")
+	}
+}
+
+func (b Bytes) floatValue(binary bool) (float64, string, bool) {
+	i := 0
+	var baseUnit Bytes = 1
+	if b < 0 {
+		baseUnit *= -1
+	}
+	for {
+		next := baseUnit
+		if binary {
+			next *= 1 << 10
+		} else {
+			next *= 1e3
+		}
+		if (baseUnit > 0 && b >= next) || (baseUnit < 0 && b <= next) {
+			i++
+			baseUnit = next
+			continue
+		}
+		if i == 0 {
+			return 0, "", false
+		}
+
+		return float64(b) / math.Abs(float64(baseUnit)), units[binary][i], true
+	}
+}

--- a/vendor/github.com/tonistiigi/units/readme.md
+++ b/vendor/github.com/tonistiigi/units/readme.md
@@ -1,0 +1,29 @@
+#### Simple byte size formatting.
+
+This package implements types that can be used in stdlib formatting functions
+like `fmt.Printf` to control the output of the expected printed string.
+
+Floating point flags `%f` and %g print the value in using the correct unit
+suffix. Decimal units are default, `#` switches to binary units. If a value is
+best represented as full bytes, integer bytes are printed instead.
+
+##### Examples:
+
+```
+fmt.Printf("%.2f", 123 * B)   => "123B"
+fmt.Printf("%.2f", 1234 * B)  => "1.23kB"
+fmt.Printf("%g", 1200 * B)    => "1.2kB"
+fmt.Printf("%#g", 1024 * B)   => "1KiB"
+```
+
+
+Integer flag `%d` always prints the value in bytes. `#` flag adds an unit prefix.
+
+##### Examples:
+
+```
+fmt.Printf("%d", 1234 * B)    => "1234"
+fmt.Printf("%#d", 1234 * B)   => "1234B"
+```
+
+`%v` is equal to `%g`


### PR DESCRIPTION
The current units package isn't suitable for progressbars as the length of the output is constantly changing. Switch to another package that lets the client have full control of the output.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>