### PR TITLE
solver: fix shared request progress and cancellation

### DIFF
--- a/api/services/control/control.proto
+++ b/api/services/control/control.proto
@@ -68,7 +68,6 @@ message Vertex {
 	google.protobuf.Timestamp started = 5 [(gogoproto.stdtime) = true ];
 	google.protobuf.Timestamp completed = 6 [(gogoproto.stdtime) = true ];
 	string error = 7; // typed errors?
-	string parent = 8 [(gogoproto.customtype) = "github.com/opencontainers/go-digest.Digest", (gogoproto.nullable) = false];
 }
 
 message VertexStatus {

--- a/cache/manager.go
+++ b/cache/manager.go
@@ -104,7 +104,7 @@ func (cm *cacheManager) get(ctx context.Context, id string, opts ...RefOption) (
 	defer rec.mu.Unlock()
 
 	if rec.mutable {
-		if len(rec.refs) != 0 {
+		if rec.dead || len(rec.refs) != 0 {
 			return nil, errors.Wrapf(errLocked, "%s is locked", id)
 		}
 		if rec.equalImmutable != nil {

--- a/client/graph.go
+++ b/client/graph.go
@@ -14,7 +14,6 @@ type Vertex struct {
 	Completed *time.Time
 	Cached    bool
 	Error     string
-	Parent    digest.Digest
 }
 
 type VertexStatus struct {
@@ -40,13 +39,3 @@ type SolveStatus struct {
 	Statuses []*VertexStatus
 	Logs     []*VertexLog
 }
-
-//
-// type VertexEvent struct {
-// 	ID        digest.Digest
-// 	Vertex    digest.Digest
-// 	Name      string
-// 	Total     int
-// 	Current   int
-// 	Timestamp int64
-// }

--- a/client/solve.go
+++ b/client/solve.go
@@ -132,7 +132,6 @@ func (c *Client) Solve(ctx context.Context, r io.Reader, opt SolveOpt, statusCha
 					Completed: v.Completed,
 					Error:     v.Error,
 					Cached:    v.Cached,
-					Parent:    v.Parent,
 				})
 			}
 			for _, v := range resp.Statuses {

--- a/solver/build.go
+++ b/solver/build.go
@@ -109,21 +109,7 @@ func (b *buildOp) Run(ctx context.Context, inputs []Reference) (outputs []Refere
 	lm.Unmount()
 	lm = nil
 
-	v, err := LoadLLB(def)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(v.Inputs()) == 0 {
-		return nil, errors.New("required vertex needs to have inputs")
-	}
-
-	index := v.Inputs()[0].Index
-	v = v.Inputs()[0].Vertex
-
-	vv := toInternalVertex(v)
-
-	newref, err := b.s.loadAndSolveChildVertex(ctx, b.v.Digest(), vv, index)
+	newref, err := b.s.loadAndSolve(ctx, b.v.Digest(), def)
 	if err != nil {
 		return nil, err
 	}

--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -326,7 +326,8 @@ func (vs *vertexStream) append(v client.Vertex) []*client.Vertex {
 			}
 		}
 	}
-	return append(out, &v)
+	vcopy := v
+	return append(out, &vcopy)
 }
 
 func (vs *vertexStream) encore() []*client.Vertex {

--- a/source/containerimage/pull.go
+++ b/source/containerimage/pull.go
@@ -295,11 +295,12 @@ func showProgress(ctx context.Context, ongoing *jobs, cs content.Store) {
 		for _, j := range ongoing.jobs() {
 			refKey := remotes.MakeRefKey(ctx, j.Descriptor)
 			if a, ok := actives[refKey]; ok {
+				started := j.started
 				pw.Write(j.Digest.String(), progress.Status{
 					Action:  a.Status,
 					Total:   int(a.Total),
 					Current: int(a.Offset),
-					Started: &j.started,
+					Started: &started,
 				})
 				continue
 			}
@@ -318,12 +319,14 @@ func showProgress(ctx context.Context, ongoing *jobs, cs content.Store) {
 				}
 
 				if done || j.done {
+					started := j.started
+					createdAt := info.CreatedAt
 					pw.Write(j.Digest.String(), progress.Status{
 						Action:    "done",
 						Current:   int(info.Size),
 						Total:     int(info.Size),
-						Completed: &info.CreatedAt,
-						Started:   &j.started,
+						Completed: &createdAt,
+						Started:   &started,
 					})
 				}
 			}

--- a/util/progress/progressui/display.go
+++ b/util/progress/progressui/display.go
@@ -100,10 +100,6 @@ func (t *trace) update(s *client.SolveStatus) {
 			t.byDigest[v.Digest] = &vertex{
 				byID: make(map[string]*status),
 			}
-		} else {
-			if prev.Parent != v.Parent { // skip vertexes already in list for other parents
-				continue
-			}
 		}
 		if v.Started != nil && (prev == nil || prev.Started == nil) {
 			if t.localTimeDiff == 0 {
@@ -112,9 +108,6 @@ func (t *trace) update(s *client.SolveStatus) {
 			t.vertexes = append(t.vertexes, t.byDigest[v.Digest])
 		}
 		t.byDigest[v.Digest].Vertex = v
-		if v.Parent != "" {
-			t.byDigest[v.Digest].indent = t.byDigest[v.Parent].indent + "=> "
-		}
 	}
 	for _, s := range s.Statuses {
 		v, ok := t.byDigest[s.Vertex]


### PR DESCRIPTION
This contains the follow-up fixes mentioned in https://github.com/moby/buildkit/pull/117#issue-256534308

The main change is that there is no `LoadLLB` function anymore for converting LLB into a generic vertex graph. Now you can only load directly into a job (a build request). This makes sure that we can report correct progress for every request in the cases that the vertexsolver is shared between them.

Places where `[][]byte` is passed around should be replaced with https://github.com/moby/buildkit/pull/114#discussion_r137623400 later (cc @AkihiroSuda) 

This should also fix the encoder race/panic that has happened in CI a couple of times.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>