### PR TITLE
Update solver public api

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -45,6 +45,7 @@ func NewController(opt Opt) (*Controller, error) {
 			Worker:           opt.Worker,
 			InstructionCache: opt.InstructionCache,
 			ImageSource:      opt.ImageSource,
+			Frontends:        opt.Frontends,
 		}),
 	}
 	return c, nil
@@ -105,7 +106,12 @@ func (c *Controller) Solve(ctx context.Context, req *controlapi.SolveRequest) (*
 		}
 	}
 
-	if err := c.solver.Solve(ctx, req.Ref, frontend, req.Definition, expi, req.FrontendAttrs, c.opt.Frontends); err != nil {
+	if err := c.solver.Solve(ctx, req.Ref, solver.SolveRequest{
+		Frontend:    frontend,
+		Definition:  req.Definition,
+		Exporter:    expi,
+		FrontendOpt: req.FrontendAttrs,
+	}); err != nil {
 		return nil, err
 	}
 	return &controlapi.SolveResponse{}, nil

--- a/frontend/dockerfile/dockerfile.go
+++ b/frontend/dockerfile/dockerfile.go
@@ -53,7 +53,9 @@ func (f *dfFrontend) Solve(ctx context.Context, llbBridge frontend.FrontendLLBBr
 		return nil, nil, err
 	}
 
-	ref, _, err := llbBridge.Solve(ctx, def.ToPB(), "", nil)
+	ref, _, err := llbBridge.Solve(ctx, frontend.SolveRequest{
+		Definition: def.ToPB(),
+	})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -112,7 +114,9 @@ func (f *dfFrontend) Solve(ctx context.Context, llbBridge frontend.FrontendLLBBr
 	if err != nil {
 		return nil, nil, err
 	}
-	retRef, _, err = llbBridge.Solve(ctx, def.ToPB(), "", nil)
+	retRef, _, err = llbBridge.Solve(ctx, frontend.SolveRequest{
+		Definition: def.ToPB(),
+	})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -15,7 +15,13 @@ type Frontend interface {
 }
 
 type FrontendLLBBridge interface {
-	Solve(ctx context.Context, def *pb.Definition, frontend string, opts map[string]string) (cache.ImmutableRef, map[string][]byte, error)
+	Solve(ctx context.Context, req SolveRequest) (cache.ImmutableRef, map[string][]byte, error)
 	ResolveImageConfig(ctx context.Context, ref string) (digest.Digest, []byte, error)
 	Exec(ctx context.Context, meta worker.Meta, rootfs cache.ImmutableRef, stdin io.ReadCloser, stdout, stderr io.WriteCloser) error
+}
+
+type SolveRequest struct {
+	Definition  *pb.Definition
+	Frontend    string
+	FrontendOpt map[string]string
 }

--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -67,7 +67,11 @@ func (gf *gatewayFrontend) Solve(ctx context.Context, llbBridge frontend.Fronten
 	var rootFS cache.ImmutableRef
 
 	if isDevel {
-		ref, exp, err := llbBridge.Solve(session.NewContext(ctx, "gateway:"+sid), nil, source, filterPrefix(opts, "gateway-"))
+		ref, exp, err := llbBridge.Solve(session.NewContext(ctx, "gateway:"+sid),
+			frontend.SolveRequest{
+				Frontend:    source,
+				FrontendOpt: filterPrefix(opts, "gateway-"),
+			})
 		if err != nil {
 			return nil, nil, err
 		}
@@ -105,7 +109,9 @@ func (gf *gatewayFrontend) Solve(ctx context.Context, llbBridge frontend.Fronten
 			return nil, nil, err
 		}
 
-		ref, _, err := llbBridge.Solve(ctx, def.ToPB(), "", nil)
+		ref, _, err := llbBridge.Solve(ctx, frontend.SolveRequest{
+			Definition: def.ToPB(),
+		})
 		if err != nil {
 			return nil, nil, err
 		}
@@ -240,7 +246,10 @@ func (lbf *llbBrideForwarder) ResolveImageConfig(ctx context.Context, req *pb.Re
 }
 
 func (lbf *llbBrideForwarder) Solve(ctx context.Context, req *pb.SolveRequest) (*pb.SolveResponse, error) {
-	ref, expResp, err := lbf.llbBridge.Solve(ctx, req.Definition, req.Frontend, nil)
+	ref, expResp, err := lbf.llbBridge.Solve(ctx, frontend.SolveRequest{
+		Definition: req.Definition,
+		Frontend:   req.Frontend,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/hack/test-integration
+++ b/hack/test-integration
@@ -5,4 +5,4 @@ set -eu -o pipefail -x
 # update this to iidfile after 17.06
 docker build -t buildkit:test --target integration-tests -f ./hack/dockerfiles/test.Dockerfile --force-rm .
 docker run --rm -v /tmp --privileged buildkit:test go test -tags 'containerd standalone' ./client
-
+docker run --rm buildkit:test go build ./frontend/gateway/client

--- a/solver/build.go
+++ b/solver/build.go
@@ -104,13 +104,13 @@ func (b *buildOp) Run(ctx context.Context, inputs []Reference) (outputs []Refere
 		f.Close()
 		return nil, err
 	}
-	defPB := def.ToPB()
-
 	f.Close()
 	lm.Unmount()
 	lm = nil
 
-	newref, err := b.s.loadAndSolve(ctx, b.v.Digest(), defPB)
+	newref, err := b.s.subBuild(ctx, b.v.Digest(), SolveRequest{
+		Definition: def.ToPB(),
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -91,30 +91,6 @@ func (jl *jobList) get(id string) (*job, error) {
 	}
 }
 
-func (jl *jobList) loadAndSolve(ctx context.Context, dgst digest.Digest, def *pb.Definition, f ResolveOpFunc, cache InstructionCache) (Reference, error) {
-	jl.mu.Lock()
-
-	st, ok := jl.actives[dgst]
-	if !ok {
-		jl.mu.Unlock()
-		return nil, errors.Errorf("no such parent vertex: %v", dgst)
-	}
-
-	var inp *Input
-	for j := range st.jobs {
-		var err error
-		inp, err = j.loadInternal(def, f)
-		if err != nil {
-			jl.mu.Unlock()
-			return nil, err
-		}
-	}
-	st = jl.actives[inp.Vertex.Digest()]
-	jl.mu.Unlock()
-
-	return getRef(st.solver, ctx, inp.Vertex.(*vertex), inp.Index, cache) // TODO: combine to pass single input
-}
-
 type job struct {
 	l       *jobList
 	pr      *progress.MultiReader


### PR DESCRIPTION
Reorganize some function to avoid big lists of arguments and share code with the llbbridge. 

You still can't launch a frontend yet from a nested build as it goes to another function `subBuild`. Need to figure out the case where the same subbuild is launched by multiple jobs without duplicating the vertexes of the subbuild for reporting.