### PR TITLE
solver: replace contentkey with contentmask

### DIFF
--- a/solver/build.go
+++ b/solver/build.go
@@ -118,6 +118,6 @@ func (b *buildOp) Run(ctx context.Context, inputs []Reference) (outputs []Refere
 	return []Reference{newref}, err
 }
 
-func (b *buildOp) ContentKeys(context.Context, [][]digest.Digest, []Reference) ([]digest.Digest, error) {
-	return nil, nil
+func (b *buildOp) ContentMask(context.Context) (digest.Digest, [][]string, error) {
+	return "", nil, nil
 }

--- a/solver/exec.go
+++ b/solver/exec.go
@@ -8,29 +8,29 @@ import (
 	"strings"
 
 	"github.com/moby/buildkit/cache"
-	"github.com/moby/buildkit/cache/contenthash"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/progress/logs"
 	"github.com/moby/buildkit/worker"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
-	"golang.org/x/sync/errgroup"
 )
 
 const execCacheType = "buildkit.exec.v0"
 
 type execOp struct {
-	op *pb.ExecOp
-	cm cache.Manager
-	w  worker.Worker
+	op        *pb.ExecOp
+	cm        cache.Manager
+	w         worker.Worker
+	numInputs int
 }
 
-func newExecOp(_ Vertex, op *pb.Op_Exec, cm cache.Manager, w worker.Worker) (Op, error) {
+func newExecOp(v Vertex, op *pb.Op_Exec, cm cache.Manager, w worker.Worker) (Op, error) {
 	return &execOp{
-		op: op.Exec,
-		cm: cm,
-		w:  w,
+		op:        op.Exec,
+		cm:        cm,
+		w:         w,
+		numInputs: len(v.Inputs()),
 	}, nil
 }
 
@@ -130,92 +130,51 @@ func (e *execOp) Run(ctx context.Context, inputs []Reference) ([]Reference, erro
 	return refs, nil
 }
 
-func (e *execOp) ContentKeys(ctx context.Context, inputs [][]digest.Digest, refs []Reference) ([]digest.Digest, error) {
-	if len(refs) == 0 {
-		return nil, nil
-	}
+func (e *execOp) ContentMask(ctx context.Context) (digest.Digest, [][]string, error) {
 	// contentKey for exec uses content based checksum for mounts and definition
 	// based checksum for root
 
-	skipped := make([]int, 0)
+	skipped := make(map[int]struct{}, 0)
 
 	type src struct {
-		index    pb.InputIndex
+		index    int
 		selector string
 	}
 
-	skip := true
-	srcsMap := make(map[src]struct{}, len(refs))
+	srcsMap := make(map[src]struct{})
 	for _, m := range e.op.Mounts {
 		if m.Input != pb.Empty {
 			if m.Dest != pb.RootMount && m.Readonly { // could also include rw if they don't have a selector, but not sure if helps performance
-				srcsMap[src{m.Input, path.Join("/", m.Selector)}] = struct{}{}
-				skip = false
+				srcsMap[src{int(m.Input), path.Join("/", m.Selector)}] = struct{}{}
 			} else {
-				skipped = append(skipped, int(m.Input))
+				skipped[int(m.Input)] = struct{}{}
 			}
 		}
 	}
-	if skip {
-		return nil, nil
+	if len(srcsMap) == 0 {
+		return "", nil, nil
 	}
 
-	srcs := make([]src, 0, len(srcsMap))
-	for s := range srcsMap {
-		srcs = append(srcs, s)
+	contentInputs := make([][]string, e.numInputs)
+	for in := range srcsMap {
+		contentInputs[in.index] = append(contentInputs[in.index], in.selector)
+	}
+	// TODO: remove nested directories
+
+	for k := range contentInputs {
+		sort.Strings(contentInputs[k])
 	}
 
-	sort.Slice(srcs, func(i, j int) bool {
-		if srcs[i].index == srcs[j].index {
-			return srcs[i].selector < srcs[j].selector
-		}
-		return srcs[i].index < srcs[j].index
+	dt, err := json.Marshal(struct {
+		Type string
+		Exec *pb.ExecOp
+	}{
+		Type: execCacheType,
+		Exec: e.op,
 	})
-
-	dgsts := make([]digest.Digest, len(srcs))
-	eg, ctx := errgroup.WithContext(ctx)
-	for i, s := range srcs {
-		func(i int, s src, ref Reference) {
-			eg.Go(func() error {
-				ref, ok := toImmutableRef(ref)
-				if !ok {
-					return errors.Errorf("invalid reference")
-				}
-				dgst, err := contenthash.Checksum(ctx, ref, s.selector)
-				if err != nil {
-					return err
-				}
-				dgsts[i] = dgst
-				return nil
-			})
-		}(i, s, refs[int(s.index)])
-	}
-	if err := eg.Wait(); err != nil {
-		return nil, err
+	if err != nil {
+		return "", nil, err
 	}
 
-	var out []digest.Digest
-	inputKeys := make([]digest.Digest, len(skipped))
-	for _, cacheKeys := range inputs {
-		for i := range inputKeys {
-			inputKeys[i] = cacheKeys[skipped[i]]
-		}
-		dt, err := json.Marshal(struct {
-			Type    string
-			Sources []digest.Digest
-			Inputs  []digest.Digest
-			Exec    *pb.ExecOp
-		}{
-			Type:    execCacheType,
-			Sources: dgsts,
-			Inputs:  inputKeys,
-			Exec:    e.op,
-		})
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, digest.FromBytes(dt))
-	}
-
-	return out, nil
+	return digest.FromBytes(dt), contentInputs, nil
 }

--- a/solver/solver.go
+++ b/solver/solver.go
@@ -60,8 +60,13 @@ type Reference interface {
 
 // Op is an implementation for running a vertex
 type Op interface {
+	// CacheKey returns a persistent cache key for operation.
 	CacheKey(context.Context) (digest.Digest, error)
+	// ContentMask returns a partial cache checksum with content paths to the
+	// inputs. User can combine the content checksum of these paths to get a valid
+	// content based cache key.
 	ContentMask(context.Context) (digest.Digest, [][]string, error)
+	// Run runs an operation and returns the output references.
 	Run(ctx context.Context, inputs []Reference) (outputs []Reference, err error)
 }
 

--- a/solver/source.go
+++ b/solver/source.go
@@ -97,6 +97,6 @@ func (s *sourceOp) Run(ctx context.Context, _ []Reference) ([]Reference, error) 
 	return []Reference{ref}, nil
 }
 
-func (s *sourceOp) ContentKeys(context.Context, [][]digest.Digest, []Reference) ([]digest.Digest, error) {
-	return nil, nil
+func (s *sourceOp) ContentMask(context.Context) (digest.Digest, [][]string, error) {
+	return "", nil, nil
 }


### PR DESCRIPTION
This has following advantages:

- content hash of an input can be calculated before all the inputs have been resolved
- the possibility that content cache hit may occur can be detected early and synchronized with other vertexes
- for distributed build content does not need to be on the same host to detect a cache hit

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>