### PR TITLE
buildd: better error msg for unsupported builds

### DIFF
--- a/cmd/buildd/main_unsupported.go
+++ b/cmd/buildd/main_unsupported.go
@@ -14,5 +14,5 @@ func appendFlags(f []cli.Flag) []cli.Flag {
 }
 
 func newController(c *cli.Context, root string) (*control.Controller, error) {
-	return nil, errors.New("invalid build")
+	return nil, errors.New("need to build daemon with either standalone or containerd build tag")
 }


### PR DESCRIPTION
I was pretty confused by the error message. I hope the one I propose will make
it more clear for other newcommers.