### PR TITLE
Add a go file on buildkit root folder

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,1 @@
+package buildkit


### PR DESCRIPTION
- Allows to add a "root" documentation on godoc.org
- Should fix errors when trying to depend on buildkit using golang/dep

Right now it does the following 

```
ensure Solve(): No versions of github.com/moby/buildkit met constraints:
        master: Could not introduce github.com/moby/buildkit@master, as its subpackage github.com/moby/buildkit/util does not contain usable Go code (*build.NoGoError).. (Package is required by (root).)
        preview1: Could not introduce github.com/moby/buildkit@preview1, as its subpackage github.com/moby/buildkit/util does not contain usable Go code (*build.NoGoError).. (Package is required by (root).)
```

Signed-off-by: Vincent Demeester <vincent@sbr.pm>