### PR TITLE
update to go1.9

### DIFF
--- a/cache/contenthash/checksum_test.go
+++ b/cache/contenthash/checksum_test.go
@@ -23,9 +23,9 @@ import (
 )
 
 const (
-	dgstFileData0     = digest.Digest("sha256:5a08b2cd870f1f48a9513629458c2c962ac11a2e44908956b3ec2d269c3e1223")
-	dgstDirD0         = digest.Digest("sha256:260564ab80256c98f63fde8a6ef289525cc542c723970d1c47d721c9c469f9ea")
-	dgstDirD0Modified = digest.Digest("sha256:60c901771ca6f68be81fefe1fcb921118458e0de00227e7c9a9676fb4f32946b")
+	dgstFileData0     = digest.Digest("sha256:cd8e75bca50f2d695f220d0cb0997d8ead387e4f926e8669a92d7f104cc9885b")
+	dgstDirD0         = digest.Digest("sha256:5f8fc802a74ea165f2dfa25d356a581a3d8282a343192421b670079819f4afa7")
+	dgstDirD0Modified = digest.Digest("sha256:4071993a2baf46d92cf3ea64a3fac9f7ab5d0b3876aed0333769ed99756f968b")
 )
 
 func TestChecksumBasicFile(t *testing.T) {
@@ -65,7 +65,7 @@ func TestChecksumBasicFile(t *testing.T) {
 	dgst, err = cc.Checksum(context.TODO(), ref, "bar")
 	assert.NoError(t, err)
 
-	assert.Equal(t, digest.Digest("sha256:cb62966e6dc11e3252ce1a14ed51c6ed0cf112de9c5d23104dc6dcc708f914f1"), dgst)
+	assert.Equal(t, digest.Digest("sha256:c2b5e234f5f38fc5864da7def04782f82501a40d46192e4207d5b3f0c3c4732b"), dgst)
 
 	// same file inside a directory
 	dgst, err = cc.Checksum(context.TODO(), ref, "d0/abc")
@@ -92,7 +92,7 @@ func TestChecksumBasicFile(t *testing.T) {
 	dgst, err = cc.Checksum(context.TODO(), ref, "/")
 	assert.NoError(t, err)
 
-	assert.Equal(t, digest.Digest("sha256:7378af5287e8b417b6cbc63154d300e130983bfc645e35e86fdadf6f5060468a"), dgst)
+	assert.Equal(t, digest.Digest("sha256:6308f8be7bb12f5f6c99635cfa09e9d7055a6c03033e0f6b034cb48849906180"), dgst)
 
 	dgst, err = cc.Checksum(context.TODO(), ref, "d0")
 	assert.NoError(t, err)
@@ -162,7 +162,7 @@ func TestChecksumBasicFile(t *testing.T) {
 	dgst, err = cc.Checksum(context.TODO(), ref, "abc/aa/foo")
 	assert.NoError(t, err)
 
-	assert.Equal(t, digest.Digest("sha256:e1e22281a1ebb637e46aa0781c7fceaca817f1268dd2047dfbce4a23a6cf50ad"), dgst)
+	assert.Equal(t, digest.Digest("sha256:1c67653c3cf95b12a0014e2c4cd1d776b474b3218aee54155d6ae27b9b999c54"), dgst)
 	assert.NotEqual(t, dgstDirD0, dgst)
 
 	// this will force rescan

--- a/examples/buildkit0/buildkit.go
+++ b/examples/buildkit0/buildkit.go
@@ -32,7 +32,7 @@ func main() {
 }
 
 func goBuildBase() llb.State {
-	goAlpine := llb.Image("docker.io/library/golang:1.8-alpine")
+	goAlpine := llb.Image("docker.io/library/golang:1.9-alpine")
 	return goAlpine.
 		AddEnv("PATH", "/usr/local/go/bin:"+system.DefaultPathEnv).
 		AddEnv("GOPATH", "/go").

--- a/examples/buildkit1/buildkit.go
+++ b/examples/buildkit1/buildkit.go
@@ -32,7 +32,7 @@ func main() {
 }
 
 func goBuildBase() llb.State {
-	goAlpine := llb.Image("docker.io/library/golang:1.8-alpine")
+	goAlpine := llb.Image("docker.io/library/golang:1.9-alpine")
 	return goAlpine.
 		AddEnv("PATH", "/usr/local/go/bin:"+system.DefaultPathEnv).
 		AddEnv("GOPATH", "/go").

--- a/examples/buildkit2/buildkit.go
+++ b/examples/buildkit2/buildkit.go
@@ -32,7 +32,7 @@ func main() {
 }
 
 func goBuildBase() llb.State {
-	goAlpine := llb.Image("docker.io/library/golang:1.8-alpine")
+	goAlpine := llb.Image("docker.io/library/golang:1.9-alpine")
 	return goAlpine.
 		AddEnv("PATH", "/usr/local/go/bin:"+system.DefaultPathEnv).
 		AddEnv("GOPATH", "/go").

--- a/examples/buildkit3/buildkit.go
+++ b/examples/buildkit3/buildkit.go
@@ -33,7 +33,7 @@ func main() {
 }
 
 func goBuildBase() llb.State {
-	goAlpine := llb.Image("docker.io/library/golang:1.8-alpine@sha256:2287e0e274c1d2e9076c1f81d04f1a63c86b73c73603b09caada5da307a8f86d")
+	goAlpine := llb.Image("docker.io/library/golang:1.9-alpine")
 	return goAlpine.
 		AddEnv("PATH", "/usr/local/go/bin:"+system.DefaultPathEnv).
 		AddEnv("GOPATH", "/go").

--- a/examples/nested-llb/main.go
+++ b/examples/nested-llb/main.go
@@ -31,7 +31,7 @@ func main() {
 }
 
 func goBuildBase() llb.State {
-	goAlpine := llb.Image("docker.io/library/golang:1.8-alpine")
+	goAlpine := llb.Image("docker.io/library/golang:1.9-alpine")
 	return goAlpine.
 		AddEnv("PATH", "/usr/local/go/bin:"+system.DefaultPathEnv).
 		AddEnv("GOPATH", "/go").

--- a/frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile
+++ b/frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8-alpine AS builder
+FROM golang:1.9-alpine AS builder
 COPY . /go/src/github.com/moby/buildkit
 RUN CGO_ENABLED=0 go build -o /dockerfile-frontend --ldflags '-extldflags "-static"' github.com/moby/buildkit/frontend/dockerfile/cmd/dockerfile-frontend
 

--- a/hack/dockerfiles/lint.Dockerfile
+++ b/hack/dockerfiles/lint.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8-alpine
+FROM golang:1.9-alpine
 RUN  apk add --no-cache git
 RUN  go get -u gopkg.in/alecthomas/gometalinter.v1 \
   && mv /go/bin/gometalinter.v1 /go/bin/gometalinter \

--- a/hack/dockerfiles/test.Dockerfile
+++ b/hack/dockerfiles/test.Dockerfile
@@ -2,7 +2,7 @@ ARG RUNC_VERSION=e775f0fba3ea329b8b766451c892c41a3d49594d
 ARG CONTAINERD_VERSION=d1e11f17ec7b325f89608dd46c128300b8727d50
 ARG BUILDKIT_TARGET=standalone
 
-FROM golang:1.8-alpine@sha256:2287e0e274c1d2e9076c1f81d04f1a63c86b73c73603b09caada5da307a8f86d AS gobuild-base
+FROM golang:1.9-alpine AS gobuild-base
 RUN apk add --no-cache g++ linux-headers
 RUN apk add --no-cache git make
 

--- a/hack/dockerfiles/vendor.Dockerfile
+++ b/hack/dockerfiles/vendor.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8-alpine AS vndr
+FROM golang:1.9-alpine AS vndr
 RUN  apk add --no-cache git
 ARG VNDR_VERSION=master
 RUN go get -d github.com/LK4D4/vndr \


### PR DESCRIPTION
This also serves as a workaround for #145 as in `go1.9` `go test` ignores vendored packages.

The test changes are for tar header changes in https://github.com/moby/moby/pull/33935 . Unlike moby, buildkit does not inject the missing bits.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>