### PR TITLE
contenthash: fix recursive directory deletes

### DIFF
--- a/cache/contenthash/checksum.go
+++ b/cache/contenthash/checksum.go
@@ -386,7 +386,9 @@ func (cc *cacheContext) commitActiveTransaction() {
 		addParentToMap(d, cc.dirtyMap)
 	}
 	for d := range cc.dirtyMap {
-		cc.txn.Insert([]byte(d), &CacheRecord{Type: CacheRecordTypeDir})
+		if _, ok := cc.txn.Get([]byte(d)); ok {
+			cc.txn.Insert([]byte(d), &CacheRecord{Type: CacheRecordTypeDir})
+		}
 	}
 	cc.tree = cc.txn.Commit()
 	cc.node = nil
@@ -402,8 +404,8 @@ func (cc *cacheContext) lazyChecksum(ctx context.Context, m *mount, p string) (*
 		}
 	}
 	k := []byte(p)
-	root = cc.tree.Root()
 	txn := cc.tree.Txn()
+	root = txn.Root()
 	cr, updated, err := cc.checksum(ctx, root, txn, m, k)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
There was an issue with updating the contenthash internals on a certain combination of changes. I struggled to hit this case with a test case because it also requires timing to match. The core of the issue was that when a big directory was deleted it also marked the parent directory dirty(invalidating cache) and the cache invalidation added the record about the already deleted directory back.

There is a related issue that the diff seems to emit deletion events for one level of children what is inconsistent. The current code should work around it but it would be more efficient if either the child events would never appear or appear fully recursively.

reported by @hinshun

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>