### PR TITLE
llb: allow defining metadata on operations

### DIFF
--- a/client/llb/imagemetaresolver/resolver.go
+++ b/client/llb/imagemetaresolver/resolver.go
@@ -22,9 +22,9 @@ import (
 var defaultImageMetaResolver llb.ImageMetaResolver
 var defaultImageMetaResolverOnce sync.Once
 
-func WithDefault(ii *llb.ImageInfo) {
-	llb.WithMetaResolver(Default())(ii)
-}
+var WithDefault = llb.ImageOptionFunc(func(ii *llb.ImageInfo) {
+	llb.WithMetaResolver(Default()).SetImageOption(ii)
+})
 
 func New() llb.ImageMetaResolver {
 	return &imageMetaResolver{

--- a/client/llb/marshal.go
+++ b/client/llb/marshal.go
@@ -16,9 +16,9 @@ type Definition struct {
 }
 
 func (def *Definition) ToPB() *pb.Definition {
-	md := make(map[digest.Digest]pb.OpMetadata)
+	md := make(map[digest.Digest]OpMetadata)
 	for k, v := range def.Metadata {
-		md[k] = v.OpMetadata
+		md[k] = v
 	}
 	return &pb.Definition{
 		Def:      def.Def,
@@ -30,13 +30,11 @@ func (def *Definition) FromPB(x *pb.Definition) {
 	def.Def = x.Def
 	def.Metadata = make(map[digest.Digest]OpMetadata)
 	for k, v := range x.Metadata {
-		def.Metadata[k] = OpMetadata{v}
+		def.Metadata[k] = v
 	}
 }
 
-type OpMetadata struct {
-	pb.OpMetadata
-}
+type OpMetadata = pb.OpMetadata
 
 func WriteTo(def *Definition, w io.Writer) error {
 	b, err := def.ToPB().Marshal()

--- a/client/llb/resolver.go
+++ b/client/llb/resolver.go
@@ -6,9 +6,9 @@ import (
 )
 
 func WithMetaResolver(mr ImageMetaResolver) ImageOption {
-	return func(ii *ImageInfo) {
+	return ImageOptionFunc(func(ii *ImageInfo) {
 		ii.metaResolver = mr
-	}
+	})
 }
 
 type ImageMetaResolver interface {

--- a/cmd/buildctl/build.go
+++ b/cmd/buildctl/build.go
@@ -85,7 +85,7 @@ func read(r io.Reader, clicontext *cli.Context) (*llb.Definition, error) {
 			if !ok {
 				opMetadata = llb.OpMetadata{}
 			}
-			opMetadata.IgnoreCache = true
+			llb.IgnoreCache(&opMetadata)
 			def.Metadata[dgst] = opMetadata
 		}
 	}

--- a/cmd/buildctl/debug/dumpllb.go
+++ b/cmd/buildctl/debug/dumpllb.go
@@ -74,7 +74,7 @@ func loadLLB(r io.Reader) ([]llbOp, error) {
 			return nil, errors.Wrap(err, "failed to parse op")
 		}
 		dgst := digest.FromBytes(dt)
-		ent := llbOp{Op: op, Digest: dgst, OpMetadata: def.Metadata[dgst].OpMetadata}
+		ent := llbOp{Op: op, Digest: dgst, OpMetadata: def.Metadata[dgst]}
 		ops = append(ops, ent)
 	}
 	return ops, nil


### PR DESCRIPTION
Allows things like `llb.Image(..., llb.IgnoreCache)` `llb.Run(..., llb.IgnoreCache)` for vertexes. Implemented so that minimal changes are required for adding new metadata helpers.

@AkihiroSuda wdyt? Doesn't seem the cleanest but don't have better ideas atm. If this looks good to you I'll add some test coverage.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>