### PR TITLE
cache: fix race on reloading mutableref

### DIFF
--- a/cache/manager.go
+++ b/cache/manager.go
@@ -117,7 +117,7 @@ func (cm *cacheManager) get(ctx context.Context, id string, opts ...RefOption) (
 }
 
 func (cm *cacheManager) load(ctx context.Context, id string, opts ...RefOption) (*cacheRecord, error) {
-	if rec, ok := cm.records[id]; ok {
+	if rec, ok := cm.records[id]; ok && !rec.dead {
 		return rec, nil
 	}
 


### PR DESCRIPTION
Fixes deletion race seen in CI:

```
	Error Trace:	manager_test.go:92
	Error:		Not equal: not found (expected)
			        != locked (actual)
			
			Diff:
			--- Expected
			+++ Actual
			@@ -1,2 +1,2 @@
			-(*errors.fundamental)(0xc42023d5c0)(not found)
			+(*errors.fundamental)(0xc42023d580)(locked)
```

Appeared because mutable deletion is in a goroutine for not taking the manager lock on finalize. The bug itself shouldn't have had much impact as it only changed the return value between different errors.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>