### PR TITLE
cache: fix setting root labels on commit

### DIFF
--- a/cache/refs.go
+++ b/cache/refs.go
@@ -185,19 +185,19 @@ func (sr *immutableRef) Release(ctx context.Context) error {
 }
 
 func (sr *immutableRef) release(ctx context.Context) error {
-	if sr.viewMount != nil {
-		if err := sr.cm.Snapshotter.Remove(ctx, sr.view); err != nil {
-			return err
-		}
-		sr.view = ""
-		sr.viewMount = nil
-	}
-
 	updateLastUsed(sr.md)
 
 	delete(sr.refs, sr)
 
 	if len(sr.refs) == 0 {
+		if sr.viewMount != nil { // TODO: release viewMount earlier if possible
+			if err := sr.cm.Snapshotter.Remove(ctx, sr.view); err != nil {
+				return err
+			}
+			sr.view = ""
+			sr.viewMount = nil
+		}
+
 		if sr.equalMutable != nil {
 			sr.equalMutable.release(ctx)
 		}

--- a/cache/refs.go
+++ b/cache/refs.go
@@ -223,7 +223,10 @@ func (cr *cacheRecord) finalize(ctx context.Context) error {
 	if mutable == nil {
 		return nil
 	}
-	err := cr.cm.Snapshotter.Commit(ctx, cr.ID(), mutable.ID())
+	labels := map[string]string{
+		"containerd.io/gc.root": time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	err := cr.cm.Snapshotter.Commit(ctx, cr.ID(), mutable.ID(), cdsnapshot.WithLabels(labels))
 	if err != nil {
 		return errors.Wrapf(err, "failed to commit %s", mutable.ID())
 	}


### PR DESCRIPTION
Fixes the "snapshot not found" issue.

```
    	standalone.go:62: time="2017-12-09T16:56:09Z" level=error msg="/moby.buildkit.v1.Control/Solve returned error: not found
....
/go/src/github.com/moby/buildkit/vendor/github.com/containerd/containerd/errdefs/grpc.go:82
    	standalone.go:62: github.com/moby/buildkit/vendor/github.com/containerd/containerd.(*remoteSnapshotter).View
    	standalone.go:62: 	/go/src/github.com/moby/buildkit/vendor/github.com/containerd/containerd/snapshot.go:111
    	standalone.go:62: github.com/moby/buildkit/snapshot/blobmapping.(*Snapshotter).View
```

First commit fixes the issue. The second one fixes another possible related problem but didn't cause the problem this time.