### PR TITLE
dockerfile: dockerignore support

### DIFF
--- a/client/llb/source.go
+++ b/client/llb/source.go
@@ -193,6 +193,9 @@ func Local(name string, opts ...LocalOption) State {
 	if gi.IncludePatterns != "" {
 		attrs[pb.AttrIncludePatterns] = gi.IncludePatterns
 	}
+	if gi.ExcludePatterns != "" {
+		attrs[pb.AttrExcludePatterns] = gi.ExcludePatterns
+	}
 
 	source := NewSource("local://"+name, attrs, gi.Metadata())
 	return NewState(source.Output())
@@ -216,8 +219,23 @@ func SessionID(id string) LocalOption {
 
 func IncludePatterns(p []string) LocalOption {
 	return localOptionFunc(func(li *LocalInfo) {
+		if len(p) == 0 {
+			li.IncludePatterns = ""
+			return
+		}
 		dt, _ := json.Marshal(p) // empty on error
 		li.IncludePatterns = string(dt)
+	})
+}
+
+func ExcludePatterns(p []string) LocalOption {
+	return localOptionFunc(func(li *LocalInfo) {
+		if len(p) == 0 {
+			li.ExcludePatterns = ""
+			return
+		}
+		dt, _ := json.Marshal(p) // empty on error
+		li.ExcludePatterns = string(dt)
 	})
 }
 
@@ -225,6 +243,7 @@ type LocalInfo struct {
 	opMetaWrapper
 	SessionID       string
 	IncludePatterns string
+	ExcludePatterns string
 }
 
 func HTTP(url string, opts ...HTTPOption) State {

--- a/client/llb/source.go
+++ b/client/llb/source.go
@@ -196,6 +196,9 @@ func Local(name string, opts ...LocalOption) State {
 	if gi.ExcludePatterns != "" {
 		attrs[pb.AttrExcludePatterns] = gi.ExcludePatterns
 	}
+	if gi.SharedKeyHint != "" {
+		attrs[pb.AttrSharedKeyHint] = gi.SharedKeyHint
+	}
 
 	source := NewSource("local://"+name, attrs, gi.Metadata())
 	return NewState(source.Output())
@@ -239,11 +242,18 @@ func ExcludePatterns(p []string) LocalOption {
 	})
 }
 
+func SharedKeyHint(h string) LocalOption {
+	return localOptionFunc(func(li *LocalInfo) {
+		li.SharedKeyHint = h
+	})
+}
+
 type LocalInfo struct {
 	opMetaWrapper
 	SessionID       string
 	IncludePatterns string
 	ExcludePatterns string
+	SharedKeyHint   string
 }
 
 func HTTP(url string, opts ...HTTPOption) State {

--- a/client/local.go
+++ b/client/local.go
@@ -1,5 +1,0 @@
-package client
-
-func getSharedKey(dir string) (string, error) {
-	return dir, nil // not implemented
-}

--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -41,6 +41,7 @@ func Build(ctx context.Context, c client.Client) error {
 	src := llb.Local(LocalNameDockerfile,
 		llb.IncludePatterns([]string{filename}),
 		llb.SessionID(c.SessionID()),
+		llb.SharedKeyHint(defaultDockerfileName),
 	)
 	var buildContext *llb.State
 	if strings.HasPrefix(opts[LocalNameContext], gitPrefix) {
@@ -70,7 +71,11 @@ func Build(ctx context.Context, c client.Client) error {
 	eg.Go(func() error {
 		dockerignoreState := buildContext
 		if dockerignoreState == nil {
-			st := llb.Local(LocalNameContext, llb.SessionID(c.SessionID()), llb.IncludePatterns([]string{dockerignoreFilename}))
+			st := llb.Local(LocalNameContext,
+				llb.SessionID(c.SessionID()),
+				llb.IncludePatterns([]string{dockerignoreFilename}),
+				llb.SharedKeyHint(dockerignoreFilename),
+			)
 			dockerignoreState = &st
 		}
 		def, err := dockerignoreState.Marshal()

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -167,7 +167,11 @@ func Dockerfile2LLB(ctx context.Context, dt []byte, opt ConvertOpt) (*llb.State,
 	if err := eg.Wait(); err != nil {
 		return nil, nil, err
 	}
-	buildContext := llb.Local(localNameContext, llb.SessionID(opt.SessionID), llb.ExcludePatterns(opt.Excludes))
+	buildContext := llb.Local(localNameContext,
+		llb.SessionID(opt.SessionID),
+		llb.ExcludePatterns(opt.Excludes),
+		llb.SharedKeyHint(localNameContext),
+	)
 	if opt.BuildContext != nil {
 		buildContext = *opt.BuildContext
 	}

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -38,6 +38,7 @@ type ConvertOpt struct {
 	BuildArgs    map[string]string
 	SessionID    string
 	BuildContext *llb.State
+	Excludes     []string
 }
 
 func Dockerfile2LLB(ctx context.Context, dt []byte, opt ConvertOpt) (*llb.State, *Image, error) {
@@ -166,8 +167,7 @@ func Dockerfile2LLB(ctx context.Context, dt []byte, opt ConvertOpt) (*llb.State,
 	if err := eg.Wait(); err != nil {
 		return nil, nil, err
 	}
-
-	buildContext := llb.Local(localNameContext, llb.SessionID(opt.SessionID))
+	buildContext := llb.Local(localNameContext, llb.SessionID(opt.SessionID), llb.ExcludePatterns(opt.Excludes))
 	if opt.BuildContext != nil {
 		buildContext = *opt.BuildContext
 	}

--- a/solver/pb/attr.go
+++ b/solver/pb/attr.go
@@ -3,6 +3,7 @@ package pb
 const AttrKeepGitDir = "git.keepgitdir"
 const AttrLocalSessionID = "local.session"
 const AttrIncludePatterns = "local.includepattern"
+const AttrExcludePatterns = "local.excludepatterns"
 const AttrLLBDefinitionFilename = "llbbuild.filename"
 
 const AttrHTTPChecksum = "http.checksum"

--- a/solver/pb/attr.go
+++ b/solver/pb/attr.go
@@ -4,6 +4,7 @@ const AttrKeepGitDir = "git.keepgitdir"
 const AttrLocalSessionID = "local.session"
 const AttrIncludePatterns = "local.includepattern"
 const AttrExcludePatterns = "local.excludepatterns"
+const AttrSharedKeyHint = "local.sharedkeyhint"
 const AttrLLBDefinitionFilename = "llbbuild.filename"
 
 const AttrHTTPChecksum = "http.checksum"

--- a/source/identifier.go
+++ b/source/identifier.go
@@ -80,6 +80,12 @@ func FromLLB(op *pb.Op_Source) (Identifier, error) {
 					return nil, err
 				}
 				id.IncludePatterns = patterns
+			case pb.AttrExcludePatterns:
+				var patterns []string
+				if err := json.Unmarshal([]byte(v), &patterns); err != nil {
+					return nil, err
+				}
+				id.ExcludePatterns = patterns
 			}
 		}
 	}
@@ -142,6 +148,7 @@ type LocalIdentifier struct {
 	Name            string
 	SessionID       string
 	IncludePatterns []string
+	ExcludePatterns []string
 }
 
 func NewLocalIdentifier(str string) (*LocalIdentifier, error) {

--- a/source/identifier.go
+++ b/source/identifier.go
@@ -86,6 +86,8 @@ func FromLLB(op *pb.Op_Source) (Identifier, error) {
 					return nil, err
 				}
 				id.ExcludePatterns = patterns
+			case pb.AttrSharedKeyHint:
+				id.SharedKeyHint = v
 			}
 		}
 	}
@@ -149,6 +151,7 @@ type LocalIdentifier struct {
 	SessionID       string
 	IncludePatterns []string
 	ExcludePatterns []string
+	SharedKeyHint   string
 }
 
 func NewLocalIdentifier(str string) (*LocalIdentifier, error) {

--- a/source/local/local.go
+++ b/source/local/local.go
@@ -79,7 +79,8 @@ func (ls *localSourceHandler) CacheKey(ctx context.Context) (string, error) {
 	dt, err := json.Marshal(struct {
 		SessionID       string
 		IncludePatterns []string
-	}{SessionID: sessionID, IncludePatterns: ls.src.IncludePatterns})
+		ExcludePatterns []string
+	}{SessionID: sessionID, IncludePatterns: ls.src.IncludePatterns, ExcludePatterns: ls.src.ExcludePatterns})
 	if err != nil {
 		return "", err
 	}
@@ -101,7 +102,7 @@ func (ls *localSourceHandler) Snapshot(ctx context.Context) (out cache.Immutable
 		return nil, err
 	}
 
-	sharedKey := keySharedKey + ":" + ls.src.Name + ":" + caller.SharedKey()
+	sharedKey := keySharedKey + ":" + ls.src.Name + ":" + ls.src.SharedKeyHint + ":" + caller.SharedKey() // TODO: replace caller.SharedKey() with source based hint from client(absolute-path+nodeid)
 
 	var mutable cache.MutableRef
 	sis, err := ls.md.Search(sharedKey)

--- a/source/local/local.go
+++ b/source/local/local.go
@@ -157,6 +157,7 @@ func (ls *localSourceHandler) Snapshot(ctx context.Context) (out cache.Immutable
 	opt := filesync.FSSendRequestOpt{
 		Name:             ls.src.Name,
 		IncludePatterns:  ls.src.IncludePatterns,
+		ExcludePatterns:  ls.src.ExcludePatterns,
 		OverrideExcludes: false,
 		DestDir:          dest,
 		CacheUpdater:     &cacheUpdater{cc},

--- a/vendor/github.com/docker/docker/builder/dockerignore/dockerignore.go
+++ b/vendor/github.com/docker/docker/builder/dockerignore/dockerignore.go
@@ -1,0 +1,64 @@
+package dockerignore
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+)
+
+// ReadAll reads a .dockerignore file and returns the list of file patterns
+// to ignore. Note this will trim whitespace from each line as well
+// as use GO's "clean" func to get the shortest/cleanest path for each.
+func ReadAll(reader io.Reader) ([]string, error) {
+	if reader == nil {
+		return nil, nil
+	}
+
+	scanner := bufio.NewScanner(reader)
+	var excludes []string
+	currentLine := 0
+
+	utf8bom := []byte{0xEF, 0xBB, 0xBF}
+	for scanner.Scan() {
+		scannedBytes := scanner.Bytes()
+		// We trim UTF8 BOM
+		if currentLine == 0 {
+			scannedBytes = bytes.TrimPrefix(scannedBytes, utf8bom)
+		}
+		pattern := string(scannedBytes)
+		currentLine++
+		// Lines starting with # (comments) are ignored before processing
+		if strings.HasPrefix(pattern, "#") {
+			continue
+		}
+		pattern = strings.TrimSpace(pattern)
+		if pattern == "" {
+			continue
+		}
+		// normalize absolute paths to paths relative to the context
+		// (taking care of '!' prefix)
+		invert := pattern[0] == '!'
+		if invert {
+			pattern = strings.TrimSpace(pattern[1:])
+		}
+		if len(pattern) > 0 {
+			pattern = filepath.Clean(pattern)
+			pattern = filepath.ToSlash(pattern)
+			if len(pattern) > 1 && pattern[0] == '/' {
+				pattern = pattern[1:]
+			}
+		}
+		if invert {
+			pattern = "!" + pattern
+		}
+
+		excludes = append(excludes, pattern)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("Error reading .dockerignore: %v", err)
+	}
+	return excludes, nil
+}


### PR DESCRIPTION
This is a different implementation than the one in `docker build --stream`. `.dockerignore` is pulled into the frontend and parsed there so that client doesn't need to know anything about that format.

The second commit adds shared key hint metadata to source op that is set by Dockerfile frontend. This is needed because 2 source requests are made to the same location. Without it, on the subsequent build, loading `dockerignore` will sync to a location where build context used to be and vice versa, making the incremental sync inefficient. 