### PR TITLE
*: update build tags (`containerd` -> `no_oci_worker`)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BINARIES=bin/buildd bin/buildctl
-BINARIES_EXTRA=bin/buildd-standalone bin/buildd-containerd bin/buildctl-darwin bin/buildd.exe bin/buildctl.exe
+BINARIES_EXTRA=bin/buildd.oci_only bin/buildd.containerd_only bin/buildctl-darwin bin/buildd.exe bin/buildctl.exe
 DESTDIR=/usr/local
 
 binaries: $(BINARIES)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The following command installs `buildd` and `buildctl` to `/usr/local/bin`:
 $ make && sudo make install
 ```
 
-You can also use `make binaries-all` to prepare `buildd-containerd` (containerd worker only) and `buildd-standalone` (OCI worker only).
+You can also use `make binaries-all` to prepare `buildd.containerd_only` and `buildd.oci_only`.
 
 `examples/buildkit*` directory contains scripts that define how to build different configurations of BuildKit and its dependencies using the `client` package. Running one of these script generates a protobuf definition of a build graph. Note that the script itself does not execute any steps of the build.
 
@@ -50,7 +50,7 @@ You can use `buildctl debug dump-llb` to see what data is in this definition. Ad
 go run examples/buildkit0/buildkit.go | buildctl debug dump-llb | jq .
 ```
 
-To start building use `buildctl build` command. The example script accepts `--target` flag to choose between `containerd` and `standalone` configurations. In standalone mode BuildKit binaries are built together with `runc`. In containerd mode, the `containerd` binary is built as well from the upstream repo.
+To start building use `buildctl build` command. The example script accepts `--target` flag to choose between `containerd-worker-only` and `oci-worker-only` configurations. In OCI worker mode BuildKit binaries are built together with `runc`. In containerd worker mode, the `containerd` binary is built as well from the upstream repo.
 
 ```bash
 go run examples/buildkit0/buildkit.go | buildctl build
@@ -143,13 +143,12 @@ buildkit can be also used by running the `buildd` daemon inside a Docker contain
 To run daemon in a container:
 
 ```
-docker run -d --privileged -p 1234:1234 tonistiigi/buildkit:standalone --addr tcp://0.0.0.0:1234
+docker run -d --privileged -p 1234:1234 tonistiigi/buildkit --addr tcp://0.0.0.0:1234 --oci-worker=true --containerd-worker=false
 export BUILDKIT_HOST=tcp://0.0.0.0:1234
 buildctl build --help
 ```
 
-The `tonistiigi/buildkit:standalone` image can be built locally using the Dockerfile in `./hack/dockerfiles/test.Dockerfile`.
-
+The `tonistiigi/buildkit` image can be built locally using the Dockerfile in `./hack/dockerfiles/test.Dockerfile`.
 
 #### Supported runc version
 
@@ -174,7 +173,7 @@ make test TESTPKGS=./client
 make test TESTPKGS=./client TESTFLAGS="--run /TestCallDiskUsage -v" 
 
 # run all integration tests with a specific worker
-# supported workers are standalone and containerd
+# supported workers are oci and containerd
 make test TESTPKGS=./client TESTFLAGS="--run //worker=containerd -v" 
 ```
 

--- a/cmd/buildd/main.go
+++ b/cmd/buildd/main.go
@@ -250,7 +250,7 @@ func newWorkerController(c *cli.Context, wiOpt workerInitializerOpt) (*worker.Co
 	}
 	nWorkers := len(wc.GetAll())
 	if nWorkers == 0 {
-		return nil, errors.New("no worker found, build the buildkit daemon with tags? (e.g. \"standalone\", \"containerd\")")
+		return nil, errors.New("no worker found, rebuild the buildkit daemon?")
 	}
 	defaultWorker, err := wc.GetDefault()
 	if err != nil {

--- a/cmd/buildd/main_containerd_worker.go
+++ b/cmd/buildd/main_containerd_worker.go
@@ -1,4 +1,4 @@
-// +build containerd
+// +build linux,!no_containerd_worker
 
 package main
 

--- a/cmd/buildd/main_oci_worker.go
+++ b/cmd/buildd/main_oci_worker.go
@@ -1,6 +1,4 @@
-// +build standalone
-
-// TODO(AkihiroSuda): s/standalone/oci/g
+// +build linux,!no_oci_worker
 
 package main
 

--- a/examples/gobuild/main.go
+++ b/examples/gobuild/main.go
@@ -35,7 +35,7 @@ func run() error {
 		Source:    src,
 		MountPath: "/go/src/github.com/moby/buildkit",
 		Pkg:       "github.com/moby/buildkit/cmd/buildd",
-		BuildTags: []string{"standalone"},
+		BuildTags: []string{"no_containerd_worker"},
 	})
 	if err != nil {
 		return err

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -609,7 +609,7 @@ RUN ["ls"]
 	cmd := sb.Cmd(args + " --exporter=image --exporter-opt=name=" + target)
 	require.NoError(t, cmd.Run())
 
-	// TODO: expose this test to standalone
+	// TODO: expose this test to OCI worker
 
 	var cdAddress string
 	if cd, ok := sb.(interface {

--- a/hack/test
+++ b/hack/test
@@ -5,7 +5,7 @@ set -eu -o pipefail -x
 # update this to iidfile after 17.06
 docker build -t buildkit:test --target integration-tests -f ./hack/dockerfiles/test.Dockerfile --force-rm .
 
-docker run --rm -v /tmp --privileged buildkit:test go test -tags standalone ${TESTFLAGS:--v} ${TESTPKGS:-./...}
+docker run --rm -v /tmp --privileged buildkit:test go test -tags no_containerd_worker ${TESTFLAGS:--v} ${TESTPKGS:-./...}
 
 docker run --rm buildkit:test go build ./frontend/gateway/client
 docker run --rm buildkit:test go build ./frontend/dockerfile/cmd/dockerfile-frontend

--- a/util/testutil/integration/containerd.go
+++ b/util/testutil/integration/containerd.go
@@ -24,7 +24,7 @@ func (c *containerd) New() (sb Sandbox, cl func() error, err error) {
 	if err := lookupBinary("containerd"); err != nil {
 		return nil, nil, err
 	}
-	if err := lookupBinary("buildd-containerd"); err != nil {
+	if err := lookupBinary("buildd"); err != nil {
 		return nil, nil, err
 	}
 	if err := requireRoot(); err != nil {
@@ -64,7 +64,10 @@ func (c *containerd) New() (sb Sandbox, cl func() error, err error) {
 		return nil, nil, err
 	}
 
-	builddSock, stop, err := runBuildd([]string{"buildd-containerd", "--containerd-worker-addr", address}, logs)
+	builddSock, stop, err := runBuildd([]string{"buildd",
+		"--oci-worker=false",
+		"--containerd-worker=true",
+		"--containerd-worker-addr", address}, logs)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/util/testutil/integration/oci.go
+++ b/util/testutil/integration/oci.go
@@ -15,25 +15,25 @@ import (
 )
 
 func init() {
-	register(&standalone{})
+	register(&oci{})
 }
 
-type standalone struct {
+type oci struct {
 }
 
-func (s *standalone) Name() string {
-	return "standalone"
+func (s *oci) Name() string {
+	return "oci"
 }
 
-func (s *standalone) New() (Sandbox, func() error, error) {
-	if err := lookupBinary("buildd-standalone"); err != nil {
+func (s *oci) New() (Sandbox, func() error, error) {
+	if err := lookupBinary("buildd"); err != nil {
 		return nil, nil, err
 	}
 	if err := requireRoot(); err != nil {
 		return nil, nil, err
 	}
 	logs := map[string]*bytes.Buffer{}
-	builddSock, stop, err := runBuildd([]string{"buildd-standalone"}, logs)
+	builddSock, stop, err := runBuildd([]string{"buildd", "--oci-worker=true", "--containerd-worker=false"}, logs)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/worker/runc/runc_test.go
+++ b/worker/runc/runc_test.go
@@ -1,4 +1,4 @@
-// +build linux,standalone
+// +build linux,no_containerd_worker
 
 package runc
 


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

Not `no_oci`, as it still conforms to the OCI spec
