### PR TITLE
dockerfile: add test for building from git repo

### DIFF
--- a/source/gitidentifier.go
+++ b/source/gitidentifier.go
@@ -35,7 +35,7 @@ func NewGitIdentifier(remoteURL string) (*GitIdentifier, error) {
 	} else {
 		u, err := url.Parse(remoteURL)
 		if err != nil {
-			return &repo, err
+			return nil, err
 		}
 
 		repo.Ref, repo.Subdir = getRefAndSubdir(u.Fragment)


### PR DESCRIPTION
The test exposed a problem for handling servers that don't support `depth`. Instead of doing some detection that would slow down the primary execution path just retry without `--depth` on error.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>