### PR TITLE
Add Docker exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,14 @@ If credentials are required, `buildctl` will attempt to read Docker configuratio
 buildctl build ... --exporter=local --exporter-opt output=path/to/output-dir
 ```
 
-#### Exporting OCI Image Format tarball to client
+##### Exporting build result to Docker
+
+```
+# exported tarball is also compatible with OCI spec
+buildctl build ... --exporter=docker --exporter-opt name=myimage | docker load
+```
+
+##### Exporting OCI Image Format tarball to client
 
 ```
 buildctl build ... --exporter=oci --exporter-opt output=path/to/output.tar

--- a/client/exporters.go
+++ b/client/exporters.go
@@ -1,9 +1,10 @@
 package client
 
 const (
-	ExporterImage = "image"
-	ExporterLocal = "local"
-	ExporterOCI   = "oci"
+	ExporterImage  = "image"
+	ExporterLocal  = "local"
+	ExporterOCI    = "oci"
+	ExporterDocker = "docker"
 
 	exporterLocalOutputDir = "output"
 	exporterOCIDestination = "output"

--- a/client/solve.go
+++ b/client/solve.go
@@ -79,7 +79,7 @@ func (c *Client) Solve(ctx context.Context, def *llb.Definition, opt SolveOpt, s
 			return errors.Errorf("output directory is required for local exporter")
 		}
 		s.Allow(filesync.NewFSSyncTarget(outputDir))
-	case ExporterOCI:
+	case ExporterOCI, ExporterDocker:
 		outputFile, ok := opt.ExporterAttrs[exporterOCIDestination]
 		if ok {
 			fi, err := os.Stat(outputFile)
@@ -91,7 +91,7 @@ func (c *Client) Solve(ctx context.Context, def *llb.Definition, opt SolveOpt, s
 			}
 		} else {
 			if _, err := console.ConsoleFromFile(os.Stdout); err == nil {
-				return errors.Errorf("output file is required for OCI exporter. refusing to write to console")
+				return errors.Errorf("output file is required for %s exporter. refusing to write to console", opt.Exporter)
 			}
 			outputFile = ""
 		}

--- a/exporter/oci/docker.go
+++ b/exporter/oci/docker.go
@@ -1,0 +1,245 @@
+package oci
+
+import (
+	"archive/tar"
+	"context"
+	"encoding/json"
+	"io"
+	"path"
+	"sort"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/platforms"
+	ocispecs "github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+// DockerExporter implements exporting to
+// Docker Combined Image JSON + Filesystem Changeset Format v1.1
+// https://github.com/moby/moby/blob/master/image/spec/v1.1.md#combined-image-json--filesystem-changeset-format
+// The outputed tarball is also compatible wih OCI Image Format Specification
+type DockerExporter struct {
+	name string
+}
+
+// Export exports tarball into writer.
+func (de *DockerExporter) Export(ctx context.Context, store content.Store, desc ocispec.Descriptor, writer io.Writer) error {
+	tw := tar.NewWriter(writer)
+	defer tw.Close()
+
+	dockerManifest, err := dockerManifestRecord(ctx, store, desc, de.name)
+	if err != nil {
+		return err
+	}
+
+	records := []tarRecord{
+		ociLayoutFile(""),
+		ociIndexRecord(desc),
+		*dockerManifest,
+	}
+
+	algorithms := map[string]struct{}{}
+	exportHandler := func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		records = append(records, blobRecord(store, desc))
+		algorithms[desc.Digest.Algorithm().String()] = struct{}{}
+		return nil, nil
+	}
+
+	handlers := images.Handlers(
+		images.ChildrenHandler(store, platforms.Default()),
+		images.HandlerFunc(exportHandler),
+	)
+
+	// Walk sequentially since the number of fetchs is likely one and doing in
+	// parallel requires locking the export handler
+	if err := images.Walk(ctx, handlers, desc); err != nil {
+		return err
+	}
+
+	if len(algorithms) > 0 {
+		records = append(records, directoryRecord("blobs/", 0755))
+		for alg := range algorithms {
+			records = append(records, directoryRecord("blobs/"+alg+"/", 0755))
+		}
+	}
+
+	return writeTar(ctx, tw, records)
+}
+
+type tarRecord struct {
+	Header *tar.Header
+	CopyTo func(context.Context, io.Writer) (int64, error)
+}
+
+func dockerManifestRecord(ctx context.Context, provider content.Provider, desc ocispec.Descriptor, name string) (*tarRecord, error) {
+	switch desc.MediaType {
+	case images.MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest:
+		p, err := content.ReadBlob(ctx, provider, desc.Digest)
+		if err != nil {
+			return nil, err
+		}
+		var manifest ocispec.Manifest
+		if err := json.Unmarshal(p, &manifest); err != nil {
+			return nil, err
+		}
+		type mfstItem struct {
+			Config   string
+			RepoTags []string
+			Layers   []string
+		}
+		item := mfstItem{
+			Config: path.Join("blobs", manifest.Config.Digest.Algorithm().String(), manifest.Config.Digest.Hex()),
+		}
+
+		for _, l := range manifest.Layers {
+			item.Layers = append(item.Layers, path.Join("blobs", l.Digest.Algorithm().String(), l.Digest.Hex()))
+		}
+
+		if name != "" {
+			item.RepoTags = append(item.RepoTags, name)
+		}
+
+		dt, err := json.Marshal([]mfstItem{item})
+		if err != nil {
+			return nil, err
+		}
+
+		return &tarRecord{
+			Header: &tar.Header{
+				Name:     "manifest.json",
+				Mode:     0444,
+				Size:     int64(len(dt)),
+				Typeflag: tar.TypeReg,
+			},
+			CopyTo: func(ctx context.Context, w io.Writer) (int64, error) {
+				n, err := w.Write(dt)
+				return int64(n), err
+			},
+		}, nil
+	default:
+		return nil, errors.Errorf("%v not supported for Docker exporter", desc.MediaType)
+	}
+
+}
+
+func blobRecord(cs content.Store, desc ocispec.Descriptor) tarRecord {
+	path := "blobs/" + desc.Digest.Algorithm().String() + "/" + desc.Digest.Hex()
+	return tarRecord{
+		Header: &tar.Header{
+			Name:     path,
+			Mode:     0444,
+			Size:     desc.Size,
+			Typeflag: tar.TypeReg,
+		},
+		CopyTo: func(ctx context.Context, w io.Writer) (int64, error) {
+			r, err := cs.ReaderAt(ctx, desc.Digest)
+			if err != nil {
+				return 0, err
+			}
+			defer r.Close()
+
+			// Verify digest
+			dgstr := desc.Digest.Algorithm().Digester()
+
+			n, err := io.Copy(io.MultiWriter(w, dgstr.Hash()), content.NewReader(r))
+			if err != nil {
+				return 0, err
+			}
+			if dgstr.Digest() != desc.Digest {
+				return 0, errors.Errorf("unexpected digest %s copied", dgstr.Digest())
+			}
+			return n, nil
+		},
+	}
+}
+
+func directoryRecord(name string, mode int64) tarRecord {
+	return tarRecord{
+		Header: &tar.Header{
+			Name:     name,
+			Mode:     mode,
+			Typeflag: tar.TypeDir,
+		},
+	}
+}
+
+func ociLayoutFile(version string) tarRecord {
+	if version == "" {
+		version = ocispec.ImageLayoutVersion
+	}
+	layout := ocispec.ImageLayout{
+		Version: version,
+	}
+
+	b, err := json.Marshal(layout)
+	if err != nil {
+		panic(err)
+	}
+
+	return tarRecord{
+		Header: &tar.Header{
+			Name:     ocispec.ImageLayoutFile,
+			Mode:     0444,
+			Size:     int64(len(b)),
+			Typeflag: tar.TypeReg,
+		},
+		CopyTo: func(ctx context.Context, w io.Writer) (int64, error) {
+			n, err := w.Write(b)
+			return int64(n), err
+		},
+	}
+
+}
+
+func ociIndexRecord(manifests ...ocispec.Descriptor) tarRecord {
+	index := ocispec.Index{
+		Versioned: ocispecs.Versioned{
+			SchemaVersion: 2,
+		},
+		Manifests: manifests,
+	}
+
+	b, err := json.Marshal(index)
+	if err != nil {
+		panic(err)
+	}
+
+	return tarRecord{
+		Header: &tar.Header{
+			Name:     "index.json",
+			Mode:     0644,
+			Size:     int64(len(b)),
+			Typeflag: tar.TypeReg,
+		},
+		CopyTo: func(ctx context.Context, w io.Writer) (int64, error) {
+			n, err := w.Write(b)
+			return int64(n), err
+		},
+	}
+}
+
+func writeTar(ctx context.Context, tw *tar.Writer, records []tarRecord) error {
+	sort.Slice(records, func(i, j int) bool {
+		return records[i].Header.Name < records[j].Header.Name
+	})
+
+	for _, record := range records {
+		if err := tw.WriteHeader(record.Header); err != nil {
+			return err
+		}
+		if record.CopyTo != nil {
+			n, err := record.CopyTo(ctx, tw)
+			if err != nil {
+				return err
+			}
+			if n != record.Header.Size {
+				return errors.Errorf("unexpected copy size for %s", record.Header.Name)
+			}
+		} else if record.Header.Size > 0 {
+			return errors.Errorf("no content to write to record with non-zero size for %s", record.Header.Name)
+		}
+	}
+	return nil
+}

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -170,11 +170,22 @@ func NewWorker(opt WorkerOpt) (*Worker, error) {
 	ociExporter, err := ociexporter.New(ociexporter.Opt{
 		SessionManager: opt.SessionManager,
 		ImageWriter:    iw,
+		Variant:        ociexporter.VariantOCI,
 	})
 	if err != nil {
 		return nil, err
 	}
 	exporters[client.ExporterOCI] = ociExporter
+
+	dockerExporter, err := ociexporter.New(ociexporter.Opt{
+		SessionManager: opt.SessionManager,
+		ImageWriter:    iw,
+		Variant:        ociexporter.VariantDocker,
+	})
+	if err != nil {
+		return nil, err
+	}
+	exporters[client.ExporterDocker] = dockerExporter
 
 	ce := cacheimport.NewCacheExporter(cacheimport.ExporterOpt{
 		Snapshotter:    bmSnapshotter,


### PR DESCRIPTION
```
buildctl build ... --exporter=docker --exporter-opt name=myimage | docker load
```

The exported tarball is compatible with Docker v1.10 and newer. Older versions that only accept the `v1.0` tarball will not work.

The tarball is also fully compatible with OCI. We can figure out later if containerd upstream is also interested of any of this code and in what way and what packages should contain what code(related to #215). My current thinking is that special package for `exporter/oci` is not needed and different variants can all be under `containerimage`.

based on #227