### PR TITLE
transport: add possibility to use TLS secured transport layer

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,12 +1,16 @@
 package client
 
 import (
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
 	"time"
 
 	controlapi "github.com/moby/buildkit/api/services/control"
 	"github.com/moby/buildkit/util/appdefaults"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 )
 
 type Client struct {
@@ -18,15 +22,26 @@ type ClientOpt interface{}
 // New returns a new buildkit client. Address can be empty for the system-default address.
 func New(address string, opts ...ClientOpt) (*Client, error) {
 	gopts := []grpc.DialOption{
-		grpc.WithInsecure(),
 		grpc.WithTimeout(30 * time.Second),
 		grpc.WithDialer(dialer),
 		grpc.FailOnNonTempDialError(true),
 	}
+	needWithInsecure := true
 	for _, o := range opts {
 		if _, ok := o.(*withBlockOpt); ok {
 			gopts = append(gopts, grpc.WithBlock(), grpc.FailOnNonTempDialError(true))
 		}
+		if credInfo, ok := o.(*withCredentials); ok {
+			opt, err := loadCredentials(credInfo)
+			if err != nil {
+				return nil, err
+			}
+			gopts = append(gopts, opt)
+			needWithInsecure = false
+		}
+	}
+	if needWithInsecure {
+		gopts = append(gopts, grpc.WithInsecure())
 	}
 	if address == "" {
 		address = appdefaults.Address
@@ -53,4 +68,50 @@ type withBlockOpt struct{}
 
 func WithBlock() ClientOpt {
 	return &withBlockOpt{}
+}
+
+type withCredentials struct {
+	ServerName string
+	CACert     string
+	Cert       string
+	Key        string
+}
+
+// WithCredentials configures the TLS parameters of the client.
+// Arguments:
+// * serverName: specifies the name of the target server
+// * ca:				 specifies the filepath of the CA certificate to use for verification
+// * cert:			 specifies the filepath of the client certificate
+// * key:				 specifies the filepath of the client key
+func WithCredentials(serverName, ca, cert, key string) ClientOpt {
+	return &withCredentials{serverName, ca, cert, key}
+}
+
+func loadCredentials(opts *withCredentials) (grpc.DialOption, error) {
+	ca, err := ioutil.ReadFile(opts.CACert)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not read ca certificate")
+	}
+
+	certPool := x509.NewCertPool()
+	if ok := certPool.AppendCertsFromPEM(ca); !ok {
+		return nil, errors.New("failed to append ca certs")
+	}
+
+	cfg := &tls.Config{
+		ServerName: opts.ServerName,
+		RootCAs:    certPool,
+	}
+
+	// we will produce an error if the user forgot about either cert or key if at least one is specified
+	if opts.Cert != "" || opts.Key != "" {
+		cert, err := tls.LoadX509KeyPair(opts.Cert, opts.Key)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not read certificate/key")
+		}
+		cfg.Certificates = []tls.Certificate{cert}
+		cfg.BuildNameToCertificate()
+	}
+
+	return grpc.WithTransportCredentials(credentials.NewTLS(cfg)), nil
 }

--- a/cmd/buildctl/main.go
+++ b/cmd/buildctl/main.go
@@ -28,8 +28,28 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "addr",
-			Usage: "listening address",
+			Usage: "buildkitd address",
 			Value: defaultAddress,
+		},
+		cli.StringFlag{
+			Name:  "server-name",
+			Usage: "buildkitd server name for certificate validation",
+			Value: "",
+		},
+		cli.StringFlag{
+			Name:  "ca-cert",
+			Usage: "CA certificate for validation",
+			Value: "",
+		},
+		cli.StringFlag{
+			Name:  "cert",
+			Usage: "client certificate",
+			Value: "",
+		},
+		cli.StringFlag{
+			Name:  "key",
+			Usage: "client key",
+			Value: "",
 		},
 	}
 
@@ -62,5 +82,13 @@ func main() {
 }
 
 func resolveClient(c *cli.Context) (*client.Client, error) {
-	return client.New(c.GlobalString("addr"), client.WithBlock())
+	serverName := c.GlobalString("server-name")
+	caCert := c.GlobalString("ca-cert")
+	cert := c.GlobalString("cert")
+	key := c.GlobalString("key")
+	opts := []client.ClientOpt{client.WithBlock()}
+	if serverName != "" {
+		opts = append(opts, client.WithCredentials(serverName, caCert, cert, key))
+	}
+	return client.New(c.GlobalString("addr"), opts...)
 }

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -84,15 +84,15 @@ func main() {
 			Value: "",
 		},
 		cli.StringFlag{
-			Name:  "cert",
+			Name:  "tlscert",
 			Usage: "certificate file to use",
 		},
 		cli.StringFlag{
-			Name:  "key",
+			Name:  "tlskey",
 			Usage: "key file to use",
 		},
 		cli.StringFlag{
-			Name:  "ca-cert",
+			Name:  "tlscacert",
 			Usage: "ca certificate to verify clients",
 		},
 	}

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -238,9 +238,9 @@ func unaryInterceptor(globalCtx context.Context) grpc.ServerOption {
 }
 
 func serverCredentials(c *cli.Context) (grpc.ServerOption, error) {
-	certFile := c.GlobalString("cert")
-	keyFile := c.GlobalString("key")
-	caFile := c.GlobalString("ca-cert")
+	certFile := c.GlobalString("tlscert")
+	keyFile := c.GlobalString("tlskey")
+	caFile := c.GlobalString("tlscacert")
 	if certFile == "" && keyFile == "" {
 		return nil, nil
 	}


### PR DESCRIPTION
## What

This PR adds logic and commandline flags for buildkitd and buildctl to configure TLS certificates, keys and CA certificates.

There are now the following three options:

* Use no TLS, the whole thing is opt-in and completely backward compatible
* Use a certificate and key on the server and a ca-certificate at the client
  * an ephemeral key exchange is performed
  * the client verifies the server certificate
* Use cert, key and ca-cert on server and client
  * the connection is verified by both ends

From the API perspective this is implemented as the ClientOption WithCredentials() which takes pathes to the requested files as arguments.

## Why

To be able to effectively prevent man in the middle attacks or unauthorized access in unsecure networks, using TLS is the way to go in the current gRPC setup.