### PR TITLE
solver: add simple locking to catch content duplicates

### DIFF
--- a/solver/solver.go
+++ b/solver/solver.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/BurntSushi/locker"
 	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/cache/cacheimport"
 	"github.com/moby/buildkit/cache/contenthash"
@@ -21,6 +22,12 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
 )
+
+var contentLock *locker.Locker
+
+func init() {
+	contentLock = locker.NewLocker()
+}
 
 // FIXME: Also we need to track the workers of the inputs.
 // TODO: REMOVE
@@ -557,6 +564,8 @@ func (vs *vertexSolver) run(ctx context.Context, signal func()) (retErr error) {
 		if err != nil {
 			return err
 		}
+		contentLock.Lock(contentKey.String())
+		defer contentLock.Unlock(contentKey.String())
 		vs.contentKey = contentKey
 
 		var extraKeys []digest.Digest


### PR DESCRIPTION
This is useful when building similar files from multiple sources concurrently. If there is a possibility for a content-based match it will wait for one source to finish before continuing with another. I'll make a better fix with the next solver refactor.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>