### PR TITLE
progress: fix skipping cached vertex progress

### DIFF
--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -258,6 +258,7 @@ func (j *job) getRef(ctx context.Context, cv client.Vertex, index Index) (Ref, e
 	if err != nil {
 		return nil, err
 	}
+	ctx = progress.WithProgress(ctx, j.pw)
 	ref, err := getRef(ctx, s, cv, index, j.cache)
 	if err != nil {
 		return nil, err
@@ -397,8 +398,9 @@ func (vs *vertexStream) append(v client.Vertex) []*client.Vertex {
 					inpv.Cached = true
 					inpv.Started = v.Completed
 					inpv.Completed = v.Completed
-					out = append(vs.append(*inpv), inpv)
 				}
+				delete(vs.cache, inp)
+				out = append(out, vs.append(*inpv)...)
 			}
 		}
 	}

--- a/util/progress/progressui/display.go
+++ b/util/progress/progressui/display.go
@@ -235,7 +235,7 @@ func (disp *display) print(d displayInfo, all bool) {
 	fmt.Fprint(disp.c, b.Column(0).ANSI)
 
 	statusStr := ""
-	if d.countCompleted > 0 && d.countCompleted == d.countTotal {
+	if d.countCompleted > 0 && d.countCompleted == d.countTotal && all {
 		statusStr = "FINISHED"
 	}
 


### PR DESCRIPTION
- When part of the build was cached progress report for some vertexes could be skipped. 
- When building with frontends that dynamically load more vertexes client could temporarily report build as finished. 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>