### PR TITLE
cache: mount readonly in readfile handler

### DIFF
--- a/cache/fsutil.go
+++ b/cache/fsutil.go
@@ -9,7 +9,7 @@ import (
 )
 
 func ReadFile(ctx context.Context, ref ImmutableRef, p string) ([]byte, error) {
-	mount, err := ref.Mount(ctx, false)
+	mount, err := ref.Mount(ctx, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Not mounting `readonly` here meant that the source snapshot for dockerignore and Dockerfile couldn't be reused(because another snapshot was created on top of it).

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>