### PR TITLE
hack: fix scripts for macos

### DIFF
--- a/hack/lint
+++ b/hack/lint
@@ -2,7 +2,7 @@
 
 set -eu -o pipefail -x
 
-iidfile=$(mktemp --tmpdir docker-iidfile.XXXXXXXXXX)
+iidfile=$(mktemp -t docker-iidfile.XXXXXXXXXX)
 docker build --iidfile $iidfile -f ./hack/dockerfiles/lint.Dockerfile --force-rm .
 iid=$(cat $iidfile)
 docker run $iid gometalinter --config=gometalinter.json ./...

--- a/hack/test
+++ b/hack/test
@@ -2,7 +2,7 @@
 
 set -eu -o pipefail -x
 
-iidfile=$(mktemp --tmpdir docker-iidfile.XXXXXXXXXX)
+iidfile=$(mktemp -t docker-iidfile.XXXXXXXXXX)
 
 docker build --iidfile $iidfile --target integration-tests -f ./hack/dockerfiles/test.Dockerfile --force-rm .
 

--- a/hack/update-vendor
+++ b/hack/update-vendor
@@ -2,7 +2,7 @@
 
 set -eu -o pipefail -x
 
-iidfile=$(mktemp --tmpdir docker-iidfile.XXXXXXXXXX)
+iidfile=$(mktemp -t docker-iidfile.XXXXXXXXXX)
 docker build --build-arg VNDR_VERSION=48ac2669d9d1bcacd3163650ef911edca2ec3b42 --iidfile $iidfile -f ./hack/dockerfiles/vendor.Dockerfile --force-rm .
 iid=$(cat $iidfile)
 cid=$(docker create $iid noop)

--- a/hack/validate-vendor
+++ b/hack/validate-vendor
@@ -2,7 +2,7 @@
 
 set -eu -o pipefail -x
 
-iidfile=$(mktemp --tmpdir docker-iidfile.XXXXXXXXXX)
+iidfile=$(mktemp -t docker-iidfile.XXXXXXXXXX)
 docker build --build-arg VNDR_VERSION=48ac2669d9d1bcacd3163650ef911edca2ec3b42 --iidfile $iidfile -f ./hack/dockerfiles/vendor.Dockerfile --force-rm .
 iid=$(cat $iidfile)
 diffs="$(docker run $iid git status --porcelain -- vendor 2>/dev/null)"


### PR DESCRIPTION
`mktemp` in `macos` doesn't support `--tmpdir` flag.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>