### PR TITLE
Remove net/context dependencies

### DIFF
--- a/cache/blobs/blobs.go
+++ b/cache/blobs/blobs.go
@@ -1,6 +1,7 @@
 package blobs
 
 import (
+	"context"
 	"time"
 
 	"github.com/containerd/containerd/content"
@@ -12,7 +13,6 @@ import (
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/cache/cacheimport/export.go
+++ b/cache/cacheimport/export.go
@@ -2,6 +2,7 @@ package cacheimport
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"time"
 
@@ -19,7 +20,6 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 const mediaTypeConfig = "application/vnd.buildkit.cacheconfig.v0"

--- a/cache/cacheimport/import.go
+++ b/cache/cacheimport/import.go
@@ -1,6 +1,7 @@
 package cacheimport
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -25,7 +26,6 @@ import (
 	"github.com/opencontainers/image-spec/identity"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/cache/fsutil.go
+++ b/cache/fsutil.go
@@ -1,11 +1,11 @@
 package cache
 
 import (
+	"context"
 	"io/ioutil"
 
 	"github.com/containerd/containerd/fs"
 	"github.com/moby/buildkit/snapshot"
-	"golang.org/x/net/context"
 )
 
 func ReadFile(ctx context.Context, ref ImmutableRef, p string) ([]byte, error) {

--- a/cache/instructioncache/instructioncache.go
+++ b/cache/instructioncache/instructioncache.go
@@ -1,7 +1,7 @@
 package instructioncache
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	digest "github.com/opencontainers/go-digest"
 )

--- a/cache/instructioncache/local/localinstructioncache.go
+++ b/cache/instructioncache/local/localinstructioncache.go
@@ -2,6 +2,7 @@ package local
 
 import (
 	"bytes"
+	"context"
 
 	"github.com/boltdb/bolt"
 	"github.com/moby/buildkit/cache"
@@ -9,7 +10,6 @@ import (
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 const cacheKey = "buildkit.instructioncache"

--- a/cache/instructioncache/union.go
+++ b/cache/instructioncache/union.go
@@ -1,7 +1,7 @@
 package instructioncache
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	digest "github.com/opencontainers/go-digest"
 )

--- a/cache/refs.go
+++ b/cache/refs.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"context"
 	"sync"
 
 	"github.com/containerd/containerd/mount"
@@ -9,7 +10,6 @@ import (
 	"github.com/moby/buildkit/util/flightcontrol"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // Ref is a reference to cacheable objects.

--- a/client/llb/imagemetaresolver/resolver.go
+++ b/client/llb/imagemetaresolver/resolver.go
@@ -16,7 +16,6 @@ import (
 	"github.com/moby/buildkit/util/imageutil"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
-	netcontext "golang.org/x/net/context"
 )
 
 var defaultImageMetaResolver llb.ImageMetaResolver
@@ -56,7 +55,7 @@ type resolveResult struct {
 	dgst   digest.Digest
 }
 
-func (imr *imageMetaResolver) ResolveImageConfig(ctx netcontext.Context, ref string) (digest.Digest, []byte, error) {
+func (imr *imageMetaResolver) ResolveImageConfig(ctx context.Context, ref string) (digest.Digest, []byte, error) {
 	imr.locker.Lock(ref)
 	defer imr.locker.Unlock(ref)
 

--- a/client/llb/resolver.go
+++ b/client/llb/resolver.go
@@ -1,8 +1,9 @@
 package llb
 
 import (
+	"context"
+
 	digest "github.com/opencontainers/go-digest"
-	"golang.org/x/net/context"
 )
 
 func WithMetaResolver(mr ImageMetaResolver) ImageOption {

--- a/control/control.go
+++ b/control/control.go
@@ -1,6 +1,8 @@
 package control
 
 import (
+	"context"
+
 	"github.com/docker/distribution/reference"
 	controlapi "github.com/moby/buildkit/api/services/control"
 	"github.com/moby/buildkit/cache/cacheimport"
@@ -13,7 +15,7 @@ import (
 	"github.com/moby/buildkit/worker"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
+	netcontext "golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 )
@@ -49,7 +51,7 @@ func (c *Controller) Register(server *grpc.Server) error {
 	return nil
 }
 
-func (c *Controller) DiskUsage(ctx context.Context, r *controlapi.DiskUsageRequest) (*controlapi.DiskUsageResponse, error) {
+func (c *Controller) DiskUsage(ctx netcontext.Context, r *controlapi.DiskUsageRequest) (*controlapi.DiskUsageResponse, error) {
 	resp := &controlapi.DiskUsageResponse{}
 	workers, err := c.opt.WorkerController.List()
 	if err != nil {
@@ -128,7 +130,7 @@ func (c *Controller) Prune(req *controlapi.PruneRequest, stream controlapi.Contr
 	return eg2.Wait()
 }
 
-func (c *Controller) Solve(ctx context.Context, req *controlapi.SolveRequest) (*controlapi.SolveResponse, error) {
+func (c *Controller) Solve(ctx netcontext.Context, req *controlapi.SolveRequest) (*controlapi.SolveResponse, error) {
 	var frontend frontend.Frontend
 	if req.Frontend != "" {
 		var ok bool
@@ -260,7 +262,7 @@ func (c *Controller) Session(stream controlapi.Control_SessionServer) error {
 	return err
 }
 
-func (c *Controller) ListWorkers(ctx context.Context, r *controlapi.ListWorkersRequest) (*controlapi.ListWorkersResponse, error) {
+func (c *Controller) ListWorkers(ctx netcontext.Context, r *controlapi.ListWorkersRequest) (*controlapi.ListWorkersResponse, error) {
 	resp := &controlapi.ListWorkersResponse{}
 	workers, err := c.opt.WorkerController.List(r.Filter...)
 	if err != nil {

--- a/executor/containerdexecutor/executor.go
+++ b/executor/containerdexecutor/executor.go
@@ -1,6 +1,7 @@
 package containerdexecutor
 
 import (
+	"context"
 	"io"
 	"syscall"
 	"time"
@@ -14,7 +15,6 @@ import (
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/snapshot"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 type containerdExecutor struct {

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1,10 +1,10 @@
 package executor
 
 import (
+	"context"
 	"io"
 
 	"github.com/moby/buildkit/cache"
-	"golang.org/x/net/context"
 )
 
 type Meta struct {

--- a/executor/oci/hosts.go
+++ b/executor/oci/hosts.go
@@ -1,11 +1,10 @@
 package oci
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-
-	"golang.org/x/net/context"
 )
 
 const hostsContent = `

--- a/executor/oci/resolvconf.go
+++ b/executor/oci/resolvconf.go
@@ -1,13 +1,13 @@
 package oci
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 
 	"github.com/docker/libnetwork/resolvconf"
 	"github.com/moby/buildkit/util/flightcontrol"
-	"golang.org/x/net/context"
 )
 
 var g flightcontrol.Group

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -1,6 +1,7 @@
 package runcexecutor
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"os"
@@ -18,7 +19,6 @@ import (
 	"github.com/moby/buildkit/identity"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 type runcExecutor struct {

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -1,6 +1,7 @@
 package containerimage
 
 import (
+	"context"
 	"time"
 
 	"github.com/containerd/containerd/errdefs"
@@ -10,7 +11,6 @@ import (
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/util/push"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -2,6 +2,7 @@ package containerimage
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"runtime"
@@ -21,7 +22,6 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -1,8 +1,9 @@
 package exporter
 
 import (
+	"context"
+
 	"github.com/moby/buildkit/cache"
-	"golang.org/x/net/context"
 )
 
 type Exporter interface {

--- a/exporter/local/export.go
+++ b/exporter/local/export.go
@@ -1,6 +1,7 @@
 package local
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"time"
@@ -12,7 +13,6 @@ import (
 	"github.com/moby/buildkit/snapshot"
 	"github.com/moby/buildkit/util/progress"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 	"golang.org/x/time/rate"
 )
 

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -1,6 +1,7 @@
 package oci
 
 import (
+	"context"
 	"time"
 
 	"github.com/containerd/containerd/images"
@@ -15,7 +16,6 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 type ExporterVariant string

--- a/frontend/dockerfile/dockerfile.go
+++ b/frontend/dockerfile/dockerfile.go
@@ -1,11 +1,12 @@
 package dockerfile
 
 import (
+	"context"
+
 	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/frontend"
 	"github.com/moby/buildkit/frontend/dockerfile/builder"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 func NewDockerfileFrontend() frontend.Frontend {

--- a/frontend/dockerfile/forward.go
+++ b/frontend/dockerfile/forward.go
@@ -1,6 +1,7 @@
 package dockerfile
 
 import (
+	"context"
 	"os"
 
 	"github.com/moby/buildkit/cache"
@@ -9,7 +10,6 @@ import (
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 func llbBridgeToGatewayClient(ctx context.Context, llbBridge frontend.FrontendLLBBridge, opts map[string]string) (*bridgeClient, error) {

--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -1,13 +1,13 @@
 package frontend
 
 import (
+	"context"
 	"io"
 
 	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/executor"
 	"github.com/moby/buildkit/solver/pb"
 	digest "github.com/opencontainers/go-digest"
-	"golang.org/x/net/context"
 )
 
 type Frontend interface {

--- a/frontend/gateway/client/client.go
+++ b/frontend/gateway/client/client.go
@@ -1,9 +1,10 @@
 package client
 
 import (
+	"context"
+
 	"github.com/moby/buildkit/solver/pb"
 	digest "github.com/opencontainers/go-digest"
-	"golang.org/x/net/context"
 )
 
 // TODO: make this take same options as LLBBridge. Add Return()

--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -21,7 +22,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
+	netcontext "golang.org/x/net/context"
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
@@ -244,7 +245,7 @@ type llbBrideForwarder struct {
 	*pipe
 }
 
-func (lbf *llbBrideForwarder) ResolveImageConfig(ctx context.Context, req *pb.ResolveImageConfigRequest) (*pb.ResolveImageConfigResponse, error) {
+func (lbf *llbBrideForwarder) ResolveImageConfig(ctx netcontext.Context, req *pb.ResolveImageConfigRequest) (*pb.ResolveImageConfigResponse, error) {
 	ctx = tracing.ContextWithSpanFromContext(ctx, lbf.callCtx)
 	dgst, dt, err := lbf.llbBridge.ResolveImageConfig(ctx, req.Ref)
 	if err != nil {
@@ -256,7 +257,7 @@ func (lbf *llbBrideForwarder) ResolveImageConfig(ctx context.Context, req *pb.Re
 	}, nil
 }
 
-func (lbf *llbBrideForwarder) Solve(ctx context.Context, req *pb.SolveRequest) (*pb.SolveResponse, error) {
+func (lbf *llbBrideForwarder) Solve(ctx netcontext.Context, req *pb.SolveRequest) (*pb.SolveResponse, error) {
 	ctx = tracing.ContextWithSpanFromContext(ctx, lbf.callCtx)
 	ref, expResp, err := lbf.llbBridge.Solve(ctx, frontend.SolveRequest{
 		Definition: req.Definition,
@@ -288,7 +289,7 @@ func (lbf *llbBrideForwarder) Solve(ctx context.Context, req *pb.SolveRequest) (
 	}
 	return &pb.SolveResponse{Ref: id}, nil
 }
-func (lbf *llbBrideForwarder) ReadFile(ctx context.Context, req *pb.ReadFileRequest) (*pb.ReadFileResponse, error) {
+func (lbf *llbBrideForwarder) ReadFile(ctx netcontext.Context, req *pb.ReadFileRequest) (*pb.ReadFileResponse, error) {
 	ctx = tracing.ContextWithSpanFromContext(ctx, lbf.callCtx)
 	ref, ok := lbf.refs[req.Ref]
 	if !ok {
@@ -305,7 +306,7 @@ func (lbf *llbBrideForwarder) ReadFile(ctx context.Context, req *pb.ReadFileRequ
 	return &pb.ReadFileResponse{Data: dt}, nil
 }
 
-func (lbf *llbBrideForwarder) Ping(context.Context, *pb.PingRequest) (*pb.PongResponse, error) {
+func (lbf *llbBrideForwarder) Ping(netcontext.Context, *pb.PingRequest) (*pb.PongResponse, error) {
 	return &pb.PongResponse{}, nil
 }
 

--- a/frontend/gateway/grpcclient/client.go
+++ b/frontend/gateway/grpcclient/client.go
@@ -1,6 +1,7 @@
 package grpcclient
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net"
@@ -13,7 +14,6 @@ import (
 	opspb "github.com/moby/buildkit/solver/pb"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
 

--- a/session/auth/auth.go
+++ b/session/auth/auth.go
@@ -1,12 +1,13 @@
 package auth
 
 import (
+	"context"
 	"io/ioutil"
 
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/moby/buildkit/session"
-	"golang.org/x/net/context"
+	netcontext "golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
 
@@ -24,7 +25,7 @@ func (ap *authProvider) Register(server *grpc.Server) {
 	RegisterAuthServer(server, ap)
 }
 
-func (ap *authProvider) Credentials(ctx context.Context, req *CredentialsRequest) (*CredentialsResponse, error) {
+func (ap *authProvider) Credentials(ctx netcontext.Context, req *CredentialsRequest) (*CredentialsResponse, error) {
 	if req.Host == "registry-1.docker.io" {
 		req.Host = "https://index.docker.io/v1/"
 	}

--- a/session/filesync/filesync.go
+++ b/session/filesync/filesync.go
@@ -1,6 +1,7 @@
 package filesync
 
 import (
+	"context"
 	"fmt"
 	io "io"
 	"os"
@@ -9,7 +10,6 @@ import (
 	"github.com/moby/buildkit/session"
 	"github.com/pkg/errors"
 	"github.com/tonistiigi/fsutil"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )

--- a/session/grpc.go
+++ b/session/grpc.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"context"
 	"net"
 	"sync/atomic"
 	"time"
@@ -9,7 +10,6 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"

--- a/session/grpchijack/dial.go
+++ b/session/grpchijack/dial.go
@@ -1,6 +1,7 @@
 package grpchijack
 
 import (
+	"context"
 	"io"
 	"net"
 	"strings"
@@ -9,7 +10,6 @@ import (
 
 	controlapi "github.com/moby/buildkit/api/services/control"
 	"github.com/moby/buildkit/session"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )

--- a/session/manager.go
+++ b/session/manager.go
@@ -1,13 +1,13 @@
 package session
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"strings"
 	"sync"
 
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
 

--- a/session/session.go
+++ b/session/session.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"context"
 	"net"
 	"strings"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"

--- a/session/testutil/testutil.go
+++ b/session/testutil/testutil.go
@@ -1,12 +1,12 @@
 package testutil
 
 import (
+	"context"
 	"io"
 	"net"
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // Handler is function called to handle incoming connection

--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -1,6 +1,7 @@
 package solver
 
 import (
+	"context"
 	"io"
 	"sync"
 	"time"
@@ -14,7 +15,6 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 type jobKeyT string

--- a/solver/llbbridge.go
+++ b/solver/llbbridge.go
@@ -1,6 +1,7 @@
 package solver
 
 import (
+	"context"
 	"io"
 	"strings"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/moby/buildkit/worker"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 // llbBridge is an helper used by frontends

--- a/solver/llbop/build.go
+++ b/solver/llbop/build.go
@@ -1,6 +1,7 @@
 package llbop
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/moby/buildkit/worker"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 const buildCacheType = "buildkit.build.v0"

--- a/solver/llbop/exec.go
+++ b/solver/llbop/exec.go
@@ -1,6 +1,7 @@
 package llbop
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"path"
@@ -15,7 +16,6 @@ import (
 	"github.com/moby/buildkit/util/progress/logs"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 const execCacheType = "buildkit.exec.v0"

--- a/solver/llbop/source.go
+++ b/solver/llbop/source.go
@@ -1,13 +1,13 @@
 package llbop
 
 import (
+	"context"
 	"sync"
 
 	"github.com/moby/buildkit/solver"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/source"
 	digest "github.com/opencontainers/go-digest"
-	"golang.org/x/net/context"
 )
 
 const sourceCacheType = "buildkit.source.v0"

--- a/solver/sharedref.go
+++ b/solver/sharedref.go
@@ -1,10 +1,10 @@
 package solver
 
 import (
+	"context"
 	"sync"
 
 	"github.com/moby/buildkit/cache"
-	"golang.org/x/net/context"
 )
 
 // SharedRef is a wrapper around releasable that allows you to make new

--- a/solver/solver.go
+++ b/solver/solver.go
@@ -1,6 +1,7 @@
 package solver
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"sync"
@@ -21,7 +22,6 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/solver/types/types.go
+++ b/solver/types/types.go
@@ -1,11 +1,12 @@
 package types
 
 import (
+	"context"
+
 	"github.com/moby/buildkit/exporter"
 	"github.com/moby/buildkit/frontend"
 	"github.com/moby/buildkit/solver/pb"
 	digest "github.com/opencontainers/go-digest"
-	"golang.org/x/net/context"
 )
 
 // These could be also defined in worker

--- a/solver/vertex.go
+++ b/solver/vertex.go
@@ -1,6 +1,7 @@
 package solver
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/progress"
 	digest "github.com/opencontainers/go-digest"
-	"golang.org/x/net/context"
 )
 
 type input struct {

--- a/source/containerimage/pull.go
+++ b/source/containerimage/pull.go
@@ -1,7 +1,7 @@
 package containerimage
 
 import (
-	gocontext "context"
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -29,7 +29,6 @@ import (
 	"github.com/opencontainers/image-spec/identity"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 // TODO: break apart containerd specifics like contentstore so the resolver
@@ -199,7 +198,7 @@ func (p *puller) Snapshot(ctx context.Context) (cache.ImmutableRef, error) {
 	// and snapshots as 1) buildkit shouldn't have a dependency on contentstore
 	// or 2) cachemanager should manage the contentstore
 	handlers := []images.Handler{
-		images.HandlerFunc(func(ctx gocontext.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 			ongoing.add(desc)
 			return nil, nil
 		}),

--- a/source/git/gitsource.go
+++ b/source/git/gitsource.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -20,7 +21,6 @@ import (
 	"github.com/moby/buildkit/util/progress/logs"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 var validHex = regexp.MustCompile(`^[a-f0-9]{40}$`)

--- a/source/http/httpsource.go
+++ b/source/http/httpsource.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
@@ -24,7 +25,6 @@ import (
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 type Opt struct {

--- a/source/local/local.go
+++ b/source/local/local.go
@@ -1,6 +1,7 @@
 package local
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -18,7 +19,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/tonistiigi/fsutil"
-	"golang.org/x/net/context"
 	"golang.org/x/time/rate"
 )
 

--- a/source/manager.go
+++ b/source/manager.go
@@ -1,11 +1,11 @@
 package source
 
 import (
+	"context"
 	"sync"
 
 	"github.com/moby/buildkit/cache"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 type Source interface {

--- a/util/bgfunc/bgfunc.go
+++ b/util/bgfunc/bgfunc.go
@@ -1,9 +1,8 @@
 package bgfunc
 
 import (
+	"context"
 	"sync"
-
-	"golang.org/x/net/context"
 )
 
 func New(ctx context.Context, fn func(context.Context, func()) error) (*F, error) {

--- a/util/bgfunc/bgfunc_test.go
+++ b/util/bgfunc/bgfunc_test.go
@@ -1,13 +1,13 @@
 package bgfunc
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 func TestBgFuncSimple(t *testing.T) {
@@ -179,14 +179,16 @@ func TestCancellation(t *testing.T) {
 
 	firstErr := make(chan error)
 	go func() {
-		ctx, _ := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
 		_, err := c1.Call(ctx, fn1)
 		firstErr <- err
 	}()
 
 	secondErr := make(chan error)
 	go func() {
-		ctx, _ := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
 		_, err := c2.Call(ctx, fn2)
 		secondErr <- err
 	}()

--- a/util/flightcontrol/flightcontrol.go
+++ b/util/flightcontrol/flightcontrol.go
@@ -1,6 +1,7 @@
 package flightcontrol
 
 import (
+	"context"
 	"io"
 	"runtime"
 	"sort"
@@ -9,7 +10,6 @@ import (
 
 	"github.com/moby/buildkit/util/progress"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 // flightcontrol is like singleflight but with support for cancellation and

--- a/util/flightcontrol/flightcontrol_test.go
+++ b/util/flightcontrol/flightcontrol_test.go
@@ -1,13 +1,13 @@
 package flightcontrol
 
 import (
+	"context"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	"context"
 	"io"
 	"io/ioutil"
 	"os"
@@ -35,7 +36,6 @@ import (
 	"github.com/moby/buildkit/worker"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 // TODO: this file should be removed. containerd defines ContainerdWorker, oci defines OCIWorker. There is no base worker.

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"context"
 	"io"
 
 	"github.com/moby/buildkit/cache"
@@ -10,7 +11,6 @@ import (
 	"github.com/moby/buildkit/exporter"
 	"github.com/moby/buildkit/solver/types"
 	digest "github.com/opencontainers/go-digest"
-	"golang.org/x/net/context"
 )
 
 type SubBuilder interface {


### PR DESCRIPTION
This causes quite a lot of errors between interface definitions and implementation. Make usage of context pkg consistent so that everything except grpc uses native package and if grpc context is needed it is defined with `netcontext` alias.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>