### PR TITLE
buildctl: fix nil panic

### DIFF
--- a/cmd/buildctl/trace.go
+++ b/cmd/buildctl/trace.go
@@ -61,7 +61,9 @@ func attachAppContext(app *cli.App) {
 	}
 
 	app.ExitErrHandler = func(clicontext *cli.Context, err error) {
-		ext.Error.Set(span, true)
+		if span != nil {
+			ext.Error.Set(span, true)
+		}
 		cli.HandleExitCoder(err)
 	}
 


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

```
$ buildctl
NAME:                             
   buildctl - build utility       

USAGE:                            
   buildctl [global options] command [command options] [arguments...]                                                                   

VERSION:                          
   0.0.0                          

COMMANDS:                         
     du       disk usage          
     prune    clean up build cache                                  
     build    build               
     debug    debug utilities     
     help, h  Shows a list of commands or help for one command      

GLOBAL OPTIONS:                   
   --debug                enable debug output in logs               
   --addr value           buildkitd address (default: "unix:///run/buildkit/buildkitd.sock")                                            
   --tlsservername value  buildkitd server name for certificate validation                                                              
   --tlscacert value      CA certificate for validation             
   --tlscert value        client certificate                        
   --tlskey value         client key                                
   --help, -h             show help                                 
   --version, -v          print the version                         
panic: runtime error: invalid memory address or nil pointer dereference                                                                 
[signal SIGSEGV: segmentation violation code=0x1 addr=0x78 pc=0x6c80f2]                                                                 

goroutine 1 [running]:            
github.com/moby/buildkit/vendor/github.com/opentracing/opentracing-go/ext.boolTagName.Set(0xab719b, 0x5, 0x0, 0x0, 0xc4201f9b01)        
        /go/src/github.com/moby/buildkit/vendor/github.com/opentracing/opentracing-go/ext/tags.go:197 +0x22                             
main.attachAppContext.func2(0xc4200ab340, 0x0, 0x0)                 
        /go/src/github.com/moby/buildkit/cmd/buildctl/trace.go:64 +0x53                                                                 
github.com/moby/buildkit/vendor/github.com/urfave/cli.(*App).handleExitCoder(0xc420150380, 0xc4200ab340, 0x0, 0x0)                      
        /go/src/github.com/moby/buildkit/vendor/github.com/urfave/cli/app.go:473 +0x50                                                  
github.com/moby/buildkit/vendor/github.com/urfave/cli.(*App).Run(0xc420150380, 0xc42000e1a0, 0x1, 0x1, 0x0, 0x0)                        
        /go/src/github.com/moby/buildkit/vendor/github.com/urfave/cli/app.go:270 +0x6a5                                                 
main.main()                       
        /go/src/github.com/moby/buildkit/cmd/buildctl/main.go:79 +0x71b
```