### PR TITLE
decouple remotecache from Docker registry

### DIFF
--- a/cache/remotecache/export.go
+++ b/cache/remotecache/export.go
@@ -10,35 +10,54 @@ import (
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
 	v1 "github.com/moby/buildkit/cache/remotecache/v1"
-	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver"
 	"github.com/moby/buildkit/util/contentutil"
 	"github.com/moby/buildkit/util/progress"
-	"github.com/moby/buildkit/util/push"
 	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
-type ExporterOpt struct {
-	SessionManager *session.Manager
+type ResolveCacheExporterFunc func(ctx context.Context, typ, target string) (Exporter, error)
+
+func oneOffProgress(ctx context.Context, id string) func(err error) error {
+	pw, _, _ := progress.FromContext(ctx)
+	now := time.Now()
+	st := progress.Status{
+		Started: &now,
+	}
+	pw.Write(id, st)
+	return func(err error) error {
+		now := time.Now()
+		st.Completed = &now
+		pw.Write(id, st)
+		pw.Close()
+		return err
+	}
 }
 
-func NewCacheExporter(opt ExporterOpt) *CacheExporter {
-	return &CacheExporter{opt: opt}
+type Exporter interface {
+	solver.CacheExporterTarget
+	Finalize(ctx context.Context) error
 }
 
-type CacheExporter struct {
-	opt ExporterOpt
+type contentCacheExporter struct {
+	solver.CacheExporterTarget
+	chains   *v1.CacheChains
+	ingester content.Ingester
 }
 
-func (ce *CacheExporter) ExporterForTarget(target string) *RegistryCacheExporter {
+func NewExporter(ingester content.Ingester) Exporter {
 	cc := v1.NewCacheChains()
-	return &RegistryCacheExporter{target: target, CacheExporterTarget: cc, chains: cc, exporter: ce}
+	return &contentCacheExporter{CacheExporterTarget: cc, chains: cc, ingester: ingester}
 }
 
-func (ce *CacheExporter) Finalize(ctx context.Context, cc *v1.CacheChains, target string) error {
+func (ce *contentCacheExporter) Finalize(ctx context.Context) error {
+	return export(ctx, ce.ingester, ce.chains)
+}
+
+func export(ctx context.Context, ingester content.Ingester, cc *v1.CacheChains) error {
 	config, descs, err := cc.Marshal()
 	if err != nil {
 		return err
@@ -58,19 +77,16 @@ func (ce *CacheExporter) Finalize(ctx context.Context, cc *v1.CacheChains, targe
 	mfst.SchemaVersion = 2
 	mfst.MediaType = images.MediaTypeDockerSchema2ManifestList
 
-	allBlobs := map[digest.Digest]struct{}{}
-	mp := contentutil.NewMultiProvider(nil)
 	for _, l := range config.Layers {
-		if _, ok := allBlobs[l.Blob]; ok {
-			continue
-		}
 		dgstPair, ok := descs[l.Blob]
 		if !ok {
 			return errors.Errorf("missing blob %s", l.Blob)
 		}
-		allBlobs[l.Blob] = struct{}{}
-		mp.Add(l.Blob, dgstPair.Provider)
-
+		layerDone := oneOffProgress(ctx, fmt.Sprintf("writing layer %s", l.Blob))
+		if err := contentutil.Copy(ctx, ingester, dgstPair.Provider, dgstPair.Descriptor); err != nil {
+			return layerDone(errors.Wrap(err, "error writing layer blob"))
+		}
+		layerDone(nil)
 		mfst.Manifests = append(mfst.Manifests, dgstPair.Descriptor)
 	}
 
@@ -85,13 +101,11 @@ func (ce *CacheExporter) Finalize(ctx context.Context, cc *v1.CacheChains, targe
 		MediaType: v1.CacheConfigMediaTypeV0,
 	}
 	configDone := oneOffProgress(ctx, fmt.Sprintf("writing config %s", dgst))
-	buf := contentutil.NewBuffer()
-	if err := content.WriteBlob(ctx, buf, dgst.String(), bytes.NewReader(dt), desc); err != nil {
+	if err := content.WriteBlob(ctx, ingester, dgst.String(), bytes.NewReader(dt), desc); err != nil {
 		return configDone(errors.Wrap(err, "error writing config blob"))
 	}
 	configDone(nil)
 
-	mp.Add(dgst, buf)
 	mfst.Manifests = append(mfst.Manifests, desc)
 
 	dt, err = json.Marshal(mfst)
@@ -100,44 +114,15 @@ func (ce *CacheExporter) Finalize(ctx context.Context, cc *v1.CacheChains, targe
 	}
 	dgst = digest.FromBytes(dt)
 
-	buf = contentutil.NewBuffer()
 	desc = ocispec.Descriptor{
-		Digest: dgst,
-		Size:   int64(len(dt)),
+		Digest:    dgst,
+		Size:      int64(len(dt)),
+		MediaType: mfst.MediaType,
 	}
 	mfstDone := oneOffProgress(ctx, fmt.Sprintf("writing manifest %s", dgst))
-	if err := content.WriteBlob(ctx, buf, dgst.String(), bytes.NewReader(dt), desc); err != nil {
+	if err := content.WriteBlob(ctx, ingester, dgst.String(), bytes.NewReader(dt), desc); err != nil {
 		return mfstDone(errors.Wrap(err, "error writing manifest blob"))
 	}
 	mfstDone(nil)
-	mp.Add(dgst, buf)
-
-	return push.Push(ctx, ce.opt.SessionManager, mp, dgst, target, false)
-}
-
-type RegistryCacheExporter struct {
-	solver.CacheExporterTarget
-	chains   *v1.CacheChains
-	target   string
-	exporter *CacheExporter
-}
-
-func (ce *RegistryCacheExporter) Finalize(ctx context.Context) error {
-	return ce.exporter.Finalize(ctx, ce.chains, ce.target)
-}
-
-func oneOffProgress(ctx context.Context, id string) func(err error) error {
-	pw, _, _ := progress.FromContext(ctx)
-	now := time.Now()
-	st := progress.Status{
-		Started: &now,
-	}
-	pw.Write(id, st)
-	return func(err error) error {
-		now := time.Now()
-		st.Completed = &now
-		pw.Write(id, st)
-		pw.Close()
-		return err
-	}
+	return nil
 }

--- a/cache/remotecache/registry/registry.go
+++ b/cache/remotecache/registry/registry.go
@@ -1,0 +1,73 @@
+package registry
+
+import (
+	"context"
+	"time"
+
+	"github.com/containerd/containerd/remotes"
+	"github.com/containerd/containerd/remotes/docker"
+	"github.com/moby/buildkit/cache/remotecache"
+	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/session/auth"
+	"github.com/moby/buildkit/util/contentutil"
+	"github.com/moby/buildkit/util/tracing"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+func ResolveCacheExporterFunc(sm *session.Manager) remotecache.ResolveCacheExporterFunc {
+	return func(ctx context.Context, typ, ref string) (remotecache.Exporter, error) {
+		if typ != "" {
+			return nil, errors.Errorf("unsupported cache exporter type: %s", typ)
+		}
+		remote := newRemoteResolver(ctx, sm)
+		pusher, err := remote.Pusher(ctx, ref)
+		if err != nil {
+			return nil, err
+		}
+		return remotecache.NewExporter(contentutil.FromPusher(pusher)), nil
+	}
+}
+
+func ResolveCacheImporterFunc(sm *session.Manager) remotecache.ResolveCacheImporterFunc {
+	return func(ctx context.Context, typ, ref string) (remotecache.Importer, specs.Descriptor, error) {
+		if typ != "" {
+			return nil, specs.Descriptor{}, errors.Errorf("unsupported cache importer type: %s", typ)
+		}
+		remote := newRemoteResolver(ctx, sm)
+		xref, desc, err := remote.Resolve(ctx, ref)
+		if err != nil {
+			return nil, specs.Descriptor{}, err
+		}
+		fetcher, err := remote.Fetcher(ctx, xref)
+		if err != nil {
+			return nil, specs.Descriptor{}, err
+		}
+		return remotecache.NewImporter(contentutil.FromFetcher(fetcher)), desc, nil
+	}
+}
+
+func newRemoteResolver(ctx context.Context, sm *session.Manager) remotes.Resolver {
+	return docker.NewResolver(docker.ResolverOptions{
+		Client:      tracing.DefaultClient,
+		Credentials: getCredentialsFunc(ctx, sm),
+	})
+}
+
+func getCredentialsFunc(ctx context.Context, sm *session.Manager) func(string) (string, string, error) {
+	id := session.FromContext(ctx)
+	if id == "" {
+		return nil
+	}
+	return func(host string) (string, string, error) {
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		caller, err := sm.Get(timeoutCtx, id)
+		if err != nil {
+			return "", "", err
+		}
+
+		return auth.CredentialsFunc(context.TODO(), caller)(host)
+	}
+}

--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -26,5 +26,5 @@ type SolveRequest struct {
 	Definition      *pb.Definition
 	Frontend        string
 	FrontendOpt     map[string]string
-	ImportCacheRefs []string
+	ImportCacheRefs []string // TODO: map[string]string for supporting non-registry ref?
 }

--- a/util/contentutil/fetcher.go
+++ b/util/contentutil/fetcher.go
@@ -5,35 +5,28 @@ import (
 	"io"
 
 	"github.com/containerd/containerd/content"
-	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/remotes"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
-func FromFetcher(f remotes.Fetcher, desc ocispec.Descriptor) content.Provider {
+func FromFetcher(f remotes.Fetcher) content.Provider {
 	return &fetchedProvider{
-		f:    f,
-		desc: desc,
+		f: f,
 	}
 }
 
 type fetchedProvider struct {
-	f    remotes.Fetcher
-	desc ocispec.Descriptor
+	f remotes.Fetcher
 }
 
 func (p *fetchedProvider) ReaderAt(ctx context.Context, desc ocispec.Descriptor) (content.ReaderAt, error) {
-	if desc.Digest != p.desc.Digest {
-		return nil, errors.Wrapf(errdefs.ErrNotFound, "content %v", desc.Digest)
-	}
-
-	rc, err := p.f.Fetch(ctx, p.desc)
+	rc, err := p.f.Fetch(ctx, desc)
 	if err != nil {
 		return nil, err
 	}
 
-	return &readerAt{Reader: rc, Closer: rc, size: p.desc.Size}, nil
+	return &readerAt{Reader: rc, Closer: rc, size: desc.Size}, nil
 }
 
 type readerAt struct {

--- a/util/contentutil/fetcher_test.go
+++ b/util/contentutil/fetcher_test.go
@@ -23,7 +23,7 @@ func TestFetcher(t *testing.T) {
 	require.NoError(t, err)
 
 	f := &localFetcher{b0}
-	p := FromFetcher(f, ocispec.Descriptor{Digest: digest.FromBytes([]byte("foobar")), Size: -1})
+	p := FromFetcher(f)
 
 	b1 := NewBuffer()
 	err = Copy(ctx, b1, p, ocispec.Descriptor{Digest: digest.FromBytes([]byte("foobar")), Size: -1})
@@ -53,7 +53,7 @@ func TestSlowFetch(t *testing.T) {
 	ctx := context.TODO()
 
 	f := &dummySlowFetcher{}
-	p := FromFetcher(f, ocispec.Descriptor{Digest: digest.FromBytes([]byte("foobar")), Size: -1})
+	p := FromFetcher(f)
 
 	rdr, err := p.ReaderAt(ctx, ocispec.Descriptor{Digest: digest.FromBytes([]byte("foobar"))})
 	require.NoError(t, err)

--- a/util/contentutil/pusher.go
+++ b/util/contentutil/pusher.go
@@ -1,0 +1,58 @@
+package contentutil
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/remotes"
+	"github.com/pkg/errors"
+)
+
+func FromPusher(p remotes.Pusher) content.Ingester {
+	return &pushingIngester{
+		p: p,
+	}
+}
+
+type pushingIngester struct {
+	p remotes.Pusher
+}
+
+// Writer implements content.Ingester. desc.MediaType must be set for manifest blobs.
+func (i *pushingIngester) Writer(ctx context.Context, opts ...content.WriterOpt) (content.Writer, error) {
+	var wOpts content.WriterOpts
+	for _, opt := range opts {
+		if err := opt(&wOpts); err != nil {
+			return nil, err
+		}
+	}
+	if wOpts.Ref == "" {
+		return nil, errors.Wrap(errdefs.ErrInvalidArgument, "ref must not be empty")
+	}
+	// pusher requires desc.MediaType to determine the PUT URL, especially for manifest blobs.
+	contentWriter, err := i.p.Push(ctx, wOpts.Desc)
+	if err != nil {
+		return nil, err
+	}
+	return &writer{
+		Writer:           contentWriter,
+		contentWriterRef: wOpts.Ref,
+	}, nil
+}
+
+type writer struct {
+	content.Writer          // returned from pusher.Push
+	contentWriterRef string // ref passed for Writer()
+}
+
+func (w *writer) Status() (content.Status, error) {
+	st, err := w.Writer.Status()
+	if err != nil {
+		return st, err
+	}
+	if w.contentWriterRef != "" {
+		st.Ref = w.contentWriterRef
+	}
+	return st, nil
+}


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

ref: #224 

This PR decouples `cacheimport` from Docker registry so that caches can be copied from a worker to another worker without registry.

The interface almost corresponds to @tonistiigi 's proposal (https://github.com/moby/buildkit/issues/224#issuecomment-352098469), but there is no `WorkerRef` yet.

 