### PR TITLE
solver: implement selector for cachemap

### DIFF
--- a/solver-next/index.go
+++ b/solver-next/index.go
@@ -186,7 +186,8 @@ func getUniqueID(k CacheKey) digest.Digest {
 
 	dgstr := digest.SHA256.Digester()
 	for _, inp := range k.Deps() {
-		dgstr.Hash().Write([]byte(getUniqueID(inp)))
+		dgstr.Hash().Write([]byte(getUniqueID(inp.CacheKey)))
+		dgstr.Hash().Write([]byte(inp.Selector))
 	}
 
 	dgstr.Hash().Write([]byte(k.Digest()))


### PR DESCRIPTION
A selector can be used to connect an identifier to the input that is merged with the input's cache key. One example where this will be used is using a mount in `execop` that mounts a subdirectory. The name of that subdirectory is added to the cache chain so that if this directory changes, cache would need to be reevaluated. The selector is not just included in the base digest so that result based cache doesn't need to include it. For example, if the location of the source files differs but they still have the same content you still get a cache match.