### PR TITLE
worker/oci: allow using naive snapshotter

### DIFF
--- a/cmd/buildkitd/main_oci_worker.go
+++ b/cmd/buildkitd/main_oci_worker.go
@@ -27,6 +27,12 @@ func init() {
 			Name:  "oci-worker-labels",
 			Usage: "user-specific annotation labels (com.example.foo=bar)",
 		},
+		cli.StringFlag{
+			Name:  "oci-worker-snapshotter",
+			Usage: "name of snapshotter (overlayfs or naive)",
+			// TODO(AkihiroSuda): autodetect overlayfs availability when the value is set to "auto"?
+			Value: "overlayfs",
+		},
 	)
 	// TODO: allow multiple oci runtimes and snapshotters
 }
@@ -43,7 +49,7 @@ func ociWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([]worker
 	if err != nil {
 		return nil, err
 	}
-	opt, err := runc.NewWorkerOpt(common.root, labels)
+	opt, err := runc.NewWorkerOpt(common.root, labels, c.GlobalString("oci-worker-snapshotter"))
 	if err != nil {
 		return nil, err
 	}

--- a/worker/runc/runc_test.go
+++ b/worker/runc/runc_test.go
@@ -38,7 +38,7 @@ func TestRuncWorker(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
-	workerOpt, err := NewWorkerOpt(tmpdir, nil)
+	workerOpt, err := NewWorkerOpt(tmpdir, nil, "overlayfs")
 	require.NoError(t, err)
 
 	workerOpt.SessionManager, err = session.NewManager()


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

Part of rootless mode ( https://twitter.com/_AkihiroSuda_/status/955698849560997888 ).

overlayfs is generally not available in userns (except Ubuntu, Plamo Linux, and some distros)

ref: https://github.com/moby/buildkit/issues/257 https://github.com/moby/buildkit/issues/252 https://github.com/cyphar/rootlesscontaine.rs/pull/6