### PR TITLE
Use local images if pull fails

### DIFF
--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -94,6 +94,7 @@ func NewWorker(opt WorkerOpt) (*Worker, error) {
 		ContentStore:   opt.ContentStore,
 		SessionManager: opt.SessionManager,
 		Applier:        opt.Applier,
+		ImageStore:     opt.ImageStore,
 		CacheAccessor:  cm,
 	})
 	if err != nil {


### PR DESCRIPTION
When using `--frontend=gateway.v0` in order to use a tagged image as the
frontend it is currently required to push the tag to a registry, so that
buildkit can pull it. One can use the `image@sha256:digest` form but this is
inconvenient for the development cycle.

Instead, if the pull fails check check the local image store (if there is one,
which is worker dependent) for a suitable image and if so use that.

With this I can now:

    buildctl build --frontend=dockerfile.v0 --local context=. --local dockerfile=. --exporter=image --exporter-opt=name=docker.io/ijc25/fe:dev
    builtctl build --frontend=gateway.v0 --frontend-opt=source=ijc25/fe:dev --exporter=image --exporter-opt=name=hello-world:dev

Without any push to a registry.

I am using the containerd worker.

Signed-off-by: Ian Campbell <ijc@docker.com>