### PR TITLE
session: clear prefix on lookup

### DIFF
--- a/session/manager.go
+++ b/session/manager.go
@@ -150,6 +150,12 @@ func (sm *Manager) handleConn(ctx context.Context, conn net.Conn, opts map[strin
 
 // Get returns a session by ID
 func (sm *Manager) Get(ctx context.Context, id string) (Caller, error) {
+	// session prefix is used to identify vertexes with different contexts so
+	// they would not collide, but for lookup we don't need the prefix
+	if p := strings.SplitN(id, ":", 2); len(p) == 2 && len(p[1]) > 0 {
+		id = p[1]
+	}
+
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 


### PR DESCRIPTION
Session prefix is used in "dev-mode" of gateway frontend to build both frontend and actual build job using frontend together. It sets a prefix to session so that local sources created with a common name (eg. "context" for dockerfile) do not collide. The local source itself had logic to correct this prefix.

The problem is that this conflicts with other use cases of the session like authentication tokens. As a quick solution, we can just skip the prefix as it is can never be used for lookup anyway. I think the more correct solution is to expose a special prefix name either to the frontend or inject it in llbbridge . Currently, sessionID is reused for this just because it is a variable that is passed together with a build, not because there is actually a different session.

Testing:

```
buildctl build --frontend=gateway.v0 --frontend-opt=gateway-devel=true --frontend-opt=source=dockerfile.v0 --local gateway-context=. --local gateway-dockerfile=./frontend/dockerfile/cmd/dockerfile-frontend --local context=. --local dockerfile=./hack/dockerfiles --frontend-opt filename=test.Dockerfile

buildctl build --frontend=gateway.v0 --frontend-opt=gateway-devel=true --frontend-opt=source=gateway.v0 --frontend-opt gateway-source=tonistiigi/dockerfile:next --local gateway-context=. --local gateway-dockerfile=./frontend/dockerfile/cmd/dockerfile-frontend --local context=. --local dockerfile=./hack/dockerfiles --frontend-opt filename=test.Dockerfile
```

I'll revisit this after we have switched to `solver-next` that enables invoking frontends from a nested build and is related to this issue.

@ijc

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>