### PR TITLE
worker/oci: allow specifying arbitrary snapshotter factory

### DIFF
--- a/worker/runc/runc_test.go
+++ b/worker/runc/runc_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/snapshots/overlay"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/executor"
 	"github.com/moby/buildkit/session"
@@ -38,7 +39,11 @@ func TestRuncWorker(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
-	workerOpt, err := NewWorkerOpt(tmpdir, nil, "overlayfs")
+	snFactory := SnapshotterFactory{
+		Name: "overlayfs",
+		New:  overlay.NewSnapshotter,
+	}
+	workerOpt, err := NewWorkerOpt(tmpdir, snFactory, nil)
 	require.NoError(t, err)
 
 	workerOpt.SessionManager, err = session.NewManager()


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

For deduplicating https://github.com/jessfraz/img/blob/f8acce2bab651ed2dc2a9ce737f3d143cbba2484/worker/runc/workeropt.go

(fuseserver and differs would be handled outside of this function)

cc @jessfraz

part of https://github.com/jessfraz/img/issues/21
