### PR TITLE
exporter/oci: split reusable dockerexporter

### DIFF
--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -12,6 +12,7 @@ import (
 	"github.com/moby/buildkit/exporter/containerimage"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/filesync"
+	"github.com/moby/buildkit/util/dockerexporter"
 	"github.com/moby/buildkit/util/progress"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -140,7 +141,7 @@ func getExporter(variant ExporterVariant, name string) (images.Exporter, error) 
 	case VariantOCI:
 		return &oci.V1Exporter{}, nil
 	case VariantDocker:
-		return &DockerExporter{name: name}, nil
+		return &dockerexporter.DockerExporter{Name: name}, nil
 	default:
 		return nil, errors.Errorf("invalid variant %q", variant)
 	}

--- a/util/dockerexporter/dockerexporter.go
+++ b/util/dockerexporter/dockerexporter.go
@@ -1,4 +1,4 @@
-package oci
+package dockerexporter
 
 import (
 	"archive/tar"
@@ -16,20 +16,22 @@ import (
 	"github.com/pkg/errors"
 )
 
-// DockerExporter implements exporting to
+// DockerExporter implements containerd/images.Exporter to
 // Docker Combined Image JSON + Filesystem Changeset Format v1.1
 // https://github.com/moby/moby/blob/master/image/spec/v1.1.md#combined-image-json--filesystem-changeset-format
 // The outputed tarball is also compatible wih OCI Image Format Specification
 type DockerExporter struct {
-	name string
+	Name string
 }
+
+var _ images.Exporter = &DockerExporter{}
 
 // Export exports tarball into writer.
 func (de *DockerExporter) Export(ctx context.Context, store content.Provider, desc ocispec.Descriptor, writer io.Writer) error {
 	tw := tar.NewWriter(writer)
 	defer tw.Close()
 
-	dockerManifest, err := dockerManifestRecord(ctx, store, desc, de.name)
+	dockerManifest, err := dockerManifestRecord(ctx, store, desc, de.Name)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

@stevvooe @dmcgowan 

Maybe we want to move this to containerd?
