### PR TITLE
Swallow a NotFound error when deleting content, to support schema 1 m…

### DIFF
--- a/source/containerimage/pull.go
+++ b/source/containerimage/pull.go
@@ -258,7 +258,7 @@ func (p *puller) Snapshot(ctx context.Context) (cache.ImmutableRef, error) {
 	}
 
 	for _, nl := range notLayerBlobs {
-		if err := p.is.ContentStore.Delete(ctx, nl.Digest); err != nil {
+		if err := p.is.ContentStore.Delete(ctx, nl.Digest); err != nil && !errdefs.IsNotFound(err) {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
…anifests

The behaviour of `github.com/containerd/containerd/remotes/docker/schema1` is
such that the manifest is not actually in the content store, so attempting to
delete it fails with `NotFound`, which with the `gateway.v0` frontend results
in:

    time="2018-02-26T17:01:15Z" level=error msg="fatal error: rpc error: code = Unknown desc = content digest sha256:178598e51a26abbc958b8a2e48825c90bc22e641de3d31e18aaf55f3258ba93b: not found"
    panic: rpc error: code = Unknown desc = content digest sha256:178598e51a26abbc958b8a2e48825c90bc22e641de3d31e18aaf55f3258ba93b: not found

It seems safe to just ignore these errors, since `NotFound` is what we wanted
after delete anyway.

This allows support for e.g. `llb.Image("docker.io/docker/whalesay:latest")`

Signed-off-by: Ian Campbell <ijc@docker.com>