### PR TITLE
Check that root is not symlink

### DIFF
--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -39,7 +39,15 @@ func New(root string) (executor.Executor, error) {
 	if err != nil {
 		return nil, err
 	}
-	// TODO: check that root is not symlink to fail early
+	
+	// Check that root is not symlink to fail early
+ 	rootInfo, err := os.Lstat(root)
+	if err != nil {
+		return nil, err
+	}
+	if rootInfo.Mode() & os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("%s is a symlink", root)
+    	}
 
 	runtime := &runc.Runc{
 		Log:          filepath.Join(root, "runc-log.json"),

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -46,7 +46,7 @@ func New(root string) (executor.Executor, error) {
 		return nil, err
 	}
 	if rootInfo.Mode() & os.ModeSymlink != 0 {
-		return nil, fmt.Errorf("%s is a symlink", root)
+		return nil, errors.Errorf("%s is a symlink", root)
     	}
 
 	runtime := &runc.Runc{

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -47,7 +47,7 @@ func New(root string) (executor.Executor, error) {
 	}
 	if rootInfo.Mode() & os.ModeSymlink != 0 {
 		return nil, errors.Errorf("%s is a symlink", root)
-    	}
+    }
 
 	runtime := &runc.Runc{
 		Log:          filepath.Join(root, "runc-log.json"),


### PR DESCRIPTION
Implements Check that root is not symlink to fail early

https://github.com/moby/buildkit/blob/c5795fea0284af50f887fffcce4fbe998b94904e/executor/runcexecutor/executor.go#L42