### PR TITLE
solver: add support for releasing cached results

### DIFF
--- a/solver-next/boltdbcachestorage/storage.go
+++ b/solver-next/boltdbcachestorage/storage.go
@@ -135,7 +135,7 @@ func (s *Store) AddResult(id string, res solver.CacheResult) error {
 	})
 }
 
-func (s *Store) Release(resultID string) error {
+func (s *Store) Release(id, resultID string) error {
 	return errors.Errorf("not-implemented")
 }
 

--- a/solver-next/cachestorage.go
+++ b/solver-next/cachestorage.go
@@ -13,6 +13,7 @@ var ErrNotFound = errors.Errorf("not found")
 // CacheKeyStorage is interface for persisting cache metadata
 type CacheKeyStorage interface {
 	Get(id string) (CacheKeyInfo, error)
+	Walk(fn func(id string) error) error
 	Set(info CacheKeyInfo) error
 
 	WalkResults(id string, fn func(CacheResult) error) error
@@ -59,4 +60,5 @@ type CacheResultStorage interface {
 	Save(Result) (CacheResult, error)
 	Load(ctx context.Context, res CacheResult) (Result, error)
 	LoadRemote(ctx context.Context, res CacheResult) (*Remote, error)
+	Exists(id string) bool
 }

--- a/solver-next/memorycachestorage.go
+++ b/solver-next/memorycachestorage.go
@@ -9,19 +9,24 @@ import (
 )
 
 func NewInMemoryCacheStorage() CacheKeyStorage {
-	return &inMemoryStore{byID: map[string]*inMemoryKey{}}
+	return &inMemoryStore{
+		byID:     map[string]*inMemoryKey{},
+		byResult: map[string]map[string]struct{}{},
+	}
 }
 
 type inMemoryStore struct {
-	mu   sync.RWMutex
-	byID map[string]*inMemoryKey
+	mu       sync.RWMutex
+	byID     map[string]*inMemoryKey
+	byResult map[string]map[string]struct{}
 }
 
 type inMemoryKey struct {
 	CacheKeyInfo
 
-	results map[string]CacheResult
-	links   map[CacheInfoLink]map[string]struct{}
+	results   map[string]CacheResult
+	links     map[CacheInfoLink]map[string]struct{}
+	backlinks map[string]struct{}
 }
 
 func (s *inMemoryStore) Get(id string) (CacheKeyInfo, error) {
@@ -40,8 +45,9 @@ func (s *inMemoryStore) Set(info CacheKeyInfo) error {
 	k, ok := s.byID[info.ID]
 	if !ok {
 		k = &inMemoryKey{
-			results: map[string]CacheResult{},
-			links:   map[CacheInfoLink]map[string]struct{}{},
+			results:   map[string]CacheResult{},
+			links:     map[CacheInfoLink]map[string]struct{}{},
+			backlinks: map[string]struct{}{},
 		}
 		s.byID[info.ID] = k
 	}
@@ -49,14 +55,37 @@ func (s *inMemoryStore) Set(info CacheKeyInfo) error {
 	return nil
 }
 
+func (s *inMemoryStore) Walk(fn func(string) error) error {
+	s.mu.RLock()
+	ids := make([]string, 0, len(s.byID))
+	for id := range s.byID {
+		ids = append(ids, id)
+	}
+	s.mu.RUnlock()
+
+	for _, id := range ids {
+		if err := fn(id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (s *inMemoryStore) WalkResults(id string, fn func(CacheResult) error) error {
 	s.mu.RLock()
-	defer s.mu.RUnlock()
+
 	k, ok := s.byID[id]
 	if !ok {
+		s.mu.RUnlock()
 		return nil
 	}
+	copy := make([]CacheResult, 0, len(k.results))
 	for _, res := range k.results {
+		copy = append(copy, res)
+	}
+	s.mu.RUnlock()
+
+	for _, res := range copy {
 		if err := fn(res); err != nil {
 			return err
 		}
@@ -86,11 +115,63 @@ func (s *inMemoryStore) AddResult(id string, res CacheResult) error {
 		return errors.Wrapf(ErrNotFound, "no such key %s", id)
 	}
 	k.results[res.ID] = res
+	m, ok := s.byResult[res.ID]
+	if !ok {
+		m = map[string]struct{}{}
+		s.byResult[res.ID] = m
+	}
+	m[id] = struct{}{}
 	return nil
 }
 
 func (s *inMemoryStore) Release(resultID string) error {
-	return errors.Errorf("not-implemented")
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ids, ok := s.byResult[resultID]
+	if !ok {
+		return nil
+	}
+
+	for id := range ids {
+		k, ok := s.byID[id]
+		if !ok {
+			continue
+		}
+
+		delete(k.results, resultID)
+		delete(s.byResult[resultID], id)
+		if len(s.byResult[resultID]) == 0 {
+			delete(s.byResult, resultID)
+		}
+
+		if len(k.results) == 0 && len(k.links) == 0 {
+			s.emptyBranchWithParents(k)
+		}
+	}
+
+	return nil
+}
+
+func (s *inMemoryStore) emptyBranchWithParents(k *inMemoryKey) {
+	if len(k.results) != 0 && len(k.links) != 0 {
+		return
+	}
+	for id := range k.backlinks {
+		p, ok := s.byID[id]
+		if !ok {
+			continue
+		}
+		for l := range p.links {
+			delete(p.links[l], k.ID)
+			if len(p.links[l]) == 0 {
+				delete(p.links, l)
+			}
+		}
+		s.emptyBranchWithParents(p)
+	}
+
+	delete(s.byID, k.ID)
 }
 
 func (s *inMemoryStore) AddLink(id string, link CacheInfoLink, target string) error {
@@ -100,12 +181,17 @@ func (s *inMemoryStore) AddLink(id string, link CacheInfoLink, target string) er
 	if !ok {
 		return errors.Wrapf(ErrNotFound, "no such key %s", id)
 	}
+	k2, ok := s.byID[target]
+	if !ok {
+		return errors.Wrapf(ErrNotFound, "no such key %s", target)
+	}
 	m, ok := k.links[link]
 	if !ok {
 		m = map[string]struct{}{}
 		k.links[link] = m
 	}
 
+	k2.backlinks[id] = struct{}{}
 	m[target] = struct{}{}
 	return nil
 }
@@ -148,4 +234,9 @@ func (s *inMemoryResultStore) Load(ctx context.Context, res CacheResult) (Result
 
 func (s *inMemoryResultStore) LoadRemote(ctx context.Context, res CacheResult) (*Remote, error) {
 	return nil, nil
+}
+
+func (s *inMemoryResultStore) Exists(id string) bool {
+	_, ok := s.m.Load(id)
+	return ok
 }

--- a/solver-next/memorycachestorage.go
+++ b/solver-next/memorycachestorage.go
@@ -145,16 +145,14 @@ func (s *inMemoryStore) Release(resultID string) error {
 			delete(s.byResult, resultID)
 		}
 
-		if len(k.results) == 0 && len(k.links) == 0 {
-			s.emptyBranchWithParents(k)
-		}
+		s.emptyBranchWithParents(k)
 	}
 
 	return nil
 }
 
 func (s *inMemoryStore) emptyBranchWithParents(k *inMemoryKey) {
-	if len(k.results) != 0 && len(k.links) != 0 {
+	if len(k.results) != 0 || len(k.links) != 0 {
 		return
 	}
 	for id := range k.backlinks {

--- a/solver-next/types.go
+++ b/solver-next/types.go
@@ -130,7 +130,7 @@ type CacheRecord struct {
 	ID           string
 	CacheKey     ExportableCacheKey
 	CacheManager CacheManager
-	// Loadable bool
+	Loadable     bool
 	// Size int
 	CreatedAt time.Time
 	Priority  int


### PR DESCRIPTION
This adds support for gradually releasing cache for objects that have been deleted. The cache chain remains intact until it still points to at least a single result, with `Query` calls returning cache records with `Loadable` set to false.