### PR TITLE
Improved schema1 support

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -42,6 +42,7 @@ func TestClientIntegration(t *testing.T) {
 		testOCIExporter,
 		testWhiteoutParentDir,
 		testDuplicateWhiteouts,
+		testSchema1Image,
 	})
 }
 
@@ -684,6 +685,24 @@ func testWhiteoutParentDir(t *testing.T, sb integration.Sandbox) {
 
 	_, ok = m["foo/"]
 	require.True(t, ok)
+}
+
+// #296
+func testSchema1Image(t *testing.T, sb integration.Sandbox) {
+	t.Parallel()
+	c, err := New(sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	st := llb.Image("gcr.io/google_containers/pause:3.0@sha256:0d093c962a6c2dd8bb8727b661e2b5f13e9df884af9945b4cc7088d9350cd3ee")
+
+	def, err := st.Marshal()
+	require.NoError(t, err)
+
+	err = c.Solve(context.TODO(), def, SolveOpt{}, nil)
+	require.NoError(t, err)
+
+	checkAllReleasable(t, c, sb, true)
 }
 
 func requiresLinux(t *testing.T) {

--- a/source/containerimage/pull.go
+++ b/source/containerimage/pull.go
@@ -240,9 +240,9 @@ func (p *puller) Snapshot(ctx context.Context) (cache.ImmutableRef, error) {
 
 		handlers := []images.Handler{
 			images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
-				usedBlobs = append(usedBlobs, desc)
 				mu.Lock()
 				defer mu.Unlock()
+				usedBlobs = append(usedBlobs, desc)
 				delete(allBlobs, desc.Digest)
 				return nil, nil
 			}),

--- a/source/containerimage/pull.go
+++ b/source/containerimage/pull.go
@@ -258,7 +258,7 @@ func (p *puller) Snapshot(ctx context.Context) (cache.ImmutableRef, error) {
 	}
 
 	for _, nl := range notLayerBlobs {
-		if err := p.is.ContentStore.Delete(ctx, nl.Digest); err != nil && !errdefs.IsNotFound(err) {
+		if err := p.is.ContentStore.Delete(ctx, nl.Digest); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
As well as reverting the wrong change from #296 and adding an integration test this fixes the cache/gc management in `puller.Snapshot`. Best explained by the commit message of the middle commit:
```
    Correct content-store management after schema1 conversion
    
    The previous code had 3 issues:
    
    - The original schema 1 manifest remained in `ongoing.added` but was not added
      to the content store by the conversion. #296 tried to address this in an
      incorrect way and was reverted by the previous commit. Instead switch in the
      schema2 manifest, which was otherwise missed.
    - Empty layers in the schema 1 manifest are not propagated to the schema 2
      version, meaning they are not referenced by anything and hence are never
      freed up and therefore leak
    - The new schema 2 image config is generated by the converter and not fetched,
      so it never passes through the `HandlerFunc` which adds things to
      `ongoing.added`.
    
    Two address these last two bullets when processing a schema 1 image walk over
    the converted image and together with `ongoing.added` produce lists of used and
    unused blobs, use the list of used blobs to perform the GC updates and simply
    delete everything on the unused list.
    
    Closes: #301.
    
    Signed-off-by: Ian Campbell <ijc@docker.com>
``` 