### PR TITLE
vendoring: try to catch more vendoring issues & fixup an existing one

### DIFF
--- a/hack/dockerfiles/vendor.Dockerfile
+++ b/hack/dockerfiles/vendor.Dockerfile
@@ -7,4 +7,6 @@ RUN go get -d github.com/LK4D4/vndr \
 	&& go install ./
 WORKDIR /go/src/github.com/moby/buildkit
 COPY . .
-RUN vndr --verbose
+# Remove vendor first to workaround  https://github.com/LK4D4/vndr/issues/63.
+RUN rm -rf vendor
+RUN vndr --verbose --strict

--- a/vendor.conf
+++ b/vendor.conf
@@ -30,6 +30,7 @@ github.com/syndtr/gocapability db04d3cc01c8b54962a58ec7e491717d06cfcc16
 github.com/Microsoft/hcsshim v0.6.7
 
 github.com/urfave/cli 7bc6a0acffa589f415f88aca16cc1de5ffd66f9c
+github.com/morikuni/aec 39771216ff4c63d11f5e604076f9c45e8be1067b
 github.com/docker/go-units v0.3.1
 github.com/google/shlex 6f45313302b9c56850fc17f99e40caebce98c716
 golang.org/x/time 8be79e1e0910c292df4e79c241bb7e8f7e725959


### PR DESCRIPTION
At the moment vendor.conf is missing entries for `github.com/tonistiigi/llb-gobuild`
and `github.com/morikuni/aec` due in part because of a combination of
https://github.com/LK4D4/vndr/issues/62 and https://github.com/LK4D4/vndr/issues/63.

The issue vndr#63 (related to lack of `github.com/morikuni/aec`) can be worked
around by removing the vendor directory before rerunning `vndr`, so do so.

Due to vndr#62 the issue with `github.com/tonistiigi/llb-gobuild` cannot be
detected at the moment, but pass `-strict` to `vndr` in anticipation of a fix
there.

This will make the CI fail on this PR (I hope). Once it has done so I will push an extra patch which fixes things by adding the `github.com/morikuni/aec` entry to `vendor.conf`.

I will not add the `github.com/tonistiigi/llb-gobuild` since the user `examples/gobuild/main.go` is marked `// +build ignore`, with current `vndr` that produces a warning (harmless due too https://github.com/LK4D4/vndr/issues/62 even we add `-strict` here)  but with newer `vndr` it does not.