### PR TITLE
client: speed up llb marshal

### DIFF
--- a/client/llb/llbbuild/llbbuild_test.go
+++ b/client/llb/llbbuild/llbbuild_test.go
@@ -12,9 +12,11 @@ import (
 func TestMarshal(t *testing.T) {
 	t.Parallel()
 	b := NewBuildOp(newDummyOutput("foobar"), WithFilename("myfilename"))
-	dt, opMeta, err := b.Marshal()
+	dgst, dt, opMeta, err := b.Marshal()
 	_ = opMeta
 	require.NoError(t, err)
+
+	require.Equal(t, dgst, digest.FromBytes(dt))
 
 	var op pb.Op
 	err = op.Unmarshal(dt)


### PR DESCRIPTION
This brings in the following optimization:

- cache for state marshalling is checked before remarshalling its children
- validation calls are cached
- digest of the cached marshalled content is cached instead of recomputing

@AkihiroSuda The last one has the least meaningful impact and is the only one that breaks the public API for the package. I'm willing to remove that one if you think it is not worth it. The other 2 have a big impact on very big graphs. 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>