### PR TITLE
worker: throttle calls to gc

### DIFF
--- a/util/throttle/throttle.go
+++ b/util/throttle/throttle.go
@@ -1,0 +1,38 @@
+package throttle
+
+import (
+	"sync"
+	"time"
+)
+
+// Throttle wraps a function so that internal function does not get called
+// more frequently than the specified duration.
+func Throttle(d time.Duration, f func()) func() {
+	var next, running bool
+	var mu sync.Mutex
+	return func() {
+		mu.Lock()
+		defer mu.Unlock()
+
+		next = true
+		if !running {
+			running = true
+			go func() {
+				for {
+					mu.Lock()
+					if next == false {
+						running = false
+						mu.Unlock()
+						return
+					}
+					mu.Unlock()
+					time.Sleep(d)
+					mu.Lock()
+					next = false
+					mu.Unlock()
+					f()
+				}
+			}()
+		}
+	}
+}

--- a/util/throttle/throttle_test.go
+++ b/util/throttle/throttle_test.go
@@ -1,0 +1,56 @@
+package throttle
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestThrottle(t *testing.T) {
+	t.Parallel()
+
+	var i int64
+	f := func() {
+		atomic.AddInt64(&i, 1)
+	}
+
+	f = Throttle(50*time.Millisecond, f)
+
+	f()
+	f()
+
+	require.Equal(t, int64(0), atomic.LoadInt64(&i))
+
+	// test that i is never incremented twice and at least once in next 600ms
+	retries := 0
+	for {
+		require.True(t, retries < 10)
+		time.Sleep(60 * time.Millisecond)
+		v := atomic.LoadInt64(&i)
+		if v > 1 {
+			require.Fail(t, "invalid value %d", v)
+		}
+		if v == 1 {
+			break
+		}
+		retries++
+	}
+
+	require.Equal(t, int64(1), atomic.LoadInt64(&i))
+
+	f()
+
+	retries = 0
+	for {
+		require.True(t, retries < 10)
+		time.Sleep(60 * time.Millisecond)
+		v := atomic.LoadInt64(&i)
+		if v == 2 {
+			break
+		}
+		retries++
+	}
+
+}


### PR DESCRIPTION
Throttle invoking the gc after object deletion for performance.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>