### PR TITLE
solver: simplify cache storage backend

### DIFF
--- a/solver-next/cachestorage.go
+++ b/solver-next/cachestorage.go
@@ -12,9 +12,8 @@ var ErrNotFound = errors.Errorf("not found")
 
 // CacheKeyStorage is interface for persisting cache metadata
 type CacheKeyStorage interface {
-	Get(id string) (CacheKeyInfo, error)
+	Exists(id string) bool
 	Walk(fn func(id string) error) error
-	Set(info CacheKeyInfo) error
 
 	WalkResults(id string, fn func(CacheResult) error) error
 	Load(id string, resultID string) (CacheResult, error)
@@ -23,20 +22,6 @@ type CacheKeyStorage interface {
 
 	AddLink(id string, link CacheInfoLink, target string) error
 	WalkLinks(id string, link CacheInfoLink, fn func(id string) error) error
-}
-
-// CacheKeyInfo is storable metadata about single cache key
-type CacheKeyInfo struct {
-	ID     string
-	Base   digest.Digest
-	Output int
-	// Deps   []CacheKeyInfoWithSelector
-}
-
-// CacheKeyInfoWithSelector is CacheKeyInfo combined with a selector
-type CacheKeyInfoWithSelector struct {
-	ID       string
-	Selector digest.Digest
 }
 
 // CacheResult is a record for a single solve result

--- a/solver-next/cachestorage.go
+++ b/solver-next/cachestorage.go
@@ -30,7 +30,7 @@ type CacheKeyInfo struct {
 	ID     string
 	Base   digest.Digest
 	Output int
-	Deps   []CacheKeyInfoWithSelector
+	// Deps   []CacheKeyInfoWithSelector
 }
 
 // CacheKeyInfoWithSelector is CacheKeyInfo combined with a selector

--- a/solver-next/types.go
+++ b/solver-next/types.go
@@ -143,7 +143,7 @@ type CacheManager interface {
 	ID() string
 	// Query searches for cache paths from one cache key to the output of a
 	// possible match.
-	Query(inp []ExportableCacheKey, inputIndex Index, dgst digest.Digest, outputIndex Index, selector digest.Digest) ([]*CacheRecord, error)
+	Query(inp []CacheKeyWithSelector, inputIndex Index, dgst digest.Digest, outputIndex Index) ([]*CacheRecord, error)
 	// Load pulls and returns the cached result
 	Load(ctx context.Context, rec *CacheRecord) (Result, error)
 	// Save saves a result based on a cache key


### PR DESCRIPTION
This changes the cache management away from every cachekey tracking its full dependencies, making the code simpler and heavily reducing the duplicate calls.

The second commit simplifies the storage backend, removing the main contentkeyinfo storage and only persisting the links.

At least some changes still required(follow-up):
- Exporter should export the indirect deps for keys found by definition if they are roots (for the additional content based key)
- Internalkey should be different by backend(starts to matter for combined cache managers)
- Prune should call `cachestorage.Release()`
- Maybe: By adding a new method `GetRecords()` to cache interface we could avoid calling `WalkResults` for each input and only call it once per parent edge.