### PR TITLE
solver: don’t cancel child pipes from state change

### DIFF
--- a/solver-next/edge.go
+++ b/solver-next/edge.go
@@ -667,10 +667,7 @@ func (e *edge) createInputRequests(desiredState edgeStatusType, f *pipeFactory) 
 				e.depRequests[req] = dep
 				dep.req = req
 			}
-		} else if dep.req != nil && !dep.req.Status().Completed {
-			dep.req.Cancel()
 		}
-
 		// initialize function to compute cache key based on dependency result
 		if dep.state == edgeStatusComplete && dep.slowCacheReq == nil && e.slowCacheFunc(dep) != nil && e.cacheMap != nil {
 			fn := e.slowCacheFunc(dep)


### PR DESCRIPTION
I saw `TestHugeGraph` failing in CI. The issue seemed to be that cache function got called twice on certain conditions because the child pipe got canceled and then restarted because of other child pipes changed the internal state of the edge. I think there is no need to ever cancel a child pipe that is already running because of the internal state change. Eventually, one of the parents will complete and cancel the incoming request, closing down the pipes. If this doesn't happen we need the result anyway so it is more performant to keep it running.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>