### PR TITLE
examples: fix gobuild example

### DIFF
--- a/examples/gobuild/main.go
+++ b/examples/gobuild/main.go
@@ -43,7 +43,7 @@ func run() error {
 	_ = buildkitd
 
 	containerd, err := gb.BuildExe(gobuild.BuildOpt{
-		Source:    llb.Git("github.com/containerd/containerd", "master"),
+		Source:    llb.Git("github.com/containerd/containerd", "v1.0.2"),
 		MountPath: "/go/src/github.com/containerd/containerd",
 		Pkg:       "github.com/containerd/containerd/cmd/containerd",
 		BuildTags: []string{"no_btrfs"},


### PR DESCRIPTION
containerd master doesn't build with `go1.9` anymore

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>