### PR TITLE
Convert ReadonlyRootFS to a RunOption

### DIFF
--- a/client/llb/exec.go
+++ b/client/llb/exec.go
@@ -315,9 +315,10 @@ func AddMount(dest string, mountState State, opts ...MountOption) RunOption {
 	})
 }
 
-func ReadonlyRootFS(ei ExecInfo) ExecInfo {
-	ei.ReadonlyRootFS = true
-	return ei
+func ReadonlyRootFS() RunOption {
+	return runOptionFunc(func(ei *ExecInfo) {
+		ei.ReadonlyRootFS = true
+	})
 }
 
 type ExecInfo struct {


### PR DESCRIPTION
This seems to have missed out on an update/refactor at some point and was not
usable in its previous form without duplicating the `runOptionFunc`
scaffolding.

Signed-off-by: Ian Campbell <ijc@docker.com>

I tried to use this with:
```
	run := llb.Image("busybox:latest").Dir("/src").Run(
		llb.ReadonlyRootFS(),
```
and got:
```
OCI runtime create failed: container_linux.go:348: starting container process caused "process_linux.go:402: container init caused \"rootfs_linux.go:58: mounting \\\"proc\\\" to rootfs \\\"/run/containerd/io.containerd.runtime.v1.linux/buildkit/z6784cdfkkt1ht90tenq4h67n/rootfs\\\" at \\\"/proc\\\" caused \\\"mkdir /run/containerd/io.containerd.runtime.v1.linux/buildkit/z6784cdfkkt1ht90tenq4h67n/rootfs/proc: read-only file system\\\"\"": unknown
```
so at least for some base images this is not quite sufficient, but it is a step in the right direction, I think, and would presumably work with some other images.