### PR TITLE
Check that mounts have a Source when generating the OCI spec

### DIFF
--- a/executor/oci/spec_unix.go
+++ b/executor/oci/spec_unix.go
@@ -50,6 +50,9 @@ func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mou
 	sm := &submounts{}
 
 	for _, m := range mounts {
+		if m.Src == nil {
+			return nil, nil, errors.Errorf("mount %s has no source", m.Dest)
+		}
 		mounts, err := m.Src.Mount(ctx, m.Readonly)
 		if err != nil {
 			sm.cleanup()

--- a/solver/llbop/exec.go
+++ b/solver/llbop/exec.go
@@ -95,6 +95,11 @@ func (e *execOp) Run(ctx context.Context, inputs []solver.Ref) ([]solver.Ref, er
 				mountable = active
 			}
 		}
+
+		if mountable == nil {
+			return nil, errors.Errorf("mount %s has no input", m.Dest)
+		}
+
 		if m.Dest == pb.RootMount {
 			root = mountable
 		} else {


### PR DESCRIPTION
Otherwise the daemon panics.

Signed-off-by: Ian Campbell <ijc@docker.com>

This was my mistake on the client side but I suppose we don't want the daemon crashing...