### PR TITLE
Make llb.ReadonlyRootFS usable with common container images

### DIFF
--- a/executor/containerdexecutor/executor.go
+++ b/executor/containerdexecutor/executor.go
@@ -62,7 +62,11 @@ func (w containerdExecutor) Exec(ctx context.Context, meta executor.Meta, root c
 		lm.Unmount()
 	}
 
-	spec, cleanup, err := oci.GenerateSpec(ctx, meta, mounts, id, resolvConf, hostsFile, containerdoci.WithUIDGID(uid, gid))
+	opts := []containerdoci.SpecOpts{containerdoci.WithUIDGID(uid, gid)}
+	if meta.ReadonlyRootFS {
+		opts = append(opts, containerdoci.WithRootFSReadonly())
+	}
+	spec, cleanup, err := oci.GenerateSpec(ctx, meta, mounts, id, resolvConf, hostsFile, opts...)
 	if err != nil {
 		return err
 	}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -8,11 +8,12 @@ import (
 )
 
 type Meta struct {
-	Args []string
-	Env  []string
-	User string
-	Cwd  string
-	Tty  bool
+	Args           []string
+	Env            []string
+	User           string
+	Cwd            string
+	Tty            bool
+	ReadonlyRootFS bool
 	// DisableNetworking bool
 }
 

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -99,7 +99,11 @@ func (w *runcExecutor) Exec(ctx context.Context, meta executor.Meta, root cache.
 		return err
 	}
 	defer f.Close()
-	spec, cleanup, err := oci.GenerateSpec(ctx, meta, mounts, id, resolvConf, hostsFile, containerdoci.WithUIDGID(uid, gid), seccomp.WithDefaultProfile())
+	opts := []containerdoci.SpecOpts{containerdoci.WithUIDGID(uid, gid), seccomp.WithDefaultProfile()}
+	if meta.ReadonlyRootFS {
+		opts = append(opts, containerdoci.WithRootFSReadonly())
+	}
+	spec, cleanup, err := oci.GenerateSpec(ctx, meta, mounts, id, resolvConf, hostsFile, opts...)
 	if err != nil {
 		return err
 	}

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -457,7 +457,7 @@ func dispatchCopy(d *dispatchState, c instructions.SourcesAndDest, sourceState l
 	commitMessage.WriteString(" " + c.Dest())
 
 	args = append(args, dest)
-	run := img.Run(append([]llb.RunOption{llb.Args(args), dfCmd(cmdToPrint)}, mounts...)...)
+	run := img.Run(append([]llb.RunOption{llb.Args(args), llb.ReadonlyRootFS(), dfCmd(cmdToPrint)}, mounts...)...)
 	d.state = run.AddMount("/dest", d.state)
 
 	return commitToHistory(&d.image, commitMessage.String(), true, &d.state)

--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -64,6 +64,7 @@ func (gf *gatewayFrontend) Solve(ctx context.Context, llbBridge frontend.Fronten
 	_, isDevel := opts[keyDevel]
 	var img ocispec.Image
 	var rootFS cache.ImmutableRef
+	var readonly bool // TODO: try to switch to read-only by default.
 
 	if isDevel {
 		ref, exp, err := llbBridge.Solve(session.NewContext(ctx, "gateway:"+sid),
@@ -154,9 +155,10 @@ func (gf *gatewayFrontend) Solve(ctx context.Context, llbBridge frontend.Fronten
 	}()
 
 	err = llbBridge.Exec(ctx, executor.Meta{
-		Env:  env,
-		Args: args,
-		Cwd:  cwd,
+		Env:            env,
+		Args:           args,
+		Cwd:            cwd,
+		ReadonlyRootFS: readonly,
 	}, rootFS, lbf.Stdin, lbf.Stdout, os.Stderr)
 
 	if err != nil {

--- a/hack/test
+++ b/hack/test
@@ -8,7 +8,7 @@ docker build --iidfile $iidfile --target integration-tests -f ./hack/dockerfiles
 
 iid=$(cat $iidfile)
 
-docker run --rm -v /tmp --privileged $iid go test -tags no_containerd_worker ${TESTFLAGS:--v} ${TESTPKGS:-./...}
+docker run --rm -v /tmp --privileged $iid go test ${TESTFLAGS:--v} ${TESTPKGS:-./...}
 
 docker run --rm $iid go build ./frontend/gateway/client
 docker run --rm $iid go build ./frontend/dockerfile/cmd/dockerfile-frontend

--- a/worker/runc/runc_test.go
+++ b/worker/runc/runc_test.go
@@ -1,4 +1,4 @@
-// +build linux,no_containerd_worker
+// +build linux,!no_runc_worker
 
 package runc
 


### PR DESCRIPTION
busybox image):

    OCI runtime create failed: container_linux.go:348:
    starting container process caused "process_linux.go:402:
    container init caused \"rootfs_linux.go:58:
    mounting \\\"proc\\\" to rootfs \\\"/.../rootfs\\\" at \\\"/proc\\\"
    caused \\\"mkdir /.../rootfs/proc: read-only file system\\\"\"": unknown

This is because we were setting the underlying snapshot readonly so the various
mountpoints (here /proc) cannot be created. This would not be necessary if
those mountpoints were present in images but they typically are not.

The right way to get around this (used e.g. by `ctr`) is to use a writeable
snapshot but to set root readonly in the OCI spec. In this configuration the
rootfs is writeable when mounts are processed but is then made readonly by the
runtime (runc) just before entering the user specified binary within the
container.

This involved a surprising amount of plumbing.

Use this new found ability in the dockerfile converter's `dispatchCopy`
function.

Signed-off-by: Ian Campbell <ijc@docker.com>

I uses #323 to regenerate the protobuf but didn't include it in this PR.