### PR TITLE
git: fix cancellation on blocking remotes

### DIFF
--- a/source/git/gitsource_unix.go
+++ b/source/git/gitsource_unix.go
@@ -1,0 +1,27 @@
+// +build !windows
+
+package git
+
+import (
+	"context"
+	"os/exec"
+	"syscall"
+)
+
+func runProcessGroup(ctx context.Context, cmd *exec.Cmd) error {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	waitDone := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		case <-waitDone:
+		}
+	}()
+	err := cmd.Wait()
+	close(waitDone)
+	return err
+}

--- a/source/git/gitsource_windows.go
+++ b/source/git/gitsource_windows.go
@@ -1,0 +1,23 @@
+// +build windows
+
+package git
+
+import (
+	"context"
+	"os/exec"
+)
+
+func runProcessGroup(ctx context.Context, cmd *exec.Cmd) error {
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	waitDone := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			cmd.Process.Kill()
+		case <-waitDone:
+		}
+	}()
+	return cmd.Wait()
+}


### PR DESCRIPTION
Fixing issue where context cancellation didn't work for some git commands that were spawning helper processes. There may be a go issue in here, eg. `CommandContext` could kill the process group if `setpgid` is set.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>