### PR TITLE
session: separate authprovider to package

### DIFF
--- a/client/solve.go
+++ b/client/solve.go
@@ -12,7 +12,6 @@ import (
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/session"
-	"github.com/moby/buildkit/session/auth"
 	"github.com/moby/buildkit/session/filesync"
 	"github.com/moby/buildkit/session/grpchijack"
 	"github.com/moby/buildkit/solver/pb"
@@ -33,7 +32,7 @@ type SolveOpt struct {
 	FrontendAttrs     map[string]string
 	ExportCache       string
 	ImportCache       string
-	// Session string
+	Session           []session.Attachable
 }
 
 // Solve calls Solve on the controller.
@@ -76,7 +75,9 @@ func (c *Client) Solve(ctx context.Context, def *llb.Definition, opt SolveOpt, s
 		s.Allow(filesync.NewFSSyncProvider(syncedDirs))
 	}
 
-	s.Allow(auth.NewDockerAuthProvider())
+	for _, a := range opt.Session {
+		s.Allow(a)
+	}
 
 	switch opt.Exporter {
 	case ExporterLocal:

--- a/cmd/buildctl/build.go
+++ b/cmd/buildctl/build.go
@@ -11,6 +11,8 @@ import (
 	"github.com/containerd/console"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/session/auth/authprovider"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/progress/progressui"
 	"github.com/opencontainers/go-digest"
@@ -125,6 +127,7 @@ func build(clicontext *cli.Context) error {
 		// FrontendAttrs is set later
 		ExportCache: clicontext.String("export-cache"),
 		ImportCache: clicontext.String("import-cache"),
+		Session:     []session.Attachable{authprovider.NewDockerAuthProvider()},
 	}
 	solveOpt.ExporterAttrs, err = attrMap(clicontext.StringSlice("exporter-opt"))
 	if err != nil {

--- a/session/auth/auth.go
+++ b/session/auth/auth.go
@@ -2,46 +2,11 @@ package auth
 
 import (
 	"context"
-	"io/ioutil"
 
-	"github.com/docker/cli/cli/config"
-	"github.com/docker/cli/cli/config/configfile"
 	"github.com/moby/buildkit/session"
-	netcontext "golang.org/x/net/context"
-	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
-
-func NewDockerAuthProvider() session.Attachable {
-	return &authProvider{
-		config: config.LoadDefaultConfigFile(ioutil.Discard),
-	}
-}
-
-type authProvider struct {
-	config *configfile.ConfigFile
-}
-
-func (ap *authProvider) Register(server *grpc.Server) {
-	RegisterAuthServer(server, ap)
-}
-
-func (ap *authProvider) Credentials(ctx netcontext.Context, req *CredentialsRequest) (*CredentialsResponse, error) {
-	if req.Host == "registry-1.docker.io" {
-		req.Host = "https://index.docker.io/v1/"
-	}
-	ac, err := ap.config.GetAuthConfig(req.Host)
-	if err != nil {
-		return nil, err
-	}
-	res := &CredentialsResponse{}
-	if ac.IdentityToken != "" {
-		res.Secret = ac.IdentityToken
-	} else {
-		res.Username = ac.Username
-		res.Secret = ac.Password
-	}
-	return res, nil
-}
 
 func CredentialsFunc(ctx context.Context, c session.Caller) func(string) (string, string, error) {
 	return func(host string) (string, string, error) {
@@ -51,6 +16,9 @@ func CredentialsFunc(ctx context.Context, c session.Caller) func(string) (string
 			Host: host,
 		})
 		if err != nil {
+			if st, ok := status.FromError(err); ok && st.Code() == codes.Unimplemented {
+				return "", "", nil
+			}
 			return "", "", err
 		}
 		return resp.Username, resp.Secret, nil

--- a/session/auth/authprovider/authprovider.go
+++ b/session/auth/authprovider/authprovider.go
@@ -1,0 +1,44 @@
+package authprovider
+
+import (
+	"io/ioutil"
+
+	"github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/config/configfile"
+	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/session/auth"
+	netcontext "golang.org/x/net/context"
+	"google.golang.org/grpc"
+)
+
+func NewDockerAuthProvider() session.Attachable {
+	return &authProvider{
+		config: config.LoadDefaultConfigFile(ioutil.Discard),
+	}
+}
+
+type authProvider struct {
+	config *configfile.ConfigFile
+}
+
+func (ap *authProvider) Register(server *grpc.Server) {
+	auth.RegisterAuthServer(server, ap)
+}
+
+func (ap *authProvider) Credentials(ctx netcontext.Context, req *auth.CredentialsRequest) (*auth.CredentialsResponse, error) {
+	if req.Host == "registry-1.docker.io" {
+		req.Host = "https://index.docker.io/v1/"
+	}
+	ac, err := ap.config.GetAuthConfig(req.Host)
+	if err != nil {
+		return nil, err
+	}
+	res := &auth.CredentialsResponse{}
+	if ac.IdentityToken != "" {
+		res.Secret = ac.IdentityToken
+	} else {
+		res.Username = ac.Username
+		res.Secret = ac.Password
+	}
+	return res, nil
+}


### PR DESCRIPTION
Separate `authprovider` pkg so that everything that needs to import `client` (for example just for types) doesn't need dependency from `docker/cli`.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>