### PR TITLE
dockerfile: allow skipping resolving manifest

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -147,9 +147,11 @@ func Dockerfile2LLB(ctx context.Context, dt []byte, opt ConvertOpt) (*llb.State,
 								return err
 							}
 							d.image = img
-							ref, err := reference.WithDigest(ref, dgst)
-							if err != nil {
-								return err
+							if dgst != "" {
+								ref, err = reference.WithDigest(ref, dgst)
+								if err != nil {
+									return err
+								}
 							}
 							d.stage.BaseName = ref.String()
 							_ = ref


### PR DESCRIPTION
Make it optional for `ResolveImageConfig` to return manifest digest, so it can be implemented if only image configs are available.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>