### PR TITLE
solver: add support for multiple cache keys

### DIFF
--- a/solver-next/cachestorage.go
+++ b/solver-next/cachestorage.go
@@ -19,6 +19,7 @@ type CacheKeyStorage interface {
 	Load(id string, resultID string) (CacheResult, error)
 	AddResult(id string, res CacheResult) error
 	Release(resultID string) error
+	WalkIDsByResult(resultID string, fn func(string) error) error
 
 	AddLink(id string, link CacheInfoLink, target string) error
 	WalkLinks(id string, link CacheInfoLink, fn func(id string) error) error

--- a/solver-next/memorycachestorage.go
+++ b/solver-next/memorycachestorage.go
@@ -116,6 +116,24 @@ func (s *inMemoryStore) AddResult(id string, res CacheResult) error {
 	return nil
 }
 
+func (s *inMemoryStore) WalkIDsByResult(resultID string, fn func(string) error) error {
+	s.mu.Lock()
+
+	ids := map[string]struct{}{}
+	for id := range s.byResult[resultID] {
+		ids[id] = struct{}{}
+	}
+	s.mu.Unlock()
+
+	for id := range ids {
+		if err := fn(id); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (s *inMemoryStore) Release(resultID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/solver-next/types.go
+++ b/solver-next/types.go
@@ -89,8 +89,9 @@ type CacheLink struct {
 
 // Op is an implementation for running a vertex
 type Op interface {
-	// CacheMap returns structure describing how the operation is cached
-	CacheMap(context.Context) (*CacheMap, error)
+	// CacheMap returns structure describing how the operation is cached.
+	// Currently only roots are allowed to return multiple cache maps per op.
+	CacheMap(context.Context, int) (*CacheMap, bool, error)
 	// Exec runs an operation given results from previous operations.
 	Exec(ctx context.Context, inputs []Result) (outputs []Result, err error)
 }


### PR DESCRIPTION
Add support for an operation to return multiple cache keys. Index parameter is added to `CacheMap` method that is incremented every time the method is called and the function returns a bool to indicate if more results may be expected. Currently, only root nodes can return multiple keys. If a key causes a cache match the later ones are not queried.

This will be used for image source where one key is the manifest digest and another image config digest(or chainID) so that you can get a quick match by one but if only blobs/config changes in the image it will not invalidate the cache. For HTTP sources this can be used to have a first cache key that is "url+etag" and a second one that is the checksum of the content. Currently, we only support checksum of the content, meaning that we need to pull the data to match it with an existing cache.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>