### PR TITLE
snapshot: update mounts to mountable interface

### DIFF
--- a/cache/blobs/blobs.go
+++ b/cache/blobs/blobs.go
@@ -59,15 +59,25 @@ func GetDiffPairs(ctx context.Context, contentStore content.Store, snapshotter s
 			var lower []mount.Mount
 			if parent != nil {
 				defer parent.Release(context.TODO())
-				lower, err = parent.Mount(ctx, true)
+				m, err := parent.Mount(ctx, true)
 				if err != nil {
 					return nil, err
 				}
+				lower, err = m.Mount()
+				if err != nil {
+					return nil, err
+				}
+				defer m.Release()
 			}
-			upper, err := ref.Mount(ctx, true)
+			m, err := ref.Mount(ctx, true)
 			if err != nil {
 				return nil, err
 			}
+			upper, err := m.Mount()
+			if err != nil {
+				return nil, err
+			}
+			defer m.Release()
 			descr, err := differ.Compare(ctx, lower, upper,
 				diff.WithMediaType(ocispec.MediaTypeImageLayerGzip),
 				diff.WithReference(ref.ID()),

--- a/cache/contenthash/checksum_test.go
+++ b/cache/contenthash/checksum_test.go
@@ -442,7 +442,7 @@ func setupCacheManager(t *testing.T, tmpdir string, snapshotter snapshots.Snapsh
 	require.NoError(t, err)
 
 	cm, err := cache.NewManager(cache.ManagerOpt{
-		Snapshotter:   snapshotter,
+		Snapshotter:   snapshot.FromContainerdSnapshotter(snapshotter),
 		MetadataStore: md,
 	})
 	require.NoError(t, err)

--- a/cache/manager.go
+++ b/cache/manager.go
@@ -10,6 +10,7 @@ import (
 	"github.com/moby/buildkit/cache/metadata"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/identity"
+	"github.com/moby/buildkit/snapshot"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
@@ -22,7 +23,7 @@ var (
 )
 
 type ManagerOpt struct {
-	Snapshotter   snapshots.Snapshotter
+	Snapshotter   snapshot.SnapshotterBase
 	GCPolicy      GCPolicy
 	MetadataStore *metadata.Store
 }
@@ -219,7 +220,7 @@ func (cm *cacheManager) New(ctx context.Context, s ImmutableRef, opts ...RefOpti
 		parentID = parent.ID()
 	}
 
-	if _, err := cm.Snapshotter.Prepare(ctx, id, parentID); err != nil {
+	if err := cm.Snapshotter.Prepare(ctx, id, parentID); err != nil {
 		if parent != nil {
 			parent.Release(context.TODO())
 		}

--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -374,7 +374,7 @@ func getCacheManager(t *testing.T, tmpdir string, snapshotter snapshots.Snapshot
 	require.NoError(t, err)
 
 	cm, err := NewManager(ManagerOpt{
-		Snapshotter:   snapshotter,
+		Snapshotter:   snapshot.FromContainerdSnapshotter(snapshotter),
 		MetadataStore: md,
 	})
 	require.NoError(t, err, fmt.Sprintf("error: %+v", err))

--- a/cache/refs.go
+++ b/cache/refs.go
@@ -7,6 +7,7 @@ import (
 	"github.com/containerd/containerd/mount"
 	"github.com/moby/buildkit/cache/metadata"
 	"github.com/moby/buildkit/identity"
+	"github.com/moby/buildkit/snapshot"
 	"github.com/moby/buildkit/util/flightcontrol"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -33,7 +34,7 @@ type MutableRef interface {
 }
 
 type Mountable interface {
-	Mount(ctx context.Context, readonly bool) ([]mount.Mount, error)
+	Mount(ctx context.Context, readonly bool) (snapshot.Mountable, error)
 }
 
 type cacheRecord struct {
@@ -49,7 +50,7 @@ type cacheRecord struct {
 	dead bool
 
 	view      string
-	viewMount []mount.Mount
+	viewMount snapshot.Mountable
 
 	sizeG flightcontrol.Group
 
@@ -120,7 +121,7 @@ func (cr *cacheRecord) Parent() ImmutableRef {
 	return p.ref()
 }
 
-func (cr *cacheRecord) Mount(ctx context.Context, readonly bool) ([]mount.Mount, error) {
+func (cr *cacheRecord) Mount(ctx context.Context, readonly bool) (snapshot.Mountable, error) {
 	cr.mu.Lock()
 	defer cr.mu.Unlock()
 
@@ -341,7 +342,19 @@ func (sr *mutableRef) release(ctx context.Context) error {
 	return nil
 }
 
-func setReadonly(mounts []mount.Mount) []mount.Mount {
+func setReadonly(mounts snapshot.Mountable) snapshot.Mountable {
+	return &readOnlyMounter{mounts}
+}
+
+type readOnlyMounter struct {
+	snapshot.Mountable
+}
+
+func (m *readOnlyMounter) Mount() ([]mount.Mount, error) {
+	mounts, err := m.Mountable.Mount()
+	if err != nil {
+		return nil, err
+	}
 	for i, m := range mounts {
 		opts := make([]string, 0, len(m.Options))
 		for _, opt := range m.Options {
@@ -352,5 +365,5 @@ func setReadonly(mounts []mount.Mount) []mount.Mount {
 		opts = append(opts, "ro")
 		mounts[i].Options = opts
 	}
-	return mounts
+	return mounts, nil
 }

--- a/executor/containerdexecutor/executor.go
+++ b/executor/containerdexecutor/executor.go
@@ -42,14 +42,20 @@ func (w containerdExecutor) Exec(ctx context.Context, meta executor.Meta, root c
 		return err
 	}
 
-	rootMounts, err := root.Mount(ctx, false)
+	mountable, err := root.Mount(ctx, false)
 	if err != nil {
 		return err
 	}
 
+	rootMounts, err := mountable.Mount()
+	if err != nil {
+		return err
+	}
+	defer mountable.Release()
+
 	uid, gid, err := oci.ParseUser(meta.User)
 	if err != nil {
-		lm := snapshot.LocalMounter(rootMounts)
+		lm := snapshot.LocalMounterWithMounts(rootMounts)
 		rootfsPath, err := lm.Mount()
 		if err != nil {
 			return err

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -92,10 +92,16 @@ func (w *runcExecutor) Exec(ctx context.Context, meta executor.Meta, root cache.
 		return err
 	}
 
-	rootMount, err := root.Mount(ctx, false)
+	mountable, err := root.Mount(ctx, false)
 	if err != nil {
 		return err
 	}
+
+	rootMount, err := mountable.Mount()
+	if err != nil {
+		return err
+	}
+	defer mountable.Release()
 
 	id := identity.NewID()
 	bundle := filepath.Join(w.root, id)

--- a/snapshot/blobmapping/snapshotter.go
+++ b/snapshot/blobmapping/snapshotter.go
@@ -16,7 +16,7 @@ const blobKey = "blobmapping.blob"
 
 type Opt struct {
 	Content       content.Store
-	Snapshotter   snapshots.Snapshotter
+	Snapshotter   snapshot.SnapshotterBase
 	MetadataStore *metadata.Store
 }
 
@@ -33,14 +33,14 @@ type DiffPair struct {
 // this snapshotter keeps an internal mapping between a snapshot and a blob
 
 type Snapshotter struct {
-	snapshots.Snapshotter
+	snapshot.SnapshotterBase
 	opt Opt
 }
 
 func NewSnapshotter(opt Opt) snapshot.Snapshotter {
 	s := &Snapshotter{
-		Snapshotter: opt.Snapshotter,
-		opt:         opt,
+		SnapshotterBase: opt.Snapshotter,
+		opt:             opt,
 	}
 
 	return s
@@ -59,7 +59,7 @@ func (s *Snapshotter) Remove(ctx context.Context, key string) error {
 		return err
 	}
 
-	if err := s.Snapshotter.Remove(ctx, key); err != nil {
+	if err := s.SnapshotterBase.Remove(ctx, key); err != nil {
 		return err
 	}
 
@@ -72,7 +72,7 @@ func (s *Snapshotter) Remove(ctx context.Context, key string) error {
 }
 
 func (s *Snapshotter) Usage(ctx context.Context, key string) (snapshots.Usage, error) {
-	u, err := s.Snapshotter.Usage(ctx, key)
+	u, err := s.SnapshotterBase.Usage(ctx, key)
 	if err != nil {
 		return snapshots.Usage{}, err
 	}

--- a/snapshot/containerd/snapshotter.go
+++ b/snapshot/containerd/snapshotter.go
@@ -16,7 +16,7 @@ import (
 func NewSnapshotter(snapshotter ctdsnapshot.Snapshotter, store content.Store, mdstore *metadata.Store, ns string, gc func(context.Context) error) snapshot.Snapshotter {
 	return blobmapping.NewSnapshotter(blobmapping.Opt{
 		Content:       store,
-		Snapshotter:   &nsSnapshotter{ns, snapshotter, gc},
+		Snapshotter:   snapshot.FromContainerdSnapshotter(&nsSnapshotter{ns, snapshotter, gc}),
 		MetadataStore: mdstore,
 	})
 }

--- a/snapshot/localmounter_unix.go
+++ b/snapshot/localmounter_unix.go
@@ -21,5 +21,9 @@ func (lm *localMounter) Unmount() error {
 		lm.target = ""
 	}
 
+	if lm.mountable != nil {
+		return lm.mountable.Release()
+	}
+
 	return nil
 }

--- a/snapshot/localmounter_windows.go
+++ b/snapshot/localmounter_windows.go
@@ -18,5 +18,9 @@ func (lm *localMounter) Unmount() error {
 		lm.target = ""
 	}
 
+	if lm.mountable != nil {
+		return lm.mountable.Release()
+	}
+
 	return nil
 }

--- a/snapshot/snapshotter.go
+++ b/snapshot/snapshotter.go
@@ -2,18 +2,136 @@ package snapshot
 
 import (
 	"context"
+	"sync"
 
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/snapshots"
 	digest "github.com/opencontainers/go-digest"
 )
 
+type Mountable interface {
+	// ID() string
+	Mount() ([]mount.Mount, error)
+	Release() error
+}
+
+type SnapshotterBase interface {
+	Mounts(ctx context.Context, key string) (Mountable, error)
+	Prepare(ctx context.Context, key, parent string, opts ...snapshots.Opt) error
+	View(ctx context.Context, key, parent string, opts ...snapshots.Opt) (Mountable, error)
+
+	Stat(ctx context.Context, key string) (snapshots.Info, error)
+	Update(ctx context.Context, info snapshots.Info, fieldpaths ...string) (snapshots.Info, error)
+	Usage(ctx context.Context, key string) (snapshots.Usage, error)
+	Commit(ctx context.Context, name, key string, opts ...snapshots.Opt) error
+	Remove(ctx context.Context, key string) error
+	Walk(ctx context.Context, fn func(context.Context, snapshots.Info) error) error
+	Close() error
+}
+
 // Snapshotter defines interface that any snapshot implementation should satisfy
 type Snapshotter interface {
-	snapshots.Snapshotter
 	Blobmapper
+	SnapshotterBase
 }
 
 type Blobmapper interface {
 	GetBlob(ctx context.Context, key string) (digest.Digest, digest.Digest, error)
 	SetBlob(ctx context.Context, key string, diffID, blob digest.Digest) error
+}
+
+func FromContainerdSnapshotter(s snapshots.Snapshotter) SnapshotterBase {
+	return &fromContainerd{Snapshotter: s}
+}
+
+type fromContainerd struct {
+	snapshots.Snapshotter
+}
+
+func (s *fromContainerd) Mounts(ctx context.Context, key string) (Mountable, error) {
+	mounts, err := s.Snapshotter.Mounts(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	return &staticMountable{mounts}, nil
+}
+func (s *fromContainerd) Prepare(ctx context.Context, key, parent string, opts ...snapshots.Opt) error {
+	_, err := s.Snapshotter.Prepare(ctx, key, parent, opts...)
+	return err
+}
+func (s *fromContainerd) View(ctx context.Context, key, parent string, opts ...snapshots.Opt) (Mountable, error) {
+	mounts, err := s.Snapshotter.View(ctx, key, parent, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &staticMountable{mounts}, nil
+}
+
+type staticMountable struct {
+	mounts []mount.Mount
+}
+
+func (m *staticMountable) Mount() ([]mount.Mount, error) {
+	return m.mounts, nil
+}
+
+func (cm *staticMountable) Release() error {
+	return nil
+}
+
+// NewContainerdSnapshotter converts snapshotter to containerd snapshotter
+func NewContainerdSnapshotter(s Snapshotter) (snapshots.Snapshotter, func() error) {
+	cs := &containerdSnapshotter{Snapshotter: s}
+	return cs, cs.release
+}
+
+type containerdSnapshotter struct {
+	mu        sync.Mutex
+	releasers []func() error
+	Snapshotter
+}
+
+func (cs *containerdSnapshotter) release() error {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	var err error
+	for _, f := range cs.releasers {
+		if err1 := f(); err != nil && err == nil {
+			err = err1
+		}
+	}
+	return err
+}
+
+func (cs *containerdSnapshotter) returnMounts(mf Mountable) ([]mount.Mount, error) {
+	mounts, err := mf.Mount()
+	if err != nil {
+		return nil, err
+	}
+	cs.mu.Lock()
+	cs.releasers = append(cs.releasers, mf.Release)
+	cs.mu.Unlock()
+	return mounts, nil
+}
+
+func (cs *containerdSnapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, error) {
+	mf, err := cs.Snapshotter.Mounts(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	return cs.returnMounts(mf)
+}
+
+func (cs *containerdSnapshotter) Prepare(ctx context.Context, key, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
+	if err := cs.Snapshotter.Prepare(ctx, key, parent, opts...); err != nil {
+		return nil, err
+	}
+	return cs.Mounts(ctx, key)
+}
+func (cs *containerdSnapshotter) View(ctx context.Context, key, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
+	mf, err := cs.Snapshotter.View(ctx, key, parent, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return cs.returnMounts(mf)
 }

--- a/source/git/gitsource_test.go
+++ b/source/git/gitsource_test.go
@@ -295,7 +295,7 @@ func setupGitSource(t *testing.T, tmpdir string) source.Source {
 	assert.NoError(t, err)
 
 	cm, err := cache.NewManager(cache.ManagerOpt{
-		Snapshotter:   snapshotter,
+		Snapshotter:   snapshot.FromContainerdSnapshotter(snapshotter),
 		MetadataStore: md,
 	})
 	assert.NoError(t, err)

--- a/source/http/httpsource_test.go
+++ b/source/http/httpsource_test.go
@@ -315,7 +315,7 @@ func newHTTPSource(tmpdir string) (source.Source, error) {
 	}
 
 	cm, err := cache.NewManager(cache.ManagerOpt{
-		Snapshotter:   snapshotter,
+		Snapshotter:   snapshot.FromContainerdSnapshotter(snapshotter),
 		MetadataStore: md,
 	})
 	if err != nil {


### PR DESCRIPTION
Wrap mounts with an interface to allow more freedom on implementing them when a stateless mounts array cannot be created.

@dmcgowan 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>