### PR TITLE
solver: fix flaky merged keys test

### DIFF
--- a/solver-next/edge.go
+++ b/solver-next/edge.go
@@ -829,6 +829,10 @@ func (e *edge) execOp(ctx context.Context) (interface{}, error) {
 			return nil, err
 		}
 
+		if exp, ok := ck.Exporter.(*exporter); ok {
+			exp.edge = e
+		}
+
 		exps := make([]Exporter, 0, len(subExporters))
 		for _, exp := range subExporters {
 			exps = append(exps, exp.Exporter)

--- a/solver-next/scheduler.go
+++ b/solver-next/scheduler.go
@@ -285,6 +285,9 @@ func (s *Scheduler) mergeTo(target, src *edge) bool {
 		for _, k := range d.keys {
 			target.secondaryExporters = append(target.secondaryExporters, expDep{i, CacheKeyWithSelector{CacheKey: k, Selector: src.cacheMap.Deps[i].Selector}})
 		}
+		if d.slowCacheKey != nil {
+			target.secondaryExporters = append(target.secondaryExporters, expDep{i, CacheKeyWithSelector{CacheKey: *d.slowCacheKey}})
+		}
 		if d.result != nil {
 			target.secondaryExporters = append(target.secondaryExporters, expDep{i, CacheKeyWithSelector{CacheKey: d.result.CacheKey(), Selector: src.cacheMap.Deps[i].Selector}})
 		}


### PR DESCRIPTION
This is a fix for flakiness of `TestCacheExportingMergedKey`. The problem was that if a merged key caused a new cache record to be saved, the deps from the original source were not carried over. Didn't appear if one the merge target already had a cache-match or result.

Also, make sure that the slow cache key from source is maintained, although in almost all cases if this key exists, it should also be the key that caused the match and already captured by the destination.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>