### PR TITLE
solver: event dispatcher update and public api cleanup

### DIFF
--- a/solver-next/edge.go
+++ b/solver-next/edge.go
@@ -23,7 +23,7 @@ func (t edgeStatusType) String() string {
 	return []string{"initial", "cache-fast", "cache-slow", "complete"}[t]
 }
 
-func newEdge(ed Edge, op activeOp, index *EdgeIndex) *edge {
+func newEdge(ed Edge, op activeOp, index *edgeIndex) *edge {
 	e := &edge{
 		edge:         ed,
 		op:           op,
@@ -61,7 +61,7 @@ type edge struct {
 
 	releaserCount int
 	keysDidChange bool
-	index         *EdgeIndex
+	index         *edgeIndex
 
 	secondaryExporters []expDep
 }

--- a/solver-next/index.go
+++ b/solver-next/index.go
@@ -6,8 +6,8 @@ import (
 	"github.com/moby/buildkit/identity"
 )
 
-// EdgeIndex is a synchronous map for detecting edge collisions.
-type EdgeIndex struct {
+// edgeIndex is a synchronous map for detecting edge collisions.
+type edgeIndex struct {
 	mu sync.Mutex
 
 	items    map[string]*indexItem
@@ -20,14 +20,14 @@ type indexItem struct {
 	deps  map[string]struct{}
 }
 
-func NewEdgeIndex() *EdgeIndex {
-	return &EdgeIndex{
+func newEdgeIndex() *edgeIndex {
+	return &edgeIndex{
 		items:    map[string]*indexItem{},
 		backRefs: map[*edge]map[string]struct{}{},
 	}
 }
 
-func (ei *EdgeIndex) Release(e *edge) {
+func (ei *edgeIndex) Release(e *edge) {
 	ei.mu.Lock()
 	defer ei.mu.Unlock()
 
@@ -37,7 +37,7 @@ func (ei *EdgeIndex) Release(e *edge) {
 	delete(ei.backRefs, e)
 }
 
-func (ei *EdgeIndex) releaseEdge(id string, e *edge) {
+func (ei *edgeIndex) releaseEdge(id string, e *edge) {
 	item, ok := ei.items[id]
 	if !ok {
 		return
@@ -53,7 +53,7 @@ func (ei *EdgeIndex) releaseEdge(id string, e *edge) {
 	}
 }
 
-func (ei *EdgeIndex) releaseLink(id, target string) {
+func (ei *edgeIndex) releaseLink(id, target string) {
 	item, ok := ei.items[id]
 	if !ok {
 		return
@@ -78,7 +78,7 @@ func (ei *EdgeIndex) releaseLink(id, target string) {
 	}
 }
 
-func (ei *EdgeIndex) LoadOrStore(k *CacheKey, e *edge) *edge {
+func (ei *edgeIndex) LoadOrStore(k *CacheKey, e *edge) *edge {
 	ei.mu.Lock()
 	defer ei.mu.Unlock()
 
@@ -121,7 +121,7 @@ func (ei *EdgeIndex) LoadOrStore(k *CacheKey, e *edge) *edge {
 }
 
 // enforceLinked adds links from current ID to all dep keys
-func (er *EdgeIndex) enforceLinked(id string, k *CacheKey) {
+func (er *edgeIndex) enforceLinked(id string, k *CacheKey) {
 	main, ok := er.items[id]
 	if !ok {
 		main = &indexItem{
@@ -153,7 +153,7 @@ func (er *EdgeIndex) enforceLinked(id string, k *CacheKey) {
 	}
 }
 
-func (ei *EdgeIndex) enforceIndexID(k *CacheKey) {
+func (ei *edgeIndex) enforceIndexID(k *CacheKey) {
 	if len(k.indexIDs) > 0 {
 		return
 	}
@@ -171,7 +171,7 @@ func (ei *EdgeIndex) enforceIndexID(k *CacheKey) {
 	}
 }
 
-func (ei *EdgeIndex) getAllMatches(k *CacheKey) []string {
+func (ei *edgeIndex) getAllMatches(k *CacheKey) []string {
 	deps := k.Deps()
 
 	if len(deps) == 0 {

--- a/solver-next/index_test.go
+++ b/solver-next/index_test.go
@@ -6,13 +6,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func checkEmpty(t *testing.T, ei *EdgeIndex) {
+func checkEmpty(t *testing.T, ei *edgeIndex) {
 	require.Equal(t, len(ei.items), 0)
 	require.Equal(t, len(ei.backRefs), 0)
 }
 
 func TestIndexSimple(t *testing.T) {
-	idx := NewEdgeIndex()
+	idx := newEdgeIndex()
 
 	e1 := &edge{}
 	e2 := &edge{}
@@ -41,7 +41,7 @@ func TestIndexSimple(t *testing.T) {
 }
 
 func TestIndexMultiLevelSimple(t *testing.T) {
-	idx := NewEdgeIndex()
+	idx := newEdgeIndex()
 
 	e1 := &edge{}
 	e2 := &edge{}
@@ -133,7 +133,7 @@ func TestIndexMultiLevelSimple(t *testing.T) {
 }
 
 func TestIndexThreeLevels(t *testing.T) {
-	idx := NewEdgeIndex()
+	idx := newEdgeIndex()
 
 	e1 := &edge{}
 	e2 := &edge{}

--- a/solver-next/scheduler.go
+++ b/solver-next/scheduler.go
@@ -12,8 +12,8 @@ import (
 
 const debugScheduler = false // TODO: replace with logs in build trace
 
-func NewScheduler(ef EdgeFactory) *Scheduler {
-	s := &Scheduler{
+func newScheduler(ef edgeFactory) *scheduler {
+	s := &scheduler{
 		waitq:    map[*edge]struct{}{},
 		incoming: map[*edge][]*edgePipe{},
 		outgoing: map[*edge][]*edgePipe{},
@@ -35,12 +35,12 @@ type dispatcher struct {
 	e    *edge
 }
 
-type Scheduler struct {
+type scheduler struct {
 	cond *cond.StatefulCond
 	mu   sync.Mutex
 	muQ  sync.Mutex
 
-	ef EdgeFactory
+	ef edgeFactory
 
 	waitq       map[*edge]struct{}
 	next        *dispatcher
@@ -53,14 +53,14 @@ type Scheduler struct {
 	outgoing map[*edge][]*edgePipe
 }
 
-func (s *Scheduler) Stop() {
+func (s *scheduler) Stop() {
 	s.stoppedOnce.Do(func() {
 		close(s.stopped)
 	})
 	<-s.closed
 }
 
-func (s *Scheduler) loop() {
+func (s *scheduler) loop() {
 	defer func() {
 		close(s.closed)
 	}()
@@ -99,7 +99,7 @@ func (s *Scheduler) loop() {
 }
 
 // dispatch schedules an edge to be processed
-func (s *Scheduler) dispatch(e *edge) {
+func (s *scheduler) dispatch(e *edge) {
 	inc := make([]pipe.Sender, len(s.incoming[e]))
 	for i, p := range s.incoming[e] {
 		inc[i] = p.Sender
@@ -158,7 +158,7 @@ func (s *Scheduler) dispatch(e *edge) {
 			if origEdge != nil {
 				logrus.Debugf("merging edge %s to %s\n", e.edge.Vertex.Name(), origEdge.edge.Vertex.Name())
 				if s.mergeTo(origEdge, e) {
-					s.ef.SetEdge(e.edge, origEdge)
+					s.ef.setEdge(e.edge, origEdge)
 				}
 			}
 		}
@@ -178,7 +178,7 @@ func (s *Scheduler) dispatch(e *edge) {
 }
 
 // signal notifies that an edge needs to be processed again
-func (s *Scheduler) signal(e *edge) {
+func (s *scheduler) signal(e *edge) {
 	s.muQ.Lock()
 	if _, ok := s.waitq[e]; !ok {
 		d := &dispatcher{e: e}
@@ -195,9 +195,9 @@ func (s *Scheduler) signal(e *edge) {
 }
 
 // build evaluates edge into a result
-func (s *Scheduler) build(ctx context.Context, edge Edge) (CachedResult, error) {
+func (s *scheduler) build(ctx context.Context, edge Edge) (CachedResult, error) {
 	s.mu.Lock()
-	e := s.ef.GetEdge(edge)
+	e := s.ef.getEdge(edge)
 	if e == nil {
 		s.mu.Unlock()
 		return nil, errors.Errorf("invalid request %v for build", edge)
@@ -232,7 +232,7 @@ func (s *Scheduler) build(ctx context.Context, edge Edge) (CachedResult, error) 
 }
 
 // newPipe creates a new request pipe between two edges
-func (s *Scheduler) newPipe(target, from *edge, req pipe.Request) *pipe.Pipe {
+func (s *scheduler) newPipe(target, from *edge, req pipe.Request) *pipe.Pipe {
 	p := &edgePipe{
 		Pipe:   pipe.New(req),
 		Target: target,
@@ -258,7 +258,7 @@ func (s *Scheduler) newPipe(target, from *edge, req pipe.Request) *pipe.Pipe {
 }
 
 // newRequestWithFunc creates a new request pipe that invokes a async function
-func (s *Scheduler) newRequestWithFunc(e *edge, f func(context.Context) (interface{}, error)) pipe.Receiver {
+func (s *scheduler) newRequestWithFunc(e *edge, f func(context.Context) (interface{}, error)) pipe.Receiver {
 	pp, start := pipe.NewWithFunction(f)
 	p := &edgePipe{
 		Pipe: pp,
@@ -275,7 +275,7 @@ func (s *Scheduler) newRequestWithFunc(e *edge, f func(context.Context) (interfa
 }
 
 // mergeTo merges the state from one edge to another. source edge is discarded.
-func (s *Scheduler) mergeTo(target, src *edge) bool {
+func (s *scheduler) mergeTo(target, src *edge) bool {
 	if !target.edge.Vertex.Options().IgnoreCache && src.edge.Vertex.Options().IgnoreCache {
 		return false
 	}
@@ -315,19 +315,19 @@ func (s *Scheduler) mergeTo(target, src *edge) bool {
 	return true
 }
 
-// EdgeFactory allows access to the edges from a shared graph
-type EdgeFactory interface {
-	GetEdge(Edge) *edge
-	SetEdge(Edge, *edge)
+// edgeFactory allows access to the edges from a shared graph
+type edgeFactory interface {
+	getEdge(Edge) *edge
+	setEdge(Edge, *edge)
 }
 
 type pipeFactory struct {
 	e *edge
-	s *Scheduler
+	s *scheduler
 }
 
 func (pf *pipeFactory) NewInputRequest(ee Edge, req *edgeRequest) pipe.Receiver {
-	target := pf.s.ef.GetEdge(ee)
+	target := pf.s.ef.getEdge(ee)
 	if target == nil {
 		panic("failed to get edge") // TODO: return errored pipe
 	}

--- a/solver-next/scheduler_test.go
+++ b/solver-next/scheduler_test.go
@@ -31,7 +31,7 @@ func TestSingleLevelActiveGraph(t *testing.T) {
 	t.Parallel()
 	ctx := context.TODO()
 
-	s := NewJobList(SolverOpt{
+	s := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 	})
 	defer s.Close()
@@ -210,7 +210,7 @@ func TestSingleLevelCache(t *testing.T) {
 	t.Parallel()
 	ctx := context.TODO()
 
-	s := NewJobList(SolverOpt{
+	s := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 	})
 	defer s.Close()
@@ -307,7 +307,7 @@ func TestSingleLevelCacheParallel(t *testing.T) {
 	t.Parallel()
 	ctx := context.TODO()
 
-	s := NewJobList(SolverOpt{
+	s := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 	})
 	defer s.Close()
@@ -383,7 +383,7 @@ func TestMultiLevelCacheParallel(t *testing.T) {
 	t.Parallel()
 	ctx := context.TODO()
 
-	s := NewJobList(SolverOpt{
+	s := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 	})
 	defer s.Close()
@@ -474,7 +474,7 @@ func TestSingleCancelCache(t *testing.T) {
 	t.Parallel()
 	ctx := context.TODO()
 
-	s := NewJobList(SolverOpt{
+	s := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 	})
 	defer s.Close()
@@ -517,7 +517,7 @@ func TestSingleCancelExec(t *testing.T) {
 	t.Parallel()
 	ctx := context.TODO()
 
-	s := NewJobList(SolverOpt{
+	s := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 	})
 	defer s.Close()
@@ -560,7 +560,7 @@ func TestSingleCancelParallel(t *testing.T) {
 	t.Parallel()
 	ctx := context.TODO()
 
-	s := NewJobList(SolverOpt{
+	s := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 	})
 	defer s.Close()
@@ -635,7 +635,7 @@ func TestMultiLevelCalculation(t *testing.T) {
 	t.Parallel()
 	ctx := context.TODO()
 
-	l := NewJobList(SolverOpt{
+	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 	})
 	defer l.Close()
@@ -723,7 +723,7 @@ func TestHugeGraph(t *testing.T) {
 
 	cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
-	l := NewJobList(SolverOpt{
+	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 		DefaultCache:  cacheManager,
 	})
@@ -783,7 +783,7 @@ func TestOptimizedCacheAccess(t *testing.T) {
 
 	cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
-	l := NewJobList(SolverOpt{
+	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 		DefaultCache:  cacheManager,
 	})
@@ -890,7 +890,7 @@ func TestOptimizedCacheAccess2(t *testing.T) {
 
 	cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
-	l := NewJobList(SolverOpt{
+	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 		DefaultCache:  cacheManager,
 	})
@@ -1041,7 +1041,7 @@ func TestSlowCache(t *testing.T) {
 
 	rand.Seed(time.Now().UnixNano())
 
-	l := NewJobList(SolverOpt{
+	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 	})
 	defer l.Close()
@@ -1123,7 +1123,7 @@ func TestParallelInputs(t *testing.T) {
 
 	rand.Seed(time.Now().UnixNano())
 
-	l := NewJobList(SolverOpt{
+	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 	})
 	defer l.Close()
@@ -1182,7 +1182,7 @@ func TestErrorReturns(t *testing.T) {
 
 	rand.Seed(time.Now().UnixNano())
 
-	l := NewJobList(SolverOpt{
+	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 	})
 	defer l.Close()
@@ -1316,7 +1316,7 @@ func TestMultipleCacheSources(t *testing.T) {
 
 	cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
-	l := NewJobList(SolverOpt{
+	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 		DefaultCache:  cacheManager,
 	})
@@ -1356,7 +1356,7 @@ func TestMultipleCacheSources(t *testing.T) {
 
 	cacheManager2 := newTrackingCacheManager(NewInMemoryCacheManager())
 
-	l2 := NewJobList(SolverOpt{
+	l2 := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 		DefaultCache:  cacheManager2,
 	})
@@ -1430,7 +1430,7 @@ func TestRepeatBuildWithIgnoreCache(t *testing.T) {
 	t.Parallel()
 	ctx := context.TODO()
 
-	l := NewJobList(SolverOpt{
+	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 	})
 	defer l.Close()
@@ -1551,7 +1551,7 @@ func TestIgnoreCacheResumeFromSlowCache(t *testing.T) {
 	t.Parallel()
 	ctx := context.TODO()
 
-	l := NewJobList(SolverOpt{
+	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 	})
 	defer l.Close()
@@ -1638,7 +1638,7 @@ func TestParallelBuildsIgnoreCache(t *testing.T) {
 	t.Parallel()
 	ctx := context.TODO()
 
-	l := NewJobList(SolverOpt{
+	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 	})
 	defer l.Close()
@@ -1801,7 +1801,7 @@ func TestSubbuild(t *testing.T) {
 	t.Parallel()
 	ctx := context.TODO()
 
-	l := NewJobList(SolverOpt{
+	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 	})
 	defer l.Close()
@@ -1865,7 +1865,7 @@ func TestCacheWithSelector(t *testing.T) {
 
 	cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
-	l := NewJobList(SolverOpt{
+	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 		DefaultCache:  cacheManager,
 	})
@@ -1999,7 +1999,7 @@ func TestCacheSlowWithSelector(t *testing.T) {
 
 	cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
-	l := NewJobList(SolverOpt{
+	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 		DefaultCache:  cacheManager,
 	})
@@ -2098,7 +2098,7 @@ func TestCacheExporting(t *testing.T) {
 
 	cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
-	l := NewJobList(SolverOpt{
+	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 		DefaultCache:  cacheManager,
 	})
@@ -2182,7 +2182,7 @@ func TestCacheExportingModeMin(t *testing.T) {
 
 	cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
-	l := NewJobList(SolverOpt{
+	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 		DefaultCache:  cacheManager,
 	})
@@ -2308,7 +2308,7 @@ func TestSlowCacheAvoidAccess(t *testing.T) {
 
 	cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
-	l := NewJobList(SolverOpt{
+	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 		DefaultCache:  cacheManager,
 	})
@@ -2396,7 +2396,7 @@ func TestCacheMultipleMaps(t *testing.T) {
 
 	cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
-	l := NewJobList(SolverOpt{
+	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 		DefaultCache:  cacheManager,
 	})
@@ -2515,7 +2515,7 @@ func TestCacheExportingPartialSelector(t *testing.T) {
 
 	cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
-	l := NewJobList(SolverOpt{
+	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 		DefaultCache:  cacheManager,
 	})
@@ -2719,7 +2719,7 @@ func TestCacheExportingMergedKey(t *testing.T) {
 
 	cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
-	l := NewJobList(SolverOpt{
+	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 		DefaultCache:  cacheManager,
 	})


### PR DESCRIPTION
Update the event dispatcher in scheduler to keep the order of the events and therefore avoid possibilities of the dispatcher running twice if a previous event wasn't yet processed. This is mostly for readability of the scheduler debug traces while previously there could be traces that were not associated with a clear trigger event. Although the this will avoid some duplicate work I don't expect a performance increase because the dispatching itself now requires a lock per message, while previously it was per message group. In my testing, I didn't notice any meaningful effect to performance.

Also, clean up the public API. Some functions were public although they were not really usable with public methods.