### PR TITLE
cache: avoid reloading snapshots in gc queue

### DIFF
--- a/cache/manager.go
+++ b/cache/manager.go
@@ -30,6 +30,7 @@ type ManagerOpt struct {
 
 type Accessor interface {
 	Get(ctx context.Context, id string, opts ...RefOption) (ImmutableRef, error)
+	GetFromSnapshotter(ctx context.Context, id string, opts ...RefOption) (ImmutableRef, error)
 	New(ctx context.Context, s ImmutableRef, opts ...RefOption) (MutableRef, error)
 	GetMutable(ctx context.Context, id string) (MutableRef, error) // Rebase?
 }
@@ -80,7 +81,7 @@ func (cm *cacheManager) init(ctx context.Context) error {
 	}
 
 	for _, si := range items {
-		if _, err := cm.getRecord(ctx, si.ID()); err != nil {
+		if _, err := cm.getRecord(ctx, si.ID(), false); err != nil {
 			logrus.Debugf("could not load snapshot %s: %v", si.ID(), err)
 			cm.md.Clear(si.ID())
 			// TODO: make sure content is deleted as well
@@ -100,12 +101,19 @@ func (cm *cacheManager) Close() error {
 func (cm *cacheManager) Get(ctx context.Context, id string, opts ...RefOption) (ImmutableRef, error) {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
-	return cm.get(ctx, id, opts...)
+	return cm.get(ctx, id, false, opts...)
+}
+
+// Get returns an immutable snapshot reference for ID
+func (cm *cacheManager) GetFromSnapshotter(ctx context.Context, id string, opts ...RefOption) (ImmutableRef, error) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	return cm.get(ctx, id, true, opts...)
 }
 
 // get requires manager lock to be taken
-func (cm *cacheManager) get(ctx context.Context, id string, opts ...RefOption) (ImmutableRef, error) {
-	rec, err := cm.getRecord(ctx, id, opts...)
+func (cm *cacheManager) get(ctx context.Context, id string, fromSnapshotter bool, opts ...RefOption) (ImmutableRef, error) {
+	rec, err := cm.getRecord(ctx, id, fromSnapshotter, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +134,7 @@ func (cm *cacheManager) get(ctx context.Context, id string, opts ...RefOption) (
 }
 
 // getRecord returns record for id. Requires manager lock.
-func (cm *cacheManager) getRecord(ctx context.Context, id string, opts ...RefOption) (cr *cacheRecord, retErr error) {
+func (cm *cacheManager) getRecord(ctx context.Context, id string, fromSnapshotter bool, opts ...RefOption) (cr *cacheRecord, retErr error) {
 	if rec, ok := cm.records[id]; ok {
 		if rec.isDead() {
 			return nil, errNotFound
@@ -134,9 +142,12 @@ func (cm *cacheManager) getRecord(ctx context.Context, id string, opts ...RefOpt
 		return rec, nil
 	}
 
-	md, _ := cm.md.Get(id)
+	md, ok := cm.md.Get(id)
+	if !ok && !fromSnapshotter {
+		return nil, errNotFound
+	}
 	if mutableID := getEqualMutable(md); mutableID != "" {
-		mutable, err := cm.getRecord(ctx, mutableID)
+		mutable, err := cm.getRecord(ctx, mutableID, fromSnapshotter)
 		if err != nil {
 			// check loading mutable deleted record from disk
 			if errors.Cause(err) == errNotFound {
@@ -164,7 +175,7 @@ func (cm *cacheManager) getRecord(ctx context.Context, id string, opts ...RefOpt
 
 	var parent ImmutableRef
 	if info.Parent != "" {
-		parent, err = cm.get(ctx, info.Parent, opts...)
+		parent, err = cm.get(ctx, info.Parent, fromSnapshotter, opts...)
 		if err != nil {
 			return nil, err
 		}
@@ -256,7 +267,7 @@ func (cm *cacheManager) GetMutable(ctx context.Context, id string) (MutableRef, 
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 
-	rec, err := cm.getRecord(ctx, id)
+	rec, err := cm.getRecord(ctx, id, false)
 	if err != nil {
 		return nil, err
 	}

--- a/source/containerimage/pull.go
+++ b/source/containerimage/pull.go
@@ -343,7 +343,7 @@ func (p *puller) Snapshot(ctx context.Context) (cache.ImmutableRef, error) {
 	}
 	unpackProgressDone(nil)
 
-	return p.is.CacheAccessor.Get(ctx, chainid, cache.WithDescription(fmt.Sprintf("pulled from %s", p.ref)))
+	return p.is.CacheAccessor.GetFromSnapshotter(ctx, chainid, cache.WithDescription(fmt.Sprintf("pulled from %s", p.ref)))
 }
 
 func (is *imageSource) unpack(ctx context.Context, desc ocispec.Descriptor, s snapshots.Snapshotter) (string, error) {


### PR DESCRIPTION
Fix another containerd gc race case that showed up in the `llbsolver-next` integration tests. For example https://travis-ci.org/moby/buildkit/builds/377155580

The problem is that when the refs are deleted there is no way to synchronously delete the underlying containerd snapshot as well. So if the timing is correct the cache will see if there is a reference to an ID, and even though it has been deleted the `snapshotter.Stat` still returns fine as the gc has not cleaned it up yet and the ref is recreated. What makes things worse is that this reference has lost all its metadata about blob references, so the cache/image exporter would use a differ for reconstructing these blobs instead of using the original ones.

Didn't find a better solution than to add an extra method. The original `Get` will not try to automatically create references from snapshots any more. Puller that needs this capability uses a new method instead.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>