### PR TITLE
cache: helper methods for immutableref

### DIFF
--- a/cache/refs.go
+++ b/cache/refs.go
@@ -26,6 +26,7 @@ type ImmutableRef interface {
 	Ref
 	Parent() ImmutableRef
 	Finalize(ctx context.Context) error // Make sure reference is flushed to driver
+	Clone() ImmutableRef
 }
 
 type MutableRef interface {
@@ -191,6 +192,13 @@ type immutableRef struct {
 
 type mutableRef struct {
 	*cacheRecord
+}
+
+func (sr *immutableRef) Clone() ImmutableRef {
+	sr.mu.Lock()
+	ref := sr.ref()
+	sr.mu.Unlock()
+	return ref
 }
 
 func (sr *immutableRef) Release(ctx context.Context) error {

--- a/solver-next/llbsolver/ops/exec.go
+++ b/solver-next/llbsolver/ops/exec.go
@@ -186,16 +186,12 @@ func (e *execOp) Exec(ctx context.Context, inputs []solver.Result) ([]solver.Res
 
 		activate := func(cache.ImmutableRef) (cache.MutableRef, error) {
 			desc := fmt.Sprintf("mount %s from exec %s", m.Dest, strings.Join(e.op.Meta.Args, " "))
-			return e.cm.New(ctx, ref, cache.WithDescription(desc)) // TODO: should be method `immutableRef.New() mutableRef`
+			return e.cm.New(ctx, ref, cache.WithDescription(desc))
 		}
 
 		if m.Output != pb.SkipOutput {
 			if m.Readonly && ref != nil && m.Dest != pb.RootMount { // exclude read-only rootfs
-				out, err := e.cm.Get(ctx, ref.ID()) // TODO: add dup to immutableRef
-				if err != nil {
-					return nil, err
-				}
-				outputs = append(outputs, out)
+				outputs = append(outputs, ref.Clone())
 			} else {
 				active, err := activate(ref)
 				if err != nil {


### PR DESCRIPTION
Add helper methods for dealing with refs. ~~`New` avoids having access to cachemanager directly.~~ `Clone()` avoids calling much heavier `Get()/Release()` method every time a ref is passed through ops.

edit: removed `New`