### PR TITLE
cache: reenable last used metadata

### DIFF
--- a/cache/metadata.go
+++ b/cache/metadata.go
@@ -185,24 +185,22 @@ func getLastUsed(si *metadata.StorageItem) (int, *time.Time) {
 	return usageCount, &tm
 }
 
-// TODO: temporarily removed until there is an implementation that can do this
-// on background or one that doesn't get new refs for every operation
-// func updateLastUsed(si *metadata.StorageItem) error {
-// 	count, _ := getLastUsed(si)
-// 	count++
-//
-// 	v, err := metadata.NewValue(count)
-// 	if err != nil {
-// 		return errors.Wrap(err, "failed to create usageCount value")
-// 	}
-// 	v2, err := metadata.NewValue(time.Now().UnixNano())
-// 	if err != nil {
-// 		return errors.Wrap(err, "failed to create lastUsedAt value")
-// 	}
-// 	return si.Update(func(b *bolt.Bucket) error {
-// 		if err := si.SetValue(b, keyUsageCount, v); err != nil {
-// 			return err
-// 		}
-// 		return si.SetValue(b, keyLastUsedAt, v2)
-// 	})
-// }
+func updateLastUsed(si *metadata.StorageItem) error {
+	count, _ := getLastUsed(si)
+	count++
+
+	v, err := metadata.NewValue(count)
+	if err != nil {
+		return errors.Wrap(err, "failed to create usageCount value")
+	}
+	v2, err := metadata.NewValue(time.Now().UnixNano())
+	if err != nil {
+		return errors.Wrap(err, "failed to create lastUsedAt value")
+	}
+	return si.Update(func(b *bolt.Bucket) error {
+		if err := si.SetValue(b, keyUsageCount, v); err != nil {
+			return err
+		}
+		return si.SetValue(b, keyLastUsedAt, v2)
+	})
+}

--- a/cache/refs.go
+++ b/cache/refs.go
@@ -212,11 +212,10 @@ func (sr *immutableRef) Release(ctx context.Context) error {
 }
 
 func (sr *immutableRef) release(ctx context.Context) error {
-	// updateLastUsed(sr.md)
-
 	delete(sr.refs, sr)
 
 	if len(sr.refs) == 0 {
+		updateLastUsed(sr.md)
 		if sr.viewMount != nil { // TODO: release viewMount earlier if possible
 			if err := sr.cm.Snapshotter.Remove(ctx, sr.view); err != nil {
 				return err
@@ -333,7 +332,6 @@ func (sr *mutableRef) Release(ctx context.Context) error {
 
 func (sr *mutableRef) release(ctx context.Context) error {
 	delete(sr.refs, sr)
-	// updateLastUsed(sr.md)
 	if getCachePolicy(sr.md) != cachePolicyRetain {
 		if sr.equalImmutable != nil {
 			if getCachePolicy(sr.equalImmutable.md) == cachePolicyRetain {
@@ -349,6 +347,8 @@ func (sr *mutableRef) release(ctx context.Context) error {
 			}
 		}
 		return sr.remove(ctx, true)
+	} else {
+		updateLastUsed(sr.md)
 	}
 	return nil
 }

--- a/solver-next/edge.go
+++ b/solver-next/edge.go
@@ -126,7 +126,7 @@ func (e *edge) release() {
 	}
 	e.index.Release(e)
 	if e.result != nil {
-		e.result.Release(context.TODO())
+		go e.result.Release(context.TODO())
 	}
 }
 

--- a/solver-next/jobs.go
+++ b/solver-next/jobs.go
@@ -688,7 +688,7 @@ func (s *sharedOp) getOp() (Op, error) {
 func (s *sharedOp) release() {
 	if s.execRes != nil {
 		for _, r := range s.execRes.execRes {
-			r.Release(context.TODO())
+			go r.Release(context.TODO())
 		}
 	}
 }


### PR DESCRIPTION
This was initially disabled in `llbsolver-next` for performance. With https://github.com/moby/buildkit/pull/376 this should be tolerable now. It can still be made much better with moving these write to async but that can be done in a separate, lower priority issue.