### PR TITLE
client: support non-npipe server addresses on Windows

### DIFF
--- a/client/client_windows.go
+++ b/client/client_windows.go
@@ -6,10 +6,19 @@ import (
 	"time"
 
 	"github.com/Microsoft/go-winio"
+	"github.com/pkg/errors"
 )
 
 func dialer(address string, timeout time.Duration) (net.Conn, error) {
-	address = strings.TrimPrefix(address, "npipe://")
-	address = strings.Replace(address, "/", "\\", 0)
-	return winio.DialPipe(address, &timeout)
+	addrParts := strings.SplitN(address, "://", 2)
+	if len(addrParts) != 2 {
+		return nil, errors.Errorf("invalid address %s", address)
+	}
+	switch addrParts[0] {
+	case "npipe":
+		address = strings.Replace(addrParts[1], "/", "\\", 0)
+		return winio.DialPipe(address, &timeout)
+	default:
+		return net.DialTimeout(addrParts[0], addrParts[1], timeout)
+	}
 }


### PR DESCRIPTION
This makes `tcp://w.x.y.z:port` work from Windows based clients (perhaps
talking to a remote Linux based buildkitd or one running in a container with
Docker for Windows and TCP port forwarding).

Signed-off-by: Ian Campbell <ijc@docker.com>