### PR TITLE
dockerfile: add syntax directive for introducing new features

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/directives.go
+++ b/frontend/dockerfile/dockerfile2llb/directives.go
@@ -1,0 +1,38 @@
+package dockerfile2llb
+
+import (
+	"bufio"
+	"io"
+	"regexp"
+	"strings"
+)
+
+const keySyntax = "syntax"
+
+var reDirective = regexp.MustCompile(`^#\s*([a-zA-Z][a-zA-Z0-9]*)\s*=\s*(.+?)\s*$`)
+
+func DetectSyntax(r io.Reader) (string, string, bool) {
+	directives := ParseDirectives(r)
+	if len(directives) == 0 {
+		return "", "", false
+	}
+	v, ok := directives[keySyntax]
+	if !ok {
+		return "", "", false
+	}
+	p := strings.SplitN(v, " ", 2)
+	return p[0], v, true
+}
+
+func ParseDirectives(r io.Reader) map[string]string {
+	m := map[string]string{}
+	s := bufio.NewScanner(r)
+	for s.Scan() {
+		match := reDirective.FindStringSubmatch(s.Text())
+		if len(match) == 0 {
+			return m
+		}
+		m[strings.ToLower(match[1])] = match[2]
+	}
+	return m
+}

--- a/frontend/dockerfile/dockerfile2llb/directives_test.go
+++ b/frontend/dockerfile/dockerfile2llb/directives_test.go
@@ -1,0 +1,70 @@
+package dockerfile2llb
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDirectives(t *testing.T) {
+	t.Parallel()
+
+	dt := `#escape=\
+# key = FOO bar
+
+# smth
+`
+
+	d := ParseDirectives(bytes.NewBuffer([]byte(dt)))
+	require.Equal(t, len(d), 2, fmt.Sprintf("%+v", d))
+
+	v, ok := d["escape"]
+	require.True(t, ok)
+	require.Equal(t, v, "\\")
+
+	v, ok = d["key"]
+	require.True(t, ok)
+	require.Equal(t, v, "FOO bar")
+
+	// for some reason Moby implementation in case insensitive for escape
+	dt = `# EScape=\
+# KEY = FOO bar
+
+# smth
+`
+
+	d = ParseDirectives(bytes.NewBuffer([]byte(dt)))
+	require.Equal(t, len(d), 2, fmt.Sprintf("%+v", d))
+
+	v, ok = d["escape"]
+	require.True(t, ok)
+	require.Equal(t, v, "\\")
+
+	v, ok = d["key"]
+	require.True(t, ok)
+	require.Equal(t, v, "FOO bar")
+}
+
+func TestSyntaxDirective(t *testing.T) {
+	t.Parallel()
+
+	dt := `# syntax = dockerfile:experimental // opts
+FROM busybox
+`
+
+	ref, cmdline, ok := DetectSyntax(bytes.NewBuffer([]byte(dt)))
+	require.True(t, ok)
+	require.Equal(t, ref, "dockerfile:experimental")
+	require.Equal(t, cmdline, "dockerfile:experimental // opts")
+
+	dt = `FROM busybox
+RUN ls
+`
+	ref, cmdline, ok = DetectSyntax(bytes.NewBuffer([]byte(dt)))
+	require.False(t, ok)
+	require.Equal(t, ref, "")
+	require.Equal(t, cmdline, "")
+
+}


### PR DESCRIPTION
Add syntax directive for specifying the builder reference so that new dockerfile features can be targeted. New Dockerfile features can be added now without breaking backward compatibility or requiring users to upgrade. The base one would remain compatible with current moby/docker.

@tiborvass 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>