### PR TITLE
dockerfile: fix hanging when encountering invalid dockerignore pattern

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -40,7 +40,7 @@ github.com/BurntSushi/locker a6e239ea1c69bff1cfdb20c4b73dadf52f784b6a
 github.com/docker/docker 53a58da551e961b3710bbbdfabbc162c3f5f30f6
 github.com/pkg/profile 5b67d428864e92711fcbd2f8629456121a56d91f
 
-github.com/tonistiigi/fsutil 93a0fd10b669d389e349ff54c48f13829708c9b0
+github.com/tonistiigi/fsutil dc68c74458923f357474a9178bd198aa3ed11a5f
 github.com/hashicorp/go-immutable-radix 826af9ccf0feeee615d546d69b11f8e98da8c8f1 git://github.com/tonistiigi/go-immutable-radix.git
 github.com/hashicorp/golang-lru a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
 github.com/mitchellh/hashstructure 2bca23e0e452137f789efbc8610126fd8b94f73b

--- a/vendor/github.com/tonistiigi/fsutil/receive.go
+++ b/vendor/github.com/tonistiigi/fsutil/receive.go
@@ -158,6 +158,8 @@ func (r *receiver) run(ctx context.Context) error {
 			}
 
 			switch p.Type {
+			case PACKET_ERR:
+				return errors.Errorf("error from sender: %s", p.Data)
 			case PACKET_STAT:
 				if p.Stat == nil {
 					if err := w.update(nil); err != nil {

--- a/vendor/github.com/tonistiigi/fsutil/send.go
+++ b/vendor/github.com/tonistiigi/fsutil/send.go
@@ -57,7 +57,11 @@ func (s *sender) run(ctx context.Context) error {
 	defer s.updateProgress(0, true)
 
 	g.Go(func() error {
-		return s.walk(ctx)
+		err := s.walk(ctx)
+		if err != nil {
+			s.conn.SendMsg(&Packet{Type: PACKET_ERR, Data: []byte(err.Error())})
+		}
+		return err
 	})
 
 	for i := 0; i < 4; i++ {


### PR DESCRIPTION
This commit fixes the case when "!" is provided alone as a dockerignore
pattern resulting in buildkit hanging. An integration test is added to
guard the bug.

The bug was due to incorrect error propagation in the fsutil package.
Thus this commit vendors a newer, fixed version of fsutil.

Signed-off-by: Tibor Vass <tibor@docker.com>

Ref https://github.com/tonistiigi/fsutil/pull/30