### PR TITLE
examples/buildkit*: add libseccomp-dev

### DIFF
--- a/examples/buildkit0/buildkit.go
+++ b/examples/buildkit0/buildkit.go
@@ -37,7 +37,7 @@ func goBuildBase() llb.State {
 		AddEnv("PATH", "/usr/local/go/bin:"+system.DefaultPathEnv).
 		AddEnv("GOPATH", "/go").
 		Run(llb.Shlex("apk add --no-cache g++ linux-headers")).
-		Run(llb.Shlex("apk add --no-cache git make")).Root()
+		Run(llb.Shlex("apk add --no-cache git libseccomp-dev make")).Root()
 }
 
 func runc(version string) llb.State {

--- a/examples/buildkit1/buildkit.go
+++ b/examples/buildkit1/buildkit.go
@@ -37,7 +37,7 @@ func goBuildBase() llb.State {
 		AddEnv("PATH", "/usr/local/go/bin:"+system.DefaultPathEnv).
 		AddEnv("GOPATH", "/go").
 		Run(llb.Shlex("apk add --no-cache g++ linux-headers")).
-		Run(llb.Shlex("apk add --no-cache git make")).Root()
+		Run(llb.Shlex("apk add --no-cache git libseccomp-dev make")).Root()
 }
 
 func runc(version string) llb.State {

--- a/examples/buildkit2/buildkit.go
+++ b/examples/buildkit2/buildkit.go
@@ -36,7 +36,7 @@ func goBuildBase() llb.State {
 	return goAlpine.
 		AddEnv("PATH", "/usr/local/go/bin:"+system.DefaultPathEnv).
 		AddEnv("GOPATH", "/go").
-		Run(llb.Shlex("apk add --no-cache g++ linux-headers make")).Root()
+		Run(llb.Shlex("apk add --no-cache g++ linux-headers libseccomp-dev make")).Root()
 }
 
 func goRepo(s llb.State, repo, ref string, g ...llb.GitOption) func(ro ...llb.RunOption) llb.State {

--- a/examples/buildkit3/buildkit.go
+++ b/examples/buildkit3/buildkit.go
@@ -37,7 +37,7 @@ func goBuildBase() llb.State {
 	return goAlpine.
 		AddEnv("PATH", "/usr/local/go/bin:"+system.DefaultPathEnv).
 		AddEnv("GOPATH", "/go").
-		Run(llb.Shlex("apk add --no-cache g++ linux-headers make")).Root()
+		Run(llb.Shlex("apk add --no-cache g++ linux-headers libseccomp-dev make")).Root()
 }
 
 func goRepo(s llb.State, repo string, src llb.State) func(ro ...llb.RunOption) llb.State {


### PR DESCRIPTION
libseccomp-dev is required for building containerd:

```
  > make bin/containerd
  ..
  # pkg-config --cflags libseccomp libseccomp
  Package libseccomp was not found in the pkg-config search path.
  ..
```

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>