### PR TITLE
Fixes for cache invalidation on modtime change

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -530,7 +530,12 @@ func dispatchCopy(d *dispatchState, c instructions.SourcesAndDest, sourceState l
 	if unpack {
 		args = append(args[:1], append([]string{"--unpack"}, args[1:]...)...)
 	}
-	run := img.Run(append([]llb.RunOption{llb.Args(args), llb.ReadonlyRootFS(), dfCmd(cmdToPrint)}, mounts...)...)
+
+	opt := []llb.RunOption{llb.Args(args), llb.ReadonlyRootFS(), dfCmd(cmdToPrint)}
+	if d.ignoreCache {
+		opt = append(opt, llb.IgnoreCache)
+	}
+	run := img.Run(append(opt, mounts...)...)
 	d.state = run.AddMount("/dest", d.state)
 
 	return commitToHistory(&d.image, commitMessage.String(), true, &d.state)


### PR DESCRIPTION
- Enable --no-cache for `COPY/ADD` commands because the checksum ignores modtime
- HTTP: include modtime in the cache checksum so the cache is invalidated if header changes in the server.