### PR TITLE
handling of foreign platform clients

### DIFF
--- a/source/containerimage/pull.go
+++ b/source/containerimage/pull.go
@@ -58,7 +58,7 @@ func (is *imageSource) ResolveImageConfig(ctx context.Context, ref string) (dige
 		dt   []byte
 	}
 	res, err := is.g.Do(ctx, ref, func(ctx context.Context) (interface{}, error) {
-		dgst, dt, err := imageutil.Config(ctx, ref, pull.NewResolver(ctx, is.SessionManager, is.ImageStore), is.ContentStore)
+		dgst, dt, err := imageutil.Config(ctx, ref, pull.NewResolver(ctx, is.SessionManager, is.ImageStore), is.ContentStore, "")
 		if err != nil {
 			return nil, err
 		}
@@ -132,7 +132,7 @@ func (p *puller) CacheKey(ctx context.Context, index int) (string, bool, error) 
 	if err != nil {
 		return "", false, nil
 	}
-	_, dt, err := imageutil.Config(ctx, ref.String(), p.Resolver, p.ContentStore)
+	_, dt, err := imageutil.Config(ctx, ref.String(), p.Resolver, p.ContentStore, "")
 	if err != nil {
 		// this happens on schema1 images
 		k, err := mainManifestKey(ctx, desc)

--- a/util/imageutil/config.go
+++ b/util/imageutil/config.go
@@ -19,7 +19,10 @@ type IngesterProvider interface {
 	content.Provider
 }
 
-func Config(ctx context.Context, str string, resolver remotes.Resolver, ingester IngesterProvider) (digest.Digest, []byte, error) {
+func Config(ctx context.Context, str string, resolver remotes.Resolver, ingester IngesterProvider, platform string) (digest.Digest, []byte, error) {
+	if platform == "" {
+		platform = platforms.Default()
+	}
 	ref, err := reference.Parse(str)
 	if err != nil {
 		return "", nil, errors.WithStack(err)
@@ -56,12 +59,12 @@ func Config(ctx context.Context, str string, resolver remotes.Resolver, ingester
 
 	handlers := []images.Handler{
 		remotes.FetchHandler(ingester, fetcher),
-		childrenConfigHandler(ingester, platforms.Default()),
+		childrenConfigHandler(ingester, platform),
 	}
 	if err := images.Dispatch(ctx, images.Handlers(handlers...), *desc); err != nil {
 		return "", nil, err
 	}
-	config, err := images.Config(ctx, ingester, *desc, platforms.Default())
+	config, err := images.Config(ctx, ingester, *desc, platform)
 	if err != nil {
 		return "", nil, err
 	}


### PR DESCRIPTION
This PR is really an issue for discussion with some illustrative code attached. It solves an issue for me on the client side but breaks the build of buildkitd.

I have a setup with a buildkit client (grpc) which runs on any of Linux/Mac/Win and talks (via tcp) to a `buildkitd` backend running on Linux (actually in a Docker container). I developed and tested on Linux and all was well but when I came to run on Mac buildkit was unable to pull the required base image -- because there was no Darwin image in the manifest (obviously), this happened because the pull was in this case running on the client e.g. `llb.Image(ref, llb.WithMetaResolver(imagemetaresolver.Default())` where `runtime.GOOS == "darwin"`.

What I actually wanted was to resolve the `linux/amd64` image unconditionally. If I apply the changes here to my vendored buildkit client and use `llb.Image(ref, llb.WithMetaResolver(imagemetaresolver.New("linux/amd64"))`.

That's an easy enough fix, and I think it would not be too hard to bubble up the change to fix the `buildkitd` build breakage (in many other contexts the native platform is precisely what is required right now) but it seems like the information about the desired platform should likely (in the long run) be incorporated in to the LLB graph somehow, with a view to eventually matching it against available workers etc (short term it could maybe just reject LLB which is "non-native" from the daemons pov).

I'm unclear which LLB object the platform would be applied to, I guess either (or both) `SourceOp` or  `ExecOp` have reasons to know (it could be attached via `attr` and `Meta` respectively) and maybe it wants to be propagated along the edges of the graph by default. I suppose it would also have to be fed into the caching infrastructure.

Do we have a model in mind for how we would like to address this, or shall we defer that and just go with the short term client side fix here for now?

FTR the buildkitd breakage with this is:
```
# github.com/moby/buildkit/source/containerimage
source/containerimage/pull.go:61:36: not enough arguments in call to imageutil.Config
	have (context.Context, string, remotes.Resolver, content.Store)
	want (context.Context, string, remotes.Resolver, imageutil.IngesterProvider, string)
source/containerimage/pull.go:135:32: not enough arguments in call to imageutil.Config
	have (context.Context, string, remotes.Resolver, content.Store)
	want (context.Context, string, remotes.Resolver, imageutil.IngesterProvider, string)
```
fixing it is a matter plumbing through things as appropriate.