### PR TITLE
exec: make stdio debugging optional

### DIFF
--- a/solver/llbsolver/ops/exec.go
+++ b/solver/llbsolver/ops/exec.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path"
 	"runtime"
 	"sort"
@@ -324,7 +325,7 @@ func (e *execOp) Exec(ctx context.Context, inputs []solver.Result) ([]solver.Res
 		meta.Env = append(meta.Env, proxyEnvList(e.op.Meta.ProxyEnv)...)
 	}
 
-	stdout, stderr := logs.NewLogStreams(ctx)
+	stdout, stderr := logs.NewLogStreams(ctx, os.Getenv("BUILDKIT_DEBUG_EXEC_OUTPUT") == "1")
 	defer stdout.Close()
 	defer stderr.Close()
 

--- a/source/git/gitsource.go
+++ b/source/git/gitsource.go
@@ -371,7 +371,7 @@ func gitWithinDir(ctx context.Context, gitDir, workDir string, args ...string) (
 
 func git(ctx context.Context, dir string, args ...string) (*bytes.Buffer, error) {
 	for {
-		stdout, stderr := logs.NewLogStreams(ctx)
+		stdout, stderr := logs.NewLogStreams(ctx, false)
 		defer stdout.Close()
 		defer stderr.Close()
 		cmd := exec.Command("git", args...)


### PR DESCRIPTION
Historically exec ops also print stdout to daemon logs. Remove this, but leave an environment variable toggle if someone wants to use it during development.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>