### PR TITLE
git: support all git transports

### DIFF
--- a/client/llb/source.go
+++ b/client/llb/source.go
@@ -141,7 +141,19 @@ type ImageInfo struct {
 }
 
 func Git(remote, ref string, opts ...GitOption) State {
+	url := ""
+
+	for _, prefix := range []string{
+		"http://", "https://", "git://", "git@",
+	} {
+		if strings.HasPrefix(remote, prefix) {
+			url = strings.Split(remote, "#")[0]
+			remote = strings.TrimPrefix(remote, prefix)
+		}
+	}
+
 	id := remote
+
 	if ref != "" {
 		id += "#" + ref
 	}
@@ -153,6 +165,9 @@ func Git(remote, ref string, opts ...GitOption) State {
 	attrs := map[string]string{}
 	if gi.KeepGitDir {
 		attrs[pb.AttrKeepGitDir] = "true"
+	}
+	if url != "" {
+		attrs[pb.AttrFullRemoteURL] = url
 	}
 	source := NewSource("git://"+id, attrs, gi.Metadata())
 	return NewState(source.Output())

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -1387,7 +1387,7 @@ COPY --from=build foo bar2
 	)
 	require.NoError(t, err)
 
-	server := httptest.NewServer(http.FileServer(http.Dir(filepath.Join(gitDir, ".git"))))
+	server := httptest.NewServer(http.FileServer(http.Dir(filepath.Join(gitDir))))
 	defer server.Close()
 
 	destDir, err := ioutil.TempDir("", "buildkit")
@@ -1401,7 +1401,7 @@ COPY --from=build foo bar2
 	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
 		Frontend: "dockerfile.v0",
 		FrontendAttrs: map[string]string{
-			"context": "git://" + server.URL + "/#first",
+			"context": server.URL + "/.git#first",
 		},
 		Exporter:          client.ExporterLocal,
 		ExporterOutputDir: destDir,
@@ -1424,7 +1424,7 @@ COPY --from=build foo bar2
 	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
 		Frontend: "dockerfile.v0",
 		FrontendAttrs: map[string]string{
-			"context": "git://" + server.URL + "/",
+			"context": server.URL + "/.git",
 		},
 		Exporter:          client.ExporterLocal,
 		ExporterOutputDir: destDir,

--- a/solver/pb/attr.go
+++ b/solver/pb/attr.go
@@ -1,6 +1,7 @@
 package pb
 
 const AttrKeepGitDir = "git.keepgitdir"
+const AttrFullRemoteURL = "git.fullurl"
 const AttrLocalSessionID = "local.session"
 const AttrIncludePatterns = "local.includepattern"
 const AttrExcludePatterns = "local.excludepatterns"

--- a/source/identifier.go
+++ b/source/identifier.go
@@ -62,6 +62,8 @@ func FromLLB(op *pb.Op_Source) (Identifier, error) {
 				if v == "true" {
 					id.KeepGitDir = true
 				}
+			case pb.AttrFullRemoteURL:
+				id.Remote = v
 			}
 		}
 	}


### PR DESCRIPTION
Add clearer support for all supported git transports that optionally switch to another attribute field instead of making invalid URLs. Also, update dockerfile to accept https://../repo.git as a git URL instead of HTTP URL

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>