### PR TITLE
oci-executor: eval symlink for root

### DIFF
--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -73,7 +73,10 @@ func New(opt Opt) (executor.Executor, error) {
 	if err != nil {
 		return nil, err
 	}
-	// TODO: check that root is not symlink to fail early
+	root, err = filepath.EvalSymlinks(root)
+	if err != nil {
+		return nil, err
+	}
 
 	runtime := &runc.Runc{
 		Command:      cmd,


### PR DESCRIPTION
Carry https://github.com/moby/buildkit/pull/298

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>