### PR TITLE
snapshot: wrap mount err

### DIFF
--- a/snapshot/localmounter.go
+++ b/snapshot/localmounter.go
@@ -65,7 +65,7 @@ func (lm *localMounter) Mount() (string, error) {
 
 	if err := mount.All(lm.mounts, dir); err != nil {
 		os.RemoveAll(dir)
-		return "", err
+		return "", errors.Wrapf(err, "failed to mount %s: %+v", dir, lm.mounts)
 	}
 	lm.target = dir
 	return dir, nil


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

e.g. https://github.com/genuinetools/img/issues/97 (going to be solved in https://github.com/genuinetools/img/pull/111)

```
$ img build -t foo .
Building docker.io/library/foo:latest
Setting up the rootfs... this may take a bit.
[+] Building 0.0s (2/2) FINISHED                                                                                      
 => local://dockerfile (Dockerfile)                                                                              0.0s
 => => transferring dockerfile: 216B                                                                             0.0s
 => local://context (.dockerignore)                                                                              0.0s
 => => transferring context: 02B                                                                                 0.0s
failed to solve: failed to mount /tmp/buildkit-mount850435638: [{Type:bind Source:/tmp/img/runc/native/snapshots/snapshots/2 Options:[ro rbind]}]: operation not permitted
```

cc @frezbo @jessfraz 