### PR TITLE
support when build without seccomp build tag

### DIFF
--- a/util/system/seccomp_linux.go
+++ b/util/system/seccomp_linux.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,seccomp
 
 package system
 

--- a/util/system/seccomp_noseccomp.go
+++ b/util/system/seccomp_noseccomp.go
@@ -1,4 +1,4 @@
-// +build !linux,seccomp
+// +build !seccomp
 
 package system
 


### PR DESCRIPTION
Fixes the issue described in https://github.com/genuinetools/img/issues/97#issuecomment-394144596