### PR TITLE
dockerfile: add run --mount support

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -893,8 +893,7 @@ func testMountWithNoSource(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{}, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "has no input")
+	require.NoError(t, err)
 
 	checkAllReleasable(t, c, sb, true)
 }

--- a/frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile
+++ b/frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile
@@ -1,6 +1,7 @@
 FROM golang:1.10-alpine AS builder
+ARG BUILDTAGS=""
 COPY . /go/src/github.com/moby/buildkit
-RUN CGO_ENABLED=0 go build -o /dockerfile-frontend --ldflags '-extldflags "-static"' github.com/moby/buildkit/frontend/dockerfile/cmd/dockerfile-frontend
+RUN CGO_ENABLED=0 go build -o /dockerfile-frontend -tags "$BUILDTAGS" --ldflags '-extldflags "-static"' github.com/moby/buildkit/frontend/dockerfile/cmd/dockerfile-frontend
 
 FROM scratch
 COPY --from=builder /dockerfile-frontend /bin/dockerfile-frontend

--- a/frontend/dockerfile/dockerfile2llb/convert_norunmount.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_norunmount.go
@@ -1,0 +1,16 @@
+// +build !dfrunmount,!dfextall
+
+package dockerfile2llb
+
+import (
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+)
+
+func detectRunMount(cmd *command, dispatchStatesByName map[string]*dispatchState, allDispatchStates []*dispatchState) bool {
+	return false
+}
+
+func dispatchRunMounts(d *dispatchState, c *instructions.RunCommand, sources []*dispatchState, opt dispatchOpt) []llb.RunOption {
+	return nil
+}

--- a/frontend/dockerfile/dockerfile2llb/convert_runmount.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_runmount.go
@@ -1,0 +1,70 @@
+// +build dfrunmount dfextall
+
+package dockerfile2llb
+
+import (
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+)
+
+func detectRunMount(cmd *command, dispatchStatesByName map[string]*dispatchState, allDispatchStates []*dispatchState) bool {
+	if c, ok := cmd.Command.(*instructions.RunCommand); ok {
+		mounts := instructions.GetMounts(c)
+		sources := make([]*dispatchState, len(mounts))
+		for i, mount := range mounts {
+			if mount.From == "" && mount.Type == "cache" {
+				mount.From = emptyImageName
+			}
+			from := mount.From
+			if from == "" {
+				continue
+			}
+			stn, ok := dispatchStatesByName[strings.ToLower(from)]
+			if !ok {
+				stn = &dispatchState{
+					stage:        instructions.Stage{BaseName: from},
+					deps:         make(map[*dispatchState]struct{}),
+					unregistered: true,
+				}
+			}
+			sources[i] = stn
+		}
+		cmd.sources = sources
+		return true
+	}
+
+	return false
+}
+
+func dispatchRunMounts(d *dispatchState, c *instructions.RunCommand, sources []*dispatchState, opt dispatchOpt) []llb.RunOption {
+	var out []llb.RunOption
+	mounts := instructions.GetMounts(c)
+
+	for i, mount := range mounts {
+		if mount.From == "" && mount.Type == "cache" {
+			mount.From = emptyImageName
+		}
+		st := opt.buildContext
+		if mount.From != "" {
+			st = sources[i].state
+		}
+		var mountOpts []llb.MountOption
+		if mount.ReadOnly {
+			mountOpts = append(mountOpts, llb.Readonly)
+		}
+		if mount.Type == "cache" {
+			mountOpts = append(mountOpts, llb.AsPersistentCacheDir(opt.cacheIDNamespace+"/"+mount.CacheID))
+		}
+		if src := path.Join("/", mount.Source); src != "/" {
+			mountOpts = append(mountOpts, llb.SourcePath(src))
+		}
+		out = append(out, llb.AddMount(path.Join("/", mount.Target), st, mountOpts...))
+
+		d.ctxPaths[path.Join("/", filepath.ToSlash(mount.Source))] = struct{}{}
+	}
+	return out
+}

--- a/frontend/dockerfile/instructions/bflag.go
+++ b/frontend/dockerfile/instructions/bflag.go
@@ -11,6 +11,7 @@ type FlagType int
 const (
 	boolType FlagType = iota
 	stringType
+	stringsType
 )
 
 // BFlags contains all flags information for the builder
@@ -23,10 +24,11 @@ type BFlags struct {
 
 // Flag contains all information for a flag
 type Flag struct {
-	bf       *BFlags
-	name     string
-	flagType FlagType
-	Value    string
+	bf           *BFlags
+	name         string
+	flagType     FlagType
+	Value        string
+	StringValues []string
 }
 
 // NewBFlags returns the new BFlags struct
@@ -67,6 +69,15 @@ func (bf *BFlags) AddString(name string, def string) *Flag {
 		return nil
 	}
 	flag.Value = def
+	return flag
+}
+
+// AddString adds a string flag to BFlags that can match multiple values
+func (bf *BFlags) AddStrings(name string) *Flag {
+	flag := bf.addFlag(name, stringsType)
+	if flag == nil {
+		return nil
+	}
 	return flag
 }
 
@@ -145,7 +156,7 @@ func (bf *BFlags) Parse() error {
 			return fmt.Errorf("Unknown flag: %s", arg)
 		}
 
-		if _, ok = bf.used[arg]; ok {
+		if _, ok = bf.used[arg]; ok || flag.flagType != stringsType {
 			return fmt.Errorf("Duplicate flag specified: %s", arg)
 		}
 
@@ -172,6 +183,12 @@ func (bf *BFlags) Parse() error {
 				return fmt.Errorf("Missing a value on flag: %s", arg)
 			}
 			flag.Value = value
+
+		case stringsType:
+			if index < 0 {
+				return fmt.Errorf("Missing a value on flag: %s", arg)
+			}
+			flag.StringValues = append(flag.StringValues, value)
 
 		default:
 			panic("No idea what kind of flag we have! Should never get here!")

--- a/frontend/dockerfile/instructions/bflag.go
+++ b/frontend/dockerfile/instructions/bflag.go
@@ -156,7 +156,7 @@ func (bf *BFlags) Parse() error {
 			return fmt.Errorf("Unknown flag: %s", arg)
 		}
 
-		if _, ok = bf.used[arg]; ok || flag.flagType != stringsType {
+		if _, ok = bf.used[arg]; ok && flag.flagType != stringsType {
 			return fmt.Errorf("Duplicate flag specified: %s", arg)
 		}
 

--- a/frontend/dockerfile/instructions/commands.go
+++ b/frontend/dockerfile/instructions/commands.go
@@ -418,11 +418,6 @@ func HasStage(s []Stage, name string) (int, bool) {
 	return -1, false
 }
 
-type cmdWithExternalData interface {
-	getExternalValue(k interface{}) interface{}
-	setExternalValue(k, v interface{})
-}
-
 type withExternalData struct {
 	m map[interface{}]interface{}
 }

--- a/frontend/dockerfile/instructions/commands.go
+++ b/frontend/dockerfile/instructions/commands.go
@@ -233,6 +233,7 @@ type ShellDependantCmdLine struct {
 //
 type RunCommand struct {
 	withNameAndCode
+	withExternalData
 	ShellDependantCmdLine
 }
 
@@ -415,4 +416,24 @@ func HasStage(s []Stage, name string) (int, bool) {
 		}
 	}
 	return -1, false
+}
+
+type cmdWithExternalData interface {
+	getExternalValue(k interface{}) interface{}
+	setExternalValue(k, v interface{})
+}
+
+type withExternalData struct {
+	m map[interface{}]interface{}
+}
+
+func (c *withExternalData) getExternalValue(k interface{}) interface{} {
+	return c.m[k]
+}
+
+func (c *withExternalData) setExternalValue(k, v interface{}) {
+	if c.m == nil {
+		c.m = map[interface{}]interface{}{}
+	}
+	c.m[k] = v
 }

--- a/frontend/dockerfile/instructions/commands_runmount.go
+++ b/frontend/dockerfile/instructions/commands_runmount.go
@@ -1,0 +1,120 @@
+// +build dfrunmount dfall
+
+package instructions
+
+import (
+	"encoding/csv"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type mountsKeyT string
+
+var mountsKey = mountsKeyT("dockerfile/run/mounts")
+
+func init() {
+	parseRunPreHooks = append(parseRunPreHooks, runMountPreHook)
+	parseRunPostHooks = append(parseRunPostHooks, runMountPostHook)
+}
+
+func runMountPreHook(cmd *RunCommand, req parseRequest) error {
+	st := &mountState{}
+	st.flag = req.flags.AddString("mount", "")
+	cmd.setExternalValue(mountsKey, st)
+	return nil
+}
+
+func runMountPostHook(cmd *RunCommand, req parseRequest) error {
+	v := cmd.getExternalValue(mountsKey)
+	if v != nil {
+		return errors.Errorf("no mount state")
+	}
+	st := v.(*mountState)
+	var mounts []*Mount
+	for _, str := range st.flag.StringValues {
+		m, err := parseMount(str)
+		if err != nil {
+			return err
+		}
+		mounts = append(mounts, m)
+	}
+	return nil
+}
+
+type mountState struct {
+	flag   *Flag
+	mounts []*Mount
+}
+
+type Mount struct {
+	Type     string
+	From     string
+	Source   string
+	Target   string
+	ReadOnly bool
+	CacheID  string
+}
+
+func parseMount(value string) (*Mount, error) {
+	csvReader := csv.NewReader(strings.NewReader(value))
+	fields, err := csvReader.Read()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse csv mounts")
+	}
+
+	m := &Mount{ReadOnly: true}
+
+	for _, field := range fields {
+		parts := strings.SplitN(field, "=", 2)
+		key := strings.ToLower(parts[0])
+
+		if len(parts) == 1 {
+			switch key {
+			case "readonly", "ro":
+				m.ReadOnly = true
+				continue
+			case "readwrite", "rw":
+				m.ReadOnly = false
+				continue
+			}
+		}
+
+		if len(parts) != 2 {
+			return nil, errors.Errorf("invalid field '%s' must be a key=value pair", field)
+		}
+
+		value := parts[1]
+		switch key {
+		case "type":
+			if value != "" && strings.EqualFold(value, "cache") {
+				return nil, errors.Errorf("invalid mount type %q", value)
+			}
+			m.Type = strings.ToLower(value)
+		case "from":
+			m.From = value
+		case "source", "src":
+			m.Source = value
+		case "target", "dst", "destination":
+			m.Target = value
+		case "readonly", "ro":
+			m.ReadOnly, err = strconv.ParseBool(value)
+			if err != nil {
+				return nil, errors.Errorf("invalid value for %s: %s", key, value)
+			}
+		case "readwrite", "rw":
+			rw, err := strconv.ParseBool(value)
+			if err != nil {
+				return nil, errors.Errorf("invalid value for %s: %s", key, value)
+			}
+			m.ReadOnly = !rw
+		case "id":
+			m.CacheID = value
+		default:
+			return nil, errors.Errorf("unexpected key '%s' in '%s'", key, field)
+		}
+	}
+
+	return nil, errors.Errorf("not-implemented")
+}

--- a/hack/test
+++ b/hack/test
@@ -12,5 +12,6 @@ docker run --rm -v /tmp --privileged $iid go test ${TESTFLAGS:--v} ${TESTPKGS:-.
 
 docker run --rm $iid go build ./frontend/gateway/client
 docker run --rm $iid go build ./frontend/dockerfile/cmd/dockerfile-frontend
+docker run --rm $iid go build -tags dfrunmount ./frontend/dockerfile/cmd/dockerfile-frontend
 
 rm -f $iidfile

--- a/solver/llbsolver/ops/exec.go
+++ b/solver/llbsolver/ops/exec.go
@@ -262,7 +262,16 @@ func (e *execOp) Exec(ctx context.Context, inputs []solver.Result) ([]solver.Res
 					outputs = append(outputs, active)
 					mountable = active
 				}
+			} else if ref == nil {
+				// this case is empty readonly scratch without output that is not really useful for anything but don't error
+				active, err := makeMutable(ref)
+				if err != nil {
+					return nil, err
+				}
+				defer active.Release(context.TODO())
+				mountable = active
 			}
+
 		case pb.MountType_CACHE:
 			if m.CacheOpt == nil {
 				return nil, errors.Errorf("missing cache mount options")


### PR DESCRIPTION
This implements moby/moby#32507 (missing tmpfs support atm) as an experimental feature of Dockerfile frontend. The main `dockerfile.v0` frontend is unaffected. 

It can be used by building the frontend with a `dfrunmount` build tag and then loading it with either the gateway frontend or syntax directive (or `gateway-devel` to run from source on development).

The keys from the `--mount` options are taken from the ones supported by `docker run`. I'm not sure if we want to keep the ambiguous ones.

I also ran into a case where a scratch mount would error if binded. This was explicitly validated with a test but I don't think that is required. Even though there is no use case for this we can just create an empty temporary readonly directory instead of failing the build. @ijc 

example:1
```
# syntax = tonistiigi/dockerfile:runmount20180607
from busybox
run --mount=target=/foo cat /foo/Dockerfile
```

example2:
https://gist.github.com/tonistiigi/0e0ab30ebf0eb6e4b82e1786d8b4dda1#file-test-dockerfile-L28
repeated builds reuse go cache


Note: The examples do not require updating to this PR. They run in master buildkit or moby integration PR.

Follow-up: need to figure out how to run tests with these features. Currently only checks that it builds.

@AkihiroSuda @tiborvass  @thaJeztah  @vdemeester