### PR TITLE
gateway: allow digest to be optional

### DIFF
--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -103,9 +103,11 @@ func (gf *gatewayFrontend) Solve(ctx context.Context, llbBridge frontend.Fronten
 			return nil, nil, err
 		}
 
-		sourceRef, err = reference.WithDigest(sourceRef, dgst)
-		if err != nil {
-			return nil, nil, err
+		if dgst != "" {
+			sourceRef, err = reference.WithDigest(sourceRef, dgst)
+			if err != nil {
+				return nil, nil, err
+			}
 		}
 
 		src := llb.Image(sourceRef.String())


### PR DESCRIPTION
Digest from `ResolveImageConfig` should be optional and gateway should work without it as well.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>