### PR TITLE
llbsolver: validate runtime platforms for exec op

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -37,7 +37,10 @@ type Controller struct { // TODO: ControlService
 }
 
 func NewController(opt Opt) (*Controller, error) {
-	solver := llbsolver.New(opt.WorkerController, opt.Frontends, opt.CacheKeyStorage, opt.CacheImporter)
+	solver, err := llbsolver.New(opt.WorkerController, opt.Frontends, opt.CacheKeyStorage, opt.CacheImporter)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create solver")
+	}
 
 	c := &Controller{
 		opt:    opt,

--- a/examples/buildkit0/buildkit.go
+++ b/examples/buildkit0/buildkit.go
@@ -24,7 +24,7 @@ func main() {
 	bk := buildkit(opt)
 	out := bk.Run(llb.Shlex("ls -l /bin")) // debug output
 
-	dt, err := out.Marshal()
+	dt, err := out.Marshal(llb.LinuxAmd64)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/buildkit1/buildkit.go
+++ b/examples/buildkit1/buildkit.go
@@ -24,7 +24,7 @@ func main() {
 	bk := buildkit(opt)
 	out := bk.Run(llb.Shlex("ls -l /bin")) // debug output
 
-	dt, err := out.Marshal()
+	dt, err := out.Marshal(llb.LinuxAmd64)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/buildkit2/buildkit.go
+++ b/examples/buildkit2/buildkit.go
@@ -24,7 +24,7 @@ func main() {
 	bk := buildkit(opt)
 	out := bk.Run(llb.Shlex("ls -l /bin")) // debug output
 
-	dt, err := out.Marshal()
+	dt, err := out.Marshal(llb.LinuxAmd64)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/buildkit3/buildkit.go
+++ b/examples/buildkit3/buildkit.go
@@ -25,7 +25,7 @@ func main() {
 
 	bk := buildkit(opt)
 	out := bk
-	dt, err := out.Marshal()
+	dt, err := out.Marshal(llb.LinuxAmd64)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/gobuild/main.go
+++ b/examples/gobuild/main.go
@@ -68,7 +68,7 @@ func run() error {
 		// With(copyAll(*buildkitd, "/")).
 		With(copyAll(*runc, "/"))
 
-	dt, err := sc.Marshal()
+	dt, err := sc.Marshal(llb.LinuxAmd64)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/nested-llb/main.go
+++ b/examples/nested-llb/main.go
@@ -23,7 +23,7 @@ func main() {
 
 	built := pb.With(llbbuild.Build())
 
-	dt, err := llb.Image("docker.io/library/alpine:latest").Run(llb.Shlex("ls -l /out"), llb.AddMount("/out", built, llb.Readonly)).Marshal()
+	dt, err := llb.Image("docker.io/library/alpine:latest").Run(llb.Shlex("ls -l /out"), llb.AddMount("/out", built, llb.Readonly)).Marshal(llb.LinuxAmd64)
 	if err != nil {
 		panic(err)
 	}

--- a/solver/llbsolver/bridge.go
+++ b/solver/llbsolver/bridge.go
@@ -15,6 +15,7 @@ import (
 	"github.com/moby/buildkit/util/tracing"
 	"github.com/moby/buildkit/worker"
 	digest "github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -25,6 +26,7 @@ type llbBridge struct {
 	ci            *remotecache.CacheImporter
 	cms           map[string]solver.CacheManager
 	cmsMu         sync.Mutex
+	platforms     []specs.Platform
 }
 
 func (b *llbBridge) Solve(ctx context.Context, req frontend.SolveRequest) (res solver.CachedResult, exp map[string][]byte, err error) {
@@ -59,7 +61,7 @@ func (b *llbBridge) Solve(ctx context.Context, req frontend.SolveRequest) (res s
 	}
 
 	if req.Definition != nil && req.Definition.Def != nil {
-		edge, err := Load(req.Definition, WithCacheSources(cms))
+		edge, err := Load(req.Definition, WithCacheSources(cms), RuntimePlatforms(b.platforms))
 		if err != nil {
 			return nil, nil, err
 		}

--- a/solver/llbsolver/vertex.go
+++ b/solver/llbsolver/vertex.go
@@ -3,10 +3,12 @@ package llbsolver
 import (
 	"strings"
 
+	"github.com/containerd/containerd/platforms"
 	"github.com/moby/buildkit/solver"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/source"
 	digest "github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -38,11 +40,44 @@ func (v *vertex) Name() string {
 	return v.name
 }
 
-type LoadOpt func(*solver.VertexOptions)
+type LoadOpt func(*pb.Op, *pb.OpMetadata, *solver.VertexOptions) error
 
 func WithCacheSources(cms []solver.CacheManager) LoadOpt {
-	return func(opt *solver.VertexOptions) {
+	return func(_ *pb.Op, _ *pb.OpMetadata, opt *solver.VertexOptions) error {
 		opt.CacheSources = cms
+		return nil
+	}
+}
+
+func RuntimePlatforms(p []specs.Platform) LoadOpt {
+	var defaultPlatform *pb.Platform
+	for i := range p {
+		p[i] = platforms.Normalize(p[i])
+	}
+	return func(op *pb.Op, _ *pb.OpMetadata, opt *solver.VertexOptions) error {
+		if op.Platform == nil {
+			if defaultPlatform == nil {
+				p := platforms.DefaultSpec()
+				defaultPlatform = &pb.Platform{
+					OS:           p.OS,
+					Architecture: p.Architecture,
+				}
+			}
+			op.Platform = defaultPlatform
+		}
+		if _, ok := op.Op.(*pb.Op_Exec); ok {
+			var found bool
+			for _, pp := range p {
+				if pp.OS == op.Platform.OS && pp.Architecture == op.Platform.Architecture && pp.Variant == op.Platform.Variant {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return errors.Errorf("runtime execution on platform %s not supported", platforms.Format(specs.Platform{OS: op.Platform.OS, Architecture: op.Platform.Architecture, Variant: op.Platform.Variant}))
+			}
+		}
+		return nil
 	}
 }
 
@@ -67,7 +102,9 @@ func newVertex(dgst digest.Digest, op *pb.Op, opMeta *pb.OpMetadata, load func(d
 		}
 	}
 	for _, fn := range opts {
-		fn(&opt)
+		if err := fn(op, opMeta, &opt); err != nil {
+			return nil, err
+		}
 	}
 	vtx := &vertex{sys: op, options: opt, digest: dgst, name: llbOpName(op)}
 	for _, in := range op.Inputs {


### PR DESCRIPTION
This builds on #461 #462 to add validation of runtime platforms to the exec ops.

Only last commit is new. Will rebase after other are merged.

@tiborvass 