### PR TITLE
add missing supplementary group IDs

### DIFF
--- a/executor/oci/user.go
+++ b/executor/oci/user.go
@@ -2,27 +2,31 @@ package oci
 
 import (
 	"context"
+	"errors"
 	"os"
 	"strconv"
 	"strings"
 
+	"github.com/containerd/containerd/containers"
+	containerdoci "github.com/containerd/containerd/oci"
 	"github.com/containerd/continuity/fs"
 	"github.com/opencontainers/runc/libcontainer/user"
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
-func GetUser(ctx context.Context, root, username string) (uint32, uint32, error) {
+func GetUser(ctx context.Context, root, username string) (uint32, uint32, []uint32, error) {
 	// fast path from uid/gid
-	if uid, gid, err := ParseUser(username); err == nil {
-		return uid, gid, nil
+	if uid, gid, err := ParseUIDGID(username); err == nil {
+		return uid, gid, nil, nil
 	}
 
 	passwdPath, err := user.GetPasswdPath()
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, nil, err
 	}
 	groupPath, err := user.GetGroupPath()
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, nil, err
 	}
 	passwdFile, err := openUserFile(root, passwdPath)
 	if err == nil {
@@ -35,33 +39,29 @@ func GetUser(ctx context.Context, root, username string) (uint32, uint32, error)
 
 	execUser, err := user.GetExecUser(username, nil, passwdFile, groupFile)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, nil, err
 	}
-
-	return uint32(execUser.Uid), uint32(execUser.Gid), nil
+	var sgids []uint32
+	for _, g := range execUser.Sgids {
+		sgids = append(sgids, uint32(g))
+	}
+	return uint32(execUser.Uid), uint32(execUser.Gid), sgids, nil
 }
 
-func ParseUser(str string) (uid uint32, gid uint32, err error) {
+// ParseUIDGID takes the fast path to parse UID and GID if and only if they are both provided
+func ParseUIDGID(str string) (uid uint32, gid uint32, err error) {
 	if str == "" {
 		return 0, 0, nil
 	}
 	parts := strings.SplitN(str, ":", 2)
-	for i, v := range parts {
-		switch i {
-		case 0:
-			uid, err = parseUID(v)
-			if err != nil {
-				return 0, 0, err
-			}
-			if len(parts) == 1 {
-				gid = uid
-			}
-		case 1:
-			gid, err = parseUID(v)
-			if err != nil {
-				return 0, 0, err
-			}
-		}
+	if len(parts) == 1 {
+		return 0, 0, errors.New("groups ID is not provided")
+	}
+	if uid, err = parseUID(parts[0]); err != nil {
+		return 0, 0, err
+	}
+	if gid, err = parseUID(parts[1]); err != nil {
+		return 0, 0, err
 	}
 	return
 }
@@ -83,4 +83,25 @@ func parseUID(str string) (uint32, error) {
 		return 0, err
 	}
 	return uint32(uid), nil
+}
+
+// WithUIDGID allows the UID and GID for the Process to be set
+// FIXME: This is a temporeray fix for the missing supplementary GIDs from containerd
+// once the PR in containerd is merged we should remove this function.
+func WithUIDGID(uid, gid uint32, sgids []uint32) containerdoci.SpecOpts {
+	return func(_ context.Context, _ containerdoci.Client, _ *containers.Container, s *containerdoci.Spec) error {
+		setProcess(s)
+		s.Process.User.UID = uid
+		s.Process.User.GID = gid
+		s.Process.User.AdditionalGids = sgids
+		return nil
+	}
+}
+
+// setProcess sets Process to empty if unset
+// FIXME: Same on this one. Need to be removed after containerd fix merged
+func setProcess(s *containerdoci.Spec) {
+	if s.Process == nil {
+		s.Process = &specs.Process{}
+	}
 }

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -133,7 +133,7 @@ func (w *runcExecutor) Exec(ctx context.Context, meta executor.Meta, root cache.
 	}
 	defer mount.Unmount(rootFSPath, 0)
 
-	uid, gid, err := oci.GetUser(ctx, rootFSPath, meta.User)
+	uid, gid, sgids, err := oci.GetUser(ctx, rootFSPath, meta.User)
 	if err != nil {
 		return err
 	}
@@ -143,7 +143,7 @@ func (w *runcExecutor) Exec(ctx context.Context, meta executor.Meta, root cache.
 		return err
 	}
 	defer f.Close()
-	opts := []containerdoci.SpecOpts{containerdoci.WithUIDGID(uid, gid)}
+	opts := []containerdoci.SpecOpts{oci.WithUIDGID(uid, gid, sgids)}
 	if system.SeccompSupported() {
 		opts = append(opts, seccomp.WithDefaultProfile())
 	}


### PR DESCRIPTION
#### What's in this PR
- This PR fixes issue #412 by adding the missing supplementary group IDs whenver `containerdexecutor` or `runcexecutor` is called.
- Lift over some dockerfile build tests from moby to enhance buildkit testing.
- Added separate fix in containerd (TBP)

cc @tonistiigi 

Signed-off-by: Anda Xu <anda.xu@docker.com>