### PR TITLE
Fix "cat: can't open '.tmp/ldflags': No such file or directory" errors

### DIFF
--- a/hack/dockerfiles/test.Dockerfile
+++ b/hack/dockerfiles/test.Dockerfile
@@ -81,10 +81,8 @@ COPY --from=buildctl /usr/bin/buildctl /usr/bin/
 COPY --from=buildkitd /usr/bin/buildkitd /usr/bin
 COPY --from=registry /bin/registry /usr/bin
 
-FROM gobuild-base AS cross-windows
+FROM buildkit-base AS cross-windows
 ENV GOOS=windows
-WORKDIR /go/src/github.com/moby/buildkit
-COPY . .
 
 FROM cross-windows AS buildctl.exe
 RUN go build -ldflags "$(cat .tmp/ldflags)" -o /buildctl.exe ./cmd/buildctl


### PR DESCRIPTION
The error appears in

```
RUN go build -ldflags "$(cat .tmp/ldflags)" -o /buildctl.exe ./cmd/buildctl
```

and

```
RUN go build -ldflags "$(cat .tmp/ldflags)" -o /buildkitd.exe ./cmd/buildkitd
```

We ignore ".tmp" by ".dockerignore" file, so `COPY . .`
does not copy ".tmp".
This commit changes the image for "cross-windows" and removes
not needed instructions which are done by "buildkit-base".

This is follow up of https://github.com/moby/buildkit/pull/398

Signed-off-by: Yuichiro Kaneko <spiketeika@gmail.com>