### PR TITLE
Fix rootless

### DIFF
--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -135,6 +135,9 @@ func main() {
 	app.Flags = append(app.Flags, appFlags...)
 
 	app.Action = func(c *cli.Context) error {
+		if os.Geteuid() != 0 {
+			return errors.New("rootless mode requires to be executed as the mapped root in a user namespace; you may use RootlessKit for setting up the namespace")
+		}
 		ctx, cancel := context.WithCancel(appcontext.Context())
 		defer cancel()
 

--- a/cmd/buildkitd/main_linux.go
+++ b/cmd/buildkitd/main_linux.go
@@ -1,9 +1,0 @@
-// +build linux
-
-package main
-
-import "github.com/opencontainers/runc/libcontainer/system"
-
-func runningAsUnprivilegedUser() bool {
-	return system.GetParentNSeuid() != 0 || system.RunningInUserNS()
-}

--- a/cmd/buildkitd/main_nolinux.go
+++ b/cmd/buildkitd/main_nolinux.go
@@ -1,7 +1,0 @@
-// +build !linux
-
-package main
-
-func runningAsUnprivilegedUser() bool {
-	return false
-}

--- a/cmd/buildkitd/main_oci_worker.go
+++ b/cmd/buildkitd/main_oci_worker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/moby/buildkit/worker/base"
 	"github.com/moby/buildkit/worker/runc"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/opencontainers/runc/libcontainer/system"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -41,7 +42,7 @@ func init() {
 	}
 	n := "oci-worker-rootless"
 	u := "enable rootless mode"
-	if runningAsUnprivilegedUser() {
+	if system.RunningInUserNS() {
 		flags = append(flags, cli.BoolTFlag{
 			Name:  n,
 			Usage: u,

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -170,9 +170,7 @@ func (w *runcExecutor) Exec(ctx context.Context, meta executor.Meta, root cache.
 	}
 
 	if w.rootless {
-		specconv.ToRootless(spec, &specconv.RootlessOpts{
-			MapSubUIDGID: true,
-		})
+		specconv.ToRootless(spec, nil)
 		// TODO(AkihiroSuda): keep Cgroups enabled if /sys/fs/cgroup/cpuset/buildkit exists and writable
 		spec.Linux.CgroupsPath = ""
 		// TODO(AkihiroSuda): ToRootless removes netns, but we should readd netns here


### PR DESCRIPTION
* rootless: fix default path configuration
  * if buildkitd is being executed as the mapepd-root ($USER==root)
in a rootless container, we need to enable the rootless mode but
we don't want to honor $HOME.
* rootless: bail if euid != 0