### PR TITLE
integration: rename "/opt/containerd-1.0/bin/containerd" worker to "containerd-1.0"

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ make test TESTPKGS=./client
 make test TESTPKGS=./client TESTFLAGS="--run /TestCallDiskUsage -v" 
 
 # run all integration tests with a specific worker
-# supported workers are oci and containerd
+# supported workers: oci, oci-rootless, containerd, containerd-1.0
 make test TESTPKGS=./client TESTFLAGS="--run //worker=containerd -v" 
 ```
 

--- a/hack/dockerfiles/test.Dockerfile
+++ b/hack/dockerfiles/test.Dockerfile
@@ -93,6 +93,7 @@ RUN apk add --no-cache shadow shadow-uidmap sudo \
   && echo "XDG_RUNTIME_DIR=/run/user/1000; export XDG_RUNTIME_DIR" >> /home/user/.profile \
   && mkdir -m 0700 -p /run/user/1000 \
   && chown -R user /run/user/1000 /home/user
+ENV BUILDKIT_INTEGRATION_CONTAINERD_EXTRA="containerd-1.0=/opt/containerd-1.0/bin"
 COPY --from=containerd10 /go/src/github.com/containerd/containerd/bin/containerd* /opt/containerd-1.0/bin/
 COPY --from=buildctl /usr/bin/buildctl /usr/bin/
 COPY --from=buildkitd /usr/bin/buildkitd /usr/bin


### PR DESCRIPTION
Having '/' in a worker name is confusing.

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>