### PR TITLE
Fixing mismatch

### DIFF
--- a/util/rootless/specconv/specconv_linux.go
+++ b/util/rootless/specconv/specconv_linux.go
@@ -63,7 +63,7 @@ func configureUserNS(spec *specs.Spec, uidMap, gidMap []user.IDMap) error {
 				ContainerID: uint32(uNextContainerID),
 				Size:        uint32(u.Count),
 			})
-		uNextContainerID += u.Count
+		uNextContainerID += int64(u.Count)
 	}
 	sort.Slice(gidMap, func(i, j int) bool { return gidMap[i].ID < gidMap[j].ID })
 	gNextContainerID := int64(0)
@@ -74,7 +74,7 @@ func configureUserNS(spec *specs.Spec, uidMap, gidMap []user.IDMap) error {
 				ContainerID: uint32(gNextContainerID),
 				Size:        uint32(g.Count),
 			})
-		gNextContainerID += g.Count
+		gNextContainerID += int64(g.Count)
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Noel Georgi <18496730+frezbo@users.noreply.github.com>

@AkihiroSuda This was failing when I updated `img` to use latest buildkit. Not sure if its the right fix.

Build Error:
```
img (aws:rean-gov-sd)(kc)(git:master)*$ make   BUILDTAGS=""
+ img
go build -tags "" -ldflags "-w -X github.com/genuinetools/img/version.GITCOMMIT=bcebacfc-dirty -X github.com/genuinetools/img/version.VERSION=v0.4.6" -o img .
# github.com/genuinetools/img/vendor/github.com/moby/buildkit/util/rootless/specconv
vendor/github.com/moby/buildkit/util/rootless/specconv/specconv_linux.go:66:20: invalid operation: uNextContainerID += u.Count (mismatched types int64 and int)
vendor/github.com/moby/buildkit/util/rootless/specconv/specconv_linux.go:77:20: invalid operation: gNextContainerID += g.Count (mismatched types int64 and int)
make: *** [Makefile:37: img] Error 2

```