### PR TITLE
[NEW FAILING TEST] client: add test case for multiple parallel builds.

### DIFF
--- a/hack/test
+++ b/hack/test
@@ -7,11 +7,10 @@ iidfile=$(mktemp -t docker-iidfile.XXXXXXXXXX)
 docker build --iidfile $iidfile --target integration-tests -f ./hack/dockerfiles/test.Dockerfile --force-rm .
 
 iid=$(cat $iidfile)
+rm -f $iidfile
 
 docker run --rm -v /tmp --privileged $iid go test ${TESTFLAGS:--v} ${TESTPKGS:-./...}
 
 docker run --rm $iid go build ./frontend/gateway/client
 docker run --rm $iid go build ./frontend/dockerfile/cmd/dockerfile-frontend
 docker run --rm $iid go build -tags dfrunmount ./frontend/dockerfile/cmd/dockerfile-frontend
-
-rm -f $iidfile


### PR DESCRIPTION
It appears that multiple parallel builds suffer some cross talk between their
mount/snapshots e.g. this new case currently fails because iterations see files
in `/src/` which correspond to other iterations (i.e. iteration 1 might see a
file called "test2.txt"). The `ls -i` and `stat` output also confirms that 
where tests see the same filename they are also apparently seeing the same
inode.

Note that each solve uses a `SolverOpt.SharedKey` of the (unique) source
directory so there should be no clashes. Use of `llb.sharedKeyHint()` is
avoided since using a unique one of these hides the issue (AIUI uniqueness of
`sharedKeyHint` is only required with a session, not between them).

The shell fragment within the test is a bit crazy, it tries to output as much
info about what it saw vs what was expected to aid debugging.

I have also been seeing cases in my own code where `cacheContext.checksum`
fails the `not found` test at the top, which seems like either the wrong thing
is mounted or it has gone away or otherwise been mutated unexpectedly. I had
been hoping that this test case would also reproduce this, but so far it has
not.

Signed-off-by: Ian Campbell <ijc@docker.com>

It's not without the realms of possibility that the bug is in my code here. FWIW it passes if only one iteration of the loop is run.

In my own code this sort of thing is happening with parallel clients in completely separate processes, here I rely on each `c.Solve` creating a new session being sufficiently similar to that.

I also snuck in a fixlet for `test/hack` to not leak the iid file on failure.