### PR TITLE
hack/test: remove `$iidfile` earlier

### DIFF
--- a/hack/test
+++ b/hack/test
@@ -7,11 +7,10 @@ iidfile=$(mktemp -t docker-iidfile.XXXXXXXXXX)
 docker build --iidfile $iidfile --target integration-tests -f ./hack/dockerfiles/test.Dockerfile --force-rm .
 
 iid=$(cat $iidfile)
+rm -f $iidfile
 
 docker run --rm -v /tmp --privileged $iid go test ${TESTFLAGS:--v} ${TESTPKGS:-./...}
 
 docker run --rm $iid go build ./frontend/gateway/client
 docker run --rm $iid go build ./frontend/dockerfile/cmd/dockerfile-frontend
 docker run --rm $iid go build -tags dfrunmount ./frontend/dockerfile/cmd/dockerfile-frontend
-
-rm -f $iidfile


### PR DESCRIPTION
We don't need it once we have assigned to `$iid`, so remove it otherwise it can
be leaked if any of the `docker run` lines fails (since we immediately exit due
to `set -e`).

Signed-off-by: Ian Campbell <ijc@docker.com>

(was an unrelated bonus in #492, not carried in #495)