### PR TITLE
exporter: export multiple refs with local/image exporter

### DIFF
--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
-	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/exporter"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/util/push"
@@ -100,7 +99,9 @@ func (e *imageExporterInstance) Name() string {
 	return "exporting to image"
 }
 
-func (e *imageExporterInstance) Export(ctx context.Context, ref cache.ImmutableRef, opt map[string][]byte) (map[string]string, error) {
+func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source) (map[string]string, error) {
+	ref := src.Ref
+	opt := src.Metadata
 	if config, ok := opt[exporterImageConfig]; ok {
 		e.config = config
 	}

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/moby/buildkit/exporter"
+	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/util/push"
 	"github.com/pkg/errors"
@@ -15,11 +16,10 @@ import (
 )
 
 const (
-	keyImageName        = "name"
-	keyPush             = "push"
-	keyInsecure         = "registry.insecure"
-	exporterImageConfig = "containerimage.config"
-	ociTypes            = "oci-mediatypes"
+	keyImageName = "name"
+	keyPush      = "push"
+	keyInsecure  = "registry.insecure"
+	ociTypes     = "oci-mediatypes"
 )
 
 type Opt struct {
@@ -67,7 +67,7 @@ func (e *imageExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 				return nil, errors.Wrapf(err, "non-bool value specified for %s", k)
 			}
 			i.insecure = b
-		case exporterImageConfig:
+		case exptypes.ExporterImageConfigKey:
 			i.config = []byte(v)
 		case ociTypes:
 			if v == "" {
@@ -102,7 +102,7 @@ func (e *imageExporterInstance) Name() string {
 func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source) (map[string]string, error) {
 	ref := src.Ref
 	opt := src.Metadata
-	if config, ok := opt[exporterImageConfig]; ok {
+	if config, ok := opt[exptypes.ExporterImageConfigKey]; ok {
 		e.config = config
 	}
 	desc, err := e.opt.ImageWriter.Commit(ctx, ref, e.config, e.ociTypes)

--- a/exporter/containerimage/exptypes/types.go
+++ b/exporter/containerimage/exptypes/types.go
@@ -1,0 +1,15 @@
+package exptypes
+
+import specs "github.com/opencontainers/image-spec/specs-go/v1"
+
+const ExporterImageConfigKey = "containerimage.config"
+const ExporterPlatformsKey = "refs.platforms"
+
+type Platforms struct {
+	Platforms []Platform
+}
+
+type Platform struct {
+	ID       string
+	Platform specs.Platform
+}

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -12,5 +12,11 @@ type Exporter interface {
 
 type ExporterInstance interface {
 	Name() string
-	Export(context.Context, cache.ImmutableRef, map[string][]byte) (map[string]string, error)
+	Export(context.Context, Source) (map[string]string, error)
+}
+
+type Source struct {
+	Ref      cache.ImmutableRef
+	Refs     map[string]cache.ImmutableRef
+	Metadata map[string][]byte
 }

--- a/exporter/local/export.go
+++ b/exporter/local/export.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/exporter"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/filesync"
@@ -58,7 +57,8 @@ func (e *localExporterInstance) Name() string {
 	return "exporting to client"
 }
 
-func (e *localExporterInstance) Export(ctx context.Context, ref cache.ImmutableRef, opt map[string][]byte) (map[string]string, error) {
+func (e *localExporterInstance) Export(ctx context.Context, inp exporter.Source) (map[string]string, error) {
+	ref := inp.Ref
 	var src string
 	var err error
 	if ref == nil {

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/moby/buildkit/exporter"
 	"github.com/moby/buildkit/exporter/containerimage"
+	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/filesync"
 	"github.com/moby/buildkit/util/dockerexporter"
@@ -22,11 +23,10 @@ import (
 type ExporterVariant string
 
 const (
-	exporterImageConfig = "containerimage.config"
-	keyImageName        = "name"
-	VariantOCI          = "oci"
-	VariantDocker       = "docker"
-	ociTypes            = "oci-mediatypes"
+	keyImageName  = "name"
+	VariantOCI    = "oci"
+	VariantDocker = "docker"
+	ociTypes      = "oci-mediatypes"
 )
 
 type Opt struct {
@@ -62,7 +62,7 @@ func (e *imageExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 	i := &imageExporterInstance{imageExporter: e, caller: caller}
 	for k, v := range opt {
 		switch k {
-		case exporterImageConfig:
+		case exptypes.ExporterImageConfigKey:
 			i.config = []byte(v)
 		case keyImageName:
 			parsed, err := reference.ParseNormalizedNamed(v)
@@ -108,7 +108,7 @@ func (e *imageExporterInstance) Name() string {
 func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source) (map[string]string, error) {
 	ref := src.Ref
 	opt := src.Metadata
-	if config, ok := opt[exporterImageConfig]; ok {
+	if config, ok := opt[exptypes.ExporterImageConfigKey]; ok {
 		e.config = config
 	}
 	desc, err := e.opt.ImageWriter.Commit(ctx, ref, e.config, e.ociTypes)

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -8,7 +8,6 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/images/oci"
 	"github.com/docker/distribution/reference"
-	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/exporter"
 	"github.com/moby/buildkit/exporter/containerimage"
 	"github.com/moby/buildkit/session"
@@ -106,7 +105,9 @@ func (e *imageExporterInstance) Name() string {
 	return "exporting to oci image format"
 }
 
-func (e *imageExporterInstance) Export(ctx context.Context, ref cache.ImmutableRef, opt map[string][]byte) (map[string]string, error) {
+func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source) (map[string]string, error) {
+	ref := src.Ref
+	opt := src.Metadata
 	if config, ok := opt[exporterImageConfig]; ok {
 		e.config = config
 	}

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -58,6 +58,11 @@ func Dockerfile2LLB(ctx context.Context, dt []byte, opt ConvertOpt) (*llb.State,
 
 	platformOpt := buildPlatformOpt(&opt)
 
+	optMetaArgs := getPlatformArgs(platformOpt)
+	for i, arg := range optMetaArgs {
+		optMetaArgs[i] = setKVValue(arg, opt.BuildArgs)
+	}
+
 	dockerfile, err := parser.Parse(bytes.NewReader(dt))
 	if err != nil {
 		return nil, nil, err
@@ -70,7 +75,6 @@ func Dockerfile2LLB(ctx context.Context, dt []byte, opt ConvertOpt) (*llb.State,
 		return nil, nil, err
 	}
 
-	optMetaArgs := []instructions.KeyValuePairOptional{}
 	for _, metaArg := range metaArgs {
 		optMetaArgs = append(optMetaArgs, setKVValue(metaArg.KeyValuePairOptional, opt.BuildArgs))
 	}

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -217,6 +217,7 @@ func Dockerfile2LLB(ctx context.Context, dt []byte, opt ConvertOpt) (*llb.State,
 					} else {
 						d.state = llb.Image(d.stage.BaseName, dfCmd(d.stage.SourceCode), llb.Platform(*platform))
 					}
+					d.platform = platform
 					return nil
 				})
 			}(i, d)
@@ -236,6 +237,7 @@ func Dockerfile2LLB(ctx context.Context, dt []byte, opt ConvertOpt) (*llb.State,
 		}
 		if d.base != nil {
 			d.state = d.base.state
+			d.platform = d.base.platform
 			d.image = clone(d.base.image)
 		}
 
@@ -645,6 +647,10 @@ func dispatchCopy(d *dispatchState, c instructions.SourcesAndDest, sourceState l
 	}
 	run := img.Run(append(runOpt, mounts...)...)
 	d.state = run.AddMount("/dest", d.state).Platform(opt.targetPlatform)
+
+	if d.platform != nil {
+		d.state = d.state.Platform(*d.platform)
+	}
 
 	return commitToHistory(&d.image, commitMessage.String(), true, &d.state)
 }

--- a/frontend/dockerfile/dockerfile2llb/platform.go
+++ b/frontend/dockerfile/dockerfile2llb/platform.go
@@ -2,6 +2,7 @@ package dockerfile2llb
 
 import (
 	"github.com/containerd/containerd/platforms"
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -33,4 +34,25 @@ func buildPlatformOpt(opt *ConvertOpt) *platformOpt {
 		buildPlatforms: buildPlatforms,
 		implicitTarget: implicitTargetPlatform,
 	}
+}
+
+func getPlatformArgs(po *platformOpt) []instructions.KeyValuePairOptional {
+	bp := po.buildPlatforms[0]
+	tp := po.targetPlatform
+	m := map[string]string{
+		"BUILDPLATFORM":  platforms.Format(bp),
+		"BUILDOS":        bp.OS,
+		"BUILDARCH":      bp.Architecture,
+		"BUILDVARIANT":   bp.Variant,
+		"TARGETPLATFORM": platforms.Format(tp),
+		"TARGETOS":       tp.OS,
+		"TARGETARCH":     tp.Architecture,
+		"TARGETVARIANT":  tp.Variant,
+	}
+	opts := make([]instructions.KeyValuePairOptional, 0, len(m))
+	for k, v := range m {
+		s := v
+		opts = append(opts, instructions.KeyValuePairOptional{Key: k, Value: &s})
+	}
+	return opts
 }

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/frontend/dockerfile/builder"
 	"github.com/moby/buildkit/identity"
+	"github.com/moby/buildkit/util/testutil"
 	"github.com/moby/buildkit/util/testutil/httpserver"
 	"github.com/moby/buildkit/util/testutil/integration"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -72,7 +73,141 @@ func TestIntegration(t *testing.T) {
 		testContextChangeDirToFile,
 		testPlatformArgsImplicit,
 		testPlatformArgsExplicit,
+		testExportMultiPlatform,
 	})
+}
+
+func testExportMultiPlatform(t *testing.T, sb integration.Sandbox) {
+	t.Parallel()
+
+	dockerfile := []byte(`
+FROM scratch
+ARG TARGETARCH
+ARG TARGETPLATFORM
+LABEL target=$TARGETPLATFORM
+COPY arch-$TARGETARCH whoami
+`)
+
+	dir, err := tmpdir(
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+		fstest.CreateFile("arch-arm", []byte(`i am arm`), 0600),
+		fstest.CreateFile("arch-amd64", []byte(`i am amd64`), 0600),
+		fstest.CreateFile("arch-s390x", []byte(`i am s390x`), 0600),
+		fstest.CreateFile("arch-ppc64le", []byte(`i am ppc64le`), 0600),
+	)
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	c, err := client.New(context.TODO(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	destDir, err := ioutil.TempDir("", "buildkit")
+	require.NoError(t, err)
+	defer os.RemoveAll(destDir)
+
+	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
+		Frontend: "dockerfile.v0",
+		LocalDirs: map[string]string{
+			builder.LocalNameDockerfile: dir,
+			builder.LocalNameContext:    dir,
+		},
+		FrontendAttrs: map[string]string{
+			"platform": "windows/amd64,linux/arm,linux/s390x",
+		},
+		Exporter:          client.ExporterLocal,
+		ExporterOutputDir: destDir,
+	}, nil)
+	require.NoError(t, err)
+
+	dt, err := ioutil.ReadFile(filepath.Join(destDir, "windows_amd64/whoami"))
+	require.NoError(t, err)
+	require.Equal(t, "i am amd64", string(dt))
+
+	dt, err = ioutil.ReadFile(filepath.Join(destDir, "linux_arm_v7/whoami"))
+	require.NoError(t, err)
+	require.Equal(t, "i am arm", string(dt))
+
+	dt, err = ioutil.ReadFile(filepath.Join(destDir, "linux_s390x/whoami"))
+	require.NoError(t, err)
+	require.Equal(t, "i am s390x", string(dt))
+
+	// repeat with oci exporter
+
+	destDir, err = ioutil.TempDir("", "buildkit")
+	require.NoError(t, err)
+	defer os.RemoveAll(destDir)
+
+	out := filepath.Join(destDir, "out.tar")
+	outW, err := os.Create(out)
+	require.NoError(t, err)
+
+	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
+		Frontend: "dockerfile.v0",
+		LocalDirs: map[string]string{
+			builder.LocalNameDockerfile: dir,
+			builder.LocalNameContext:    dir,
+		},
+		FrontendAttrs: map[string]string{
+			"platform": "windows/amd64,linux/arm/v6,linux/ppc64le",
+		},
+		Exporter:       client.ExporterOCI,
+		ExporterOutput: outW,
+	}, nil)
+	require.NoError(t, err)
+
+	dt, err = ioutil.ReadFile(filepath.Join(destDir, "out.tar"))
+	require.NoError(t, err)
+
+	m, err := testutil.ReadTarToMap(dt, false)
+	require.NoError(t, err)
+
+	var idx ocispec.Index
+	err = json.Unmarshal(m["index.json"].Data, &idx)
+	require.NoError(t, err)
+
+	mlistHex := idx.Manifests[0].Digest.Hex()
+
+	idx = ocispec.Index{}
+	err = json.Unmarshal(m["blobs/sha256/"+mlistHex].Data, &idx)
+	require.NoError(t, err)
+
+	require.Equal(t, 3, len(idx.Manifests))
+
+	for i, exp := range []struct {
+		p    string
+		os   string
+		arch string
+		dt   string
+	}{
+		{p: "windows/amd64", os: "windows", arch: "amd64", dt: "i am amd64"},
+		{p: "linux/arm/v6", os: "linux", arch: "arm", dt: "i am arm"},
+		{p: "linux/ppc64le", os: "linux", arch: "ppc64le", dt: "i am ppc64le"},
+	} {
+		t.Run(exp.p, func(t *testing.T) {
+			require.Equal(t, exp.p, platforms.Format(*idx.Manifests[i].Platform))
+
+			var mfst ocispec.Manifest
+			err = json.Unmarshal(m["blobs/sha256/"+idx.Manifests[i].Digest.Hex()].Data, &mfst)
+			require.NoError(t, err)
+
+			require.Equal(t, 1, len(mfst.Layers))
+
+			m2, err := testutil.ReadTarToMap(m["blobs/sha256/"+mfst.Layers[0].Digest.Hex()].Data, true)
+			require.NoError(t, err)
+			require.Equal(t, exp.dt, string(m2["whoami"].Data))
+
+			var img ocispec.Image
+			err = json.Unmarshal(m["blobs/sha256/"+mfst.Config.Digest.Hex()].Data, &img)
+			require.NoError(t, err)
+
+			require.Equal(t, exp.os, img.OS)
+			require.Equal(t, exp.arch, img.Architecture)
+			v, ok := img.Config.Labels["target"]
+			require.True(t, ok)
+			require.Equal(t, exp.p, v)
+		})
+	}
 }
 
 // tonistiigi/fsutil#46

--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -16,6 +16,7 @@ import (
 	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/executor"
+	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/frontend"
 	pb "github.com/moby/buildkit/frontend/gateway/pb"
 	"github.com/moby/buildkit/identity"
@@ -37,9 +38,8 @@ import (
 )
 
 const (
-	keySource           = "source"
-	keyDevel            = "gateway-devel"
-	exporterImageConfig = "containerimage.config"
+	keySource = "source"
+	keyDevel  = "gateway-devel"
 )
 
 func NewGatewayFrontend(w frontend.WorkerInfos) frontend.Frontend {
@@ -97,7 +97,7 @@ func (gf *gatewayFrontend) Solve(ctx context.Context, llbBridge frontend.Fronten
 			return nil, errors.Errorf("invalid ref: %T", devRes.Ref.Sys())
 		}
 		rootFS = workerRef.ImmutableRef
-		config, ok := devRes.Metadata[exporterImageConfig]
+		config, ok := devRes.Metadata[exptypes.ExporterImageConfigKey]
 		if ok {
 			if err := json.Unmarshal(config, &img); err != nil {
 				return nil, err

--- a/source/containerimage/pull.go
+++ b/source/containerimage/pull.go
@@ -58,7 +58,11 @@ func (is *imageSource) ResolveImageConfig(ctx context.Context, ref string, platf
 		dgst digest.Digest
 		dt   []byte
 	}
-	res, err := is.g.Do(ctx, ref, func(ctx context.Context) (interface{}, error) {
+	key := ref
+	if platform != nil {
+		key += platforms.Format(*platform)
+	}
+	res, err := is.g.Do(ctx, key, func(ctx context.Context) (interface{}, error) {
 		dgst, dt, err := imageutil.Config(ctx, ref, pull.NewResolver(ctx, is.SessionManager, is.ImageStore), is.ContentStore, platform)
 		if err != nil {
 			return nil, err

--- a/util/dockerexporter/dockerexporter.go
+++ b/util/dockerexporter/dockerexporter.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
-	"github.com/containerd/containerd/platforms"
 	ocispecs "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -51,8 +50,6 @@ func (de *DockerExporter) Export(ctx context.Context, store content.Provider, de
 
 	// Get all the children for a descriptor
 	childrenHandler := images.ChildrenHandler(store)
-	// Filter the childen by the platform
-	childrenHandler = images.FilterPlatforms(childrenHandler, platforms.Default())
 
 	handlers := images.Handlers(
 		childrenHandler,

--- a/util/pull/pull.go
+++ b/util/pull/pull.go
@@ -182,7 +182,7 @@ func (p *Puller) Pull(ctx context.Context) (*Pulled, error) {
 	var layerBlobs []ocispec.Descriptor
 	for _, j := range usedBlobs {
 		switch j.MediaType {
-		case ocispec.MediaTypeImageLayer, images.MediaTypeDockerSchema2Layer, ocispec.MediaTypeImageLayerGzip, images.MediaTypeDockerSchema2LayerGzip:
+		case ocispec.MediaTypeImageLayer, images.MediaTypeDockerSchema2Layer, ocispec.MediaTypeImageLayerGzip, images.MediaTypeDockerSchema2LayerGzip, images.MediaTypeDockerSchema2LayerForeign, images.MediaTypeDockerSchema2LayerForeignGzip:
 			layerBlobs = append(layerBlobs, j)
 		default:
 			notLayerBlobs = append(notLayerBlobs, j)

--- a/util/testutil/tar.go
+++ b/util/testutil/tar.go
@@ -1,0 +1,51 @@
+package testutil
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"io"
+	"io/ioutil"
+
+	"github.com/pkg/errors"
+)
+
+type TarItem struct {
+	Header *tar.Header
+	Data   []byte
+}
+
+func ReadTarToMap(dt []byte, compressed bool) (map[string]*TarItem, error) {
+	m := map[string]*TarItem{}
+	var r io.Reader = bytes.NewBuffer(dt)
+	if compressed {
+		gz, err := gzip.NewReader(r)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error creating gzip reader")
+		}
+		defer gz.Close()
+		r = gz
+	}
+	tr := tar.NewReader(r)
+	for {
+		h, err := tr.Next()
+		if err != nil {
+			if err == io.EOF {
+				return m, nil
+			}
+			return nil, errors.Wrap(err, "error reading tar")
+		}
+		if _, ok := m[h.Name]; ok {
+			return nil, errors.Errorf("duplicate entries for %s", h.Name)
+		}
+
+		var dt []byte
+		if h.Typeflag == tar.TypeReg {
+			dt, err = ioutil.ReadAll(tr)
+			if err != nil {
+				return nil, errors.Wrapf(err, "error reading file")
+			}
+		}
+		m[h.Name] = &TarItem{Header: h, Data: dt}
+	}
+}


### PR DESCRIPTION
~based on #496~

Add support for:
- exporting map of references with local/image/oci exporter
- specifying multiple target platforms for Dockerfile frontend
- Implicit platform build args in Dockerfile. Updated version of https://github.com/moby/moby/issues/32487


Example:

```
from --platform=$BUILDPLATFORM busybox AS bb
arg TARGETPLATFORM
run echo "i am $TARGETPLATFORM" > /whoami
from scratch
copy --from=bb whoami .
```

```
buildctl build --frontend-opt platform=linux/arm,linux/amd64,windows/arm,windows/amd64 --frontend=dockerfile.v0 --local context=. --local dockerfile=. --exporter=local --exporter-opt output=/tmp/out
```

```
> ls -l /tmp/out
drwxr-xr-x 2 root root 4096 Jul 10 22:49 linux_amd64
drwxr-xr-x 2 root root 4096 Jul 10 22:49 linux_arm_v7
drwxr-xr-x 2 root root 4096 Jul 10 22:49 windows_amd64
drwxr-xr-x 2 root root 4096 Jul 10 22:49 windows_arm_v7
> cat /tmp/out/linux_arm_v7/whoami
i am linux/arm/v7
```