### PR TITLE
cache: avoid commit on finalize when possible

### DIFF
--- a/cache/blobs/blobs.go
+++ b/cache/blobs/blobs.go
@@ -32,6 +32,10 @@ func GetDiffPairs(ctx context.Context, contentStore content.Store, snapshotter s
 		return nil, nil
 	}
 
+	if err := ref.Finalize(ctx, true); err != nil {
+		return nil, err
+	}
+
 	eg, ctx := errgroup.WithContext(ctx)
 	var diffPairs []DiffPair
 	var currentPair DiffPair

--- a/cache/manager.go
+++ b/cache/manager.go
@@ -225,7 +225,7 @@ func (cm *cacheManager) New(ctx context.Context, s ImmutableRef, opts ...RefOpti
 		if err != nil {
 			return nil, err
 		}
-		if err := parent.Finalize(ctx); err != nil {
+		if err := parent.Finalize(ctx, true); err != nil {
 			return nil, err
 		}
 		parentID = parent.ID()

--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -82,7 +82,7 @@ func TestManager(t *testing.T) {
 
 	checkDiskUsage(ctx, t, cm, 1, 0)
 
-	err = snap.Finalize(ctx)
+	err = snap.Finalize(ctx, true)
 	require.NoError(t, err)
 
 	err = snap.Release(ctx)
@@ -301,7 +301,7 @@ func TestLazyCommit(t *testing.T) {
 	require.NoError(t, err)
 
 	// this time finalize commit
-	err = snap.Finalize(ctx)
+	err = snap.Finalize(ctx, true)
 	require.NoError(t, err)
 
 	err = snap.Release(ctx)
@@ -358,7 +358,7 @@ func TestLazyCommit(t *testing.T) {
 	snap2, err = cm.Get(ctx, snap.ID())
 	require.NoError(t, err)
 
-	err = snap2.Finalize(ctx)
+	err = snap2.Finalize(ctx, true)
 	require.NoError(t, err)
 
 	err = snap2.Release(ctx)

--- a/solver/llbsolver/bridge.go
+++ b/solver/llbsolver/bridge.go
@@ -103,7 +103,7 @@ func (b *llbBridge) Solve(ctx context.Context, req frontend.SolveRequest) (res s
 			return nil, nil, errors.Errorf("invalid reference for exporting: %T", res.Sys())
 		}
 		if wr.ImmutableRef != nil {
-			if err := wr.ImmutableRef.Finalize(ctx); err != nil {
+			if err := wr.ImmutableRef.Finalize(ctx, false); err != nil {
 				return nil, nil, err
 			}
 		}


### PR DESCRIPTION
Do not finalize records unless the blobs or child snapshots are needed. In other cases just mark the record as retained so it does not get cleaned up.

This fixes an issue where currently in Dockerfile, `dockerfile` and `dockerignore` locals would not be reused on repeated builds because the local refs were the output of build and therefore committed into an immutable snapshot.