### PR TITLE
local: add followpaths to the cache key

### DIFF
--- a/source/local/local.go
+++ b/source/local/local.go
@@ -80,7 +80,8 @@ func (ls *localSourceHandler) CacheKey(ctx context.Context, index int) (string, 
 		SessionID       string
 		IncludePatterns []string
 		ExcludePatterns []string
-	}{SessionID: sessionID, IncludePatterns: ls.src.IncludePatterns, ExcludePatterns: ls.src.ExcludePatterns})
+		FollowPaths     []string
+	}{SessionID: sessionID, IncludePatterns: ls.src.IncludePatterns, ExcludePatterns: ls.src.ExcludePatterns, FollowPaths: ls.src.FollowPaths})
 	if err != nil {
 		return "", false, err
 	}


### PR DESCRIPTION
FollowPaths is a special case of IncludePatterns and
should behave same way.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>