### PR TITLE
Refactoring dispatchEnv

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -252,9 +252,7 @@ func Dockerfile2LLB(ctx context.Context, dt []byte, opt ConvertOpt) (*llb.State,
 			if len(parts) > 1 {
 				v = parts[1]
 			}
-			if err := dispatchEnv(d, &instructions.EnvCommand{Env: []instructions.KeyValuePair{{Key: parts[0], Value: v}}}, false); err != nil {
-				return nil, nil, err
-			}
+			d.state = d.state.AddEnv(parts[0], v)
 		}
 		if d.image.Config.WorkingDir != "" {
 			if err = dispatchWorkdir(d, &instructions.WorkdirCommand{Path: d.image.Config.WorkingDir}, false); err != nil {

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -394,7 +394,7 @@ func dispatch(d *dispatchState, cmd command, opt dispatchOpt) error {
 	case *instructions.MaintainerCommand:
 		err = dispatchMaintainer(d, c)
 	case *instructions.EnvCommand:
-		err = dispatchEnv(d, c, true)
+		err = dispatchEnv(d, c)
 	case *instructions.RunCommand:
 		err = dispatchRun(d, c, opt.proxyEnv, cmd.sources, opt)
 	case *instructions.WorkdirCommand:
@@ -525,17 +525,14 @@ func dispatchOnBuild(d *dispatchState, triggers []string, opt dispatchOpt) error
 	return nil
 }
 
-func dispatchEnv(d *dispatchState, c *instructions.EnvCommand, commit bool) error {
+func dispatchEnv(d *dispatchState, c *instructions.EnvCommand) error {
 	commitMessage := bytes.NewBufferString("ENV")
 	for _, e := range c.Env {
 		commitMessage.WriteString(" " + e.String())
 		d.state = d.state.AddEnv(e.Key, e.Value)
 		d.image.Config.Env = addEnv(d.image.Config.Env, e.Key, e.Value, true)
 	}
-	if commit {
-		return commitToHistory(&d.image, commitMessage.String(), false, nil)
-	}
-	return nil
+	return commitToHistory(&d.image, commitMessage.String(), false, nil)
 }
 
 func dispatchRun(d *dispatchState, c *instructions.RunCommand, proxy *llb.ProxyEnv, sources []*dispatchState, dopt dispatchOpt) error {


### PR DESCRIPTION
`dispatchEnv` called in `Dockerfile2LLB` does 2 things

* `AddEnv` to `d.state`
* `addEnv` to update `d.image.Config.Env`

But updating `d.image.Config.Env` has no effect on `d.image.Config.Env` because this is in for-loop of `range d.image.Config.Env`. So replace it with `d.state = d.state.AddEnv(parts[0], v)`.
And omit commit argument of `dispatchEnv `.