### PR TITLE
Refactor `toEnvList`

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -526,7 +526,7 @@ func dispatchEnv(d *dispatchState, c *instructions.EnvCommand) error {
 	for _, e := range c.Env {
 		commitMessage.WriteString(" " + e.String())
 		d.state = d.state.AddEnv(e.Key, e.Value)
-		d.image.Config.Env = addEnv(d.image.Config.Env, e.Key, e.Value, true)
+		d.image.Config.Env = addEnv(d.image.Config.Env, e.Key, e.Value)
 	}
 	return commitToHistory(&d.image, commitMessage.String(), false, nil)
 }
@@ -819,14 +819,12 @@ func splitWildcards(name string) (string, string) {
 	return path.Dir(name[:i]), base + name[i:]
 }
 
-func addEnv(env []string, k, v string, override bool) []string {
+func addEnv(env []string, k, v string) []string {
 	gotOne := false
 	for i, envVar := range env {
 		key, _ := parseKeyValue(envVar)
 		if shell.EqualEnvKeys(key, k) {
-			if override {
-				env[i] = k + "=" + v
-			}
+			env[i] = k + "=" + v
 			gotOne = true
 			break
 		}

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -378,7 +378,7 @@ type dispatchOpt struct {
 func dispatch(d *dispatchState, cmd command, opt dispatchOpt) error {
 	if ex, ok := cmd.Command.(instructions.SupportsSingleWordExpansion); ok {
 		err := ex.Expand(func(word string) (string, error) {
-			return opt.shlex.ProcessWordWithMap(word, toEnvList(d.buildArgs, d.image.Config.Env))
+			return opt.shlex.ProcessWordWithMap(word, toEnvMap(d.buildArgs, d.image.Config.Env))
 		})
 		if err != nil {
 			return err
@@ -714,7 +714,7 @@ func dispatchHealthcheck(d *dispatchState, c *instructions.HealthCheckCommand) e
 func dispatchExpose(d *dispatchState, c *instructions.ExposeCommand, shlex *shell.Lex) error {
 	ports := []string{}
 	for _, p := range c.Ports {
-		ps, err := shlex.ProcessWordsWithMap(p, toEnvList(d.buildArgs, d.image.Config.Env))
+		ps, err := shlex.ProcessWordsWithMap(p, toEnvMap(d.buildArgs, d.image.Config.Env))
 		if err != nil {
 			return err
 		}
@@ -852,7 +852,7 @@ func setKVValue(kvpo instructions.KeyValuePairOptional, values map[string]string
 	return kvpo
 }
 
-func toEnvList(args []instructions.KeyValuePairOptional, env []string) map[string]string {
+func toEnvMap(args []instructions.KeyValuePairOptional, env []string) map[string]string {
 	m := shell.BuildEnvs(env)
 
 	for _, arg := range args {

--- a/frontend/dockerfile/dockerfile2llb/convert_test.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_test.go
@@ -3,6 +3,7 @@ package dockerfile2llb
 import (
 	"testing"
 
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/util/appcontext"
 	"github.com/stretchr/testify/assert"
 )
@@ -125,4 +126,53 @@ func TestParseKeyValue(t *testing.T) {
 	k, v = parseKeyValue("key")
 	assert.Equal(t, "key", k)
 	assert.Equal(t, "", v)
+}
+
+func TestToEnvList(t *testing.T) {
+	// args has no duplicated key with env
+	v := "val2"
+	args := []instructions.KeyValuePairOptional{{Key: "key2", Value: &v}}
+	env := []string{"key1=val1"}
+	resutl := toEnvList(args, env)
+	assert.Equal(t, []string{"key1=val1", "key2=val2"}, resutl)
+
+	// value of args is nil
+	args = []instructions.KeyValuePairOptional{{Key: "key2", Value: nil}}
+	env = []string{"key1=val1"}
+	resutl = toEnvList(args, env)
+	assert.Equal(t, []string{"key1=val1", "key2="}, resutl)
+
+	// args has duplicated key with env
+	v = "val2"
+	args = []instructions.KeyValuePairOptional{{Key: "key1", Value: &v}}
+	env = []string{"key1=val1"}
+	resutl = toEnvList(args, env)
+	assert.Equal(t, []string{"key1=val1"}, resutl)
+
+	v = "val2"
+	args = []instructions.KeyValuePairOptional{{Key: "key1", Value: &v}}
+	env = []string{"key1="}
+	resutl = toEnvList(args, env)
+	assert.Equal(t, []string{"key1="}, resutl)
+
+	v = "val2"
+	args = []instructions.KeyValuePairOptional{{Key: "key1", Value: &v}}
+	env = []string{"key1"}
+	resutl = toEnvList(args, env)
+	assert.Equal(t, []string{"key1"}, resutl)
+
+	// env has duplicated keys
+	v = "val2"
+	args = []instructions.KeyValuePairOptional{{Key: "key2", Value: &v}}
+	env = []string{"key1=val1", "key1=val1_2"}
+	resutl = toEnvList(args, env)
+	assert.Equal(t, []string{"key1=val1", "key1=val1_2", "key2=val2"}, resutl)
+
+	// args has duplicated keys
+	v1 := "v1"
+	v2 := "v2"
+	args = []instructions.KeyValuePairOptional{{Key: "key2", Value: &v1}, {Key: "key2", Value: &v2}}
+	env = []string{"key1=val1"}
+	resutl = toEnvList(args, env)
+	assert.Equal(t, []string{"key1=val1", "key2=v1"}, resutl)
 }

--- a/frontend/dockerfile/dockerfile2llb/convert_test.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_test.go
@@ -109,39 +109,39 @@ func TestToEnvList(t *testing.T) {
 	v := "val2"
 	args := []instructions.KeyValuePairOptional{{Key: "key2", Value: &v}}
 	env := []string{"key1=val1"}
-	resutl := toEnvList(args, env)
+	resutl := toEnvMap(args, env)
 	assert.Equal(t, map[string]string{"key1": "val1", "key2": "val2"}, resutl)
 
 	// value of args is nil
 	args = []instructions.KeyValuePairOptional{{Key: "key2", Value: nil}}
 	env = []string{"key1=val1"}
-	resutl = toEnvList(args, env)
+	resutl = toEnvMap(args, env)
 	assert.Equal(t, map[string]string{"key1": "val1", "key2": ""}, resutl)
 
 	// args has duplicated key with env
 	v = "val2"
 	args = []instructions.KeyValuePairOptional{{Key: "key1", Value: &v}}
 	env = []string{"key1=val1"}
-	resutl = toEnvList(args, env)
+	resutl = toEnvMap(args, env)
 	assert.Equal(t, map[string]string{"key1": "val1"}, resutl)
 
 	v = "val2"
 	args = []instructions.KeyValuePairOptional{{Key: "key1", Value: &v}}
 	env = []string{"key1="}
-	resutl = toEnvList(args, env)
+	resutl = toEnvMap(args, env)
 	assert.Equal(t, map[string]string{"key1": ""}, resutl)
 
 	v = "val2"
 	args = []instructions.KeyValuePairOptional{{Key: "key1", Value: &v}}
 	env = []string{"key1"}
-	resutl = toEnvList(args, env)
+	resutl = toEnvMap(args, env)
 	assert.Equal(t, map[string]string{"key1": ""}, resutl)
 
 	// env has duplicated keys
 	v = "val2"
 	args = []instructions.KeyValuePairOptional{{Key: "key2", Value: &v}}
 	env = []string{"key1=val1", "key1=val1_2"}
-	resutl = toEnvList(args, env)
+	resutl = toEnvMap(args, env)
 	assert.Equal(t, map[string]string{"key1": "val1", "key2": "val2"}, resutl)
 
 	// args has duplicated keys
@@ -149,6 +149,6 @@ func TestToEnvList(t *testing.T) {
 	v2 := "v2"
 	args = []instructions.KeyValuePairOptional{{Key: "key2", Value: &v1}, {Key: "key2", Value: &v2}}
 	env = []string{"key1=val1"}
-	resutl = toEnvList(args, env)
+	resutl = toEnvMap(args, env)
 	assert.Equal(t, map[string]string{"key1": "val1", "key2": "v1"}, resutl)
 }

--- a/frontend/dockerfile/dockerfile2llb/convert_test.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_test.go
@@ -134,39 +134,39 @@ func TestToEnvList(t *testing.T) {
 	args := []instructions.KeyValuePairOptional{{Key: "key2", Value: &v}}
 	env := []string{"key1=val1"}
 	resutl := toEnvList(args, env)
-	assert.Equal(t, []string{"key1=val1", "key2=val2"}, resutl)
+	assert.Equal(t, map[string]string{"key1": "val1", "key2": "val2"}, resutl)
 
 	// value of args is nil
 	args = []instructions.KeyValuePairOptional{{Key: "key2", Value: nil}}
 	env = []string{"key1=val1"}
 	resutl = toEnvList(args, env)
-	assert.Equal(t, []string{"key1=val1", "key2="}, resutl)
+	assert.Equal(t, map[string]string{"key1": "val1", "key2": ""}, resutl)
 
 	// args has duplicated key with env
 	v = "val2"
 	args = []instructions.KeyValuePairOptional{{Key: "key1", Value: &v}}
 	env = []string{"key1=val1"}
 	resutl = toEnvList(args, env)
-	assert.Equal(t, []string{"key1=val1"}, resutl)
+	assert.Equal(t, map[string]string{"key1": "val1"}, resutl)
 
 	v = "val2"
 	args = []instructions.KeyValuePairOptional{{Key: "key1", Value: &v}}
 	env = []string{"key1="}
 	resutl = toEnvList(args, env)
-	assert.Equal(t, []string{"key1="}, resutl)
+	assert.Equal(t, map[string]string{"key1": ""}, resutl)
 
 	v = "val2"
 	args = []instructions.KeyValuePairOptional{{Key: "key1", Value: &v}}
 	env = []string{"key1"}
 	resutl = toEnvList(args, env)
-	assert.Equal(t, []string{"key1"}, resutl)
+	assert.Equal(t, map[string]string{"key1": ""}, resutl)
 
 	// env has duplicated keys
 	v = "val2"
 	args = []instructions.KeyValuePairOptional{{Key: "key2", Value: &v}}
 	env = []string{"key1=val1", "key1=val1_2"}
 	resutl = toEnvList(args, env)
-	assert.Equal(t, []string{"key1=val1", "key1=val1_2", "key2=val2"}, resutl)
+	assert.Equal(t, map[string]string{"key1": "val1", "key2": "val2"}, resutl)
 
 	// args has duplicated keys
 	v1 := "v1"
@@ -174,5 +174,5 @@ func TestToEnvList(t *testing.T) {
 	args = []instructions.KeyValuePairOptional{{Key: "key2", Value: &v1}, {Key: "key2", Value: &v2}}
 	env = []string{"key1=val1"}
 	resutl = toEnvList(args, env)
-	assert.Equal(t, []string{"key1=val1", "key2=v1"}, resutl)
+	assert.Equal(t, map[string]string{"key1": "val1", "key2": "v1"}, resutl)
 }

--- a/frontend/dockerfile/dockerfile2llb/convert_test.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_test.go
@@ -66,51 +66,27 @@ COPY --from=0 f2 /
 
 func TestAddEnv(t *testing.T) {
 	// k exists in env as key
-	// override = false
-	env := []string{"key1=val1", "key2=val2"}
-	result := addEnv(env, "key1", "value1", false)
-	assert.Equal(t, []string{"key1=val1", "key2=val2"}, result)
-
-	// k exists in env as key
 	// override = true
-	env = []string{"key1=val1", "key2=val2"}
-	result = addEnv(env, "key1", "value1", true)
+	env := []string{"key1=val1", "key2=val2"}
+	result := addEnv(env, "key1", "value1")
 	assert.Equal(t, []string{"key1=value1", "key2=val2"}, result)
 
 	// k does not exist in env as key
-	// override = false
-	env = []string{"key1=val1", "key2=val2"}
-	result = addEnv(env, "key3", "val3", false)
-	assert.Equal(t, []string{"key1=val1", "key2=val2", "key3=val3"}, result)
-
-	// k does not exist in env as key
 	// override = true
 	env = []string{"key1=val1", "key2=val2"}
-	result = addEnv(env, "key3", "val3", true)
+	result = addEnv(env, "key3", "val3")
 	assert.Equal(t, []string{"key1=val1", "key2=val2", "key3=val3"}, result)
-
-	// env has same keys
-	// override = false
-	env = []string{"key1=val1", "key1=val2"}
-	result = addEnv(env, "key1", "value1", false)
-	assert.Equal(t, []string{"key1=val1", "key1=val2"}, result)
 
 	// env has same keys
 	// override = true
 	env = []string{"key1=val1", "key1=val2"}
-	result = addEnv(env, "key1", "value1", true)
+	result = addEnv(env, "key1", "value1")
 	assert.Equal(t, []string{"key1=value1", "key1=val2"}, result)
 
 	// k matches with key only string in env
-	// override = false
-	env = []string{"key1=val1", "key2=val2", "key3"}
-	result = addEnv(env, "key3", "val3", false)
-	assert.Equal(t, []string{"key1=val1", "key2=val2", "key3"}, result)
-
-	// k matches with key only string in env
 	// override = true
 	env = []string{"key1=val1", "key2=val2", "key3"}
-	result = addEnv(env, "key3", "val3", true)
+	result = addEnv(env, "key3", "val3")
 	assert.Equal(t, []string{"key1=val1", "key2=val2", "key3=val3"}, result)
 }
 

--- a/frontend/dockerfile/shell/lex.go
+++ b/frontend/dockerfile/shell/lex.go
@@ -51,6 +51,11 @@ func (s *Lex) ProcessWordWithMap(word string, env map[string]string) (string, er
 	return word, err
 }
 
+func (s *Lex) ProcessWordsWithMap(word string, env map[string]string) ([]string, error) {
+	_, words, err := s.process(word, env)
+	return words, err
+}
+
 func (s *Lex) process(word string, env map[string]string) (string, []string, error) {
 	sw := &shellWord{
 		envs:        env,

--- a/frontend/dockerfile/shell/lex.go
+++ b/frontend/dockerfile/shell/lex.go
@@ -28,7 +28,7 @@ func NewLex(escapeToken rune) *Lex {
 // ProcessWord will use the 'env' list of environment variables,
 // and replace any env var references in 'word'.
 func (s *Lex) ProcessWord(word string, env []string) (string, error) {
-	word, _, err := s.process(word, buildEnvs(env))
+	word, _, err := s.process(word, BuildEnvs(env))
 	return word, err
 }
 
@@ -40,7 +40,7 @@ func (s *Lex) ProcessWord(word string, env []string) (string, error) {
 // Note, each one is trimmed to remove leading and trailing spaces (unless
 // they are quoted", but ProcessWord retains spaces between words.
 func (s *Lex) ProcessWords(word string, env []string) ([]string, error) {
-	_, words, err := s.process(word, buildEnvs(env))
+	_, words, err := s.process(word, BuildEnvs(env))
 	return words, err
 }
 
@@ -373,7 +373,7 @@ func (sw *shellWord) getEnv(name string) string {
 	return ""
 }
 
-func buildEnvs(env []string) map[string]string {
+func BuildEnvs(env []string) map[string]string {
 	envs := map[string]string{}
 
 	for _, e := range env {

--- a/frontend/dockerfile/shell/lex_test.go
+++ b/frontend/dockerfile/shell/lex_test.go
@@ -103,7 +103,24 @@ func TestShellParser4Words(t *testing.T) {
 		test := strings.TrimSpace(words[0])
 		expected := strings.Split(strings.TrimLeft(words[1], " "), ",")
 
+		// test for ProcessWords
 		result, err := shlex.ProcessWords(test, envs)
+
+		if err != nil {
+			result = []string{"error"}
+		}
+
+		if len(result) != len(expected) {
+			t.Fatalf("Error on line %d. %q was suppose to result in %q, but got %q instead", lineNum, test, expected, result)
+		}
+		for i, w := range expected {
+			if w != result[i] {
+				t.Fatalf("Error on line %d. %q was suppose to result in %q, but got %q instead", lineNum, test, expected, result)
+			}
+		}
+
+		// test for ProcessWordsWithMap
+		result, err = shlex.ProcessWordsWithMap(test, buildEnvs(envs))
 
 		if err != nil {
 			result = []string{"error"}

--- a/frontend/dockerfile/shell/lex_test.go
+++ b/frontend/dockerfile/shell/lex_test.go
@@ -22,7 +22,7 @@ func TestShellParser4EnvVars(t *testing.T) {
 	shlex := NewLex('\\')
 	scanner := bufio.NewScanner(file)
 	envs := []string{"PWD=/home", "SHELL=bash", "KOREAN=한국어"}
-	envsMap := buildEnvs(envs)
+	envsMap := BuildEnvs(envs)
 	for scanner.Scan() {
 		line := scanner.Text()
 		lineCount++
@@ -120,7 +120,7 @@ func TestShellParser4Words(t *testing.T) {
 		}
 
 		// test for ProcessWordsWithMap
-		result, err = shlex.ProcessWordsWithMap(test, buildEnvs(envs))
+		result, err = shlex.ProcessWordsWithMap(test, BuildEnvs(envs))
 
 		if err != nil {
 			result = []string{"error"}
@@ -140,27 +140,27 @@ func TestShellParser4Words(t *testing.T) {
 func TestGetEnv(t *testing.T) {
 	sw := &shellWord{envs: nil}
 
-	sw.envs = buildEnvs([]string{})
+	sw.envs = BuildEnvs([]string{})
 	if sw.getEnv("foo") != "" {
 		t.Fatal("2 - 'foo' should map to ''")
 	}
 
-	sw.envs = buildEnvs([]string{"foo"})
+	sw.envs = BuildEnvs([]string{"foo"})
 	if sw.getEnv("foo") != "" {
 		t.Fatal("3 - 'foo' should map to ''")
 	}
 
-	sw.envs = buildEnvs([]string{"foo="})
+	sw.envs = BuildEnvs([]string{"foo="})
 	if sw.getEnv("foo") != "" {
 		t.Fatal("4 - 'foo' should map to ''")
 	}
 
-	sw.envs = buildEnvs([]string{"foo=bar"})
+	sw.envs = BuildEnvs([]string{"foo=bar"})
 	if sw.getEnv("foo") != "bar" {
 		t.Fatal("5 - 'foo' should map to 'bar'")
 	}
 
-	sw.envs = buildEnvs([]string{"foo=bar", "car=hat"})
+	sw.envs = BuildEnvs([]string{"foo=bar", "car=hat"})
 	if sw.getEnv("foo") != "bar" {
 		t.Fatal("6 - 'foo' should map to 'bar'")
 	}
@@ -169,7 +169,7 @@ func TestGetEnv(t *testing.T) {
 	}
 
 	// Make sure we grab the first 'car' in the list
-	sw.envs = buildEnvs([]string{"foo=bar", "car=hat", "car=bike"})
+	sw.envs = BuildEnvs([]string{"foo=bar", "car=hat", "car=bike"})
 	if sw.getEnv("car") != "hat" {
 		t.Fatal("8 - 'car' should map to 'hat'")
 	}


### PR DESCRIPTION
* Use `ProcessWord(s)WithMap` to avoid string contatination and string split.
* Omit needless argument `override` from `addEnv`