### PR TITLE
solver: improve multi-key root caching

### DIFF
--- a/solver/edge.go
+++ b/solver/edge.go
@@ -144,7 +144,9 @@ func (e *edge) commitOptions() ([]*CacheKey, []CachedResult) {
 	inputs := make([][]CacheKeyWithSelector, len(e.deps))
 	results := make([]CachedResult, len(e.deps))
 	for i, dep := range e.deps {
-		inputs[i] = append(inputs[i], CacheKeyWithSelector{CacheKey: dep.result.CacheKey(), Selector: e.cacheMap.Deps[i].Selector})
+		for _, k := range dep.result.CacheKeys() {
+			inputs[i] = append(inputs[i], CacheKeyWithSelector{CacheKey: k, Selector: e.cacheMap.Deps[i].Selector})
+		}
 		if dep.slowCacheKey != nil {
 			inputs[i] = append(inputs[i], CacheKeyWithSelector{CacheKey: *dep.slowCacheKey})
 		}
@@ -245,7 +247,9 @@ func (e *edge) currentIndexKey() *CacheKey {
 			keys[i] = append(keys[i], CacheKeyWithSelector{Selector: e.cacheMap.Deps[i].Selector, CacheKey: k})
 		}
 		if d.result != nil {
-			keys[i] = append(keys[i], CacheKeyWithSelector{Selector: e.cacheMap.Deps[i].Selector, CacheKey: d.result.CacheKey()})
+			for _, rk := range d.result.CacheKeys() {
+				keys[i] = append(keys[i], CacheKeyWithSelector{Selector: e.cacheMap.Deps[i].Selector, CacheKey: rk})
+			}
 			if d.slowCacheKey != nil {
 				keys[i] = append(keys[i], CacheKeyWithSelector{CacheKey: ExportableCacheKey{CacheKey: d.slowCacheKey.CacheKey, Exporter: &exporter{k: d.slowCacheKey.CacheKey}}})
 			}
@@ -461,11 +465,14 @@ func (e *edge) processUpdate(upt pipe.Receiver) (depChanged bool) {
 				k := NewCacheKey(upt.Status().Value.(digest.Digest), -1)
 				dep.slowCacheKey = &ExportableCacheKey{CacheKey: k, Exporter: &exporter{k: k}}
 				slowKeyExp := CacheKeyWithSelector{CacheKey: *dep.slowCacheKey}
-				defKeyExp := CacheKeyWithSelector{CacheKey: dep.result.CacheKey(), Selector: e.cacheMap.Deps[i].Selector}
+				defKeys := make([]CacheKeyWithSelector, 0, len(dep.result.CacheKeys()))
+				for _, dk := range dep.result.CacheKeys() {
+					defKeys = append(defKeys, CacheKeyWithSelector{CacheKey: dk, Selector: e.cacheMap.Deps[i].Selector})
+				}
 				dep.slowCacheFoundKey = e.probeCache(dep, []CacheKeyWithSelector{slowKeyExp})
 
 				// connect def key to slow key
-				e.op.Cache().Query([]CacheKeyWithSelector{defKeyExp, slowKeyExp}, dep.index, e.cacheMap.Digest, e.edge.Index)
+				e.op.Cache().Query(append(defKeys, slowKeyExp), dep.index, e.cacheMap.Digest, e.edge.Index)
 
 				dep.slowCacheComplete = true
 				e.keysDidChange = true
@@ -510,7 +517,9 @@ func (e *edge) recalcCurrentState() {
 		mergedKey.deps = make([][]CacheKeyWithSelector, len(e.deps))
 		for i, dep := range e.deps {
 			if dep.result != nil {
-				mergedKey.deps[i] = append(mergedKey.deps[i], CacheKeyWithSelector{Selector: e.cacheMap.Deps[i].Selector, CacheKey: dep.result.CacheKey()})
+				for _, dk := range dep.result.CacheKeys() {
+					mergedKey.deps[i] = append(mergedKey.deps[i], CacheKeyWithSelector{Selector: e.cacheMap.Deps[i].Selector, CacheKey: dk})
+				}
 				if dep.slowCacheKey != nil {
 					mergedKey.deps[i] = append(mergedKey.deps[i], CacheKeyWithSelector{CacheKey: *dep.slowCacheKey})
 				}
@@ -789,7 +798,7 @@ func (e *edge) loadCache(ctx context.Context) (interface{}, error) {
 		return nil, err
 	}
 
-	return NewCachedResult(res, ExportableCacheKey{CacheKey: rec.key, Exporter: &exporter{k: rec.key, record: rec, edge: e}}), nil
+	return NewCachedResult(res, []ExportableCacheKey{{CacheKey: rec.key, Exporter: &exporter{k: rec.key, record: rec, edge: e}}}), nil
 }
 
 // execOp creates a request to execute the vertex operation
@@ -834,12 +843,15 @@ func (e *edge) execOp(ctx context.Context) (interface{}, error) {
 		exporters = append(exporters, exps...)
 	}
 
-	ck := &ExportableCacheKey{
-		CacheKey: cacheKeys[0],
-		Exporter: &mergedExporter{exporters: exporters},
+	ek := make([]ExportableCacheKey, 0, len(cacheKeys))
+	for _, ck := range cacheKeys {
+		ek = append(ek, ExportableCacheKey{
+			CacheKey: ck,
+			Exporter: &mergedExporter{exporters: exporters},
+		})
 	}
 
-	return NewCachedResult(res, *ck), nil
+	return NewCachedResult(res, ek), nil
 }
 
 func toResultSlice(cres []CachedResult) (out []Result) {

--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -161,7 +161,7 @@ func (sb *subBuilder) Build(ctx context.Context, e Edge) (CachedResult, error) {
 		return nil, err
 	}
 	sb.mu.Lock()
-	sb.exporters = append(sb.exporters, res.CacheKey())
+	sb.exporters = append(sb.exporters, res.CacheKeys()[0]) // all keys already have full export chain
 	sb.mu.Unlock()
 	return res, nil
 }

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -125,7 +125,8 @@ func (s *Solver) Solve(ctx context.Context, id string, req frontend.SolveRequest
 		if err := j.Call(ctx, "exporting cache", func(ctx context.Context) error {
 			prepareDone := oneOffProgress(ctx, "preparing build cache for export")
 			if err := res.EachRef(func(res solver.CachedResult) error {
-				_, err := res.CacheKey().Exporter.ExportTo(ctx, e, solver.CacheExportOpt{
+				// all keys have same export chain so exporting others is not needed
+				_, err := res.CacheKeys()[0].Exporter.ExportTo(ctx, e, solver.CacheExportOpt{
 					Convert: workerRefConverter,
 					Mode:    exp.CacheExportMode,
 				})

--- a/solver/result.go
+++ b/solver/result.go
@@ -58,16 +58,16 @@ func (r *splitResult) Release(ctx context.Context) error {
 }
 
 // NewCachedResult combines a result and cache key into cached result
-func NewCachedResult(res Result, k ExportableCacheKey) CachedResult {
+func NewCachedResult(res Result, k []ExportableCacheKey) CachedResult {
 	return &cachedResult{res, k}
 }
 
 type cachedResult struct {
 	Result
-	k ExportableCacheKey
+	k []ExportableCacheKey
 }
 
-func (cr *cachedResult) CacheKey() ExportableCacheKey {
+func (cr *cachedResult) CacheKeys() []ExportableCacheKey {
 	return cr.k
 }
 
@@ -95,8 +95,8 @@ func (r *clonedCachedResult) ID() string {
 	return r.Result.ID()
 }
 
-func (cr *clonedCachedResult) CacheKey() ExportableCacheKey {
-	return cr.cr.CacheKey()
+func (cr *clonedCachedResult) CacheKeys() []ExportableCacheKey {
+	return cr.cr.CacheKeys()
 }
 
 type SharedCachedResult struct {

--- a/solver/scheduler.go
+++ b/solver/scheduler.go
@@ -306,7 +306,9 @@ func (s *scheduler) mergeTo(target, src *edge) bool {
 			target.secondaryExporters = append(target.secondaryExporters, expDep{i, CacheKeyWithSelector{CacheKey: *d.slowCacheKey}})
 		}
 		if d.result != nil {
-			target.secondaryExporters = append(target.secondaryExporters, expDep{i, CacheKeyWithSelector{CacheKey: d.result.CacheKey(), Selector: src.cacheMap.Deps[i].Selector}})
+			for _, dk := range d.result.CacheKeys() {
+				target.secondaryExporters = append(target.secondaryExporters, expDep{i, CacheKeyWithSelector{CacheKey: dk, Selector: src.cacheMap.Deps[i].Selector}})
+			}
 		}
 	}
 

--- a/solver/types.go
+++ b/solver/types.go
@@ -50,7 +50,7 @@ type Result interface {
 // CachedResult is a result connected with its cache key
 type CachedResult interface {
 	Result
-	CacheKey() ExportableCacheKey
+	CacheKeys() []ExportableCacheKey
 }
 
 // CacheExportMode is the type for setting cache exporting modes


### PR DESCRIPTION
Cache keys for multi-key roots only worked for the vertex itself but only a single key was linked to the parent vertex.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>