### PR TITLE
Test dockerfile in gateway mode

### DIFF
--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -151,14 +151,23 @@ func dispatchAll(t *testing.T, m Mode) {
 }
 
 func TestDockerfileBuiltinIntegration(t *testing.T) {
+	if m := os.Getenv("BUILDKIT_DOCKERFILE_INTEGRATION_MODE"); m != "" && m != "builtin" {
+		t.Skip("skipping Dockerfile integration in builtin mode")
+	}
 	dispatchAll(t, ModeBuiltin)
 }
 
 func TestDockerfileMasterGatewayIntegration(t *testing.T) {
+	if m := os.Getenv("BUILDKIT_DOCKERFILE_INTEGRATION_MODE"); m != "master-gateway" {
+		t.Skip("skipping Dockerfile integration in master-gateway mode")
+	}
 	dispatchAll(t, ModeMasterGateway)
 }
 
 func TestDockerfileClientIntegration(t *testing.T) {
+	if m := os.Getenv("BUILDKIT_DOCKERFILE_INTEGRATION_MODE"); m != "client" {
+		t.Skip("skipping Dockerfile integration in client mode")
+	}
 	dispatchAll(t, ModeClient)
 }
 

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -36,49 +36,133 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIntegration(t *testing.T) {
-	integration.Run(t, []integration.Test{
-		testNoSnapshotLeak,
-		testCmdShell,
-		testGlobalArg,
-		testDockerfileDirs,
-		testDockerfileInvalidCommand,
-		testDockerfileADDFromURL,
-		testDockerfileAddArchive,
-		testDockerfileScratchConfig,
-		testExportedHistory,
-		testExposeExpansion,
-		testUser,
-		testDockerignore,
-		testDockerignoreInvalid,
-		testDockerfileFromGit,
-		testCopyChown,
-		testCopyWildcards,
-		testCopyOverrideFiles,
-		testMultiStageImplicitFrom,
-		testCopyVarSubstitution,
-		testMultiStageCaseInsensitive,
-		testLabels,
-		testCacheImportExport,
-		testReproducibleIDs,
-		testImportExportReproducibleIDs,
-		testNoCache,
-		testDockerfileFromHTTP,
-		testBuiltinArgs,
-		testPullScratch,
-		testSymlinkDestination,
-		testHTTPDockerfile,
-		testCopySymlinks,
-		testContextChangeDirToFile,
-		testPlatformArgsImplicit,
-		testPlatformArgsExplicit,
-		testExportMultiPlatform,
-		testQuotedMetaArgs,
-		testIgnoreEntrypoint,
+type Mode string
+
+var (
+	ModeBuiltin       = Mode("builtin")
+	ModeMasterGateway = Mode("master-gateway")
+	ModeClient        = Mode("client")
+
+	gatewayMasterImage = "tonistiigi/dockerfile:master"
+)
+
+type SolverFn func(context.Context, client.SolveOpt, chan *client.SolveStatus) (*client.SolveResponse, error)
+type frontend struct {
+	t    *testing.T
+	mode Mode
+}
+
+func (f *frontend) solver(c *client.Client) SolverFn {
+	switch f.mode {
+	case ModeBuiltin:
+		return func(ctx context.Context, opt client.SolveOpt, statusChan chan *client.SolveStatus) (*client.SolveResponse, error) {
+			opt.Frontend = "dockerfile.v0"
+			return c.Solve(ctx, nil, opt, statusChan)
+		}
+	case ModeMasterGateway:
+		return func(ctx context.Context, opt client.SolveOpt, statusChan chan *client.SolveStatus) (*client.SolveResponse, error) {
+			opt.Frontend = "gateway.v0"
+			if opt.FrontendAttrs == nil {
+				opt.FrontendAttrs = make(map[string]string)
+			}
+			opt.FrontendAttrs["source"] = gatewayMasterImage
+			return c.Solve(ctx, nil, opt, statusChan)
+		}
+	case ModeClient:
+		return func(ctx context.Context, opt client.SolveOpt, statusChan chan *client.SolveStatus) (*client.SolveResponse, error) {
+			return c.Build(ctx, opt, "", builder.Build, statusChan)
+		}
+	default:
+		f.t.Fatalf("unknown frontend mode %q", f.mode)
+		return nil // not reached
+	}
+}
+
+func (f *frontend) dfCmdArgs(ctx, dockerfile string) (string, string) {
+	traceFile := filepath.Join(os.TempDir(), "trace"+identity.NewID())
+	cmd := "build --progress=plain"
+	switch f.mode {
+	case ModeBuiltin:
+		cmd += " --frontend dockerfile.v0"
+	case ModeMasterGateway:
+		cmd += " --frontend gateway.v0 --frontend-opt=source=" + gatewayMasterImage
+	case ModeClient:
+		f.t.Skip("no buildctl method to invoke client side dockerfile")
+	default:
+		f.t.Fatalf("unknown frontend mode %q", f.mode)
+	}
+	cmd += fmt.Sprintf(" --local context=%s --local dockerfile=%s --trace=%s", ctx, dockerfile, traceFile)
+	return cmd, traceFile
+}
+
+type TestWithFrontend struct {
+	t func(*testing.T, integration.Sandbox, *frontend)
+	m Mode
+}
+
+func (f TestWithFrontend) Call(t *testing.T, sb integration.Sandbox) {
+	f.t(t, sb, &frontend{t, f.m})
+}
+
+func (f TestWithFrontend) NamingFunc() interface{} {
+	return f.t
+}
+
+func dispatchAll(t *testing.T, m Mode) {
+	integration.Dispatch(t, []integration.TestDispatcher{
+		TestWithFrontend{testNoSnapshotLeak, m},
+		TestWithFrontend{testCmdShell, m},
+		TestWithFrontend{testGlobalArg, m},
+		TestWithFrontend{testDockerfileDirs, m},
+		TestWithFrontend{testDockerfileInvalidCommand, m},
+		TestWithFrontend{testDockerfileADDFromURL, m},
+		TestWithFrontend{testDockerfileAddArchive, m},
+		TestWithFrontend{testDockerfileScratchConfig, m},
+		TestWithFrontend{testExportedHistory, m},
+		TestWithFrontend{testExposeExpansion, m},
+		TestWithFrontend{testUser, m},
+		TestWithFrontend{testDockerignore, m},
+		TestWithFrontend{testDockerignoreInvalid, m},
+		TestWithFrontend{testDockerfileFromGit, m},
+		TestWithFrontend{testCopyChown, m},
+		TestWithFrontend{testCopyWildcards, m},
+		TestWithFrontend{testCopyOverrideFiles, m},
+		TestWithFrontend{testMultiStageImplicitFrom, m},
+		TestWithFrontend{testCopyVarSubstitution, m},
+		TestWithFrontend{testMultiStageCaseInsensitive, m},
+		TestWithFrontend{testLabels, m},
+		TestWithFrontend{testCacheImportExport, m},
+		TestWithFrontend{testReproducibleIDs, m},
+		TestWithFrontend{testImportExportReproducibleIDs, m},
+		TestWithFrontend{testNoCache, m},
+		TestWithFrontend{testDockerfileFromHTTP, m},
+		TestWithFrontend{testBuiltinArgs, m},
+		TestWithFrontend{testPullScratch, m},
+		TestWithFrontend{testSymlinkDestination, m},
+		TestWithFrontend{testHTTPDockerfile, m},
+		TestWithFrontend{testCopySymlinks, m},
+		TestWithFrontend{testContextChangeDirToFile, m},
+		TestWithFrontend{testPlatformArgsImplicit, m},
+		TestWithFrontend{testPlatformArgsExplicit, m},
+		TestWithFrontend{testExportMultiPlatform, m},
+		TestWithFrontend{testQuotedMetaArgs, m},
+		TestWithFrontend{testIgnoreEntrypoint, m},
 	})
 }
 
-func testIgnoreEntrypoint(t *testing.T, sb integration.Sandbox) {
+func TestDockerfileBuiltinIntegration(t *testing.T) {
+	dispatchAll(t, ModeBuiltin)
+}
+
+func TestDockerfileMasterGatewayIntegration(t *testing.T) {
+	dispatchAll(t, ModeMasterGateway)
+}
+
+func TestDockerfileClientIntegration(t *testing.T) {
+	dispatchAll(t, ModeClient)
+}
+
+func testIgnoreEntrypoint(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	dockerfile := []byte(`
@@ -97,8 +181,7 @@ RUN ["ls"]
 	require.NoError(t, err)
 	defer c.Close()
 
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend: "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		LocalDirs: map[string]string{
 			builder.LocalNameDockerfile: dir,
 			builder.LocalNameContext:    dir,
@@ -107,7 +190,7 @@ RUN ["ls"]
 	require.NoError(t, err)
 }
 
-func testQuotedMetaArgs(t *testing.T, sb integration.Sandbox) {
+func testQuotedMetaArgs(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	dockerfile := []byte(`
@@ -135,8 +218,7 @@ COPY --from=build /out .
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend: "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		LocalDirs: map[string]string{
 			builder.LocalNameDockerfile: dir,
 			builder.LocalNameContext:    dir,
@@ -151,7 +233,7 @@ COPY --from=build /out .
 	require.Equal(t, "bar-box-foo", string(dt))
 }
 
-func testExportMultiPlatform(t *testing.T, sb integration.Sandbox) {
+func testExportMultiPlatform(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	dockerfile := []byte(`
@@ -180,8 +262,7 @@ COPY arch-$TARGETARCH whoami
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend: "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		LocalDirs: map[string]string{
 			builder.LocalNameDockerfile: dir,
 			builder.LocalNameContext:    dir,
@@ -216,8 +297,7 @@ COPY arch-$TARGETARCH whoami
 	outW, err := os.Create(out)
 	require.NoError(t, err)
 
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend: "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		LocalDirs: map[string]string{
 			builder.LocalNameDockerfile: dir,
 			builder.LocalNameContext:    dir,
@@ -285,7 +365,7 @@ COPY arch-$TARGETARCH whoami
 }
 
 // tonistiigi/fsutil#46
-func testContextChangeDirToFile(t *testing.T, sb integration.Sandbox) {
+func testContextChangeDirToFile(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	dockerfile := []byte(`
@@ -305,8 +385,7 @@ COPY foo /
 	require.NoError(t, err)
 	defer c.Close()
 
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend: "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		LocalDirs: map[string]string{
 			builder.LocalNameDockerfile: dir,
 			builder.LocalNameContext:    dir,
@@ -325,8 +404,7 @@ COPY foo /
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend:          "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		Exporter:          client.ExporterLocal,
 		ExporterOutputDir: destDir,
 		LocalDirs: map[string]string{
@@ -341,7 +419,7 @@ COPY foo /
 	require.Equal(t, "contents2", string(dt))
 }
 
-func testNoSnapshotLeak(t *testing.T, sb integration.Sandbox) {
+func testNoSnapshotLeak(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	dockerfile := []byte(`
@@ -360,8 +438,7 @@ COPY foo /
 	require.NoError(t, err)
 	defer c.Close()
 
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend: "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		LocalDirs: map[string]string{
 			builder.LocalNameDockerfile: dir,
 			builder.LocalNameContext:    dir,
@@ -372,8 +449,7 @@ COPY foo /
 	du, err := c.DiskUsage(context.TODO())
 	require.NoError(t, err)
 
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend: "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		LocalDirs: map[string]string{
 			builder.LocalNameDockerfile: dir,
 			builder.LocalNameContext:    dir,
@@ -387,7 +463,7 @@ COPY foo /
 	require.Equal(t, len(du), len(du2))
 }
 
-func testCopySymlinks(t *testing.T, sb integration.Sandbox) {
+func testCopySymlinks(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	dockerfile := []byte(`
@@ -415,8 +491,7 @@ COPY sub/l* alllinks/
 	require.NoError(t, err)
 	defer c.Close()
 
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend: "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		LocalDirs: map[string]string{
 			builder.LocalNameDockerfile: dir,
 			builder.LocalNameContext:    dir,
@@ -425,7 +500,7 @@ COPY sub/l* alllinks/
 	require.NoError(t, err)
 }
 
-func testHTTPDockerfile(t *testing.T, sb integration.Sandbox) {
+func testHTTPDockerfile(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	dockerfile := []byte(`
@@ -460,8 +535,7 @@ COPY --from=0 /foo /foo
 	require.NoError(t, err)
 	defer c.Close()
 
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend: "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		FrontendAttrs: map[string]string{
 			"context":  server.URL + "/df",
 			"filename": "mydockerfile", // this is bogus, any name should work
@@ -477,7 +551,7 @@ COPY --from=0 /foo /foo
 
 }
 
-func testCmdShell(t *testing.T, sb integration.Sandbox) {
+func testCmdShell(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	var cdAddress string
@@ -505,8 +579,7 @@ CMD ["test"]
 	defer c.Close()
 
 	target := "docker.io/moby/cmdoverridetest:latest"
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend: "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		Exporter: client.ExporterImage,
 		ExporterAttrs: map[string]string{
 			"name": target,
@@ -531,8 +604,7 @@ ENTRYPOINT my entrypoint
 	defer os.RemoveAll(dir)
 
 	target = "docker.io/moby/cmdoverridetest2:latest"
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend: "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		Exporter: client.ExporterImage,
 		ExporterAttrs: map[string]string{
 			"name": target,
@@ -567,7 +639,7 @@ ENTRYPOINT my entrypoint
 	require.Equal(t, []string{"ls", "my entrypoint"}, ociimg.Config.Entrypoint)
 }
 
-func testPullScratch(t *testing.T, sb integration.Sandbox) {
+func testPullScratch(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	var cdAddress string
@@ -595,8 +667,7 @@ LABEL foo=bar
 	defer c.Close()
 
 	target := "docker.io/moby/testpullscratch:latest"
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend: "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		Exporter: client.ExporterImage,
 		ExporterAttrs: map[string]string{
 			"name": target,
@@ -622,8 +693,7 @@ COPY foo .
 	defer os.RemoveAll(dir)
 
 	target = "docker.io/moby/testpullscratch2:latest"
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend: "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		Exporter: client.ExporterImage,
 		ExporterAttrs: map[string]string{
 			"name": target,
@@ -689,7 +759,7 @@ COPY foo .
 	require.Equal(t, "foo0", string(dt))
 }
 
-func testGlobalArg(t *testing.T, sb integration.Sandbox) {
+func testGlobalArg(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 	dockerfile := []byte(`
 ARG tag=nosuchtag
@@ -706,8 +776,7 @@ FROM busybox:${tag}
 	require.NoError(t, err)
 	defer c.Close()
 
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend: "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		FrontendAttrs: map[string]string{
 			"build-arg:tag": "latest",
 		},
@@ -719,7 +788,7 @@ FROM busybox:${tag}
 	require.NoError(t, err)
 }
 
-func testDockerfileDirs(t *testing.T, sb integration.Sandbox) {
+func testDockerfileDirs(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 	dockerfile := []byte(`
 	FROM busybox
@@ -738,7 +807,7 @@ func testDockerfileDirs(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	args, trace := dfCmdArgs(dir, dir)
+	args, trace := f.dfCmdArgs(dir, dir)
 	defer os.RemoveAll(trace)
 
 	cmd := sb.Cmd(args)
@@ -748,7 +817,7 @@ func testDockerfileDirs(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 
 	// relative urls
-	args, trace = dfCmdArgs(".", ".")
+	args, trace = f.dfCmdArgs(".", ".")
 	defer os.RemoveAll(trace)
 
 	cmd = sb.Cmd(args)
@@ -771,7 +840,7 @@ func testDockerfileDirs(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir2)
 
-	args, trace = dfCmdArgs(dir2, dir1)
+	args, trace = f.dfCmdArgs(dir2, dir1)
 	defer os.RemoveAll(trace)
 
 	cmd = sb.Cmd(args)
@@ -785,7 +854,7 @@ func testDockerfileDirs(t *testing.T, sb integration.Sandbox) {
 	// TODO: output metadata about original dockerfile command in trace
 }
 
-func testDockerfileInvalidCommand(t *testing.T, sb integration.Sandbox) {
+func testDockerfileInvalidCommand(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 	dockerfile := []byte(`
 	FROM busybox
@@ -798,7 +867,7 @@ func testDockerfileInvalidCommand(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	args, trace := dfCmdArgs(dir, dir)
+	args, trace := f.dfCmdArgs(dir, dir)
 	defer os.RemoveAll(trace)
 
 	cmd := sb.Cmd(args)
@@ -810,7 +879,7 @@ func testDockerfileInvalidCommand(t *testing.T, sb integration.Sandbox) {
 	require.Contains(t, stdout.String(), "executor failed running")
 }
 
-func testDockerfileADDFromURL(t *testing.T, sb integration.Sandbox) {
+func testDockerfileADDFromURL(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	modTime := time.Now().Add(-24 * time.Hour) // avoid falso positive with current time
@@ -843,7 +912,7 @@ ADD %s /dest/
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	args, trace := dfCmdArgs(dir, dir)
+	args, trace := f.dfCmdArgs(dir, dir)
 	defer os.RemoveAll(trace)
 
 	destDir, err := tmpdir()
@@ -870,7 +939,7 @@ ADD %s /dest/
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	args, trace = dfCmdArgs(dir, dir)
+	args, trace = f.dfCmdArgs(dir, dir)
 	defer os.RemoveAll(trace)
 
 	destDir, err = tmpdir()
@@ -891,7 +960,7 @@ ADD %s /dest/
 	require.Equal(t, modTime.Format(http.TimeFormat), fi.ModTime().Format(http.TimeFormat))
 }
 
-func testDockerfileAddArchive(t *testing.T, sb integration.Sandbox) {
+func testDockerfileAddArchive(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	buf := bytes.NewBuffer(nil)
@@ -921,7 +990,7 @@ ADD t.tar /
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	args, trace := dfCmdArgs(dir, dir)
+	args, trace := f.dfCmdArgs(dir, dir)
 	defer os.RemoveAll(trace)
 
 	destDir, err := tmpdir()
@@ -955,7 +1024,7 @@ ADD t.tar.gz /
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	args, trace = dfCmdArgs(dir, dir)
+	args, trace = f.dfCmdArgs(dir, dir)
 	defer os.RemoveAll(trace)
 
 	destDir, err = tmpdir()
@@ -982,7 +1051,7 @@ COPY t.tar.gz /
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	args, trace = dfCmdArgs(dir, dir)
+	args, trace = f.dfCmdArgs(dir, dir)
 	defer os.RemoveAll(trace)
 
 	destDir, err = tmpdir()
@@ -1018,7 +1087,7 @@ ADD %s /
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	args, trace = dfCmdArgs(dir, dir)
+	args, trace = f.dfCmdArgs(dir, dir)
 	defer os.RemoveAll(trace)
 
 	destDir, err = tmpdir()
@@ -1044,7 +1113,7 @@ ADD %s /newname.tar.gz
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	args, trace = dfCmdArgs(dir, dir)
+	args, trace = f.dfCmdArgs(dir, dir)
 	defer os.RemoveAll(trace)
 
 	destDir, err = tmpdir()
@@ -1059,7 +1128,7 @@ ADD %s /newname.tar.gz
 	require.Equal(t, buf2.Bytes(), dt)
 }
 
-func testSymlinkDestination(t *testing.T, sb integration.Sandbox) {
+func testSymlinkDestination(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	buf := bytes.NewBuffer(nil)
@@ -1089,7 +1158,7 @@ COPY foo /symlink/
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	args, trace := dfCmdArgs(dir, dir)
+	args, trace := f.dfCmdArgs(dir, dir)
 	defer os.RemoveAll(trace)
 
 	destDir, err := tmpdir()
@@ -1104,7 +1173,7 @@ COPY foo /symlink/
 	require.Equal(t, expectedContent, dt)
 }
 
-func testDockerfileScratchConfig(t *testing.T, sb integration.Sandbox) {
+func testDockerfileScratchConfig(t *testing.T, sb integration.Sandbox, f *frontend) {
 	var cdAddress string
 	if cd, ok := sb.(interface {
 		ContainerdAddress() string
@@ -1126,7 +1195,7 @@ ENV foo=bar
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	args, trace := dfCmdArgs(dir, dir)
+	args, trace := f.dfCmdArgs(dir, dir)
 	defer os.RemoveAll(trace)
 
 	target := "example.com/moby/dockerfilescratch:test"
@@ -1174,7 +1243,7 @@ ENV foo=bar
 	})
 }
 
-func testExposeExpansion(t *testing.T, sb integration.Sandbox) {
+func testExposeExpansion(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	dockerfile := []byte(`
@@ -1195,8 +1264,7 @@ EXPOSE 5000
 	defer c.Close()
 
 	target := "example.com/moby/dockerfileexpansion:test"
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend: "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		Exporter: client.ExporterImage,
 		ExporterAttrs: map[string]string{
 			"name": target,
@@ -1250,7 +1318,7 @@ EXPOSE 5000
 	require.Equal(t, "5000/tcp", ports[2])
 }
 
-func testDockerignore(t *testing.T, sb integration.Sandbox) {
+func testDockerignore(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	dockerfile := []byte(`
@@ -1284,8 +1352,7 @@ Dockerfile
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend:          "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		Exporter:          client.ExporterLocal,
 		ExporterOutputDir: destDir,
 		LocalDirs: map[string]string{
@@ -1320,7 +1387,7 @@ Dockerfile
 	require.Equal(t, "bay-contents", string(dt))
 }
 
-func testDockerignoreInvalid(t *testing.T, sb integration.Sandbox) {
+func testDockerignoreInvalid(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	dockerfile := []byte(`
@@ -1342,8 +1409,7 @@ COPY . .
 	require.NoError(t, err)
 	defer c.Close()
 
-	_, err = c.Solve(ctx, nil, client.SolveOpt{
-		Frontend: "dockerfile.v0",
+	_, err = f.solver(c)(ctx, client.SolveOpt{
 		LocalDirs: map[string]string{
 			builder.LocalNameDockerfile: dir,
 			builder.LocalNameContext:    dir,
@@ -1358,7 +1424,7 @@ COPY . .
 	}
 }
 
-func testExportedHistory(t *testing.T, sb integration.Sandbox) {
+func testExportedHistory(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	// using multi-stage to test that history is scoped to one stage
@@ -1380,7 +1446,7 @@ RUN ["ls"]
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	args, trace := dfCmdArgs(dir, dir)
+	args, trace := f.dfCmdArgs(dir, dir)
 	defer os.RemoveAll(trace)
 
 	target := "example.com/moby/dockerfilescratch:test"
@@ -1432,7 +1498,7 @@ RUN ["ls"]
 	require.Equal(t, true, ociimg.History[5].EmptyLayer)
 }
 
-func testUser(t *testing.T, sb integration.Sandbox) {
+func testUser(t *testing.T, sb integration.Sandbox, f *frontend) {
 	if sb.Rootless() {
 		t.Skip("only for rootful worker, due to lack of support for additional gids (https://github.com/opencontainers/runc/issues/1835)")
 	}
@@ -1513,8 +1579,7 @@ USER nobody
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend:          "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		Exporter:          client.ExporterLocal,
 		ExporterOutputDir: destDir,
 		LocalDirs: map[string]string{
@@ -1534,8 +1599,7 @@ USER nobody
 
 	// test user in exported
 	target := "example.com/moby/dockerfileuser:test"
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend: "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		Exporter: client.ExporterImage,
 		ExporterAttrs: map[string]string{
 			"name": target,
@@ -1578,7 +1642,7 @@ USER nobody
 	require.Equal(t, "nobody", ociimg.Config.User)
 }
 
-func testCopyChown(t *testing.T, sb integration.Sandbox) {
+func testCopyChown(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	dockerfile := []byte(`
@@ -1609,8 +1673,7 @@ COPY --from=base /out /
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend:          "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		Exporter:          client.ExporterLocal,
 		ExporterOutputDir: destDir,
 		LocalDirs: map[string]string{
@@ -1629,7 +1692,7 @@ COPY --from=base /out /
 	require.Equal(t, "1000 nogroup\n", string(dt))
 }
 
-func testCopyOverrideFiles(t *testing.T, sb integration.Sandbox) {
+func testCopyOverrideFiles(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	dockerfile := []byte(`
@@ -1661,8 +1724,7 @@ COPY files dest
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend:          "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		Exporter:          client.ExporterLocal,
 		ExporterOutputDir: destDir,
 		LocalDirs: map[string]string{
@@ -1681,7 +1743,7 @@ COPY files dest
 	require.Equal(t, "foo.go-contents", string(dt))
 }
 
-func testCopyVarSubstitution(t *testing.T, sb integration.Sandbox) {
+func testCopyVarSubstitution(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	dockerfile := []byte(`
@@ -1706,8 +1768,7 @@ COPY $FOO baz
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend:          "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		Exporter:          client.ExporterLocal,
 		ExporterOutputDir: destDir,
 		LocalDirs: map[string]string{
@@ -1722,7 +1783,7 @@ COPY $FOO baz
 	require.Equal(t, "bar-contents", string(dt))
 }
 
-func testCopyWildcards(t *testing.T, sb integration.Sandbox) {
+func testCopyWildcards(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	dockerfile := []byte(`
@@ -1758,8 +1819,7 @@ COPY sub/dir1 subdest6
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend:          "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		Exporter:          client.ExporterLocal,
 		ExporterOutputDir: destDir,
 		LocalDirs: map[string]string{
@@ -1810,7 +1870,7 @@ COPY sub/dir1 subdest6
 	require.Equal(t, "foo-contents", string(dt))
 }
 
-func testDockerfileFromGit(t *testing.T, sb integration.Sandbox) {
+func testDockerfileFromGit(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	gitDir, err := ioutil.TempDir("", "buildkit")
@@ -1862,8 +1922,7 @@ COPY --from=build foo bar2
 	require.NoError(t, err)
 	defer c.Close()
 
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend: "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		FrontendAttrs: map[string]string{
 			"context": server.URL + "/.git#first",
 		},
@@ -1885,8 +1944,7 @@ COPY --from=build foo bar2
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend: "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		FrontendAttrs: map[string]string{
 			"context": server.URL + "/.git",
 		},
@@ -1904,7 +1962,7 @@ COPY --from=build foo bar2
 	require.Equal(t, "fromgit", string(dt))
 }
 
-func testDockerfileFromHTTP(t *testing.T, sb integration.Sandbox) {
+func testDockerfileFromHTTP(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	buf := bytes.NewBuffer(nil)
@@ -1948,8 +2006,7 @@ COPY foo bar
 	require.NoError(t, err)
 	defer c.Close()
 
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend: "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		FrontendAttrs: map[string]string{
 			"context":  server.URL + "/myurl",
 			"filename": "mydockerfile",
@@ -1964,7 +2021,7 @@ COPY foo bar
 	require.Equal(t, "foo-contents", string(dt))
 }
 
-func testMultiStageImplicitFrom(t *testing.T, sb integration.Sandbox) {
+func testMultiStageImplicitFrom(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	dockerfile := []byte(`
@@ -1986,8 +2043,7 @@ COPY --from=busybox /etc/passwd test
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend:          "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		Exporter:          client.ExporterLocal,
 		ExporterOutputDir: destDir,
 		LocalDirs: map[string]string{
@@ -2021,8 +2077,7 @@ COPY --from=golang /usr/bin/go go
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend:          "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		Exporter:          client.ExporterLocal,
 		ExporterOutputDir: destDir,
 		LocalDirs: map[string]string{
@@ -2037,7 +2092,7 @@ COPY --from=golang /usr/bin/go go
 	require.Contains(t, string(dt), "foo")
 }
 
-func testMultiStageCaseInsensitive(t *testing.T, sb integration.Sandbox) {
+func testMultiStageCaseInsensitive(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	dockerfile := []byte(`
@@ -2063,8 +2118,7 @@ COPY --from=stage1 baz bax
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend:          "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		Exporter:          client.ExporterLocal,
 		ExporterOutputDir: destDir,
 		LocalDirs: map[string]string{
@@ -2082,7 +2136,7 @@ COPY --from=stage1 baz bax
 	require.Contains(t, string(dt), "foo-contents")
 }
 
-func testLabels(t *testing.T, sb integration.Sandbox) {
+func testLabels(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	dockerfile := []byte(`
@@ -2104,8 +2158,7 @@ LABEL foo=bar
 	defer os.RemoveAll(destDir)
 
 	target := "example.com/moby/dockerfilelabels:test"
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend: "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		FrontendAttrs: map[string]string{
 			"label:bar": "baz",
 		},
@@ -2157,7 +2210,7 @@ LABEL foo=bar
 	require.Equal(t, "baz", v)
 }
 
-func testCacheImportExport(t *testing.T, sb integration.Sandbox) {
+func testCacheImportExport(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	registry, err := sb.NewRegistry()
@@ -2193,8 +2246,7 @@ COPY --from=base unique /
 
 	target := registry + "/buildkit/testexportdf:latest"
 
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend:          "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		Exporter:          client.ExporterLocal,
 		ExporterOutputDir: destDir,
 		ExportCache:       target,
@@ -2221,8 +2273,7 @@ COPY --from=base unique /
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
-	_, err = c.Solve(context.TODO(), nil, client.SolveOpt{
-		Frontend: "dockerfile.v0",
+	_, err = f.solver(c)(context.TODO(), client.SolveOpt{
 		FrontendAttrs: map[string]string{
 			"cache-from": target,
 		},
@@ -2248,7 +2299,7 @@ COPY --from=base unique /
 	defer os.RemoveAll(destDir)
 }
 
-func testReproducibleIDs(t *testing.T, sb integration.Sandbox) {
+func testReproducibleIDs(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	dockerfile := []byte(`
@@ -2274,7 +2325,6 @@ RUN echo bar > bar
 
 	target := "example.com/moby/dockerfileids:test"
 	opt := client.SolveOpt{
-		Frontend:      "dockerfile.v0",
 		FrontendAttrs: map[string]string{},
 		Exporter:      client.ExporterImage,
 		ExporterAttrs: map[string]string{
@@ -2286,13 +2336,13 @@ RUN echo bar > bar
 		},
 	}
 
-	_, err = c.Solve(context.TODO(), nil, opt, nil)
+	_, err = f.solver(c)(context.TODO(), opt, nil)
 	require.NoError(t, err)
 
 	target2 := "example.com/moby/dockerfileids2:test"
 	opt.ExporterAttrs["name"] = target2
 
-	_, err = c.Solve(context.TODO(), nil, opt, nil)
+	_, err = f.solver(c)(context.TODO(), opt, nil)
 	require.NoError(t, err)
 
 	var cdAddress string
@@ -2318,7 +2368,7 @@ RUN echo bar > bar
 	require.Equal(t, img.Target, img2.Target)
 }
 
-func testImportExportReproducibleIDs(t *testing.T, sb integration.Sandbox) {
+func testImportExportReproducibleIDs(t *testing.T, sb integration.Sandbox, f *frontend) {
 	var cdAddress string
 	if cd, ok := sb.(interface {
 		ContainerdAddress() string
@@ -2361,7 +2411,6 @@ RUN echo bar > bar
 	target := "example.com/moby/dockerfileexpids:test"
 	cacheTarget := registry + "/test/dockerfileexpids:cache"
 	opt := client.SolveOpt{
-		Frontend:      "dockerfile.v0",
 		FrontendAttrs: map[string]string{},
 		Exporter:      client.ExporterImage,
 		ExportCache:   cacheTarget,
@@ -2380,7 +2429,7 @@ RUN echo bar > bar
 
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit")
 
-	_, err = c.Solve(context.TODO(), nil, opt, nil)
+	_, err = f.solver(c)(context.TODO(), opt, nil)
 	require.NoError(t, err)
 
 	img, err := ctd.ImageService().Get(ctx, target)
@@ -2399,7 +2448,7 @@ RUN echo bar > bar
 	opt.ExporterAttrs["name"] = target2
 	opt.FrontendAttrs["cache-from"] = cacheTarget
 
-	_, err = c.Solve(context.TODO(), nil, opt, nil)
+	_, err = f.solver(c)(context.TODO(), opt, nil)
 	require.NoError(t, err)
 
 	img2, err := ctd.ImageService().Get(ctx, target2)
@@ -2408,7 +2457,7 @@ RUN echo bar > bar
 	require.Equal(t, img.Target, img2.Target)
 }
 
-func testNoCache(t *testing.T, sb integration.Sandbox) {
+func testNoCache(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	dockerfile := []byte(`
@@ -2435,7 +2484,6 @@ COPY --from=s1 unique2 /
 	defer os.RemoveAll(destDir)
 
 	opt := client.SolveOpt{
-		Frontend:          "dockerfile.v0",
 		FrontendAttrs:     map[string]string{},
 		Exporter:          client.ExporterLocal,
 		ExporterOutputDir: destDir,
@@ -2445,7 +2493,7 @@ COPY --from=s1 unique2 /
 		},
 	}
 
-	_, err = c.Solve(context.TODO(), nil, opt, nil)
+	_, err = f.solver(c)(context.TODO(), opt, nil)
 	require.NoError(t, err)
 
 	destDir2, err := ioutil.TempDir("", "buildkit")
@@ -2455,7 +2503,7 @@ COPY --from=s1 unique2 /
 	opt.FrontendAttrs["no-cache"] = ""
 	opt.ExporterOutputDir = destDir2
 
-	_, err = c.Solve(context.TODO(), nil, opt, nil)
+	_, err = f.solver(c)(context.TODO(), opt, nil)
 	require.NoError(t, err)
 
 	unique1Dir1, err := ioutil.ReadFile(filepath.Join(destDir, "unique"))
@@ -2480,7 +2528,7 @@ COPY --from=s1 unique2 /
 	opt.FrontendAttrs["no-cache"] = "s1"
 	opt.ExporterOutputDir = destDir3
 
-	_, err = c.Solve(context.TODO(), nil, opt, nil)
+	_, err = f.solver(c)(context.TODO(), opt, nil)
 	require.NoError(t, err)
 
 	unique1Dir3, err := ioutil.ReadFile(filepath.Join(destDir3, "unique"))
@@ -2493,7 +2541,7 @@ COPY --from=s1 unique2 /
 	require.NotEqual(t, string(unique2Dir1), string(unique2Dir3))
 }
 
-func testPlatformArgsImplicit(t *testing.T, sb integration.Sandbox) {
+func testPlatformArgsImplicit(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	dockerfile := []byte(fmt.Sprintf(`
@@ -2520,7 +2568,6 @@ COPY foo2 bar2
 	defer os.RemoveAll(destDir)
 
 	opt := client.SolveOpt{
-		Frontend:          "dockerfile.v0",
 		Exporter:          client.ExporterLocal,
 		ExporterOutputDir: destDir,
 		LocalDirs: map[string]string{
@@ -2529,7 +2576,7 @@ COPY foo2 bar2
 		},
 	}
 
-	_, err = c.Solve(context.TODO(), nil, opt, nil)
+	_, err = f.solver(c)(context.TODO(), opt, nil)
 	require.NoError(t, err)
 
 	dt, err := ioutil.ReadFile(filepath.Join(destDir, "bar"))
@@ -2541,7 +2588,7 @@ COPY foo2 bar2
 	require.Equal(t, "d1", string(dt))
 }
 
-func testPlatformArgsExplicit(t *testing.T, sb integration.Sandbox) {
+func testPlatformArgsExplicit(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	dockerfile := []byte(`
@@ -2568,7 +2615,6 @@ COPY --from=build out .
 	defer os.RemoveAll(destDir)
 
 	opt := client.SolveOpt{
-		Frontend: "dockerfile.v0",
 		Exporter: client.ExporterLocal,
 		FrontendAttrs: map[string]string{
 			"platform":           "darwin/ppc64le",
@@ -2581,7 +2627,7 @@ COPY --from=build out .
 		},
 	}
 
-	_, err = c.Solve(context.TODO(), nil, opt, nil)
+	_, err = f.solver(c)(context.TODO(), opt, nil)
 	require.NoError(t, err)
 
 	dt, err := ioutil.ReadFile(filepath.Join(destDir, "platform"))
@@ -2593,7 +2639,7 @@ COPY --from=build out .
 	require.Equal(t, "freebsd", string(dt))
 }
 
-func testBuiltinArgs(t *testing.T, sb integration.Sandbox) {
+func testBuiltinArgs(t *testing.T, sb integration.Sandbox, f *frontend) {
 	t.Parallel()
 
 	dockerfile := []byte(`
@@ -2621,7 +2667,6 @@ COPY --from=build /out /
 	defer os.RemoveAll(destDir)
 
 	opt := client.SolveOpt{
-		Frontend: "dockerfile.v0",
 		FrontendAttrs: map[string]string{
 			"build-arg:FOO":        "foocontents",
 			"build-arg:http_proxy": "hpvalue",
@@ -2635,7 +2680,7 @@ COPY --from=build /out /
 		},
 	}
 
-	_, err = c.Solve(context.TODO(), nil, opt, nil)
+	_, err = f.solver(c)(context.TODO(), opt, nil)
 	require.NoError(t, err)
 
 	dt, err := ioutil.ReadFile(filepath.Join(destDir, "out"))
@@ -2648,7 +2693,6 @@ COPY --from=build /out /
 	defer os.RemoveAll(destDir)
 
 	opt = client.SolveOpt{
-		Frontend: "dockerfile.v0",
 		FrontendAttrs: map[string]string{
 			"build-arg:FOO":        "foocontents",
 			"build-arg:http_proxy": "hpvalue2",
@@ -2661,7 +2705,7 @@ COPY --from=build /out /
 		},
 	}
 
-	_, err = c.Solve(context.TODO(), nil, opt, nil)
+	_, err = f.solver(c)(context.TODO(), opt, nil)
 	require.NoError(t, err)
 
 	dt, err = ioutil.ReadFile(filepath.Join(destDir, "out"))
@@ -2674,7 +2718,6 @@ COPY --from=build /out /
 	defer os.RemoveAll(destDir)
 
 	opt = client.SolveOpt{
-		Frontend: "dockerfile.v0",
 		FrontendAttrs: map[string]string{
 			"build-arg:FOO":        "foocontents2",
 			"build-arg:http_proxy": "hpvalue2",
@@ -2687,7 +2730,7 @@ COPY --from=build /out /
 		},
 	}
 
-	_, err = c.Solve(context.TODO(), nil, opt, nil)
+	_, err = f.solver(c)(context.TODO(), opt, nil)
 	require.NoError(t, err)
 
 	dt, err = ioutil.ReadFile(filepath.Join(destDir, "out"))
@@ -2704,11 +2747,6 @@ func tmpdir(appliers ...fstest.Applier) (string, error) {
 		return "", err
 	}
 	return tmpdir, nil
-}
-
-func dfCmdArgs(ctx, dockerfile string) (string, string) {
-	traceFile := filepath.Join(os.TempDir(), "trace"+identity.NewID())
-	return fmt.Sprintf("build --progress=plain --frontend dockerfile.v0 --local context=%s --local dockerfile=%s --trace=%s", ctx, dockerfile, traceFile), traceFile
 }
 
 func runShell(dir string, cmds ...string) error {

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -68,7 +68,6 @@ func TestIntegration(t *testing.T) {
 		testPullScratch,
 		testSymlinkDestination,
 		testHTTPDockerfile,
-		testNoSnapshotLeak,
 		testCopySymlinks,
 		testContextChangeDirToFile,
 		testPlatformArgsImplicit,

--- a/hack/test
+++ b/hack/test
@@ -9,7 +9,12 @@ docker build --iidfile $iidfile --target integration-tests -f ./hack/dockerfiles
 iid=$(cat $iidfile)
 rm -f $iidfile
 
-docker run --rm -v /tmp --privileged $iid go test ${TESTFLAGS:--v} ${TESTPKGS:-./...}
+docker run --rm -v /tmp --privileged -e BUILDKIT_DOCKERFILE_INTEGRATION_MODE=${BUILDKIT_DOCKERFILE_INTEGRATION_MODE:-} $iid go test ${TESTFLAGS:--v} ${TESTPKGS:-./...}
+if [ -z "${BUILDKIT_DOCKERFILE_INTEGRATION_MODE:+x}" ] ; then
+    for mode in "master-gateway" "client" ; do
+	docker run --rm -v /tmp --privileged -e BUILDKIT_DOCKERFILE_INTEGRATION_MODE=$mode $iid go test ${TESTFLAGS:--v -test.run 'TestDockerfile.*Integration'} ${TESTPKGS:-./frontend/dockerfile}
+    done
+fi
 
 docker run --rm $iid go build ./frontend/gateway/client
 docker run --rm $iid go build ./frontend/dockerfile/cmd/dockerfile-frontend


### PR DESCRIPTION
This arose as a possibility in https://github.com/moby/buildkit/pull/533#discussion_r205855343. I have a few concerns though:
* This pulls `tonistiigi/dockerfile:latest`, which I suspect (I'm not entirely sure, but I am pretty confident) isn't always going to work e.g. when adding a new dockerfile feature and testing it. Need to find a mechanism to instead inject a locally freshly built image.
* When run independently the `builtin` tests take 3m51 (wallclock) and the `gateway` ones 5m55 (wallclock).
    * a) `gateway` is a surprising amount slower (nb: this was run on my laptop, so not exactly controlled conditions)
    * b) when adding `client` (i.e. the work in #533) as a third mode the overall test breaches the 10min limit imposed by `go test` on a single test (even though it is 3 separate top level `TestFoo` functions). I couldn't see a programmatic way to get around that (could use `go test -timeout` but that's not ideal).
* I marked a bunch of tests as `t.Skip`/TBD in gateway mode since they were failing for me, need to investigate why.

Also:
* Dropped a duplicated `testNoSnapshotLeak`