### PR TITLE
 executor: allow network providers

### DIFF
--- a/executor/containerdexecutor/executor.go
+++ b/executor/containerdexecutor/executor.go
@@ -78,11 +78,16 @@ func (w containerdExecutor) Exec(ctx context.Context, meta executor.Meta, root c
 		lm.Unmount()
 	}
 
-	hostNetworkEnabled := false
-	iface, err := w.networkProvider.NewInterface()
-	if err != nil || iface == nil {
+	hostNetworkEnabled := true
+	var iface network.Interface
+	if w.networkProvider != nil {
+		iface, err = w.networkProvider.NewInterface()
+		if err == nil && iface != nil {
+			hostNetworkEnabled = false
+		}
+	}
+	if hostNetworkEnabled {
 		logrus.Info("enabling HostNetworking")
-		hostNetworkEnabled = true
 	}
 
 	opts := []containerdoci.SpecOpts{oci.WithUIDGID(uid, gid, sgids)}

--- a/executor/oci/spec_unix.go
+++ b/executor/oci/spec_unix.go
@@ -21,7 +21,7 @@ import (
 // Ideally we don't have to import whole containerd just for the default spec
 
 // GenerateSpec generates spec using containerd functionality.
-func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mount, id, resolvConf, hostsFile string, opts ...oci.SpecOpts) (*specs.Spec, func(), error) {
+func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mount, id, resolvConf, hostsFile string, hostNetwork bool, opts ...oci.SpecOpts) (*specs.Spec, func(), error) {
 	c := &containers.Container{
 		ID: id,
 	}
@@ -30,9 +30,9 @@ func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mou
 		ctx = namespaces.WithNamespace(ctx, "buildkit")
 	}
 
-	opts = append(opts,
-		oci.WithHostNamespace(specs.NetworkNamespace),
-	)
+	if hostNetwork {
+		opts = append(opts, oci.WithHostNamespace(specs.NetworkNamespace))
+	}
 
 	// Note that containerd.GenerateSpec is namespaced so as to make
 	// specs.Linux.CgroupsPath namespaced

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 
 	"github.com/containerd/containerd/contrib/seccomp"
@@ -21,8 +22,10 @@ import (
 	"github.com/moby/buildkit/executor"
 	"github.com/moby/buildkit/executor/oci"
 	"github.com/moby/buildkit/identity"
+	"github.com/moby/buildkit/util/network"
 	rootlessspecconv "github.com/moby/buildkit/util/rootless/specconv"
 	"github.com/moby/buildkit/util/system"
+	runcsystem "github.com/opencontainers/runc/libcontainer/system"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -39,13 +42,14 @@ type Opt struct {
 var defaultCommandCandidates = []string{"buildkit-runc", "runc"}
 
 type runcExecutor struct {
-	runc     *runc.Runc
-	root     string
-	cmd      string
-	rootless bool
+	runc            *runc.Runc
+	root            string
+	cmd             string
+	rootless        bool
+	networkProvider network.Provider
 }
 
-func New(opt Opt) (executor.Executor, error) {
+func New(opt Opt, networkProvider network.Provider) (executor.Executor, error) {
 	cmds := opt.CommandCandidates
 	if cmds == nil {
 		cmds = defaultCommandCandidates
@@ -64,6 +68,10 @@ func New(opt Opt) (executor.Executor, error) {
 	}
 
 	root := opt.Root
+
+	if err := setSubReaper(); err != nil {
+		return nil, err
+	}
 
 	if err := os.MkdirAll(root, 0700); err != nil {
 		return nil, errors.Wrapf(err, "failed to create %s", root)
@@ -89,9 +97,10 @@ func New(opt Opt) (executor.Executor, error) {
 	}
 
 	w := &runcExecutor{
-		runc:     runtime,
-		root:     root,
-		rootless: opt.Rootless,
+		runc:            runtime,
+		root:            root,
+		rootless:        opt.Rootless,
+		networkProvider: networkProvider,
 	}
 	return w, nil
 }
@@ -148,6 +157,14 @@ func (w *runcExecutor) Exec(ctx context.Context, meta executor.Meta, root cache.
 		return err
 	}
 	defer f.Close()
+
+	hostNetworkEnabled := false
+	iface, err := w.networkProvider.NewInterface()
+	if err != nil || iface == nil {
+		logrus.Info("enabling HostNetworking")
+		hostNetworkEnabled = true
+	}
+
 	opts := []containerdoci.SpecOpts{oci.WithUIDGID(uid, gid, sgids)}
 	if system.SeccompSupported() {
 		opts = append(opts, seccomp.WithDefaultProfile())
@@ -155,7 +172,7 @@ func (w *runcExecutor) Exec(ctx context.Context, meta executor.Meta, root cache.
 	if meta.ReadonlyRootFS {
 		opts = append(opts, containerdoci.WithRootFSReadonly())
 	}
-	spec, cleanup, err := oci.GenerateSpec(ctx, meta, mounts, id, resolvConf, hostsFile, opts...)
+	spec, cleanup, err := oci.GenerateSpec(ctx, meta, mounts, id, resolvConf, hostsFile, hostNetworkEnabled, opts...)
 	if err != nil {
 		return err
 	}
@@ -187,38 +204,185 @@ func (w *runcExecutor) Exec(ctx context.Context, meta executor.Meta, root cache.
 		return err
 	}
 
-	logrus.Debugf("> running %s %v", id, meta.Args)
+	f.Sync()
 
-	status, err := w.runc.Run(ctx, id, bundle, &runc.CreateOpts{
-		IO: &forwardIO{stdin: stdin, stdout: stdout, stderr: stderr},
-	})
-	logrus.Debugf("< completed %s %v %v", id, status, err)
-	if status != 0 {
-		select {
-		case <-ctx.Done():
-			// runc can't report context.Cancelled directly
-			return errors.Wrapf(ctx.Err(), "exit code %d", status)
-		default:
-		}
-		return errors.Errorf("exit code %d", status)
+	forwardIO, err := newForwardIO(stdin, stdout, stderr)
+	if err != nil {
+		return errors.Wrap(err, "creating new forwarding IO")
+	}
+	defer forwardIO.Close()
+
+	pidFilePath := filepath.Join(w.root, "runc_pid_"+identity.NewID())
+	defer os.RemoveAll(pidFilePath)
+
+	logrus.Debugf("> creating %s %v", id, meta.Args)
+	if err := w.runc.Create(ctx, id, bundle, &runc.CreateOpts{
+		PidFile: pidFilePath,
+		IO:      forwardIO,
+	}); err != nil {
+		return err
+	}
+	forwardIO.release()
+
+	dt, err := ioutil.ReadFile(pidFilePath)
+	if err != nil {
+		return err
+	}
+	pid, err := strconv.Atoi(string(dt))
+	if err != nil {
+		return err
 	}
 
-	return err
+	if iface != nil {
+		if err := iface.Set(pid); err != nil {
+			return errors.Wrap(err, "could not set the network")
+		}
+	}
+
+	defer func() {
+		if iface != nil {
+			iface.Remove(pid)
+			w.networkProvider.Release(iface)
+		}
+		if err := w.runc.Delete(context.TODO(), id, &runc.DeleteOpts{}); err != nil {
+			logrus.Errorf("failed to delete %s: %+v", id, err)
+		}
+	}()
+
+	err = w.runc.Start(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+
+	status := 0
+	ps, err := p.Wait()
+	if err != nil {
+		status = 255
+	}
+
+	if ws, ok := ps.Sys().(syscall.WaitStatus); ok {
+		status = ws.ExitStatus()
+	}
+	if status != 0 {
+		return errors.Errorf("exit code: %d", status)
+	}
+
+	return nil
 }
 
 type forwardIO struct {
-	stdin          io.ReadCloser
-	stdout, stderr io.WriteCloser
+	stdin, stdout, stderr *os.File
+	toRelease             []io.Closer
+	toClose               []io.Closer
+}
+
+func newForwardIO(stdin io.ReadCloser, stdout, stderr io.WriteCloser) (f *forwardIO, err error) {
+	fio := &forwardIO{}
+	defer func() {
+		if err != nil {
+			fio.Close()
+		}
+	}()
+	if stdin != nil {
+		fio.stdin, err = fio.readCloserToFile(stdin)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if stdout != nil {
+		fio.stdout, err = fio.writeCloserToFile(stdout)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if stderr != nil {
+		fio.stderr, err = fio.writeCloserToFile(stderr)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return fio, nil
 }
 
 func (s *forwardIO) Close() error {
-	return nil
+	s.release()
+	var err error
+	for _, cl := range s.toClose {
+		if err1 := cl.Close(); err == nil {
+			err = err1
+		}
+	}
+	s.toClose = nil
+	return err
+}
+
+// release releases active FDs if the process doesn't need them any more
+func (s *forwardIO) release() {
+	for _, cl := range s.toRelease {
+		cl.Close()
+	}
+	s.toRelease = nil
 }
 
 func (s *forwardIO) Set(cmd *exec.Cmd) {
 	cmd.Stdin = s.stdin
 	cmd.Stdout = s.stdout
 	cmd.Stderr = s.stderr
+}
+
+func (s *forwardIO) readCloserToFile(rc io.ReadCloser) (*os.File, error) {
+	if f, ok := rc.(*os.File); ok {
+		return f, nil
+	}
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	s.toClose = append(s.toClose, pw)
+	s.toRelease = append(s.toRelease, pr)
+	go func() {
+		_, err := io.Copy(pw, rc)
+		if err1 := pw.Close(); err == nil {
+			err = err1
+		}
+		_ = err
+	}()
+	return pr, nil
+}
+
+func (s *forwardIO) writeCloserToFile(wc io.WriteCloser) (*os.File, error) {
+	if f, ok := wc.(*os.File); ok {
+		return f, nil
+	}
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	s.toClose = append(s.toClose, pr)
+	s.toRelease = append(s.toRelease, pw)
+	go func() {
+		_, err := io.Copy(wc, pr)
+		if err1 := pw.Close(); err == nil {
+			err = err1
+		}
+		_ = err
+	}()
+	return pw, nil
+}
+
+var subReaperOnce sync.Once
+var subReaperError error
+
+func setSubReaper() error {
+	subReaperOnce.Do(func() {
+		subReaperError = runcsystem.SetSubreaper(1)
+	})
+	return subReaperError
 }
 
 func (s *forwardIO) Stdin() io.WriteCloser {

--- a/util/network/network.go
+++ b/util/network/network.go
@@ -1,0 +1,22 @@
+package network
+
+// Provider interface for Network
+type Provider interface {
+	NewInterface() (Interface, error)
+	Release(Interface) error
+}
+
+// Interface of network for workers
+type Interface interface {
+	// Set the pid with network interace namespace
+	Set(int) error
+	// Removes the network interface
+	Remove(int) error
+}
+
+// NetworkOpts hold network options
+type NetworkOpts struct {
+	Type          string
+	CNIConfigPath string
+	CNIPluginPath string
+}

--- a/worker/containerd/containerd.go
+++ b/worker/containerd/containerd.go
@@ -107,7 +107,7 @@ func newContainerd(root string, client *containerd.Client, snapshotterName strin
 		ID:            id,
 		Labels:        xlabels,
 		MetadataStore: md,
-		Executor:      containerdexecutor.New(client, root),
+		Executor:      containerdexecutor.New(client, root, nil),
 		Snapshotter:   containerdsnapshot.NewSnapshotter(client.SnapshotService(snapshotterName), cs, md, "buildkit", gc),
 		ContentStore:  cs,
 		Applier:       winlayers.NewFileSystemApplierWithWindows(cs, df),

--- a/worker/runc/runc.go
+++ b/worker/runc/runc.go
@@ -48,7 +48,7 @@ func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, labe
 		Root: filepath.Join(root, "executor"),
 		// without root privileges
 		Rootless: rootless,
-	})
+	}, nil)
 	if err != nil {
 		return opt, err
 	}

--- a/worker/runc/runc_test.go
+++ b/worker/runc/runc_test.go
@@ -112,7 +112,7 @@ func TestRuncWorker(t *testing.T) {
 	root, err := w.CacheManager.New(ctx, snap)
 	require.NoError(t, err)
 
-	err = w.Executor.Exec(ctx, meta, root, nil, nil, nil, nil)
+	err = w.Executor.Exec(ctx, meta, root, nil, nil, nil, &nopCloser{stderr})
 	require.NoError(t, err)
 
 	meta = executor.Meta{


### PR DESCRIPTION
I separated out part of the work done by @kunalkushwaha in #309 

This only adds the changes made to the executors and the new network provider interface so should be safe to merge. I will use this for bridge networking in moby integration similar way as the cni PR does.

@kunalkushwaha @AkihiroSuda 