### PR TITLE
Initialise `src.Metadata` in all `{image,oci}ExporterInstance.Export`

### DIFF
--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -99,6 +99,9 @@ func (e *imageExporterInstance) Name() string {
 }
 
 func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source) (map[string]string, error) {
+	if src.Metadata == nil {
+		src.Metadata = make(map[string][]byte)
+	}
 	for k, v := range e.meta {
 		src.Metadata[k] = v
 	}

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -109,6 +109,9 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source)
 		return nil, errors.Errorf("docker exporter does not currently support exporting manifest lists")
 	}
 
+	if src.Metadata == nil {
+		src.Metadata = make(map[string][]byte)
+	}
 	for k, v := range e.meta {
 		src.Metadata[k] = v
 	}


### PR DESCRIPTION
Failure to do so would potentially lead to a panic. Belt & braces followup
for #555.

`localExporterInstance` has no `e.meta` to merge and makes no use of the
`Metadata` anyhow (since that doesn't seem to make sense for a local export) so
is unmodified.

Signed-off-by: Ian Campbell <ijc@docker.com>
