### PR TITLE
exporters: allow for more than one non-standard metadata key

### DIFF
--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -78,8 +78,8 @@ func (e *imageExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 		default:
 			if i.meta == nil {
 				i.meta = make(map[string][]byte)
-				i.meta[k] = []byte(v)
 			}
+			i.meta[k] = []byte(v)
 		}
 	}
 	return i, nil

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -80,8 +80,8 @@ func (e *imageExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 		default:
 			if i.meta == nil {
 				i.meta = make(map[string][]byte)
-				i.meta[k] = []byte(v)
 			}
+			i.meta[k] = []byte(v)
 		}
 	}
 	if ot == nil {


### PR DESCRIPTION
I think this was just a thinko.

Signed-off-by: Ian Campbell <ijc@docker.com>

Should the `local` one reject a non-empty `opt` argument to `Resolve`? (cf https://github.com/moby/buildkit/pull/557#discussion_r207817906)