### PR TITLE
dockerfile: do not require `=` as a separator between flag and argument

### DIFF
--- a/frontend/dockerfile/instructions/bflag.go
+++ b/frontend/dockerfile/instructions/bflag.go
@@ -191,7 +191,7 @@ func (bf *BFlags) Parse() error {
 			flag.StringValues = append(flag.StringValues, value)
 
 		default:
-			panic("No idea what kind of flag we have! Should never get here!")
+			return fmt.Errorf("invalid flag type %v", flag.flagType)
 		}
 
 	}

--- a/frontend/dockerfile/instructions/parse_test.go
+++ b/frontend/dockerfile/instructions/parse_test.go
@@ -170,7 +170,7 @@ func TestErrorCases(t *testing.T) {
 		},
 		{
 			name:          "MAINTAINER unknown flag",
-			dockerfile:    "MAINTAINER --boo joe@example.com",
+			dockerfile:    "MAINTAINER --boo=ba joe@example.com",
 			expectedError: "Unknown flag: boo",
 		},
 		{


### PR DESCRIPTION
This patch allows to parse the following Dockerfile instruction:
`COPY --from base /src /dest`
whereas previously only an `=` sign was required:
`COPY --from=base /src /dest`

Signed-off-by: Tibor Vass <tibor@docker.com>