### PR TITLE
progressui: allow caller to customise "Building" string

### DIFF
--- a/cmd/buildctl/build.go
+++ b/cmd/buildctl/build.go
@@ -228,7 +228,7 @@ func build(clicontext *cli.Context) error {
 			}
 		}
 		// not using shared context to not disrupt display but let is finish reporting errors
-		return progressui.DisplaySolveStatus(context.TODO(), c, os.Stdout, displayCh)
+		return progressui.DisplaySolveStatus(context.TODO(), "", c, os.Stdout, displayCh)
 	})
 
 	return eg.Wait()

--- a/examples/build-using-dockerfile/main.go
+++ b/examples/build-using-dockerfile/main.go
@@ -92,7 +92,7 @@ func action(clicontext *cli.Context) error {
 			c = cn
 		}
 		// not using shared context to not disrupt display but let is finish reporting errors
-		return progressui.DisplaySolveStatus(context.TODO(), c, os.Stdout, ch)
+		return progressui.DisplaySolveStatus(context.TODO(), "", c, os.Stdout, ch)
 	})
 	eg.Go(func() error {
 		if err := loadDockerTar(pipeR); err != nil {

--- a/util/progress/progressui/display.go
+++ b/util/progress/progressui/display.go
@@ -16,12 +16,16 @@ import (
 	"golang.org/x/time/rate"
 )
 
-func DisplaySolveStatus(ctx context.Context, c console.Console, w io.Writer, ch chan *client.SolveStatus) error {
+func DisplaySolveStatus(ctx context.Context, phase string, c console.Console, w io.Writer, ch chan *client.SolveStatus) error {
 
 	modeConsole := c != nil
 
-	disp := &display{c: c}
+	disp := &display{c: c, phase: phase}
 	printer := &textMux{w: w}
+
+	if disp.phase == "" {
+		disp.phase = "Building"
+	}
 
 	t := newTrace(w)
 
@@ -323,6 +327,7 @@ func addTime(tm *time.Time, d time.Duration) *time.Time {
 
 type display struct {
 	c         console.Console
+	phase     string
 	lineCount int
 	repeated  bool
 }
@@ -359,7 +364,7 @@ func (disp *display) print(d displayInfo, all bool) {
 	fmt.Fprint(disp.c, aec.Hide)
 	defer fmt.Fprint(disp.c, aec.Show)
 
-	out := fmt.Sprintf("[+] Building %.1fs (%d/%d) %s", time.Since(d.startTime).Seconds(), d.countCompleted, d.countTotal, statusStr)
+	out := fmt.Sprintf("[+] %s %.1fs (%d/%d) %s", disp.phase, time.Since(d.startTime).Seconds(), d.countCompleted, d.countTotal, statusStr)
 	out = align(out, "", width)
 	fmt.Fprintln(disp.c, out)
 	lineCount := 0


### PR DESCRIPTION
In clients which are doinging multiple builds or phases it can be useful to say
something more specific here (e.g. "Building first image", "Probing" etc)

Signed-off-by: Ian Campbell <ijc@docker.com>