### PR TITLE
dockerfile: implement secret type mounts

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert_nosecrets.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_nosecrets.go
@@ -1,0 +1,13 @@
+// +build dfrunmount,!dfsecrets
+
+package dockerfile2llb
+
+import (
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+	"github.com/pkg/errors"
+)
+
+func dispatchSecret(m *instructions.Mount) (llb.RunOption, error) {
+	return nil, errors.Errorf("secret mounts not allowed")
+}

--- a/frontend/dockerfile/dockerfile2llb/convert_runmount.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_runmount.go
@@ -57,6 +57,14 @@ func dispatchRunMounts(d *dispatchState, c *instructions.RunCommand, sources []*
 			st = llb.Scratch()
 			mountOpts = append(mountOpts, llb.Tmpfs())
 		}
+		if mount.Type == instructions.MountTypeSecret {
+			secret, err := dispatchSecret(mount)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, secret)
+			continue
+		}
 		if mount.ReadOnly {
 			mountOpts = append(mountOpts, llb.Readonly)
 		}

--- a/frontend/dockerfile/dockerfile2llb/convert_secrets.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_secrets.go
@@ -1,0 +1,32 @@
+// +build dfsecrets dfextall
+
+package dockerfile2llb
+
+import (
+	"path"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+	"github.com/pkg/errors"
+)
+
+func dispatchSecret(m *instructions.Mount) (llb.RunOption, error) {
+	id := m.CacheID
+	if m.Source != "" {
+		id = m.Source
+	}
+
+	if id == "" {
+		if m.Target == "" {
+			return nil, errors.Errorf("one of source, target required")
+		}
+		id = path.Base(m.Target)
+	}
+
+	target := m.Target
+	if target == "" {
+		target = "/run/secrets/" + path.Base(id)
+	}
+
+	return llb.AddSecret(target, llb.SecretID(id)), nil
+}

--- a/frontend/dockerfile/instructions/commands_nosecrets.go
+++ b/frontend/dockerfile/instructions/commands_nosecrets.go
@@ -1,0 +1,7 @@
+// +build !dfsecrets
+
+package instructions
+
+func isSecretMountsSupported() bool {
+	return false
+}

--- a/frontend/dockerfile/instructions/commands_secrets.go
+++ b/frontend/dockerfile/instructions/commands_secrets.go
@@ -1,0 +1,7 @@
+// +build dfsecrets dfextall
+
+package instructions
+
+func isSecretMountsSupported() bool {
+	return true
+}


### PR DESCRIPTION
Add secret mounts support for Dockerfile using the `RUN --mount` as a base.

```
RUN --mount=type=secret,id=mysecret,target=/foo/bar cmd
```

```
buildctl build --secret id=mysecret,src=path/to/secret
```

ID defaults to the basename of the target and target defaults to `/run/secrets/<id>`.

Pushed an image with support to be used in Dockerfiles:

```
# syntax = docker.io/tonistiigi/dockerfile:secrets20180808
```


Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>