### PR TITLE
dockerfile: allow multi-target external builds

### DIFF
--- a/frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile
+++ b/frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile
@@ -1,6 +1,9 @@
-FROM golang:1.10-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.10-alpine AS builder
 ARG BUILDTAGS=""
 COPY . /go/src/github.com/moby/buildkit
+ARG TARGETOS
+ARG TARGETARCH
+ENV GOOS=$TARGETOS GOARCH=$TARGETARCH
 RUN CGO_ENABLED=0 go build -o /dockerfile-frontend -tags "$BUILDTAGS" --ldflags '-extldflags "-static"' github.com/moby/buildkit/frontend/dockerfile/cmd/dockerfile-frontend
 
 FROM scratch


### PR DESCRIPTION
Make it easy to export manifest list when building the custom Dockerfile frontend versions.

Docker 18.06 users can set args manually, the defaults still work as well for current platform.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>