### PR TITLE
solver: Don't solve both the provided Defininiton & frontend

### DIFF
--- a/solver/llbsolver/bridge.go
+++ b/solver/llbsolver/bridge.go
@@ -74,6 +74,10 @@ func (b *llbBridge) Solve(ctx context.Context, req frontend.SolveRequest) (res *
 		b.cmsMu.Unlock()
 	}
 
+	if req.Definition != nil && req.Definition.Def != nil && req.Frontend != "" {
+		return nil, errors.New("cannot solve with both Definition and Frontend specified")
+	}
+
 	if req.Definition != nil && req.Definition.Def != nil {
 		edge, err := Load(req.Definition, WithCacheSources(cms), RuntimePlatforms(b.platforms), WithValidateCaps())
 		if err != nil {

--- a/solver/llbsolver/bridge.go
+++ b/solver/llbsolver/bridge.go
@@ -85,8 +85,7 @@ func (b *llbBridge) Solve(ctx context.Context, req frontend.SolveRequest) (res *
 		}
 
 		res = &frontend.Result{Ref: ref}
-	}
-	if req.Frontend != "" {
+	} else if req.Frontend != "" {
 		f, ok := b.frontends[req.Frontend]
 		if !ok {
 			return nil, errors.Errorf("invalid frontend: %s", req.Frontend)

--- a/solver/llbsolver/bridge.go
+++ b/solver/llbsolver/bridge.go
@@ -99,9 +99,7 @@ func (b *llbBridge) Solve(ctx context.Context, req frontend.SolveRequest) (res *
 			return nil, err
 		}
 	} else {
-		if req.Definition == nil || req.Definition.Def == nil {
-			return &frontend.Result{}, nil
-		}
+		return &frontend.Result{}, nil
 	}
 
 	if err := res.EachRef(func(r solver.CachedResult) error {


### PR DESCRIPTION
This seems wasteful. I think there is no side-effects of the Load+Build of the
definition which would make a difference to the frontend solve.

Note that this changes the presedence of the actual result, previously the
frontend result would overwrite the definition's one, while now the frontend
would not be run.

Signed-off-by: Ian Campbell <ijc@docker.com>