### PR TITLE
[WIP] exporters: allow frontend control of the exported image name

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -2,8 +2,11 @@ package exporter
 
 import (
 	"context"
+	"strings"
+	"text/template"
 
 	"github.com/moby/buildkit/cache"
+	"github.com/pkg/errors"
 )
 
 type Exporter interface {
@@ -19,4 +22,19 @@ type Source struct {
 	Ref      cache.ImmutableRef
 	Refs     map[string]cache.ImmutableRef
 	Metadata map[string][]byte
+}
+
+func ResolveNameTemplate(tmpl string, m map[string][]byte) (string, error) {
+	if tmpl == "" {
+		return "", nil
+	}
+	t, err := template.New("name").Parse(tmpl)
+	if err != nil {
+		return "", errors.Wrapf(err, "parsing %q", tmpl)
+	}
+	var b strings.Builder
+	if err := t.Execute(&b, m); err != nil {
+		return "", errors.Wrapf(err, "executing %q", tmpl)
+	}
+	return b.String(), nil
 }


### PR DESCRIPTION
By templating the image name based on frontend returned metadata.

Signed-off-by: Ian Campbell <ijc@docker.com>

WIP because I think the easiest/sanest way to test would be to use the stuff #533 to use a client side frontend which returned some metadata, but opening now to get feedback on the general shape of the feature itself.