### PR TITLE
Allow some Metadata to be return from frontend to the control client

### DIFF
--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -2,6 +2,7 @@ package llbsolver
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/moby/buildkit/cache"
@@ -191,6 +192,16 @@ func (s *Solver) Solve(ctx context.Context, id string, req frontend.SolveRequest
 			return e.Finalize(ctx)
 		}); err != nil {
 			return nil, err
+		}
+	}
+
+	if exporterResponse == nil {
+		exporterResponse = make(map[string]string)
+	}
+
+	for k, v := range res.Metadata {
+		if strings.HasPrefix(k, "frontend.") {
+			exporterResponse[k] = string(v)
 		}
 	}
 


### PR DESCRIPTION
Propagate anything in the `frontend.*` namespace from the `frontend.Result`
into the `client.SolveResponse`.

Signed-off-by: Ian Campbell <ijc@docker.com>

I'm a bit unsure about sticking this stuff in to `ExporterResponse`. Perhaps adding a `FrontendMetadata` field to `SolveResponse` might be a better plan? And in that case including everything instead of just `frontend.*` I guess.

WIP because I think it's only really testable once #533 lands.