### PR TITLE
exporters: allow frontend control of the exported image name

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -226,7 +226,9 @@ func testFrontendImageNaming(t *testing.T, sb integration.Sandbox) {
 					imageName := "image-" + exp + "-fe:latest"
 
 					switch exp {
-					case ExporterOCI, ExporterDocker:
+					case ExporterOCI:
+						t.Skip("oci exporter does not support named images")
+					case ExporterDocker:
 						outW, err := os.Create(out)
 						require.NoError(t, err)
 						so.ExporterOutput = outW
@@ -671,12 +673,13 @@ func testOCIExporter(t *testing.T, sb integration.Sandbox) {
 		outW, err := os.Create(out)
 		require.NoError(t, err)
 		target := "example.com/buildkit/testoci:latest"
-
+		attrs := map[string]string{}
+		if exp == ExporterDocker {
+			attrs["name"] = target
+		}
 		_, err = c.Solve(context.TODO(), def, SolveOpt{
-			Exporter: exp,
-			ExporterAttrs: map[string]string{
-				"name": target,
-			},
+			Exporter:       exp,
+			ExporterAttrs:  attrs,
 			ExporterOutput: outW,
 		}, nil)
 		require.NoError(t, err)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -46,7 +46,7 @@ func TestClientIntegration(t *testing.T) {
 		testUser,
 		testOCIExporter,
 		testWhiteoutParentDir,
-		testFrontendImageNameTemplating,
+		testFrontendImageNaming,
 		testDuplicateWhiteouts,
 		testSchema1Image,
 		testMountWithNoSource,
@@ -114,7 +114,7 @@ func testNetworkMode(t *testing.T, sb integration.Sandbox) {
 	require.Contains(t, err.Error(), "network.host is not allowed")
 }
 
-func testFrontendImageNameTemplating(t *testing.T, sb integration.Sandbox) {
+func testFrontendImageNaming(t *testing.T, sb integration.Sandbox) {
 	requiresLinux(t)
 	t.Parallel()
 	c, err := New(context.TODO(), sb.Address())
@@ -224,7 +224,10 @@ func testFrontendImageNameTemplating(t *testing.T, sb integration.Sandbox) {
 			if winner == "ctrl" {
 				feName = "loser:latest"
 				so.ExporterAttrs["name"] = imageName
+			} else {
+				so.ExporterAttrs["name"] = "%s"
 			}
+
 			frontend := func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
 				res := gateway.NewResult()
 				res.AddMeta("image.name", []byte(feName))

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -243,7 +243,7 @@ func testFrontendImageNaming(t *testing.T, sb integration.Sandbox) {
 						feName = "loser:latest"
 						so.ExporterAttrs["name"] = imageName
 					case "frontend":
-						so.ExporterAttrs["name"] = "%s"
+						so.ExporterAttrs["name"] = "*"
 					}
 
 					frontend := func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -194,8 +194,8 @@ func testFrontendImageNaming(t *testing.T, sb integration.Sandbox) {
 		},
 	}
 
-	// ctrl takes precedence over fe
-	for _, winner := range []string{"fe", "ctrl"} {
+	// A caller provided name takes precedence over one returned by the frontend. Iterate over both options.
+	for _, winner := range []string{"frontend", "caller"} {
 		for _, exp := range []string{ExporterOCI, ExporterDocker, ExporterImage} {
 			destDir, err := ioutil.TempDir("", "buildkit")
 			require.NoError(t, err)
@@ -221,10 +221,11 @@ func testFrontendImageNaming(t *testing.T, sb integration.Sandbox) {
 			}
 
 			feName := imageName
-			if winner == "ctrl" {
+			switch winner {
+			case "caller":
 				feName = "loser:latest"
 				so.ExporterAttrs["name"] = imageName
-			} else {
+			case "frontend":
 				so.ExporterAttrs["name"] = "%s"
 			}
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/continuity/fs/fstest"
 	"github.com/moby/buildkit/client/llb"
+	gateway "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/secrets/secretsprovider"
@@ -45,6 +46,7 @@ func TestClientIntegration(t *testing.T) {
 		testUser,
 		testOCIExporter,
 		testWhiteoutParentDir,
+		testFrontendImageNameTemplating,
 		testDuplicateWhiteouts,
 		testSchema1Image,
 		testMountWithNoSource,
@@ -110,6 +112,133 @@ func testNetworkMode(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "network.host is not allowed")
+}
+
+func testFrontendImageNameTemplating(t *testing.T, sb integration.Sandbox) {
+	requiresLinux(t)
+	t.Parallel()
+	c, err := New(context.TODO(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	registry, err := sb.NewRegistry()
+	if errors.Cause(err) == integration.ErrorRequirements {
+		t.Skip(err.Error())
+	}
+	require.NoError(t, err)
+
+	checkImageName := map[string]func(out, imageName string){
+		ExporterOCI: func(out, imageName string) {
+			// Nothing to check
+			return
+		},
+		ExporterDocker: func(out, imageName string) {
+			dt, err := ioutil.ReadFile(out)
+			require.NoError(t, err)
+
+			m, err := testutil.ReadTarToMap(dt, false)
+			require.NoError(t, err)
+
+			_, ok := m["oci-layout"]
+			require.True(t, ok)
+
+			var index ocispec.Index
+			err = json.Unmarshal(m["index.json"].Data, &index)
+			require.NoError(t, err)
+			require.Equal(t, 2, index.SchemaVersion)
+			require.Equal(t, 1, len(index.Manifests))
+
+			var dockerMfst []struct {
+				RepoTags []string
+			}
+			err = json.Unmarshal(m["manifest.json"].Data, &dockerMfst)
+			require.NoError(t, err)
+			require.Equal(t, 1, len(dockerMfst))
+			require.Equal(t, 1, len(dockerMfst[0].RepoTags))
+			require.Equal(t, "docker.io/library/"+imageName, dockerMfst[0].RepoTags[0])
+		},
+		ExporterImage: func(_, imageName string) {
+			// check if we can pull (requires containerd)
+			var cdAddress string
+			if cd, ok := sb.(interface {
+				ContainerdAddress() string
+			}); !ok {
+				return
+			} else {
+				cdAddress = cd.ContainerdAddress()
+			}
+
+			// TODO: make public pull helper function so this can be checked for standalone as well
+
+			client, err := containerd.New(cdAddress)
+			require.NoError(t, err)
+			defer client.Close()
+
+			ctx := namespaces.WithNamespace(context.Background(), "buildkit")
+
+			// check image in containerd
+			_, err = client.ImageService().Get(ctx, imageName)
+			require.NoError(t, err)
+
+			// deleting image should release all content
+			err = client.ImageService().Delete(ctx, imageName, images.SynchronousDelete())
+			require.NoError(t, err)
+
+			checkAllReleasable(t, c, sb, true)
+
+			_, err = client.Pull(ctx, imageName)
+			require.NoError(t, err)
+
+			err = client.ImageService().Delete(ctx, imageName, images.SynchronousDelete())
+			require.NoError(t, err)
+		},
+	}
+
+	// ctrl takes precedence over fe
+	for _, winner := range []string{"fe", "ctrl"} {
+		for _, exp := range []string{ExporterOCI, ExporterDocker, ExporterImage} {
+			destDir, err := ioutil.TempDir("", "buildkit")
+			require.NoError(t, err)
+			defer os.RemoveAll(destDir)
+
+			so := SolveOpt{
+				Exporter:      exp,
+				ExporterAttrs: map[string]string{},
+			}
+
+			out := filepath.Join(destDir, "out.tar")
+
+			imageName := "image-" + exp + "-fe:latest"
+
+			switch exp {
+			case ExporterOCI, ExporterDocker:
+				outW, err := os.Create(out)
+				require.NoError(t, err)
+				so.ExporterOutput = outW
+			case ExporterImage:
+				imageName = registry + "/" + imageName
+				so.ExporterAttrs["push"] = "true"
+			}
+
+			feName := imageName
+			if winner == "ctrl" {
+				feName = "loser:latest"
+				so.ExporterAttrs["name"] = imageName
+			}
+			frontend := func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
+				res := gateway.NewResult()
+				res.AddMeta("image.name", []byte(feName))
+				return res, nil
+			}
+
+			_, err = c.Build(context.TODO(), so, "", frontend, nil)
+			require.NoError(t, err)
+
+			checkImageName[exp](out, imageName)
+		}
+	}
+
+	checkAllReleasable(t, c, sb, true)
 }
 
 func testSecretMounts(t *testing.T, sb integration.Sandbox) {

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -115,6 +115,10 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source)
 		e.opt.ImageWriter.ContentStore().Delete(context.TODO(), desc.Digest)
 	}()
 
+	if n, ok := src.Metadata["image.name"]; e.targetName == "" && ok {
+		e.targetName = string(n)
+	}
+
 	if e.targetName != "" {
 		targetNames := strings.Split(e.targetName, ",")
 		for _, targetName := range targetNames {

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -117,7 +117,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source)
 
 	resp := make(map[string]string)
 
-	if n, ok := src.Metadata["image.name"]; e.targetName == "%s" && ok {
+	if n, ok := src.Metadata["image.name"]; e.targetName == "*" && ok {
 		e.targetName = string(n)
 	}
 

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -115,6 +115,8 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source)
 		e.opt.ImageWriter.ContentStore().Delete(context.TODO(), desc.Digest)
 	}()
 
+	resp := make(map[string]string)
+
 	if n, ok := src.Metadata["image.name"]; e.targetName == "%s" && ok {
 		e.targetName = string(n)
 	}
@@ -147,9 +149,9 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source)
 				}
 			}
 		}
+		resp["image.name"] = e.targetName
 	}
 
-	return map[string]string{
-		"containerimage.digest": desc.Digest.String(),
-	}, nil
+	resp["containerimage.digest"] = desc.Digest.String()
+	return resp, nil
 }

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -115,7 +115,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source)
 		e.opt.ImageWriter.ContentStore().Delete(context.TODO(), desc.Digest)
 	}()
 
-	if n, ok := src.Metadata["image.name"]; e.targetName == "" && ok {
+	if n, ok := src.Metadata["image.name"]; e.targetName == "%s" && ok {
 		e.targetName = string(n)
 	}
 

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -141,10 +141,16 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source)
 	}
 	desc.Annotations[ocispec.AnnotationCreated] = time.Now().UTC().Format(time.RFC3339)
 
+	resp := make(map[string]string)
+
 	if n, ok := src.Metadata["image.name"]; e.name == "%s" && ok {
 		if e.name, err = normalize(string(n)); err != nil {
 			return nil, err
 		}
+	}
+
+	if e.name != "" {
+		resp["image.name"] = e.name
 	}
 
 	exp, err := getExporter(e.opt.Variant, e.name)
@@ -161,7 +167,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source)
 		w.Close()
 		return nil, report(err)
 	}
-	return nil, report(w.Close())
+	return resp, report(w.Close())
 }
 
 func oneOffProgress(ctx context.Context, id string) func(err error) error {

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -72,9 +72,12 @@ func (e *imageExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 	for k, v := range opt {
 		switch k {
 		case keyImageName:
-			i.name, err = normalize(v)
-			if err != nil {
-				return nil, err
+			i.name = v
+			if i.name != "%s" {
+				i.name, err = normalize(i.name)
+				if err != nil {
+					return nil, err
+				}
 			}
 		case ociTypes:
 			ot = new(bool)
@@ -138,7 +141,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source)
 	}
 	desc.Annotations[ocispec.AnnotationCreated] = time.Now().UTC().Format(time.RFC3339)
 
-	if n, ok := src.Metadata["image.name"]; e.name == "" && ok {
+	if n, ok := src.Metadata["image.name"]; e.name == "%s" && ok {
 		if e.name, err = normalize(string(n)); err != nil {
 			return nil, err
 		}

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -73,7 +73,7 @@ func (e *imageExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 		switch k {
 		case keyImageName:
 			i.name = v
-			if i.name != "%s" {
+			if i.name != "*" {
 				i.name, err = normalize(i.name)
 				if err != nil {
 					return nil, err
@@ -143,7 +143,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source)
 
 	resp := make(map[string]string)
 
-	if n, ok := src.Metadata["image.name"]; e.name == "%s" && ok {
+	if n, ok := src.Metadata["image.name"]; e.name == "*" && ok {
 		if e.name, err = normalize(string(n)); err != nil {
 			return nil, err
 		}

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -190,6 +190,9 @@ func oneOffProgress(ctx context.Context, id string) func(err error) error {
 func getExporter(variant ExporterVariant, name string) (images.Exporter, error) {
 	switch variant {
 	case VariantOCI:
+		if name != "" {
+			return nil, errors.New("oci exporter cannot export named image")
+		}
 		return &oci.V1Exporter{}, nil
 	case VariantDocker:
 		return &dockerexporter.DockerExporter{Name: name}, nil


### PR DESCRIPTION
Returning a metadata item named "image.name" will set the name to use.

Signed-off-by: Ian Campbell <ijc@docker.com>

This is my less ambitious (not templated) replacement for #572, although since the client-gateway stuff has been merged it is now rebased on that and includes a test case so it is a fair bit more code.

This will (probably) conflict with #574 because it adds the same import of the gateway client package in the same place.