### PR TITLE
source: Have ResolveMode implement fmt.Stringer interface

### DIFF
--- a/source/identifier.go
+++ b/source/identifier.go
@@ -235,6 +235,19 @@ func (_ *HttpIdentifier) ID() string {
 	return HttpsScheme
 }
 
+func (r ResolveMode) String() string {
+	switch r {
+	case ResolveModeDefault:
+		return pb.AttrImageResolveModeDefault
+	case ResolveModeForcePull:
+		return pb.AttrImageResolveModeForcePull
+	case ResolveModePreferLocal:
+		return pb.AttrImageResolveModePreferLocal
+	default:
+		return ""
+	}
+}
+
 func ParseImageResolveMode(v string) (ResolveMode, error) {
 	switch v {
 	case pb.AttrImageResolveModeDefault, "":


### PR DESCRIPTION
Out of the two ResolveMode types in buildkit, only the lower-level one in client/llb
had a String() method. This patch makes the ResolveMode type from the source package
also have a String() method.

Signed-off-by: Tibor Vass <tibor@docker.com>