### PR TITLE
runcexecutor: allow disabling subreaper

### DIFF
--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -404,6 +404,12 @@ func (s *forwardIO) writeCloserToFile(wc io.WriteCloser) (*os.File, error) {
 var subReaperOnce sync.Once
 var subReaperError error
 
+// DisableSubReaper prevents setting subreaper on the current process.
+// Do not rely on this function it may change or be removed.
+func DisableSubReaper() {
+	subReaperOnce.Do(func() {})
+}
+
 func setSubReaper() error {
 	subReaperOnce.Do(func() {
 		subReaperError = runcsystem.SetSubreaper(1)


### PR DESCRIPTION
When other daemons such as dockerd set subreaper, there can be issues.
This allows those daemons to disable subreaping if they need to.

Hopefully this commit either gets reverted soon or will have a valid
concrete usecase, as the investigation continues on
https://github.com/moby/moby/issues/37676

Signed-off-by: Tibor Vass <tibor@docker.com>

cc @AkihiroSuda @ijc 