### PR TITLE
Refactor networking with ns paths

### DIFF
--- a/executor/containerdexecutor/executor.go
+++ b/executor/containerdexecutor/executor.go
@@ -79,10 +79,6 @@ func (w containerdExecutor) Exec(ctx context.Context, meta executor.Meta, root c
 		lm.Unmount()
 	}
 
-	// FIXME: still uses host if no provider configured
-	if meta.NetMode == pb.NetMode_UNSET {
-		meta.NetMode = pb.NetMode_HOST
-	}
 	provider, ok := w.networkProviders[meta.NetMode]
 	if !ok {
 		return errors.Errorf("unknown network mode %s", meta.NetMode)

--- a/executor/containerdexecutor/executor.go
+++ b/executor/containerdexecutor/executor.go
@@ -23,16 +23,16 @@ import (
 )
 
 type containerdExecutor struct {
-	client          *containerd.Client
-	root            string
-	networkProvider network.Provider
+	client           *containerd.Client
+	root             string
+	networkProviders map[pb.NetMode]network.Provider
 }
 
-func New(client *containerd.Client, root string, networkProvider network.Provider) executor.Executor {
+func New(client *containerd.Client, root string, networkProviders map[pb.NetMode]network.Provider) executor.Executor {
 	return containerdExecutor{
-		client:          client,
-		root:            root,
-		networkProvider: networkProvider,
+		client:           client,
+		root:             root,
+		networkProviders: networkProviders,
 	}
 }
 
@@ -79,27 +79,23 @@ func (w containerdExecutor) Exec(ctx context.Context, meta executor.Meta, root c
 		lm.Unmount()
 	}
 
-	var iface network.Interface
 	// FIXME: still uses host if no provider configured
 	if meta.NetMode == pb.NetMode_UNSET {
-		if w.networkProvider != nil {
-			var err error
-			iface, err = w.networkProvider.NewInterface()
-			if err != nil || iface == nil {
-				meta.NetMode = pb.NetMode_HOST
-			}
-		} else {
-			meta.NetMode = pb.NetMode_HOST
-		}
+		meta.NetMode = pb.NetMode_HOST
 	}
+	provider, ok := w.networkProviders[meta.NetMode]
+	if !ok {
+		return errors.Errorf("unknown network mode %s", meta.NetMode)
+	}
+	namespace, err := provider.New()
+	if err != nil {
+		return err
+	}
+	defer namespace.Close()
+
 	if meta.NetMode == pb.NetMode_HOST {
 		logrus.Info("enabling HostNetworking")
 	}
-	defer func() {
-		if iface != nil {
-			w.networkProvider.Release(iface)
-		}
-	}()
 
 	opts := []containerdoci.SpecOpts{oci.WithUIDGID(uid, gid, sgids)}
 	if meta.ReadonlyRootFS {
@@ -108,7 +104,7 @@ func (w containerdExecutor) Exec(ctx context.Context, meta executor.Meta, root c
 	if system.SeccompSupported() {
 		opts = append(opts, seccomp.WithDefaultProfile())
 	}
-	spec, cleanup, err := oci.GenerateSpec(ctx, meta, mounts, id, resolvConf, hostsFile, meta.NetMode == pb.NetMode_HOST, opts...)
+	spec, cleanup, err := oci.GenerateSpec(ctx, meta, mounts, id, resolvConf, hostsFile, namespace, opts...)
 	if err != nil {
 		return err
 	}
@@ -135,18 +131,7 @@ func (w containerdExecutor) Exec(ctx context.Context, meta executor.Meta, root c
 	if err != nil {
 		return err
 	}
-
-	if iface != nil {
-		if err := iface.Set(int(task.Pid())); err != nil {
-			return errors.Wrap(err, "could not set the network")
-		}
-	}
-
 	defer func() {
-		if iface != nil {
-			iface.Remove(int(task.Pid()))
-		}
-
 		if _, err1 := task.Delete(context.TODO()); err == nil && err1 != nil {
 			err = errors.Wrapf(err1, "failed to delete task %s", id)
 		}

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -101,10 +101,6 @@ func New(opt Opt, networkProviders map[pb.NetMode]network.Provider) (executor.Ex
 }
 
 func (w *runcExecutor) Exec(ctx context.Context, meta executor.Meta, root cache.Mountable, mounts []executor.Mount, stdin io.ReadCloser, stdout, stderr io.WriteCloser) error {
-	// FIXME: still uses host if no provider configured
-	if meta.NetMode == pb.NetMode_UNSET {
-		meta.NetMode = pb.NetMode_HOST
-	}
 	provider, ok := w.networkProviders[meta.NetMode]
 	if !ok {
 		return errors.Errorf("unknown network mode %s", meta.NetMode)

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
 	"syscall"
 
 	"github.com/containerd/containerd/contrib/seccomp"
@@ -26,7 +25,6 @@ import (
 	"github.com/moby/buildkit/util/network"
 	rootlessspecconv "github.com/moby/buildkit/util/rootless/specconv"
 	"github.com/moby/buildkit/util/system"
-	runcsystem "github.com/opencontainers/runc/libcontainer/system"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -43,14 +41,14 @@ type Opt struct {
 var defaultCommandCandidates = []string{"buildkit-runc", "runc"}
 
 type runcExecutor struct {
-	runc            *runc.Runc
-	root            string
-	cmd             string
-	rootless        bool
-	networkProvider network.Provider
+	runc             *runc.Runc
+	root             string
+	cmd              string
+	rootless         bool
+	networkProviders map[pb.NetMode]network.Provider
 }
 
-func New(opt Opt, networkProvider network.Provider) (executor.Executor, error) {
+func New(opt Opt, networkProviders map[pb.NetMode]network.Provider) (executor.Executor, error) {
 	cmds := opt.CommandCandidates
 	if cmds == nil {
 		cmds = defaultCommandCandidates
@@ -69,10 +67,6 @@ func New(opt Opt, networkProvider network.Provider) (executor.Executor, error) {
 	}
 
 	root := opt.Root
-
-	if err := setSubReaper(); err != nil {
-		return nil, err
-	}
 
 	if err := os.MkdirAll(root, 0700); err != nil {
 		return nil, errors.Wrapf(err, "failed to create %s", root)
@@ -98,36 +92,32 @@ func New(opt Opt, networkProvider network.Provider) (executor.Executor, error) {
 	}
 
 	w := &runcExecutor{
-		runc:            runtime,
-		root:            root,
-		rootless:        opt.Rootless,
-		networkProvider: networkProvider,
+		runc:             runtime,
+		root:             root,
+		rootless:         opt.Rootless,
+		networkProviders: networkProviders,
 	}
 	return w, nil
 }
 
 func (w *runcExecutor) Exec(ctx context.Context, meta executor.Meta, root cache.Mountable, mounts []executor.Mount, stdin io.ReadCloser, stdout, stderr io.WriteCloser) error {
-	var iface network.Interface
 	// FIXME: still uses host if no provider configured
 	if meta.NetMode == pb.NetMode_UNSET {
-		if w.networkProvider != nil {
-			var err error
-			iface, err = w.networkProvider.NewInterface()
-			if err != nil || iface == nil {
-				meta.NetMode = pb.NetMode_HOST
-			}
-		} else {
-			meta.NetMode = pb.NetMode_HOST
-		}
+		meta.NetMode = pb.NetMode_HOST
 	}
+	provider, ok := w.networkProviders[meta.NetMode]
+	if !ok {
+		return errors.Errorf("unknown network mode %s", meta.NetMode)
+	}
+	namespace, err := provider.New()
+	if err != nil {
+		return err
+	}
+	defer namespace.Close()
+
 	if meta.NetMode == pb.NetMode_HOST {
 		logrus.Info("enabling HostNetworking")
 	}
-	defer func() {
-		if iface != nil {
-			w.networkProvider.Release(iface)
-		}
-	}()
 
 	resolvConf, err := oci.GetResolvConf(ctx, w.root)
 	if err != nil {
@@ -187,7 +177,7 @@ func (w *runcExecutor) Exec(ctx context.Context, meta executor.Meta, root cache.
 	if meta.ReadonlyRootFS {
 		opts = append(opts, containerdoci.WithRootFSReadonly())
 	}
-	spec, cleanup, err := oci.GenerateSpec(ctx, meta, mounts, id, resolvConf, hostsFile, meta.NetMode == pb.NetMode_HOST, opts...)
+	spec, cleanup, err := oci.GenerateSpec(ctx, meta, mounts, id, resolvConf, hostsFile, namespace, opts...)
 	if err != nil {
 		return err
 	}
@@ -225,75 +215,14 @@ func (w *runcExecutor) Exec(ctx context.Context, meta executor.Meta, root cache.
 	}
 	defer forwardIO.Close()
 
-	pidFilePath := filepath.Join(w.root, "runc_pid_"+identity.NewID())
-	defer os.RemoveAll(pidFilePath)
-
 	logrus.Debugf("> creating %s %v", id, meta.Args)
-	err = w.runc.Create(ctx, id, bundle, &runc.CreateOpts{
-		PidFile: pidFilePath,
-		IO:      forwardIO,
+	status, err := w.runc.Run(ctx, id, bundle, &runc.CreateOpts{
+		IO: forwardIO,
 	})
 	if err != nil {
 		return err
 	}
-	forwardIO.release()
 
-	defer func() {
-		go func() {
-			if err := w.runc.Delete(context.TODO(), id, &runc.DeleteOpts{}); err != nil {
-				logrus.Errorf("failed to delete %s: %+v", id, err)
-			}
-		}()
-	}()
-
-	dt, err := ioutil.ReadFile(pidFilePath)
-	if err != nil {
-		return err
-	}
-	pid, err := strconv.Atoi(string(dt))
-	if err != nil {
-		return err
-	}
-
-	done := make(chan struct{})
-	defer close(done)
-
-	go func() {
-		select {
-		case <-done:
-		case <-ctx.Done():
-			syscall.Kill(-pid, syscall.SIGKILL)
-		}
-	}()
-
-	if iface != nil {
-		if err := iface.Set(pid); err != nil {
-			return errors.Wrap(err, "could not set the network")
-		}
-		defer func() {
-			iface.Remove(pid)
-		}()
-	}
-
-	err = w.runc.Start(ctx, id)
-	if err != nil {
-		return err
-	}
-
-	p, err := os.FindProcess(pid)
-	if err != nil {
-		return err
-	}
-
-	status := 0
-	ps, err := p.Wait()
-	if err != nil {
-		status = 255
-	}
-
-	if ws, ok := ps.Sys().(syscall.WaitStatus); ok {
-		status = ws.ExitStatus()
-	}
 	if status != 0 {
 		return errors.Errorf("exit code: %d", status)
 	}
@@ -336,7 +265,7 @@ func newForwardIO(stdin io.ReadCloser, stdout, stderr io.WriteCloser) (f *forwar
 }
 
 func (s *forwardIO) Close() error {
-	s.release()
+	s.CloseAfterStart()
 	var err error
 	for _, cl := range s.toClose {
 		if err1 := cl.Close(); err == nil {
@@ -348,11 +277,12 @@ func (s *forwardIO) Close() error {
 }
 
 // release releases active FDs if the process doesn't need them any more
-func (s *forwardIO) release() {
+func (s *forwardIO) CloseAfterStart() error {
 	for _, cl := range s.toRelease {
 		cl.Close()
 	}
 	s.toRelease = nil
+	return nil
 }
 
 func (s *forwardIO) Set(cmd *exec.Cmd) {
@@ -399,16 +329,6 @@ func (s *forwardIO) writeCloserToFile(wc io.WriteCloser) (*os.File, error) {
 		_ = err
 	}()
 	return pw, nil
-}
-
-var subReaperOnce sync.Once
-var subReaperError error
-
-func setSubReaper() error {
-	subReaperOnce.Do(func() {
-		subReaperError = runcsystem.SetSubreaper(1)
-	})
-	return subReaperError
 }
 
 func (s *forwardIO) Stdin() io.WriteCloser {

--- a/util/network/host.go
+++ b/util/network/host.go
@@ -1,0 +1,28 @@
+package network
+
+import (
+	"github.com/containerd/containerd/oci"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func NewHostProvider() Provider {
+	return &host{}
+}
+
+type host struct {
+}
+
+func (h *host) New() (Namespace, error) {
+	return &hostNS{}, nil
+}
+
+type hostNS struct {
+}
+
+func (h *hostNS) Set(s *specs.Spec) {
+	oci.WithHostNamespace(specs.NetworkNamespace)(nil, nil, nil, s)
+}
+
+func (h *hostNS) Close() error {
+	return nil
+}

--- a/util/network/network.go
+++ b/util/network/network.go
@@ -1,17 +1,30 @@
 package network
 
-// Provider interface for Network
-type Provider interface {
-	NewInterface() (Interface, error)
-	Release(Interface) error
+import (
+	"io"
+
+	"github.com/moby/buildkit/solver/pb"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// Default returns the default network provider set
+func Default() map[pb.NetMode]Provider {
+	return map[pb.NetMode]Provider{
+		pb.NetMode_HOST: NewHostProvider(),
+		pb.NetMode_NONE: NewNoneProvider(),
+	}
 }
 
-// Interface of network for workers
-type Interface interface {
-	// Set the pid with network interace namespace
-	Set(int) error
-	// Removes the network interface
-	Remove(int) error
+// Provider interface for Network
+type Provider interface {
+	New() (Namespace, error)
+}
+
+// Namespace of network for workers
+type Namespace interface {
+	io.Closer
+	// Set the namespace on the spec
+	Set(*specs.Spec)
 }
 
 // NetworkOpts hold network options

--- a/util/network/network.go
+++ b/util/network/network.go
@@ -10,8 +10,10 @@ import (
 // Default returns the default network provider set
 func Default() map[pb.NetMode]Provider {
 	return map[pb.NetMode]Provider{
-		pb.NetMode_HOST: NewHostProvider(),
-		pb.NetMode_NONE: NewNoneProvider(),
+		// FIXME: still uses host if no provider configured
+		pb.NetMode_UNSET: NewHostProvider(),
+		pb.NetMode_HOST:  NewHostProvider(),
+		pb.NetMode_NONE:  NewNoneProvider(),
 	}
 }
 

--- a/util/network/none.go
+++ b/util/network/none.go
@@ -1,0 +1,26 @@
+package network
+
+import (
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func NewNoneProvider() Provider {
+	return &none{}
+}
+
+type none struct {
+}
+
+func (h *none) New() (Namespace, error) {
+	return &noneNS{}, nil
+}
+
+type noneNS struct {
+}
+
+func (h *noneNS) Set(s *specs.Spec) {
+}
+
+func (h *noneNS) Close() error {
+	return nil
+}

--- a/worker/containerd/containerd.go
+++ b/worker/containerd/containerd.go
@@ -15,6 +15,7 @@ import (
 	"github.com/moby/buildkit/executor/containerdexecutor"
 	"github.com/moby/buildkit/identity"
 	containerdsnapshot "github.com/moby/buildkit/snapshot/containerd"
+	"github.com/moby/buildkit/util/network"
 	"github.com/moby/buildkit/util/throttle"
 	"github.com/moby/buildkit/util/winlayers"
 	"github.com/moby/buildkit/worker/base"
@@ -107,7 +108,7 @@ func newContainerd(root string, client *containerd.Client, snapshotterName strin
 		ID:            id,
 		Labels:        xlabels,
 		MetadataStore: md,
-		Executor:      containerdexecutor.New(client, root, nil),
+		Executor:      containerdexecutor.New(client, root, network.Default()),
 		Snapshotter:   containerdsnapshot.NewSnapshotter(client.SnapshotService(snapshotterName), cs, md, "buildkit", gc),
 		ContentStore:  cs,
 		Applier:       winlayers.NewFileSystemApplierWithWindows(cs, df),

--- a/worker/runc/runc.go
+++ b/worker/runc/runc.go
@@ -16,6 +16,7 @@ import (
 	"github.com/moby/buildkit/cache/metadata"
 	"github.com/moby/buildkit/executor/runcexecutor"
 	containerdsnapshot "github.com/moby/buildkit/snapshot/containerd"
+	"github.com/moby/buildkit/util/network"
 	"github.com/moby/buildkit/util/throttle"
 	"github.com/moby/buildkit/util/winlayers"
 	"github.com/moby/buildkit/worker/base"
@@ -48,7 +49,7 @@ func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, labe
 		Root: filepath.Join(root, "executor"),
 		// without root privileges
 		Rootless: rootless,
-	}, nil)
+	}, network.Default())
 	if err != nil {
 		return opt, err
 	}


### PR DESCRIPTION
This fixes the issues where buildkit and callers do not have to be a
subpreaper in order to use networking.  I can add CNI provider later,
with a hidden sub command to create a new network namespace and bind
mount it to buildkit's state dir.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>