### PR TITLE
solver: fix panic on creating input requests

### DIFF
--- a/solver/scheduler.go
+++ b/solver/scheduler.go
@@ -2,6 +2,7 @@ package solver
 
 import (
 	"context"
+	"os"
 	"sync"
 
 	"github.com/moby/buildkit/solver/internal/pipe"
@@ -10,7 +11,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const debugScheduler = false // TODO: replace with logs in build trace
+var debugScheduler = false // TODO: replace with logs in build trace
+
+func init() {
+	if os.Getenv("BUILDKIT_SCHEDULER_DEBUG") == "1" {
+		debugScheduler = true
+	}
+}
 
 func newScheduler(ef edgeFactory) *scheduler {
 	s := &scheduler{


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/37603

The issue is from the mixed handling of `dep.keys` and `dep.keyMap` while they have a different meaning(with `keyMap` only containing the keys that have also passed the query against current node).

I'll follow up with another change that adds a non-intrusive handling for these kinds of errors instead of a panic.


@AkihiroSuda @tiborvass 