### PR TITLE
solver: gracefully handle scheduler bugs

### DIFF
--- a/solver/edge.go
+++ b/solver/edge.go
@@ -340,7 +340,7 @@ func (e *edge) unpark(incoming []pipe.Sender, updates, allPipes []pipe.Receiver,
 
 	if e.execReq == nil {
 		if added := e.createInputRequests(desiredState, f, false); !added && !e.hasActiveOutgoing && !cacheMapReq {
-			logrus.Errorf("buildkit scheluding error: leaving incoming open. forcing solve. please report this with BUILDKIT_SCHEDULER_DEBUG=1")
+			logrus.Errorf("buildkit scheluding error: leaving incoming open. forcing solve. Please report this with BUILDKIT_SCHEDULER_DEBUG=1")
 			e.createInputRequests(desiredState, f, true)
 		}
 	}
@@ -352,6 +352,11 @@ func (e *edge) makeExportable(k *CacheKey, records []*CacheRecord) ExportableCac
 		CacheKey: k,
 		Exporter: &exporter{k: k, records: records, override: e.edge.Vertex.Options().ExportCache},
 	}
+}
+
+func (e *edge) markFailed(f *pipeFactory, err error) {
+	e.err = err
+	e.postpone(f)
 }
 
 // processUpdate is called by unpark for every updated pipe request

--- a/solver/scheduler.go
+++ b/solver/scheduler.go
@@ -120,11 +120,14 @@ func (s *scheduler) dispatch(e *edge) {
 		}
 	}
 
+	pf := &pipeFactory{s: s, e: e}
+
 	// unpark the edge
 	debugSchedulerPreUnpark(e, inc, updates, out)
-	e.unpark(inc, updates, out, &pipeFactory{s: s, e: e})
+	e.unpark(inc, updates, out, pf)
 	debugSchedulerPostUnpark(e, inc)
 
+postUnpark:
 	// set up new requests that didn't complete/were added by this run
 	openIncoming := make([]*edgePipe, 0, len(inc))
 	for _, r := range s.incoming[e] {
@@ -170,10 +173,12 @@ func (s *scheduler) dispatch(e *edge) {
 	// to error the edge instead. They can only appear from algorithm bugs in
 	// unpark(), not for any external input.
 	if len(openIncoming) > 0 && len(openOutgoing) == 0 {
-		panic("invalid dispatch: return leaving incoming open")
+		e.markFailed(pf, errors.New("buildkit scheduler error: return leaving incoming open. Please report this with BUILDKIT_SCHEDULER_DEBUG=1"))
+		goto postUnpark
 	}
 	if len(openIncoming) == 0 && len(openOutgoing) > 0 {
-		panic("invalid dispatch: return leaving outgoing open")
+		e.markFailed(pf, errors.New("buildkit scheduler error: return leaving outgoing open. Please report this with BUILDKIT_SCHEDULER_DEBUG=1"))
+		goto postUnpark
 	}
 }
 


### PR DESCRIPTION
Instead of panicking on scheduler bugs, try to fix the error case and if that doesn't work clean up and fail the build leaving daemon usable for next requests.

related to #590

@AkihiroSuda @tiborvass 