### PR TITLE
Initialise workers' label maps before assigning.

### DIFF
--- a/cmd/buildkitd/main_containerd_worker.go
+++ b/cmd/buildkitd/main_containerd_worker.go
@@ -91,6 +91,9 @@ func applyContainerdFlags(c *cli.Context, cfg *config.Config) error {
 	if err != nil {
 		return err
 	}
+	if cfg.Workers.Containerd.Labels == nil {
+		cfg.Workers.Containerd.Labels = make(map[string]string)
+	}
 	for k, v := range labels {
 		cfg.Workers.Containerd.Labels[k] = v
 	}

--- a/cmd/buildkitd/main_oci_worker.go
+++ b/cmd/buildkitd/main_oci_worker.go
@@ -93,6 +93,9 @@ func applyOCIFlags(c *cli.Context, cfg *config.Config) error {
 	if err != nil {
 		return err
 	}
+	if cfg.Workers.OCI.Labels == nil {
+		cfg.Workers.OCI.Labels = make(map[string]string)
+	}
 	for k, v := range labels {
 		cfg.Workers.OCI.Labels[k] = v
 	}

--- a/util/testutil/integration/containerd.go
+++ b/util/testutil/integration/containerd.go
@@ -118,7 +118,9 @@ disabled_plugins = ["cri"]
 	buildkitdSock, stop, err := runBuildkitd([]string{"buildkitd",
 		"--oci-worker=false",
 		"--containerd-worker=true",
-		"--containerd-worker-addr", address}, logs, 0, 0)
+		"--containerd-worker-addr", address,
+		"--containerd-worker-labels=org.mobyproject.buildkit.worker.sandbox=true", // Include use of --containerd-worker-labels to trigger https://github.com/moby/buildkit/pull/603
+	}, logs, 0, 0)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/util/testutil/integration/oci.go
+++ b/util/testutil/integration/oci.go
@@ -52,7 +52,8 @@ func (s *oci) New() (Sandbox, func() error, error) {
 		return nil, nil, err
 	}
 	logs := map[string]*bytes.Buffer{}
-	buildkitdArgs := []string{"buildkitd", "--oci-worker=true", "--containerd-worker=false"}
+	// Include use of --oci-worker-labels to trigger https://github.com/moby/buildkit/pull/603
+	buildkitdArgs := []string{"buildkitd", "--oci-worker=true", "--containerd-worker=false", "--oci-worker-labels=org.mobyproject.buildkit.worker.sandbox=true"}
 	if s.uid != 0 {
 		if s.gid == 0 {
 			return nil, nil, errors.Errorf("unsupported id pair: uid=%d, gid=%d", s.uid, s.gid)


### PR DESCRIPTION
Otherwise:

    panic: assignment to entry in nil map

    goroutine 1 [running]:
    main.applyOCIFlags(0xc4200e71e0, 0xc420400000, 0x0, 0x0)
    	/go/src/github.com/moby/buildkit/cmd/buildkitd/main_oci_worker.go:97 +0x1ac
    main.ociWorkerInitializer(0xc4200e71e0, 0xc4204104e0, 0xc420400000, 0x43409b, 0x12, 0xc42026b0f8, 0x4337fc, 0xc420000180)
    	/go/src/github.com/moby/buildkit/cmd/buildkitd/main_oci_worker.go:118 +0x50
    main.newWorkerController(0xc4200e71e0, 0xc4204104e0, 0xc420400000, 0xc420422000, 0xe5dc54, 0x11)
    	/go/src/github.com/moby/buildkit/cmd/buildkitd/main.go:520 +0x324
    main.newController(0xc4200e71e0, 0xc420400000, 0x1c0, 0x0, 0x0)
    	/go/src/github.com/moby/buildkit/cmd/buildkitd/main.go:489 +0xdc
    main.main.func3(0xc4200e71e0, 0x0, 0x0)
    	/go/src/github.com/moby/buildkit/cmd/buildkitd/main.go:203 +0x3dd
    github.com/moby/buildkit/vendor/github.com/urfave/cli.HandleAction(0xcdd420, 0xe93e98, 0xc4200e71e0, 0xc4200e71e0, 0xc42026b888)
    	/go/src/github.com/moby/buildkit/vendor/github.com/urfave/cli/app.go:502 +0xc8
    github.com/moby/buildkit/vendor/github.com/urfave/cli.(*App).Run(0xc4201b6540, 0xc4200300a0, 0xa, 0xa, 0x0, 0x0)
    	/go/src/github.com/moby/buildkit/vendor/github.com/urfave/cli/app.go:268 +0x60c
    main.main()
    	/go/src/github.com/moby/buildkit/cmd/buildkitd/main.go:238 +0xc64

Also add some random labels to the integration sandbox (which I have confirmed
is enough to trigger this issue before the fix).

Signed-off-by: Ian Campbell <ijc@docker.com>