### PR TITLE
cmd,worker: support customize namespace for containerd worker

### DIFF
--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -56,6 +56,7 @@ type ContainerdConfig struct {
 	Labels    map[string]string `toml:"labels"`
 	Platforms []string          `toml:"platforms"`
 	GCPolicy  []GCPolicy        `toml:"gcpolicy"`
+	Namespace string            `toml:"namespace"`
 }
 
 type GCPolicy struct {

--- a/cmd/buildkitd/config/config_test.go
+++ b/cmd/buildkitd/config/config_test.go
@@ -29,6 +29,7 @@ foo="bar"
 "aa.bb.cc"="baz"
 
 [worker.containerd]
+namespace="non-default"
 platforms=["linux/amd64"]
 address="containerd.sock"
 [[worker.containerd.gcpolicy]]
@@ -68,6 +69,7 @@ keepDuration=7200
 	require.Equal(t, "containerd.sock", cfg.Workers.Containerd.Address)
 
 	require.Equal(t, 0, len(cfg.Workers.OCI.GCPolicy))
+	require.Equal(t, "non-default", cfg.Workers.Containerd.Namespace)
 	require.Equal(t, 2, len(cfg.Workers.Containerd.GCPolicy))
 
 	require.Equal(t, true, cfg.Workers.Containerd.GCPolicy[0].All)


### PR DESCRIPTION
allow user to customize containerd namespace, not just `buildkit`. it
can help user to integration with existing data easily.

Signed-off-by: Wei Fu <fuweid89@gmail.com>