### PR TITLE
resolver: add config support for mirrors/plainhttp

### DIFF
--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -22,6 +22,8 @@ type Config struct {
 		OCI        OCIConfig        `toml:"oci"`
 		Containerd ContainerdConfig `toml:"containerd"`
 	} `toml:"worker"`
+
+	Registries map[string]RegistryConfig `toml:"registry"`
 }
 
 type GRPCConfig struct {
@@ -33,6 +35,11 @@ type GRPCConfig struct {
 	TLS TLSConfig `toml:"tls"`
 	// MaxRecvMsgSize int    `toml:"max_recv_message_size"`
 	// MaxSendMsgSize int    `toml:"max_send_message_size"`
+}
+
+type RegistryConfig struct {
+	Mirrors   []string `toml:"mirrors"`
+	PlainHTTP bool     `toml:"http"`
 }
 
 type TLSConfig struct {

--- a/cmd/buildkitd/config/config_test.go
+++ b/cmd/buildkitd/config/config_test.go
@@ -39,6 +39,10 @@ keepDuration=3600
 [[worker.containerd.gcpolicy]]
 keepBytes=40
 keepDuration=7200
+
+[registry."docker.io"]
+mirrors=["hub.docker.io"]
+http=true
 `
 
 	cfg, md, err := Load(bytes.NewBuffer([]byte(testConfig)))
@@ -78,4 +82,7 @@ keepDuration=7200
 	require.Equal(t, int64(7200), cfg.Workers.Containerd.GCPolicy[1].KeepDuration)
 	require.Equal(t, 1, len(cfg.Workers.Containerd.GCPolicy[0].Filters))
 	require.Equal(t, 0, len(cfg.Workers.Containerd.GCPolicy[1].Filters))
+
+	require.Equal(t, cfg.Registries["docker.io"].PlainHTTP, true)
+	require.Equal(t, cfg.Registries["docker.io"].Mirrors[0], "hub.docker.io")
 }

--- a/cmd/buildkitd/main_containerd_worker.go
+++ b/cmd/buildkitd/main_containerd_worker.go
@@ -125,6 +125,7 @@ func containerdWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([
 	}
 	opt.SessionManager = common.sessionManager
 	opt.GCPolicy = getGCPolicy(cfg.GCPolicy, common.config.Root)
+	opt.ResolveOptionsFunc = resolverFunc(common.config)
 
 	if platformsStr := cfg.Platforms; len(platformsStr) != 0 {
 		platforms, err := parsePlatforms(platformsStr)

--- a/cmd/buildkitd/main_oci_worker.go
+++ b/cmd/buildkitd/main_oci_worker.go
@@ -142,6 +142,7 @@ func ociWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([]worker
 	}
 	opt.SessionManager = common.sessionManager
 	opt.GCPolicy = getGCPolicy(cfg.GCPolicy, common.config.Root)
+	opt.ResolveOptionsFunc = resolverFunc(common.config)
 
 	if platformsStr := cfg.Platforms; len(platformsStr) != 0 {
 		platforms, err := parsePlatforms(platformsStr)

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -11,6 +11,7 @@ import (
 	"github.com/moby/buildkit/exporter"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/util/push"
+	"github.com/moby/buildkit/util/resolver"
 	"github.com/pkg/errors"
 )
 
@@ -25,6 +26,7 @@ type Opt struct {
 	SessionManager *session.Manager
 	ImageWriter    *ImageWriter
 	Images         images.Store
+	ResolverOpt    resolver.ResolveOptionsFunc
 }
 
 type imageExporter struct {
@@ -144,7 +146,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source)
 				tagDone(nil)
 			}
 			if e.push {
-				if err := push.Push(ctx, e.opt.SessionManager, e.opt.ImageWriter.ContentStore(), desc.Digest, targetName, e.insecure); err != nil {
+				if err := push.Push(ctx, e.opt.SessionManager, e.opt.ImageWriter.ContentStore(), desc.Digest, targetName, e.insecure, e.opt.ResolverOpt); err != nil {
 					return nil, err
 				}
 			}

--- a/util/resolver/resolver.go
+++ b/util/resolver/resolver.go
@@ -1,0 +1,45 @@
+package resolver
+
+import (
+	"math/rand"
+
+	"github.com/containerd/containerd/remotes/docker"
+	"github.com/docker/distribution/reference"
+	"github.com/moby/buildkit/util/tracing"
+)
+
+type RegistryConf struct {
+	Mirrors   []string
+	PlainHTTP bool
+}
+
+type ResolveOptionsFunc func(string) docker.ResolverOptions
+
+func NewResolveOptionsFunc(m map[string]RegistryConf) ResolveOptionsFunc {
+	return func(ref string) docker.ResolverOptions {
+		def := docker.ResolverOptions{
+			Client: tracing.DefaultClient,
+		}
+
+		parsed, err := reference.ParseNormalizedNamed(ref)
+		if err != nil {
+			return def
+		}
+		host := reference.Domain(parsed)
+
+		c, ok := m[host]
+		if !ok {
+			return def
+		}
+
+		if len(c.Mirrors) > 0 {
+			def.Host = func(string) (string, error) {
+				return c.Mirrors[rand.Intn(len(c.Mirrors))], nil
+			}
+		}
+
+		def.PlainHTTP = c.PlainHTTP
+
+		return def
+	}
+}

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -39,6 +39,7 @@ import (
 	"github.com/moby/buildkit/source/local"
 	"github.com/moby/buildkit/util/contentutil"
 	"github.com/moby/buildkit/util/progress"
+	"github.com/moby/buildkit/util/resolver"
 	"github.com/moby/buildkit/worker"
 	digest "github.com/opencontainers/go-digest"
 	ociidentity "github.com/opencontainers/image-spec/identity"
@@ -55,18 +56,19 @@ const labelCreatedAt = "buildkit/createdat"
 // WorkerOpt is specific to a worker.
 // See also CommonOpt.
 type WorkerOpt struct {
-	ID             string
-	Labels         map[string]string
-	Platforms      []specs.Platform
-	GCPolicy       []client.PruneInfo
-	SessionManager *session.Manager
-	MetadataStore  *metadata.Store
-	Executor       executor.Executor
-	Snapshotter    snapshot.Snapshotter
-	ContentStore   content.Store
-	Applier        diff.Applier
-	Differ         diff.Comparer
-	ImageStore     images.Store // optional
+	ID                 string
+	Labels             map[string]string
+	Platforms          []specs.Platform
+	GCPolicy           []client.PruneInfo
+	SessionManager     *session.Manager
+	MetadataStore      *metadata.Store
+	Executor           executor.Executor
+	Snapshotter        snapshot.Snapshotter
+	ContentStore       content.Store
+	Applier            diff.Applier
+	Differ             diff.Comparer
+	ImageStore         images.Store // optional
+	ResolveOptionsFunc resolver.ResolveOptionsFunc
 }
 
 // Worker is a local worker instance with dedicated snapshotter, cache, and so on.
@@ -108,6 +110,7 @@ func NewWorker(opt WorkerOpt) (*Worker, error) {
 		Applier:        opt.Applier,
 		ImageStore:     opt.ImageStore,
 		CacheAccessor:  cm,
+		ResolverOpt:    opt.ResolveOptionsFunc,
 	})
 	if err != nil {
 		return nil, err
@@ -160,6 +163,7 @@ func NewWorker(opt WorkerOpt) (*Worker, error) {
 		Images:         opt.ImageStore,
 		SessionManager: opt.SessionManager,
 		ImageWriter:    iw,
+		ResolverOpt:    opt.ResolveOptionsFunc,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
#606

Config allows:
```
[registry."docker.io"]
mirrors=["localhost:5000"]
http=true
```

I'll follow up with a change that makes integration tests use a local mirror so we have test coverage.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>