### PR TITLE
integration: use local registry mirrors

### DIFF
--- a/util/contentutil/copy.go
+++ b/util/contentutil/copy.go
@@ -3,10 +3,13 @@ package contentutil
 import (
 	"context"
 	"io"
+	"sync"
 
 	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/remotes"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
 )
 
 func Copy(ctx context.Context, ingester content.Ingester, provider content.Provider, desc ocispec.Descriptor) error {
@@ -40,4 +43,39 @@ func (r *rc) Read(b []byte) (int, error) {
 		err = nil
 	}
 	return n, err
+}
+
+func CopyChain(ctx context.Context, ingester content.Ingester, provider content.Provider, desc ocispec.Descriptor) error {
+	var m sync.Mutex
+	manifestStack := []ocispec.Descriptor{}
+
+	filterHandler := images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		switch desc.MediaType {
+		case images.MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest,
+			images.MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
+			m.Lock()
+			manifestStack = append(manifestStack, desc)
+			m.Unlock()
+			return nil, images.ErrStopHandler
+		default:
+			return nil, nil
+		}
+	})
+	handlers := []images.Handler{
+		images.ChildrenHandler(provider),
+		filterHandler,
+		remotes.FetchHandler(ingester, &localFetcher{provider}),
+	}
+
+	if err := images.Dispatch(ctx, images.Handlers(handlers...), desc); err != nil {
+		return errors.WithStack(err)
+	}
+
+	for i := len(manifestStack) - 1; i >= 0; i-- {
+		if err := Copy(ctx, ingester, provider, manifestStack[i]); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	return nil
 }

--- a/util/contentutil/fetcher.go
+++ b/util/contentutil/fetcher.go
@@ -55,6 +55,9 @@ func (r *readerAt) ReadAt(b []byte, off int64) (int, error) {
 	var totalN int
 	for len(b) > 0 {
 		n, err := r.Reader.Read(b)
+		if err == io.EOF && n == len(b) {
+			err = nil
+		}
 		r.offset += int64(n)
 		totalN += n
 		b = b[n:]

--- a/util/contentutil/refs.go
+++ b/util/contentutil/refs.go
@@ -1,0 +1,57 @@
+package contentutil
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/remotes"
+	"github.com/containerd/containerd/remotes/docker"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func ProviderFromRef(ref string) (ocispec.Descriptor, content.Provider, error) {
+	remote := docker.NewResolver(docker.ResolverOptions{
+		Client: http.DefaultClient,
+	})
+
+	name, desc, err := remote.Resolve(context.TODO(), ref)
+	if err != nil {
+		return ocispec.Descriptor{}, nil, err
+	}
+
+	fetcher, err := remote.Fetcher(context.TODO(), name)
+	if err != nil {
+		return ocispec.Descriptor{}, nil, err
+	}
+	return desc, FromFetcher(fetcher), nil
+}
+
+func IngesterFromRef(ref string) (content.Ingester, error) {
+	remote := docker.NewResolver(docker.ResolverOptions{
+		Client: http.DefaultClient,
+	})
+
+	pusher, err := remote.Pusher(context.TODO(), ref)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ingester{
+		pusher: pusher,
+	}, nil
+}
+
+type ingester struct {
+	pusher remotes.Pusher
+}
+
+func (w *ingester) Writer(ctx context.Context, opts ...content.WriterOpt) (content.Writer, error) {
+	var wo content.WriterOpts
+	for _, o := range opts {
+		if err := o(&wo); err != nil {
+			return nil, err
+		}
+	}
+	return w.pusher.Push(ctx, wo.Desc)
+}

--- a/util/testutil/integration/containerd.go
+++ b/util/testutil/integration/containerd.go
@@ -132,6 +132,9 @@ disabled_plugins = ["cri"]
 		if err != nil {
 			return nil, nil, err
 		}
+		deferF.append(func() error {
+			return os.RemoveAll(dir)
+		})
 		buildkitdArgs = append(buildkitdArgs, "--config="+filepath.Join(dir, "buildkitd.toml"))
 	}
 

--- a/util/testutil/integration/containerd.go
+++ b/util/testutil/integration/containerd.go
@@ -48,7 +48,12 @@ func (c *containerd) Name() string {
 	return c.name
 }
 
-func (c *containerd) New() (sb Sandbox, cl func() error, err error) {
+func (c *containerd) New(opt ...SandboxOpt) (sb Sandbox, cl func() error, err error) {
+	var conf SandboxConf
+	for _, o := range opt {
+		o(&conf)
+	}
+
 	if err := lookupBinary(c.containerd); err != nil {
 		return nil, nil, err
 	}
@@ -115,12 +120,22 @@ disabled_plugins = ["cri"]
 	}
 	deferF.append(ctdStop)
 
-	buildkitdSock, stop, err := runBuildkitd([]string{"buildkitd",
+	buildkitdArgs := []string{"buildkitd",
 		"--oci-worker=false",
 		"--containerd-worker=true",
 		"--containerd-worker-addr", address,
 		"--containerd-worker-labels=org.mobyproject.buildkit.worker.sandbox=true", // Include use of --containerd-worker-labels to trigger https://github.com/moby/buildkit/pull/603
-	}, logs, 0, 0)
+	}
+
+	if conf.mirror != "" {
+		dir, err := configWithMirror(conf.mirror)
+		if err != nil {
+			return nil, nil, err
+		}
+		buildkitdArgs = append(buildkitdArgs, "--config="+filepath.Join(dir, "buildkitd.toml"))
+	}
+
+	buildkitdSock, stop, err := runBuildkitd(buildkitdArgs, logs, 0, 0)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -146,10 +146,13 @@ func configWithMirror(mirror string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if err := os.Chmod(tmpdir, 0711); err != nil {
+		return "", err
+	}
 	if err := ioutil.WriteFile(filepath.Join(tmpdir, "buildkitd.toml"), []byte(fmt.Sprintf(`
 [registry."docker.io"]
 mirrors=["%s"]
-`, mirror)), 0600); err != nil {
+`, mirror)), 0644); err != nil {
 		return "", err
 	}
 	return tmpdir, nil

--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -1,12 +1,19 @@
 package integration
 
 import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"reflect"
 	"runtime"
 	"strings"
+	"syscall"
 	"testing"
 
+	"github.com/moby/buildkit/util/contentutil"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,8 +28,20 @@ type Sandbox interface {
 }
 
 type Worker interface {
-	New() (Sandbox, func() error, error)
+	New(...SandboxOpt) (Sandbox, func() error, error)
 	Name() string
+}
+
+type SandboxConf struct {
+	mirror string
+}
+
+type SandboxOpt func(*SandboxConf)
+
+func WithMirror(h string) SandboxOpt {
+	return func(c *SandboxConf) {
+		c.mirror = h
+	}
 }
 
 type Test func(*testing.T, Sandbox)
@@ -41,10 +60,37 @@ func Run(t *testing.T, testCases []Test) {
 	if testing.Short() {
 		t.Skip("skipping in short mode")
 	}
+
+	mirrorDir := os.Getenv("BUILDKIT_REGISTRY_MIRROR_DIR")
+
+	var f *os.File
+	if mirrorDir != "" {
+		var err error
+		f, err = os.Create(filepath.Join(mirrorDir, "lock"))
+		require.NoError(t, err)
+		// defer f.Close() // this defer runs after subtest, cleanup on exit
+
+		err = syscall.Flock(int(f.Fd()), syscall.LOCK_EX)
+		require.NoError(t, err)
+	}
+
+	mirror, cleanup, err := newRegistry(mirrorDir)
+	require.NoError(t, err)
+	_ = cleanup
+	// defer cleanup() // this defer runs after subtest, cleanup on exit
+
+	err = copyImagesLocal(t, mirror)
+	require.NoError(t, err)
+
+	if mirrorDir != "" {
+		err = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		require.NoError(t, err)
+	}
+
 	for _, br := range List() {
 		for _, tc := range testCases {
 			ok := t.Run(getFunctionName(tc)+"/worker="+br.Name(), func(t *testing.T) {
-				sb, close, err := br.New()
+				sb, close, err := br.New(WithMirror(mirror))
 				if err != nil {
 					if errors.Cause(err) == ErrorRequirements {
 						t.Skip(err.Error())
@@ -68,4 +114,47 @@ func getFunctionName(i interface{}) string {
 	fullname := runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
 	dot := strings.LastIndex(fullname, ".") + 1
 	return strings.Title(fullname[dot:])
+}
+
+func copyImagesLocal(t *testing.T, host string) error {
+	for to, from := range offlineImages() {
+		desc, provider, err := contentutil.ProviderFromRef(from)
+		if err != nil {
+			return err
+		}
+		ingester, err := contentutil.IngesterFromRef(host + "/" + to)
+		if err != nil {
+			return err
+		}
+		if err := contentutil.CopyChain(context.TODO(), ingester, provider, desc); err != nil {
+			return err
+		}
+		t.Logf("copied %s to local mirror %s", from, host+"/"+to)
+	}
+	return nil
+}
+
+func offlineImages() map[string]string {
+	arch := runtime.GOARCH
+	if arch == "arm64" {
+		arch = "arm64v8"
+	}
+	return map[string]string{
+		"library/busybox:latest": "docker.io/" + arch + "/busybox:latest",
+		"library/alpine:latest":  "docker.io/" + arch + "/alpine:latest",
+	}
+}
+
+func configWithMirror(mirror string) (string, error) {
+	tmpdir, err := ioutil.TempDir("", "bktest_config")
+	if err != nil {
+		return "", err
+	}
+	if err := ioutil.WriteFile(filepath.Join(tmpdir, "buildkitd.toml"), []byte(fmt.Sprintf(`
+[registry."docker.io"]
+mirrors=["%s"]
+`, mirror)), 0600); err != nil {
+		return "", err
+	}
+	return tmpdir, nil
 }


### PR DESCRIPTION
Use a local mirror for integration tests instead of pulling images all the time.

In the future, we may want to pass in the list of images per package as some of them are dockerfile specific. Also it may be easier (especially for the cleanup) if we would switch to `TestMain`.

For sharing between packages one can set `export BUILDKIT_REGISTRY_MIRROR_DIR=$(mktemp -d)`, but then they need to clean up this dir themselves as well. We could also set it in `hack/test` script later.