### PR TITLE
buildctl: replace withblock with dial error check

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -25,12 +25,11 @@ type ClientOpt interface{}
 func New(ctx context.Context, address string, opts ...ClientOpt) (*Client, error) {
 	gopts := []grpc.DialOption{
 		grpc.WithDialer(dialer),
-		grpc.FailOnNonTempDialError(true),
 	}
 	needWithInsecure := true
 	for _, o := range opts {
-		if _, ok := o.(*withBlockOpt); ok {
-			gopts = append(gopts, grpc.WithBlock(), grpc.FailOnNonTempDialError(true))
+		if _, ok := o.(*withFailFast); ok {
+			gopts = append(gopts, grpc.FailOnNonTempDialError(true))
 		}
 		if credInfo, ok := o.(*withCredentials); ok {
 			opt, err := loadCredentials(credInfo)
@@ -52,7 +51,6 @@ func New(ctx context.Context, address string, opts ...ClientOpt) (*Client, error
 	if address == "" {
 		address = appdefaults.Address
 	}
-
 	conn, err := grpc.DialContext(ctx, address, gopts...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to dial %q . make sure buildkitd is running", address)
@@ -71,10 +69,10 @@ func (c *Client) Close() error {
 	return c.conn.Close()
 }
 
-type withBlockOpt struct{}
+type withFailFast struct{}
 
-func WithBlock() ClientOpt {
-	return &withBlockOpt{}
+func WithFailFast() ClientOpt {
+	return &withFailFast{}
 }
 
 type withCredentials struct {

--- a/cmd/buildctl/debug/workers.go
+++ b/cmd/buildctl/debug/workers.go
@@ -32,7 +32,7 @@ var WorkersCommand = cli.Command{
 }
 
 func resolveClient(c *cli.Context) (*client.Client, error) {
-	return client.New(commandContext(c), c.GlobalString("addr"), client.WithBlock())
+	return client.New(commandContext(c), c.GlobalString("addr"), client.WithFailFast())
 }
 
 func listWorkers(clicontext *cli.Context) error {

--- a/cmd/buildctl/main.go
+++ b/cmd/buildctl/main.go
@@ -116,7 +116,7 @@ func resolveClient(c *cli.Context) (*client.Client, error) {
 	cert := c.GlobalString("tlscert")
 	key := c.GlobalString("tlskey")
 
-	opts := []client.ClientOpt{client.WithBlock()}
+	opts := []client.ClientOpt{client.WithFailFast()}
 
 	ctx := commandContext(c)
 

--- a/examples/build-using-dockerfile/main.go
+++ b/examples/build-using-dockerfile/main.go
@@ -77,7 +77,7 @@ func action(clicontext *cli.Context) error {
 	if tag := clicontext.String("tag"); tag == "" {
 		return errors.New("tag is not specified")
 	}
-	c, err := client.New(ctx, clicontext.String("buildkit-addr"), client.WithBlock())
+	c, err := client.New(ctx, clicontext.String("buildkit-addr"), client.WithFailFast())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Corrects the logic for quickly showing error when socket is down.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>