### PR TITLE
cache: fix usage counters

### DIFF
--- a/cache/manager.go
+++ b/cache/manager.go
@@ -128,17 +128,24 @@ func (cm *cacheManager) get(ctx context.Context, id string, fromSnapshotter bool
 	rec.mu.Lock()
 	defer rec.mu.Unlock()
 
+	triggerUpdate := true
+	for _, o := range opts {
+		if o == NoUpdateLastUsed {
+			triggerUpdate = false
+		}
+	}
+
 	if rec.mutable {
 		if len(rec.refs) != 0 {
 			return nil, errors.Wrapf(ErrLocked, "%s is locked", id)
 		}
 		if rec.equalImmutable != nil {
-			return rec.equalImmutable.ref(), nil
+			return rec.equalImmutable.ref(triggerUpdate), nil
 		}
-		return rec.mref().commit(ctx)
+		return rec.mref(triggerUpdate).commit(ctx)
 	}
 
-	return rec.ref(), nil
+	return rec.ref(triggerUpdate), nil
 }
 
 // getRecord returns record for id. Requires manager lock.
@@ -166,8 +173,8 @@ func (cm *cacheManager) getRecord(ctx context.Context, id string, fromSnapshotte
 		rec := &cacheRecord{
 			mu:           &sync.Mutex{},
 			cm:           cm,
-			refs:         make(map[Mountable]struct{}),
-			parent:       mutable.Parent(),
+			refs:         make(map[ref]struct{}),
+			parent:       mutable.parentRef(false),
 			md:           md,
 			equalMutable: &mutableRef{cacheRecord: mutable},
 		}
@@ -183,7 +190,7 @@ func (cm *cacheManager) getRecord(ctx context.Context, id string, fromSnapshotte
 
 	var parent ImmutableRef
 	if info.Parent != "" {
-		parent, err = cm.get(ctx, info.Parent, fromSnapshotter, opts...)
+		parent, err = cm.get(ctx, info.Parent, fromSnapshotter, append(opts, NoUpdateLastUsed)...)
 		if err != nil {
 			return nil, err
 		}
@@ -198,7 +205,7 @@ func (cm *cacheManager) getRecord(ctx context.Context, id string, fromSnapshotte
 		mu:      &sync.Mutex{},
 		mutable: info.Kind != snapshots.KindCommitted,
 		cm:      cm,
-		refs:    make(map[Mountable]struct{}),
+		refs:    make(map[ref]struct{}),
 		parent:  parent,
 		md:      md,
 	}
@@ -229,7 +236,7 @@ func (cm *cacheManager) New(ctx context.Context, s ImmutableRef, opts ...RefOpti
 	var parentID string
 	if s != nil {
 		var err error
-		parent, err = cm.Get(ctx, s.ID())
+		parent, err = cm.Get(ctx, s.ID(), NoUpdateLastUsed)
 		if err != nil {
 			return nil, err
 		}
@@ -252,7 +259,7 @@ func (cm *cacheManager) New(ctx context.Context, s ImmutableRef, opts ...RefOpti
 		mu:      &sync.Mutex{},
 		mutable: true,
 		cm:      cm,
-		refs:    make(map[Mountable]struct{}),
+		refs:    make(map[ref]struct{}),
 		parent:  parent,
 		md:      md,
 	}
@@ -269,7 +276,7 @@ func (cm *cacheManager) New(ctx context.Context, s ImmutableRef, opts ...RefOpti
 
 	cm.records[id] = rec // TODO: save to db
 
-	return rec.mref(), nil
+	return rec.mref(true), nil
 }
 func (cm *cacheManager) GetMutable(ctx context.Context, id string) (MutableRef, error) {
 	cm.mu.Lock()
@@ -301,7 +308,7 @@ func (cm *cacheManager) GetMutable(ctx context.Context, id string) (MutableRef, 
 		rec.equalImmutable = nil
 	}
 
-	return rec.mref(), nil
+	return rec.mref(true), nil
 }
 
 func (cm *cacheManager) Prune(ctx context.Context, ch chan client.UsageInfo, opts ...client.PruneInfo) error {
@@ -669,7 +676,7 @@ func (cm *cacheManager) DiskUsage(ctx context.Context, opt client.DiskUsageInfo)
 		if d.Size == sizeUnknown {
 			func(d *client.UsageInfo) {
 				eg.Go(func() error {
-					ref, err := cm.Get(ctx, d.ID)
+					ref, err := cm.Get(ctx, d.ID, NoUpdateLastUsed)
 					if err != nil {
 						d.Size = 0
 						return nil
@@ -700,7 +707,7 @@ func IsNotFound(err error) bool {
 	return errors.Cause(err) == errNotFound
 }
 
-type RefOption func(withMetadata) error
+type RefOption interface{}
 
 type cachePolicy int
 
@@ -712,6 +719,10 @@ const (
 type withMetadata interface {
 	Metadata() *metadata.StorageItem
 }
+
+type noUpdateLastUsed struct{}
+
+var NoUpdateLastUsed noUpdateLastUsed
 
 func HasCachePolicyRetain(m withMetadata) bool {
 	return getCachePolicy(m.Metadata()) == cachePolicyRetain
@@ -750,8 +761,10 @@ func initializeMetadata(m withMetadata, opts ...RefOption) error {
 	}
 
 	for _, opt := range opts {
-		if err := opt(m); err != nil {
-			return err
+		if fn, ok := opt.(func(withMetadata) error); ok {
+			if err := fn(m); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -223,8 +223,12 @@ func (w *Worker) GCPolicy() []client.PruneInfo {
 	return w.WorkerOpt.GCPolicy
 }
 
-func (w *Worker) LoadRef(id string) (cache.ImmutableRef, error) {
-	return w.CacheManager.Get(context.TODO(), id)
+func (w *Worker) LoadRef(id string, hidden bool) (cache.ImmutableRef, error) {
+	var opts []cache.RefOption
+	if hidden {
+		opts = append(opts, cache.NoUpdateLastUsed)
+	}
+	return w.CacheManager.Get(context.TODO(), id, opts...)
 }
 
 func (w *Worker) ResolveOp(v solver.Vertex, s frontend.FrontendLLBBridge) (solver.Op, error) {

--- a/worker/cacheresult.go
+++ b/worker/cacheresult.go
@@ -36,7 +36,7 @@ func (s *cacheResultStorage) Save(res solver.Result) (solver.CacheResult, error)
 	return solver.CacheResult{ID: ref.ID(), CreatedAt: time.Now()}, nil
 }
 func (s *cacheResultStorage) Load(ctx context.Context, res solver.CacheResult) (solver.Result, error) {
-	return s.load(res.ID)
+	return s.load(res.ID, false)
 }
 
 func (s *cacheResultStorage) getWorkerRef(id string) (Worker, string, error) {
@@ -51,7 +51,7 @@ func (s *cacheResultStorage) getWorkerRef(id string) (Worker, string, error) {
 	return w, refID, nil
 }
 
-func (s *cacheResultStorage) load(id string) (solver.Result, error) {
+func (s *cacheResultStorage) load(id string, hidden bool) (solver.Result, error) {
 	w, refID, err := s.getWorkerRef(id)
 	if err != nil {
 		return nil, err
@@ -59,7 +59,7 @@ func (s *cacheResultStorage) load(id string) (solver.Result, error) {
 	if refID == "" {
 		return NewWorkerRefResult(nil, w), nil
 	}
-	ref, err := w.LoadRef(refID)
+	ref, err := w.LoadRef(refID, hidden)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func (s *cacheResultStorage) LoadRemote(ctx context.Context, res solver.CacheRes
 	if err != nil {
 		return nil, err
 	}
-	ref, err := w.LoadRef(refID)
+	ref, err := w.LoadRef(refID, true)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func (s *cacheResultStorage) LoadRemote(ctx context.Context, res solver.CacheRes
 	return remote, nil
 }
 func (s *cacheResultStorage) Exists(id string) bool {
-	ref, err := s.load(id)
+	ref, err := s.load(id, true)
 	if err != nil {
 		return false
 	}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -21,7 +21,7 @@ type Worker interface {
 	Labels() map[string]string
 	Platforms() []specs.Platform
 	GCPolicy() []client.PruneInfo
-	LoadRef(id string) (cache.ImmutableRef, error)
+	LoadRef(id string, hidden bool) (cache.ImmutableRef, error)
 	// ResolveOp resolves Vertex.Sys() to Op implementation.
 	ResolveOp(v solver.Vertex, s frontend.FrontendLLBBridge) (solver.Op, error)
 	ResolveImageConfig(ctx context.Context, ref string, opt gw.ResolveImageConfigOpt) (digest.Digest, []byte, error)


### PR DESCRIPTION
Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>

The usage counters on `du -v` that are also used gc were not working properly. Most notably they increased when `du` itself was run. There were other issues as well with extra counting mutable releases, increasing the count on startup when cache was checked and not increasing counters for parent nodes.