### PR TITLE
dockerfile: allow relative paths in mount targets

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert_runmount.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_runmount.go
@@ -78,9 +78,12 @@ func dispatchRunMounts(d *dispatchState, c *instructions.RunCommand, sources []*
 			}
 			mountOpts = append(mountOpts, llb.AsPersistentCacheDir(opt.cacheIDNamespace+"/"+mount.CacheID, sharing))
 		}
-		target := path.Join("/", mount.Target)
+		target := mount.Target
+		if !filepath.IsAbs(filepath.Clean(mount.Target)) {
+			target = filepath.Join("/", d.state.GetDir(), mount.Target)
+		}
 		if target == "/" {
-			return nil, errors.Errorf("invalid mount target %q", mount.Target)
+			return nil, errors.Errorf("invalid mount target %q", target)
 		}
 		if src := path.Join("/", mount.Source); src != "/" {
 			mountOpts = append(mountOpts, llb.SourcePath(src))


### PR DESCRIPTION
Allow `target=` in `RUN --mount` to be relative to the current working directory.

docker.io/tonistiigi/dockerfile:runmount20180917
docker.io/tonistiigi/dockerfile:secrets20180917

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>