### PR TITLE
runc: fix process leak on cancellation

### DIFF
--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/containerd/containerd/contrib/seccomp"
 	"github.com/containerd/containerd/mount"
@@ -88,7 +89,7 @@ func New(opt Opt, networkProviders map[pb.NetMode]network.Provider) (executor.Ex
 		Command:      cmd,
 		Log:          filepath.Join(root, "runc-log.json"),
 		LogFormat:    runc.JSON,
-		PdeathSignal: syscall.SIGKILL,
+		PdeathSignal: syscall.SIGKILL, // this can still leak the process
 		Setpgid:      true,
 		// we don't execute runc with --rootless=(true|false) explicitly,
 		// so as to support non-runc runtimes
@@ -220,10 +221,43 @@ func (w *runcExecutor) Exec(ctx context.Context, meta executor.Meta, root cache.
 		return err
 	}
 
+	// runCtx/killCtx is used for extra check in case the kill command blocks
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	defer cancelRun()
+
+	done := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				killCtx, timeout := context.WithTimeout(context.Background(), 7*time.Second)
+				if err := w.runc.Kill(killCtx, id, int(syscall.SIGKILL), nil); err != nil {
+					logrus.Errorf("failed to kill runc %s: %+v", id, err)
+					select {
+					case <-killCtx.Done():
+						timeout()
+						cancelRun()
+						return
+					default:
+					}
+				}
+				timeout()
+				select {
+				case <-time.After(50 * time.Millisecond):
+				case <-done:
+					return
+				}
+			case <-done:
+				return
+			}
+		}
+	}()
+
 	logrus.Debugf("> creating %s %v", id, meta.Args)
-	status, err := w.runc.Run(ctx, id, bundle, &runc.CreateOpts{
+	status, err := w.runc.Run(runCtx, id, bundle, &runc.CreateOpts{
 		IO: &forwardIO{stdin: stdin, stdout: stdout, stderr: stderr},
 	})
+	close(done)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Apparently killing `runc run` can still leak the container process, so change the cancel to manual signal send like in containerd executor.

This also fixes a case where cgroups could be leaked because the cleanup didn't run as part of `runc run` when it was killed.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>