### PR TITLE
Push setting of default PATH down into the executor(s)

### DIFF
--- a/client/llb/exec.go
+++ b/client/llb/exec.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	"github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/util/system"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
@@ -140,6 +141,13 @@ func (e *ExecOp) Marshal(c *Constraints) (digest.Digest, []byte, *pb.OpMetadata,
 		}
 		if _, ok := e.meta.Env.Get("SSH_AUTH_SOCK"); !ok {
 			e.meta.Env = e.meta.Env.AddOrReplace("SSH_AUTH_SOCK", e.ssh[0].Target)
+		}
+	}
+	if c.Caps != nil {
+		if err := c.Caps.Supports(pb.CapExecMetaSetsDefaultPath); err != nil {
+			e.meta.Env = e.meta.Env.SetDefault("PATH", system.DefaultPathEnv)
+		} else {
+			addCap(&e.constraints, pb.CapExecMetaSetsDefaultPath)
 		}
 	}
 

--- a/client/llb/meta.go
+++ b/client/llb/meta.go
@@ -23,10 +23,6 @@ var (
 	keyNetwork   = contextKeyT("llb.network")
 )
 
-func addEnv(key, value string) StateOption {
-	return addEnvf(key, value)
-}
-
 func addEnvf(key, value string, v ...interface{}) StateOption {
 	return func(s State) State {
 		return s.WithValue(keyEnv, getEnv(s).AddOrReplace(key, fmt.Sprintf(value, v...)))

--- a/client/llb/meta.go
+++ b/client/llb/meta.go
@@ -175,6 +175,13 @@ func (e EnvList) AddOrReplace(k, v string) EnvList {
 	return e
 }
 
+func (e EnvList) SetDefault(k, v string) EnvList {
+	if _, ok := e.Get(k); !ok {
+		e = append(e, KeyValue{key: k, value: v})
+	}
+	return e
+}
+
 func (e EnvList) Delete(k string) EnvList {
 	e = append([]KeyValue(nil), e...)
 	if i, ok := e.Index(k); ok {

--- a/client/llb/state.go
+++ b/client/llb/state.go
@@ -9,7 +9,6 @@ import (
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/apicaps"
-	"github.com/moby/buildkit/util/system"
 	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -34,7 +33,6 @@ func NewState(o Output) State {
 		ctx: context.Background(),
 	}
 	s = dir("/")(s)
-	s = addEnv("PATH", system.DefaultPathEnv)(s)
 	s = s.ensurePlatform()
 	return s
 }

--- a/solver/pb/caps.go
+++ b/solver/pb/caps.go
@@ -30,15 +30,16 @@ const (
 
 	CapBuildOpLLBFileName apicaps.CapID = "source.buildop.llbfilename"
 
-	CapExecMetaBase          apicaps.CapID = "exec.meta.base"
-	CapExecMetaProxy         apicaps.CapID = "exec.meta.proxyenv"
-	CapExecMetaNetwork       apicaps.CapID = "exec.meta.network"
-	CapExecMountBind         apicaps.CapID = "exec.mount.bind"
-	CapExecMountCache        apicaps.CapID = "exec.mount.cache"
-	CapExecMountCacheSharing apicaps.CapID = "exec.mount.cache.sharing"
-	CapExecMountSelector     apicaps.CapID = "exec.mount.selector"
-	CapExecMountTmpfs        apicaps.CapID = "exec.mount.tmpfs"
-	CapMountSecret           apicaps.CapID = "exec.mount.secret"
+	CapExecMetaBase            apicaps.CapID = "exec.meta.base"
+	CapExecMetaProxy           apicaps.CapID = "exec.meta.proxyenv"
+	CapExecMetaNetwork         apicaps.CapID = "exec.meta.network"
+	CapExecMetaSetsDefaultPath apicaps.CapID = "exec.meta.setsdefaultpath"
+	CapExecMountBind           apicaps.CapID = "exec.mount.bind"
+	CapExecMountCache          apicaps.CapID = "exec.mount.cache"
+	CapExecMountCacheSharing   apicaps.CapID = "exec.mount.cache.sharing"
+	CapExecMountSelector       apicaps.CapID = "exec.mount.selector"
+	CapExecMountTmpfs          apicaps.CapID = "exec.mount.tmpfs"
+	CapMountSecret             apicaps.CapID = "exec.mount.secret"
 
 	CapConstraints apicaps.CapID = "constraints"
 	CapPlatform    apicaps.CapID = "platform"
@@ -165,6 +166,12 @@ func init() {
 
 	Caps.Init(apicaps.Cap{
 		ID:      CapExecMetaNetwork,
+		Enabled: true,
+		Status:  apicaps.CapStatusExperimental,
+	})
+
+	Caps.Init(apicaps.Cap{
+		ID:      CapExecMetaSetsDefaultPath,
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})


### PR DESCRIPTION
Setting the default `PATH` in the `llb.State` on the client side means it
depends on the `GOOS` of the buildkit client, rather than of the environment
where it will actually execute.

Instead defer this to execution time and insert the default PATH at that point
if one is not present. Doing this in executor/oci/spec_unix.go covers both the
runc and containerd executors at once.

No special handling is needed for a Windows executor since there is no fallback
path in that case.

Fixes #604

Signed-off-by: Ian Campbell <ijc@docker.com>