### PR TITLE
contenthash: fix issues on symlinks on parent paths

### DIFF
--- a/cache/contenthash/checksum_test.go
+++ b/cache/contenthash/checksum_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/moby/buildkit/snapshot"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tonistiigi/fsutil"
 )
@@ -55,53 +54,53 @@ func TestChecksumBasicFile(t *testing.T) {
 	// phase but consistency is
 
 	cc, err := newCacheContext(ref.Metadata())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = cc.Checksum(context.TODO(), ref, "nosuch")
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	dgst, err := cc.Checksum(context.TODO(), ref, "foo")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, dgstFileData0, dgst)
+	require.Equal(t, dgstFileData0, dgst)
 
 	// second file returns different hash
 	dgst, err = cc.Checksum(context.TODO(), ref, "bar")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, digest.Digest("sha256:c2b5e234f5f38fc5864da7def04782f82501a40d46192e4207d5b3f0c3c4732b"), dgst)
+	require.Equal(t, digest.Digest("sha256:c2b5e234f5f38fc5864da7def04782f82501a40d46192e4207d5b3f0c3c4732b"), dgst)
 
 	// same file inside a directory
 	dgst, err = cc.Checksum(context.TODO(), ref, "d0/abc")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, dgstFileData0, dgst)
+	require.Equal(t, dgstFileData0, dgst)
 
 	// repeat because codepath is different
 	dgst, err = cc.Checksum(context.TODO(), ref, "d0/abc")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, dgstFileData0, dgst)
+	require.Equal(t, dgstFileData0, dgst)
 
 	// symlink to the same file is followed, returns same hash
 	dgst, err = cc.Checksum(context.TODO(), ref, "d0/def")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, dgstFileData0, dgst)
+	require.Equal(t, dgstFileData0, dgst)
 
 	_, err = cc.Checksum(context.TODO(), ref, "d0/ghi")
-	assert.Error(t, err)
-	assert.Equal(t, errNotFound, errors.Cause(err))
+	require.Error(t, err)
+	require.Equal(t, errNotFound, errors.Cause(err))
 
 	dgst, err = cc.Checksum(context.TODO(), ref, "/")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, digest.Digest("sha256:427c9cf9ae98c0f81fb57a3076b965c7c149b6b0a85625ad4e884236649a42c6"), dgst)
+	require.Equal(t, digest.Digest("sha256:427c9cf9ae98c0f81fb57a3076b965c7c149b6b0a85625ad4e884236649a42c6"), dgst)
 
 	dgst, err = cc.Checksum(context.TODO(), ref, "d0")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, dgstDirD0, dgst)
+	require.Equal(t, dgstDirD0, dgst)
 
 	err = ref.Release(context.TODO())
 	require.NoError(t, err)
@@ -116,12 +115,12 @@ func TestChecksumBasicFile(t *testing.T) {
 	ref = createRef(t, cm, ch)
 
 	cc, err = newCacheContext(ref.Metadata())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	dgst, err = cc.Checksum(context.TODO(), ref, "/")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, dgstDirD0, dgst)
+	require.Equal(t, dgstDirD0, dgst)
 
 	err = ref.Release(context.TODO())
 	require.NoError(t, err)
@@ -135,13 +134,13 @@ func TestChecksumBasicFile(t *testing.T) {
 	ref = createRef(t, cm, ch)
 
 	cc, err = newCacheContext(ref.Metadata())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	dgst, err = cc.Checksum(context.TODO(), ref, "/")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, dgstDirD0Modified, dgst)
-	assert.NotEqual(t, dgstDirD0, dgst)
+	require.Equal(t, dgstDirD0Modified, dgst)
+	require.NotEqual(t, dgstDirD0, dgst)
 
 	err = ref.Release(context.TODO())
 	require.NoError(t, err)
@@ -161,19 +160,19 @@ func TestChecksumBasicFile(t *testing.T) {
 	ref = createRef(t, cm, ch)
 
 	cc, err = newCacheContext(ref.Metadata())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	dgst, err = cc.Checksum(context.TODO(), ref, "abc/aa/foo")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, digest.Digest("sha256:1c67653c3cf95b12a0014e2c4cd1d776b474b3218aee54155d6ae27b9b999c54"), dgst)
-	assert.NotEqual(t, dgstDirD0, dgst)
+	require.Equal(t, digest.Digest("sha256:1c67653c3cf95b12a0014e2c4cd1d776b474b3218aee54155d6ae27b9b999c54"), dgst)
+	require.NotEqual(t, dgstDirD0, dgst)
 
 	// this will force rescan
 	dgst, err = cc.Checksum(context.TODO(), ref, "d0")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, dgstDirD0, dgst)
+	require.Equal(t, dgstDirD0, dgst)
 
 	err = ref.Release(context.TODO())
 	require.NoError(t, err)
@@ -205,53 +204,53 @@ func TestHandleChange(t *testing.T) {
 	// phase but consistency is
 
 	cc, err := newCacheContext(ref.Metadata())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = emit(cc.HandleChange, changeStream(ch))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	dgstFoo, err := cc.Checksum(context.TODO(), ref, "foo")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, dgstFileData0, dgstFoo)
+	require.Equal(t, dgstFileData0, dgstFoo)
 
 	// symlink to the same file is followed, returns same hash
 	dgst, err := cc.Checksum(context.TODO(), ref, "d0/def")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, dgstFoo, dgst)
+	require.Equal(t, dgstFoo, dgst)
 
 	// symlink to the same file is followed, returns same hash
 	dgst, err = cc.Checksum(context.TODO(), ref, "d0")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, dgstDirD0, dgst)
+	require.Equal(t, dgstDirD0, dgst)
 
 	ch = []string{
 		"DEL d0/ghi file",
 	}
 
 	err = emit(cc.HandleChange, changeStream(ch))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	dgst, err = cc.Checksum(context.TODO(), ref, "d0")
-	assert.NoError(t, err)
-	assert.Equal(t, dgstDirD0Modified, dgst)
+	require.NoError(t, err)
+	require.Equal(t, dgstDirD0Modified, dgst)
 
 	ch = []string{
 		"DEL d0 dir",
 	}
 
 	err = emit(cc.HandleChange, changeStream(ch))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = cc.Checksum(context.TODO(), ref, "d0")
-	assert.Error(t, err)
-	assert.Equal(t, errNotFound, errors.Cause(err))
+	require.Error(t, err)
+	require.Equal(t, errNotFound, errors.Cause(err))
 
 	_, err = cc.Checksum(context.TODO(), ref, "d0/abc")
-	assert.Error(t, err)
-	assert.Equal(t, errNotFound, errors.Cause(err))
+	require.Error(t, err)
+	require.Equal(t, errNotFound, errors.Cause(err))
 
 	err = ref.Release(context.TODO())
 	require.NoError(t, err)
@@ -281,13 +280,13 @@ func TestHandleRecursiveDir(t *testing.T) {
 	ref := createRef(t, cm, nil)
 
 	cc, err := newCacheContext(ref.Metadata())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = emit(cc.HandleChange, changeStream(ch))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	dgst, err := cc.Checksum(context.TODO(), ref, "d0/foo/bar")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	ch = []string{
 		"DEL d0 dir",
@@ -296,14 +295,14 @@ func TestHandleRecursiveDir(t *testing.T) {
 	}
 
 	err = emit(cc.HandleChange, changeStream(ch))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	dgst2, err := cc.Checksum(context.TODO(), ref, "d1")
-	assert.NoError(t, err)
-	assert.Equal(t, dgst2, dgst)
+	require.NoError(t, err)
+	require.Equal(t, dgst2, dgst)
 
 	_, err = cc.Checksum(context.TODO(), ref, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestChecksumUnorderedFiles(t *testing.T) {
@@ -328,15 +327,15 @@ func TestChecksumUnorderedFiles(t *testing.T) {
 	ref := createRef(t, cm, nil)
 
 	cc, err := newCacheContext(ref.Metadata())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = emit(cc.HandleChange, changeStream(ch))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	dgst, err := cc.Checksum(context.TODO(), ref, "d0")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, dgst, digest.Digest("sha256:14276c302c940a80f82ca5477bf766c98a24702d6a9948ee71bb277cdad3ae05"))
+	require.Equal(t, dgst, digest.Digest("sha256:14276c302c940a80f82ca5477bf766c98a24702d6a9948ee71bb277cdad3ae05"))
 
 	// check regression from earier version that didn't track some files
 	ch = []string{
@@ -348,15 +347,15 @@ func TestChecksumUnorderedFiles(t *testing.T) {
 	ref = createRef(t, cm, nil)
 
 	cc, err = newCacheContext(ref.Metadata())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = emit(cc.HandleChange, changeStream(ch))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	dgst2, err := cc.Checksum(context.TODO(), ref, "d0")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.NotEqual(t, dgst, dgst2)
+	require.NotEqual(t, dgst, dgst2)
 }
 
 func TestPersistence(t *testing.T) {
@@ -383,18 +382,18 @@ func TestPersistence(t *testing.T) {
 	id := ref.ID()
 
 	dgst, err := Checksum(context.TODO(), ref, "foo")
-	assert.NoError(t, err)
-	assert.Equal(t, dgstFileData0, dgst)
+	require.NoError(t, err)
+	require.Equal(t, dgstFileData0, dgst)
 
 	err = ref.Release(context.TODO())
 	require.NoError(t, err)
 
 	ref, err = cm.Get(context.TODO(), id)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	dgst, err = Checksum(context.TODO(), ref, "foo")
-	assert.NoError(t, err)
-	assert.Equal(t, dgstFileData0, dgst)
+	require.NoError(t, err)
+	require.Equal(t, dgstFileData0, dgst)
 
 	err = ref.Release(context.TODO())
 	require.NoError(t, err)
@@ -408,11 +407,11 @@ func TestPersistence(t *testing.T) {
 	defer cm.Close()
 
 	ref, err = cm.Get(context.TODO(), id)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	dgst, err = Checksum(context.TODO(), ref, "foo")
-	assert.NoError(t, err)
-	assert.Equal(t, dgstFileData0, dgst)
+	require.NoError(t, err)
+	require.Equal(t, dgstFileData0, dgst)
 }
 
 func createRef(t *testing.T, cm cache.Manager, files []string) cache.ImmutableRef {

--- a/cache/contenthash/path.go
+++ b/cache/contenthash/path.go
@@ -1,0 +1,107 @@
+package contenthash
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+var (
+	errTooManyLinks = errors.New("too many links")
+)
+
+type onSymlinkFunc func(string, string) error
+
+// rootPath joins a path with a root, evaluating and bounding any
+// symlink to the root directory.
+// This is containerd/continuity/fs RootPath implementation with a callback on
+// resolving the symlink.
+func rootPath(root, path string, cb onSymlinkFunc) (string, error) {
+	if path == "" {
+		return root, nil
+	}
+	var linksWalked int // to protect against cycles
+	for {
+		i := linksWalked
+		newpath, err := walkLinks(root, path, &linksWalked, cb)
+		if err != nil {
+			return "", err
+		}
+		path = newpath
+		if i == linksWalked {
+			newpath = filepath.Join("/", newpath)
+			if path == newpath {
+				return filepath.Join(root, newpath), nil
+			}
+			path = newpath
+		}
+	}
+}
+
+func walkLink(root, path string, linksWalked *int, cb onSymlinkFunc) (newpath string, islink bool, err error) {
+	if *linksWalked > 255 {
+		return "", false, errTooManyLinks
+	}
+
+	path = filepath.Join("/", path)
+	if path == "/" {
+		return path, false, nil
+	}
+	realPath := filepath.Join(root, path)
+
+	fi, err := os.Lstat(realPath)
+	if err != nil {
+		// If path does not yet exist, treat as non-symlink
+		if os.IsNotExist(err) {
+			return path, false, nil
+		}
+		return "", false, err
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		return path, false, nil
+	}
+	newpath, err = os.Readlink(realPath)
+	if err != nil {
+		return "", false, err
+	}
+	if cb != nil {
+		if err := cb(path, newpath); err != nil {
+			return "", false, err
+		}
+	}
+	*linksWalked++
+	return newpath, true, nil
+}
+
+func walkLinks(root, path string, linksWalked *int, cb onSymlinkFunc) (string, error) {
+	switch dir, file := filepath.Split(path); {
+	case dir == "":
+		newpath, _, err := walkLink(root, file, linksWalked, cb)
+		return newpath, err
+	case file == "":
+		if os.IsPathSeparator(dir[len(dir)-1]) {
+			if dir == "/" {
+				return dir, nil
+			}
+			return walkLinks(root, dir[:len(dir)-1], linksWalked, cb)
+		}
+		newpath, _, err := walkLink(root, dir, linksWalked, cb)
+		return newpath, err
+	default:
+		newdir, err := walkLinks(root, dir, linksWalked, cb)
+		if err != nil {
+			return "", err
+		}
+		newpath, islink, err := walkLink(root, filepath.Join(newdir, file), linksWalked, cb)
+		if err != nil {
+			return "", err
+		}
+		if !islink {
+			return newpath, nil
+		}
+		if filepath.IsAbs(newpath) {
+			return newpath, nil
+		}
+		return filepath.Join(newdir, newpath), nil
+	}
+}

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -164,9 +164,10 @@ func testCopyThroughSymlinkMultiStage(t *testing.T, sb integration.Sandbox) {
 
 	dockerfile := []byte(`
 FROM busybox AS build
-RUN mkdir -p /out/sub && ln -s out/sub /sub && echo -n "data" > /sub/foo
+RUN mkdir -p /out/sub && ln -s /out/sub /sub && ln -s out/sub /sub2 && echo -n "data" > /sub/foo
 FROM scratch
 COPY --from=build /sub/foo .
+COPY --from=build /sub2/foo bar
 `)
 
 	dir, err := tmpdir(


### PR DESCRIPTION
Fix handling of paths that contain symlinks in the parent components in the checksum calculation