### PR TITLE
Fix typo in error getting diff pairs

### DIFF
--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -158,7 +158,7 @@ func (ic *ImageWriter) exportLayers(ctx context.Context, refs ...cache.Immutable
 			eg.Go(func() error {
 				diffPairs, err := blobs.GetDiffPairs(ctx, ic.opt.ContentStore, ic.opt.Snapshotter, ic.opt.Differ, ref, true)
 				if err != nil {
-					return errors.Wrap(err, "failed calculaing diff pairs for exported snapshot")
+					return errors.Wrap(err, "failed calculating diff pairs for exported snapshot")
 				}
 				out[i] = diffPairs
 				return nil

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -286,7 +286,7 @@ func (w *Worker) Exporter(name string) (exporter.Exporter, error) {
 func (w *Worker) GetRemote(ctx context.Context, ref cache.ImmutableRef, createIfNeeded bool) (*solver.Remote, error) {
 	diffPairs, err := blobs.GetDiffPairs(ctx, w.ContentStore, w.Snapshotter, w.Differ, ref, createIfNeeded)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed calculaing diff pairs for exported snapshot")
+		return nil, errors.Wrap(err, "failed calculating diff pairs for exported snapshot")
 	}
 	if len(diffPairs) == 0 {
 		return nil, nil


### PR DESCRIPTION
Noticed a typo while trying to reproduce a bug (I think it's `COPY --chown` related).