### PR TITLE
imagerefchecker: fix concurrent map access

### DIFF
--- a/snapshot/imagerefchecker/checker.go
+++ b/snapshot/imagerefchecker/checker.go
@@ -90,9 +90,13 @@ func (c *checker) init() {
 		return
 	}
 
+	var mu sync.Mutex
+
 	for _, img := range imgs {
 		if err := images.Dispatch(context.TODO(), images.Handlers(layersHandler(c.opt.ContentStore, func(layers []specs.Descriptor) {
+			mu.Lock()
 			c.registerLayers(layers)
+			mu.Unlock()
 		})), img.Target); err != nil {
 			return
 		}


### PR DESCRIPTION
`images.Dispatch` calls handlers concurrently so the map access needs to be protected.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>