### PR TITLE
dockerfile: substitute build args in addition to env vars in RUN's CustomName

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -608,8 +608,10 @@ func dispatchRun(d *dispatchState, c *instructions.RunCommand, proxy *llb.ProxyE
 	if c.PrependShell {
 		args = withShell(d.image, args)
 	}
+	env := d.state.Env()
 	opt := []llb.RunOption{llb.Args(args)}
 	for _, arg := range d.buildArgs {
+		env = append(env, fmt.Sprintf("%s=%s", arg.Key, arg.ValueString()))
 		opt = append(opt, llb.AddEnv(arg.Key, arg.ValueString()))
 	}
 	opt = append(opt, dfCmd(c))
@@ -625,7 +627,7 @@ func dispatchRun(d *dispatchState, c *instructions.RunCommand, proxy *llb.ProxyE
 		return err
 	}
 	opt = append(opt, runMounts...)
-	opt = append(opt, llb.WithCustomName(prefixCommand(d, uppercaseCmd(processCmdEnv(dopt.shlex, c.String(), d.state.Run(opt...).Env())), d.prefixPlatform, d.state.GetPlatform())))
+	opt = append(opt, llb.WithCustomName(prefixCommand(d, uppercaseCmd(processCmdEnv(dopt.shlex, c.String(), env)), d.prefixPlatform, d.state.GetPlatform())))
 	for _, h := range dopt.extraHosts {
 		opt = append(opt, llb.AddExtraHost(h.Host, h.IP))
 	}


### PR DESCRIPTION
Example Dockerfile:
```
 FROM busybox
 ARG foo=abc
 ENV bar=def
 RUN echo $foo $bar $baz
```
Output without fix:
```
 #5 [2/2] RUN echo  def
 #5       digest: sha256:647df948c9689163efaf92b24b38779bc9f8b350482ecc3de3533f86a544c196
 #5         name: "[2/2] RUN echo  def "
 #5      started: 2018-09-29 19:01:11.376665368 +0000 UTC
 #5 0.764 abc def
 #5    completed: 2018-09-29 19:01:12.320141054 +0000 UTC
 #5     duration: 943.475686ms
```
Output with fix:
```
 #5 [2/2] RUN echo abc def
 #5       digest: sha256:647df948c9689163efaf92b24b38779bc9f8b350482ecc3de3533f86a544c196
 #5         name: "[2/2] RUN echo abc def "
 #5      started: 2018-09-29 19:01:11.376665368 +0000 UTC
 #5 0.764 abc def
 #5    completed: 2018-09-29 19:01:12.320141054 +0000 UTC
 #5     duration: 943.475686ms
```

Signed-off-by: Tibor Vass <tibor@docker.com>

**Notes**:
- Not sure how to write a test for this
- We could change the substitution logic (in the output only) to return `$baz` if `baz` was not defined, however I'm not convinced that is a good idea, as it feels like it's special-casing, and is not distinguishable from `\$baz`.

cc @tonistiigi 