### PR TITLE
dockerfile: fix building dfextall

### DIFF
--- a/frontend/dockerfile/instructions/commands_nosecrets.go
+++ b/frontend/dockerfile/instructions/commands_nosecrets.go
@@ -1,4 +1,4 @@
-// +build !dfsecrets
+// +build !dfsecrets,!dfextall
 
 package instructions
 

--- a/hack/test
+++ b/hack/test
@@ -13,4 +13,7 @@ docker run --rm -v /tmp --privileged $iid go test ${TESTFLAGS:--v} ${TESTPKGS:-.
 
 docker run --rm $iid go build ./frontend/gateway/client
 docker run --rm $iid go build ./frontend/dockerfile/cmd/dockerfile-frontend
+
 docker run --rm $iid go build -tags dfrunmount ./frontend/dockerfile/cmd/dockerfile-frontend
+docker run --rm $iid go build -tags "dfrunmount dfsecrets" ./frontend/dockerfile/cmd/dockerfile-frontend
+docker run --rm $iid go build -tags dfextall ./frontend/dockerfile/cmd/dockerfile-frontend


### PR DESCRIPTION
fixes #657

This is a temp fix. I'll do something better soon that also tests all variants.

I'm also ok with just removing `dfextall`, replacing it with a list of tags that we count as experimental and building with `-tags $(cat ./extalltags)`

@AkihiroSuda 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>