### PR TITLE
executor: fix spec incompatibilities

### DIFF
--- a/executor/oci/hosts.go
+++ b/executor/oci/hosts.go
@@ -13,7 +13,7 @@ import (
 )
 
 const hostsContent = `
-127.0.0.1	localhost
+127.0.0.1	localhost buildkitsandbox
 ::1	localhost ip6-localhost ip6-loopback
 `
 

--- a/executor/oci/spec_unix.go
+++ b/executor/oci/spec_unix.go
@@ -44,6 +44,7 @@ func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mou
 	s.Process.Args = meta.Args
 	s.Process.Env = meta.Env
 	s.Process.Cwd = meta.Cwd
+	s.Process.Rlimits = nil // reset open files limit
 	s.Hostname = "buildkitsandbox"
 
 	s.Mounts = GetMounts(ctx,

--- a/executor/oci/spec_unix.go
+++ b/executor/oci/spec_unix.go
@@ -44,6 +44,7 @@ func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mou
 	s.Process.Args = meta.Args
 	s.Process.Env = meta.Env
 	s.Process.Cwd = meta.Cwd
+	s.Hostname = "buildkitsandbox"
 
 	s.Mounts = GetMounts(ctx,
 		withROBind(resolvConf, "/etc/resolv.conf"),

--- a/executor/oci/spec_unix.go
+++ b/executor/oci/spec_unix.go
@@ -49,6 +49,14 @@ func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mou
 		withROBind(resolvConf, "/etc/resolv.conf"),
 		withROBind(hostsFile, "/etc/hosts"),
 	)
+
+	s.Mounts = append(s.Mounts, specs.Mount{
+		Destination: "/sys/fs/cgroup",
+		Type:        "cgroup",
+		Source:      "cgroup",
+		Options:     []string{"ro", "nosuid", "noexec", "nodev"},
+	})
+
 	// TODO: User
 
 	sm := &submounts{}

--- a/solver/pb/caps.go
+++ b/solver/pb/caps.go
@@ -41,6 +41,7 @@ const (
 	CapExecMountTmpfs          apicaps.CapID = "exec.mount.tmpfs"
 	CapExecMountSecret         apicaps.CapID = "exec.mount.secret"
 	CapExecMountSSH            apicaps.CapID = "exec.mount.ssh"
+	CapExecCgroupsMounted      apicaps.CapID = "exec.cgroup"
 
 	CapConstraints apicaps.CapID = "constraints"
 	CapPlatform    apicaps.CapID = "platform"
@@ -215,6 +216,12 @@ func init() {
 
 	Caps.Init(apicaps.Cap{
 		ID:      CapExecMountSSH,
+		Enabled: true,
+		Status:  apicaps.CapStatusExperimental,
+	})
+
+	Caps.Init(apicaps.Cap{
+		ID:      CapExecCgroupsMounted,
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})


### PR DESCRIPTION
FIx problems from where containerd and moby default spec differ
- cgroups not mounted inside container
- hostname not set and not resolvable
- constant open file limit (fixes #643)