### PR TITLE
update rootlesskit

### DIFF
--- a/hack/dockerfiles/test.Dockerfile
+++ b/hack/dockerfiles/test.Dockerfile
@@ -5,7 +5,7 @@ ARG CONTAINERD10_VERSION=v1.0.3
 # available targets: buildkitd, buildkitd.oci_only, buildkitd.containerd_only
 ARG BUILDKIT_TARGET=buildkitd
 ARG REGISTRY_VERSION=2.6
-ARG ROOTLESSKIT_VERSION=20b0fc24b305b031a61ef1a1ca456aadafaf5e77
+ARG ROOTLESSKIT_VERSION=d843aadf00d72082fd7a31572ef018d1e792535f
 
 # The `buildkitd` stage and the `buildctl` stage are placed here
 # so that they can be built quickly with legacy DAG-unaware `docker build --target=...`


### PR DESCRIPTION
For fix subgid interpretation (rootless-containers/rootlesskit@7c48b83f9cf2275a2029559af8f06cf1863b371c)

Full changes: https://github.com/rootless-containers/rootlesskit/compare/20b0fc...d843aa

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>