### PR TITLE
solver: fix opentracing providers

### DIFF
--- a/util/tracing/multispan.go
+++ b/util/tracing/multispan.go
@@ -1,0 +1,22 @@
+package tracing
+
+import (
+	opentracing "github.com/opentracing/opentracing-go"
+)
+
+// MultiSpan allows shared tracing to multiple spans.
+// TODO: This is a temporary solution and doesn't really support shared tracing yet. Instead the first always wins.
+
+type MultiSpan struct {
+	opentracing.Span
+}
+
+func NewMultiSpan() *MultiSpan {
+	return &MultiSpan{}
+}
+
+func (ms *MultiSpan) Add(s opentracing.Span) {
+	if ms.Span == nil {
+		ms.Span = s
+	}
+}


### PR DESCRIPTION
Some opentracing providers were lost with the solver refactor. This adds back the previous support.

Sharing a trace for 2 parallel jobs waiting on the same vertex is still not supported. In this case, the first job wins and span would only be logged for it.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>