### PR TITLE
dockerfile: change output when loading Dockerfile

### DIFF
--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -96,10 +96,7 @@ func Build(ctx context.Context, c client.Client) (*client.Result, error) {
 		}
 	}
 
-	name := "load Dockerfile"
-	if filename != "Dockerfile" {
-		name += " from " + filename
-	}
+	name := "load build definition from " + filename
 
 	src := llb.Local(LocalNameDockerfile,
 		llb.IncludePatterns([]string{filename}),


### PR DESCRIPTION
Previously, the output said "load Dockerfile from " + filename when the
file is not named Dockerfile. With this patch, it is changed to always
show "load build definition from " + filename.

This is because `# syntax = ...` can be put in non-Dockerfiles.

Signed-off-by: Tibor Vass <tibor@docker.com>