### PR TITLE
solver: specify SSH key ID in error message when required key was not forwarded

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -157,7 +157,7 @@ func testSSHMount(t *testing.T, sb integration.Sandbox) {
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{}, nil)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "no ssh forwarded from the client")
+	require.Contains(t, err.Error(), "no SSH key ")
 
 	// custom ID not exposed
 	st = llb.Image("busybox:latest").Run(llb.Shlex(`nosuchcmd`), llb.AddSSHSocket(llb.SSHID("customID")))

--- a/solver/llbsolver/ops/exec.go
+++ b/solver/llbsolver/ops/exec.go
@@ -302,7 +302,7 @@ func (e *execOp) getSSHMountable(ctx context.Context, m *pb.Mount) (cache.Mounta
 			return nil, nil
 		}
 		if st, ok := status.FromError(err); ok && st.Code() == codes.Unimplemented {
-			return nil, errors.Errorf("no ssh forwarded from the client")
+			return nil, errors.Errorf("no SSH key %q forwarded from the client", m.SSHOpt.ID)
 		}
 		return nil, err
 	}


### PR DESCRIPTION

Signed-off-by: Tibor Vass <tibor@docker.com>