### PR TITLE
fix setting uncompressed label on content

### DIFF
--- a/cache/blobs/blobs.go
+++ b/cache/blobs/blobs.go
@@ -115,7 +115,7 @@ func getDiffPairs(ctx context.Context, contentStore content.Store, snapshotter s
 			}
 			diffIDStr, ok := info.Labels[containerdUncompressed]
 			if !ok {
-				return nil, errors.Errorf("invalid differ response with no diffID")
+				return nil, errors.Errorf("invalid differ response with no diffID: %v", descr.Digest)
 			}
 			diffIDDigest, err := digest.Parse(diffIDStr)
 			if err != nil {

--- a/snapshot/blobmapping/snapshotter.go
+++ b/snapshot/blobmapping/snapshotter.go
@@ -107,9 +107,20 @@ func (s *Snapshotter) GetBlob(ctx context.Context, key string) (digest.Digest, d
 // Checks that there is a blob in the content store.
 // If same blob has already been set then this is a noop.
 func (s *Snapshotter) SetBlob(ctx context.Context, key string, diffID, blobsum digest.Digest) error {
-	_, err := s.opt.Content.Info(ctx, blobsum)
+	info, err := s.opt.Content.Info(ctx, blobsum)
 	if err != nil {
 		return err
+	}
+	if _, ok := info.Labels["containerd.io/uncompressed"]; !ok {
+		labels := map[string]string{
+			"containerd.io/uncompressed": diffID.String(),
+		}
+		if _, err := s.opt.Content.Update(ctx, content.Info{
+			Digest: blobsum,
+			Labels: labels,
+		}, "labels.containerd.io/uncompressed"); err != nil {
+			return err
+		}
 	}
 	md, _ := s.opt.MetadataStore.Get(key)
 

--- a/util/pull/pull.go
+++ b/util/pull/pull.go
@@ -241,8 +241,7 @@ func unpack(ctx context.Context, desc ocispec.Descriptor, cs content.Store, csh 
 	var chain []digest.Digest
 	for _, layer := range layers {
 		labels := map[string]string{
-			"containerd.io/gc.root":      time.Now().UTC().Format(time.RFC3339Nano),
-			"containerd.io/uncompressed": layer.Diff.Digest.String(),
+			"containerd.io/gc.root": time.Now().UTC().Format(time.RFC3339Nano),
 		}
 		if _, err := rootfs.ApplyLayer(ctx, layer, chain, csh, applier, ctdsnapshot.WithLabels(labels)); err != nil {
 			return "", err

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -388,10 +388,7 @@ func (w *Worker) unpack(ctx context.Context, descs []ocispec.Descriptor, s cdsna
 
 	var chain []digest.Digest
 	for _, layer := range layers {
-		labels := map[string]string{
-			"containerd.io/uncompressed": layer.Diff.Digest.String(),
-		}
-		if _, err := rootfs.ApplyLayer(ctx, layer, chain, s, w.Applier, cdsnapshot.WithLabels(labels)); err != nil {
+		if _, err := rootfs.ApplyLayer(ctx, layer, chain, s, w.Applier); err != nil {
 			return nil, err
 		}
 		chain = append(chain, layer.Diff.Digest)


### PR DESCRIPTION
Uncompressed label was set on a wrong object. There is still a possible race left where differ could match a blob before the label update has run. But that needs a containerd fix in the differ.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>