### PR TITLE
configurable registry ca certificates

### DIFF
--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -40,7 +40,7 @@ type GRPCConfig struct {
 type RegistryConfig struct {
 	Mirrors   []string `toml:"mirrors"`
 	PlainHTTP bool     `toml:"http"`
-	ExtraCA   string   `toml:"ca"`
+	ExtraCA   string   `toml:"extraca"`
 }
 
 type TLSConfig struct {
@@ -110,7 +110,7 @@ func (cfg Config) checkFileReferences() error {
 	for _, file := range fileReferences {
 		if file != "" {
 			if err := checkFile(file); err != nil {
-				return errors.Wrapf(err, "file '%v' not valid", file)
+				return errors.Wrapf(err, "file '%v' from config is not readable", file)
 			}
 		}
 	}

--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -40,7 +40,7 @@ type GRPCConfig struct {
 type RegistryConfig struct {
 	Mirrors   []string `toml:"mirrors"`
 	PlainHTTP bool     `toml:"http"`
-	CA        string   `toml:"ca"`
+	ExtraCA   string   `toml:"ca"`
 }
 
 type TLSConfig struct {

--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -40,6 +40,7 @@ type GRPCConfig struct {
 type RegistryConfig struct {
 	Mirrors   []string `toml:"mirrors"`
 	PlainHTTP bool     `toml:"http"`
+	CA        string   `toml:"ca"`
 }
 
 type TLSConfig struct {

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -525,7 +525,7 @@ func resolverFunc(cfg *config.Config) resolver.ResolveOptionsFunc {
 		m[k] = resolver.RegistryConf{
 			Mirrors:   v.Mirrors,
 			PlainHTTP: v.PlainHTTP,
-			CA:        v.CA,
+			ExtraCA:   v.ExtraCA,
 		}
 	}
 	return resolver.NewResolveOptionsFunc(m)

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -525,6 +525,7 @@ func resolverFunc(cfg *config.Config) resolver.ResolveOptionsFunc {
 		m[k] = resolver.RegistryConf{
 			Mirrors:   v.Mirrors,
 			PlainHTTP: v.PlainHTTP,
+			CA:        v.CA,
 		}
 	}
 	return resolver.NewResolveOptionsFunc(m)

--- a/util/resolver/resolver.go
+++ b/util/resolver/resolver.go
@@ -17,7 +17,7 @@ import (
 type RegistryConf struct {
 	Mirrors   []string
 	PlainHTTP bool
-	CA        string
+	ExtraCA   string
 }
 
 type ResolveOptionsFunc func(string) docker.ResolverOptions
@@ -45,15 +45,15 @@ func NewResolveOptionsFunc(m map[string]RegistryConf) ResolveOptionsFunc {
 			}
 		}
 
-		if c.CA != "" {
+		if c.ExtraCA != "" {
 			// if a CA is specified for this registry, add it to the trusted CA pool.
 			rootCAs, _ := x509.SystemCertPool()
 			if rootCAs == nil {
 				rootCAs = x509.NewCertPool()
 			}
-			certs, err := ioutil.ReadFile(c.CA)
+			certs, err := ioutil.ReadFile(c.ExtraCA)
 			if err != nil {
-				log.Fatalf("Failed to append %q to RootCAs: %v", c.CA, err)
+				log.Fatalf("Failed to append %q to RootCAs: %v", c.ExtraCA, err)
 			}
 			if ok := rootCAs.AppendCertsFromPEM(certs); !ok {
 				log.Println("No certs appended, using system certs only")

--- a/util/resolver/resolver.go
+++ b/util/resolver/resolver.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"io/ioutil"
-	"log"
 	"math/rand"
 	"net/http"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/moby/buildkit/util/tracing"
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
+	"github.com/sirupsen/logrus"
 )
 
 type RegistryConf struct {
@@ -53,10 +53,10 @@ func NewResolveOptionsFunc(m map[string]RegistryConf) ResolveOptionsFunc {
 			}
 			certs, err := ioutil.ReadFile(c.ExtraCA)
 			if err != nil {
-				log.Fatalf("Failed to append %q to RootCAs: %v", c.ExtraCA, err)
+				logrus.Errorf("Failed to append %q to RootCAs: %v", c.ExtraCA, err)
 			}
 			if ok := rootCAs.AppendCertsFromPEM(certs); !ok {
-				log.Println("No certs appended, using system certs only")
+				logrus.Infof("No certs appended, using system certs only")
 			}
 			config := &tls.Config{
 				RootCAs: rootCAs,


### PR DESCRIPTION
**What**

This PR adds the possibility to specify a CA certificate to be used to verify the authenticity of a registry.

* add config option in RegistryConfig
* add handling in util/resolver to patch the transport with the appropriate TLS config

**Why**

I need a way to push to a registry which is secured using a self signed certificate.