### PR TITLE
testutil: avoid excessive daemons in integration tests

### DIFF
--- a/client/build_test.go
+++ b/client/build_test.go
@@ -27,7 +27,6 @@ func TestClientGatewayIntegration(t *testing.T) {
 }
 
 func testClientGatewaySolve(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	requiresLinux(t)
 
 	ctx := context.TODO()
@@ -102,7 +101,6 @@ func testClientGatewaySolve(t *testing.T, sb integration.Sandbox) {
 }
 
 func testClientGatewayFailedSolve(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	requiresLinux(t)
 
 	ctx := context.TODO()
@@ -121,7 +119,6 @@ func testClientGatewayFailedSolve(t *testing.T, sb integration.Sandbox) {
 }
 
 func testClientGatewayEmptySolve(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	requiresLinux(t)
 
 	ctx := context.TODO()
@@ -146,7 +143,6 @@ func testClientGatewayEmptySolve(t *testing.T, sb integration.Sandbox) {
 }
 
 func testNoBuildID(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	requiresLinux(t)
 
 	ctx := context.TODO()
@@ -162,7 +158,6 @@ func testNoBuildID(t *testing.T, sb integration.Sandbox) {
 }
 
 func testUnknownBuildID(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	requiresLinux(t)
 
 	ctx := context.TODO()

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -94,7 +94,6 @@ func testHostnameLookup(t *testing.T, sb integration.Sandbox) {
 	if sb.Rootless() {
 		t.SkipNow()
 	}
-	t.Parallel()
 
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
@@ -111,8 +110,6 @@ func testHostnameLookup(t *testing.T, sb integration.Sandbox) {
 
 // moby/buildkit#614
 func testStdinClosed(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
-
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -127,8 +124,6 @@ func testStdinClosed(t *testing.T, sb integration.Sandbox) {
 }
 
 func testSSHMount(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
-
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -283,8 +278,6 @@ func testSSHMount(t *testing.T, sb integration.Sandbox) {
 }
 
 func testExtraHosts(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
-
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -300,8 +293,6 @@ func testExtraHosts(t *testing.T, sb integration.Sandbox) {
 }
 
 func testNetworkMode(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
-
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -331,7 +322,6 @@ func testNetworkMode(t *testing.T, sb integration.Sandbox) {
 
 func testFrontendImageNaming(t *testing.T, sb integration.Sandbox) {
 	requiresLinux(t)
-	t.Parallel()
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -480,8 +470,6 @@ func testFrontendImageNaming(t *testing.T, sb integration.Sandbox) {
 }
 
 func testSecretMounts(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
-
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -541,7 +529,6 @@ func testSecretMounts(t *testing.T, sb integration.Sandbox) {
 }
 
 func testTmpfsMounts(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	requiresLinux(t)
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
@@ -558,7 +545,6 @@ func testTmpfsMounts(t *testing.T, sb integration.Sandbox) {
 }
 
 func testLocalSymlinkEscape(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	requiresLinux(t)
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
@@ -616,7 +602,6 @@ func testLocalSymlinkEscape(t *testing.T, sb integration.Sandbox) {
 }
 
 func testRelativeWorkDir(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	requiresLinux(t)
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
@@ -647,7 +632,6 @@ func testRelativeWorkDir(t *testing.T, sb integration.Sandbox) {
 }
 
 func testCallDiskUsage(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -656,7 +640,6 @@ func testCallDiskUsage(t *testing.T, sb integration.Sandbox) {
 }
 
 func testBuildMultiMount(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	requiresLinux(t)
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
@@ -678,8 +661,6 @@ func testBuildMultiMount(t *testing.T, sb integration.Sandbox) {
 }
 
 func testBuildHTTPSource(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
-
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -767,7 +748,6 @@ func testBuildHTTPSource(t *testing.T, sb integration.Sandbox) {
 
 func testResolveAndHosts(t *testing.T, sb integration.Sandbox) {
 	requiresLinux(t)
-	t.Parallel()
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -807,7 +787,6 @@ func testResolveAndHosts(t *testing.T, sb integration.Sandbox) {
 
 func testUser(t *testing.T, sb integration.Sandbox) {
 	requiresLinux(t)
-	t.Parallel()
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -860,7 +839,6 @@ func testUser(t *testing.T, sb integration.Sandbox) {
 
 func testOCIExporter(t *testing.T, sb integration.Sandbox) {
 	requiresLinux(t)
-	t.Parallel()
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -960,7 +938,6 @@ func testOCIExporter(t *testing.T, sb integration.Sandbox) {
 
 func testFrontendMetadataReturn(t *testing.T, sb integration.Sandbox) {
 	requiresLinux(t)
-	t.Parallel()
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -988,7 +965,6 @@ func testFrontendMetadataReturn(t *testing.T, sb integration.Sandbox) {
 
 func testBuildPushAndValidate(t *testing.T, sb integration.Sandbox) {
 	requiresLinux(t)
-	t.Parallel()
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -1182,8 +1158,6 @@ func testBuildPushAndValidate(t *testing.T, sb integration.Sandbox) {
 
 func testBasicCacheImportExport(t *testing.T, sb integration.Sandbox) {
 	requiresLinux(t)
-	t.Parallel()
-
 	registry, err := sb.NewRegistry()
 	if errors.Cause(err) == integration.ErrorRequirements {
 		t.Skip(err.Error())
@@ -1254,7 +1228,6 @@ func testBasicCacheImportExport(t *testing.T, sb integration.Sandbox) {
 
 func testCachedMounts(t *testing.T, sb integration.Sandbox) {
 	requiresLinux(t)
-	t.Parallel()
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -1316,7 +1289,6 @@ func testCachedMounts(t *testing.T, sb integration.Sandbox) {
 
 func testSharedCacheMounts(t *testing.T, sb integration.Sandbox) {
 	requiresLinux(t)
-	t.Parallel()
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -1341,7 +1313,6 @@ func testSharedCacheMounts(t *testing.T, sb integration.Sandbox) {
 
 func testLockedCacheMounts(t *testing.T, sb integration.Sandbox) {
 	requiresLinux(t)
-	t.Parallel()
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -1366,7 +1337,6 @@ func testLockedCacheMounts(t *testing.T, sb integration.Sandbox) {
 
 func testDuplicateCacheMount(t *testing.T, sb integration.Sandbox) {
 	requiresLinux(t)
-	t.Parallel()
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -1387,7 +1357,6 @@ func testDuplicateCacheMount(t *testing.T, sb integration.Sandbox) {
 // containerd/containerd#2119
 func testDuplicateWhiteouts(t *testing.T, sb integration.Sandbox) {
 	requiresLinux(t)
-	t.Parallel()
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -1455,7 +1424,6 @@ func testDuplicateWhiteouts(t *testing.T, sb integration.Sandbox) {
 // #276
 func testWhiteoutParentDir(t *testing.T, sb integration.Sandbox) {
 	requiresLinux(t)
-	t.Parallel()
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -1517,7 +1485,6 @@ func testWhiteoutParentDir(t *testing.T, sb integration.Sandbox) {
 
 // #296
 func testSchema1Image(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -1535,7 +1502,6 @@ func testSchema1Image(t *testing.T, sb integration.Sandbox) {
 
 // #319
 func testMountWithNoSource(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -1565,7 +1531,6 @@ func testMountWithNoSource(t *testing.T, sb integration.Sandbox) {
 
 // #324
 func testReadonlyRootFS(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -1593,8 +1558,6 @@ func testReadonlyRootFS(t *testing.T, sb integration.Sandbox) {
 }
 
 func testProxyEnv(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
-
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -1754,7 +1717,6 @@ loop0:
 
 func testInvalidExporter(t *testing.T, sb integration.Sandbox) {
 	requiresLinux(t)
-	t.Parallel()
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -1809,7 +1771,6 @@ func testInvalidExporter(t *testing.T, sb integration.Sandbox) {
 
 // moby/buildkit#492
 func testParallelLocalBuilds(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 

--- a/cmd/buildctl/build_test.go
+++ b/cmd/buildctl/build_test.go
@@ -20,7 +20,6 @@ import (
 )
 
 func testBuildWithLocalFiles(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	dir, err := tmpdir(
 		fstest.CreateFile("foo", []byte("bar"), 0600),
 	)
@@ -44,7 +43,6 @@ func testBuildWithLocalFiles(t *testing.T, sb integration.Sandbox) {
 }
 
 func testBuildLocalExporter(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	st := llb.Image("busybox").
 		Run(llb.Shlex("sh -c 'echo -n bar > /out/foo'"))
 
@@ -69,8 +67,6 @@ func testBuildLocalExporter(t *testing.T, sb integration.Sandbox) {
 }
 
 func testBuildContainerdExporter(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
-
 	var cdAddress string
 	if cd, ok := sb.(interface {
 		ContainerdAddress() string

--- a/cmd/buildctl/buildctl_test.go
+++ b/cmd/buildctl/buildctl_test.go
@@ -21,8 +21,6 @@ func TestCLIIntegration(t *testing.T) {
 }
 
 func testUsage(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
-
 	require.NoError(t, sb.Cmd().Run())
 
 	require.NoError(t, sb.Cmd("--help").Run())

--- a/cmd/buildctl/diskusage_test.go
+++ b/cmd/buildctl/diskusage_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func testDiskUsage(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	cmd := sb.Cmd("du")
 	err := cmd.Run()
 	assert.NoError(t, err)

--- a/cmd/buildctl/prune_test.go
+++ b/cmd/buildctl/prune_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func testPrune(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	cmd := sb.Cmd("prune")
 	err := cmd.Run()
 	assert.NoError(t, err)

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -119,7 +119,6 @@ func TestIntegration(t *testing.T) {
 }
 
 func testCopyChownCreateDest(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -149,7 +148,6 @@ RUN [ "$(stat -c "%U %G" /dest)" == "user user" ]
 }
 
 func testCopyThroughSymlinkContext(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -190,7 +188,6 @@ COPY link/foo .
 }
 
 func testCopyThroughSymlinkMultiStage(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -231,7 +228,6 @@ COPY --from=build /sub2/foo bar
 }
 
 func testIgnoreEntrypoint(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -260,7 +256,6 @@ RUN ["ls"]
 }
 
 func testQuotedMetaArgs(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -304,7 +299,6 @@ COPY --from=build /out .
 }
 
 func testExportMultiPlatform(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -437,7 +431,6 @@ COPY arch-$TARGETARCH whoami
 
 // tonistiigi/fsutil#46
 func testContextChangeDirToFile(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -492,7 +485,6 @@ COPY foo /
 }
 
 func testNoSnapshotLeak(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -537,7 +529,6 @@ COPY foo /
 }
 
 func testCopySymlinks(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -575,7 +566,6 @@ COPY sub/l* alllinks/
 }
 
 func testHTTPDockerfile(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -627,7 +617,6 @@ COPY --from=0 /foo /foo
 }
 
 func testCmdShell(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	var cdAddress string
@@ -716,7 +705,6 @@ ENTRYPOINT my entrypoint
 }
 
 func testPullScratch(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	var cdAddress string
@@ -837,7 +825,6 @@ COPY foo .
 }
 
 func testGlobalArg(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -868,7 +855,6 @@ FROM busybox:${tag}
 }
 
 func testDockerfileDirs(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 	f.RequiresBuildctl(t)
 
@@ -937,7 +923,6 @@ func testDockerfileDirs(t *testing.T, sb integration.Sandbox) {
 }
 
 func testDockerfileInvalidCommand(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 	f.RequiresBuildctl(t)
 	dockerfile := []byte(`
@@ -964,7 +949,6 @@ func testDockerfileInvalidCommand(t *testing.T, sb integration.Sandbox) {
 }
 
 func testDockerfileADDFromURL(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 	f.RequiresBuildctl(t)
 
@@ -1047,7 +1031,6 @@ ADD %s /dest/
 }
 
 func testDockerfileAddArchive(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 	f.RequiresBuildctl(t)
 
@@ -1217,7 +1200,6 @@ ADD %s /newname.tar.gz
 }
 
 func testSymlinkDestination(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 	f.RequiresBuildctl(t)
 
@@ -1273,7 +1255,6 @@ func testDockerfileScratchConfig(t *testing.T, sb integration.Sandbox) {
 		cdAddress = cd.ContainerdAddress()
 	}
 
-	t.Parallel()
 	f := getFrontend(t, sb)
 	f.RequiresBuildctl(t)
 	dockerfile := []byte(`
@@ -1336,7 +1317,6 @@ ENV foo=bar
 }
 
 func testExposeExpansion(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -1412,7 +1392,6 @@ EXPOSE 5000
 }
 
 func testDockerignore(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -1482,7 +1461,6 @@ Dockerfile
 }
 
 func testDockerignoreInvalid(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -1520,7 +1498,6 @@ COPY . .
 }
 
 func testExportedHistory(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 	f.RequiresBuildctl(t)
 
@@ -1600,7 +1577,6 @@ func testUser(t *testing.T, sb integration.Sandbox) {
 		t.Skip("only for rootful worker, due to lack of support for additional gids (https://github.com/opencontainers/runc/issues/1835)")
 	}
 
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -1741,7 +1717,6 @@ USER nobody
 }
 
 func testCopyChown(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -1792,7 +1767,6 @@ COPY --from=base /out /
 }
 
 func testCopyOverrideFiles(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -1844,7 +1818,6 @@ COPY files dest
 }
 
 func testCopyVarSubstitution(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -1885,7 +1858,6 @@ COPY $FOO baz
 }
 
 func testCopyWildcards(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -1973,7 +1945,6 @@ COPY sub/dir1 subdest6
 }
 
 func testDockerfileFromGit(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	gitDir, err := ioutil.TempDir("", "buildkit")
@@ -2066,7 +2037,6 @@ COPY --from=build foo bar2
 }
 
 func testDockerfileFromHTTP(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	buf := bytes.NewBuffer(nil)
@@ -2126,7 +2096,6 @@ COPY foo bar
 }
 
 func testMultiStageImplicitFrom(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -2198,7 +2167,6 @@ COPY --from=golang /usr/bin/go go
 }
 
 func testMultiStageCaseInsensitive(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -2243,7 +2211,6 @@ COPY --from=stage1 baz bax
 }
 
 func testLabels(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -2318,7 +2285,6 @@ LABEL foo=bar
 }
 
 func testCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	registry, err := sb.NewRegistry()
@@ -2408,7 +2374,6 @@ COPY --from=base unique /
 }
 
 func testReproducibleIDs(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -2487,7 +2452,6 @@ func testImportExportReproducibleIDs(t *testing.T, sb integration.Sandbox) {
 		cdAddress = cd.ContainerdAddress()
 	}
 
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	registry, err := sb.NewRegistry()
@@ -2568,7 +2532,6 @@ RUN echo bar > bar
 }
 
 func testNoCache(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -2653,7 +2616,6 @@ COPY --from=s1 unique2 /
 }
 
 func testPlatformArgsImplicit(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(fmt.Sprintf(`
@@ -2701,7 +2663,6 @@ COPY foo2 bar2
 }
 
 func testPlatformArgsExplicit(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -2753,7 +2714,6 @@ COPY --from=build out .
 }
 
 func testBuiltinArgs(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`

--- a/frontend/frontend_test.go
+++ b/frontend/frontend_test.go
@@ -32,7 +32,6 @@ func TestFrontendIntegration(t *testing.T) {
 }
 
 func testRefReadFile(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	ctx := context.TODO()
 
 	c, err := client.New(ctx, sb.Address())
@@ -98,7 +97,6 @@ func testRefReadFile(t *testing.T, sb integration.Sandbox) {
 }
 
 func testRefReadDir(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	ctx := context.TODO()
 
 	c, err := client.New(ctx, sb.Address())
@@ -215,7 +213,6 @@ func testRefReadDir(t *testing.T, sb integration.Sandbox) {
 }
 
 func testRefStatFile(t *testing.T, sb integration.Sandbox) {
-	t.Parallel()
 	ctx := context.TODO()
 
 	c, err := client.New(ctx, sb.Address())


### PR DESCRIPTION
Rework integration tests so that it does not create too many daemon helper processes. When `t.Parallel()` is reached currently it would pause the test and put it into a queue for future execution, but because daemons are already started at this point it will create a lot of new daemon instances. Change is to automatically make all integration tests parallel and run the initialization code after test already has resumed. If some test in the future requires to be run without `t.Parallel()` it can do so by making its name end with `NoParallel` suffix.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>