### PR TITLE
llbsolver: keep session for context calls

### DIFF
--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -171,6 +171,7 @@ func (sb *subBuilder) Build(ctx context.Context, e Edge) (CachedResult, error) {
 }
 
 func (sb *subBuilder) Context(ctx context.Context) context.Context {
+	ctx = session.NewContext(ctx, sb.state.getSessionID())
 	return opentracing.ContextWithSpan(progress.WithProgress(ctx, sb.mpw), sb.mspan)
 }
 
@@ -475,6 +476,7 @@ func (j *Job) Discard() error {
 }
 
 func (j *Job) Context(ctx context.Context) context.Context {
+	ctx = session.NewContext(ctx, j.SessionID)
 	return progress.WithProgress(ctx, j.pw)
 }
 


### PR DESCRIPTION
The op methods set session from vertex to the context before calling but it was missing for the one-off calls in vertex context. Most notably `ResolveImageConfig` is called this way, meaning that when called to the gateway frontend the session was lost and authentication didn't work for that call.

Reported in https://github.com/moby/buildkit/issues/720#issuecomment-438911728

Note that fix actually disables a workaround for grc.io authentication because a side effect of this bug caused manifest and blob pulls happen together.


Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>