### PR TITLE
buildctl: allow import-cache on frontend builds

### DIFF
--- a/cmd/buildctl/build.go
+++ b/cmd/buildctl/build.go
@@ -221,6 +221,10 @@ func build(clicontext *cli.Context) error {
 		solveOpt.FrontendAttrs["no-cache"] = ""
 	}
 
+	if clicontext.String("frontend") != "" && len(clicontext.StringSlice("import-cache")) != 0 {
+		solveOpt.FrontendAttrs["cache-from"] = strings.Join(clicontext.StringSlice("import-cache"), ",")
+	}
+
 	eg.Go(func() error {
 		resp, err := c.Solve(ctx, def, solveOpt, ch)
 		if err != nil {


### PR DESCRIPTION
Allow `--import-cache` on frontends similarily to #708

Related to #723

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>