### PR TITLE
oci: avoid nonewprivileges in default spec

### DIFF
--- a/executor/oci/spec_unix.go
+++ b/executor/oci/spec_unix.go
@@ -44,7 +44,8 @@ func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mou
 	s.Process.Args = meta.Args
 	s.Process.Env = meta.Env
 	s.Process.Cwd = meta.Cwd
-	s.Process.Rlimits = nil // reset open files limit
+	s.Process.Rlimits = nil           // reset open files limit
+	s.Process.NoNewPrivileges = false // reset nonewprivileges
 	s.Hostname = "buildkitsandbox"
 
 	s.Mounts = GetMounts(ctx,


### PR DESCRIPTION
Docker and containerd defaults differ here. Use Docker value for compatibility.

fixes #744

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>