### PR TITLE
support --oci-worker-no-process-sandbox

### DIFF
--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -49,12 +49,13 @@ type TLSConfig struct {
 }
 
 type OCIConfig struct {
-	Enabled     *bool             `toml:"enabled"`
-	Labels      map[string]string `toml:"labels"`
-	Platforms   []string          `toml:"platforms"`
-	Snapshotter string            `toml:"snapshotter"`
-	Rootless    bool              `toml:"rootless"`
-	GCPolicy    []GCPolicy        `toml:"gcpolicy"`
+	Enabled          *bool             `toml:"enabled"`
+	Labels           map[string]string `toml:"labels"`
+	Platforms        []string          `toml:"platforms"`
+	Snapshotter      string            `toml:"snapshotter"`
+	Rootless         bool              `toml:"rootless"`
+	NoProcessSandbox bool              `toml:"noProcessSandbox"`
+	GCPolicy         []GCPolicy        `toml:"gcpolicy"`
 }
 
 type ContainerdConfig struct {

--- a/docs/rootless.md
+++ b/docs/rootless.md
@@ -6,7 +6,6 @@ Requirements:
 - RHEL/CentOS 7 requires `sudo sh -c "echo 28633 > /proc/sys/user/max_user_namespaces"`. You may also need `sudo grubby --args="namespace.unpriv_enable=1 user_namespace.enable=1" --update-kernel="$(grubby --default-kernel)"`.
 - `newuidmap` and `newgidmap` need to be installed on the host. These commands are provided by the `uidmap` package. For RHEL/CentOS 7, RPM is not officially provided but available at https://copr.fedorainfracloud.org/coprs/vbatts/shadow-utils-newxidmap/ .
 - `/etc/subuid` and `/etc/subgid` should contain >= 65536 sub-IDs. e.g. `penguin:231072:65536`.
-- To run in a Docker container with non-root `USER`, `docker run --privileged` is still required. See also Jessie's blog: https://blog.jessfraz.com/post/building-container-images-securely-on-kubernetes/
 
 
 ## Set up
@@ -63,8 +62,29 @@ Docker image is available as [`moby/buildkit:rootless`](https://hub.docker.com/r
 $ docker run --name buildkitd -d --privileged -p 1234:1234  moby/buildkit:rootless --addr tcp://0.0.0.0:1234
 ```
 
-`docker run` requires `--privileged` but the BuildKit daemon is executed as a normal user.
-See [`docker/cli#1347`](https://github.com/docker/cli/pull/1347) for the ongoing work to remove this requirement
+```
+$ go get ./examples/build-using-dockerfile
+$ build-using-dockerfile --buildkit-addr tcp://127.0.0.1:1234 -t foo /path/to/somewhere
+```
+
+### Security consideration
+
+Although `moby/buildkit:rootless` executes the BuildKit daemon as a normal user, `docker run` still requires `--privileged`.
+This is to allow build executor containers to mount `/proc`, by providing "unmasked" `/proc` to the BuildKit daemon container.
+
+See [`docker/cli#1347`](https://github.com/docker/cli/pull/1347) for the ongoing work to remove this requirement.
+See also [Disabling process sandbox](#disabling-process-sandbox).
+
+#### UID/GID
+
+The `moby/buildkit:rootless` image has the following UID/GID configuration:
+
+Actual ID (shown in the host and the BuildKit daemon container)| Mapped ID (shown in build executor containers)
+----------|----------
+1000      | 0
+100000    | 1
+...       | ...
+165535    | 65536
 
 ```
 $ docker exec buildkitd id
@@ -75,9 +95,91 @@ PID   USER     TIME   COMMAND
    13 user       0:00 /proc/self/exe buildkitd --addr tcp://0.0.0.0:1234
    21 user       0:00 buildkitd --addr tcp://0.0.0.0:1234
    29 user       0:00 ps aux
+$ docker exec cat /etc/subuid
+user:100000:65536
 ```
 
+To change the UID/GID configuration, you need to modify and build the BuildKit image manually.
 ```
-$ go get ./examples/build-using-dockerfile
-$ build-using-dockerfile --buildkit-addr tcp://127.0.0.1:1234 -t foo /path/to/somewhere
+$ vi hack/dockerfiles/test.Dockerfile
+$ docker build -t buildkit-rootless-custom --target rootless -f hack/dockerfiles/test.Dockerfile .
 ```
+
+#### Disabling process sandbox
+
+By passing `--oci-worker-no-process-sandbox` to the `buildkitd` arguments, BuildKit can be executed in a container without `--privileged`.
+However, you still need to pass `--security-opt seccomp=unconfined --security-opt apparmor=unconfined` to `docker run`.
+
+```
+$ docker run --name buildkitd -d --security-opt seccomp=unconfined --security-opt apparmor=unconfined -p 1234:1234 moby/buildkit:rootless --addr tcp://0.0.0.0:1234 --oci-worker-no-process-sandbox
+```
+
+Note that `--oci-worker-no-process-sandbox` allows build executor containers to `kill` (and potentially `ptrace` depending on the seccomp configuration) an arbitrary process in the BuildKit daemon container.
+
+
+## Set up (using Kubernetes)
+
+### With `securityContext`
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: buildkitd
+  name: buildkitd
+spec:
+  selector:
+    matchLabels:
+      app: buildkitd
+  template:
+    metadata:
+      labels:
+        app: buildkitd
+    spec:
+      containers:
+      - image: moby/buildkit:rootless
+        args:
+        - --addr
+        - tcp://0.0.0.0:1234
+        name: buildkitd
+        ports:
+        - containerPort: 1234
+        securityContext:
+          privileged: true
+```
+
+This configuration requires privileged containers to be enabled.
+
+If you are using Kubernetes v1.12+ with either Docker v18.06+, containerd v1.2+, or CRI-O v1.12+ as the CRI runtime, you can replace `privileged: true` with `procMount: Unmasked`.
+
+### Without `securityContext` but with `--oci-worker-no-process-sandbox`
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: buildkitd
+  name: buildkitd
+spec:
+  selector:
+    matchLabels:
+      app: buildkitd
+  template:
+    metadata:
+      labels:
+        app: buildkitd
+    spec:
+      containers:
+      - image: moby/buildkit:rootless
+        args:
+        - --addr
+        - tcp://0.0.0.0:1234
+        - --oci-worker-no-process-sandbox
+        name: buildkitd
+        ports:
+        - containerPort: 1234
+```
+
+See [Disabling process sandbox](#disabling-process-sandbox) for security notice.

--- a/executor/containerdexecutor/executor.go
+++ b/executor/containerdexecutor/executor.go
@@ -120,7 +120,8 @@ func (w containerdExecutor) Exec(ctx context.Context, meta executor.Meta, root c
 		}
 		opts = append(opts, containerdoci.WithCgroup(cgroupsPath))
 	}
-	spec, cleanup, err := oci.GenerateSpec(ctx, meta, mounts, id, resolvConf, hostsFile, namespace, opts...)
+	processMode := oci.ProcessSandbox // FIXME(AkihiroSuda)
+	spec, cleanup, err := oci.GenerateSpec(ctx, meta, mounts, id, resolvConf, hostsFile, namespace, processMode, opts...)
 	if err != nil {
 		return err
 	}

--- a/executor/oci/mounts.go
+++ b/executor/oci/mounts.go
@@ -2,16 +2,19 @@ package oci
 
 import (
 	"context"
+	"path/filepath"
+	"strings"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
 )
 
 // MountOpts sets oci spec specific info for mount points
-type MountOpts func([]specs.Mount) []specs.Mount
+type MountOpts func([]specs.Mount) ([]specs.Mount, error)
 
 //GetMounts returns default required for buildkit
 // https://github.com/moby/buildkit/issues/429
-func GetMounts(ctx context.Context, mountOpts ...MountOpts) []specs.Mount {
+func GetMounts(ctx context.Context, mountOpts ...MountOpts) ([]specs.Mount, error) {
 	mounts := []specs.Mount{
 		{
 			Destination: "/proc",
@@ -49,20 +52,66 @@ func GetMounts(ctx context.Context, mountOpts ...MountOpts) []specs.Mount {
 			Options:     []string{"nosuid", "noexec", "nodev", "ro"},
 		},
 	}
+	var err error
 	for _, o := range mountOpts {
-		mounts = o(mounts)
+		mounts, err = o(mounts)
+		if err != nil {
+			return nil, err
+		}
 	}
-	return mounts
+	return mounts, nil
 }
 
-func withROBind(src, dest string) func(m []specs.Mount) []specs.Mount {
-	return func(m []specs.Mount) []specs.Mount {
+func withROBind(src, dest string) func(m []specs.Mount) ([]specs.Mount, error) {
+	return func(m []specs.Mount) ([]specs.Mount, error) {
 		m = append(m, specs.Mount{
 			Destination: dest,
 			Type:        "bind",
 			Source:      src,
 			Options:     []string{"rbind", "ro"},
 		})
-		return m
+		return m, nil
+	}
+}
+
+func hasPrefix(p, prefixDir string) bool {
+	prefixDir = filepath.Clean(prefixDir)
+	if prefixDir == "/" {
+		return true
+	}
+	p = filepath.Clean(p)
+	return p == prefixDir || strings.HasPrefix(p, prefixDir+"/")
+}
+
+func removeMountsWithPrefix(mounts []specs.Mount, prefixDir string) []specs.Mount {
+	var ret []specs.Mount
+	for _, m := range mounts {
+		if !hasPrefix(m.Destination, prefixDir) {
+			ret = append(ret, m)
+		}
+	}
+	return ret
+}
+
+func withProcessMode(processMode ProcessMode) func([]specs.Mount) ([]specs.Mount, error) {
+	return func(m []specs.Mount) ([]specs.Mount, error) {
+		switch processMode {
+		case ProcessSandbox:
+			// keep the default
+		case NoProcessSandbox:
+			m = removeMountsWithPrefix(m, "/proc")
+			procMount := specs.Mount{
+				Destination: "/proc",
+				Type:        "bind",
+				Source:      "/proc",
+				// NOTE: "rbind"+"ro" does not make /proc read-only recursively.
+				// So we keep maskedPath and readonlyPaths (although not mandatory for rootless mode)
+				Options: []string{"rbind"},
+			}
+			m = append([]specs.Mount{procMount}, m...)
+		default:
+			return nil, errors.Errorf("unknown process mode: %v", processMode)
+		}
+		return m, nil
 	}
 }

--- a/executor/oci/mounts_test.go
+++ b/executor/oci/mounts_test.go
@@ -1,0 +1,56 @@
+package oci
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasPrefix(t *testing.T) {
+	type testCase struct {
+		path     string
+		prefix   string
+		expected bool
+	}
+	testCases := []testCase{
+		{
+			path:     "/foo/bar",
+			prefix:   "/foo",
+			expected: true,
+		},
+		{
+			path:     "/foo/bar",
+			prefix:   "/foo/",
+			expected: true,
+		},
+		{
+			path:     "/foo/bar",
+			prefix:   "/",
+			expected: true,
+		},
+		{
+			path:     "/foo",
+			prefix:   "/foo",
+			expected: true,
+		},
+		{
+			path:     "/foo/bar",
+			prefix:   "/bar",
+			expected: false,
+		},
+		{
+			path:     "/foo/bar",
+			prefix:   "foo",
+			expected: false,
+		},
+		{
+			path:     "/foobar",
+			prefix:   "/foo",
+			expected: false,
+		},
+	}
+	for i, tc := range testCases {
+		actual := hasPrefix(tc.path, tc.prefix)
+		require.Equal(t, tc.expected, actual, "#%d: under(%q,%q)", i, tc.path, tc.prefix)
+	}
+}

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -39,6 +39,8 @@ type Opt struct {
 	Rootless bool
 	// DefaultCgroupParent is the cgroup-parent name for executor
 	DefaultCgroupParent string
+	// ProcessMode
+	ProcessMode oci.ProcessMode
 }
 
 var defaultCommandCandidates = []string{"buildkit-runc", "runc"}
@@ -50,6 +52,7 @@ type runcExecutor struct {
 	cgroupParent     string
 	rootless         bool
 	networkProviders map[pb.NetMode]network.Provider
+	processMode      oci.ProcessMode
 }
 
 func New(opt Opt, networkProviders map[pb.NetMode]network.Provider) (executor.Executor, error) {
@@ -105,6 +108,7 @@ func New(opt Opt, networkProviders map[pb.NetMode]network.Provider) (executor.Ex
 		cgroupParent:     opt.DefaultCgroupParent,
 		rootless:         opt.Rootless,
 		networkProviders: networkProviders,
+		processMode:      opt.ProcessMode,
 	}
 	return w, nil
 }
@@ -193,7 +197,7 @@ func (w *runcExecutor) Exec(ctx context.Context, meta executor.Meta, root cache.
 		}
 		opts = append(opts, containerdoci.WithCgroup(cgroupsPath))
 	}
-	spec, cleanup, err := oci.GenerateSpec(ctx, meta, mounts, id, resolvConf, hostsFile, namespace, opts...)
+	spec, cleanup, err := oci.GenerateSpec(ctx, meta, mounts, id, resolvConf, hostsFile, namespace, w.processMode, opts...)
 	if err != nil {
 		return err
 	}

--- a/worker/runc/runc.go
+++ b/worker/runc/runc.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containerd/containerd/platforms"
 	ctdsnapshot "github.com/containerd/containerd/snapshots"
 	"github.com/moby/buildkit/cache/metadata"
+	"github.com/moby/buildkit/executor/oci"
 	"github.com/moby/buildkit/executor/runcexecutor"
 	containerdsnapshot "github.com/moby/buildkit/snapshot/containerd"
 	"github.com/moby/buildkit/util/network"
@@ -33,7 +34,7 @@ type SnapshotterFactory struct {
 // NewWorkerOpt creates a WorkerOpt.
 // But it does not set the following fields:
 //  - SessionManager
-func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, labels map[string]string) (base.WorkerOpt, error) {
+func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, processMode oci.ProcessMode, labels map[string]string) (base.WorkerOpt, error) {
 	var opt base.WorkerOpt
 	name := "runc-" + snFactory.Name
 	root = filepath.Join(root, name)
@@ -48,7 +49,8 @@ func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, labe
 		// Root directory
 		Root: filepath.Join(root, "executor"),
 		// without root privileges
-		Rootless: rootless,
+		Rootless:    rootless,
+		ProcessMode: processMode,
 	}, network.Default())
 	if err != nil {
 		return opt, err


### PR DESCRIPTION
`--oci-worker-no-process-sandbox` is useful for running in a Kubernetes container without `securityContext.procMount=Unmasked`.
Note that  this mode  allows build executor containers to `kill` (and potentially `ptrace`, depending on the (future) seccomp configuration for build containers) an arbitrary process in the BuildKit host namespace.
This mode should be enabled only when the BuildKit is running in a container as an unprivileged user.

Fix https://github.com/moby/buildkit/issues/765

Unlike kaniko/makisu, `buildkitd` container requires seccomp and apparmor to be disabled. (Kubernetes disables them by default)

## Example session
```console
$ docker run -d --name buildkitd --security-opt seccomp=unconfined --security-opt apparmor=unconfined -p 1234:1234 moby/buildkit:rootless --addr tcp://0.0.0.0:1234 --oci-worker-no-process-sandbox
$ cat Dockerfile
FROM busybox
RUN cat /proc/mounts
RUN ps auxw
RUN ls -lR /proc/$(pgrep buildkitd)/root
RUN killall -9 buildkitd
$ sudo BUILDKIT_HOST=tcp://localhost:1234 buildctl build --progress plain --frontend=dockerfile.v0 --local context=. --local dockerfile=. --no-cache
...
#4 [2/5] RUN cat /proc/mounts
#4       digest: sha256:0bd2862c8e70db27fd152f61f895e17b616d1f9feacfa791f46176d5b758b35f
#4         name: "[2/5] RUN cat /proc/mounts"
#4      started: 2019-01-03 11:33:16.851191038 +0000 UTC
#4 0.163 overlay / overlay rw,relatime,lowerdir=/home/user/.local/share/buildkit/runc-overlayfs/snapshots/snapshots/3/fs,upperdir=/home/user/.local/share/buildkit/runc-overlayfs/snapshots/snapshots/4/fs,workdir=/home/user/.local/share/buildkit/runc-overlayfs/snapshots/snapshots/4/work 0 0
#4 0.163 proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
#4 0.163 proc /proc/bus proc ro,relatime 0 0
#4 0.163 proc /proc/fs proc ro,relatime 0 0
#4 0.163 proc /proc/irq proc ro,relatime 0 0
#4 0.163 proc /proc/sys proc ro,relatime 0 0
#4 0.163 proc /proc/sysrq-trigger proc ro,relatime 0 0
#4 0.163 tmpfs /proc/acpi tmpfs ro,relatime 0 0
#4 0.163 tmpfs /proc/kcore tmpfs rw,nosuid,size=65536k,mode=755 0 0
#4 0.163 tmpfs /proc/keys tmpfs rw,nosuid,size=65536k,mode=755 0 0
#4 0.163 tmpfs /proc/timer_list tmpfs rw,nosuid,size=65536k,mode=755 0 0
#4 0.163 tmpfs /proc/sched_debug tmpfs rw,nosuid,size=65536k,mode=755 0 0
#4 0.163 tmpfs /proc/scsi tmpfs ro,relatime 0 0
#4 0.163 tmpfs /dev tmpfs rw,nosuid,size=65536k,mode=755,uid=1000,gid=1000 0 0
#4 0.163 devpts /dev/pts devpts rw,nosuid,noexec,relatime,gid=100004,mode=620,ptmxmode=666 0 0
#4 0.163 shm /dev/shm tmpfs rw,nosuid,nodev,noexec,relatime,size=65536k,uid=1000,gid=1000 0 0
#4 0.163 mqueue /dev/mqueue mqueue rw,nosuid,nodev,noexec,relatime 0 0
#4 0.163 /dev/sda2 /etc/resolv.conf ext4 ro,relatime,data=ordered 0 0
#4 0.163 /dev/sda2 /etc/hosts ext4 ro,relatime,data=ordered 0 0
#4 0.163 tmpfs /dev/null tmpfs rw,nosuid,size=65536k,mode=755 0 0
#4 0.163 tmpfs /dev/random tmpfs rw,nosuid,size=65536k,mode=755 0 0
#4 0.163 tmpfs /dev/full tmpfs rw,nosuid,size=65536k,mode=755 0 0
#4 0.163 tmpfs /dev/tty tmpfs rw,nosuid,size=65536k,mode=755 0 0
#4 0.163 tmpfs /dev/zero tmpfs rw,nosuid,size=65536k,mode=755 0 0
#4 0.163 tmpfs /dev/urandom tmpfs rw,nosuid,size=65536k,mode=755 0 0
#4 0.163 proc /proc/bus proc ro,relatime 0 0
#4 0.163 proc /proc/fs proc ro,relatime 0 0
#4 0.163 proc /proc/irq proc ro,relatime 0 0
#4 0.163 proc /proc/sys proc ro,relatime 0 0
#4 0.163 proc /proc/sysrq-trigger proc ro,relatime 0 0
#4 0.163 tmpfs /proc/acpi tmpfs ro,relatime,uid=1000,gid=1000 0 0
#4 0.163 tmpfs /proc/kcore tmpfs rw,nosuid,size=65536k,mode=755 0 0
#4 0.163 tmpfs /proc/keys tmpfs rw,nosuid,size=65536k,mode=755 0 0
#4 0.163 tmpfs /proc/timer_list tmpfs rw,nosuid,size=65536k,mode=755 0 0
#4 0.163 tmpfs /proc/sched_debug tmpfs rw,nosuid,size=65536k,mode=755 0 0
#4 0.163 tmpfs /proc/scsi tmpfs ro,relatime,uid=1000,gid=1000 0 0
#4    completed: 2019-01-03 11:33:17.120924484 +0000 UTC
#4     duration: 269.733446ms


#5 [3/5] RUN ps auxw
#5       digest: sha256:535ca8d35a9c8046e7bc44a804d98f15e61f15ec65f5d68d3952aa491c34369e
#5         name: "[3/5] RUN ps auxw"
#5      started: 2019-01-03 11:33:17.122484069 +0000 UTC
#5 0.123 PID   USER     TIME  COMMAND
#5 0.123     1 root      0:00 rootlesskit buildkitd --addr tcp://0.0.0.0:1234 --oci-worker-no-process-sandbox
#5 0.123     9 root      0:00 /proc/self/exe buildkitd --addr tcp://0.0.0.0:1234 --oci-worker-no-process-sandbox
#5 0.123    15 root      0:00 buildkitd --addr tcp://0.0.0.0:1234 --oci-worker-no-process-sandbox
#5 0.123    44 root      0:00 buildkit-runc --log /home/user/.local/share/buildkit/runc-overlayfs/executor/runc-log.json --log-format json run --bundle /home/user/.local/share/buildkit/runc-overlayfs/executor/m2g9hiqhddo6xrsxqufy8tagp m2g9hiqhddo6xrsxqufy8tagp
#5 0.123    54 root      0:00 ps auxw
#5    completed: 2019-01-03 11:33:17.334221138 +0000 UTC
#5     duration: 211.737069ms


#6 [4/5] RUN ls -lR /proc/$(pgrep buildkitd)/root
#6       digest: sha256:32e4ecb217b2db92166a3fd064879b64f3bf15c35a7aabaef51ad9e92ca5814e
#6         name: "[4/5] RUN ls -lR /proc/$(pgrep buildkitd)/root"
#6      started: 2019-01-03 11:33:17.336399895 +0000 UTC
#6    completed: 2019-01-03 11:33:17.561248275 +0000 UTC
#6     duration: 224.84838ms
#6 0.135 lrwxrwxrwx    1 root     root             0 Jan  3 11:33 /proc/15/root
#6 0.135 ls: /proc/15/root: cannot read link: Permission denied


#7 [5/5] RUN killall -9 buildkitd
#7       digest: sha256:1e6754879a9385b49daff3b1284c267801c915a170acc26fa49d734265b0b61d
#7         name: "[5/5] RUN killall -9 buildkitd"
#7      started: 2019-01-03 11:33:17.564581844 +0000 UTC
error: failed to receive status: rpc error: code = Unavailable desc = transport is closing
(`buildkitd` is killed here)
```