### PR TITLE
Have parser error on dockerfiles without instructions

### DIFF
--- a/frontend/dockerfile/parser/parser.go
+++ b/frontend/dockerfile/parser/parser.go
@@ -275,6 +275,11 @@ func Parse(rwc io.Reader) (*Result, error) {
 	if len(warnings) > 0 {
 		warnings = append(warnings, "[WARNING]: Empty continuation lines will become errors in a future release.")
 	}
+
+	if root.StartLine < 0 {
+		return nil, errors.New("file with no instructions.")
+	}
+
 	return &Result{
 		AST:         root,
 		Warnings:    warnings,

--- a/frontend/dockerfile/parser/testfiles-negative/only_comments/Dockerfile
+++ b/frontend/dockerfile/parser/testfiles-negative/only_comments/Dockerfile
@@ -1,0 +1,3 @@
+# Hello
+# These are just comments
+


### PR DESCRIPTION
`docker build` panics on a dockerfile with no instructions (e.g., a dockerfile that contains only comments). This patch produces a parse error for such a dockerfile -- we detect this by determining whether the root AST node has an invalid "StartLine" position.

See https://github.com/moby/moby/pull/38487 for more discussion.