### PR TITLE
`make generated-files` only copies over generated files from scratch container

### DIFF
--- a/hack/dockerfiles/generated-files.buildkit.Dockerfile
+++ b/hack/dockerfiles/generated-files.buildkit.Dockerfile
@@ -31,7 +31,7 @@ RUN --mount=target=/tmp/src \
 	git ls-files -m --others -- **/*.pb.go | tar -cf - --files-from - | tar -C /generated-files -xf -
 
 FROM scratch AS update
-COPY --from=generated generated-files /
+COPY --from=generated /generated-files /generated-files
 
 FROM gobuild-base AS validate
 RUN --mount=target=/tmp/src \

--- a/hack/update-generated-files
+++ b/hack/update-generated-files
@@ -11,11 +11,14 @@ if [ "$CONTINUOUS_INTEGRATION" == "true" ]; then progressFlag="--progress=plain"
 gogo_version=$(awk '$1 == "github.com/gogo/protobuf" { print $2 }' vendor.conf)
 case $buildmode in
 "buildkit")
+  output=$(mktemp -d -t buildctl-output.XXXXXXXXXX)
   buildctl build $progressFlag --frontend=dockerfile.v0 --local context=. --local dockerfile=. \
     --frontend-opt build-arg:GOGO_VERSION=$gogo_version \
     --frontend-opt target=update \
     --frontend-opt filename=./hack/dockerfiles/generated-files.buildkit.Dockerfile \
-    --exporter=local --exporter-opt output=.
+    --exporter=local --exporter-opt output=$output
+  cp -R "$output/generated-files/" .
+  rm -rf $output
   ;;
 *)
   iidfile=$(mktemp -t docker-iidfile.XXXXXXXXXX)
@@ -31,14 +34,7 @@ case $buildmode in
   iid=$(cat $iidfile)
   cid=$(docker create $iid noop)
 
-  case $buildmode in
-  "docker-buildkit")
-    docker export $cid | tar -xf - 
-    ;;
-  *)
-    docker export $cid | tar -xf - --strip-components=1 generated-files
-    ;;
-  esac
+  docker export $cid | tar -xf - --strip-components=1 generated-files
 
   docker rm $cid
 


### PR DESCRIPTION
To avoid dropping the extra files from the exported `update` target image in the repo, the output from `go generate` is thrown in `generated-files/` and only that directory is untarred back into the repo.

Result of nuking a generated file and regenerating it:

```
$ rm api/types/worker.pb.go
$ git status
On branch clean-generated-files-export
Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

        deleted:    api/types/worker.pb.go

no changes added to commit (use "git add" and/or "git commit -a")
$ make generated-files
...
$ git status
On branch clean-generated-files-export
nothing to commit, working tree clean
```

Also still works fine when generating via buildkit directly:

```
$ rm api/types/worker.pb.go
$ git status
On branch clean-generated-files-export
Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

        deleted:    api/types/worker.pb.go

no changes added to commit (use "git add" and/or "git commit -a")
$ PREFER_BUILDCTL=1 make generated-files
...
$ git status
On branch clean-generated-files-export
nothing to commit, working tree clean
```

Fixes https://github.com/moby/buildkit/issues/764