### PR TITLE
allow exporting cache metadata in the image config

### DIFF
--- a/cache/remotecache/import.go
+++ b/cache/remotecache/import.go
@@ -4,13 +4,19 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"sync"
 
 	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/images"
 	v1 "github.com/moby/buildkit/cache/remotecache/v1"
 	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/util/imageutil"
 	"github.com/moby/buildkit/worker"
+	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 )
 
 // ResolveCacheImporterFunc returns importer and descriptor.
@@ -55,7 +61,7 @@ func (ci *contentCacheImporter) Resolve(ctx context.Context, desc ocispec.Descri
 	}
 
 	if configDesc.Digest == "" {
-		return nil, errors.Errorf("invalid build cache from %+v, lacks manifest with MediaType=%s", desc, v1.CacheConfigMediaTypeV0)
+		return ci.importInlineCache(ctx, dt, id, w)
 	}
 
 	dt, err = readBlob(ctx, ci.provider, configDesc)
@@ -94,4 +100,127 @@ func readBlob(ctx context.Context, provider content.Provider, desc ocispec.Descr
 		}
 	}
 	return dt, err
+}
+
+func (ci *contentCacheImporter) importInlineCache(ctx context.Context, dt []byte, id string, w worker.Worker) (solver.CacheManager, error) {
+	m := map[digest.Digest][]byte{}
+
+	if err := ci.allDistributionManifests(ctx, dt, m); err != nil {
+		return nil, err
+	}
+
+	var mu sync.Mutex
+	cc := v1.NewCacheChains()
+
+	eg, ctx := errgroup.WithContext(ctx)
+	for dgst, dt := range m {
+		func(dgst digest.Digest, dt []byte) {
+			eg.Go(func() error {
+				var m ocispec.Manifest
+
+				if err := json.Unmarshal(dt, &m); err != nil {
+					return err
+				}
+
+				if m.Config.Digest == "" || len(m.Layers) == 0 {
+					return nil
+				}
+
+				p, err := content.ReadBlob(ctx, ci.provider, m.Config)
+				if err != nil {
+					return err
+				}
+
+				var img struct {
+					Rootfs struct {
+						DiffIDs []digest.Digest `json:"diff_ids"`
+					} `json:"rootfs"`
+					Cache json.RawMessage `json:"moby.buildkit.cache.v0"`
+				}
+
+				if err := json.Unmarshal(p, &img); err != nil {
+					return err
+				}
+
+				if len(img.Rootfs.DiffIDs) != len(m.Layers) {
+					logrus.Warnf("invalid image with mismatching manifest and config")
+					return nil
+				}
+
+				if img.Cache == nil {
+					return nil
+				}
+
+				var config v1.CacheConfig
+				if err := json.Unmarshal(img.Cache, &config.Records); err != nil {
+					return err
+				}
+
+				layers := v1.DescriptorProvider{}
+				for i, m := range m.Layers {
+					if m.Annotations == nil {
+						m.Annotations = map[string]string{}
+					}
+					m.Annotations["containerd.io/uncompressed"] = img.Rootfs.DiffIDs[i].String()
+					layers[m.Digest] = v1.DescriptorProviderPair{
+						Descriptor: m,
+						Provider:   ci.provider,
+					}
+					config.Layers = append(config.Layers, v1.CacheLayer{
+						Blob:        m.Digest,
+						ParentIndex: i - 1,
+					})
+				}
+
+				mu.Lock()
+				if err := v1.ParseConfig(config, layers, cc); err != nil {
+					return err
+				}
+				mu.Unlock()
+				return nil
+			})
+		}(dgst, dt)
+	}
+
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
+	keysStorage, resultStorage, err := v1.NewCacheKeyStorage(cc, w)
+	if err != nil {
+		return nil, err
+	}
+	return solver.NewCacheManager(id, keysStorage, resultStorage), nil
+}
+
+func (ci *contentCacheImporter) allDistributionManifests(ctx context.Context, dt []byte, m map[digest.Digest][]byte) error {
+	mt, err := imageutil.DetectManifestBlobMediaType(dt)
+	if err != nil {
+		return err
+	}
+
+	switch mt {
+	case images.MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest:
+		m[digest.FromBytes(dt)] = dt
+	case images.MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
+		var index ocispec.Index
+		if err := json.Unmarshal(dt, &index); err != nil {
+			return err
+		}
+
+		for _, d := range index.Manifests {
+			if _, ok := m[d.Digest]; ok {
+				continue
+			}
+			p, err := content.ReadBlob(ctx, ci.provider, d)
+			if err != nil {
+				return err
+			}
+			if err := ci.allDistributionManifests(ctx, p, m); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }

--- a/cache/remotecache/inline/inline.go
+++ b/cache/remotecache/inline/inline.go
@@ -1,0 +1,70 @@
+package registry
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/moby/buildkit/cache/remotecache"
+	v1 "github.com/moby/buildkit/cache/remotecache/v1"
+	"github.com/moby/buildkit/solver"
+	digest "github.com/opencontainers/go-digest"
+	"github.com/sirupsen/logrus"
+)
+
+func ResolveCacheExporterFunc() remotecache.ResolveCacheExporterFunc {
+	return func(ctx context.Context, _ map[string]string) (remotecache.Exporter, error) {
+		return NewExporter(), nil
+	}
+}
+
+func NewExporter() remotecache.Exporter {
+	cc := v1.NewCacheChains()
+	return &exporter{CacheExporterTarget: cc, chains: cc}
+}
+
+type exporter struct {
+	solver.CacheExporterTarget
+	chains *v1.CacheChains
+}
+
+func (ce *exporter) Finalize(ctx context.Context) (map[string]string, error) {
+	return nil, nil
+}
+
+func (ce *exporter) ExportForLayers(layers []digest.Digest) ([]byte, error) {
+	config, descs, err := ce.chains.Marshal()
+	if err != nil {
+		return nil, err
+	}
+
+	descs2 := map[digest.Digest]v1.DescriptorProviderPair{}
+	for _, k := range layers {
+		if v, ok := descs[k]; ok {
+			descs2[k] = v
+		}
+	}
+
+	cc := v1.NewCacheChains()
+	if err := v1.ParseConfig(*config, descs, cc); err != nil {
+		return nil, err
+	}
+
+	cfg, _, err := cc.Marshal()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(cfg.Layers) == 0 {
+		logrus.Warn("failed to match any cache with layers")
+		return nil, nil
+	}
+
+	// TODO: are the layers always ordered already or should we check?
+
+	dt, err := json.Marshal(cfg.Records)
+	if err != nil {
+		return nil, err
+	}
+
+	return dt, nil
+}

--- a/cache/remotecache/v1/cachestorage.go
+++ b/cache/remotecache/v1/cachestorage.go
@@ -27,6 +27,7 @@ func NewCacheKeyStorage(cc *CacheChains, w worker.Worker) (solver.CacheKeyStorag
 	results := &cacheResultStorage{
 		w:        w,
 		byID:     storage.byID,
+		byItem:   storage.byItem,
 		byResult: storage.byResult,
 	}
 
@@ -204,19 +205,54 @@ type cacheResultStorage struct {
 	w        worker.Worker
 	byID     map[string]*itemWithOutgoingLinks
 	byResult map[string]map[string]struct{}
+	byItem   map[*item]string
 }
 
 func (cs *cacheResultStorage) Save(res solver.Result, createdAt time.Time) (solver.CacheResult, error) {
 	return solver.CacheResult{}, errors.Errorf("importer is immutable")
 }
 
-func (cs *cacheResultStorage) Load(ctx context.Context, res solver.CacheResult) (solver.Result, error) {
-	remote, err := cs.LoadRemote(ctx, res)
-	if err != nil {
+func (cs *cacheResultStorage) LoadWithParents(ctx context.Context, res solver.CacheResult) (map[string]solver.Result, error) {
+	v := cs.byResultID(res.ID)
+	if v == nil || v.result == nil {
+		return nil, errors.WithStack(solver.ErrNotFound)
+	}
+
+	m := map[string]solver.Result{}
+
+	if err := v.walkAllResults(func(i *item) error {
+		if i.result == nil {
+			return nil
+		}
+		id, ok := cs.byItem[i]
+		if !ok {
+			return nil
+		}
+		if isSubRemote(*i.result, *v.result) {
+			ref, err := cs.w.FromRemote(ctx, i.result)
+			if err != nil {
+				return err
+			}
+			m[id] = worker.NewWorkerRefResult(ref, cs.w)
+		}
+		return nil
+	}); err != nil {
+		for _, v := range m {
+			v.Release(context.TODO())
+		}
 		return nil, err
 	}
 
-	ref, err := cs.w.FromRemote(ctx, remote)
+	return m, nil
+}
+
+func (cs *cacheResultStorage) Load(ctx context.Context, res solver.CacheResult) (solver.Result, error) {
+	item := cs.byResultID(res.ID)
+	if item == nil || item.result == nil {
+		return nil, errors.WithStack(solver.ErrNotFound)
+	}
+
+	ref, err := cs.w.FromRemote(ctx, item.result)
 	if err != nil {
 		return nil, err
 	}
@@ -224,8 +260,8 @@ func (cs *cacheResultStorage) Load(ctx context.Context, res solver.CacheResult) 
 }
 
 func (cs *cacheResultStorage) LoadRemote(ctx context.Context, res solver.CacheResult) (*solver.Remote, error) {
-	if r := cs.byResultID(res.ID); r != nil {
-		return r, nil
+	if r := cs.byResultID(res.ID); r != nil && r.result != nil {
+		return r.result, nil
 	}
 	return nil, errors.WithStack(solver.ErrNotFound)
 }
@@ -234,7 +270,7 @@ func (cs *cacheResultStorage) Exists(id string) bool {
 	return cs.byResultID(id) != nil
 }
 
-func (cs *cacheResultStorage) byResultID(resultID string) *solver.Remote {
+func (cs *cacheResultStorage) byResultID(resultID string) *itemWithOutgoingLinks {
 	m, ok := cs.byResult[resultID]
 	if !ok || len(m) == 0 {
 		return nil
@@ -243,9 +279,7 @@ func (cs *cacheResultStorage) byResultID(resultID string) *solver.Remote {
 	for id := range m {
 		it, ok := cs.byID[id]
 		if ok {
-			if r := it.result; r != nil {
-				return r
-			}
+			return it
 		}
 	}
 

--- a/cache/remotecache/v1/cachestorage.go
+++ b/cache/remotecache/v1/cachestorage.go
@@ -155,8 +155,22 @@ func (cs *cacheKeyStorage) WalkLinks(id string, link solver.CacheInfoLink, fn fu
 	return nil
 }
 
-// TODO:
 func (cs *cacheKeyStorage) WalkBacklinks(id string, fn func(id string, link solver.CacheInfoLink) error) error {
+	for k, it := range cs.byID {
+		for nl, ids := range it.links {
+			for _, id2 := range ids {
+				if id == id2 {
+					if err := fn(k, solver.CacheInfoLink{
+						Input:    solver.Index(nl.input),
+						Selector: digest.Digest(nl.selector),
+						Digest:   nl.dgst,
+					}); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
 	return nil
 }
 

--- a/cache/remotecache/v1/chains.go
+++ b/cache/remotecache/v1/chains.go
@@ -128,6 +128,20 @@ func (c *item) LinkFrom(rec solver.CacheExporterRecord, index int, selector stri
 	c.links[index][link{src: src, selector: selector}] = struct{}{}
 }
 
+func (c *item) walkAllResults(fn func(i *item) error) error {
+	if err := fn(c); err != nil {
+		return err
+	}
+	for _, links := range c.links {
+		for l := range links {
+			if err := l.src.walkAllResults(fn); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 type nopRecord struct {
 }
 

--- a/cache/remotecache/v1/doc.go
+++ b/cache/remotecache/v1/doc.go
@@ -6,7 +6,7 @@ package cacheimport
 // https://github.com/opencontainers/image-spec/blob/master/image-index.md .
 // Manifests array contains descriptors to the cache layers and one instance of
 // build cache config with media type application/vnd.buildkit.cacheconfig.v0 .
-// The cache layer descripts need to have an annotation with uncompressed digest
+// The cache layer descriptors need to have an annotation with uncompressed digest
 // to allow deduplication on extraction and optionally "buildkit/createdat"
 // annotation to support maintaining original timestamps.
 //

--- a/cache/remotecache/v1/utils.go
+++ b/cache/remotecache/v1/utils.go
@@ -304,3 +304,15 @@ func marshalItem(it *item, state *marshalState) error {
 	state.records = append(state.records, rec)
 	return nil
 }
+
+func isSubRemote(sub, main solver.Remote) bool {
+	if len(sub.Descriptors) > len(main.Descriptors) {
+		return false
+	}
+	for i := range sub.Descriptors {
+		if sub.Descriptors[i].Digest != main.Descriptors[i].Digest {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/docker/go-connections/sockets"
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	"github.com/moby/buildkit/cache/remotecache"
+	inlineremotecache "github.com/moby/buildkit/cache/remotecache/inline"
 	localremotecache "github.com/moby/buildkit/cache/remotecache/local"
 	registryremotecache "github.com/moby/buildkit/cache/remotecache/registry"
 	"github.com/moby/buildkit/client"
@@ -513,6 +514,7 @@ func newController(c *cli.Context, cfg *config.Config) (*control.Controller, err
 	remoteCacheExporterFuncs := map[string]remotecache.ResolveCacheExporterFunc{
 		"registry": registryremotecache.ResolveCacheExporterFunc(sessionManager, resolverFn),
 		"local":    localremotecache.ResolveCacheExporterFunc(sessionManager),
+		"inline":   inlineremotecache.ResolveCacheExporterFunc(),
 	}
 	remoteCacheImporterFuncs := map[string]remotecache.ResolveCacheImporterFunc{
 		"registry": registryremotecache.ResolveCacheImporterFunc(sessionManager, resolverFn),

--- a/exporter/containerimage/exptypes/types.go
+++ b/exporter/containerimage/exptypes/types.go
@@ -3,6 +3,7 @@ package exptypes
 import specs "github.com/opencontainers/image-spec/specs-go/v1"
 
 const ExporterImageConfigKey = "containerimage.config"
+const ExporterInlineCache = "containerimage.inlinecache"
 const ExporterPlatformsKey = "refs.platforms"
 
 type Platforms struct {

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -350,7 +350,11 @@ func patchImageConfig(dt []byte, dps []blobs.DiffPair, history []ocispec.History
 	}
 
 	if cache != nil {
-		m["moby.buildkit.cache.v0"] = cache
+		dt, err := json.Marshal(cache)
+		if err != nil {
+			return nil, err
+		}
+		m["moby.buildkit.cache.v0"] = dt
 	}
 
 	dt, err = json.Marshal(m)

--- a/solver/cachemanager.go
+++ b/solver/cachemanager.go
@@ -144,6 +144,79 @@ func (c *cacheManager) Load(ctx context.Context, rec *CacheRecord) (Result, erro
 	return c.results.Load(ctx, res)
 }
 
+type LoadedResult struct {
+	Result      Result
+	CacheResult CacheResult
+	CacheKey    *CacheKey
+}
+
+func (c *cacheManager) filterResults(m map[string]Result, ck *CacheKey) (results []LoadedResult, err error) {
+	id := c.getID(ck)
+	if err := c.backend.WalkResults(id, func(cr CacheResult) error {
+		res, ok := m[id]
+		if ok {
+			results = append(results, LoadedResult{
+				Result:      res,
+				CacheKey:    ck,
+				CacheResult: cr,
+			})
+			delete(m, id)
+		}
+		return nil
+	}); err != nil {
+		for _, r := range results {
+			r.Result.Release(context.TODO())
+		}
+	}
+	for _, keys := range ck.Deps() {
+		for _, key := range keys {
+			res, err := c.filterResults(m, key.CacheKey.CacheKey)
+			if err != nil {
+				for _, r := range results {
+					r.Result.Release(context.TODO())
+				}
+				return nil, err
+			}
+			results = append(results, res...)
+		}
+	}
+	return
+}
+
+func (c *cacheManager) LoadWithParents(ctx context.Context, rec *CacheRecord) ([]LoadedResult, error) {
+	lwp, ok := c.results.(interface {
+		LoadWithParents(context.Context, CacheResult) (map[string]Result, error)
+	})
+	if !ok {
+		res, err := c.Load(ctx, rec)
+		if err != nil {
+			return nil, err
+		}
+		return []LoadedResult{{Result: res, CacheKey: rec.key, CacheResult: CacheResult{ID: c.getID(rec.key), CreatedAt: rec.CreatedAt}}}, nil
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	cr, err := c.backend.Load(c.getID(rec.key), rec.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	m, err := lwp.LoadWithParents(ctx, cr)
+	if err != nil {
+		return nil, err
+	}
+
+	results, err := c.filterResults(m, rec.key)
+	if err != nil {
+		for _, r := range m {
+			r.Release(context.TODO())
+		}
+	}
+
+	return results, nil
+}
+
 func (c *cacheManager) Save(k *CacheKey, r Result, createdAt time.Time) (*ExportableCacheKey, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/solver/combinedcache.go
+++ b/solver/combinedcache.go
@@ -67,15 +67,27 @@ func (cm *combinedCacheManager) Query(inp []CacheKeyWithSelector, inputIndex Ind
 	return out, nil
 }
 
-func (cm *combinedCacheManager) Load(ctx context.Context, rec *CacheRecord) (Result, error) {
-	res, err := rec.cacheManager.Load(ctx, rec)
+func (cm *combinedCacheManager) Load(ctx context.Context, rec *CacheRecord) (res Result, err error) {
+	results, err := rec.cacheManager.LoadWithParents(ctx, rec)
 	if err != nil {
 		return nil, err
 	}
-	if _, err := cm.main.Save(rec.key, res, rec.CreatedAt); err != nil {
-		return nil, err
+	defer func() {
+		for i, res := range results {
+			if err == nil && i == 0 {
+				continue
+			}
+			res.Result.Release(context.TODO())
+		}
+	}()
+	if rec.cacheManager != cm.main {
+		for _, res := range results {
+			if _, err := cm.main.Save(res.CacheKey, res.Result, res.CacheResult.CreatedAt); err != nil {
+				return nil, err
+			}
+		}
 	}
-	return res, nil
+	return results[0].Result, nil
 }
 
 func (cm *combinedCacheManager) Save(key *CacheKey, s Result, createdAt time.Time) (*ExportableCacheKey, error) {

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -2,6 +2,7 @@ package llbsolver
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/moby/buildkit/client"
 	controlgateway "github.com/moby/buildkit/control/gateway"
 	"github.com/moby/buildkit/exporter"
+	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/frontend"
 	"github.com/moby/buildkit/frontend/gateway"
 	"github.com/moby/buildkit/identity"
@@ -138,7 +140,7 @@ func (s *Solver) Solve(ctx context.Context, id string, req frontend.SolveRequest
 	}()
 
 	var exporterResponse map[string]string
-	if exp := exp.Exporter; exp != nil {
+	if e := exp.Exporter; e != nil {
 		inp := exporter.Source{
 			Metadata: res.Metadata,
 		}
@@ -151,6 +153,14 @@ func (s *Solver) Solve(ctx context.Context, id string, req frontend.SolveRequest
 				return nil, errors.Errorf("invalid reference: %T", res.Sys())
 			}
 			inp.Ref = workerRef.ImmutableRef
+
+			dt, err := inlineCache(ctx, exp.CacheExporter, res)
+			if err != nil {
+				return nil, err
+			}
+			if dt != nil {
+				inp.Metadata[exptypes.ExporterInlineCache] = dt
+			}
 		}
 		if res.Refs != nil {
 			m := make(map[string]cache.ImmutableRef, len(res.Refs))
@@ -163,13 +173,21 @@ func (s *Solver) Solve(ctx context.Context, id string, req frontend.SolveRequest
 						return nil, errors.Errorf("invalid reference: %T", res.Sys())
 					}
 					m[k] = workerRef.ImmutableRef
+
+					dt, err := inlineCache(ctx, exp.CacheExporter, res)
+					if err != nil {
+						return nil, err
+					}
+					if dt != nil {
+						inp.Metadata[fmt.Sprintf("%s/%s", exptypes.ExporterInlineCache, k)] = dt
+					}
 				}
 			}
 			inp.Refs = m
 		}
 
-		if err := inVertexContext(j.Context(ctx), exp.Name(), "", func(ctx context.Context) error {
-			exporterResponse, err = exp.Export(ctx, inp)
+		if err := inVertexContext(j.Context(ctx), e.Name(), "", func(ctx context.Context) error {
+			exporterResponse, err = e.Export(ctx, inp)
 			return err
 		}); err != nil {
 			return nil, err
@@ -216,6 +234,37 @@ func (s *Solver) Solve(ctx context.Context, id string, req frontend.SolveRequest
 	return &client.SolveResponse{
 		ExporterResponse: exporterResponse,
 	}, nil
+}
+
+func inlineCache(ctx context.Context, e remotecache.Exporter, res solver.CachedResult) ([]byte, error) {
+	if efl, ok := e.(interface {
+		ExportForLayers([]digest.Digest) ([]byte, error)
+	}); ok {
+		workerRef, ok := res.Sys().(*worker.WorkerRef)
+		if !ok {
+			return nil, errors.Errorf("invalid reference: %T", res.Sys())
+		}
+
+		remote, err := workerRef.Worker.GetRemote(ctx, workerRef.ImmutableRef, true)
+		if err != nil || remote == nil {
+			return nil, nil
+		}
+
+		digests := make([]digest.Digest, 0, len(remote.Descriptors))
+		for _, desc := range remote.Descriptors {
+			digests = append(digests, desc.Digest)
+		}
+
+		if _, err := res.CacheKeys()[0].Exporter.ExportTo(ctx, e, solver.CacheExportOpt{
+			Convert: workerRefConverter,
+			Mode:    solver.CacheExportModeMin,
+		}); err != nil {
+			return nil, err
+		}
+
+		return efl.ExportForLayers(digests)
+	}
+	return nil, nil
 }
 
 func (s *Solver) Status(ctx context.Context, id string, statusChan chan *client.SolveStatus) error {

--- a/util/imageutil/config.go
+++ b/util/imageutil/config.go
@@ -135,17 +135,21 @@ func childrenConfigHandler(provider content.Provider, platform platforms.MatchCo
 func DetectManifestMediaType(ra content.ReaderAt) (string, error) {
 	// TODO: schema1
 
-	p := make([]byte, ra.Size())
-	if _, err := ra.ReadAt(p, 0); err != nil {
+	dt := make([]byte, ra.Size())
+	if _, err := ra.ReadAt(dt, 0); err != nil {
 		return "", err
 	}
 
+	return DetectManifestBlobMediaType(dt)
+}
+
+func DetectManifestBlobMediaType(dt []byte) (string, error) {
 	var mfst struct {
 		MediaType string          `json:"mediaType"`
 		Config    json.RawMessage `json:"config"`
 	}
 
-	if err := json.Unmarshal(p, &mfst); err != nil {
+	if err := json.Unmarshal(dt, &mfst); err != nil {
 		return "", err
 	}
 

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -372,7 +372,11 @@ func (w *Worker) FromRemote(ctx context.Context, remote *solver.Remote) (cache.I
 				return nil, err
 			}
 		}
-		ref, err := w.CacheManager.Get(ctx, chainID, cache.WithDescription(fmt.Sprintf("imported %s", remote.Descriptors[i].Digest)), cache.WithCreationTime(tm))
+		descr := fmt.Sprintf("imported %s", remote.Descriptors[i].Digest)
+		if v, ok := remote.Descriptors[i].Annotations["buildkit/description"]; ok {
+			descr = v
+		}
+		ref, err := w.CacheManager.Get(ctx, chainID, cache.WithDescription(descr), cache.WithCreationTime(tm))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
fixes #752

based on  #615

Exporting with `--export-cache type=inline` importing is connected with the regular registry importer that falls back to inline if the registry ref is not a special cache manifest.

TODO:
- tests
- currently not deterministic on local sources
- @AkihiroSuda I'm thinking of changing the value to base64 of the protobuf and turn the existing cacheconfig types to proto (manifest list variant will remain json). maybe even store digests as bytes with a custom marshaler. thoughts?