### PR TITLE
Make exported build cache deterministic

### DIFF
--- a/cache/remotecache/v1/cachestorage.go
+++ b/cache/remotecache/v1/cachestorage.go
@@ -2,6 +2,7 @@ package cacheimport
 
 import (
 	"context"
+	"time"
 
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/solver"
@@ -191,7 +192,7 @@ type cacheResultStorage struct {
 	byResult map[string]map[string]struct{}
 }
 
-func (cs *cacheResultStorage) Save(res solver.Result) (solver.CacheResult, error) {
+func (cs *cacheResultStorage) Save(res solver.Result, createdAt time.Time) (solver.CacheResult, error) {
 	return solver.CacheResult{}, errors.Errorf("importer is immutable")
 }
 

--- a/cache/remotecache/v1/chains.go
+++ b/cache/remotecache/v1/chains.go
@@ -1,6 +1,7 @@
 package cacheimport
 
 import (
+	"strings"
 	"time"
 
 	"github.com/containerd/containerd/content"
@@ -19,6 +20,9 @@ type CacheChains struct {
 }
 
 func (c *CacheChains) Add(dgst digest.Digest) solver.CacheExporterRecord {
+	if strings.HasPrefix(dgst.String(), "random:") {
+		return &nopRecord{}
+	}
 	it := &item{c: c, dgst: dgst}
 	c.items = append(c.items, it)
 	return it
@@ -122,6 +126,15 @@ func (c *item) LinkFrom(rec solver.CacheExporterRecord, index int, selector stri
 	}
 
 	c.links[index][link{src: src, selector: selector}] = struct{}{}
+}
+
+type nopRecord struct {
+}
+
+func (c *nopRecord) AddResult(createdAt time.Time, result *solver.Remote) {
+}
+
+func (c *nopRecord) LinkFrom(rec solver.CacheExporterRecord, index int, selector string) {
 }
 
 var _ solver.CacheExporterTarget = &CacheChains{}

--- a/solver/cachemanager.go
+++ b/solver/cachemanager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/moby/buildkit/identity"
 	digest "github.com/opencontainers/go-digest"
@@ -143,15 +144,14 @@ func (c *cacheManager) Load(ctx context.Context, rec *CacheRecord) (Result, erro
 	return c.results.Load(ctx, res)
 }
 
-func (c *cacheManager) Save(k *CacheKey, r Result) (*ExportableCacheKey, error) {
+func (c *cacheManager) Save(k *CacheKey, r Result, createdAt time.Time) (*ExportableCacheKey, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	res, err := c.results.Save(r)
+	res, err := c.results.Save(r, createdAt)
 	if err != nil {
 		return nil, err
 	}
-
 	if err := c.backend.AddResult(c.getID(k), res); err != nil {
 		return nil, err
 	}

--- a/solver/cachemanager.go
+++ b/solver/cachemanager.go
@@ -3,6 +3,7 @@ package solver
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/moby/buildkit/identity"
@@ -273,5 +274,8 @@ func (c *cacheManager) getIDFromDeps(k *CacheKey) string {
 }
 
 func rootKey(dgst digest.Digest, output Index) digest.Digest {
+	if strings.HasPrefix(dgst.String(), "random:") {
+		return digest.Digest("random:" + strings.TrimPrefix(digest.FromBytes([]byte(fmt.Sprintf("%s@%d", dgst, output))).String(), digest.Canonical.String()+":"))
+	}
 	return digest.FromBytes([]byte(fmt.Sprintf("%s@%d", dgst, output)))
 }

--- a/solver/cachestorage.go
+++ b/solver/cachestorage.go
@@ -44,7 +44,7 @@ type CacheInfoLink struct {
 // CacheResultStorage is interface for converting cache metadata result to
 // actual solve result
 type CacheResultStorage interface {
-	Save(Result) (CacheResult, error)
+	Save(Result, time.Time) (CacheResult, error)
 	Load(ctx context.Context, res CacheResult) (Result, error)
 	LoadRemote(ctx context.Context, res CacheResult) (*Remote, error)
 	Exists(id string) bool

--- a/solver/combinedcache.go
+++ b/solver/combinedcache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"sync"
+	"time"
 
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
@@ -71,14 +72,14 @@ func (cm *combinedCacheManager) Load(ctx context.Context, rec *CacheRecord) (Res
 	if err != nil {
 		return nil, err
 	}
-	if _, err := cm.main.Save(rec.key, res); err != nil {
+	if _, err := cm.main.Save(rec.key, res, rec.CreatedAt); err != nil {
 		return nil, err
 	}
 	return res, nil
 }
 
-func (cm *combinedCacheManager) Save(key *CacheKey, s Result) (*ExportableCacheKey, error) {
-	return cm.main.Save(key, s)
+func (cm *combinedCacheManager) Save(key *CacheKey, s Result, createdAt time.Time) (*ExportableCacheKey, error) {
+	return cm.main.Save(key, s, createdAt)
 }
 
 func (cm *combinedCacheManager) Records(ck *CacheKey) ([]*CacheRecord, error) {

--- a/solver/edge.go
+++ b/solver/edge.go
@@ -3,6 +3,7 @@ package solver
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/moby/buildkit/solver/internal/pipe"
 	digest "github.com/opencontainers/go-digest"
@@ -845,7 +846,7 @@ func (e *edge) execOp(ctx context.Context) (interface{}, error) {
 	var exporters []CacheExporter
 
 	for _, cacheKey := range cacheKeys {
-		ck, err := e.op.Cache().Save(cacheKey, res)
+		ck, err := e.op.Cache().Save(cacheKey, res, time.Now())
 		if err != nil {
 			return nil, err
 		}

--- a/solver/llbsolver/bridge.go
+++ b/solver/llbsolver/bridge.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/containerd/containerd/platforms"
 	"github.com/moby/buildkit/cache"
@@ -190,11 +191,11 @@ func (lcm *lazyCacheManager) Load(ctx context.Context, rec *solver.CacheRecord) 
 	}
 	return lcm.main.Load(ctx, rec)
 }
-func (lcm *lazyCacheManager) Save(key *solver.CacheKey, s solver.Result) (*solver.ExportableCacheKey, error) {
+func (lcm *lazyCacheManager) Save(key *solver.CacheKey, s solver.Result, createdAt time.Time) (*solver.ExportableCacheKey, error) {
 	if err := lcm.wait(); err != nil {
 		return nil, err
 	}
-	return lcm.main.Save(key, s)
+	return lcm.main.Save(key, s, createdAt)
 }
 
 func (lcm *lazyCacheManager) wait() error {

--- a/solver/llbsolver/ops/source.go
+++ b/solver/llbsolver/ops/source.go
@@ -2,6 +2,7 @@ package ops
 
 import (
 	"context"
+	"strings"
 	"sync"
 
 	"github.com/moby/buildkit/solver"
@@ -59,9 +60,15 @@ func (s *sourceOp) CacheMap(ctx context.Context, index int) (*solver.CacheMap, b
 		return nil, false, err
 	}
 
+	dgst := digest.FromBytes([]byte(sourceCacheType + ":" + k))
+
+	if strings.HasPrefix(k, "session:") {
+		dgst = digest.Digest("random:" + strings.TrimPrefix(dgst.String(), dgst.Algorithm().String()+":"))
+	}
+
 	return &solver.CacheMap{
 		// TODO: add os/arch
-		Digest: digest.FromBytes([]byte(sourceCacheType + ":" + k)),
+		Digest: dgst,
 	}, done, nil
 }
 

--- a/solver/memorycachestorage.go
+++ b/solver/memorycachestorage.go
@@ -284,9 +284,9 @@ type inMemoryResultStore struct {
 	m *sync.Map
 }
 
-func (s *inMemoryResultStore) Save(r Result) (CacheResult, error) {
+func (s *inMemoryResultStore) Save(r Result, createdAt time.Time) (CacheResult, error) {
 	s.m.Store(r.ID(), r)
-	return CacheResult{ID: r.ID(), CreatedAt: time.Now()}, nil
+	return CacheResult{ID: r.ID(), CreatedAt: createdAt}, nil
 }
 
 func (s *inMemoryResultStore) Load(ctx context.Context, res CacheResult) (Result, error) {

--- a/solver/types.go
+++ b/solver/types.go
@@ -164,5 +164,5 @@ type CacheManager interface {
 	// Load pulls and returns the cached result
 	Load(ctx context.Context, rec *CacheRecord) (Result, error)
 	// Save saves a result based on a cache key
-	Save(key *CacheKey, s Result) (*ExportableCacheKey, error)
+	Save(key *CacheKey, s Result, createdAt time.Time) (*ExportableCacheKey, error)
 }

--- a/worker/cacheresult.go
+++ b/worker/cacheresult.go
@@ -20,7 +20,7 @@ type cacheResultStorage struct {
 	wc *Controller
 }
 
-func (s *cacheResultStorage) Save(res solver.Result) (solver.CacheResult, error) {
+func (s *cacheResultStorage) Save(res solver.Result, createdAt time.Time) (solver.CacheResult, error) {
 	ref, ok := res.Sys().(*WorkerRef)
 	if !ok {
 		return solver.CacheResult{}, errors.Errorf("invalid result: %T", res.Sys())
@@ -33,7 +33,7 @@ func (s *cacheResultStorage) Save(res solver.Result) (solver.CacheResult, error)
 			ref.ImmutableRef.Metadata().Commit()
 		}
 	}
-	return solver.CacheResult{ID: ref.ID(), CreatedAt: time.Now()}, nil
+	return solver.CacheResult{ID: ref.ID(), CreatedAt: createdAt}, nil
 }
 func (s *cacheResultStorage) Load(ctx context.Context, res solver.CacheResult) (solver.Result, error) {
 	return s.load(res.ID, false)


### PR DESCRIPTION
Improves #615 #777

- Avoid exporting local cache keys based on random seed because they would be regenerated on every run.
- Keep original creation date when copying record from remote store to local instead of using the current time.

Its possible there are still some edge cases that can be improved but these require extra debugging. This should cover most of it. Some cases where uploaded cache changes over time are by-design as if over time new metadata is determined that applies to same record, we want to upload that data as well.