### PR TITLE
Fix the wrong check condition

### DIFF
--- a/cmd/buildkitd/main_containerd_worker.go
+++ b/cmd/buildkitd/main_containerd_worker.go
@@ -145,7 +145,7 @@ func applyContainerdFlags(c *cli.Context, cfg *config.Config) error {
 		cfg.Workers.Containerd.Platforms = platforms
 	}
 
-	if c.GlobalIsSet("containerd-worker-namespace") || cfg.Workers.Containerd.Namespace == "" {
+	if c.GlobalIsSet("containerd-worker-namespace") && cfg.Workers.Containerd.Namespace == "" {
 		cfg.Workers.Containerd.Namespace = c.GlobalString("containerd-worker-namespace")
 	}
 


### PR DESCRIPTION
`GlobalString` return empty string if the flag is not set.

Signed-off-by: Dave Chen <dave.chen@arm.com>