### PR TITLE
fix typo

### DIFF
--- a/docs/experimental-syntaxes.md
+++ b/docs/experimental-syntaxes.md
@@ -1,4 +1,4 @@
 # Dockerfile frontend experimental syntaxes
 
 Documentation for experimental Dockerfile syntaxes can be found in the
-[Dockerfile frontend docmentation](/frontend/dockerfile/docs/experimental.md)
+[Dockerfile frontend documentation](/frontend/dockerfile/docs/experimental.md)


### PR DESCRIPTION
replace with `documentation`