### PR TITLE
http: add better support for misconfigured servers

### DIFF
--- a/source/http/httpsource_test.go
+++ b/source/http/httpsource_test.go
@@ -112,7 +112,7 @@ func TestHTTPSource(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, expectedContent2, k)
-	require.Equal(t, server.Stats("/foo").AllRequests, 3)
+	require.Equal(t, server.Stats("/foo").AllRequests, 4)
 	require.Equal(t, server.Stats("/foo").CachedRequests, 1)
 
 	ref, err = h.Snapshot(ctx)


### PR DESCRIPTION
When testing with github source URLs I found that the http source implementation didn't cooperate very well. From tracing the requests it seems to be a server fault but made some changes to handle misbehaving servers better.

Instead of sending multipe if-none-match headers (that should be supported) now join them into a single value.

Do an extra HEAD request for detecting the unchanged etag, in case server does not actually handle the in-none-match header.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>