### PR TITLE
worker/containerd: imagestore+differ default ns

### DIFF
--- a/worker/containerd/containerd.go
+++ b/worker/containerd/containerd.go
@@ -101,6 +101,13 @@ func newContainerd(root string, client *containerd.Client, snapshotterName, ns s
 		}
 	}
 
+	is := client.ImageService()
+	if ns != "" {
+		is = &nsImageStore{
+			Store: is,
+			ns:    ns,
+		}
+	}
 	opt := base.WorkerOpt{
 		ID:            id,
 		Labels:        xlabels,
@@ -109,8 +116,8 @@ func newContainerd(root string, client *containerd.Client, snapshotterName, ns s
 		Snapshotter:   containerdsnapshot.NewSnapshotter(client.SnapshotService(snapshotterName), cs, md, ns, gc),
 		ContentStore:  cs,
 		Applier:       winlayers.NewFileSystemApplierWithWindows(cs, df),
-		Differ:        winlayers.NewWalkingDiffWithWindows(cs, df),
-		ImageStore:    client.ImageService(),
+		Differ:        winlayers.NewWalkingDiffWithWindows(cs, df, ns),
+		ImageStore:    is,
 		Platforms:     platforms,
 	}
 	return opt, nil

--- a/worker/containerd/imagestore.go
+++ b/worker/containerd/imagestore.go
@@ -1,0 +1,38 @@
+package containerd
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/namespaces"
+)
+
+type nsImageStore struct {
+	ns string
+	images.Store
+}
+
+func (i *nsImageStore) Get(ctx context.Context, name string) (images.Image, error) {
+	ctx = namespaces.WithNamespace(ctx, i.ns)
+	return i.Store.Get(ctx, name)
+}
+
+func (i *nsImageStore) List(ctx context.Context, filters ...string) ([]images.Image, error) {
+	ctx = namespaces.WithNamespace(ctx, i.ns)
+	return i.Store.List(ctx, filters...)
+}
+
+func (i *nsImageStore) Create(ctx context.Context, image images.Image) (images.Image, error) {
+	ctx = namespaces.WithNamespace(ctx, i.ns)
+	return i.Store.Create(ctx, image)
+}
+
+func (i *nsImageStore) Update(ctx context.Context, image images.Image, fieldpaths ...string) (images.Image, error) {
+	ctx = namespaces.WithNamespace(ctx, i.ns)
+	return i.Store.Update(ctx, image, fieldpaths...)
+}
+
+func (i *nsImageStore) Delete(ctx context.Context, name string, opts ...images.DeleteOpt) error {
+	ctx = namespaces.WithNamespace(ctx, i.ns)
+	return i.Store.Delete(ctx, name, opts...)
+}

--- a/worker/runc/runc.go
+++ b/worker/runc/runc.go
@@ -104,7 +104,7 @@ func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, proc
 		Snapshotter:   containerdsnapshot.NewSnapshotter(mdb.Snapshotter(snFactory.Name), c, md, "buildkit", gc),
 		ContentStore:  c,
 		Applier:       winlayers.NewFileSystemApplierWithWindows(c, apply.NewFileSystemApplier(c)),
-		Differ:        winlayers.NewWalkingDiffWithWindows(c, walking.NewWalkingDiff(c)),
+		Differ:        winlayers.NewWalkingDiffWithWindows(c, walking.NewWalkingDiff(c), ""),
 		ImageStore:    nil, // explicitly
 		Platforms:     []specs.Platform{platforms.Normalize(platforms.DefaultSpec())},
 	}


### PR DESCRIPTION
If the configuration specifies a namespace for containerd, include it in
remote requests.

This is aiming to solve the same `namespace is undefined` problem as 
https://github.com/moby/buildkit/pull/713 , the goal is to respect the globally configured namespace.

Signed-off-by: Peter Wagner <thepwagner@github.com>