### PR TITLE
buildctl: add `b` as an alias for `build`

### DIFF
--- a/cmd/buildctl/build.go
+++ b/cmd/buildctl/build.go
@@ -26,9 +26,10 @@ import (
 )
 
 var buildCommand = cli.Command{
-	Name:   "build",
-	Usage:  "build",
-	Action: build,
+	Name:    "build",
+	Aliases: []string{"b"},
+	Usage:   "build",
+	Action:  build,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "exporter",


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>