### PR TITLE
client: fix strings.Replace call args

### DIFF
--- a/client/client_windows.go
+++ b/client/client_windows.go
@@ -16,7 +16,7 @@ func dialer(address string, timeout time.Duration) (net.Conn, error) {
 	}
 	switch addrParts[0] {
 	case "npipe":
-		address = strings.Replace(addrParts[1], "/", "\\", 0)
+		address = strings.Replace(addrParts[1], "/", "\\", -1)
 		return winio.DialPipe(address, &timeout)
 	default:
 		return net.DialTimeout(addrParts[0], addrParts[1], timeout)


### PR DESCRIPTION
strings.Replace call with n=0 argument makes no sense
as it will do nothing. Probably -1 is intended.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>