### PR TITLE
llbsolver: fix selectors dedupe

### DIFF
--- a/solver/llbsolver/ops/exec.go
+++ b/solver/llbsolver/ops/exec.go
@@ -165,7 +165,7 @@ func dedupePaths(inp []string) []string {
 	for p1 := range old {
 		var skip bool
 		for p2 := range old {
-			if p1 != p2 && strings.HasPrefix(p1, p2) {
+			if p1 != p2 && strings.HasPrefix(p1, p2+"/") {
 				skip = true
 				break
 			}

--- a/solver/llbsolver/ops/exec_test.go
+++ b/solver/llbsolver/ops/exec_test.go
@@ -1,0 +1,27 @@
+package ops
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDedupPaths(t *testing.T) {
+	res := dedupePaths([]string{"Gemfile", "Gemfile/foo"})
+	require.Equal(t, []string{"Gemfile"}, res)
+
+	res = dedupePaths([]string{"Gemfile/bar", "Gemfile/foo"})
+	require.Equal(t, []string{"Gemfile/bar", "Gemfile/foo"}, res)
+
+	res = dedupePaths([]string{"Gemfile", "Gemfile.lock"})
+	require.Equal(t, []string{"Gemfile", "Gemfile.lock"}, res)
+
+	res = dedupePaths([]string{"Gemfile.lock", "Gemfile"})
+	require.Equal(t, []string{"Gemfile", "Gemfile.lock"}, res)
+
+	res = dedupePaths([]string{"foo", "Gemfile", "Gemfile/foo"})
+	require.Equal(t, []string{"Gemfile", "foo"}, res)
+
+	res = dedupePaths([]string{"foo/bar/baz", "foo/bara", "foo/bar/bax", "foo/bar"})
+	require.Equal(t, []string{"foo/bar", "foo/bara"}, res)
+}


### PR DESCRIPTION
fix #853

The issue only appeared when one of the checksummed paths contained another.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>