### PR TITLE
Don't miss the Variant for arm32 platform

### DIFF
--- a/solver/llbsolver/vertex.go
+++ b/solver/llbsolver/vertex.go
@@ -80,10 +80,20 @@ func RuntimePlatforms(p []specs.Platform) LoadOpt {
 				defaultPlatform = &pb.Platform{
 					OS:           p.OS,
 					Architecture: p.Architecture,
+					Variant:      p.Variant,
 				}
 			}
 			op.Platform = defaultPlatform
 		}
+		platform := specs.Platform{OS: op.Platform.OS, Architecture: op.Platform.Architecture, Variant: op.Platform.Variant}
+		normalizedPlatform := platforms.Normalize(platform)
+
+		op.Platform = &pb.Platform{
+			OS:           normalizedPlatform.OS,
+			Architecture: normalizedPlatform.Architecture,
+			Variant:      normalizedPlatform.Variant,
+		}
+
 		if _, ok := op.Op.(*pb.Op_Exec); ok {
 			var found bool
 			for _, pp := range pp {


### PR DESCRIPTION
The `defaultPlatform` got on the build system include the variant for arm v6, v7 etc.
This is an important information for us to find the matched platform, but this information
is missed since the code doesn't include variant when assemble the platform information.

And since "V8" variant for arm64 is normalized to an empty string, so we need to take care
of this as well.

Signed-off-by: Dave Chen <dave.chen@arm.com>