### PR TITLE
remotecache: allow uncompressed digest in inline export

### DIFF
--- a/cache/remotecache/inline/inline.go
+++ b/cache/remotecache/inline/inline.go
@@ -41,6 +41,13 @@ func (ce *exporter) ExportForLayers(layers []digest.Digest) ([]byte, error) {
 	for _, k := range layers {
 		if v, ok := descs[k]; ok {
 			descs2[k] = v
+			continue
+		}
+		// fallback for uncompressed digests
+		for _, v := range descs {
+			if uc := v.Descriptor.Annotations["containerd.io/uncompressed"]; uc == string(k) {
+				descs2[v.Descriptor.Digest] = v
+			}
 		}
 	}
 


### PR DESCRIPTION
Moby integration doesn't have a contentstore yet. Therefore the descriptors are not over compressed data. This change allows both compressed and uncompressed digests on inline export that should be safe because the collisions are not possible.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>