### PR TITLE
hack: fix tagging latest images on release

### DIFF
--- a/hack/images
+++ b/hack/images
@@ -41,7 +41,7 @@ imageDockerCommon() {
 		docker push $REPO:$TAG-rootless
 		set +x
 	fi
-	if [[ "gitTag" == "$TAG" ]]; then
+	if [[ "$gitTag" == "$TAG" ]]; then
 		set -x
 		docker tag $REPO:$TAG $REPO:latest
 		docker tag $REPO:$TAG-rootless $REPO:rootless
@@ -71,7 +71,7 @@ image() {
 
 	tagLatest=""
 	tagLatestRootless=""
-	if [[ "gitTag" == "$TAG" ]]; then
+	if [[ "$gitTag" == "$TAG" ]]; then
 		tagLatest=",$REPO:latest"
 		tagLatestRootless=",$REPO:rootless"
 	fi


### PR DESCRIPTION
typo from https://github.com/moby/buildkit/pull/847/files#diff-ed0ae453c7dab73db35f74c6092f6e88R74

I manually retagged the `v0.4.0` images so no need to run it again.

@AkihiroSuda 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>