### PR TITLE
content: fix setting wrong gc labels on config query

### DIFF
--- a/snapshot/containerd/content.go
+++ b/snapshot/containerd/content.go
@@ -82,10 +82,13 @@ func (c *nsContent) writer(ctx context.Context, retries int, opts ...content.Wri
 			return nil, err
 		}
 	}
+	_, noRoot := wOpts.Desc.Annotations["buildkit/noroot"]
+	delete(wOpts.Desc.Annotations, "buildkit/noroot")
+	opts = append(opts, content.WithDescriptor(wOpts.Desc))
 	ctx = namespaces.WithNamespace(ctx, c.ns)
 	w, err := c.Store.Writer(ctx, opts...)
 	if err != nil {
-		if errdefs.IsAlreadyExists(err) && wOpts.Desc.Digest != "" && retries > 0 {
+		if !noRoot && errdefs.IsAlreadyExists(err) && wOpts.Desc.Digest != "" && retries > 0 {
 			_, err2 := c.Update(ctx, content.Info{
 				Digest: wOpts.Desc.Digest,
 				Labels: map[string]string{


### PR DESCRIPTION
There's a bug where if you build dockerfiles and get cache matches and then run prune, the blobs do not get deleted. This is is because on pull the layers blobs are set as root, metadata blobs are not set as roots, and layers point to metadata blobs and metadata blobs point to layers(this comes from containerd). This makes sure that when last layers are deleted the metadata gets deleted as well. Problem appears when dockerfile frontend looks up the config on the subsequent build when the cache already exists. It receives an `erralreadyexists` and makes the manifest/config a root. Now when layers roots deleted manifests still remain and because they keep references to layers, layers remain as well.

Fix is to determine the cases where root labels should not be added on `erralreadyexists` by using a custom annotation.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>