### PR TITLE
client: set cap if fileop used

### DIFF
--- a/client/llb/fileop.go
+++ b/client/llb/fileop.go
@@ -642,6 +642,8 @@ func (f *FileOp) Marshal(c *Constraints) (digest.Digest, []byte, *pb.OpMetadata,
 		return "", nil, nil, err
 	}
 
+	addCap(&f.constraints, pb.CapFileBase)
+
 	pfo := &pb.FileOp{}
 
 	pop, md := MarshalConstraints(c, &f.constraints)

--- a/solver/pb/caps.go
+++ b/solver/pb/caps.go
@@ -232,6 +232,10 @@ func init() {
 		ID:      CapFileBase,
 		Enabled: true,
 		Status:  apicaps.CapStatusPrerelease,
+		SupportedHint: map[string]string{
+			"docker":   "Docker v19.03",
+			"buildkit": "BuildKit v0.5.0",
+		},
 	})
 
 	Caps.Init(apicaps.Cap{


### PR DESCRIPTION
Allows a better error if fileop is used with a daemon that doesn't support it. Dockerfile frontend will never hit this cause it has a fallback builtin.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>