### PR TITLE
ops: fix concurrent map writes in test

### DIFF
--- a/solver/llbsolver/ops/file_test.go
+++ b/solver/llbsolver/ops/file_test.go
@@ -2,6 +2,7 @@ package ops
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -640,6 +641,7 @@ func (b *testFileBackend) Copy(_ context.Context, m1, m, user, group fileoptypes
 }
 
 type testFileRefBackend struct {
+	mu     sync.Mutex
 	refs   map[*testFileRef]struct{}
 	mounts map[string]*testMount
 }
@@ -663,7 +665,9 @@ func (b *testFileRefBackend) Prepare(ctx context.Context, ref fileoptypes.Ref, r
 	}
 	m.initID = m.id
 	m.active = active
+	b.mu.Lock()
 	b.mounts[m.initID] = m
+	b.mu.Unlock()
 	m2 := *m
 	m2.chain = append([]mod{}, m2.chain...)
 	return &m2, nil

--- a/solver/llbsolver/ops/file_test.go
+++ b/solver/llbsolver/ops/file_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestMkdirMkfile(t *testing.T) {
+	t.Parallel()
 	fo := &pb.FileOp{
 		Actions: []*pb.FileAction{
 			{
@@ -56,6 +57,7 @@ func TestMkdirMkfile(t *testing.T) {
 }
 
 func TestChownOpt(t *testing.T) {
+	t.Parallel()
 	fo := &pb.FileOp{
 		Actions: []*pb.FileAction{
 			{
@@ -125,6 +127,7 @@ func TestChownOpt(t *testing.T) {
 }
 
 func TestChownCopy(t *testing.T) {
+	t.Parallel()
 	fo := &pb.FileOp{
 		Actions: []*pb.FileAction{
 			{
@@ -185,6 +188,7 @@ func TestChownCopy(t *testing.T) {
 }
 
 func TestInvalidNoOutput(t *testing.T) {
+	t.Parallel()
 	fo := &pb.FileOp{
 		Actions: []*pb.FileAction{
 			{
@@ -210,6 +214,7 @@ func TestInvalidNoOutput(t *testing.T) {
 }
 
 func TestInvalidDuplicateOutput(t *testing.T) {
+	t.Parallel()
 	fo := &pb.FileOp{
 		Actions: []*pb.FileAction{
 			{
@@ -246,6 +251,7 @@ func TestInvalidDuplicateOutput(t *testing.T) {
 }
 
 func TestActionInvalidIndex(t *testing.T) {
+	t.Parallel()
 	fo := &pb.FileOp{
 		Actions: []*pb.FileAction{
 			{
@@ -271,6 +277,7 @@ func TestActionInvalidIndex(t *testing.T) {
 }
 
 func TestActionLoop(t *testing.T) {
+	t.Parallel()
 	fo := &pb.FileOp{
 		Actions: []*pb.FileAction{
 			{
@@ -307,6 +314,7 @@ func TestActionLoop(t *testing.T) {
 }
 
 func TestMultiOutput(t *testing.T) {
+	t.Parallel()
 	fo := &pb.FileOp{
 		Actions: []*pb.FileAction{
 			{
@@ -355,6 +363,7 @@ func TestMultiOutput(t *testing.T) {
 }
 
 func TestFileFromScratch(t *testing.T) {
+	t.Parallel()
 	fo := &pb.FileOp{
 		Actions: []*pb.FileAction{
 			{
@@ -398,6 +407,7 @@ func TestFileFromScratch(t *testing.T) {
 }
 
 func TestFileCopyInputSrc(t *testing.T) {
+	t.Parallel()
 	fo := &pb.FileOp{
 		Actions: []*pb.FileAction{
 			{
@@ -429,6 +439,7 @@ func TestFileCopyInputSrc(t *testing.T) {
 }
 
 func TestFileCopyInputRm(t *testing.T) {
+	t.Parallel()
 	fo := &pb.FileOp{
 		Actions: []*pb.FileAction{
 			{
@@ -484,6 +495,7 @@ func TestFileCopyInputRm(t *testing.T) {
 }
 
 func TestFileParallelActions(t *testing.T) {
+	t.Parallel()
 	// two mkdirs from scratch copied over each other. mkdirs should happen in parallel
 	fo := &pb.FileOp{
 		Actions: []*pb.FileAction{


### PR DESCRIPTION
saw this in ci https://travis-ci.org/moby/buildkit/builds/508667135#L5042

The backend causing this is only used in tests.

```
fatal error: concurrent map writes
goroutine 167 [running]:
runtime.throw(0xf97e4b, 0x15)
	/usr/local/go/src/runtime/panic.go:617 +0x72 fp=0xc000069da8 sp=0xc000069d78 pc=0x721402
runtime.mapassign_faststr(0xe90e00, 0xc00034e5d0, 0xc000038b40, 0xd, 0x7)
	/usr/local/go/src/runtime/map_faststr.go:211 +0x42a fp=0xc000069e10 sp=0xc000069da8 pc=0x706b1a
github.com/moby/buildkit/solver/llbsolver/ops.(*testFileRefBackend).Prepare(0xc00030ac30, 0x1096e00, 0xc00027f400, 0x107bf60, 0xc00034e690, 0x0, 0x2, 0xc000354080, 0x3, 0x3)
	/src/solver/llbsolver/ops/file_test.go:666 +0xb8 fp=0xc000069ea0 sp=0xc000069e10 pc=0xddf6a8
github.com/moby/buildkit/solver/llbsolver/ops.(*FileOpSolver).getInput.func1.2.1(0xc000000008, 0xfbfed0)
	/src/solver/llbsolver/ops/file.go:415 +0x1a9 fp=0xc000069f88 sp=0xc000069ea0 pc=0xde09d9
golang.org/x/sync/errgroup.(*Group).Go.func1(0xc00034e9c0, 0xc00031aee0)
	/src/vendor/golang.org/x/sync/errgroup/errgroup.go:58 +0x57 fp=0xc000069fd0 sp=0xc000069f88 pc=0x85a897
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1337 +0x1 fp=0xc000069fd8 sp=0xc000069fd0 pc=0x74fe41
created by golang.org/x/sync/errgroup.(*Group).Go
	/src/vendor/golang.org/x/sync/errgroup/errgroup.go:55 +0x66
```