### PR TITLE
test: avoid the error message when creating a user

### DIFF
--- a/hack/dockerfiles/test.Dockerfile
+++ b/hack/dockerfiles/test.Dockerfile
@@ -98,6 +98,7 @@ COPY --from=buildkitd /usr/bin/buildkitd /usr/bin
 FROM buildkit-base AS integration-tests
 ENV BUILDKIT_INTEGRATION_ROOTLESS_IDPAIR="1000:1000"
 RUN apk add --no-cache shadow shadow-uidmap sudo \
+  && mkdir -p /var/mail \
   && useradd --create-home --home-dir /home/user --uid 1000 -s /bin/sh user \
   && echo "XDG_RUNTIME_DIR=/run/user/1000; export XDG_RUNTIME_DIR" >> /home/user/.profile \
   && mkdir -m 0700 -p /run/user/1000 \


### PR DESCRIPTION
Run this command:
`docker build -f ./hack/dockerfiles/test.Dockerfile --target integration-tests`
will throw this error message:
`Executing busybox-1.29.3-r10.trigger OK: 184 MiB in 43 packages

Creating mailbox file: No such file or directory`

Not impact functionality but a little bit annoying.

Signed-off-by: Dave Chen <dave.chen@arm.com>