### PR TITLE
Stop using the deprecated flag "--frontend-opt" for build

### DIFF
--- a/frontend/dockerfile/cmd/dockerfile-frontend/hack/release
+++ b/frontend/dockerfile/cmd/dockerfile-frontend/hack/release
@@ -81,10 +81,10 @@ case $TYP in
   set -x
   buildctl build $progressFlag --frontend=dockerfile.v0 \
     --local context=. --local dockerfile=. \
-    --frontend-opt filename=./frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile \
-    --frontend-opt platform=$PLATFORMS \
-    --frontend-opt "build-arg:CHANNEL=$TAG" \
-    --frontend-opt "build-arg:BUILDTAGS=$buildTags" \
+    --opt filename=./frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile \
+    --opt platform=$PLATFORMS \
+    --opt "build-arg:CHANNEL=$TAG" \
+    --opt "build-arg:BUILDTAGS=$buildTags" \
     --output type=image,name=$REPO:$pushTag,$pushFlag
   ;;
 "tag")
@@ -100,10 +100,10 @@ case $TYP in
   set -x
   buildctl build $progressFlag --frontend=dockerfile.v0 \
     --local context=. --local dockerfile=. \
-    --frontend-opt filename=./frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile \
-    --frontend-opt platform=$PLATFORMS \
-    --frontend-opt "build-arg:CHANNEL=$TAG" \
-    --frontend-opt "build-arg:BUILDTAGS=$buildTags" \
+    --opt filename=./frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile \
+    --opt platform=$PLATFORMS \
+    --opt "build-arg:CHANNEL=$TAG" \
+    --opt "build-arg:BUILDTAGS=$buildTags" \
     --output type=image,name=$publishedNames,$pushFlag
   ;;
 "daily")
@@ -128,12 +128,12 @@ case $TYP in
     dt=$(date +%Y%m%d)
     buildctl build $progressFlag --progress=plain --frontend=dockerfile.v0 \
       --local context=. --local dockerfile=. \
-      --frontend-opt filename=./frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile \
-      --frontend-opt "build-arg:CHANNEL=$TAG" \
-      --frontend-opt "build-arg:REPO=$REPO" \
-      --frontend-opt "build-arg:DATE=$dt" \
-      --frontend-opt "build-arg:BUILDTAGS=$buildTags" \
-      --frontend-opt target=buildid\
+      --opt filename=./frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile \
+      --opt "build-arg:CHANNEL=$TAG" \
+      --opt "build-arg:REPO=$REPO" \
+      --opt "build-arg:DATE=$dt" \
+      --opt "build-arg:BUILDTAGS=$buildTags" \
+      --opt target=buildid\
       --output type=local,dest=$tmp
     
     if [ -f $tmp/buildid ]; then
@@ -142,10 +142,10 @@ case $TYP in
       
       buildctl build $progressFlag --frontend=dockerfile.v0 \
         --local context=. --local dockerfile=. \
-        --frontend-opt filename=./frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile \
-        --frontend-opt platform=$PLATFORMS \
-        --frontend-opt "build-arg:CHANNEL=$TAG" \
-        --frontend-opt "build-arg:BUILDTAGS=$buildTags" \
+        --opt filename=./frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile \
+        --opt platform=$PLATFORMS \
+        --opt "build-arg:CHANNEL=$TAG" \
+        --opt "build-arg:BUILDTAGS=$buildTags" \
         --output type=image,name=$REPO:$dt-$TAG,$pushFlag
       rm $tmp/buildid
     fi

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -3623,7 +3623,7 @@ func (f *gatewayFrontend) Solve(ctx context.Context, c *client.Client, opt clien
 }
 
 func (f *gatewayFrontend) DFCmdArgs(ctx, dockerfile string) (string, string) {
-	return dfCmdArgs(ctx, dockerfile, "--frontend gateway.v0 --frontend-opt=source="+f.gw)
+	return dfCmdArgs(ctx, dockerfile, "--frontend gateway.v0 --opt=source="+f.gw)
 }
 
 func (f *gatewayFrontend) RequiresBuildctl(t *testing.T) {}

--- a/hack/binaries
+++ b/hack/binaries
@@ -61,12 +61,12 @@ binariesDocker() {
 binaries() {
   platformFlag=""
   if [ ! -z "$TARGETPLATFORM" ]; then
-    platformFlag="--frontend-opt=platform=$TARGETPLATFORM"
+    platformFlag="--opt platform=$TARGETPLATFORM"
   fi
   buildctl build $progressFlag --frontend=dockerfile.v0 \
     --local context=. --local dockerfile=. \
-    --frontend-opt filename=./hack/dockerfiles/test.buildkit.Dockerfile \
-    --frontend-opt target=binaries $platformFlag \
+    --opt filename=./hack/dockerfiles/test.buildkit.Dockerfile \
+    --opt target=binaries $platformFlag \
     --output type=local,dest=./bin/
 }
 

--- a/hack/cross
+++ b/hack/cross
@@ -6,4 +6,4 @@
 
 set -ex
 
-buildctl build --progress=plain --frontend=dockerfile.v0 --local context=. --local dockerfile=. --frontend-opt filename=./hack/dockerfiles/test.buildkit.Dockerfile --frontend-opt platform=$PLATFORMS
+buildctl build --progress=plain --frontend=dockerfile.v0 --local context=. --local dockerfile=. --opt filename=./hack/dockerfiles/test.buildkit.Dockerfile --opt platform=$PLATFORMS

--- a/hack/images
+++ b/hack/images
@@ -80,15 +80,15 @@ image() {
 
 	buildctl build $progressFlag --frontend=dockerfile.v0 \
 		--local context=. --local dockerfile=. \
-		--frontend-opt filename=./hack/dockerfiles/test.buildkit.Dockerfile \
-		--frontend-opt platform=$PLATFORMS \
+		--opt filename=./hack/dockerfiles/test.buildkit.Dockerfile \
+		--opt platform=$PLATFORMS \
 		--output type=image,name=$REPO:$TAG$tagLatest,$pushFlag
 
 	buildctl build $progressFlag --frontend=dockerfile.v0 \
 		--local context=. --local dockerfile=. \
-		--frontend-opt target=rootless \
-		--frontend-opt filename=./hack/dockerfiles/test.buildkit.Dockerfile \
-		--frontend-opt platform=$PLATFORMS \
+		--opt target=rootless \
+		--opt filename=./hack/dockerfiles/test.buildkit.Dockerfile \
+		--opt platform=$PLATFORMS \
 		--output type=image,name=$REPO:$TAG-rootless$tagLatestRootless,$pushFlag
 }
 

--- a/hack/lint
+++ b/hack/lint
@@ -24,7 +24,7 @@ lintDocker() {
 lint() {
   buildctl build $progressFlag --frontend=dockerfile.v0 \
     --local context=. --local dockerfile=. \
-    --frontend-opt filename=./hack/dockerfiles/lint.buildkit.Dockerfile
+    --opt filename=./hack/dockerfiles/lint.buildkit.Dockerfile
 }
 
 case $buildmode in

--- a/hack/release-tar
+++ b/hack/release-tar
@@ -26,8 +26,8 @@ set -x
 
 buildctl build $progressFlag --frontend=dockerfile.v0 \
   --local context=. --local dockerfile=. \
-  --frontend-opt filename=./hack/dockerfiles/test.buildkit.Dockerfile \
-  --frontend-opt target=release \
-  --frontend-opt platform=$PLATFORMS \
+  --opt filename=./hack/dockerfiles/test.buildkit.Dockerfile \
+  --opt target=release \
+  --opt platform=$PLATFORMS \
   --exporter local \
   --exporter-opt output=$OUT

--- a/hack/test
+++ b/hack/test
@@ -42,8 +42,8 @@ case $buildmode in
 "buildkit")
   tmpfile=$(mktemp -t docker-iidfile.XXXXXXXXXX)
   buildctl build $progressFlag --frontend=dockerfile.v0 --local context=. --local dockerfile=. \
-    --frontend-opt target=integration-tests \
-    --frontend-opt filename=./hack/dockerfiles/test.buildkit.Dockerfile \
+    --opt target=integration-tests \
+    --opt filename=./hack/dockerfiles/test.buildkit.Dockerfile \
     --output type=docker,name=$iid,dest=$tmpfile
   docker load -i $tmpfile
   rm $tmpfile
@@ -86,8 +86,8 @@ if [ "$TEST_DOCKERFILE" == 1 ]; then
     case $buildmode in
     "buildkit")
       buildctl build $progressFlag --frontend=dockerfile.v0 --local context=. --local dockerfile=. \
-        --frontend-opt filename=./frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile \
-        --frontend-opt build-arg:BUILDTAGS="$buildtags" \
+        --opt filename=./frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile \
+        --opt build-arg:BUILDTAGS="$buildtags" \
         --output type=oci,dest=$tarout
       ;;
     "docker-buildkit")

--- a/hack/update-generated-files
+++ b/hack/update-generated-files
@@ -13,9 +13,9 @@ case $buildmode in
 "buildkit")
   output=$(mktemp -d -t buildctl-output.XXXXXXXXXX)
   buildctl build $progressFlag --frontend=dockerfile.v0 --local context=. --local dockerfile=. \
-    --frontend-opt build-arg:GOGO_VERSION=$gogo_version \
-    --frontend-opt target=update \
-    --frontend-opt filename=./hack/dockerfiles/generated-files.buildkit.Dockerfile \
+    --opt build-arg:GOGO_VERSION=$gogo_version \
+    --opt target=update \
+    --opt filename=./hack/dockerfiles/generated-files.buildkit.Dockerfile \
     --output type=local,dest=$output
   cp -R "$output/generated-files/" .
   rm -rf $output

--- a/hack/update-vendor
+++ b/hack/update-vendor
@@ -12,8 +12,8 @@ case $buildmode in
 "buildkit")
    output=$(mktemp -d -t buildctl-output.XXXXXXXXXX)
   buildctl build $progressFlag --frontend=dockerfile.v0 --local context=. --local dockerfile=. \
-    --frontend-opt target=update \
-    --frontend-opt filename=./hack/dockerfiles/vendor.buildkit.Dockerfile \
+    --opt target=update \
+    --opt filename=./hack/dockerfiles/vendor.buildkit.Dockerfile \
     --output type=local,dest=$output
   rm -rf ./vendor
   cp -R "$output/out/" .

--- a/hack/validate-generated-files
+++ b/hack/validate-generated-files
@@ -11,7 +11,7 @@ case ${1:-} in
   gogo_version=$(awk '$1 == "github.com/gogo/protobuf" { print $2 }' go.mod)
   case $buildmode in
   "buildkit")
-    buildctl build $progressFlag --frontend=dockerfile.v0 --local context=. --local dockerfile=. --frontend-opt build-arg:GOGO_VERSION=$gogo_version --frontend-opt target=validate --frontend-opt filename=./hack/dockerfiles/generated-files.buildkit.Dockerfile
+    buildctl build $progressFlag --frontend=dockerfile.v0 --local context=. --local dockerfile=. --opt build-arg:GOGO_VERSION=$gogo_version --opt target=validate --opt filename=./hack/dockerfiles/generated-files.buildkit.Dockerfile
     ;;
   "docker-buildkit")
     export DOCKER_BUILDKIT=1

--- a/hack/validate-vendor
+++ b/hack/validate-vendor
@@ -13,7 +13,7 @@ case ${1:-} in
   . $(dirname $0)/util
   case $buildmode in
   "buildkit")
-    buildctl build $progressFlag --frontend=dockerfile.v0 --local context=. --local dockerfile=. --frontend-opt filename=./hack/dockerfiles/vendor.buildkit.Dockerfile --frontend-opt target=validate
+    buildctl build $progressFlag --frontend=dockerfile.v0 --local context=. --local dockerfile=. --opt filename=./hack/dockerfiles/vendor.buildkit.Dockerfile --opt target=validate
     ;;
   "docker-buildkit")
     export DOCKER_BUILDKIT=1


### PR DESCRIPTION
This patch replace "--frontend-opt" to "--opt" for the place
where it is appliable.

Signed-off-by: Dave Chen <dave.chen@arm.com>