### PR TITLE
client: add docker:// connhelper 

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -5,9 +5,12 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"io/ioutil"
+	"net"
+	"time"
 
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	controlapi "github.com/moby/buildkit/api/services/control"
+	"github.com/moby/buildkit/client/connhelper"
 	"github.com/moby/buildkit/util/appdefaults"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -23,8 +26,14 @@ type ClientOpt interface{}
 
 // New returns a new buildkit client. Address can be empty for the system-default address.
 func New(ctx context.Context, address string, opts ...ClientOpt) (*Client, error) {
+	dialFn, err := resolveDialer(address)
+	if err != nil {
+		return nil, err
+	}
 	gopts := []grpc.DialOption{
-		grpc.WithDialer(dialer),
+		// TODO(AkihiroSuda): use WithContextDialer (requires grpc 1.19)
+		// https://github.com/grpc/grpc-go/commit/40cb5618f475e7b9d61aa7920ae4b04ef9bbaf89
+		grpc.WithDialer(dialFn),
 	}
 	needWithInsecure := true
 	for _, o := range opts {
@@ -127,4 +136,20 @@ func WithTracer(t opentracing.Tracer) ClientOpt {
 
 type withTracer struct {
 	tracer opentracing.Tracer
+}
+
+func resolveDialer(address string) (func(string, time.Duration) (net.Conn, error), error) {
+	ch, err := connhelper.GetConnectionHelper(address)
+	if err != nil {
+		return nil, err
+	}
+	if ch != nil {
+		f := func(a string, _ time.Duration) (net.Conn, error) {
+			ctx := context.Background()
+			return ch.ContextDialer(ctx, a)
+		}
+		return f, nil
+	}
+	// basic dialer
+	return dialer, nil
 }

--- a/client/connhelper/connhelper.go
+++ b/client/connhelper/connhelper.go
@@ -1,0 +1,37 @@
+// Package connhelper provides helpers for connecting to a remote daemon host with custom logic.
+package connhelper
+
+import (
+	"context"
+	"net"
+	"net/url"
+
+	"github.com/docker/cli/cli/connhelper/commandconn"
+)
+
+// ConnectionHelper allows to connect to a remote host with custom stream provider binary.
+type ConnectionHelper struct {
+	// ContextDialer can be passed to grpc.WithContextDialer
+	ContextDialer func(ctx context.Context, addr string) (net.Conn, error)
+}
+
+// GetConnectionHelper returns BuildKit-specific connection helper for the given URL.
+// GetConnectionHelper returns nil without error when no helper is registered for the scheme.
+//
+// docker://<container> URL requires BuildKit v0.5.0 or later in the container.
+func GetConnectionHelper(daemonURL string) (*ConnectionHelper, error) {
+	u, err := url.Parse(daemonURL)
+	if err != nil {
+		return nil, err
+	}
+	switch scheme := u.Scheme; scheme {
+	case "docker":
+		container := u.Host
+		return &ConnectionHelper{
+			ContextDialer: func(ctx context.Context, addr string) (net.Conn, error) {
+				return commandconn.New(ctx, "docker", "exec", "-i", container, "buildctl", "dial-stdio")
+			},
+		}, nil
+	}
+	return nil, err
+}

--- a/cmd/buildctl/dialstdio.go
+++ b/cmd/buildctl/dialstdio.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"io"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+)
+
+var dialStdioCommand = cli.Command{
+	Name:   "dial-stdio",
+	Usage:  "Proxy the stdio stream to the daemon connection. Should not be invoked manually.",
+	Hidden: true,
+	Action: dialStdioAction,
+}
+
+func dialStdioAction(clicontext *cli.Context) error {
+	addr := clicontext.GlobalString("addr")
+	timeout := time.Duration(clicontext.GlobalInt("timeout")) * time.Second
+	conn, err := dialer(addr, timeout)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	var connHalfCloser halfCloser
+	switch t := conn.(type) {
+	case halfCloser:
+		connHalfCloser = t
+	case halfReadWriteCloser:
+		connHalfCloser = &nopCloseReader{t}
+	default:
+		return errors.New("the raw stream connection does not implement halfCloser")
+	}
+
+	stdin2conn := make(chan error, 1)
+	conn2stdout := make(chan error, 1)
+	go func() {
+		stdin2conn <- copier(connHalfCloser, &halfReadCloserWrapper{os.Stdin}, "stdin to stream")
+	}()
+	go func() {
+		conn2stdout <- copier(&halfWriteCloserWrapper{os.Stdout}, connHalfCloser, "stream to stdout")
+	}()
+	select {
+	case err = <-stdin2conn:
+		if err != nil {
+			return err
+		}
+		// wait for stdout
+		err = <-conn2stdout
+	case err = <-conn2stdout:
+		// return immediately without waiting for stdin to be closed.
+		// (stdin is never closed when tty)
+	}
+	return err
+}
+
+func dialer(address string, timeout time.Duration) (net.Conn, error) {
+	addrParts := strings.SplitN(address, "://", 2)
+	if len(addrParts) != 2 {
+		return nil, errors.Errorf("invalid address %s", address)
+	}
+	if addrParts[0] != "unix" {
+		return nil, errors.Errorf("invalid address %s (expected unix://, got %s://)", address, addrParts[0])
+	}
+	return net.DialTimeout(addrParts[0], addrParts[1], timeout)
+}
+
+func copier(to halfWriteCloser, from halfReadCloser, debugDescription string) error {
+	defer func() {
+		if err := from.CloseRead(); err != nil {
+			logrus.Errorf("error while CloseRead (%s): %v", debugDescription, err)
+		}
+		if err := to.CloseWrite(); err != nil {
+			logrus.Errorf("error while CloseWrite (%s): %v", debugDescription, err)
+		}
+	}()
+	if _, err := io.Copy(to, from); err != nil {
+		return errors.Wrapf(err, "error while Copy (%s)", debugDescription)
+	}
+	return nil
+}
+
+type halfReadCloser interface {
+	io.Reader
+	CloseRead() error
+}
+
+type halfWriteCloser interface {
+	io.Writer
+	CloseWrite() error
+}
+
+type halfCloser interface {
+	halfReadCloser
+	halfWriteCloser
+}
+
+type halfReadWriteCloser interface {
+	io.Reader
+	halfWriteCloser
+}
+
+type nopCloseReader struct {
+	halfReadWriteCloser
+}
+
+func (x *nopCloseReader) CloseRead() error {
+	return nil
+}
+
+type halfReadCloserWrapper struct {
+	io.ReadCloser
+}
+
+func (x *halfReadCloserWrapper) CloseRead() error {
+	return x.Close()
+}
+
+type halfWriteCloserWrapper struct {
+	io.WriteCloser
+}
+
+func (x *halfWriteCloserWrapper) CloseWrite() error {
+	return x.Close()
+}

--- a/cmd/buildctl/main.go
+++ b/cmd/buildctl/main.go
@@ -73,6 +73,7 @@ func main() {
 		pruneCommand,
 		buildCommand,
 		debugCommand,
+		dialStdioCommand,
 	}
 
 	var debugEnabled bool

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
 	github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd // indirect
 	github.com/coreos/go-systemd v0.0.0-20161114122254-48702e0da86b // indirect
-	github.com/docker/cli v0.0.0-20190131223713-234462756460
+	github.com/docker/cli v0.0.0-20190321234815-f40f9c240ab0
 	github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible
 	github.com/docker/docker v1.14.0-0.20190319215453-e7b5f7dbe98c
 	github.com/docker/docker-credential-helpers v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/docker/cli v0.0.0-20190131223713-234462756460 h1:pil/Gt3dlnN7WIX+6uS3Ok3firOdyzmxqUtYrIik27I=
-github.com/docker/cli v0.0.0-20190131223713-234462756460/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v0.0.0-20190321234815-f40f9c240ab0 h1:E7NTtHfZYV+iu35yZ49AbrxqhMHpiOl3FstDYm38vQ0=
+github.com/docker/cli v0.0.0-20190321234815-f40f9c240ab0/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible h1:dvc1KSkIYTVjZgHf/CTC2diTYC8PzhaA5sFISRfNVrE=
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v0.0.0-20180531152204-71cd53e4a197 h1:raQhUHOMIAZAWHmo3hLEwoIy0aVkKb2uxZdWw/Up+HI=

--- a/hack/dockerfiles/test.Dockerfile
+++ b/hack/dockerfiles/test.Dockerfile
@@ -188,6 +188,7 @@ ENV HOME /home/user
 ENV USER user
 ENV XDG_RUNTIME_DIR=/run/user/1000
 ENV TMPDIR=/home/user/.local/tmp
+ENV BUILDKIT_HOST=unix:///run/user/1000/buildkit/buildkitd.sock
 VOLUME /home/user/.local/share/buildkit
 ENTRYPOINT ["rootlesskit", "buildkitd"]
 

--- a/hack/dockerfiles/test.buildkit.Dockerfile
+++ b/hack/dockerfiles/test.buildkit.Dockerfile
@@ -255,6 +255,7 @@ ENV HOME /home/user
 ENV USER user
 ENV XDG_RUNTIME_DIR=/run/user/1000
 ENV TMPDIR=/home/user/.local/tmp
+ENV BUILDKIT_HOST=unix:///run/user/1000/buildkit/buildkitd.sock
 VOLUME /home/user/.local/share/buildkit
 ENTRYPOINT ["rootlesskit", "buildkitd"]
 

--- a/vendor/github.com/docker/cli/AUTHORS
+++ b/vendor/github.com/docker/cli/AUTHORS
@@ -67,6 +67,7 @@ Barnaby Gray <barnaby@pickle.me.uk>
 Bastiaan Bakker <bbakker@xebia.com>
 BastianHofmann <bastianhofmann@me.com>
 Ben Bonnefoy <frenchben@docker.com>
+Ben Creasy <ben@bencreasy.com>
 Ben Firshman <ben@firshman.co.uk>
 Benjamin Boudreau <boudreau.benjamin@gmail.com>
 Benoit Sigoure <tsunanet@gmail.com>
@@ -126,6 +127,8 @@ Colin Hebert <hebert.colin@gmail.com>
 Collin Guarino <collin.guarino@gmail.com>
 Colm Hally <colmhally@gmail.com>
 Corey Farrell <git@cfware.com>
+Corey Quon <corey.quon@docker.com>
+Craig Wilhite <crwilhit@microsoft.com>
 Cristian Staretu <cristian.staretu@gmail.com>
 Daehyeok Mun <daehyeok@gmail.com>
 Dafydd Crosby <dtcrsby@gmail.com>
@@ -185,6 +188,8 @@ Elango Sivanandam <elango.siva@docker.com>
 Eli Uriegas <eli.uriegas@docker.com>
 Eli Uriegas <seemethere101@gmail.com>
 Elias Faxö <elias.faxo@tre.se>
+Elliot Luo <956941328@qq.com>
+Eric Curtin <ericcurtin17@gmail.com>
 Eric G. Noriega <enoriega@vizuri.com>
 Eric Rosenberg <ehaydenr@gmail.com>
 Eric Sage <eric.david.sage@gmail.com>
@@ -205,9 +210,11 @@ Fabio Falci <fabiofalci@gmail.com>
 Fabrizio Soppelsa <fsoppelsa@mirantis.com>
 Felix Hupfeld <felix@quobyte.com>
 Felix Rabe <felix@rabe.io>
+Filip Jareš <filipjares@gmail.com>
 Flavio Crisciani <flavio.crisciani@docker.com>
 Florian Klein <florian.klein@free.fr>
 Foysal Iqbal <foysal.iqbal.fb@gmail.com>
+François Scala <francois.scala@swiss-as.com>
 Fred Lifton <fred.lifton@docker.com>
 Frederic Hemberger <mail@frederic-hemberger.de>
 Frederick F. Kautz IV <fkautz@redhat.com>
@@ -273,8 +280,9 @@ Jasmine Hegman <jasmine@jhegman.com>
 Jason Heiss <jheiss@aput.net>
 Jason Plum <jplum@devonit.com>
 Jay Kamat <github@jgkamat.33mail.com>
+Jean Rouge <rougej+github@gmail.com>
+Jean-Christophe Sirot <jean-christophe.sirot@docker.com>
 Jean-Pierre Huynh <jean-pierre.huynh@ounet.fr>
-Jean-Pierre Huynh <jp@moogsoft.com>
 Jeff Lindsay <progrium@gmail.com>
 Jeff Nickoloff <jeff.nickoloff@gmail.com>
 Jeff Silberman <jsilberm@gmail.com>
@@ -412,11 +420,13 @@ Mark Oates <fl0yd@me.com>
 Marsh Macy <marsma@microsoft.com>
 Martin Mosegaard Amdisen <martin.amdisen@praqma.com>
 Mary Anthony <mary.anthony@docker.com>
+Mason Fish <mason.fish@docker.com>
 Mason Malone <mason.malone@gmail.com>
 Mateusz Major <apkd@users.noreply.github.com>
 Mathieu Champlon <mathieu.champlon@docker.com>
 Matt Gucci <matt9ucci@gmail.com>
 Matt Robenolt <matt@ydekproductions.com>
+Matteo Orefice <matteo.orefice@bites4bits.software>
 Matthew Heon <mheon@redhat.com>
 Matthieu Hauglustaine <matt.hauglustaine@gmail.com>
 Mauro Porras P <mauroporrasp@gmail.com>
@@ -453,6 +463,7 @@ Mindaugas Rukas <momomg@gmail.com>
 Misty Stanley-Jones <misty@docker.com>
 Mohammad Banikazemi <mb@us.ibm.com>
 Mohammed Aaqib Ansari <maaquib@gmail.com>
+Mohini Anne Dsouza <mohini3917@gmail.com>
 Moorthy RS <rsmoorthy@gmail.com>
 Morgan Bauer <mbauer@us.ibm.com>
 Moysés Borges <moysesb@gmail.com>
@@ -470,6 +481,7 @@ Nathan Hsieh <hsieh.nathan@gmail.com>
 Nathan LeClaire <nathan.leclaire@docker.com>
 Nathan McCauley <nathan.mccauley@docker.com>
 Neil Peterson <neilpeterson@outlook.com>
+Nick Adcock <nick.adcock@docker.com>
 Nico Stapelbroek <nstapelbroek@gmail.com>
 Nicola Kabar <nicolaka@gmail.com>
 Nicolas Borboën <ponsfrilus@gmail.com>
@@ -509,6 +521,7 @@ Peter Waller <p@pwaller.net>
 Phil Estes <estesp@linux.vnet.ibm.com>
 Philip Alexander Etling <paetling@gmail.com>
 Philipp Gillé <philipp.gille@gmail.com>
+Philipp Schmied <pschmied@schutzwerk.com>
 pidster <pid@pidster.com>
 pixelistik <pixelistik@users.noreply.github.com>
 Pratik Karki <prertik@outlook.com>
@@ -544,6 +557,8 @@ Rui Cao <ruicao@alauda.io>
 Ryan Belgrave <rmb1993@gmail.com>
 Ryan Detzel <ryan.detzel@gmail.com>
 Ryan Stelly <ryan.stelly@live.com>
+Ryan Wilson-Perkin <ryanwilsonperkin@gmail.com>
+Ryan Zhang <ryan.zhang@docker.com>
 Sainath Grandhi <sainath.grandhi@intel.com>
 Sakeven Jiang <jc5930@sina.cn>
 Sally O'Malley <somalley@redhat.com>
@@ -582,9 +597,11 @@ Srini Brahmaroutu <srbrahma@us.ibm.com>
 Stefan S. <tronicum@user.github.com>
 Stefan Scherer <scherer_stefan@icloud.com>
 Stefan Weil <sw@weilnetz.de>
+Stephane Jeandeaux <stephane.jeandeaux@gmail.com>
 Stephen Day <stevvooe@gmail.com>
 Stephen Rust <srust@blockbridge.com>
 Steve Durrheimer <s.durrheimer@gmail.com>
+Steve Richards <steve.richards@docker.com>
 Steven Burgess <steven.a.burgess@hotmail.com>
 Subhajit Ghosh <isubuz.g@gmail.com>
 Sun Jianbo <wonderflow.sun@gmail.com>
@@ -633,6 +650,7 @@ Tristan Carel <tristan@cogniteev.com>
 Tycho Andersen <tycho@docker.com>
 Tycho Andersen <tycho@tycho.ws>
 uhayate <uhayate.gong@daocloud.io>
+Ulysses Souza <ulysses.souza@docker.com>
 Umesh Yadav <umesh4257@gmail.com>
 Valentin Lorentz <progval+git@progval.net>
 Veres Lajos <vlajos@gmail.com>
@@ -683,6 +701,7 @@ Zhang Wentao <zhangwentao234@huawei.com>
 ZhangHang <stevezhang2014@gmail.com>
 zhenghenghuo <zhenghenghuo@zju.edu.cn>
 Zhou Hao <zhouhao@cn.fujitsu.com>
+Zhoulin Xie <zhoulin.xie@daocloud.io>
 Zhu Guihua <zhugh.fnst@cn.fujitsu.com>
 Álex González <agonzalezro@gmail.com>
 Álvaro Lázaro <alvaro.lazaro.g@gmail.com>

--- a/vendor/github.com/docker/cli/cli/config/config.go
+++ b/vendor/github.com/docker/cli/cli/config/config.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/config/credentials"
@@ -43,12 +44,16 @@ func ContextStoreDir() string {
 
 // SetDir sets the directory the configuration file is stored in
 func SetDir(dir string) {
-	configDir = dir
+	configDir = filepath.Clean(dir)
 }
 
 // Path returns the path to a file relative to the config dir
-func Path(p ...string) string {
-	return filepath.Join(append([]string{Dir()}, p...)...)
+func Path(p ...string) (string, error) {
+	path := filepath.Join(append([]string{Dir()}, p...)...)
+	if !strings.HasPrefix(path, Dir()+string(filepath.Separator)) {
+		return "", errors.Errorf("path %q is outside of root config directory %q", path, Dir())
+	}
+	return path, nil
 }
 
 // LegacyLoadFromReader is a convenience function that creates a ConfigFile object from

--- a/vendor/github.com/docker/cli/cli/connhelper/commandconn/commandconn.go
+++ b/vendor/github.com/docker/cli/cli/connhelper/commandconn/commandconn.go
@@ -1,0 +1,281 @@
+// Package commandconn provides a net.Conn implementation that can be used for
+// proxying (or emulating) stream via a custom command.
+//
+// For example, to provide an http.Client that can connect to a Docker daemon
+// running in a Docker container ("DIND"):
+//
+//  httpClient := &http.Client{
+//  	Transport: &http.Transport{
+//  		DialContext: func(ctx context.Context, _network, _addr string) (net.Conn, error) {
+//  			return commandconn.New(ctx, "docker", "exec", "-it", containerID, "docker", "system", "dial-stdio")
+//  		},
+//  	},
+//  }
+package commandconn
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// New returns net.Conn
+func New(ctx context.Context, cmd string, args ...string) (net.Conn, error) {
+	var (
+		c   commandConn
+		err error
+	)
+	c.cmd = exec.CommandContext(ctx, cmd, args...)
+	// we assume that args never contains sensitive information
+	logrus.Debugf("commandconn: starting %s with %v", cmd, args)
+	c.cmd.Env = os.Environ()
+	setPdeathsig(c.cmd)
+	c.stdin, err = c.cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	c.stdout, err = c.cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	c.cmd.Stderr = &stderrWriter{
+		stderrMu:    &c.stderrMu,
+		stderr:      &c.stderr,
+		debugPrefix: fmt.Sprintf("commandconn (%s):", cmd),
+	}
+	c.localAddr = dummyAddr{network: "dummy", s: "dummy-0"}
+	c.remoteAddr = dummyAddr{network: "dummy", s: "dummy-1"}
+	return &c, c.cmd.Start()
+}
+
+// commandConn implements net.Conn
+type commandConn struct {
+	cmd           *exec.Cmd
+	cmdExited     bool
+	cmdWaitErr    error
+	cmdMutex      sync.Mutex
+	stdin         io.WriteCloser
+	stdout        io.ReadCloser
+	stderrMu      sync.Mutex
+	stderr        bytes.Buffer
+	stdioClosedMu sync.Mutex // for stdinClosed and stdoutClosed
+	stdinClosed   bool
+	stdoutClosed  bool
+	localAddr     net.Addr
+	remoteAddr    net.Addr
+}
+
+// killIfStdioClosed kills the cmd if both stdin and stdout are closed.
+func (c *commandConn) killIfStdioClosed() error {
+	c.stdioClosedMu.Lock()
+	stdioClosed := c.stdoutClosed && c.stdinClosed
+	c.stdioClosedMu.Unlock()
+	if !stdioClosed {
+		return nil
+	}
+	return c.kill()
+}
+
+// killAndWait tries sending SIGTERM to the process before sending SIGKILL.
+func killAndWait(cmd *exec.Cmd) error {
+	var werr error
+	if runtime.GOOS != "windows" {
+		werrCh := make(chan error)
+		go func() { werrCh <- cmd.Wait() }()
+		cmd.Process.Signal(syscall.SIGTERM)
+		select {
+		case werr = <-werrCh:
+		case <-time.After(3 * time.Second):
+			cmd.Process.Kill()
+			werr = <-werrCh
+		}
+	} else {
+		cmd.Process.Kill()
+		werr = cmd.Wait()
+	}
+	return werr
+}
+
+// kill returns nil if the command terminated, regardless to the exit status.
+func (c *commandConn) kill() error {
+	var werr error
+	c.cmdMutex.Lock()
+	if c.cmdExited {
+		werr = c.cmdWaitErr
+	} else {
+		werr = killAndWait(c.cmd)
+		c.cmdWaitErr = werr
+		c.cmdExited = true
+	}
+	c.cmdMutex.Unlock()
+	if werr == nil {
+		return nil
+	}
+	wExitErr, ok := werr.(*exec.ExitError)
+	if ok {
+		if wExitErr.ProcessState.Exited() {
+			return nil
+		}
+	}
+	return errors.Wrapf(werr, "commandconn: failed to wait")
+}
+
+func (c *commandConn) onEOF(eof error) error {
+	// when we got EOF, the command is going to be terminated
+	var werr error
+	c.cmdMutex.Lock()
+	if c.cmdExited {
+		werr = c.cmdWaitErr
+	} else {
+		werrCh := make(chan error)
+		go func() { werrCh <- c.cmd.Wait() }()
+		select {
+		case werr = <-werrCh:
+			c.cmdWaitErr = werr
+			c.cmdExited = true
+		case <-time.After(10 * time.Second):
+			c.cmdMutex.Unlock()
+			c.stderrMu.Lock()
+			stderr := c.stderr.String()
+			c.stderrMu.Unlock()
+			return errors.Errorf("command %v did not exit after %v: stderr=%q", c.cmd.Args, eof, stderr)
+		}
+	}
+	c.cmdMutex.Unlock()
+	if werr == nil {
+		return eof
+	}
+	c.stderrMu.Lock()
+	stderr := c.stderr.String()
+	c.stderrMu.Unlock()
+	return errors.Errorf("command %v has exited with %v, please make sure the URL is valid, and Docker 18.09 or later is installed on the remote host: stderr=%s", c.cmd.Args, werr, stderr)
+}
+
+func ignorableCloseError(err error) bool {
+	errS := err.Error()
+	ss := []string{
+		os.ErrClosed.Error(),
+	}
+	for _, s := range ss {
+		if strings.Contains(errS, s) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *commandConn) CloseRead() error {
+	// NOTE: maybe already closed here
+	if err := c.stdout.Close(); err != nil && !ignorableCloseError(err) {
+		logrus.Warnf("commandConn.CloseRead: %v", err)
+	}
+	c.stdioClosedMu.Lock()
+	c.stdoutClosed = true
+	c.stdioClosedMu.Unlock()
+	if err := c.killIfStdioClosed(); err != nil {
+		logrus.Warnf("commandConn.CloseRead: %v", err)
+	}
+	return nil
+}
+
+func (c *commandConn) Read(p []byte) (int, error) {
+	n, err := c.stdout.Read(p)
+	if err == io.EOF {
+		err = c.onEOF(err)
+	}
+	return n, err
+}
+
+func (c *commandConn) CloseWrite() error {
+	// NOTE: maybe already closed here
+	if err := c.stdin.Close(); err != nil && !ignorableCloseError(err) {
+		logrus.Warnf("commandConn.CloseWrite: %v", err)
+	}
+	c.stdioClosedMu.Lock()
+	c.stdinClosed = true
+	c.stdioClosedMu.Unlock()
+	if err := c.killIfStdioClosed(); err != nil {
+		logrus.Warnf("commandConn.CloseWrite: %v", err)
+	}
+	return nil
+}
+
+func (c *commandConn) Write(p []byte) (int, error) {
+	n, err := c.stdin.Write(p)
+	if err == io.EOF {
+		err = c.onEOF(err)
+	}
+	return n, err
+}
+
+func (c *commandConn) Close() error {
+	var err error
+	if err = c.CloseRead(); err != nil {
+		logrus.Warnf("commandConn.Close: CloseRead: %v", err)
+	}
+	if err = c.CloseWrite(); err != nil {
+		logrus.Warnf("commandConn.Close: CloseWrite: %v", err)
+	}
+	return err
+}
+
+func (c *commandConn) LocalAddr() net.Addr {
+	return c.localAddr
+}
+func (c *commandConn) RemoteAddr() net.Addr {
+	return c.remoteAddr
+}
+func (c *commandConn) SetDeadline(t time.Time) error {
+	logrus.Debugf("unimplemented call: SetDeadline(%v)", t)
+	return nil
+}
+func (c *commandConn) SetReadDeadline(t time.Time) error {
+	logrus.Debugf("unimplemented call: SetReadDeadline(%v)", t)
+	return nil
+}
+func (c *commandConn) SetWriteDeadline(t time.Time) error {
+	logrus.Debugf("unimplemented call: SetWriteDeadline(%v)", t)
+	return nil
+}
+
+type dummyAddr struct {
+	network string
+	s       string
+}
+
+func (d dummyAddr) Network() string {
+	return d.network
+}
+
+func (d dummyAddr) String() string {
+	return d.s
+}
+
+type stderrWriter struct {
+	stderrMu    *sync.Mutex
+	stderr      *bytes.Buffer
+	debugPrefix string
+}
+
+func (w *stderrWriter) Write(p []byte) (int, error) {
+	logrus.Debugf("%s%s", w.debugPrefix, string(p))
+	w.stderrMu.Lock()
+	if w.stderr.Len() > 4096 {
+		w.stderr.Reset()
+	}
+	n, err := w.stderr.Write(p)
+	w.stderrMu.Unlock()
+	return n, err
+}

--- a/vendor/github.com/docker/cli/cli/connhelper/commandconn/commandconn_linux.go
+++ b/vendor/github.com/docker/cli/cli/connhelper/commandconn/commandconn_linux.go
@@ -1,0 +1,12 @@
+package commandconn
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func setPdeathsig(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Pdeathsig: syscall.SIGKILL,
+	}
+}

--- a/vendor/github.com/docker/cli/cli/connhelper/commandconn/commandconn_nolinux.go
+++ b/vendor/github.com/docker/cli/cli/connhelper/commandconn/commandconn_nolinux.go
@@ -1,0 +1,10 @@
+// +build !linux
+
+package commandconn
+
+import (
+	"os/exec"
+)
+
+func setPdeathsig(cmd *exec.Cmd) {
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -106,7 +106,8 @@ github.com/containerd/go-runc
 github.com/containerd/typeurl
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/docker/cli v0.0.0-20190131223713-234462756460
+# github.com/docker/cli v0.0.0-20190321234815-f40f9c240ab0
+github.com/docker/cli/cli/connhelper/commandconn
 github.com/docker/cli/cli/config
 github.com/docker/cli/cli/config/configfile
 github.com/docker/cli/cli/config/credentials


### PR DESCRIPTION
Usage:
```console
$ docker run -d --name buildkit-rootless --security-opt seccomp=unconfined --security-opt apparmor=unconfined moby/buildkit:local-rootless --oci-worker-no-process-sandbox
$ export BUILDKIT_HOST=docker://buildkit-rootless
$ buildctl build ...
```

Part of #769 
`kubepod+experimental://` helper will be also added later.
