### PR TITLE
exporter: add tarball exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,14 @@ The local client will copy the files directly to the client. This is useful if B
 buildctl build ... --output type=local,dest=path/to/output-dir
 ```
 
+Tar exporter is similar to local exporter but transfers the files through a tarball.
+
+```
+buildctl build ... --output type=tar,dest=out.tar
+buildctl build ... --output type=tar > out.tar
+```
+
+
 ##### Exporting built image to Docker
 
 ```

--- a/client/exporters.go
+++ b/client/exporters.go
@@ -3,6 +3,7 @@ package client
 const (
 	ExporterImage  = "image"
 	ExporterLocal  = "local"
+	ExporterTar    = "tar"
 	ExporterOCI    = "oci"
 	ExporterDocker = "docker"
 )

--- a/client/solve.go
+++ b/client/solve.go
@@ -124,7 +124,7 @@ func (c *Client) solve(ctx context.Context, def *llb.Definition, runGateway runG
 			return nil, errors.New("output directory is required for local exporter")
 		}
 		s.Allow(filesync.NewFSSyncTargetDir(ex.OutputDir))
-	case ExporterOCI, ExporterDocker:
+	case ExporterOCI, ExporterDocker, ExporterTar:
 		if ex.OutputDir != "" {
 			return nil, errors.Errorf("output directory %s is not supported by %s exporter", ex.OutputDir, ex.Type)
 		}

--- a/cmd/buildctl/build/output.go
+++ b/cmd/buildctl/build/output.go
@@ -95,8 +95,8 @@ func resolveExporterDest(exporter, dest string) (io.WriteCloser, string, error) 
 			return nil, "", errors.New("output directory is required for local exporter")
 		}
 		return nil, dest, nil
-	case client.ExporterOCI, client.ExporterDocker:
-		if dest != "" {
+	case client.ExporterOCI, client.ExporterDocker, client.ExporterTar:
+		if dest != "" && dest != "-" {
 			fi, err := os.Stat(dest)
 			if err != nil && !os.IsNotExist(err) {
 				return nil, "", errors.Wrapf(err, "invalid destination file: %s", dest)

--- a/exporter/local/export.go
+++ b/exporter/local/export.go
@@ -93,10 +93,13 @@ func (e *localExporterInstance) Export(ctx context.Context, inp exporter.Source)
 			lbl := "copying files"
 			if isMap {
 				lbl += " " + k
-				fs = fsutil.SubDirFS(fs, fstypes.Stat{
+				fs, err = fsutil.SubDirFS([]fsutil.Dir{{FS: fs, Stat: fstypes.Stat{
 					Mode: uint32(os.ModeDir | 0755),
 					Path: strings.Replace(k, "/", "_", -1),
-				})
+				}}})
+				if err != nil {
+					return err
+				}
 			}
 
 			progress := newProgressHandler(ctx, lbl)

--- a/exporter/tar/export.go
+++ b/exporter/tar/export.go
@@ -1,0 +1,155 @@
+package local
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/moby/buildkit/cache"
+	"github.com/moby/buildkit/exporter"
+	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/session/filesync"
+	"github.com/moby/buildkit/snapshot"
+	"github.com/moby/buildkit/util/progress"
+	"github.com/pkg/errors"
+	"github.com/tonistiigi/fsutil"
+	fstypes "github.com/tonistiigi/fsutil/types"
+)
+
+type Opt struct {
+	SessionManager *session.Manager
+}
+
+type localExporter struct {
+	opt Opt
+	// session manager
+}
+
+func New(opt Opt) (exporter.Exporter, error) {
+	le := &localExporter{opt: opt}
+	return le, nil
+}
+
+func (e *localExporter) Resolve(ctx context.Context, opt map[string]string) (exporter.ExporterInstance, error) {
+	id := session.FromContext(ctx)
+	if id == "" {
+		return nil, errors.New("could not access local files without session")
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	caller, err := e.opt.SessionManager.Get(timeoutCtx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	li := &localExporterInstance{localExporter: e, caller: caller}
+	return li, nil
+}
+
+type localExporterInstance struct {
+	*localExporter
+	caller session.Caller
+}
+
+func (e *localExporterInstance) Name() string {
+	return "exporting to client"
+}
+
+func (e *localExporterInstance) Export(ctx context.Context, inp exporter.Source) (map[string]string, error) {
+	var defers []func()
+
+	defer func() {
+		for i := len(defers) - 1; i >= 0; i-- {
+			defers[i]()
+		}
+	}()
+
+	getDir := func(ctx context.Context, k string, ref cache.ImmutableRef) (*fsutil.Dir, error) {
+		var src string
+		var err error
+		if ref == nil {
+			src, err = ioutil.TempDir("", "buildkit")
+			if err != nil {
+				return nil, err
+			}
+			defers = append(defers, func() { os.RemoveAll(src) })
+		} else {
+			mount, err := ref.Mount(ctx, true)
+			if err != nil {
+				return nil, err
+			}
+
+			lm := snapshot.LocalMounter(mount)
+
+			src, err = lm.Mount()
+			if err != nil {
+				return nil, err
+			}
+			defers = append(defers, func() { lm.Unmount() })
+		}
+
+		return &fsutil.Dir{
+			FS: fsutil.NewFS(src, nil),
+			Stat: fstypes.Stat{
+				Mode: uint32(os.ModeDir | 0755),
+				Path: strings.Replace(k, "/", "_", -1),
+			},
+		}, nil
+	}
+
+	var fs fsutil.FS
+
+	if len(inp.Refs) > 0 {
+		dirs := make([]fsutil.Dir, 0, len(inp.Refs))
+		for k, ref := range inp.Refs {
+			d, err := getDir(ctx, k, ref)
+			if err != nil {
+				return nil, err
+			}
+			dirs = append(dirs, *d)
+		}
+		var err error
+		fs, err = fsutil.SubDirFS(dirs)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		d, err := getDir(ctx, "", inp.Ref)
+		if err != nil {
+			return nil, err
+		}
+		fs = d.FS
+	}
+
+	w, err := filesync.CopyFileWriter(ctx, e.caller)
+	if err != nil {
+		return nil, err
+	}
+	report := oneOffProgress(ctx, "sending tarball")
+	if err := fsutil.WriteTar(ctx, fs, w); err != nil {
+		w.Close()
+		return nil, report(err)
+	}
+	return nil, report(w.Close())
+}
+
+func oneOffProgress(ctx context.Context, id string) func(err error) error {
+	pw, _, _ := progress.FromContext(ctx)
+	now := time.Now()
+	st := progress.Status{
+		Started: &now,
+	}
+	pw.Write(id, st)
+	return func(err error) error {
+		// TODO: set error on status
+		now := time.Now()
+		st.Completed = &now
+		pw.Write(id, st)
+		pw.Close()
+		return err
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/sirupsen/logrus v1.3.0
 	github.com/stretchr/testify v1.3.0
 	github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8 // indirect
-	github.com/tonistiigi/fsutil v0.0.0-20190319020005-1bdbf124ad49
+	github.com/tonistiigi/fsutil v0.0.0-20190327153851-3bbb99cdbd76
 	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea
 	github.com/uber/jaeger-client-go v0.0.0-20180103221425-e02c85f9069e
 	github.com/uber/jaeger-lib v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8 h1:zLV6q4e8Jv9EHjNg/iHfzwDkCve6Ua5jCygptrtXHvI=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
-github.com/tonistiigi/fsutil v0.0.0-20190319020005-1bdbf124ad49 h1:UFQ7uDVXIH4fFfOb+fISgTl8Ukk0CkGQudHQh980l+0=
-github.com/tonistiigi/fsutil v0.0.0-20190319020005-1bdbf124ad49/go.mod h1:pzh7kdwkDRh+Bx8J30uqaKJ1M4QrSH/um8fcIXeM8rc=
+github.com/tonistiigi/fsutil v0.0.0-20190327153851-3bbb99cdbd76 h1:eGfgYrNUSD448sa4mxH6nQpyZfN39QH0mLB7QaKIjus=
+github.com/tonistiigi/fsutil v0.0.0-20190327153851-3bbb99cdbd76/go.mod h1:pzh7kdwkDRh+Bx8J30uqaKJ1M4QrSH/um8fcIXeM8rc=
 github.com/tonistiigi/go-immutable-radix v0.0.0-20170803185627-826af9ccf0fe h1:pd7hrFSqUPxYS9IB+UMG1AB/8EXGXo17ssx0bSQ5L6Y=
 github.com/tonistiigi/go-immutable-radix v0.0.0-20170803185627-826af9ccf0fe/go.mod h1:/+MCh11CJf2oz0BXmlmqyopK/ad1rKkcOXPoYuPCJYU=
 github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea h1:SXhTLE6pb6eld/v/cCndK0AMpt1wiVFb/YYmqB3/QG0=

--- a/vendor/github.com/tonistiigi/fsutil/tarwriter.go
+++ b/vendor/github.com/tonistiigi/fsutil/tarwriter.go
@@ -1,0 +1,72 @@
+package fsutil
+
+import (
+	"archive/tar"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/tonistiigi/fsutil/types"
+)
+
+func WriteTar(ctx context.Context, fs FS, w io.Writer) error {
+	tw := tar.NewWriter(w)
+	err := fs.Walk(ctx, func(path string, fi os.FileInfo, err error) error {
+		stat, ok := fi.Sys().(*types.Stat)
+		if !ok {
+			return errors.Wrapf(err, "invalid fileinfo without stat info: %s", path)
+		}
+		hdr, err := tar.FileInfoHeader(fi, stat.Linkname)
+		if err != nil {
+			return err
+		}
+
+		name := filepath.ToSlash(path)
+		if fi.IsDir() && !strings.HasSuffix(name, "/") {
+			name += "/"
+		}
+		hdr.Name = name
+
+		hdr.Uid = int(stat.Uid)
+		hdr.Gid = int(stat.Gid)
+		hdr.Devmajor = stat.Devmajor
+		hdr.Devminor = stat.Devminor
+		hdr.Linkname = stat.Linkname
+		if hdr.Linkname != "" {
+			hdr.Size = 0
+			hdr.Typeflag = tar.TypeLink
+		}
+
+		if len(stat.Xattrs) > 0 {
+			hdr.PAXRecords = map[string]string{}
+		}
+		for k, v := range stat.Xattrs {
+			hdr.PAXRecords["SCHILY.xattr."+k] = string(v)
+		}
+
+		if err := tw.WriteHeader(hdr); err != nil {
+			return errors.Wrap(err, "failed to write file header")
+		}
+
+		if hdr.Typeflag == tar.TypeReg && hdr.Size > 0 && hdr.Linkname == "" {
+			rc, err := fs.Open(path)
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(tw, rc); err != nil {
+				return err
+			}
+			if err := rc.Close(); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	return tw.Close()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -215,7 +215,7 @@ github.com/stretchr/testify/require
 github.com/stretchr/testify/assert
 # github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8
 github.com/syndtr/gocapability/capability
-# github.com/tonistiigi/fsutil v0.0.0-20190319020005-1bdbf124ad49
+# github.com/tonistiigi/fsutil v0.0.0-20190327153851-3bbb99cdbd76
 github.com/tonistiigi/fsutil
 github.com/tonistiigi/fsutil/types
 github.com/tonistiigi/fsutil/copy

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -23,6 +23,7 @@ import (
 	imageexporter "github.com/moby/buildkit/exporter/containerimage"
 	localexporter "github.com/moby/buildkit/exporter/local"
 	ociexporter "github.com/moby/buildkit/exporter/oci"
+	tarexporter "github.com/moby/buildkit/exporter/tar"
 	"github.com/moby/buildkit/frontend"
 	gw "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/identity"
@@ -250,6 +251,10 @@ func (w *Worker) Exporter(name string, sm *session.Manager) (exporter.Exporter, 
 		})
 	case client.ExporterLocal:
 		return localexporter.New(localexporter.Opt{
+			SessionManager: sm,
+		})
+	case client.ExporterTar:
+		return tarexporter.New(tarexporter.Opt{
 			SessionManager: sm,
 		})
 	case client.ExporterOCI:


### PR DESCRIPTION
Add a possibility to export to a tarball on the client side. Similar to local exporter but allows preserving the uid/gid values.

`buildctl build -o type=tar,dest=foo.tar ...`
`buildctl build -o type=tar ... > foo.tar`

~depends on https://github.com/tonistiigi/fsutil/pull/65~

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>