### PR TITLE
connhelper: refactor helpers to own packages

### DIFF
--- a/client/connhelper/docker/docker.go
+++ b/client/connhelper/docker/docker.go
@@ -1,0 +1,26 @@
+// Package connhelper provides helpers for connecting to a remote daemon host with custom logic.
+package connhelper
+
+import (
+	"context"
+	"net"
+	"net/url"
+
+	"github.com/docker/cli/cli/connhelper/commandconn"
+	"github.com/moby/buildkit/client/connhelper"
+)
+
+func init() {
+	connhelper.Register("docker", DockerHelper)
+}
+
+// DockerHelper returns helper for connecting to Docker container.
+// docker://<container> URL requires BuildKit v0.5.0 or later in the container.
+func DockerHelper(u *url.URL) (*connhelper.ConnectionHelper, error) {
+	container := u.Host
+	return &connhelper.ConnectionHelper{
+		ContextDialer: func(ctx context.Context, addr string) (net.Conn, error) {
+			return commandconn.New(ctx, "docker", "exec", "-i", container, "buildctl", "dial-stdio")
+		},
+	}, nil
+}

--- a/cmd/buildctl/main.go
+++ b/cmd/buildctl/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	_ "github.com/moby/buildkit/client/connhelper/docker"
 	bccommon "github.com/moby/buildkit/cmd/buildctl/common"
 	"github.com/moby/buildkit/util/apicaps"
 	"github.com/moby/buildkit/util/appdefaults"


### PR DESCRIPTION
Removes cli repo dependency from client so it can be vendored to moby.

@AkihiroSuda @tiborvass 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>