### PR TITLE
progressui: allow vertex reset

### DIFF
--- a/util/progress/progressui/display.go
+++ b/util/progress/progressui/display.go
@@ -227,7 +227,10 @@ func (t *trace) update(s *client.SolveStatus, termWidth int) {
 			}
 			t.vertexes = append(t.vertexes, t.byDigest[v.Digest])
 		}
-		t.byDigest[v.Digest].Vertex = v
+		// allow a duplicate initial vertex that shouldn't reset state
+		if !(prev != nil && prev.Started != nil && v.Started == nil) {
+			t.byDigest[v.Digest].Vertex = v
+		}
 		t.byDigest[v.Digest].jobCached = false
 	}
 	for _, s := range s.Statuses {


### PR DESCRIPTION
buildx can merge progress from multiple builds. When a repeated vertex appears with an initial state, avoid resetting the vertex that would cause a duplicate vertex in the jobs array.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>