### PR TITLE
hack/binaries: add BUILDKITD_TAGS

### DIFF
--- a/hack/binaries
+++ b/hack/binaries
@@ -22,11 +22,11 @@ binariesLegacy() {
     copysrc="/out/."
     ;;
   "windows")
-    docker build --iidfile $iidfile --target buildctl.exe -f ./hack/dockerfiles/test.Dockerfile --force-rm .
+    docker build --iidfile $iidfile --build-arg BUILDKITD_TAGS="${BUILDKITD_TAGS}" --target buildctl.exe -f ./hack/dockerfiles/test.Dockerfile --force-rm .
     copysrc="/out/."
     ;;
   *)
-    docker build --iidfile $iidfile --target buildkit-binaries -f ./hack/dockerfiles/test.Dockerfile --force-rm .
+    docker build --iidfile $iidfile --build-arg BUILDKITD_TAGS="${BUILDKITD_TAGS}" --target buildkit-binaries -f ./hack/dockerfiles/test.Dockerfile --force-rm .
     ;;
   esac
 
@@ -47,7 +47,7 @@ binariesDocker() {
     target="linux"
   fi
 
-  docker build $platformFlag --target binaries-$target --iidfile $iidfile -f ./hack/dockerfiles/test.buildkit.Dockerfile --force-rm .
+  docker build $platformFlag --build-arg BUILDKITD_TAGS="${BUILDKITD_TAGS}" --target binaries-$target --iidfile $iidfile -f ./hack/dockerfiles/test.buildkit.Dockerfile --force-rm .
   iid=$(cat $iidfile)
   containerID=$(docker create $iid copy)
   docker cp $containerID:/ bin/tmp
@@ -66,6 +66,7 @@ binaries() {
   buildctl build $progressFlag --frontend=dockerfile.v0 \
     --local context=. --local dockerfile=. \
     --opt filename=./hack/dockerfiles/test.buildkit.Dockerfile \
+    --opt build-arg:BUILDKITD_TAGS="$BUILDKITD_TAGS" \
     --opt target=binaries $platformFlag \
     --output type=local,dest=./bin/
 }

--- a/hack/dockerfiles/test.buildkit.Dockerfile
+++ b/hack/dockerfiles/test.buildkit.Dockerfile
@@ -91,10 +91,11 @@ RUN --mount=target=. --mount=target=/root/.cache,type=cache \
 FROM buildkit-base AS buildkitd
 ENV CGO_ENABLED=1
 ARG TARGETPLATFORM
+ARG BUILDKITD_TAGS
 RUN --mount=target=. --mount=target=/root/.cache,type=cache \
   --mount=target=/go/pkg/mod,type=cache \
   --mount=source=/tmp/.ldflags,target=/tmp/.ldflags,from=buildkit-version \
-  go build -ldflags "$(cat /tmp/.ldflags) -w -extldflags -static" -tags 'osusergo seccomp netgo cgo static_build ' -o /usr/bin/buildkitd ./cmd/buildkitd && \
+  go build -ldflags "$(cat /tmp/.ldflags) -w -extldflags -static" -tags "osusergo seccomp netgo cgo static_build ${BUILDKITD_TAGS}" -o /usr/bin/buildkitd ./cmd/buildkitd && \
   file /usr/bin/buildkitd | grep "statically linked"
 
 FROM scratch AS binaries-linux


### PR DESCRIPTION
Applying the patch that @tonistiigi suggested in https://github.com/moby/buildkit/issues/928#issuecomment-483535274

This makes setting build-tags more convenient;

    make binaries BUILDKITD_TAGS="$(cat frontend/dockerfile/release/experimental/tags)"
