### PR TITLE
MAINTAINERS: update Akihiro Suda's email address

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -7,8 +7,9 @@
 # For explanation on this file format: man git-shortlog
 
 Aaron L. Xu <likexu@harmonycloud.cn>
-Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
-Akihiro Suda <suda.akihiro@lab.ntt.co.jp> <suda.kyoto@gmail.com>
+Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
+Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp> <suda.kyoto@gmail.com>
+Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp> <suda.akihiro@lab.ntt.co.jp>
 Allen Sun <allen.sun@daocloud.io>
 Bin Liu <liubin0329@gmail.com>
 Daniel Nephin <dnephin@gmail.com>

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -180,7 +180,7 @@ made through a pull request.
 
 	[people.akihirosuda]
 	Name = "Akihiro Suda"
-	Email = "suda.akihiro@lab.ntt.co.jp"
+	Email = "akihiro.suda.cz@hco.ntt.co.jp"
 	GitHub = "AkihiroSuda"
 
 	[People.ijc]


### PR DESCRIPTION
No affiliation change (NTT).

The former email address will continue to be available for the time
being.

For daily communication, I still prefer to use my gmail.com address.

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>