### PR TITLE
Replace boss callout with vab

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ BuildKit is used by the following projects:
 - [OpenFaaS Cloud](https://github.com/openfaas/openfaas-cloud)
 - [container build interface](https://github.com/containerbuilding/cbi)
 - [Knative Build Templates](https://github.com/knative/build-templates)
-- [boss](https://github.com/crosbymichael/boss)
+- [vab](https://github.com/stellarproject/vab)
 - [Rio](https://github.com/rancher/rio) (on roadmap)
 
 ### Quick start


### PR DESCRIPTION
`vab` is a small build frontend that uses buildkit to build images or
output files localy from a Dockerfile.  Its pretty sweet.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>