### PR TITLE
[18.09 backport] Have parser error on dockerfiles without instructions

### DIFF
--- a/frontend/dockerfile/parser/parser.go
+++ b/frontend/dockerfile/parser/parser.go
@@ -275,6 +275,11 @@ func Parse(rwc io.Reader) (*Result, error) {
 	if len(warnings) > 0 {
 		warnings = append(warnings, "[WARNING]: Empty continuation lines will become errors in a future release.")
 	}
+
+	if root.StartLine < 0 {
+		return nil, errors.New("file with no instructions.")
+	}
+
 	return &Result{
 		AST:         root,
 		Warnings:    warnings,

--- a/frontend/dockerfile/parser/testfiles-negative/only_comments/Dockerfile
+++ b/frontend/dockerfile/parser/testfiles-negative/only_comments/Dockerfile
@@ -1,0 +1,3 @@
+# Hello
+# These are just comments
+


### PR DESCRIPTION
backport of https://github.com/moby/buildkit/pull/771 for the docker-18.09 branch

See https://github.com/moby/moby/pull/38487 for more discussion.
