### PR TITLE
exporter: put arm variant in the image config

### DIFF
--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -5,12 +5,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"runtime"
 	"time"
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/diff"
 	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/platforms"
 	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/cache/blobs"
 	"github.com/moby/buildkit/exporter"
@@ -291,9 +291,21 @@ func (ic *ImageWriter) ContentStore() content.Store {
 }
 
 func emptyImageConfig() ([]byte, error) {
-	img := ocispec.Image{
-		Architecture: runtime.GOARCH,
-		OS:           runtime.GOOS,
+	pl := platforms.Normalize(platforms.DefaultSpec())
+
+	type image struct {
+		ocispec.Image
+
+		// Variant defines platform variant. To be added to OCI.
+		Variant string `json:"variant,omitempty"`
+	}
+
+	img := image{
+		Image: ocispec.Image{
+			Architecture: pl.Architecture,
+			OS:           pl.OS,
+		},
+		Variant: pl.Variant,
 	}
 	img.RootFS.Type = "layers"
 	img.Config.WorkingDir = "/"

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -390,6 +390,7 @@ func Dockerfile2LLB(ctx context.Context, dt []byte, opt ConvertOpt) (*llb.State,
 	if !platformOpt.implicitTarget {
 		target.image.OS = platformOpt.targetPlatform.OS
 		target.image.Architecture = platformOpt.targetPlatform.Architecture
+		target.image.Variant = platformOpt.targetPlatform.Variant
 	}
 
 	return &st, &target.image, nil

--- a/frontend/dockerfile/dockerfile2llb/image.go
+++ b/frontend/dockerfile/dockerfile2llb/image.go
@@ -50,6 +50,9 @@ type Image struct {
 
 	// Config defines the execution parameters which should be used as a base when running a container using the image.
 	Config ImageConfig `json:"config,omitempty"`
+
+	// Variant defines platform variant. To be added to OCI.
+	Variant string `json:"variant,omitempty"`
 }
 
 func clone(src Image) Image {
@@ -67,6 +70,7 @@ func emptyImage(platform specs.Platform) Image {
 			Architecture: platform.Architecture,
 			OS:           platform.OS,
 		},
+		Variant: platform.Variant,
 	}
 	img.RootFS.Type = "layers"
 	img.Config.WorkingDir = "/"


### PR DESCRIPTION
Arm variant is missing in the current image config, causing issues when working with manifest lists. The types are planned to be updated https://github.com/dmcgowan/docker/issues/45 . With this PR we start adding variant info to images built with buildkit so we don't have to rebuild everything when types eventually land in spec.

@tiborvass @dmcgowan 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>