### PR TITLE
runexecutor: support NoPivot

### DIFF
--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -41,6 +41,8 @@ type Opt struct {
 	// ProcessMode
 	ProcessMode     oci.ProcessMode
 	IdentityMapping *idtools.IdentityMapping
+	// runc run --no-pivot (unrecommended)
+	NoPivot bool
 }
 
 var defaultCommandCandidates = []string{"buildkit-runc", "runc"}
@@ -54,6 +56,7 @@ type runcExecutor struct {
 	networkProviders map[pb.NetMode]network.Provider
 	processMode      oci.ProcessMode
 	idmap            *idtools.IdentityMapping
+	noPivot          bool
 }
 
 func New(opt Opt, networkProviders map[pb.NetMode]network.Provider) (executor.Executor, error) {
@@ -111,6 +114,7 @@ func New(opt Opt, networkProviders map[pb.NetMode]network.Provider) (executor.Ex
 		networkProviders: networkProviders,
 		processMode:      opt.ProcessMode,
 		idmap:            opt.IdentityMapping,
+		noPivot:          opt.NoPivot,
 	}
 	return w, nil
 }
@@ -269,7 +273,8 @@ func (w *runcExecutor) Exec(ctx context.Context, meta executor.Meta, root cache.
 
 	logrus.Debugf("> creating %s %v", id, meta.Args)
 	status, err := w.runc.Run(runCtx, id, bundle, &runc.CreateOpts{
-		IO: &forwardIO{stdin: stdin, stdout: stdout, stderr: stderr},
+		IO:      &forwardIO{stdin: stdin, stdout: stdout, stderr: stderr},
+		NoPivot: w.noPivot,
 	})
 	close(done)
 	if err != nil {


### PR DESCRIPTION
This flag allows DOCKER_BUILDKIT to be running on minikube host: https://github.com/kubernetes/minikube/issues/4143

moby/builder/build-next needs to be updated to set NoPivot when
$DOCKER_RAMDISK is set.

This flag is deprecated from its birth and not exposed to the standalone buildkitd OCI worker.
See https://github.com/kubernetes/minikube/issues/3512

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>