### PR TITLE
session/grpchijack: fix race

### DIFF
--- a/session/grpchijack/dial.go
+++ b/session/grpchijack/dial.go
@@ -46,6 +46,7 @@ type conn struct {
 
 	closedOnce sync.Once
 	readMu     sync.Mutex
+	writeMu    sync.Mutex
 	err        error
 	closeCh    chan struct{}
 }
@@ -79,6 +80,8 @@ func (c *conn) Read(b []byte) (n int, err error) {
 }
 
 func (c *conn) Write(b []byte) (int, error) {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
 	m := &controlapi.BytesMessage{Data: b}
 	if err := c.stream.SendMsg(m); err != nil {
 		return 0, err
@@ -93,7 +96,9 @@ func (c *conn) Close() (err error) {
 		}()
 
 		if cs, ok := c.stream.(grpc.ClientStream); ok {
+			c.writeMu.Lock()
 			err = cs.CloseSend()
+			c.writeMu.Unlock()
 			if err != nil {
 				return
 			}


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>

From #936 

```
==================
WARNING: DATA RACE
Write at 0x00c0000d5a50 by goroutine 6:
  google.golang.org/grpc.(*clientStream).CloseSend()
      /src/vendor/google.golang.org/grpc/stream.go:757 +0x64
  github.com/moby/buildkit/api/services/control.(*controlSessionClient).CloseSend()
      <autogenerated>:1 +0x62
  github.com/moby/buildkit/session/grpchijack.(*conn).Close.func1()
      /src/session/grpchijack/dial.go:96 +0x5df
  sync.(*Once).Do()
      /usr/local/go/src/sync/once.go:44 +0xde
  github.com/moby/buildkit/session/grpchijack.(*conn).Close()
      /src/session/grpchijack/dial.go:90 +0x7d
  github.com/moby/buildkit/session.(*Session).Close()
      /src/session/session.go:111 +0x103
  github.com/moby/buildkit/client.(*Client).solve.func2.1()
      /src/client/solve.go:171 +0xae
  github.com/moby/buildkit/client.(*Client).solve.func2()
      /src/client/solve.go:189 +0x769
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /src/vendor/golang.org/x/sync/errgroup/errgroup.go:58 +0x64

Previous read at 0x00c0000d5a50 by goroutine 131:
  google.golang.org/grpc.(*clientStream).SendMsg()
      /src/vendor/google.golang.org/grpc/stream.go:674 +0xf8
  github.com/moby/buildkit/api/services/control.(*controlSessionClient).SendMsg()
      <autogenerated>:1 +0x7a
  github.com/moby/buildkit/session/grpchijack.(*conn).Write()
      /src/session/grpchijack/dial.go:83 +0xf3
  bufio.(*Writer).Flush()
      /usr/local/go/src/bufio/bufio.go:590 +0x13f
  golang.org/x/net/http2.(*bufferedWriter).Flush()
      /src/vendor/golang.org/x/net/http2/http2.go:293 +0x67
  golang.org/x/net/http2.(*serverConn).Flush()
      /src/vendor/golang.org/x/net/http2/server.go:568 +0x50
  golang.org/x/net/http2.(*flushFrameWriter).writeFrame()
      /src/vendor/golang.org/x/net/http2/write.go:68 +0x54
  golang.org/x/net/http2.(*serverConn).writeFrameAsync()
      /src/vendor/golang.org/x/net/http2/server.go:741 +0x58

Goroutine 6 (running) created at:
  golang.org/x/sync/errgroup.(*Group).Go()
      /src/vendor/golang.org/x/sync/errgroup/errgroup.go:55 +0x73
  github.com/moby/buildkit/client.(*Client).solve()
      /src/client/solve.go:161 +0xe1f
  github.com/moby/buildkit/client.(*Client).Build()
      /src/client/build.go:59 +0x5fb
  github.com/moby/buildkit/client.testClientGatewayFailedSolve()
      /src/client/build_test.go:125 +0x1e9
  github.com/moby/buildkit/util/testutil/integration.Run.func2.1()
      /src/util/testutil/integration/run.go:172 +0x2c2
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:865 +0x163

Goroutine 131 (running) created at:
  golang.org/x/net/http2.(*serverConn).startFrameWrite()
      /src/vendor/golang.org/x/net/http2/server.go:1119 +0x367
  golang.org/x/net/http2.(*serverConn).scheduleFrameWrite()
      /src/vendor/golang.org/x/net/http2/server.go:1225 +0x2de
  golang.org/x/net/http2.(*serverConn).wroteFrame()
      /src/vendor/golang.org/x/net/http2/server.go:1181 +0x1de
  golang.org/x/net/http2.(*serverConn).serve()
      /src/vendor/golang.org/x/net/http2/server.go:834 +0x134d
  golang.org/x/net/http2.(*Server).ServeConn()
      /src/vendor/golang.org/x/net/http2/server.go:438 +0xd7b
  github.com/moby/buildkit/session.serve()
      /src/session/grpc.go:24 +0x17b
  github.com/moby/buildkit/session.(*Session).Run()
      /src/session/session.go:103 +0xa10
  github.com/moby/buildkit/client.(*Client).solve.func1()
      /src/client/solve.go:156 +0xf4
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /src/vendor/golang.org/x/sync/errgroup/errgroup.go:58 +0x64
==================
```