### PR TITLE
Add missing locks around broadcasts

### DIFF
--- a/control/gateway/gateway.go
+++ b/control/gateway/gateway.go
@@ -63,7 +63,9 @@ func (gwf *GatewayForwarder) lookupForwarder(ctx context.Context) (gateway.LLBBr
 
 	go func() {
 		<-ctx.Done()
+		gwf.mu.Lock()
 		gwf.updateCond.Broadcast()
+		gwf.mu.Unlock()
 	}()
 
 	gwf.mu.RLock()

--- a/session/manager.go
+++ b/session/manager.go
@@ -162,7 +162,9 @@ func (sm *Manager) Get(ctx context.Context, id string) (Caller, error) {
 	go func() {
 		select {
 		case <-ctx.Done():
+			sm.mu.Lock()
 			sm.updateCondition.Broadcast()
+			sm.mu.Unlock()
 		}
 	}()
 

--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -404,7 +404,9 @@ func (jl *Solver) Get(id string) (*Job, error) {
 
 	go func() {
 		<-ctx.Done()
+		jl.mu.Lock()
 		jl.updateCond.Broadcast()
+		jl.mu.Unlock()
 	}()
 
 	jl.mu.RLock()

--- a/util/progress/progress.go
+++ b/util/progress/progress.go
@@ -101,7 +101,9 @@ func (pr *progressReader) Read(ctx context.Context) ([]*Progress, error) {
 		select {
 		case <-done:
 		case <-ctx.Done():
+			pr.mu.Lock()
 			pr.cond.Broadcast()
+			pr.mu.Unlock()
 		}
 	}()
 	pr.mu.Lock()
@@ -163,7 +165,9 @@ func pipe() (*progressReader, *progressWriter, func()) {
 	pr.cond = sync.NewCond(&pr.mu)
 	go func() {
 		<-ctx.Done()
+		pr.mu.Lock()
 		pr.cond.Broadcast()
+		pr.mu.Unlock()
 	}()
 	pw := &progressWriter{
 		reader: pr,


### PR DESCRIPTION
To avoid race conditions related to broadcasting prior to the intended thread having invoked Wait already you need to lock the wrapping mutex before broadcasting.

https://pastebin.com/tNitJ5L2 demonstrates why unlocked broadcasts are problematic.