### PR TITLE
[dockerfile2llb] fix daemon crash: check for circular dependency in convert

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -209,7 +209,7 @@ func Dockerfile2LLB(ctx context.Context, dt []byte, opt ConvertOpt) (*llb.State,
 
 	if has, state := hasCircularDependency(allDispatchStates.states); has {
 		return nil, nil, fmt.Errorf("circular dependency detected on stage: %s", state.stageName)
-        }
+	}
 
 	eg, ctx := errgroup.WithContext(ctx)
 	for i, d := range allDispatchStates.states {
@@ -1135,38 +1135,38 @@ func isReachable(from, to *dispatchState) (ret bool) {
 }
 
 func hasCircularDependency(states []*dispatchState) (bool, *dispatchState) {
-       var visit func (state *dispatchState) bool
-       if states == nil {
-               return false, nil
-       }
-       visited := make(map[*dispatchState]struct{})
-       path := make(map[*dispatchState]struct{})
+	var visit func(state *dispatchState) bool
+	if states == nil {
+		return false, nil
+	}
+	visited := make(map[*dispatchState]struct{})
+	path := make(map[*dispatchState]struct{})
 
-       visit = func (state *dispatchState) bool {
-               _, ok := visited[state]
-               if ok {
-                       return false
-               }
-               visited[state] = struct{}{}
-               path[state] = struct{}{}
-               for dep := range state.deps {
-                       _, ok = path[dep]
-                       if ok {
-                               return true
-                       }
-                       if visit(dep) {
-                               return true
-                       }
-               }
-               delete(path, state)
-               return false
-       }
-       for _, state := range states {
-               if visit(state) {
-                       return true, state
-               }
-       }
-       return false, nil
+	visit = func(state *dispatchState) bool {
+		_, ok := visited[state]
+		if ok {
+			return false
+		}
+		visited[state] = struct{}{}
+		path[state] = struct{}{}
+		for dep := range state.deps {
+			_, ok = path[dep]
+			if ok {
+				return true
+			}
+			if visit(dep) {
+				return true
+			}
+		}
+		delete(path, state)
+		return false
+	}
+	for _, state := range states {
+		if visit(state) {
+			return true, state
+		}
+	}
+	return false, nil
 }
 
 func parseUser(str string) (uid uint32, gid uint32, err error) {

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -172,10 +172,6 @@ func Dockerfile2LLB(ctx context.Context, dt []byte, opt ConvertOpt) (*llb.State,
 		}
 	}
 
-	if len(allDispatchStates.states) == 1 {
-		allDispatchStates.states[0].stageName = ""
-	}
-
 	var target *dispatchState
 	if opt.Target == "" {
 		target = allDispatchStates.lastTarget()
@@ -209,6 +205,10 @@ func Dockerfile2LLB(ctx context.Context, dt []byte, opt ConvertOpt) (*llb.State,
 
 	if has, state := hasCircularDependency(allDispatchStates.states); has {
 		return nil, nil, fmt.Errorf("circular dependency detected on stage: %s", state.stageName)
+	}
+
+	if len(allDispatchStates.states) == 1 {
+		allDispatchStates.states[0].stageName = ""
 	}
 
 	eg, ctx := errgroup.WithContext(ctx)


### PR DESCRIPTION
Signed-off-by: Stepan Blyshchak <stepanblischak@gmail.com>

By creating a simple dockerfile like this:
```Dockerfile
FROM alpine:latest AS stage0
FROM alpine:latest AS stage1
COPY --from=stage1 bin /
```
and building using following command:
DOCKER_BUILDKIT=1 /usr/bin/docker build -t test .

dockerd crashes (part of log):
```
runtime: goroutine stack exceeds 1000000000-byte limit
fatal error: stack overflow

runtime stack:
runtime.throw(0x1d33169, 0xe)
        /usr/local/go/src/runtime/panic.go:617 +0x74
runtime.newstack()
        /usr/local/go/src/runtime/stack.go:1041 +0x6f4
runtime.morestack()
        /usr/local/go/src/runtime/asm_amd64.s:429 +0x84

goroutine 677 [running]:
github.com/docker/docker/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb.isReachable(0x0, 0xc0008b8900, 0xffffffffffffffff)
        /go/src/github.com/docker/docker/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert.go:1118 +0x15c fp=0xc024000360 sp=0xc024000358 pc=0x161990c
github.com/docker/docker/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb.isReachable(0xc0008b8c00, 0xc0008b8900, 0xc024000400)
        /go/src/github.com/docker/docker/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert.go:1122 +0x128 fp=0xc0240003e8 sp=0xc024000360 pc=0x16198d8
github.com/docker/docker/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb.isReachable(0xc0008b8c00, 0xc0008b8900, 0xc024000488)
        /go/src/github.com/docker/docker/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert.go:1126 +0xcd fp=0xc024000470 sp=0xc0240003e8 pc=0x161987d
github.com/docker/docker/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb.isReachable(0xc0008b8c00, 0xc0008b8900, 0xc024000510)
        /go/src/github.com/docker/docker/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert.go:1126 +0xcd fp=0xc0240004f8 sp=0xc024000470 pc=0x161987d
github.com/docker/docker/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb.isReachable(0xc0008b8c00, 0xc0008b8900, 0xc024000598)
        /go/src/github.com/docker/docker/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert.go:1126 +0xcd fp=0xc024000580 sp=0xc0240004f8 pc=0x161987d

```

Interestingly that dockerfile:
```Dockerfile
FROM alpine:latest AS stage1
COPY --from=stage2 bin /

FROM alpine:latest AS stage2
COPY --from=stage1 bin /
```
does not crashes that daemon however there is a cyclic dependency on stages and IMO resulted image is undefined.
Lagacy builder with same dockerfile fails with a another error:
```
root@819191141f53:~/test# /usr/bin/docker build -t test .
Sending build context to Docker daemon  2.048kB
Step 1/4 : FROM alpine:latest AS stage1
 ---> cdf98d1859c1
Step 2/4 : COPY --from=stage2 bin /
invalid from flag value stage2: pull access denied for stage2, repository does not exist or may require 'docker login': denied: requested access to the resource is denied

```

I have added a check for circular dependency after convert fills all dependencies in, so now I get:
```
root@819191141f53:~/test# cat Dockerfile
FROM alpine:latest AS stage1
COPY --from=stage2 bin /

FROM alpine:latest AS stage2
COPY --from=stage1 bin /

root@819191141f53:~/test# DOCKER_BUILDKIT=1 /usr/bin/docker build -t test .
[+] Building 0.2s (2/2) FINISHED
 => [internal] load build definition from Dockerfile                                                           0.1s
 => => transferring dockerfile: 31B                                                                            0.0s
 => [internal] load .dockerignore                                                                              0.1s
 => => transferring context: 2B                                                                                0.0s
failed to create LLB definition: circular dependency detected on stage: stage1
```
