### PR TITLE
gateway: handle grpc server errors

### DIFF
--- a/frontend/gateway/grpcclient/client.go
+++ b/frontend/gateway/grpcclient/client.go
@@ -28,6 +28,8 @@ type GrpcClient interface {
 }
 
 func New(ctx context.Context, opts map[string]string, session, product string, c pb.LLBBridgeClient, w []client.WorkerInfo) (GrpcClient, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
 	resp, err := c.Ping(ctx, &pb.PingRequest{})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
mitigates #991

From logs in #991 , something seems to go wrong when calling `ServeConn` on frontend stdio. Not sure what is the error and hopefully it can be captured from the daemon logs. This fixes error handling in this case by making the build error instead of leaving it hanging.

@msg555