### PR TITLE
bump up rootlesskit to v0.4.1

### DIFF
--- a/hack/dockerfiles/test.Dockerfile
+++ b/hack/dockerfiles/test.Dockerfile
@@ -5,7 +5,8 @@ ARG CONTAINERD10_VERSION=v1.0.3
 # available targets: buildkitd, buildkitd.oci_only, buildkitd.containerd_only
 ARG BUILDKIT_TARGET=buildkitd
 ARG REGISTRY_VERSION=v2.7.0-rc.0
-ARG ROOTLESSKIT_VERSION=4f7ae4607d626f0a22fb495056d55b17cce8c01b
+# v0.4.1
+ARG ROOTLESSKIT_VERSION=27a0c7a2483732b33d4192c1d178c83c6b9e202d
 
 # The `buildkitd` stage and the `buildctl` stage are placed here
 # so that they can be built quickly with legacy DAG-unaware `docker build --target=...`

--- a/hack/dockerfiles/test.buildkit.Dockerfile
+++ b/hack/dockerfiles/test.buildkit.Dockerfile
@@ -7,7 +7,8 @@ ARG CONTAINERD10_VERSION=v1.0.3
 # available targets: buildkitd, buildkitd.oci_only, buildkitd.containerd_only
 ARG BUILDKIT_TARGET=buildkitd
 ARG REGISTRY_VERSION=v2.7.0-rc.0
-ARG ROOTLESSKIT_VERSION=4f7ae4607d626f0a22fb495056d55b17cce8c01b
+# v0.4.1
+ARG ROOTLESSKIT_VERSION=27a0c7a2483732b33d4192c1d178c83c6b9e202d
 ARG ROOTLESS_BASE_MODE=external
 
 # git stage is used for checking out remote repository sources


### PR DESCRIPTION
Now the child process is killed when the parent dies (rootless-containers/rootlesskit#66)

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>

ref: https://github.com/moby/moby/pull/39222