### PR TITLE
local: handle canceled uploads

### DIFF
--- a/cache/contenthash/checksum.go
+++ b/cache/contenthash/checksum.go
@@ -60,6 +60,10 @@ func SetCacheContext(ctx context.Context, md *metadata.StorageItem, cc CacheCont
 	return getDefaultManager().SetCacheContext(ctx, md, cc)
 }
 
+func ClearCacheContext(md *metadata.StorageItem) {
+	getDefaultManager().clearCacheContext(md.ID())
+}
+
 type CacheContext interface {
 	Checksum(ctx context.Context, ref cache.Mountable, p string, followLinks bool) (digest.Digest, error)
 	ChecksumWildcard(ctx context.Context, ref cache.Mountable, p string, followLinks bool) (digest.Digest, error)
@@ -140,6 +144,12 @@ func (cm *cacheManager) SetCacheContext(ctx context.Context, md *metadata.Storag
 	cm.lru.Add(md.ID(), cc)
 	cm.lruMu.Unlock()
 	return nil
+}
+
+func (cm *cacheManager) clearCacheContext(id string) {
+	cm.lruMu.Lock()
+	cm.lru.Remove(id)
+	cm.lruMu.Unlock()
 }
 
 type cacheContext struct {

--- a/cache/manager.go
+++ b/cache/manager.go
@@ -737,6 +737,10 @@ func CachePolicyRetain(m withMetadata) error {
 	return queueCachePolicy(m.Metadata(), cachePolicyRetain)
 }
 
+func CachePolicyDefault(m withMetadata) error {
+	return queueCachePolicy(m.Metadata(), cachePolicyDefault)
+}
+
 func WithDescription(descr string) RefOption {
 	return func(m withMetadata) error {
 		return queueDescription(m.Metadata(), descr)

--- a/source/local/local.go
+++ b/source/local/local.go
@@ -133,6 +133,12 @@ func (ls *localSourceHandler) Snapshot(ctx context.Context) (out cache.Immutable
 
 	defer func() {
 		if retErr != nil && mutable != nil {
+			// on error remove the record as checksum update is in undefined state
+			cache.CachePolicyDefault(mutable)
+			if err := mutable.Metadata().Commit(); err != nil {
+				logrus.Errorf("failed to reset mutable cachepolicy: %v", err)
+			}
+			contenthash.ClearCacheContext(mutable.Metadata())
 			go mutable.Release(context.TODO())
 		}
 	}()


### PR DESCRIPTION
When the transfer of local sources is canceled or errors, checksum calculation is left in undefined state. After another build completes the transfer, the checksums may not correspond to the actual data on disk. With this quick patch, we always clean up the ref on error so next build starts from empty state. Later this could be optimized, for example do a full scan instead.

The reason this didn't show up very often is because of the lru cache for cache context. If cache was looked up from lru it still had the previous incomplete state that matched the disk state in 99% of cases(depending on where exactly the error happened).

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>