### PR TITLE
frontend/dockerfile/parser: export endLine (make public)

### DIFF
--- a/frontend/dockerfile/parser/parser.go
+++ b/frontend/dockerfile/parser/parser.go
@@ -35,7 +35,7 @@ type Node struct {
 	Original   string          // original line used before parsing
 	Flags      []string        // only top Node should have this set
 	StartLine  int             // the line in the original dockerfile where the node begins
-	endLine    int             // the line in the original dockerfile where the node ends
+	EndLine    int             // the line in the original dockerfile where the node ends
 }
 
 // Dump dumps the AST defined by `node` as a list of sexps.
@@ -65,7 +65,7 @@ func (node *Node) Dump() string {
 
 func (node *Node) lines(start, end int) {
 	node.StartLine = start
-	node.endLine = end
+	node.EndLine = end
 }
 
 // AddChild adds a new child node, and updates line information
@@ -74,7 +74,7 @@ func (node *Node) AddChild(child *Node, startLine, endLine int) {
 	if node.StartLine < 0 {
 		node.StartLine = startLine
 	}
-	node.endLine = endLine
+	node.EndLine = endLine
 	node.Children = append(node.Children, child)
 }
 

--- a/frontend/dockerfile/parser/parser_test.go
+++ b/frontend/dockerfile/parser/parser_test.go
@@ -117,7 +117,7 @@ func TestParseIncludesLineNumbers(t *testing.T) {
 
 	ast := result.AST
 	assert.Check(t, is.Equal(5, ast.StartLine))
-	assert.Check(t, is.Equal(31, ast.endLine))
+	assert.Check(t, is.Equal(31, ast.EndLine))
 	assert.Check(t, is.Len(ast.Children, 3))
 	expected := [][]int{
 		{5, 5},
@@ -126,7 +126,7 @@ func TestParseIncludesLineNumbers(t *testing.T) {
 	}
 	for i, child := range ast.Children {
 		msg := fmt.Sprintf("Child %d", i)
-		assert.Check(t, is.DeepEqual(expected[i], []int{child.StartLine, child.endLine}), msg)
+		assert.Check(t, is.DeepEqual(expected[i], []int{child.StartLine, child.EndLine}), msg)
 	}
 }
 


### PR DESCRIPTION
`StartLine` is already public. Tests pass locally.

https://github.com/moby/buildkit/issues/1028

cc @tonistiigi 