### PR TITLE
executor/oci: Fix windows compile

### DIFF
--- a/executor/oci/spec.go
+++ b/executor/oci/spec.go
@@ -1,0 +1,13 @@
+package oci
+
+// ProcMode configures PID namespaces
+type ProcessMode int
+
+const (
+	// ProcessSandbox unshares pidns and mount procfs.
+	ProcessSandbox ProcessMode = iota
+	// NoProcessSandbox uses host pidns and bind-mount procfs.
+	// Note that NoProcessSandbox allows build containers to kill (and potentially ptrace) an arbitrary process in the BuildKit host namespace.
+	// NoProcessSandbox should be enabled only when the BuildKit is running in a container as an unprivileged user.
+	NoProcessSandbox
+)

--- a/executor/oci/spec_unix.go
+++ b/executor/oci/spec_unix.go
@@ -27,18 +27,6 @@ import (
 
 // Ideally we don't have to import whole containerd just for the default spec
 
-// ProcMode configures PID namespaces
-type ProcessMode int
-
-const (
-	// ProcessSandbox unshares pidns and mount procfs.
-	ProcessSandbox ProcessMode = iota
-	// NoProcessSandbox uses host pidns and bind-mount procfs.
-	// Note that NoProcessSandbox allows build containers to kill (and potentially ptrace) an arbitrary process in the BuildKit host namespace.
-	// NoProcessSandbox should be enabled only when the BuildKit is running in a container as an unprivileged user.
-	NoProcessSandbox
-)
-
 // GenerateSpec generates spec using containerd functionality.
 // opts are ignored for s.Process, s.Hostname, and s.Mounts .
 func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mount, id, resolvConf, hostsFile string, namespace network.Namespace, processMode ProcessMode, idmap *idtools.IdentityMapping, opts ...oci.SpecOpts) (*specs.Spec, func(), error) {

--- a/executor/oci/user.go
+++ b/executor/oci/user.go
@@ -20,19 +20,11 @@ func GetUser(ctx context.Context, root, username string) (uint32, uint32, []uint
 		return uid, gid, nil, nil
 	}
 
-	passwdPath, err := user.GetPasswdPath()
-	if err != nil {
-		return 0, 0, nil, err
-	}
-	groupPath, err := user.GetGroupPath()
-	if err != nil {
-		return 0, 0, nil, err
-	}
-	passwdFile, err := openUserFile(root, passwdPath)
+	passwdFile, err := openUserFile(root, "/etc/passwd")
 	if err == nil {
 		defer passwdFile.Close()
 	}
-	groupFile, err := openUserFile(root, groupPath)
+	groupFile, err := openUserFile(root, "/etc/group")
 	if err == nil {
 		defer groupFile.Close()
 	}


### PR DESCRIPTION
Because only buildctl but not buildkitd supports windows, the packages were not cross built in CI.
First commit adds changes to buildkit-flavored Dockerfile to build buildkitd for windows, only when doing hack/cross so that it is released in hack/release.

Second commit makes the test pass.