### PR TITLE
Simplify regular expression by using raw string literal

### DIFF
--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -50,8 +50,8 @@ const (
 	keyContextSubDir           = "contextsubdir"
 )
 
-var httpPrefix = regexp.MustCompile("^https?://")
-var gitUrlPathWithFragmentSuffix = regexp.MustCompile("\\.git(?:#.+)?$")
+var httpPrefix = regexp.MustCompile(`^https?://`)
+var gitUrlPathWithFragmentSuffix = regexp.MustCompile(`\.git(?:#.+)?$`)
 
 func Build(ctx context.Context, c client.Client) (*client.Result, error) {
 	opts := c.BuildOpts().Opts

--- a/util/testutil/integration/registry.go
+++ b/util/testutil/integration/registry.go
@@ -79,7 +79,7 @@ http:
 }
 
 func detectPort(ctx context.Context, rc io.ReadCloser) (string, error) {
-	r := regexp.MustCompile("listening on 127\\.0\\.0\\.1:(\\d+)")
+	r := regexp.MustCompile(`listening on 127\.0\.0\.1:(\d+)`)
 	s := bufio.NewScanner(rc)
 	found := make(chan struct{})
 	defer func() {


### PR DESCRIPTION
backslash(`\`) can be used freely, without the need of escaping.

regular expressions have their own escape sequences, raw strings can improve their readability.