### PR TITLE
hack: fix runtime panic due to osuser build tag not set

### DIFF
--- a/hack/dockerfiles/test.buildkit.Dockerfile
+++ b/hack/dockerfiles/test.buildkit.Dockerfile
@@ -92,11 +92,10 @@ RUN --mount=target=. --mount=target=/root/.cache,type=cache \
 FROM buildkit-base AS buildkitd
 ARG TARGETPLATFORM
 ARG BUILDKITD_TAGS
-ENV BUILDKITD_TAGS="osusergo netgo static_build seccomp ${BUILDKITD_TAGS}"
 RUN --mount=target=. --mount=target=/root/.cache,type=cache \
   --mount=target=/go/pkg/mod,type=cache \
   --mount=source=/tmp/.ldflags,target=/tmp/.ldflags,from=buildkit-version \
-  go build -ldflags "$(cat /tmp/.ldflags) -w -extldflags -static" -tags "${BUILDKITD_TAGS}" -o /usr/bin/buildkitd ./cmd/buildkitd && \
+  go build -ldflags "$(cat /tmp/.ldflags) -w -extldflags -static" -tags "osusergo netgo static_build seccomp ${BUILDKITD_TAGS}" -o /usr/bin/buildkitd ./cmd/buildkitd && \
   file /usr/bin/buildkitd | egrep "statically linked|Windows"
 
 FROM scratch AS binaries-linux


### PR DESCRIPTION
Looks like due to a bug in Dockerfile frontend, only the BUILDKITD_TAGS
build arg was taken into account, not the env var.

Signed-off-by: Tibor Vass <tibor@docker.com>

This fixes cgo call issues at runtime for os/user as seen in https://travis-ci.org/moby/buildkit/builds/556573787

I'll fix the bug in a followup, but quick repro:
```
FROM busybox
ARG foo
ENV foo="bar $foo"
RUN echo foo is $foo
```

```
$ buildctl build --opt build-arg:foo='' --frontend dockerfile.v0 --local dockerfile=. --progress plain --local context=. --no-cache
...
#5 [2/2] RUN echo foo is bar
#5 0.165 foo is
#5 DONE 0.2s
```