### PR TITLE
exporter: keep lease when exporting images

### DIFF
--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -46,13 +46,13 @@ github.com/containerd/containerd/containers
 github.com/containerd/containerd/contrib/seccomp
 github.com/containerd/containerd/namespaces
 github.com/containerd/containerd/errdefs
+github.com/containerd/containerd/leases
 github.com/containerd/containerd/rootfs
 github.com/containerd/containerd/images/oci
 github.com/containerd/containerd/api/services/content/v1
 github.com/containerd/containerd/content/proxy
 github.com/containerd/containerd/services/content/contentserver
 github.com/containerd/containerd/reference
-github.com/containerd/containerd/leases
 github.com/containerd/containerd/metadata
 github.com/containerd/containerd/remotes/docker/schema1
 github.com/containerd/containerd/images/archive

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -255,6 +255,7 @@ func (w *Worker) Exporter(name string, sm *session.Manager) (exporter.Exporter, 
 			SessionManager: sm,
 			ImageWriter:    w.imageWriter,
 			ResolverOpt:    w.ResolveOptionsFunc,
+			LeaseManager:   w.LeaseManager,
 		})
 	case client.ExporterLocal:
 		return localexporter.New(localexporter.Opt{
@@ -269,12 +270,14 @@ func (w *Worker) Exporter(name string, sm *session.Manager) (exporter.Exporter, 
 			SessionManager: sm,
 			ImageWriter:    w.imageWriter,
 			Variant:        ociexporter.VariantOCI,
+			LeaseManager:   w.LeaseManager,
 		})
 	case client.ExporterDocker:
 		return ociexporter.New(ociexporter.Opt{
 			SessionManager: sm,
 			ImageWriter:    w.imageWriter,
 			Variant:        ociexporter.VariantDocker,
+			LeaseManager:   w.LeaseManager,
 		})
 	default:
 		return nil, errors.Errorf("exporter %q could not be found", name)


### PR DESCRIPTION
fixes https://github.com/docker/buildx/issues/101

If images are exported without the containerd imagestore, manifests and configs are temporary and released after export. If the same image is built twice in parallel one build may release the manifest+config before the export for another finishes.

@dmcgowan @shykes 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>