### PR TITLE
Implement frontend support for RUN --security=insecure

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -647,6 +647,11 @@ func dispatchRun(d *dispatchState, c *instructions.RunCommand, proxy *llb.ProxyE
 	}
 	opt = append(opt, runMounts...)
 
+	err = dispatchRunSecurity(d, c)
+	if err != nil {
+		return err
+	}
+
 	shlex := *dopt.shlex
 	shlex.RawQuotes = true
 	shlex.SkipUnsetEnv = true

--- a/frontend/dockerfile/dockerfile2llb/convert_norunsecurity.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_norunsecurity.go
@@ -1,0 +1,11 @@
+// +build !dfrunsecurity
+
+package dockerfile2llb
+
+import (
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+)
+
+func dispatchRunSecurity(d *dispatchState, c *instructions.RunCommand) error {
+	return nil
+}

--- a/frontend/dockerfile/dockerfile2llb/convert_runsecurity.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_runsecurity.go
@@ -1,0 +1,27 @@
+// +build dfrunsecurity
+
+package dockerfile2llb
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+	"github.com/moby/buildkit/solver/pb"
+)
+
+func dispatchRunSecurity(d *dispatchState, c *instructions.RunCommand) error {
+	security := instructions.GetSecurity(c)
+
+	for _, sec := range security {
+		switch sec {
+		case instructions.SecurityInsecure:
+			d.state = d.state.Security(pb.SecurityMode_INSECURE)
+		case instructions.SecuritySandbox:
+			d.state = d.state.Security(pb.SecurityMode_SANDBOX)
+		default:
+			return errors.Errorf("unsupported security mode %q", sec)
+		}
+	}
+
+	return nil
+}

--- a/frontend/dockerfile/dockerfile_runsecurity_test.go
+++ b/frontend/dockerfile/dockerfile_runsecurity_test.go
@@ -1,0 +1,131 @@
+// +build dfrunsecurity
+
+package dockerfile
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/containerd/continuity/fs/fstest"
+	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/frontend/dockerfile/builder"
+	"github.com/moby/buildkit/util/entitlements"
+	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/stretchr/testify/require"
+)
+
+var runSecurityTests = []integration.Test{
+	testRunSecurityInsecure,
+	testRunSecuritySandbox,
+	testRunSecurityDefault,
+}
+
+func init() {
+	securityTests = append(securityTests, runSecurityTests...)
+
+}
+
+func testRunSecurityInsecure(t *testing.T, sb integration.Sandbox) {
+	f := getFrontend(t, sb)
+
+	dockerfile := []byte(`
+FROM busybox
+RUN --security=insecure [ "$(cat /proc/self/status | grep CapBnd)" == "CapBnd:	0000003fffffffff" ]
+`)
+
+	dir, err := tmpdir(
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+	)
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	c, err := client.New(context.TODO(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = f.Solve(context.TODO(), c, client.SolveOpt{
+		LocalDirs: map[string]string{
+			builder.DefaultLocalNameDockerfile: dir,
+			builder.DefaultLocalNameContext:    dir,
+		},
+		AllowedEntitlements: []entitlements.Entitlement{entitlements.EntitlementSecurityInsecure},
+	}, nil)
+
+	secMode := sb.Value("secmode")
+	switch secMode {
+	case securitySandbox:
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "entitlement security.insecure is not allowed")
+	case securityInsecure:
+		require.NoError(t, err)
+	default:
+		require.Fail(t, "unexpected secmode")
+	}
+}
+
+func testRunSecuritySandbox(t *testing.T, sb integration.Sandbox) {
+	f := getFrontend(t, sb)
+
+	dockerfile := []byte(`
+FROM busybox
+RUN --security=sandbox [ "$(cat /proc/self/status | grep CapBnd)" == "CapBnd:	00000000a80425fb" ]
+`)
+
+	dir, err := tmpdir(
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+	)
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	c, err := client.New(context.TODO(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = f.Solve(context.TODO(), c, client.SolveOpt{
+		LocalDirs: map[string]string{
+			builder.DefaultLocalNameDockerfile: dir,
+			builder.DefaultLocalNameContext:    dir,
+		},
+	}, nil)
+
+	require.NoError(t, err)
+}
+
+func testRunSecurityDefault(t *testing.T, sb integration.Sandbox) {
+	f := getFrontend(t, sb)
+
+	dockerfile := []byte(`
+FROM busybox
+RUN [ "$(cat /proc/self/status | grep CapBnd)" == "CapBnd:	00000000a80425fb" ]
+`)
+
+	dir, err := tmpdir(
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+	)
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	c, err := client.New(context.TODO(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = f.Solve(context.TODO(), c, client.SolveOpt{
+		LocalDirs: map[string]string{
+			builder.DefaultLocalNameDockerfile: dir,
+			builder.DefaultLocalNameContext:    dir,
+		},
+		AllowedEntitlements: []entitlements.Entitlement{entitlements.EntitlementSecurityInsecure},
+	}, nil)
+
+	secMode := sb.Value("secmode")
+	switch secMode {
+	case securitySandbox:
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "entitlement security.insecure is not allowed")
+	case securityInsecure:
+		require.NoError(t, err)
+	default:
+		require.Fail(t, "unexpected secmode")
+	}
+}

--- a/frontend/dockerfile/docs/experimental.md
+++ b/frontend/dockerfile/docs/experimental.md
@@ -138,3 +138,25 @@ $ buildctl build --frontend=dockerfile.v0 --local context=. --local dockerfile=.
 You can also specify a path to `*.pem` file on the host directly instead of `$SSH_AUTH_SOCK`.
 However, pem files with passphrases are not supported.
 
+### RUN --security=insecure|sandbox
+
+With `--security=insecure`, this runs the command without sandbox in insecure mode,
+which allows to run flows requiring elevated privileges (e.g. containerd). This is equivalent
+to running `docker run --privileged`. In order to access this feature, entitlement
+`security.insecure` should be enabled when starting the buildkitd daemon
+(`--allow-insecure-entitlement security.insecure`) and for a build request
+(`--allow security.insecure`).
+
+Default sandbox mode can be activated via `--security=sandbox`, but that is no-op.
+
+#### Example: check entitlements
+
+```dockerfile
+# syntax = docker/dockerfile:experimental
+FROM ubuntu
+RUN --security=insecure cat /proc/self/status | grep CapEff
+```
+
+```
+#84 0.093 CapEff:	0000003fffffffff
+```

--- a/frontend/dockerfile/instructions/commands_runsecurity.go
+++ b/frontend/dockerfile/instructions/commands_runsecurity.go
@@ -1,0 +1,83 @@
+// +build dfrunsecurity
+
+package instructions
+
+import (
+	"encoding/csv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	SecurityInsecure = "insecure"
+	SecuritySandbox  = "sandbox"
+)
+
+var allowedSecurity = map[string]struct{}{
+	SecurityInsecure: {},
+	SecuritySandbox:  {},
+}
+
+func isValidSecurity(value string) bool {
+	_, ok := allowedSecurity[value]
+	return ok
+}
+
+type securityKeyT string
+
+var securityKey = securityKeyT("dockerfile/run/security")
+
+func init() {
+	parseRunPreHooks = append(parseRunPreHooks, runSecurityPreHook)
+	parseRunPostHooks = append(parseRunPostHooks, runSecurityPostHook)
+}
+
+func runSecurityPreHook(cmd *RunCommand, req parseRequest) error {
+	st := &securityState{}
+	st.flag = req.flags.AddStrings("security")
+	cmd.setExternalValue(securityKey, st)
+	return nil
+}
+
+func runSecurityPostHook(cmd *RunCommand, req parseRequest) error {
+	st := getSecurityState(cmd)
+	if st == nil {
+		return errors.Errorf("no security state")
+	}
+
+	for _, value := range st.flag.StringValues {
+		csvReader := csv.NewReader(strings.NewReader(value))
+		fields, err := csvReader.Read()
+		if err != nil {
+			return errors.Wrap(err, "failed to parse csv security")
+		}
+
+		for _, field := range fields {
+			if !isValidSecurity(field) {
+				return errors.Errorf("security %q is not valid", field)
+			}
+
+			st.security = append(st.security, field)
+		}
+	}
+
+	return nil
+}
+
+func getSecurityState(cmd *RunCommand) *securityState {
+	v := cmd.getExternalValue(securityKey)
+	if v == nil {
+		return nil
+	}
+	return v.(*securityState)
+}
+
+func GetSecurity(cmd *RunCommand) []string {
+	return getSecurityState(cmd).security
+}
+
+type securityState struct {
+	flag     *Flag
+	security []string
+}

--- a/frontend/dockerfile/release/experimental/tags
+++ b/frontend/dockerfile/release/experimental/tags
@@ -1,1 +1,1 @@
-dfrunmount dfsecrets dfssh
+dfrunmount dfrunsecurity dfsecrets dfssh


### PR DESCRIPTION
This follows syntax suggested in #950.

Example:

    RUN --ents=security.insecure cat /proc/self/status | grep CapEff
    #84 0.093 CapEff:	0000003fffffffff