### PR TITLE
Fix updating /sys/fs/cgroup mount to 'rw'

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -483,6 +483,10 @@ func testSecurityMode(t *testing.T, sb integration.Sandbox) {
 }
 
 func testSecurityModeSysfs(t *testing.T, sb integration.Sandbox) {
+	if sb.Rootless() {
+		t.SkipNow()
+	}
+
 	mode := llb.SecurityModeSandbox
 	var allowedEntitlements []entitlements.Entitlement
 	secMode := sb.Value("secmode")
@@ -509,7 +513,7 @@ func testSecurityModeSysfs(t *testing.T, sb integration.Sandbox) {
 		AllowedEntitlements: allowedEntitlements,
 	}, nil)
 
-	if secMode == securitySandbox || sb.Rootless() {
+	if secMode == securitySandbox {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "exit code: 1")
 	} else {

--- a/executor/oci/spec_unix.go
+++ b/executor/oci/spec_unix.go
@@ -101,11 +101,11 @@ func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mou
 	}
 
 	if meta.SecurityMode == pb.SecurityMode_INSECURE {
-		//make sysfs rw mount for insecure mode.
-		for i, m := range s.Mounts {
-			if m.Destination == "/sys/fs/cgroup" {
-				s.Mounts[i].Options = []string{"nosuid", "noexec", "nodev", "rw"}
-			}
+		if err = oci.WithWriteableCgroupfs(ctx, nil, c, s); err != nil {
+			return nil, nil, err
+		}
+		if err = oci.WithWriteableSysfs(ctx, nil, c, s); err != nil {
+			return nil, nil, err
 		}
 	}
 

--- a/executor/oci/spec_unix.go
+++ b/executor/oci/spec_unix.go
@@ -102,9 +102,9 @@ func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mou
 
 	if meta.SecurityMode == pb.SecurityMode_INSECURE {
 		//make sysfs rw mount for insecure mode.
-		for _, m := range s.Mounts {
-			if m.Type == "sysfs" {
-				m.Options = []string{"nosuid", "noexec", "nodev", "rw"}
+		for i, m := range s.Mounts {
+			if m.Destination == "/sys/fs/cgroup" {
+				s.Mounts[i].Options = []string{"nosuid", "noexec", "nodev", "rw"}
 			}
 		}
 	}


### PR DESCRIPTION
There were two bugs: Mount was matched by Type which is actually
`cgroup`, not `sysfs`. And the second problem was that copy of the value
was modified, not value in the slice.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>