### PR TITLE
solver: support no-cache for exec cache mounts

### DIFF
--- a/cache/manager.go
+++ b/cache/manager.go
@@ -36,6 +36,7 @@ type Accessor interface {
 	New(ctx context.Context, s ImmutableRef, opts ...RefOption) (MutableRef, error)
 	GetMutable(ctx context.Context, id string) (MutableRef, error) // Rebase?
 	IdentityMapping() *idtools.IdentityMapping
+	Metadata(string) *metadata.StorageItem
 }
 
 type Controller interface {
@@ -122,6 +123,16 @@ func (cm *cacheManager) GetFromSnapshotter(ctx context.Context, id string, opts 
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 	return cm.get(ctx, id, true, opts...)
+}
+
+func (cm *cacheManager) Metadata(id string) *metadata.StorageItem {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	r, ok := cm.records[id]
+	if !ok {
+		return nil
+	}
+	return r.Metadata()
 }
 
 // get requires manager lock to be taken

--- a/solver/llbsolver/bridge.go
+++ b/solver/llbsolver/bridge.go
@@ -29,6 +29,7 @@ type llbBridge struct {
 	builder                   solver.Builder
 	frontends                 map[string]frontend.Frontend
 	resolveWorker             func() (worker.Worker, error)
+	eachWorker                func(func(worker.Worker) error) error
 	resolveCacheImporterFuncs map[string]remotecache.ResolveCacheImporterFunc
 	cms                       map[string]solver.CacheManager
 	cmsMu                     sync.Mutex
@@ -91,11 +92,25 @@ func (b *llbBridge) Solve(ctx context.Context, req frontend.SolveRequest) (res *
 		if err != nil {
 			return nil, err
 		}
+		dpc := &detectPrunedCacheID{}
 
-		edge, err := Load(req.Definition, ValidateEntitlements(ent), WithCacheSources(cms), RuntimePlatforms(b.platforms), WithValidateCaps())
+		edge, err := Load(req.Definition, dpc.Load, ValidateEntitlements(ent), WithCacheSources(cms), RuntimePlatforms(b.platforms), WithValidateCaps())
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to load LLB")
 		}
+
+		if len(dpc.ids) > 0 {
+			ids := make([]string, 0, len(dpc.ids))
+			for id := range dpc.ids {
+				ids = append(ids, id)
+			}
+			if err := b.eachWorker(func(w worker.Worker) error {
+				return w.PruneCacheMounts(ids)
+			}); err != nil {
+				return nil, err
+			}
+		}
+
 		ref, err := b.builder.Build(ctx, edge)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to build LLB")

--- a/solver/llbsolver/bridge.go
+++ b/solver/llbsolver/bridge.go
@@ -105,7 +105,7 @@ func (b *llbBridge) Solve(ctx context.Context, req frontend.SolveRequest) (res *
 				ids = append(ids, id)
 			}
 			if err := b.eachWorker(func(w worker.Worker) error {
-				return w.PruneCacheMounts(ids)
+				return w.PruneCacheMounts(ctx, ids)
 			}); err != nil {
 				return nil, err
 			}

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/containerd/containerd/content"
@@ -51,6 +52,7 @@ import (
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	bolt "go.etcd.io/bbolt"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -215,6 +217,39 @@ func (w *Worker) ResolveOp(v solver.Vertex, s frontend.FrontendLLBBridge, sm *se
 		}
 	}
 	return nil, errors.Errorf("could not resolve %v", v)
+}
+
+func (w *Worker) PruneCacheMounts(ids []string) error {
+	mu := ops.CacheMountsLocker()
+	mu.Lock()
+	defer mu.Unlock()
+
+	for _, id := range ids {
+		id = "cache-dir:" + id
+		sis, err := w.MetadataStore.Search(id)
+		if err != nil {
+			return err
+		}
+		for _, si := range sis {
+			for _, k := range si.Indexes() {
+				if k == id || strings.HasPrefix(k, id+":") {
+					if err := cache.CachePolicyDefault(si); err != nil {
+						return err
+					}
+					si.Queue(func(b *bolt.Bucket) error {
+						return si.SetValue(b, k, nil)
+					})
+					if err := si.Commit(); err != nil {
+						return err
+					}
+					break
+				}
+			}
+		}
+	}
+
+	ops.ClearActiveCacheMounts()
+	return nil
 }
 
 func (w *Worker) ResolveImageConfig(ctx context.Context, ref string, opt gw.ResolveImageConfigOpt, sm *session.Manager) (digest.Digest, []byte, error) {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -33,7 +33,7 @@ type Worker interface {
 	Prune(ctx context.Context, ch chan client.UsageInfo, opt ...client.PruneInfo) error
 	GetRemote(ctx context.Context, ref cache.ImmutableRef, createIfNeeded bool) (*solver.Remote, error)
 	FromRemote(ctx context.Context, remote *solver.Remote) (cache.ImmutableRef, error)
-	PruneCacheMounts(ids []string) error
+	PruneCacheMounts(ctx context.Context, ids []string) error
 }
 
 // Pre-defined label keys

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -33,6 +33,7 @@ type Worker interface {
 	Prune(ctx context.Context, ch chan client.UsageInfo, opt ...client.PruneInfo) error
 	GetRemote(ctx context.Context, ref cache.ImmutableRef, createIfNeeded bool) (*solver.Remote, error)
 	FromRemote(ctx context.Context, remote *solver.Remote) (cache.ImmutableRef, error)
+	PruneCacheMounts(ids []string) error
 }
 
 // Pre-defined label keys


### PR DESCRIPTION
fixes https://github.com/docker/buildx/issues/109

No-cache doesn't really work in combination with cache mounts as it is solver level and caches instructions. But the behavior is non-obvious from the user perspective. So if no-cache is used in a run operation that uses cache mounts, all cache volumes with the matching id are released before the build even starts now.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>