### PR TITLE
dockerfile: fix default cache IDs

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert_runmount.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_runmount.go
@@ -124,6 +124,9 @@ func dispatchRunMounts(d *dispatchState, c *instructions.RunCommand, sources []*
 			if mount.CacheSharing == instructions.MountSharingLocked {
 				sharing = llb.CacheMountLocked
 			}
+			if mount.CacheID == "" {
+				mount.CacheID = path.Clean(mount.Target)
+			}
 			mountOpts = append(mountOpts, llb.AsPersistentCacheDir(opt.cacheIDNamespace+"/"+mount.CacheID, sharing))
 		}
 		target := mount.Target


### PR DESCRIPTION
Default cache mount ID to target path if not set.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>