### PR TITLE
executor: ignore workdir if already exists

### DIFF
--- a/executor/containerdexecutor/executor.go
+++ b/executor/containerdexecutor/executor.go
@@ -99,9 +99,11 @@ func (w containerdExecutor) Exec(ctx context.Context, meta executor.Meta, root c
 			lm.Unmount()
 			return errors.Wrapf(err, "working dir %s points to invalid target", newp)
 		}
-		if err := idtools.MkdirAllAndChown(newp, 0755, identity); err != nil {
-			lm.Unmount()
-			return errors.Wrapf(err, "failed to create working directory %s", newp)
+		if _, err := os.Stat(newp); err != nil {
+			if err := idtools.MkdirAllAndChown(newp, 0755, identity); err != nil {
+				lm.Unmount()
+				return errors.Wrapf(err, "failed to create working directory %s", newp)
+			}
 		}
 
 		lm.Unmount()

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -236,8 +236,10 @@ func (w *runcExecutor) Exec(ctx context.Context, meta executor.Meta, root cache.
 	if err != nil {
 		return errors.Wrapf(err, "working dir %s points to invalid target", newp)
 	}
-	if err := idtools.MkdirAllAndChown(newp, 0755, identity); err != nil {
-		return errors.Wrapf(err, "failed to create working directory %s", newp)
+	if _, err := os.Stat(newp); err != nil {
+		if err := idtools.MkdirAllAndChown(newp, 0755, identity); err != nil {
+			return errors.Wrapf(err, "failed to create working directory %s", newp)
+		}
 	}
 
 	if err := setOOMScoreAdj(spec); err != nil {


### PR DESCRIPTION
fixes https://github.com/moby/buildkit/issues/973#issuecomment-514443912

if workdir exists with specific mode/owner no not try to recreate it with default settings.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>