### PR TITLE
exporter: allow oci exporters visibility to response metadata

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -740,7 +740,7 @@ func testFrontendImageNaming(t *testing.T, sb integration.Sandbox) {
 					case ExporterDocker:
 						outW, err := os.Create(out)
 						require.NoError(t, err)
-						so.Exports[0].Output = outW
+						so.Exports[0].Output = fixedWriteCloser(outW)
 					case ExporterImage:
 						imageName = registry + "/" + imageName
 						so.Exports[0].Attrs["push"] = "true"
@@ -1304,7 +1304,7 @@ func testOCIExporter(t *testing.T, sb integration.Sandbox) {
 				{
 					Type:   exp,
 					Attrs:  attrs,
-					Output: outW,
+					Output: fixedWriteCloser(outW),
 				},
 			},
 		}, nil)
@@ -1388,7 +1388,7 @@ func testFrontendMetadataReturn(t *testing.T, sb integration.Sandbox) {
 			{
 				Type:   ExporterOCI,
 				Attrs:  map[string]string{},
-				Output: nopWriteCloser{ioutil.Discard},
+				Output: fixedWriteCloser(nopWriteCloser{ioutil.Discard}),
 			},
 		},
 	}, "", frontend, nil)
@@ -2060,7 +2060,7 @@ func testDuplicateWhiteouts(t *testing.T, sb integration.Sandbox) {
 		Exports: []ExportEntry{
 			{
 				Type:   ExporterOCI,
-				Output: outW,
+				Output: fixedWriteCloser(outW),
 			},
 		},
 	}, nil)
@@ -2130,7 +2130,7 @@ func testWhiteoutParentDir(t *testing.T, sb integration.Sandbox) {
 		Exports: []ExportEntry{
 			{
 				Type:   ExporterOCI,
-				Output: outW,
+				Output: fixedWriteCloser(outW),
 			},
 		},
 	}, nil)
@@ -2465,7 +2465,7 @@ func testInvalidExporter(t *testing.T, sb integration.Sandbox) {
 			{
 				Type:   ExporterLocal,
 				Attrs:  attrs,
-				Output: f,
+				Output: fixedWriteCloser(f),
 			},
 		},
 	}, nil)
@@ -2611,3 +2611,9 @@ func (*netModeDefault) UpdateConfigFile(in string) string {
 
 var hostNetwork integration.ConfigUpdater = &netModeHost{}
 var defaultNetwork integration.ConfigUpdater = &netModeDefault{}
+
+func fixedWriteCloser(wc io.WriteCloser) func(map[string]string) (io.WriteCloser, error) {
+	return func(map[string]string) (io.WriteCloser, error) {
+		return wc, nil
+	}
+}

--- a/client/solve.go
+++ b/client/solve.go
@@ -46,8 +46,8 @@ type SolveOpt struct {
 type ExportEntry struct {
 	Type      string
 	Attrs     map[string]string
-	Output    io.WriteCloser // for ExporterOCI and ExporterDocker
-	OutputDir string         // for ExporterLocal
+	Output    func(map[string]string) (io.WriteCloser, error) // for ExporterOCI and ExporterDocker
+	OutputDir string                                          // for ExporterLocal
 }
 
 type CacheOptionsEntry struct {

--- a/examples/build-using-dockerfile/main.go
+++ b/examples/build-using-dockerfile/main.go
@@ -166,7 +166,9 @@ func newSolveOpt(clicontext *cli.Context, w io.WriteCloser) (*client.SolveOpt, e
 				Attrs: map[string]string{
 					"name": clicontext.String("tag"),
 				},
-				Output: w,
+				Output: func(_ map[string]string) (io.WriteCloser, error) {
+					return w, nil
+				},
 			},
 		},
 		LocalDirs:     localDirs,

--- a/exporter/tar/export.go
+++ b/exporter/tar/export.go
@@ -147,7 +147,7 @@ func (e *localExporterInstance) Export(ctx context.Context, inp exporter.Source)
 		fs = d.FS
 	}
 
-	w, err := filesync.CopyFileWriter(ctx, e.caller)
+	w, err := filesync.CopyFileWriter(ctx, nil, e.caller)
 	if err != nil {
 		return nil, err
 	}

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -385,7 +385,7 @@ FROM stage-$TARGETOS
 		Exports: []client.ExportEntry{
 			{
 				Type:   client.ExporterTar,
-				Output: &nopWriteCloser{buf},
+				Output: fixedWriteCloser(&nopWriteCloser{buf}),
 			},
 		},
 		LocalDirs: map[string]string{
@@ -408,7 +408,7 @@ FROM stage-$TARGETOS
 		Exports: []client.ExportEntry{
 			{
 				Type:   client.ExporterTar,
-				Output: &nopWriteCloser{buf},
+				Output: fixedWriteCloser(&nopWriteCloser{buf}),
 			},
 		},
 		FrontendAttrs: map[string]string{
@@ -1129,7 +1129,7 @@ COPY arch-$TARGETARCH whoami
 		Exports: []client.ExportEntry{
 			{
 				Type:   client.ExporterOCI,
-				Output: outW,
+				Output: fixedWriteCloser(outW),
 			},
 		},
 	}, nil)
@@ -4244,3 +4244,9 @@ func (*secModeInsecure) UpdateConfigFile(in string) string {
 
 var securitySandbox integration.ConfigUpdater = &secModeSandbox{}
 var securityInsecure integration.ConfigUpdater = &secModeInsecure{}
+
+func fixedWriteCloser(wc io.WriteCloser) func(map[string]string) (io.WriteCloser, error) {
+	return func(map[string]string) (io.WriteCloser, error) {
+		return wc, nil
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -175,8 +175,8 @@ github.com/gogo/protobuf/protoc-gen-gogo/descriptor
 # github.com/golang/protobuf v1.2.0
 github.com/golang/protobuf/ptypes/timestamp
 github.com/golang/protobuf/proto
-github.com/golang/protobuf/ptypes/any
 github.com/golang/protobuf/ptypes
+github.com/golang/protobuf/ptypes/any
 github.com/golang/protobuf/ptypes/duration
 # github.com/google/go-cmp v0.2.0
 github.com/google/go-cmp/cmp
@@ -296,10 +296,10 @@ google.golang.org/genproto/googleapis/rpc/status
 google.golang.org/grpc
 google.golang.org/grpc/credentials
 google.golang.org/grpc/metadata
+google.golang.org/grpc/codes
+google.golang.org/grpc/status
 google.golang.org/grpc/health
 google.golang.org/grpc/health/grpc_health_v1
-google.golang.org/grpc/status
-google.golang.org/grpc/codes
 google.golang.org/grpc/balancer
 google.golang.org/grpc/balancer/roundrobin
 google.golang.org/grpc/connectivity


### PR DESCRIPTION
Allow `oci` exporter visibility to exporter metadata. For example, to see if the data already exists and report it back to the daemon. Later this should be extended by adding the contentstore api to the control api, and the exporter can use that to pull individual blobs during the export phase.