### PR TITLE
hack: fix update-vendor script when using PREFER_BUILDCTL=1

### DIFF
--- a/hack/update-vendor
+++ b/hack/update-vendor
@@ -16,7 +16,7 @@ case $buildmode in
     --opt filename=./hack/dockerfiles/vendor.buildkit.Dockerfile \
     --output type=local,dest=$output
   rm -rf ./vendor
-  cp -R "$output/out/" .
+  cp -R "$output"/out/* .
   rm -rf $output
   ;;
 *)


### PR DESCRIPTION
Signed-off-by: Tibor Vass <tibor@docker.com>