### PR TITLE
debug: add `fileop` to `--dot`

### DIFF
--- a/cmd/buildctl/debug/dumpllb.go
+++ b/cmd/buildctl/debug/dumpllb.go
@@ -111,6 +111,26 @@ func attr(dgst digest.Digest, op pb.Op) (string, string) {
 		return strings.Join(op.Exec.Meta.Args, " "), "box"
 	case *pb.Op_Build:
 		return "build", "box3d"
+	case *pb.Op_File:
+		names := []string{}
+
+		for _, action := range op.File.Actions {
+			var name string
+
+			switch act := action.Action.(type) {
+			case *pb.FileAction_Copy:
+				name = fmt.Sprintf("copy{src=%s, dest=%s}", act.Copy.Src, act.Copy.Dest)
+			case *pb.FileAction_Mkfile:
+				name = fmt.Sprintf("mkfile{path=%s}", act.Mkfile.Path)
+			case *pb.FileAction_Mkdir:
+				name = fmt.Sprintf("mkdir{path=%s}", act.Mkdir.Path)
+			case *pb.FileAction_Rm:
+				name = fmt.Sprintf("rm{path=%s}", act.Rm.Path)
+			}
+
+			names = append(names, name)
+		}
+		return strings.Join(names, ","), "note"
 	default:
 		return dgst.String(), "plaintext"
 	}

--- a/examples/buildkit3/buildkit.go
+++ b/examples/buildkit3/buildkit.go
@@ -9,10 +9,10 @@ import (
 )
 
 type buildOpt struct {
-	withContainerd bool
+	buildkit       string
 	containerd     string
 	runc           string
-	buildkit       string
+	withContainerd bool
 }
 
 func main() {
@@ -112,10 +112,11 @@ func copyFrom(src llb.State, srcPath, destPath string) llb.StateOption {
 	}
 }
 
-// copy copies files between 2 states using cp until there is no copyOp
+// copy copies files between 2 states using cp
 func copy(src llb.State, srcPath string, dest llb.State, destPath string) llb.State {
-	cpImage := llb.Image("docker.io/library/alpine:latest@sha256:1072e499f3f655a032e88542330cf75b02e7bdf673278f701d7ba61629ee3ebe")
-	cp := cpImage.Run(llb.Shlexf("cp -a /src%s /dest%s", srcPath, destPath))
-	cp.AddMount("/src", src, llb.Readonly)
-	return cp.AddMount("/dest", dest)
+	return dest.File(llb.Copy(src, srcPath, destPath, &llb.CopyInfo{
+		AllowWildcard:  true,
+		AttemptUnpack:  true,
+		CreateDestPath: true,
+	}))
 }


### PR DESCRIPTION
Hey,

First of all - thank you for putting so much work on `buildkit`!

<br />

Onto the PR - in the `buildctl` code, I added a case for `Op_File` in order to allow folks to visualize the LLB's graph look when leveraging the `--dot`-based output.


As I had to inspect the json-based output quite a few times, I end up implementing that in the `--dot` one, which made my life way easier. Do you think this is a valid addition? I wasn't sure if there was a reason for such case not being treated there.


![fileops-bk](https://user-images.githubusercontent.com/3574444/62429149-ddaffc00-b6d8-11e9-90c1-5f314237c3b6.png)

To make that demonstrable, I end up modifying the `buildkit3` to leverage file operations. 

Also, I'm not very sure about the format (`action{prop1=<val1>,...},...`) - wdyt?

<br/>
Thank you!

