### PR TITLE
correct int64 alignment

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -38,13 +38,13 @@ type Opt struct {
 }
 
 type Controller struct { // TODO: ControlService
+	buildCount       int64
 	opt              Opt
 	solver           *llbsolver.Solver
 	cache            solver.CacheManager
 	gatewayForwarder *controlgateway.GatewayForwarder
 	throttledGC      func()
 	gcmu             sync.Mutex
-	buildCount       int64
 }
 
 func NewController(opt Opt) (*Controller, error) {

--- a/solver/result.go
+++ b/solver/result.go
@@ -40,9 +40,9 @@ func dup(res Result) (Result, Result) {
 }
 
 type splitResult struct {
-	Result
 	released int64
 	sem      *int64
+	Result
 }
 
 func (r *splitResult) Release(ctx context.Context) error {

--- a/util/pull/resolver.go
+++ b/util/pull/resolver.go
@@ -135,9 +135,9 @@ type resolverCache struct {
 }
 
 type cachedResolver struct {
+	counter int64
 	timeout time.Time
 	remotes.Resolver
-	counter int64
 }
 
 func (cr *cachedResolver) Resolve(ctx context.Context, ref string) (name string, desc ocispec.Descriptor, err error) {


### PR DESCRIPTION
follow-up to moby/buildkit#1082

we tried to detect these places with lint on moby/buildkit#1082 but seems it doesn't work reliably

related to: https://github.com/docker/buildx/issues/129

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>