### PR TITLE
network: refactor cni support to multiple packages

### DIFF
--- a/cmd/buildkitd/main_containerd_worker.go
+++ b/cmd/buildkitd/main_containerd_worker.go
@@ -10,7 +10,8 @@ import (
 
 	ctd "github.com/containerd/containerd"
 	"github.com/moby/buildkit/cmd/buildkitd/config"
-	"github.com/moby/buildkit/util/network"
+	"github.com/moby/buildkit/util/network/cniprovider"
+	"github.com/moby/buildkit/util/network/netproviders"
 	"github.com/moby/buildkit/worker"
 	"github.com/moby/buildkit/worker/base"
 	"github.com/moby/buildkit/worker/containerd"
@@ -200,11 +201,13 @@ func containerdWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([
 
 	dns := getDNSConfig(common.config.DNS)
 
-	nc := network.Opt{
-		Root:          common.config.Root,
-		Mode:          common.config.Workers.Containerd.NetworkConfig.Mode,
-		CNIConfigPath: common.config.Workers.Containerd.CNIConfigPath,
-		CNIBinaryDir:  common.config.Workers.Containerd.CNIBinaryPath,
+	nc := netproviders.Opt{
+		Mode: common.config.Workers.Containerd.NetworkConfig.Mode,
+		CNI: cniprovider.Opt{
+			Root:       common.config.Root,
+			ConfigPath: common.config.Workers.Containerd.CNIConfigPath,
+			BinaryDir:  common.config.Workers.Containerd.CNIBinaryPath,
+		},
 	}
 
 	opt, err := containerd.NewWorkerOpt(common.config.Root, cfg.Address, ctd.DefaultSnapshotter, cfg.Namespace, cfg.Labels, dns, nc, ctd.WithTimeout(60*time.Second))

--- a/cmd/buildkitd/main_oci_worker.go
+++ b/cmd/buildkitd/main_oci_worker.go
@@ -11,7 +11,8 @@ import (
 	"github.com/containerd/containerd/snapshots/overlay"
 	"github.com/moby/buildkit/cmd/buildkitd/config"
 	"github.com/moby/buildkit/executor/oci"
-	"github.com/moby/buildkit/util/network"
+	"github.com/moby/buildkit/util/network/cniprovider"
+	"github.com/moby/buildkit/util/network/netproviders"
 	"github.com/moby/buildkit/worker"
 	"github.com/moby/buildkit/worker/base"
 	"github.com/moby/buildkit/worker/runc"
@@ -222,11 +223,13 @@ func ociWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([]worker
 
 	dns := getDNSConfig(common.config.DNS)
 
-	nc := network.Opt{
-		Root:          common.config.Root,
-		Mode:          common.config.Workers.OCI.NetworkConfig.Mode,
-		CNIConfigPath: common.config.Workers.OCI.CNIConfigPath,
-		CNIBinaryDir:  common.config.Workers.OCI.CNIBinaryPath,
+	nc := netproviders.Opt{
+		Mode: common.config.Workers.OCI.NetworkConfig.Mode,
+		CNI: cniprovider.Opt{
+			Root:       common.config.Root,
+			ConfigPath: common.config.Workers.OCI.CNIConfigPath,
+			BinaryDir:  common.config.Workers.OCI.CNIBinaryPath,
+		},
 	}
 
 	opt, err := runc.NewWorkerOpt(common.config.Root, snFactory, cfg.Rootless, processMode, cfg.Labels, idmapping, nc, dns)

--- a/util/network/cniprovider/cni_unsafe.go
+++ b/util/network/cniprovider/cni_unsafe.go
@@ -1,6 +1,6 @@
 // +build linux
 
-package network
+package cniprovider
 
 import (
 	_ "unsafe" // required for go:linkname.

--- a/util/network/cniprovider/createns_linux.go
+++ b/util/network/cniprovider/createns_linux.go
@@ -1,6 +1,6 @@
 // +build linux
 
-package network
+package cniprovider
 
 import (
 	"os"

--- a/util/network/cniprovider/createns_nolinux.go
+++ b/util/network/cniprovider/createns_nolinux.go
@@ -1,6 +1,6 @@
 // +build !linux
 
-package network
+package cniprovider
 
 import "github.com/pkg/errors"
 

--- a/util/network/netproviders/network.go
+++ b/util/network/netproviders/network.go
@@ -1,0 +1,50 @@
+package netproviders
+
+import (
+	"os"
+
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/util/network"
+	"github.com/moby/buildkit/util/network/cniprovider"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+type Opt struct {
+	CNI  cniprovider.Opt
+	Mode string
+}
+
+// Providers returns the network provider set
+func Providers(opt Opt) (map[pb.NetMode]network.Provider, error) {
+	var defaultProvider network.Provider
+	switch opt.Mode {
+	case "cni":
+		cniProvider, err := cniprovider.New(opt.CNI)
+		if err != nil {
+			return nil, err
+		}
+		defaultProvider = cniProvider
+	case "host":
+		defaultProvider = network.NewHostProvider()
+	case "auto", "":
+		if _, err := os.Stat(opt.CNI.ConfigPath); err == nil {
+			cniProvider, err := cniprovider.New(opt.CNI)
+			if err != nil {
+				return nil, err
+			}
+			defaultProvider = cniProvider
+		} else {
+			logrus.Warnf("using host network as the default")
+			defaultProvider = network.NewHostProvider()
+		}
+	default:
+		return nil, errors.Errorf("invalid network mode: %q", opt.Mode)
+	}
+
+	return map[pb.NetMode]network.Provider{
+		pb.NetMode_UNSET: defaultProvider,
+		pb.NetMode_HOST:  network.NewHostProvider(),
+		pb.NetMode_NONE:  network.NewNoneProvider(),
+	}, nil
+}

--- a/util/network/network.go
+++ b/util/network/network.go
@@ -2,54 +2,9 @@ package network
 
 import (
 	"io"
-	"os"
 
-	"github.com/moby/buildkit/solver/pb"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
-
-type Opt struct {
-	Root          string
-	Mode          string
-	CNIConfigPath string
-	CNIBinaryDir  string
-}
-
-// Providers returns the network provider set
-func Providers(opt Opt) (map[pb.NetMode]Provider, error) {
-	var defaultProvider Provider
-	switch opt.Mode {
-	case "cni":
-		cniProvider, err := NewCNIProvider(opt)
-		if err != nil {
-			return nil, err
-		}
-		defaultProvider = cniProvider
-	case "host":
-		defaultProvider = NewHostProvider()
-	case "auto", "":
-		if _, err := os.Stat(opt.CNIConfigPath); err == nil {
-			cniProvider, err := NewCNIProvider(opt)
-			if err != nil {
-				return nil, err
-			}
-			defaultProvider = cniProvider
-		} else {
-			logrus.Warnf("using host network as the default")
-			defaultProvider = NewHostProvider()
-		}
-	default:
-		return nil, errors.Errorf("invalid network mode: %q", opt.Mode)
-	}
-
-	return map[pb.NetMode]Provider{
-		pb.NetMode_UNSET: defaultProvider,
-		pb.NetMode_HOST:  NewHostProvider(),
-		pb.NetMode_NONE:  NewNoneProvider(),
-	}, nil
-}
 
 // Provider interface for Network
 type Provider interface {
@@ -61,11 +16,4 @@ type Namespace interface {
 	io.Closer
 	// Set the namespace on the spec
 	Set(*specs.Spec)
-}
-
-// NetworkOpts hold network options
-type NetworkOpts struct {
-	Type          string
-	CNIConfigPath string
-	CNIPluginPath string
 }

--- a/worker/containerd/containerd.go
+++ b/worker/containerd/containerd.go
@@ -17,7 +17,7 @@ import (
 	"github.com/moby/buildkit/identity"
 	containerdsnapshot "github.com/moby/buildkit/snapshot/containerd"
 	"github.com/moby/buildkit/util/leaseutil"
-	"github.com/moby/buildkit/util/network"
+	"github.com/moby/buildkit/util/network/netproviders"
 	"github.com/moby/buildkit/util/throttle"
 	"github.com/moby/buildkit/util/winlayers"
 	"github.com/moby/buildkit/worker/base"
@@ -27,7 +27,7 @@ import (
 )
 
 // NewWorkerOpt creates a WorkerOpt.
-func NewWorkerOpt(root string, address, snapshotterName, ns string, labels map[string]string, dns *oci.DNSConfig, nopt network.Opt, opts ...containerd.ClientOpt) (base.WorkerOpt, error) {
+func NewWorkerOpt(root string, address, snapshotterName, ns string, labels map[string]string, dns *oci.DNSConfig, nopt netproviders.Opt, opts ...containerd.ClientOpt) (base.WorkerOpt, error) {
 	opts = append(opts, containerd.WithDefaultNamespace(ns))
 	client, err := containerd.New(address, opts...)
 	if err != nil {
@@ -36,7 +36,7 @@ func NewWorkerOpt(root string, address, snapshotterName, ns string, labels map[s
 	return newContainerd(root, client, snapshotterName, ns, labels, dns, nopt)
 }
 
-func newContainerd(root string, client *containerd.Client, snapshotterName, ns string, labels map[string]string, dns *oci.DNSConfig, nopt network.Opt) (base.WorkerOpt, error) {
+func newContainerd(root string, client *containerd.Client, snapshotterName, ns string, labels map[string]string, dns *oci.DNSConfig, nopt netproviders.Opt) (base.WorkerOpt, error) {
 	if strings.Contains(snapshotterName, "/") {
 		return base.WorkerOpt{}, errors.Errorf("bad snapshotter name: %q", snapshotterName)
 	}
@@ -103,7 +103,7 @@ func newContainerd(root string, client *containerd.Client, snapshotterName, ns s
 		}
 	}
 
-	np, err := network.Providers(nopt)
+	np, err := netproviders.Providers(nopt)
 	if err != nil {
 		return base.WorkerOpt{}, err
 	}

--- a/worker/runc/runc.go
+++ b/worker/runc/runc.go
@@ -18,7 +18,7 @@ import (
 	"github.com/moby/buildkit/executor/runcexecutor"
 	containerdsnapshot "github.com/moby/buildkit/snapshot/containerd"
 	"github.com/moby/buildkit/util/leaseutil"
-	"github.com/moby/buildkit/util/network"
+	"github.com/moby/buildkit/util/network/netproviders"
 	"github.com/moby/buildkit/util/throttle"
 	"github.com/moby/buildkit/util/winlayers"
 	"github.com/moby/buildkit/worker/base"
@@ -34,7 +34,7 @@ type SnapshotterFactory struct {
 }
 
 // NewWorkerOpt creates a WorkerOpt.
-func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, processMode oci.ProcessMode, labels map[string]string, idmap *idtools.IdentityMapping, nopt network.Opt, dns *oci.DNSConfig) (base.WorkerOpt, error) {
+func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, processMode oci.ProcessMode, labels map[string]string, idmap *idtools.IdentityMapping, nopt netproviders.Opt, dns *oci.DNSConfig) (base.WorkerOpt, error) {
 	var opt base.WorkerOpt
 	name := "runc-" + snFactory.Name
 	root = filepath.Join(root, name)
@@ -46,7 +46,7 @@ func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, proc
 		return opt, err
 	}
 
-	np, err := network.Providers(nopt)
+	np, err := netproviders.Providers(nopt)
 	if err != nil {
 		return opt, err
 	}

--- a/worker/runc/runc_test.go
+++ b/worker/runc/runc_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/snapshot"
 	"github.com/moby/buildkit/source"
-	"github.com/moby/buildkit/util/network"
+	"github.com/moby/buildkit/util/network/netproviders"
 	"github.com/moby/buildkit/worker/base"
 	"github.com/stretchr/testify/require"
 )
@@ -40,7 +40,7 @@ func newWorkerOpt(t *testing.T, processMode oci.ProcessMode) (base.WorkerOpt, fu
 		},
 	}
 	rootless := false
-	workerOpt, err := NewWorkerOpt(tmpdir, snFactory, rootless, processMode, nil, nil, network.Opt{Mode: "host"}, nil)
+	workerOpt, err := NewWorkerOpt(tmpdir, snFactory, rootless, processMode, nil, nil, netproviders.Opt{Mode: "host"}, nil)
 	require.NoError(t, err)
 
 	return workerOpt, cleanup


### PR DESCRIPTION
Separate CNI support to own package so it doesn't need to be imported in moby.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>