### PR TITLE
remotecache: other fix to record sorting

### DIFF
--- a/cache/remotecache/v1/utils.go
+++ b/cache/remotecache/v1/utils.go
@@ -78,10 +78,14 @@ func sortConfig(cc *CacheConfig) {
 				if ri.Inputs[i][j].Selector != rj.Inputs[i][j].Selector {
 					return ri.Inputs[i][j].Selector < rj.Inputs[i][j].Selector
 				}
-				return cc.Records[ri.Inputs[i][j].LinkIndex].Digest < cc.Records[rj.Inputs[i][j].LinkIndex].Digest
+				inputDigesti := cc.Records[ri.Inputs[i][j].LinkIndex].Digest
+				inputDigestj := cc.Records[rj.Inputs[i][j].LinkIndex].Digest
+				if inputDigesti != inputDigestj {
+					return inputDigesti < inputDigestj
+				}
 			}
 		}
-		return ri.Digest < rj.Digest
+		return false
 	})
 	for i, l := range sortedRecords {
 		l.newIndex = i


### PR DESCRIPTION
Updated record comparator to do a full lexicographical comparison on cache records

Signed-off-by: Mark Gordon <msg555@gmail.com>