### PR TITLE
ops: fix readwrite mounts it no output

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert_runmount.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_runmount.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+	"github.com/moby/buildkit/solver/pb"
 	"github.com/pkg/errors"
 )
 
@@ -113,7 +114,7 @@ func dispatchRunMounts(d *dispatchState, c *instructions.RunCommand, sources []*
 		}
 		if mount.ReadOnly {
 			mountOpts = append(mountOpts, llb.Readonly)
-		} else if mount.Type == instructions.MountTypeBind {
+		} else if mount.Type == instructions.MountTypeBind && opt.llbCaps.Supports(pb.CapExecMountBindReadWriteNoOuput) == nil {
 			mountOpts = append(mountOpts, llb.ForceNoOutput)
 		}
 		if mount.Type == instructions.MountTypeCache {

--- a/frontend/dockerfile/dockerfile_mount_test.go
+++ b/frontend/dockerfile/dockerfile_mount_test.go
@@ -95,7 +95,7 @@ copy cachebust /
 run mkdir out && echo foo > out/foo
 
 from busybox as second
-RUN --mount=from=build,src=out,target=/out,rw cat /dev/urandom | head -c 100 | sha256sum > /unique
+RUN --mount=from=build,src=out,target=/out,rw touch /out/bar && cat /dev/urandom | head -c 100 | sha256sum > /unique
 
 from scratch
 COPY --from=second /unique /unique

--- a/solver/llbsolver/ops/exec.go
+++ b/solver/llbsolver/ops/exec.go
@@ -256,7 +256,7 @@ func (e *execOp) getRefCacheDir(ctx context.Context, ref cache.ImmutableRef, id 
 }
 
 func (e *execOp) getRefCacheDirNoCache(ctx context.Context, key string, ref cache.ImmutableRef, id string, m *pb.Mount, block bool) (cache.MutableRef, error) {
-	makeMutable := func(cache.ImmutableRef) (cache.MutableRef, error) {
+	makeMutable := func(ref cache.ImmutableRef) (cache.MutableRef, error) {
 		desc := fmt.Sprintf("cached mount %s from exec %s", m.Dest, strings.Join(e.op.Meta.Args, " "))
 		return e.cm.New(ctx, ref, cache.WithRecordType(client.UsageRecordTypeCacheMount), cache.WithDescription(desc), cache.CachePolicyRetain)
 	}
@@ -585,7 +585,7 @@ func (e *execOp) Exec(ctx context.Context, inputs []solver.Result) ([]solver.Res
 			mountable = ref
 		}
 
-		makeMutable := func(cache.ImmutableRef) (cache.MutableRef, error) {
+		makeMutable := func(ref cache.ImmutableRef) (cache.MutableRef, error) {
 			desc := fmt.Sprintf("mount %s from exec %s", m.Dest, strings.Join(e.op.Meta.Args, " "))
 			return e.cm.New(ctx, ref, cache.WithDescription(desc))
 		}
@@ -606,7 +606,7 @@ func (e *execOp) Exec(ctx context.Context, inputs []solver.Result) ([]solver.Res
 					outputs = append(outputs, active)
 					mountable = active
 				}
-			} else if ref == nil {
+			} else if (!m.Readonly || ref == nil) && m.Dest != pb.RootMount {
 				// this case is empty readonly scratch without output that is not really useful for anything but don't error
 				active, err := makeMutable(ref)
 				if err != nil {

--- a/solver/pb/caps.go
+++ b/solver/pb/caps.go
@@ -30,19 +30,20 @@ const (
 
 	CapBuildOpLLBFileName apicaps.CapID = "source.buildop.llbfilename"
 
-	CapExecMetaBase            apicaps.CapID = "exec.meta.base"
-	CapExecMetaProxy           apicaps.CapID = "exec.meta.proxyenv"
-	CapExecMetaNetwork         apicaps.CapID = "exec.meta.network"
-	CapExecMetaSecurity        apicaps.CapID = "exec.meta.security"
-	CapExecMetaSetsDefaultPath apicaps.CapID = "exec.meta.setsdefaultpath"
-	CapExecMountBind           apicaps.CapID = "exec.mount.bind"
-	CapExecMountCache          apicaps.CapID = "exec.mount.cache"
-	CapExecMountCacheSharing   apicaps.CapID = "exec.mount.cache.sharing"
-	CapExecMountSelector       apicaps.CapID = "exec.mount.selector"
-	CapExecMountTmpfs          apicaps.CapID = "exec.mount.tmpfs"
-	CapExecMountSecret         apicaps.CapID = "exec.mount.secret"
-	CapExecMountSSH            apicaps.CapID = "exec.mount.ssh"
-	CapExecCgroupsMounted      apicaps.CapID = "exec.cgroup"
+	CapExecMetaBase                  apicaps.CapID = "exec.meta.base"
+	CapExecMetaProxy                 apicaps.CapID = "exec.meta.proxyenv"
+	CapExecMetaNetwork               apicaps.CapID = "exec.meta.network"
+	CapExecMetaSecurity              apicaps.CapID = "exec.meta.security"
+	CapExecMetaSetsDefaultPath       apicaps.CapID = "exec.meta.setsdefaultpath"
+	CapExecMountBind                 apicaps.CapID = "exec.mount.bind"
+	CapExecMountBindReadWriteNoOuput apicaps.CapID = "exec.mount.bind.readwrite-nooutput"
+	CapExecMountCache                apicaps.CapID = "exec.mount.cache"
+	CapExecMountCacheSharing         apicaps.CapID = "exec.mount.cache.sharing"
+	CapExecMountSelector             apicaps.CapID = "exec.mount.selector"
+	CapExecMountTmpfs                apicaps.CapID = "exec.mount.tmpfs"
+	CapExecMountSecret               apicaps.CapID = "exec.mount.secret"
+	CapExecMountSSH                  apicaps.CapID = "exec.mount.ssh"
+	CapExecCgroupsMounted            apicaps.CapID = "exec.cgroup"
 
 	CapFileBase apicaps.CapID = "file.base"
 
@@ -189,6 +190,12 @@ func init() {
 
 	Caps.Init(apicaps.Cap{
 		ID:      CapExecMountBind,
+		Enabled: true,
+		Status:  apicaps.CapStatusExperimental,
+	})
+
+	Caps.Init(apicaps.Cap{
+		ID:      CapExecMountBindReadWriteNoOuput,
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})


### PR DESCRIPTION
#922 had a bug that caused readwrite mounts with no outputs to be mounted as readonly

Fix this and add a cap so that new frontends would rather use inefficient caching than mount in a wrong way when talking with old servers.