### PR TITLE
dockerfile: ignore relative source paths for compatibility

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -746,9 +746,9 @@ func dispatchCopyFileOp(d *dispatchState, c instructions.SourcesAndDest, sourceS
 			}}, copyOpt...)
 
 			if a == nil {
-				a = llb.Copy(sourceState, src, dest, opts...)
+				a = llb.Copy(sourceState, filepath.Join("/", src), dest, opts...)
 			} else {
-				a = a.Copy(sourceState, src, dest, opts...)
+				a = a.Copy(sourceState, filepath.Join("/", src), dest, opts...)
 			}
 		}
 	}

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -109,6 +109,7 @@ var fileOpTests = []integration.Test{
 	testTarContextExternalDockerfile,
 	testWorkdirUser,
 	testWorkdirExists,
+	testWorkdirCopyIgnoreRelative,
 }
 
 var securityTests = []integration.Test{}
@@ -782,6 +783,41 @@ RUN adduser -D user
 USER user
 WORKDIR /mydir
 RUN [ "$(stat -c "%U %G" /mydir)" == "user user" ]
+`)
+
+	dir, err := tmpdir(
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+	)
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	c, err := client.New(context.TODO(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = f.Solve(context.TODO(), c, client.SolveOpt{
+		FrontendAttrs: map[string]string{
+			"build-arg:BUILDKIT_DISABLE_FILEOP": strconv.FormatBool(!isFileOp),
+		},
+		LocalDirs: map[string]string{
+			builder.DefaultLocalNameDockerfile: dir,
+			builder.DefaultLocalNameContext:    dir,
+		},
+	}, nil)
+	require.NoError(t, err)
+}
+
+func testWorkdirCopyIgnoreRelative(t *testing.T, sb integration.Sandbox) {
+	f := getFrontend(t, sb)
+	isFileOp := getFileOp(t, sb)
+
+	dockerfile := []byte(`
+FROM scratch AS base
+WORKDIR /foo
+COPY Dockerfile / 
+FROM scratch
+# relative path still loaded as absolute
+COPY --from=base Dockerfile .
 `)
 
 	dir, err := tmpdir(


### PR DESCRIPTION
The legacy builder handles relative source paths as they were absolute and so does the copy image. Fileop based implementation took the workdir of source stage into an account. While this behavior can be quite useful it is better to revert to the behavior that is compatible with old builders.

Found when looking at https://github.com/moby/buildkit/issues/1123

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>