### PR TITLE
remotecache: fix inline cache in manifest lists

### DIFF
--- a/cache/remotecache/inline/inline.go
+++ b/cache/remotecache/inline/inline.go
@@ -31,6 +31,12 @@ func (ce *exporter) Finalize(ctx context.Context) (map[string]string, error) {
 	return nil, nil
 }
 
+func (ce *exporter) reset() {
+	cc := v1.NewCacheChains()
+	ce.CacheExporterTarget = cc
+	ce.chains = cc
+}
+
 func (ce *exporter) ExportForLayers(layers []digest.Digest) ([]byte, error) {
 	config, descs, err := ce.chains.Marshal()
 	if err != nil {
@@ -82,6 +88,7 @@ func (ce *exporter) ExportForLayers(layers []digest.Digest) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	ce.reset()
 
 	return dt, nil
 }

--- a/solver/combinedcache.go
+++ b/solver/combinedcache.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func newCombinedCacheManager(cms []CacheManager, main CacheManager) CacheManager {
+func NewCombinedCacheManager(cms []CacheManager, main CacheManager) CacheManager {
 	return &combinedCacheManager{cms: cms, main: main}
 }
 
@@ -80,7 +80,7 @@ func (cm *combinedCacheManager) Load(ctx context.Context, rec *CacheRecord) (res
 			res.Result.Release(context.TODO())
 		}
 	}()
-	if rec.cacheManager != cm.main {
+	if rec.cacheManager != cm.main && cm.main != nil {
 		for _, res := range results {
 			if _, err := cm.main.Save(res.CacheKey, res.Result, res.CacheResult.CreatedAt); err != nil {
 				return nil, err
@@ -91,6 +91,9 @@ func (cm *combinedCacheManager) Load(ctx context.Context, rec *CacheRecord) (res
 }
 
 func (cm *combinedCacheManager) Save(key *CacheKey, s Result, createdAt time.Time) (*ExportableCacheKey, error) {
+	if cm.main == nil {
+		return nil, nil
+	}
 	return cm.main.Save(key, s, createdAt)
 }
 

--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -141,7 +141,7 @@ func (s *state) combinedCacheManager() CacheManager {
 		return s.mainCache
 	}
 
-	return newCombinedCacheManager(cms, s.mainCache)
+	return NewCombinedCacheManager(cms, s.mainCache)
 }
 
 func (s *state) Release() {


### PR DESCRIPTION
Fix issues where inline cache was exported to/imported from manifest lists. Previously the importer could only match one submanifest and exporter didn't export in deterministic order.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>