### PR TITLE
git: updates for keep git dir

### DIFF
--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -49,6 +49,7 @@ const (
 	keyNameContext             = "contextkey"
 	keyNameDockerfile          = "dockerfilekey"
 	keyContextSubDir           = "contextsubdir"
+	keyContextKeepGitDir       = "build-arg:BUILDKIT_CONTEXT_KEEP_GIT_DIR"
 )
 
 var httpPrefix = regexp.MustCompile(`^https?://`)
@@ -129,7 +130,7 @@ func Build(ctx context.Context, c client.Client) (*client.Result, error) {
 
 	var buildContext *llb.State
 	isScratchContext := false
-	if st, ok := detectGitContext(opts[localNameContext]); ok {
+	if st, ok := detectGitContext(opts[localNameContext], opts[keyContextKeepGitDir]); ok {
 		if !forceLocalDockerfile {
 			src = *st
 		}
@@ -451,10 +452,17 @@ func filter(opt map[string]string, key string) map[string]string {
 	return m
 }
 
-func detectGitContext(ref string) (*llb.State, bool) {
+func detectGitContext(ref, gitContext string) (*llb.State, bool) {
 	found := false
 	if httpPrefix.MatchString(ref) && gitUrlPathWithFragmentSuffix.MatchString(ref) {
 		found = true
+	}
+
+	keepGit := false
+	if gitContext != "" {
+		if v, err := strconv.ParseBool(gitContext); err == nil {
+			keepGit = v
+		}
 	}
 
 	for _, prefix := range []string{"git://", "github.com/", "git@"} {
@@ -472,7 +480,12 @@ func detectGitContext(ref string) (*llb.State, bool) {
 	if len(parts) > 1 {
 		branch = parts[1]
 	}
-	st := llb.Git(parts[0], branch, dockerfile2llb.WithInternalName("load git source "+ref))
+	gitOpts := []llb.GitOption{dockerfile2llb.WithInternalName("load git source " + ref)}
+	if keepGit {
+		gitOpts = append(gitOpts, llb.KeepGitDir())
+	}
+
+	st := llb.Git(parts[0], branch, gitOpts...)
 	return &st, true
 }
 

--- a/source/git/gitsource_test.go
+++ b/source/git/gitsource_test.go
@@ -53,7 +53,12 @@ func testRepeatedFetch(t *testing.T, keepGitDir bool) {
 	require.NoError(t, err)
 	require.True(t, done)
 
-	require.Equal(t, 40, len(key1))
+	expLen := 40
+	if keepGitDir {
+		expLen += 4
+	}
+
+	require.Equal(t, expLen, len(key1))
 
 	ref1, err := g.Snapshot(ctx)
 	require.NoError(t, err)
@@ -171,7 +176,12 @@ func testFetchBySHA(t *testing.T, keepGitDir bool) {
 	require.NoError(t, err)
 	require.True(t, done)
 
-	require.Equal(t, 40, len(key1))
+	expLen := 40
+	if keepGitDir {
+		expLen += 4
+	}
+
+	require.Equal(t, expLen, len(key1))
 
 	ref1, err := g.Snapshot(ctx)
 	require.NoError(t, err)
@@ -244,13 +254,18 @@ func testMultipleRepos(t *testing.T, keepGitDir bool) {
 	g2, err := gs.Resolve(ctx, id2, nil)
 	require.NoError(t, err)
 
+	expLen := 40
+	if keepGitDir {
+		expLen += 4
+	}
+
 	key1, _, err := g.CacheKey(ctx, 0)
 	require.NoError(t, err)
-	require.Equal(t, 40, len(key1))
+	require.Equal(t, expLen, len(key1))
 
 	key2, _, err := g2.CacheKey(ctx, 0)
 	require.NoError(t, err)
-	require.Equal(t, 40, len(key2))
+	require.Equal(t, expLen, len(key2))
 
 	require.NotEqual(t, key1, key2)
 


### PR DESCRIPTION
Fix issues with keeping `.git` directory around on git checkouts. Also add a build arg for triggering git context to keep the git directory. Normally this should be the default but because the option was broken before I'd rather not break anyone.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>