### PR TITLE
Implement support for RUN --network=none|default|host

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -650,7 +650,9 @@ func dispatchRun(d *dispatchState, c *instructions.RunCommand, proxy *llb.ProxyE
 	if err != nil {
 		return err
 	}
-	opt = append(opt, networkOpt)
+	if networkOpt != nil {
+		opt = append(opt, networkOpt)
+	}
 
 	shlex := *dopt.shlex
 	shlex.RawQuotes = true

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -644,7 +644,9 @@ func dispatchRun(d *dispatchState, c *instructions.RunCommand, proxy *llb.ProxyE
 	if err != nil {
 		return err
 	}
-	opt = append(opt, securityOpt)
+	if securityOpt != nil {
+		opt = append(opt, securityOpt)
+	}
 
 	networkOpt, err := dispatchRunNetwork(c)
 	if err != nil {

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -640,15 +640,17 @@ func dispatchRun(d *dispatchState, c *instructions.RunCommand, proxy *llb.ProxyE
 	}
 	opt = append(opt, runMounts...)
 
-	err = dispatchRunSecurity(d, c)
+	securityOpt, err := dispatchRunSecurity(c)
 	if err != nil {
 		return err
 	}
+	opt = append(opt, securityOpt)
 
-	err = dispatchRunNetwork(d, c)
+	networkOpt, err := dispatchRunNetwork(c)
 	if err != nil {
 		return err
 	}
+	opt = append(opt, networkOpt)
 
 	shlex := *dopt.shlex
 	shlex.RawQuotes = true

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -645,6 +645,11 @@ func dispatchRun(d *dispatchState, c *instructions.RunCommand, proxy *llb.ProxyE
 		return err
 	}
 
+	err = dispatchRunNetwork(d, c)
+	if err != nil {
+		return err
+	}
+
 	shlex := *dopt.shlex
 	shlex.RawQuotes = true
 	shlex.SkipUnsetEnv = true

--- a/frontend/dockerfile/dockerfile2llb/convert_norunnetwork.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_norunnetwork.go
@@ -5,9 +5,8 @@ package dockerfile2llb
 import (
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
-	"github.com/moby/buildkit/solver/pb"
 )
 
 func dispatchRunNetwork(c *instructions.RunCommand) (llb.RunOption, error) {
-	return llb.Network(pb.NetMode_UNSET), nil
+	return nil, nil
 }

--- a/frontend/dockerfile/dockerfile2llb/convert_norunnetwork.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_norunnetwork.go
@@ -1,0 +1,11 @@
+// +build !dfrunnetwork
+
+package dockerfile2llb
+
+import (
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+)
+
+func dispatchRunNetwork(d *dispatchState, c *instructions.RunCommand) error {
+	return nil
+}

--- a/frontend/dockerfile/dockerfile2llb/convert_norunnetwork.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_norunnetwork.go
@@ -3,9 +3,11 @@
 package dockerfile2llb
 
 import (
+	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+	"github.com/moby/buildkit/solver/pb"
 )
 
-func dispatchRunNetwork(d *dispatchState, c *instructions.RunCommand) error {
-	return nil
+func dispatchRunNetwork(c *instructions.RunCommand) (llb.RunOption, error) {
+	return llb.Network(pb.NetMode_UNSET), nil
 }

--- a/frontend/dockerfile/dockerfile2llb/convert_norunsecurity.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_norunsecurity.go
@@ -3,9 +3,11 @@
 package dockerfile2llb
 
 import (
+	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+	"github.com/moby/buildkit/solver/pb"
 )
 
-func dispatchRunSecurity(d *dispatchState, c *instructions.RunCommand) error {
-	return nil
+func dispatchRunSecurity(c *instructions.RunCommand) (llb.RunOption, error) {
+	return llb.Security(pb.SecurityMode_SANDBOX), nil
 }

--- a/frontend/dockerfile/dockerfile2llb/convert_norunsecurity.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_norunsecurity.go
@@ -5,9 +5,8 @@ package dockerfile2llb
 import (
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
-	"github.com/moby/buildkit/solver/pb"
 )
 
 func dispatchRunSecurity(c *instructions.RunCommand) (llb.RunOption, error) {
-	return llb.Security(pb.SecurityMode_SANDBOX), nil
+	return nil, nil
 }

--- a/frontend/dockerfile/dockerfile2llb/convert_runnetwork.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_runnetwork.go
@@ -1,0 +1,27 @@
+// +build dfrunnetwork
+
+package dockerfile2llb
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+	"github.com/moby/buildkit/solver/pb"
+)
+
+func dispatchRunNetwork(d *dispatchState, c *instructions.RunCommand) error {
+	network := instructions.GetNetwork(c)
+
+	switch network {
+	case instructions.NetworkDefault:
+		d.state = d.state.Network(pb.NetMode_UNSET)
+	case instructions.NetworkNone:
+		d.state = d.state.Network(pb.NetMode_NONE)
+	case instructions.NetworkHost:
+		d.state = d.state.Network(pb.NetMode_HOST)
+	default:
+		return errors.Errorf("unsupported network mode %q", network)
+	}
+
+	return nil
+}

--- a/frontend/dockerfile/dockerfile2llb/convert_runnetwork.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_runnetwork.go
@@ -15,7 +15,7 @@ func dispatchRunNetwork(c *instructions.RunCommand) (llb.RunOption, error) {
 
 	switch network {
 	case instructions.NetworkDefault:
-		return llb.Network(pb.NetMode_UNSET), nil
+		return nil, nil
 	case instructions.NetworkNone:
 		return llb.Network(pb.NetMode_NONE), nil
 	case instructions.NetworkHost:

--- a/frontend/dockerfile/dockerfile2llb/convert_runnetwork.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_runnetwork.go
@@ -5,23 +5,22 @@ package dockerfile2llb
 import (
 	"github.com/pkg/errors"
 
+	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/solver/pb"
 )
 
-func dispatchRunNetwork(d *dispatchState, c *instructions.RunCommand) error {
+func dispatchRunNetwork(c *instructions.RunCommand) (llb.RunOption, error) {
 	network := instructions.GetNetwork(c)
 
 	switch network {
 	case instructions.NetworkDefault:
-		d.state = d.state.Network(pb.NetMode_UNSET)
+		return llb.Network(pb.NetMode_UNSET), nil
 	case instructions.NetworkNone:
-		d.state = d.state.Network(pb.NetMode_NONE)
+		return llb.Network(pb.NetMode_NONE), nil
 	case instructions.NetworkHost:
-		d.state = d.state.Network(pb.NetMode_HOST)
+		return llb.Network(pb.NetMode_HOST), nil
 	default:
-		return errors.Errorf("unsupported network mode %q", network)
+		return nil, errors.Errorf("unsupported network mode %q", network)
 	}
-
-	return nil
 }

--- a/frontend/dockerfile/dockerfile2llb/convert_runsecurity.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_runsecurity.go
@@ -5,23 +5,20 @@ package dockerfile2llb
 import (
 	"github.com/pkg/errors"
 
+	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/solver/pb"
 )
 
-func dispatchRunSecurity(d *dispatchState, c *instructions.RunCommand) error {
+func dispatchRunSecurity(c *instructions.RunCommand) (llb.RunOption, error) {
 	security := instructions.GetSecurity(c)
 
-	for _, sec := range security {
-		switch sec {
-		case instructions.SecurityInsecure:
-			d.state = d.state.Security(pb.SecurityMode_INSECURE)
-		case instructions.SecuritySandbox:
-			d.state = d.state.Security(pb.SecurityMode_SANDBOX)
-		default:
-			return errors.Errorf("unsupported security mode %q", sec)
-		}
+	switch security {
+	case instructions.SecurityInsecure:
+		return llb.Security(pb.SecurityMode_INSECURE), nil
+	case instructions.SecuritySandbox:
+		return llb.Security(pb.SecurityMode_SANDBOX), nil
+	default:
+		return nil, errors.Errorf("unsupported security mode %q", security)
 	}
-
-	return nil
 }

--- a/frontend/dockerfile/dockerfile_runnetwork_test.go
+++ b/frontend/dockerfile/dockerfile_runnetwork_test.go
@@ -62,11 +62,16 @@ RUN ip link show eth0
 }
 
 func runNoNetwork(t *testing.T, sb integration.Sandbox) {
+	if os.Getenv("BUILDKIT_RUN_NETWORK_INTEGRATION_TESTS") == "" {
+		t.SkipNow()
+	}
+
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
 FROM busybox
 RUN --network=none ! ip link show eth0
+RUN ip link show eth0
 `)
 
 	dir, err := tmpdir(
@@ -138,10 +143,6 @@ RUN ! nc 127.0.0.1 %s | grep foo
 }
 
 func runGlobalNetwork(t *testing.T, sb integration.Sandbox) {
-	if os.Getenv("BUILDKIT_RUN_NETWORK_INTEGRATION_TESTS") == "" {
-		t.SkipNow()
-	}
-
 	f := getFrontend(t, sb)
 
 	s, err := echoserver.NewTestServer("foo")

--- a/frontend/dockerfile/dockerfile_runnetwork_test.go
+++ b/frontend/dockerfile/dockerfile_runnetwork_test.go
@@ -19,17 +19,17 @@ import (
 )
 
 var runNetworkTests = []integration.Test{
-	runDefaultNetwork,
-	runNoNetwork,
-	runHostNetwork,
-	runGlobalNetwork,
+	testRunDefaultNetwork,
+	testRunNoNetwork,
+	testRunHostNetwork,
+	testRunGlobalNetwork,
 }
 
 func init() {
 	networkTests = append(networkTests, runNetworkTests...)
 }
 
-func runDefaultNetwork(t *testing.T, sb integration.Sandbox) {
+func testRunDefaultNetwork(t *testing.T, sb integration.Sandbox) {
 	if os.Getenv("BUILDKIT_RUN_NETWORK_INTEGRATION_TESTS") == "" {
 		t.SkipNow()
 	}
@@ -61,7 +61,7 @@ RUN ip link show eth0
 	require.NoError(t, err)
 }
 
-func runNoNetwork(t *testing.T, sb integration.Sandbox) {
+func testRunNoNetwork(t *testing.T, sb integration.Sandbox) {
 	if os.Getenv("BUILDKIT_RUN_NETWORK_INTEGRATION_TESTS") == "" {
 		t.SkipNow()
 	}
@@ -94,7 +94,7 @@ RUN ip link show eth0
 	require.NoError(t, err)
 }
 
-func runHostNetwork(t *testing.T, sb integration.Sandbox) {
+func testRunHostNetwork(t *testing.T, sb integration.Sandbox) {
 	if os.Getenv("BUILDKIT_RUN_NETWORK_INTEGRATION_TESTS") == "" {
 		t.SkipNow()
 	}
@@ -142,7 +142,7 @@ RUN ! nc 127.0.0.1 %s | grep foo
 	}
 }
 
-func runGlobalNetwork(t *testing.T, sb integration.Sandbox) {
+func testRunGlobalNetwork(t *testing.T, sb integration.Sandbox) {
 	f := getFrontend(t, sb)
 
 	s, err := echoserver.NewTestServer("foo")

--- a/frontend/dockerfile/dockerfile_runnetwork_test.go
+++ b/frontend/dockerfile/dockerfile_runnetwork_test.go
@@ -30,6 +30,10 @@ func init() {
 }
 
 func runDefaultNetwork(t *testing.T, sb integration.Sandbox) {
+	if os.Getenv("BUILDKIT_RUN_NETWORK_INTEGRATION_TESTS") == "" {
+		t.SkipNow()
+	}
+
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -86,6 +90,10 @@ RUN --network=none ! ip link show eth0
 }
 
 func runHostNetwork(t *testing.T, sb integration.Sandbox) {
+	if os.Getenv("BUILDKIT_RUN_NETWORK_INTEGRATION_TESTS") == "" {
+		t.SkipNow()
+	}
+
 	f := getFrontend(t, sb)
 
 	s, err := echoserver.NewTestServer("foo")
@@ -96,7 +104,7 @@ func runHostNetwork(t *testing.T, sb integration.Sandbox) {
 	dockerfile := fmt.Sprintf(`
 FROM busybox
 RUN --network=host nc 127.0.0.1 %s | grep foo
-RUN ! nc -z 127.0.0.1 %s
+RUN ! nc 127.0.0.1 %s | grep foo
 `, port, port)
 
 	dir, err := tmpdir(
@@ -130,6 +138,10 @@ RUN ! nc -z 127.0.0.1 %s
 }
 
 func runGlobalNetwork(t *testing.T, sb integration.Sandbox) {
+	if os.Getenv("BUILDKIT_RUN_NETWORK_INTEGRATION_TESTS") == "" {
+		t.SkipNow()
+	}
+
 	f := getFrontend(t, sb)
 
 	s, err := echoserver.NewTestServer("foo")

--- a/frontend/dockerfile/dockerfile_runnetwork_test.go
+++ b/frontend/dockerfile/dockerfile_runnetwork_test.go
@@ -22,6 +22,7 @@ var runNetworkTests = []integration.Test{
 	runDefaultNetwork,
 	runNoNetwork,
 	runHostNetwork,
+	runGlobalNetwork,
 }
 
 func init() {
@@ -114,6 +115,53 @@ RUN ! nc -z 127.0.0.1 %s
 			builder.DefaultLocalNameContext:    dir,
 		},
 		AllowedEntitlements: []entitlements.Entitlement{entitlements.EntitlementNetworkHost},
+	}, nil)
+
+	hostAllowed := sb.Value("network.host")
+	switch hostAllowed {
+	case networkHostGranted:
+		require.NoError(t, err)
+	case networkHostDenied:
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "entitlement network.host is not allowed")
+	default:
+		require.Fail(t, "unexpected network.host mode %q", hostAllowed)
+	}
+}
+
+func runGlobalNetwork(t *testing.T, sb integration.Sandbox) {
+	f := getFrontend(t, sb)
+
+	s, err := echoserver.NewTestServer("foo")
+	require.NoError(t, err)
+	addrParts := strings.Split(s.Addr().String(), ":")
+	port := addrParts[len(addrParts)-1]
+
+	dockerfile := fmt.Sprintf(`
+FROM busybox
+RUN nc 127.0.0.1 %s | grep foo
+RUN --network=none ! nc -z 127.0.0.1 %s
+`, port, port)
+
+	dir, err := tmpdir(
+		fstest.CreateFile("Dockerfile", []byte(dockerfile), 0600),
+	)
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	c, err := client.New(context.TODO(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = f.Solve(context.TODO(), c, client.SolveOpt{
+		LocalDirs: map[string]string{
+			builder.DefaultLocalNameDockerfile: dir,
+			builder.DefaultLocalNameContext:    dir,
+		},
+		AllowedEntitlements: []entitlements.Entitlement{entitlements.EntitlementNetworkHost},
+		FrontendAttrs: map[string]string{
+			"force-network-mode": "host",
+		},
 	}, nil)
 
 	hostAllowed := sb.Value("network.host")

--- a/frontend/dockerfile/dockerfile_runsecurity_test.go
+++ b/frontend/dockerfile/dockerfile_runsecurity_test.go
@@ -32,6 +32,7 @@ func testRunSecurityInsecure(t *testing.T, sb integration.Sandbox) {
 	dockerfile := []byte(`
 FROM busybox
 RUN --security=insecure [ "$(cat /proc/self/status | grep CapBnd)" == "CapBnd:	0000003fffffffff" ]
+RUN [ "$(cat /proc/self/status | grep CapBnd)" == "CapBnd:	00000000a80425fb" ]
 `)
 
 	dir, err := tmpdir(

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -112,7 +112,11 @@ var fileOpTests = []integration.Test{
 	testWorkdirCopyIgnoreRelative,
 }
 
+// Tests that depend on the `security.*` entitlements
 var securityTests = []integration.Test{}
+
+// Tests that depend on the `network.*` entitlements
+var networkTests = []integration.Test{}
 
 var opts []integration.TestOpt
 
@@ -156,9 +160,14 @@ func TestIntegration(t *testing.T) {
 		"false": false,
 	}))...)
 	integration.Run(t, securityTests, append(opts,
-		integration.WithMatrix("secmode", map[string]interface{}{
-			"sandbox":  securitySandbox,
-			"insecure": securityInsecure,
+		integration.WithMatrix("security.insecure", map[string]interface{}{
+			"granted": securityInsecureGranted,
+			"denied":  securityInsecureDenied,
+		}))...)
+	integration.Run(t, networkTests, append(opts,
+		integration.WithMatrix("network.host", map[string]interface{}{
+			"granted": networkHostGranted,
+			"denied":  networkHostDenied,
 		}))...)
 }
 
@@ -4278,8 +4287,23 @@ func (*secModeInsecure) UpdateConfigFile(in string) string {
 	return in + "\n\ninsecure-entitlements = [\"security.insecure\"]\n"
 }
 
-var securitySandbox integration.ConfigUpdater = &secModeSandbox{}
-var securityInsecure integration.ConfigUpdater = &secModeInsecure{}
+var securityInsecureGranted integration.ConfigUpdater = &secModeInsecure{}
+var securityInsecureDenied integration.ConfigUpdater = &secModeSandbox{}
+
+type networkModeHost struct{}
+
+func (*networkModeHost) UpdateConfigFile(in string) string {
+	return in + "\n\ninsecure-entitlements = [\"network.host\"]\n"
+}
+
+type networkModeSandbox struct{}
+
+func (*networkModeSandbox) UpdateConfigFile(in string) string {
+	return in
+}
+
+var networkHostGranted integration.ConfigUpdater = &networkModeHost{}
+var networkHostDenied integration.ConfigUpdater = &networkModeSandbox{}
 
 func fixedWriteCloser(wc io.WriteCloser) func(map[string]string) (io.WriteCloser, error) {
 	return func(map[string]string) (io.WriteCloser, error) {

--- a/frontend/dockerfile/docs/experimental.md
+++ b/frontend/dockerfile/docs/experimental.md
@@ -179,9 +179,6 @@ which needs to be enabled when starting the buildkitd daemon
 (`--allow-insecure-entitlement network.host`) and on the build request
 (`--allow network.host`).
 
-_Note that the `network.host` entitlement is enabled by default when using
-buildkit through the docker daemon._
-
 #### Example: isolating external effects
 
 ```dockerfile

--- a/frontend/dockerfile/instructions/commands_runnetwork.go
+++ b/frontend/dockerfile/instructions/commands_runnetwork.go
@@ -32,7 +32,7 @@ func init() {
 
 func runNetworkPreHook(cmd *RunCommand, req parseRequest) error {
 	st := &networkState{}
-	st.flag = req.flags.AddString("network", "default")
+	st.flag = req.flags.AddString("network", NetworkDefault)
 	cmd.setExternalValue(networkKey, st)
 	return nil
 }

--- a/frontend/dockerfile/instructions/commands_runnetwork.go
+++ b/frontend/dockerfile/instructions/commands_runnetwork.go
@@ -1,0 +1,63 @@
+// +build dfrunnetwork
+
+package instructions
+
+import (
+	"github.com/pkg/errors"
+)
+
+const (
+	NetworkDefault = "default"
+	NetworkNone    = "none"
+	NetworkHost    = "host"
+)
+
+var allowedNetwork = map[string]struct{}{
+	NetworkDefault: {},
+	NetworkNone:    {},
+	NetworkHost:    {},
+}
+
+func isValidNetwork(value string) bool {
+	_, ok := allowedNetwork[value]
+	return ok
+}
+
+var networkKey = "dockerfile/run/network"
+
+func init() {
+	parseRunPreHooks = append(parseRunPreHooks, runNetworkPreHook)
+	parseRunPostHooks = append(parseRunPostHooks, runNetworkPostHook)
+}
+
+func runNetworkPreHook(cmd *RunCommand, req parseRequest) error {
+	st := &networkState{}
+	st.flag = req.flags.AddString("network", "default")
+	cmd.setExternalValue(networkKey, st)
+	return nil
+}
+
+func runNetworkPostHook(cmd *RunCommand, req parseRequest) error {
+	st := cmd.getExternalValue(networkKey).(*networkState)
+	if st == nil {
+		return errors.Errorf("no network state")
+	}
+
+	value := st.flag.Value
+	if !isValidNetwork(value) {
+		return errors.Errorf("invalid network mode %q", value)
+	}
+
+	st.networkMode = value
+
+	return nil
+}
+
+func GetNetwork(cmd *RunCommand) string {
+	return cmd.getExternalValue(networkKey).(*networkState).networkMode
+}
+
+type networkState struct {
+	flag        *Flag
+	networkMode string
+}

--- a/frontend/dockerfile/instructions/commands_runsecurity.go
+++ b/frontend/dockerfile/instructions/commands_runsecurity.go
@@ -3,9 +3,6 @@
 package instructions
 
 import (
-	"encoding/csv"
-	"strings"
-
 	"github.com/pkg/errors"
 )
 
@@ -24,9 +21,7 @@ func isValidSecurity(value string) bool {
 	return ok
 }
 
-type securityKeyT string
-
-var securityKey = securityKeyT("dockerfile/run/security")
+var securityKey = "dockerfile/run/security"
 
 func init() {
 	parseRunPreHooks = append(parseRunPreHooks, runSecurityPreHook)
@@ -35,49 +30,32 @@ func init() {
 
 func runSecurityPreHook(cmd *RunCommand, req parseRequest) error {
 	st := &securityState{}
-	st.flag = req.flags.AddStrings("security")
+	st.flag = req.flags.AddString("security", SecuritySandbox)
 	cmd.setExternalValue(securityKey, st)
 	return nil
 }
 
 func runSecurityPostHook(cmd *RunCommand, req parseRequest) error {
-	st := getSecurityState(cmd)
+	st := cmd.getExternalValue(securityKey).(*securityState)
 	if st == nil {
 		return errors.Errorf("no security state")
 	}
 
-	for _, value := range st.flag.StringValues {
-		csvReader := csv.NewReader(strings.NewReader(value))
-		fields, err := csvReader.Read()
-		if err != nil {
-			return errors.Wrap(err, "failed to parse csv security")
-		}
-
-		for _, field := range fields {
-			if !isValidSecurity(field) {
-				return errors.Errorf("security %q is not valid", field)
-			}
-
-			st.security = append(st.security, field)
-		}
+	value := st.flag.Value
+	if !isValidSecurity(value) {
+		return errors.Errorf("security %q is not valid", value)
 	}
+
+	st.security = value
 
 	return nil
 }
 
-func getSecurityState(cmd *RunCommand) *securityState {
-	v := cmd.getExternalValue(securityKey)
-	if v == nil {
-		return nil
-	}
-	return v.(*securityState)
-}
-
-func GetSecurity(cmd *RunCommand) []string {
-	return getSecurityState(cmd).security
+func GetSecurity(cmd *RunCommand) string {
+	return cmd.getExternalValue(securityKey).(*securityState).security
 }
 
 type securityState struct {
 	flag     *Flag
-	security []string
+	security string
 }

--- a/frontend/dockerfile/release/experimental/tags
+++ b/frontend/dockerfile/release/experimental/tags
@@ -1,1 +1,1 @@
-dfrunmount dfrunsecurity dfsecrets dfssh
+dfrunmount dfrunsecurity dfsecrets dfssh dfrunnetwork


### PR DESCRIPTION
Following a similar pattern to #1081, this adds support in the experimental Dockerfile for `RUN` instructions with customised networking modes:

```
RUN --network=none ip link list

1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
```

Allowed arguments for `--network` are:

* `none` - No networking is available during the invocation (useful for preventing external effects)
* `host` - Expose the host's network stack to the invocation (requires the `network.host` entitlement)
* `default` - The invocation is run in the standard internal network (equivalent to not specifying the network)