### PR TITLE
solver: fix pipe signaling on incoming updates

### DIFF
--- a/solver/edge.go
+++ b/solver/edge.go
@@ -177,6 +177,9 @@ func (e *edge) finishIncoming(req pipe.Sender) {
 
 // updateIncoming updates the current value of incoming pipe request
 func (e *edge) updateIncoming(req pipe.Sender) {
+	if debugScheduler {
+		logrus.Debugf("updateIncoming %s %#v desired=%s", e.edge.Vertex.Name(), e.edgeState, req.Request().Payload.(*edgeRequest).desiredState)
+	}
 	req.Update(&e.edgeState)
 }
 

--- a/solver/internal/pipe/pipe.go
+++ b/solver/internal/pipe/pipe.go
@@ -11,11 +11,15 @@ import (
 type channel struct {
 	OnSendCompletion func()
 	value            atomic.Value
-	lastValue        interface{}
+	lastValue        *wrappedValue
+}
+
+type wrappedValue struct {
+	value interface{}
 }
 
 func (c *channel) Send(v interface{}) {
-	c.value.Store(v)
+	c.value.Store(&wrappedValue{value: v})
 	if c.OnSendCompletion != nil {
 		c.OnSendCompletion()
 	}
@@ -23,11 +27,11 @@ func (c *channel) Send(v interface{}) {
 
 func (c *channel) Receive() (interface{}, bool) {
 	v := c.value.Load()
-	if c.lastValue == v {
+	if v == nil || v.(*wrappedValue) == c.lastValue {
 		return nil, false
 	}
-	c.lastValue = v
-	return v, true
+	c.lastValue = v.(*wrappedValue)
+	return v.(*wrappedValue).value, true
 }
 
 type Pipe struct {


### PR DESCRIPTION
fix cases where some events were dropped resulting inefficient parallelization.

issue shows with following dockerfile:
```
# Image one
FROM alpine as one
RUN mkdir -p /opt/one/
RUN sleep 5

# Image two
FROM alpine as two
RUN mkdir -p /opt/two/
RUN sleep 5

# Image three
FROM alpine as three
RUN mkdir -p /opt/three/
RUN sleep 5

# Image four
FROM alpine as four
RUN mkdir -p /opt/four/
RUN sleep 5

# Image Final
FROM alpine:latest
COPY --from=one /opt/one /opt/one
COPY --from=two /opt/two /opt/two
COPY --from=three /opt/three /opt/three
COPY --from=four /opt/four /opt/four
```

It is possible that cases like this became more likely after `FileOp` introduction as it reduces the number of cache keys for `COPY` command in dockerfile.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>