### PR TITLE
Expand shell variable expansion - add mandatory variables

### DIFF
--- a/frontend/dockerfile/shell/envVarTest
+++ b/frontend/dockerfile/shell/envVarTest
@@ -46,6 +46,12 @@ A|he${XXX:-$PWD}xx         |     he/homexx
 A|he${XXX:-${PWD:-yyy}}xx  |     he/homexx
 A|he${XXX:-${YYY:-yyy}}xx  |     heyyyxx
 A|he${XXX:YYY}             |     error
+A|he${XXX?}                |     error
+A|he${XXX:?}               |     error
+A|he${PWD?}                |     he/home
+A|he${PWD:?}               |     he/home
+A|he${NULL?}               |     he
+A|he${NULL:?}              |     error
 A|he${XXX:+${PWD}}xx       |     hexx
 A|he${PWD:+${XXX}}xx       |     hexx
 A|he${PWD:+${SHELL}}xx     |     hebashxx


### PR DESCRIPTION
The aim is to add `${name?word}` and `${name:?word}` [[src](https://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_06_02)] to allow enforcing environment variables/build args to be set, e.g.
```Dockerfile
ARG REQUIRED
# will fail if $REQUIRED is empty or undefined
ENV NOT_EMPTY=${REQUIRED:?}
# will fail if $REQUIRED is undefined
ENV NOT_UNSET=${REQUIRED?}
```
* [x] expand `shellWord.processDollar`
* [x] expand `TestShellParser4EnvVars` and `frontend/dockerfile/shell/envVarTest`
* [x] add test for error message