### PR TITLE
executor/oci: fix panic when resolv.conf does not exist 

### DIFF
--- a/executor/oci/resolvconf.go
+++ b/executor/oci/resolvconf.go
@@ -91,14 +91,12 @@ func GetResolvConf(ctx context.Context, stateDir string, idmap *idtools.Identity
 			if err != nil {
 				return "", err
 			}
-		} else {
-			// Logic seems odd here: why are we filtering localhost IPs
-			// only if neither of the DNS configs were specified?
-			// Logic comes from https://github.com/docker/libnetwork/blob/164a77ee6d24fb2b1d61f8ad3403a51d8453899e/sandbox_dns_unix.go#L230-L269
-			f, err = resolvconf.FilterResolvDNS(f.Content, true)
-			if err != nil {
-				return "", err
-			}
+			dt = f.Content
+		}
+
+		f, err = resolvconf.FilterResolvDNS(dt, true)
+		if err != nil {
+			return "", err
 		}
 
 		tmpPath := p + ".tmp"

--- a/executor/oci/resolvconf.go
+++ b/executor/oci/resolvconf.go
@@ -16,6 +16,9 @@ var g flightcontrol.Group
 var notFirstRun bool
 var lastNotEmpty bool
 
+// overridden by tests
+var resolvconfGet = resolvconf.Get
+
 type DNSConfig struct {
 	Nameservers   []string
 	Options       []string
@@ -59,7 +62,7 @@ func GetResolvConf(ctx context.Context, stateDir string, idmap *idtools.Identity
 		}
 
 		var dt []byte
-		f, err := resolvconf.Get()
+		f, err := resolvconfGet()
 		if err != nil {
 			if !os.IsNotExist(err) {
 				return "", err

--- a/executor/oci/resolvconf_test.go
+++ b/executor/oci/resolvconf_test.go
@@ -1,0 +1,39 @@
+package oci
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/docker/libnetwork/resolvconf"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolvConfNotExist modifies a global variable
+// It must not run in parallel.
+func TestResolvConfNotExist(t *testing.T) {
+	oldResolvconfGet := resolvconfGet
+	defer func() {
+		resolvconfGet = oldResolvconfGet
+	}()
+	resolvconfGet = func() (*resolvconf.File, error) {
+		return nil, os.ErrNotExist
+	}
+
+	defaultResolvConf := `
+nameserver 8.8.8.8
+nameserver 8.8.4.4
+nameserver 2001:4860:4860::8888
+nameserver 2001:4860:4860::8844`
+
+	dir, err := ioutil.TempDir("", "buildkit-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+	ctx := context.Background()
+	p, err := GetResolvConf(ctx, dir, nil, nil)
+	require.NoError(t, err)
+	b, err := ioutil.ReadFile(p)
+	require.NoError(t, err)
+	require.Equal(t, string(b), defaultResolvConf)
+}


### PR DESCRIPTION
Fixes #1193 