### PR TITLE
frontend: add padding to align steps in stage

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/url"
 	"path"
 	"path/filepath"
@@ -1325,7 +1326,7 @@ func prefixCommand(ds *dispatchState, str string, prefixPlatform bool, platform 
 		out += ds.stageName + " "
 	}
 	ds.cmdIndex++
-	out += fmt.Sprintf("%d/%d] ", ds.cmdIndex, ds.cmdTotal)
+	out += fmt.Sprintf("%*d/%d] ", int(1+math.Log10(float64(ds.cmdTotal))), ds.cmdIndex, ds.cmdTotal)
 	return out + str
 }
 


### PR DESCRIPTION
This adds a one space padding, so that the output of stages that have 10 steps or more align better;

Before:

     => [dev 1/24] RUN groupadd -r docker                                        0.7s
     => [dev 2/24] RUN useradd --create-home --gid docker unprivilegeduser       1.0s
     => [dev 3/24] RUN ln -sfv /go/src/github.com/docker/docker/.bashrc ~/.bas   0.9s
     => [dev 4/24] RUN echo "source /usr/share/bash-completion/bash_completion"  1.0s
     => [dev 5/24] RUN ln -s /usr/local/completion/bash/docker /etc/bash_c       0.8s
     => [dev 6/24] RUN ldconfig                                                  1.6s
     => [dev 7/24] RUN --mount=type=cache,sharing=locked,id=moby-dev-aptlib,    44.8s
     => [dev 8/24] RUN pip3 install yamllint==1.16.0                             4.0s
     => [dev 9/24] COPY --from=swagger /build/swagger* /usr/local/bin/           0.2s
     => [dev 10/24] COPY --from=frozen-images /build/ /docker-frozen-images      2.0s
     => [dev 11/24] COPY --from=golangci_lint /build/ /usr/local/bin/            0.3s
     => [dev 12/24] COPY --from=gotestsum /build/ /usr/local/bin/                0.3s

After:

     => [dev  1/24] RUN groupadd -r docker                                       0.7s
     => [dev  2/24] RUN useradd --create-home --gid docker unprivilegeduser      1.0s
     => [dev  3/24] RUN ln -sfv /go/src/github.com/docker/docker/.bashrc ~/.bas  0.9s
     => [dev  4/24] RUN echo "source /usr/share/bash-completion/bash_completion" 1.0s
     => [dev  5/24] RUN ln -s /usr/local/completion/bash/docker /etc/bash_c      0.8s
     => [dev  6/24] RUN ldconfig                                                 1.6s
     => [dev  7/24] RUN --mount=type=cache,sharing=locked,id=moby-dev-aptlib,   44.8s
     => [dev  8/24] RUN pip3 install yamllint==1.16.0                            4.0s
     => [dev  9/24] COPY --from=swagger /build/swagger* /usr/local/bin/          0.2s
     => [dev 10/24] COPY --from=frozen-images /build/ /docker-frozen-images      2.0s
     => [dev 11/24] COPY --from=golangci_lint /build/ /usr/local/bin/            0.3s
     => [dev 12/24] COPY --from=gotestsum /build/ /usr/local/bin/                0.3s
