### PR TITLE
Hide the testing T in the backend config

### DIFF
--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -45,6 +45,8 @@ type Sandbox interface {
 type BackendConfig struct {
 	Logs       map[string]*bytes.Buffer
 	ConfigFile string
+
+	t testing.TB
 }
 
 type Worker interface {
@@ -148,7 +150,7 @@ func Run(t *testing.T, testCases []Test, opt ...TestOpt) {
 						if !strings.HasSuffix(fn, "NoParallel") {
 							t.Parallel()
 						}
-						sb, closer, err := newSandbox(br, mirror, mv)
+						sb, closer, err := newSandbox(t, br, mirror, mv)
 						if err != nil {
 							if errors.Cause(err) == ErrorRequirements {
 								t.Skip(err.Error())

--- a/util/testutil/integration/sandbox.go
+++ b/util/testutil/integration/sandbox.go
@@ -71,9 +71,11 @@ func (sb *sandbox) Value(k string) interface{} {
 	return sb.mv.values[k].value
 }
 
-func newSandbox(w Worker, mirror string, mv matrixValue) (s Sandbox, cl func() error, err error) {
+func newSandbox(tb testing.TB, w Worker, mirror string, mv matrixValue) (s Sandbox, cl func() error, err error) {
 	cfg := &BackendConfig{
 		Logs: make(map[string]*bytes.Buffer),
+
+		t: tb,
 	}
 
 	var upt []ConfigUpdater


### PR DESCRIPTION
We'd talked about not doing this, but the docker daemon tests are failing and I don't see a way to get logs without using the [`WithTestLogger`](https://godoc.org/github.com/docker/docker/testutil/daemon#WithTestLogger) option. Since we can't implement [`testing.TB`](https://godoc.org/testing#TB) (it has a `private()` method to prevent other implementations) to adapt the integration tests log aggregation map, this was the best way I could see to make sure that the docker daemon can log to the tests.

Thoughts? /cc @tonistiigi, @tiborvass 

**EDIT:** note that this is not used in this PR, I just pulled this out to make it easier to discuss/review. It would end up being used here: https://github.com/moby/buildkit/pull/1164/files#diff-ffeb8040e26124206567c7443ef5afd3R50