### PR TITLE
cache: follow-up updates to storage leases

### DIFF
--- a/cache/manager.go
+++ b/cache/manager.go
@@ -100,8 +100,10 @@ func (cm *cacheManager) GetByBlob(ctx context.Context, desc ocispec.Descriptor, 
 	chainID := diffID
 	blobChainID := imagespecidentity.ChainID([]digest.Digest{desc.Digest, diffID})
 
-	if _, err := cm.ContentStore.Info(ctx, desc.Digest); err != nil {
-		return nil, errors.Wrapf(err, "failed to get blob %s", desc.Digest)
+	if desc.Digest != "" {
+		if _, err := cm.ContentStore.Info(ctx, desc.Digest); err != nil {
+			return nil, errors.Wrapf(err, "failed to get blob %s", desc.Digest)
+		}
 	}
 
 	var p *immutableRef
@@ -202,11 +204,13 @@ func (cm *cacheManager) GetByBlob(ctx context.Context, desc ocispec.Descriptor, 
 		return nil, errors.Wrapf(err, "failed to add snapshot %s to lease", id)
 	}
 
-	if err := cm.ManagerOpt.LeaseManager.AddResource(ctx, leases.Lease{ID: id}, leases.Resource{
-		ID:   desc.Digest.String(),
-		Type: "content",
-	}); err != nil {
-		return nil, errors.Wrapf(err, "failed to add blob %s to lease", id)
+	if desc.Digest != "" {
+		if err := cm.ManagerOpt.LeaseManager.AddResource(ctx, leases.Lease{ID: id}, leases.Resource{
+			ID:   desc.Digest.String(),
+			Type: "content",
+		}); err != nil {
+			return nil, errors.Wrapf(err, "failed to add blob %s to lease", id)
+		}
 	}
 
 	md, _ := cm.md.Get(id)

--- a/cache/migrate_v2.go
+++ b/cache/migrate_v2.go
@@ -148,6 +148,9 @@ func MigrateV2(ctx context.Context, from, to string, cs content.Store, s snapsho
 		if err := v.Unmarshal(&blob); err != nil {
 			return errors.WithStack(err)
 		}
+		if _, err := cs.Info(ctx, digest.Digest(blob.Blobsum)); err != nil {
+			continue
+		}
 		queueDiffID(item, blob.DiffID)
 		queueBlob(item, blob.Blobsum)
 		queueMediaType(item, images.MediaTypeDockerSchema2LayerGzip)


### PR DESCRIPTION
follow-up to #1176

Allow tracking descriptors without blobs data so it can be used in moby where current implementation doesn't have a content store yet.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>