### PR TITLE
Fix update generated files via docker buildkit

### DIFF
--- a/hack/update-generated-files
+++ b/hack/update-generated-files
@@ -20,7 +20,7 @@ case $buildmode in
   cp -R "$output/generated-files/" .
   rm -rf $output
   ;;
-"docker-buildkt")
+"docker-buildkit")
   iidfile=$(mktemp -t docker-iidfile.XXXXXXXXXX)
   export DOCKER_BUILDKIT=1
   docker build --build-arg GOGO_VERSION=$gogo_version --iidfile $iidfile -f ./hack/dockerfiles/generated-files.Dockerfile --target update --force-rm .


### PR DESCRIPTION
There's a typo in `./hack/update-generated-files` which causes the error:
```sh
$ make generated-files
./hack/update-generated-files
+ :
+ progressFlag=
+ '[' '' == true ']'
++ awk '$1 == "github.com/gogo/protobuf" { print $2 }' go.mod
+ gogo_version=v1.2.0
+ case $buildmode in
+ echo 'Unsupported build mode: docker-buildkit'
Unsupported build mode: docker-buildkit
+ exit 1
Makefile:35: recipe for target 'generated-files' failed
make: *** [generated-files] Error 1
```