### PR TITLE
client: add context to some test failures

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1098,10 +1098,14 @@ func testFileOpRmWildcard(t *testing.T, sb integration.Sandbox) {
 	require.Equal(t, true, fi.IsDir())
 
 	_, err = os.Stat(filepath.Join(destDir, "foo/target"))
-	require.Equal(t, true, os.IsNotExist(err))
+	if !os.IsNotExist(err) {
+		t.Errorf("expected %s/foo/target to not exist, got error %v", destDir, err)
+	}
 
 	_, err = os.Stat(filepath.Join(destDir, "bar/target"))
-	require.Equal(t, true, os.IsNotExist(err))
+	if !os.IsNotExist(err) {
+		t.Errorf("expected %s/bar/target to not exist, got error %v", destDir, err)
+	}
 }
 
 func testCallDiskUsage(t *testing.T, sb integration.Sandbox) {


### PR DESCRIPTION
The use of an assertion framework is masking the underlying error, making [my test failure] harder to debug. This adds some context around the failures so that the underlying error is discoverable, and so that someone reading the test output knows what is being tested (not just that `true != false`).

[my test failure]: https://ci.docker.com/public/blue/organizations/jenkins/moby/detail/PR-40023/149/pipeline/151