### PR TITLE
examples/kubernetes: use Parallel mode for StatefulSet

### DIFF
--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -67,7 +67,7 @@ $ buildctl \
   build --frontend dockerfile.v0 --local context=/path/to/dir --local dockerfile=/path/to/dir
 ```
 
-See `[./consistenthash`](./consistenthash) for how to use consistent hashing.
+See [`./consistenthash`](./consistenthash) for how to use consistent hashing.
 
 ## `Job`
 

--- a/examples/kubernetes/statefulset.privileged.yaml
+++ b/examples/kubernetes/statefulset.privileged.yaml
@@ -6,6 +6,7 @@ metadata:
   name: buildkitd
 spec:
   serviceName: buildkitd
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:

--- a/examples/kubernetes/statefulset.rootless.yaml
+++ b/examples/kubernetes/statefulset.rootless.yaml
@@ -6,6 +6,7 @@ metadata:
   name: buildkitd
 spec:
   serviceName: buildkitd
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:


### PR DESCRIPTION
Parallel mode releaxes the pod creation order constraint.

https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#parallel-pod-management

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>