### PR TITLE
cache: fix possible concurrent maps write on parent release

### DIFF
--- a/cache/refs.go
+++ b/cache/refs.go
@@ -254,7 +254,10 @@ func (cr *cacheRecord) Mount(ctx context.Context, readonly bool) (snapshot.Mount
 func (cr *cacheRecord) remove(ctx context.Context, removeSnapshot bool) error {
 	delete(cr.cm.records, cr.ID())
 	if cr.parent != nil {
-		if err := cr.parent.release(ctx); err != nil {
+		cr.parent.mu.Lock()
+		err := cr.parent.release(ctx)
+		cr.parent.mu.Unlock()
+		if err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
fixes https://github.com/moby/buildkit/issues/1250

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>

@bpaquet @tiborvass 