### PR TITLE
[19.03] cache: fix possible concurrent maps write on parent release

### DIFF
--- a/cache/refs.go
+++ b/cache/refs.go
@@ -185,7 +185,10 @@ func (cr *cacheRecord) Mount(ctx context.Context, readonly bool) (snapshot.Mount
 func (cr *cacheRecord) remove(ctx context.Context, removeSnapshot bool) error {
 	delete(cr.cm.records, cr.ID())
 	if cr.parent != nil {
-		if err := cr.parent.release(ctx); err != nil {
+		cr.parent.mu.Lock()
+		err := cr.parent.release(ctx)
+		cr.parent.mu.Unlock()
+		if err != nil {
 			return err
 		}
 	}
@@ -398,11 +401,6 @@ func (sr *mutableRef) release(ctx context.Context) error {
 				return nil
 			}
 			if err := sr.equalImmutable.remove(ctx, false); err != nil {
-				return err
-			}
-		}
-		if sr.parent != nil {
-			if err := sr.parent.release(ctx); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
19.03 version of https://github.com/moby/buildkit/pull/1256

@tiborvass @andrewhsu 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>