### PR TITLE
Add readiness and liveness probe to the kubernetes examples

### DIFF
--- a/examples/kubernetes/deployment+service.privileged.yaml
+++ b/examples/kubernetes/deployment+service.privileged.yaml
@@ -28,6 +28,24 @@ spec:
         - /certs/cert.pem
         - --tlskey
         - /certs/key.pem
+# the probe below will only work after Release v0.6.3
+        readinessProbe:
+          exec:
+            command:
+            - buildctl 
+            - debug 
+            - workers
+          initialDelaySeconds: 5
+          periodSeconds: 30
+# the probe below will only work after Release v0.6.3
+        livenessProbe:
+          exec:
+            command:
+            - buildctl 
+            - debug 
+            - workers
+          initialDelaySeconds: 5
+          periodSeconds: 30
         securityContext:
           privileged: true
         ports:

--- a/examples/kubernetes/deployment+service.rootless.yaml
+++ b/examples/kubernetes/deployment+service.rootless.yaml
@@ -33,6 +33,24 @@ spec:
         - --tlskey
         - /certs/key.pem
         - --oci-worker-no-process-sandbox
+# the probe below will only work after Release v0.6.3        
+        readinessProbe:
+          exec:
+            command:
+            - buildctl 
+            - debug 
+            - workers
+          initialDelaySeconds: 5
+          periodSeconds: 30
+# the probe below will only work after Release v0.6.3        
+        livenessProbe:
+          exec:
+            command:
+            - buildctl 
+            - debug 
+            - workers
+          initialDelaySeconds: 5
+          periodSeconds: 30        
         securityContext:
 # To change UID/GID, you need to rebuild the image
           runAsUser: 1000

--- a/examples/kubernetes/pod.privileged.yaml
+++ b/examples/kubernetes/pod.privileged.yaml
@@ -6,5 +6,21 @@ spec:
   containers:
   - name: buildkitd
     image: moby/buildkit:master
+    readinessProbe:
+      exec:
+        command:
+        - buildctl 
+        - debug 
+        - workers
+      initialDelaySeconds: 5
+      periodSeconds: 30
+    livenessProbe:
+      exec:
+        command:
+        - buildctl 
+        - debug 
+        - workers
+      initialDelaySeconds: 5
+      periodSeconds: 30
     securityContext:
       privileged: true

--- a/examples/kubernetes/pod.rootless.yaml
+++ b/examples/kubernetes/pod.rootless.yaml
@@ -12,6 +12,22 @@ spec:
     image: moby/buildkit:master-rootless
     args:
     - --oci-worker-no-process-sandbox
+    readinessProbe:
+      exec:
+        command:
+        - buildctl 
+        - debug 
+        - workers
+      initialDelaySeconds: 5
+      periodSeconds: 30
+    livenessProbe:
+      exec:
+        command:
+        - buildctl 
+        - debug 
+        - workers
+      initialDelaySeconds: 5
+      periodSeconds: 30
     securityContext:
 # To change UID/GID, you need to rebuild the image
       runAsUser: 1000

--- a/examples/kubernetes/statefulset.privileged.yaml
+++ b/examples/kubernetes/statefulset.privileged.yaml
@@ -19,5 +19,21 @@ spec:
       containers:
       - name: buildkitd
         image: moby/buildkit:master
+        readinessProbe:
+          exec:
+            command:
+            - buildctl 
+            - debug 
+            - workers
+          initialDelaySeconds: 5
+          periodSeconds: 30
+        livenessProbe:
+          exec:
+            command:
+            - buildctl 
+            - debug 
+            - workers
+          initialDelaySeconds: 5
+          periodSeconds: 30
         securityContext:
           privileged: true

--- a/examples/kubernetes/statefulset.rootless.yaml
+++ b/examples/kubernetes/statefulset.rootless.yaml
@@ -25,6 +25,22 @@ spec:
         image: moby/buildkit:master-rootless
         args:
         - --oci-worker-no-process-sandbox
+        readinessProbe:
+          exec:
+            command:
+            - buildctl 
+            - debug 
+            - workers
+          initialDelaySeconds: 5
+          periodSeconds: 30
+        livenessProbe:
+          exec:
+            command:
+            - buildctl 
+            - debug 
+            - workers
+          initialDelaySeconds: 5
+          periodSeconds: 30
         securityContext:
 # To change UID/GID, you need to rebuild the image
           runAsUser: 1000


### PR DESCRIPTION
# Enhance Documentation 
Our team is on the way to migrate to buildkit. In order for us to monitor our CICD stack we needed to have a readiness and liveness probe for the deployment. 

Thanks to the help of @AkihiroSuda 
#1261 