### PR TITLE
Change result type to array of refs

### DIFF
--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -479,7 +479,7 @@ func (lbf *llbBridgeForwarder) Solve(ctx context.Context, req *pb.SolveRequest) 
 		if req.AllowResultArrayRef {
 			refMap := make(map[string]*pb.Ref, len(res.Refs))
 			for k, id := range ids {
-				refMap[k] = &pb.Ref{Ids: []string{id}}
+				refMap[k] = pb.NewRef(id)
 			}
 			pbRes.Result = &pb.Result_Refs{Refs: &pb.RefMap{Refs: refMap}}
 		} else {
@@ -495,7 +495,7 @@ func (lbf *llbBridgeForwarder) Solve(ctx context.Context, req *pb.SolveRequest) 
 		defaultID = id
 
 		if req.AllowResultArrayRef {
-			pbRes.Result = &pb.Result_Ref{Ref: &pb.Ref{Ids: []string{id}}}
+			pbRes.Result = &pb.Result_Ref{Ref: pb.NewRef(id)}
 		} else {
 			pbRes.Result = &pb.Result_RefDeprecated{RefDeprecated: id}
 		}

--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -701,6 +701,10 @@ func (lbf *llbBridgeForwarder) convertRef(ids []string) (solver.CachedResult, er
 		return nil, nil
 	}
 
+	if len(ids) > 1 {
+		return nil, errors.Errorf("return reference has multi-result array")
+	}
+
 	lbf.mu.Lock()
 	defer lbf.mu.Unlock()
 

--- a/frontend/gateway/grpcclient/client.go
+++ b/frontend/gateway/grpcclient/client.go
@@ -112,7 +112,7 @@ func (c *grpcClient) Run(ctx context.Context, f client.BuildFunc) (retError erro
 							retError = err
 							continue
 						}
-						m[k] = &pb.Ref{Ids: []string{id}}
+						m[k] = pb.NewRef(id)
 					}
 					pbRes.Result = &pb.Result_Refs{Refs: &pb.RefMap{Refs: m}}
 				} else {
@@ -120,7 +120,7 @@ func (c *grpcClient) Run(ctx context.Context, f client.BuildFunc) (retError erro
 					if err != nil {
 						retError = err
 					} else {
-						pbRes.Result = &pb.Result_Ref{Ref: &pb.Ref{Ids: []string{id}}}
+						pbRes.Result = &pb.Result_Ref{Ref: pb.NewRef(id)}
 					}
 				}
 				if retError == nil {

--- a/frontend/gateway/grpcclient/client.go
+++ b/frontend/gateway/grpcclient/client.go
@@ -324,13 +324,20 @@ func (c *grpcClient) Solve(ctx context.Context, creq client.SolveRequest) (*clie
 				res.AddRef(k, ref)
 			}
 		case *pb.Result_Ref:
-			if ids := pbRes.Ref.Ids; len(ids) > 0 {
+			ids := pbRes.Ref.Ids
+			if len(ids) > 0 {
+				if len(ids) > 1 {
+					return nil, errors.Errorf("solve returned multi-result array")
+				}
 				res.SetRef(&reference{id: ids[0], c: c})
 			}
 		case *pb.Result_Refs:
 			for k, v := range pbRes.Refs.Refs {
 				var ref *reference
 				if len(v.Ids) > 0 {
+					if len(v.Ids) > 1 {
+						return nil, errors.Errorf("solve returned multi-result array")
+					}
 					ref = &reference{id: v.Ids[0], c: c}
 				}
 				res.AddRef(k, ref)

--- a/frontend/gateway/pb/gateway.pb.go
+++ b/frontend/gateway/pb/gateway.pb.go
@@ -35,6 +35,8 @@ const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
 
 type Result struct {
 	// Types that are valid to be assigned to Result:
+	//	*Result_RefDeprecated
+	//	*Result_RefsDeprecated
 	//	*Result_Ref
 	//	*Result_Refs
 	Result               isResult_Result   `protobuf_oneof:"result"`
@@ -48,7 +50,7 @@ func (m *Result) Reset()         { *m = Result{} }
 func (m *Result) String() string { return proto.CompactTextString(m) }
 func (*Result) ProtoMessage()    {}
 func (*Result) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gateway_eff078cadb286ceb, []int{0}
+	return fileDescriptor_gateway_f66b6a1c7ba3b979, []int{0}
 }
 func (m *Result) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -83,15 +85,23 @@ type isResult_Result interface {
 	Size() int
 }
 
+type Result_RefDeprecated struct {
+	RefDeprecated string `protobuf:"bytes,1,opt,name=refDeprecated,proto3,oneof"`
+}
+type Result_RefsDeprecated struct {
+	RefsDeprecated *RefMapDeprecated `protobuf:"bytes,2,opt,name=refsDeprecated,proto3,oneof"`
+}
 type Result_Ref struct {
-	Ref string `protobuf:"bytes,1,opt,name=ref,proto3,oneof"`
+	Ref *Ref `protobuf:"bytes,3,opt,name=ref,proto3,oneof"`
 }
 type Result_Refs struct {
-	Refs *RefMap `protobuf:"bytes,2,opt,name=refs,proto3,oneof"`
+	Refs *RefMap `protobuf:"bytes,4,opt,name=refs,proto3,oneof"`
 }
 
-func (*Result_Ref) isResult_Result()  {}
-func (*Result_Refs) isResult_Result() {}
+func (*Result_RefDeprecated) isResult_Result()  {}
+func (*Result_RefsDeprecated) isResult_Result() {}
+func (*Result_Ref) isResult_Result()            {}
+func (*Result_Refs) isResult_Result()           {}
 
 func (m *Result) GetResult() isResult_Result {
 	if m != nil {
@@ -100,11 +110,25 @@ func (m *Result) GetResult() isResult_Result {
 	return nil
 }
 
-func (m *Result) GetRef() string {
+func (m *Result) GetRefDeprecated() string {
+	if x, ok := m.GetResult().(*Result_RefDeprecated); ok {
+		return x.RefDeprecated
+	}
+	return ""
+}
+
+func (m *Result) GetRefsDeprecated() *RefMapDeprecated {
+	if x, ok := m.GetResult().(*Result_RefsDeprecated); ok {
+		return x.RefsDeprecated
+	}
+	return nil
+}
+
+func (m *Result) GetRef() *Ref {
 	if x, ok := m.GetResult().(*Result_Ref); ok {
 		return x.Ref
 	}
-	return ""
+	return nil
 }
 
 func (m *Result) GetRefs() *RefMap {
@@ -124,6 +148,8 @@ func (m *Result) GetMetadata() map[string][]byte {
 // XXX_OneofFuncs is for the internal use of the proto package.
 func (*Result) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
 	return _Result_OneofMarshaler, _Result_OneofUnmarshaler, _Result_OneofSizer, []interface{}{
+		(*Result_RefDeprecated)(nil),
+		(*Result_RefsDeprecated)(nil),
 		(*Result_Ref)(nil),
 		(*Result_Refs)(nil),
 	}
@@ -133,11 +159,21 @@ func _Result_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
 	m := msg.(*Result)
 	// result
 	switch x := m.Result.(type) {
-	case *Result_Ref:
+	case *Result_RefDeprecated:
 		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Ref)
-	case *Result_Refs:
+		_ = b.EncodeStringBytes(x.RefDeprecated)
+	case *Result_RefsDeprecated:
 		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.RefsDeprecated); err != nil {
+			return err
+		}
+	case *Result_Ref:
+		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.Ref); err != nil {
+			return err
+		}
+	case *Result_Refs:
+		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
 		if err := b.EncodeMessage(x.Refs); err != nil {
 			return err
 		}
@@ -151,14 +187,30 @@ func _Result_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
 func _Result_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
 	m := msg.(*Result)
 	switch tag {
-	case 1: // result.ref
+	case 1: // result.refDeprecated
 		if wire != proto.WireBytes {
 			return true, proto.ErrInternalBadWireType
 		}
 		x, err := b.DecodeStringBytes()
-		m.Result = &Result_Ref{x}
+		m.Result = &Result_RefDeprecated{x}
 		return true, err
-	case 2: // result.refs
+	case 2: // result.refsDeprecated
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(RefMapDeprecated)
+		err := b.DecodeMessage(msg)
+		m.Result = &Result_RefsDeprecated{msg}
+		return true, err
+	case 3: // result.ref
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(Ref)
+		err := b.DecodeMessage(msg)
+		m.Result = &Result_Ref{msg}
+		return true, err
+	case 4: // result.refs
 		if wire != proto.WireBytes {
 			return true, proto.ErrInternalBadWireType
 		}
@@ -175,10 +227,20 @@ func _Result_OneofSizer(msg proto.Message) (n int) {
 	m := msg.(*Result)
 	// result
 	switch x := m.Result.(type) {
-	case *Result_Ref:
+	case *Result_RefDeprecated:
 		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Ref)))
-		n += len(x.Ref)
+		n += proto.SizeVarint(uint64(len(x.RefDeprecated)))
+		n += len(x.RefDeprecated)
+	case *Result_RefsDeprecated:
+		s := proto.Size(x.RefsDeprecated)
+		n += 1 // tag and wire
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *Result_Ref:
+		s := proto.Size(x.Ref)
+		n += 1 // tag and wire
+		n += proto.SizeVarint(uint64(s))
+		n += s
 	case *Result_Refs:
 		s := proto.Size(x.Refs)
 		n += 1 // tag and wire
@@ -191,18 +253,112 @@ func _Result_OneofSizer(msg proto.Message) (n int) {
 	return n
 }
 
-type RefMap struct {
+type RefMapDeprecated struct {
 	Refs                 map[string]string `protobuf:"bytes,1,rep,name=refs,proto3" json:"refs,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
 	XXX_unrecognized     []byte            `json:"-"`
 	XXX_sizecache        int32             `json:"-"`
 }
 
+func (m *RefMapDeprecated) Reset()         { *m = RefMapDeprecated{} }
+func (m *RefMapDeprecated) String() string { return proto.CompactTextString(m) }
+func (*RefMapDeprecated) ProtoMessage()    {}
+func (*RefMapDeprecated) Descriptor() ([]byte, []int) {
+	return fileDescriptor_gateway_f66b6a1c7ba3b979, []int{1}
+}
+func (m *RefMapDeprecated) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *RefMapDeprecated) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_RefMapDeprecated.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalTo(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (dst *RefMapDeprecated) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RefMapDeprecated.Merge(dst, src)
+}
+func (m *RefMapDeprecated) XXX_Size() int {
+	return m.Size()
+}
+func (m *RefMapDeprecated) XXX_DiscardUnknown() {
+	xxx_messageInfo_RefMapDeprecated.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_RefMapDeprecated proto.InternalMessageInfo
+
+func (m *RefMapDeprecated) GetRefs() map[string]string {
+	if m != nil {
+		return m.Refs
+	}
+	return nil
+}
+
+type Ref struct {
+	Ids                  []string `protobuf:"bytes,1,rep,name=ids,proto3" json:"ids,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *Ref) Reset()         { *m = Ref{} }
+func (m *Ref) String() string { return proto.CompactTextString(m) }
+func (*Ref) ProtoMessage()    {}
+func (*Ref) Descriptor() ([]byte, []int) {
+	return fileDescriptor_gateway_f66b6a1c7ba3b979, []int{2}
+}
+func (m *Ref) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *Ref) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_Ref.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalTo(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (dst *Ref) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Ref.Merge(dst, src)
+}
+func (m *Ref) XXX_Size() int {
+	return m.Size()
+}
+func (m *Ref) XXX_DiscardUnknown() {
+	xxx_messageInfo_Ref.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_Ref proto.InternalMessageInfo
+
+func (m *Ref) GetIds() []string {
+	if m != nil {
+		return m.Ids
+	}
+	return nil
+}
+
+type RefMap struct {
+	Refs                 map[string]*Ref `protobuf:"bytes,1,rep,name=refs,proto3" json:"refs,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	XXX_NoUnkeyedLiteral struct{}        `json:"-"`
+	XXX_unrecognized     []byte          `json:"-"`
+	XXX_sizecache        int32           `json:"-"`
+}
+
 func (m *RefMap) Reset()         { *m = RefMap{} }
 func (m *RefMap) String() string { return proto.CompactTextString(m) }
 func (*RefMap) ProtoMessage()    {}
 func (*RefMap) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gateway_eff078cadb286ceb, []int{1}
+	return fileDescriptor_gateway_f66b6a1c7ba3b979, []int{3}
 }
 func (m *RefMap) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -231,7 +387,7 @@ func (m *RefMap) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_RefMap proto.InternalMessageInfo
 
-func (m *RefMap) GetRefs() map[string]string {
+func (m *RefMap) GetRefs() map[string]*Ref {
 	if m != nil {
 		return m.Refs
 	}
@@ -250,7 +406,7 @@ func (m *ReturnRequest) Reset()         { *m = ReturnRequest{} }
 func (m *ReturnRequest) String() string { return proto.CompactTextString(m) }
 func (*ReturnRequest) ProtoMessage()    {}
 func (*ReturnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gateway_eff078cadb286ceb, []int{2}
+	return fileDescriptor_gateway_f66b6a1c7ba3b979, []int{4}
 }
 func (m *ReturnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -303,7 +459,7 @@ func (m *ReturnResponse) Reset()         { *m = ReturnResponse{} }
 func (m *ReturnResponse) String() string { return proto.CompactTextString(m) }
 func (*ReturnResponse) ProtoMessage()    {}
 func (*ReturnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gateway_eff078cadb286ceb, []int{3}
+	return fileDescriptor_gateway_f66b6a1c7ba3b979, []int{5}
 }
 func (m *ReturnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -346,7 +502,7 @@ func (m *ResolveImageConfigRequest) Reset()         { *m = ResolveImageConfigReq
 func (m *ResolveImageConfigRequest) String() string { return proto.CompactTextString(m) }
 func (*ResolveImageConfigRequest) ProtoMessage()    {}
 func (*ResolveImageConfigRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gateway_eff078cadb286ceb, []int{4}
+	return fileDescriptor_gateway_f66b6a1c7ba3b979, []int{6}
 }
 func (m *ResolveImageConfigRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -415,7 +571,7 @@ func (m *ResolveImageConfigResponse) Reset()         { *m = ResolveImageConfigRe
 func (m *ResolveImageConfigResponse) String() string { return proto.CompactTextString(m) }
 func (*ResolveImageConfigResponse) ProtoMessage()    {}
 func (*ResolveImageConfigResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gateway_eff078cadb286ceb, []int{5}
+	return fileDescriptor_gateway_f66b6a1c7ba3b979, []int{7}
 }
 func (m *ResolveImageConfigResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -461,6 +617,7 @@ type SolveRequest struct {
 	// for each of the ImportCacheRefs entry to CacheImports for compatibility. (planned to be removed)
 	ImportCacheRefsDeprecated []string `protobuf:"bytes,4,rep,name=ImportCacheRefsDeprecated,proto3" json:"ImportCacheRefsDeprecated,omitempty"`
 	AllowResultReturn         bool     `protobuf:"varint,5,opt,name=allowResultReturn,proto3" json:"allowResultReturn,omitempty"`
+	AllowResultArrayRef       bool     `protobuf:"varint,6,opt,name=allowResultArrayRef,proto3" json:"allowResultArrayRef,omitempty"`
 	// apicaps.CapSolveInlineReturn deprecated
 	Final        bool   `protobuf:"varint,10,opt,name=Final,proto3" json:"Final,omitempty"`
 	ExporterAttr []byte `protobuf:"bytes,11,opt,name=ExporterAttr,proto3" json:"ExporterAttr,omitempty"`
@@ -476,7 +633,7 @@ func (m *SolveRequest) Reset()         { *m = SolveRequest{} }
 func (m *SolveRequest) String() string { return proto.CompactTextString(m) }
 func (*SolveRequest) ProtoMessage()    {}
 func (*SolveRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gateway_eff078cadb286ceb, []int{6}
+	return fileDescriptor_gateway_f66b6a1c7ba3b979, []int{8}
 }
 func (m *SolveRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -540,6 +697,13 @@ func (m *SolveRequest) GetAllowResultReturn() bool {
 	return false
 }
 
+func (m *SolveRequest) GetAllowResultArrayRef() bool {
+	if m != nil {
+		return m.AllowResultArrayRef
+	}
+	return false
+}
+
 func (m *SolveRequest) GetFinal() bool {
 	if m != nil {
 		return m.Final
@@ -574,7 +738,7 @@ func (m *CacheOptionsEntry) Reset()         { *m = CacheOptionsEntry{} }
 func (m *CacheOptionsEntry) String() string { return proto.CompactTextString(m) }
 func (*CacheOptionsEntry) ProtoMessage()    {}
 func (*CacheOptionsEntry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gateway_eff078cadb286ceb, []int{7}
+	return fileDescriptor_gateway_f66b6a1c7ba3b979, []int{9}
 }
 func (m *CacheOptionsEntry) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -631,7 +795,7 @@ func (m *SolveResponse) Reset()         { *m = SolveResponse{} }
 func (m *SolveResponse) String() string { return proto.CompactTextString(m) }
 func (*SolveResponse) ProtoMessage()    {}
 func (*SolveResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gateway_eff078cadb286ceb, []int{8}
+	return fileDescriptor_gateway_f66b6a1c7ba3b979, []int{10}
 }
 func (m *SolveResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -687,7 +851,7 @@ func (m *ReadFileRequest) Reset()         { *m = ReadFileRequest{} }
 func (m *ReadFileRequest) String() string { return proto.CompactTextString(m) }
 func (*ReadFileRequest) ProtoMessage()    {}
 func (*ReadFileRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gateway_eff078cadb286ceb, []int{9}
+	return fileDescriptor_gateway_f66b6a1c7ba3b979, []int{11}
 }
 func (m *ReadFileRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -749,7 +913,7 @@ func (m *FileRange) Reset()         { *m = FileRange{} }
 func (m *FileRange) String() string { return proto.CompactTextString(m) }
 func (*FileRange) ProtoMessage()    {}
 func (*FileRange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gateway_eff078cadb286ceb, []int{10}
+	return fileDescriptor_gateway_f66b6a1c7ba3b979, []int{12}
 }
 func (m *FileRange) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -803,7 +967,7 @@ func (m *ReadFileResponse) Reset()         { *m = ReadFileResponse{} }
 func (m *ReadFileResponse) String() string { return proto.CompactTextString(m) }
 func (*ReadFileResponse) ProtoMessage()    {}
 func (*ReadFileResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gateway_eff078cadb286ceb, []int{11}
+	return fileDescriptor_gateway_f66b6a1c7ba3b979, []int{13}
 }
 func (m *ReadFileResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -852,7 +1016,7 @@ func (m *ReadDirRequest) Reset()         { *m = ReadDirRequest{} }
 func (m *ReadDirRequest) String() string { return proto.CompactTextString(m) }
 func (*ReadDirRequest) ProtoMessage()    {}
 func (*ReadDirRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gateway_eff078cadb286ceb, []int{12}
+	return fileDescriptor_gateway_f66b6a1c7ba3b979, []int{14}
 }
 func (m *ReadDirRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -913,7 +1077,7 @@ func (m *ReadDirResponse) Reset()         { *m = ReadDirResponse{} }
 func (m *ReadDirResponse) String() string { return proto.CompactTextString(m) }
 func (*ReadDirResponse) ProtoMessage()    {}
 func (*ReadDirResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gateway_eff078cadb286ceb, []int{13}
+	return fileDescriptor_gateway_f66b6a1c7ba3b979, []int{15}
 }
 func (m *ReadDirResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -961,7 +1125,7 @@ func (m *StatFileRequest) Reset()         { *m = StatFileRequest{} }
 func (m *StatFileRequest) String() string { return proto.CompactTextString(m) }
 func (*StatFileRequest) ProtoMessage()    {}
 func (*StatFileRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gateway_eff078cadb286ceb, []int{14}
+	return fileDescriptor_gateway_f66b6a1c7ba3b979, []int{16}
 }
 func (m *StatFileRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1015,7 +1179,7 @@ func (m *StatFileResponse) Reset()         { *m = StatFileResponse{} }
 func (m *StatFileResponse) String() string { return proto.CompactTextString(m) }
 func (*StatFileResponse) ProtoMessage()    {}
 func (*StatFileResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gateway_eff078cadb286ceb, []int{15}
+	return fileDescriptor_gateway_f66b6a1c7ba3b979, []int{17}
 }
 func (m *StatFileResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1061,7 +1225,7 @@ func (m *PingRequest) Reset()         { *m = PingRequest{} }
 func (m *PingRequest) String() string { return proto.CompactTextString(m) }
 func (*PingRequest) ProtoMessage()    {}
 func (*PingRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gateway_eff078cadb286ceb, []int{16}
+	return fileDescriptor_gateway_f66b6a1c7ba3b979, []int{18}
 }
 func (m *PingRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1103,7 +1267,7 @@ func (m *PongResponse) Reset()         { *m = PongResponse{} }
 func (m *PongResponse) String() string { return proto.CompactTextString(m) }
 func (*PongResponse) ProtoMessage()    {}
 func (*PongResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_gateway_eff078cadb286ceb, []int{17}
+	return fileDescriptor_gateway_f66b6a1c7ba3b979, []int{19}
 }
 func (m *PongResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1156,8 +1320,11 @@ func (m *PongResponse) GetWorkers() []*types1.WorkerRecord {
 func init() {
 	proto.RegisterType((*Result)(nil), "moby.buildkit.v1.frontend.Result")
 	proto.RegisterMapType((map[string][]byte)(nil), "moby.buildkit.v1.frontend.Result.MetadataEntry")
+	proto.RegisterType((*RefMapDeprecated)(nil), "moby.buildkit.v1.frontend.RefMapDeprecated")
+	proto.RegisterMapType((map[string]string)(nil), "moby.buildkit.v1.frontend.RefMapDeprecated.RefsEntry")
+	proto.RegisterType((*Ref)(nil), "moby.buildkit.v1.frontend.Ref")
 	proto.RegisterType((*RefMap)(nil), "moby.buildkit.v1.frontend.RefMap")
-	proto.RegisterMapType((map[string]string)(nil), "moby.buildkit.v1.frontend.RefMap.RefsEntry")
+	proto.RegisterMapType((map[string]*Ref)(nil), "moby.buildkit.v1.frontend.RefMap.RefsEntry")
 	proto.RegisterType((*ReturnRequest)(nil), "moby.buildkit.v1.frontend.ReturnRequest")
 	proto.RegisterType((*ReturnResponse)(nil), "moby.buildkit.v1.frontend.ReturnResponse")
 	proto.RegisterType((*ResolveImageConfigRequest)(nil), "moby.buildkit.v1.frontend.ResolveImageConfigRequest")
@@ -1509,21 +1676,21 @@ func (m *Result) MarshalTo(dAtA []byte) (int, error) {
 	return i, nil
 }
 
-func (m *Result_Ref) MarshalTo(dAtA []byte) (int, error) {
+func (m *Result_RefDeprecated) MarshalTo(dAtA []byte) (int, error) {
 	i := 0
 	dAtA[i] = 0xa
 	i++
-	i = encodeVarintGateway(dAtA, i, uint64(len(m.Ref)))
-	i += copy(dAtA[i:], m.Ref)
+	i = encodeVarintGateway(dAtA, i, uint64(len(m.RefDeprecated)))
+	i += copy(dAtA[i:], m.RefDeprecated)
 	return i, nil
 }
-func (m *Result_Refs) MarshalTo(dAtA []byte) (int, error) {
+func (m *Result_RefsDeprecated) MarshalTo(dAtA []byte) (int, error) {
 	i := 0
-	if m.Refs != nil {
+	if m.RefsDeprecated != nil {
 		dAtA[i] = 0x12
 		i++
-		i = encodeVarintGateway(dAtA, i, uint64(m.Refs.Size()))
-		n2, err := m.Refs.MarshalTo(dAtA[i:])
+		i = encodeVarintGateway(dAtA, i, uint64(m.RefsDeprecated.Size()))
+		n2, err := m.RefsDeprecated.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
@@ -1531,7 +1698,35 @@ func (m *Result_Refs) MarshalTo(dAtA []byte) (int, error) {
 	}
 	return i, nil
 }
-func (m *RefMap) Marshal() (dAtA []byte, err error) {
+func (m *Result_Ref) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.Ref != nil {
+		dAtA[i] = 0x1a
+		i++
+		i = encodeVarintGateway(dAtA, i, uint64(m.Ref.Size()))
+		n3, err := m.Ref.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n3
+	}
+	return i, nil
+}
+func (m *Result_Refs) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.Refs != nil {
+		dAtA[i] = 0x22
+		i++
+		i = encodeVarintGateway(dAtA, i, uint64(m.Refs.Size()))
+		n4, err := m.Refs.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n4
+	}
+	return i, nil
+}
+func (m *RefMapDeprecated) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalTo(dAtA)
@@ -1541,7 +1736,7 @@ func (m *RefMap) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *RefMap) MarshalTo(dAtA []byte) (int, error) {
+func (m *RefMapDeprecated) MarshalTo(dAtA []byte) (int, error) {
 	var i int
 	_ = i
 	var l int
@@ -1569,6 +1764,91 @@ func (m *RefMap) MarshalTo(dAtA []byte) (int, error) {
 	return i, nil
 }
 
+func (m *Ref) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Ref) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.Ids) > 0 {
+		for _, s := range m.Ids {
+			dAtA[i] = 0xa
+			i++
+			l = len(s)
+			for l >= 1<<7 {
+				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
+				l >>= 7
+				i++
+			}
+			dAtA[i] = uint8(l)
+			i++
+			i += copy(dAtA[i:], s)
+		}
+	}
+	if m.XXX_unrecognized != nil {
+		i += copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func (m *RefMap) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *RefMap) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.Refs) > 0 {
+		for k, _ := range m.Refs {
+			dAtA[i] = 0xa
+			i++
+			v := m.Refs[k]
+			msgSize := 0
+			if v != nil {
+				msgSize = v.Size()
+				msgSize += 1 + sovGateway(uint64(msgSize))
+			}
+			mapSize := 1 + len(k) + sovGateway(uint64(len(k))) + msgSize
+			i = encodeVarintGateway(dAtA, i, uint64(mapSize))
+			dAtA[i] = 0xa
+			i++
+			i = encodeVarintGateway(dAtA, i, uint64(len(k)))
+			i += copy(dAtA[i:], k)
+			if v != nil {
+				dAtA[i] = 0x12
+				i++
+				i = encodeVarintGateway(dAtA, i, uint64(v.Size()))
+				n5, err := v.MarshalTo(dAtA[i:])
+				if err != nil {
+					return 0, err
+				}
+				i += n5
+			}
+		}
+	}
+	if m.XXX_unrecognized != nil {
+		i += copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
 func (m *ReturnRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -1588,21 +1868,21 @@ func (m *ReturnRequest) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintGateway(dAtA, i, uint64(m.Result.Size()))
-		n3, err := m.Result.MarshalTo(dAtA[i:])
+		n6, err := m.Result.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n3
+		i += n6
 	}
 	if m.Error != nil {
 		dAtA[i] = 0x12
 		i++
 		i = encodeVarintGateway(dAtA, i, uint64(m.Error.Size()))
-		n4, err := m.Error.MarshalTo(dAtA[i:])
+		n7, err := m.Error.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n4
+		i += n7
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
@@ -1656,11 +1936,11 @@ func (m *ResolveImageConfigRequest) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x12
 		i++
 		i = encodeVarintGateway(dAtA, i, uint64(m.Platform.Size()))
-		n5, err := m.Platform.MarshalTo(dAtA[i:])
+		n8, err := m.Platform.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n5
+		i += n8
 	}
 	if len(m.ResolveMode) > 0 {
 		dAtA[i] = 0x1a
@@ -1732,11 +2012,11 @@ func (m *SolveRequest) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintGateway(dAtA, i, uint64(m.Definition.Size()))
-		n6, err := m.Definition.MarshalTo(dAtA[i:])
+		n9, err := m.Definition.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n6
+		i += n9
 	}
 	if len(m.Frontend) > 0 {
 		dAtA[i] = 0x12
@@ -1780,6 +2060,16 @@ func (m *SolveRequest) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x28
 		i++
 		if m.AllowResultReturn {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i++
+	}
+	if m.AllowResultArrayRef {
+		dAtA[i] = 0x30
+		i++
+		if m.AllowResultArrayRef {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
@@ -1889,11 +2179,11 @@ func (m *SolveResponse) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1a
 		i++
 		i = encodeVarintGateway(dAtA, i, uint64(m.Result.Size()))
-		n7, err := m.Result.MarshalTo(dAtA[i:])
+		n10, err := m.Result.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n7
+		i += n10
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
@@ -1932,11 +2222,11 @@ func (m *ReadFileRequest) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1a
 		i++
 		i = encodeVarintGateway(dAtA, i, uint64(m.Range.Size()))
-		n8, err := m.Range.MarshalTo(dAtA[i:])
+		n11, err := m.Range.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n8
+		i += n11
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
@@ -2126,11 +2416,11 @@ func (m *StatFileResponse) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintGateway(dAtA, i, uint64(m.Stat.Size()))
-		n9, err := m.Stat.MarshalTo(dAtA[i:])
+		n12, err := m.Stat.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n9
+		i += n12
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
@@ -2252,14 +2542,38 @@ func (m *Result) Size() (n int) {
 	return n
 }
 
+func (m *Result_RefDeprecated) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.RefDeprecated)
+	n += 1 + l + sovGateway(uint64(l))
+	return n
+}
+func (m *Result_RefsDeprecated) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.RefsDeprecated != nil {
+		l = m.RefsDeprecated.Size()
+		n += 1 + l + sovGateway(uint64(l))
+	}
+	return n
+}
 func (m *Result_Ref) Size() (n int) {
 	if m == nil {
 		return 0
 	}
 	var l int
 	_ = l
-	l = len(m.Ref)
-	n += 1 + l + sovGateway(uint64(l))
+	if m.Ref != nil {
+		l = m.Ref.Size()
+		n += 1 + l + sovGateway(uint64(l))
+	}
 	return n
 }
 func (m *Result_Refs) Size() (n int) {
@@ -2274,7 +2588,7 @@ func (m *Result_Refs) Size() (n int) {
 	}
 	return n
 }
-func (m *RefMap) Size() (n int) {
+func (m *RefMapDeprecated) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -2285,6 +2599,49 @@ func (m *RefMap) Size() (n int) {
 			_ = k
 			_ = v
 			mapEntrySize := 1 + len(k) + sovGateway(uint64(len(k))) + 1 + len(v) + sovGateway(uint64(len(v)))
+			n += mapEntrySize + 1 + sovGateway(uint64(mapEntrySize))
+		}
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *Ref) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.Ids) > 0 {
+		for _, s := range m.Ids {
+			l = len(s)
+			n += 1 + l + sovGateway(uint64(l))
+		}
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *RefMap) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.Refs) > 0 {
+		for k, v := range m.Refs {
+			_ = k
+			_ = v
+			l = 0
+			if v != nil {
+				l = v.Size()
+				l += 1 + sovGateway(uint64(l))
+			}
+			mapEntrySize := 1 + len(k) + sovGateway(uint64(len(k))) + l
 			n += mapEntrySize + 1 + sovGateway(uint64(mapEntrySize))
 		}
 	}
@@ -2403,6 +2760,9 @@ func (m *SolveRequest) Size() (n int) {
 		}
 	}
 	if m.AllowResultReturn {
+		n += 2
+	}
+	if m.AllowResultArrayRef {
 		n += 2
 	}
 	if m.Final {
@@ -2690,7 +3050,7 @@ func (m *Result) Unmarshal(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Ref", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field RefDeprecated", wireType)
 			}
 			var stringLen uint64
 			for shift := uint(0); ; shift += 7 {
@@ -2715,9 +3075,73 @@ func (m *Result) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Result = &Result_Ref{string(dAtA[iNdEx:postIndex])}
+			m.Result = &Result_RefDeprecated{string(dAtA[iNdEx:postIndex])}
 			iNdEx = postIndex
 		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RefsDeprecated", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGateway
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGateway
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &RefMapDeprecated{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.Result = &Result_RefsDeprecated{v}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Ref", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGateway
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGateway
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &Ref{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.Result = &Result_Ref{v}
+			iNdEx = postIndex
+		case 4:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Refs", wireType)
 			}
@@ -2890,7 +3314,7 @@ func (m *Result) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *RefMap) Unmarshal(dAtA []byte) error {
+func (m *RefMapDeprecated) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -2913,10 +3337,10 @@ func (m *RefMap) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: RefMap: wiretype end group for non-group")
+			return fmt.Errorf("proto: RefMapDeprecated: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: RefMap: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: RefMapDeprecated: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -3020,6 +3444,260 @@ func (m *RefMap) Unmarshal(dAtA []byte) error {
 					}
 					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
 					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := skipGateway(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if skippy < 0 {
+						return ErrInvalidLengthGateway
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Refs[mapkey] = mapvalue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipGateway(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthGateway
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *Ref) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowGateway
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: Ref: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: Ref: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Ids", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGateway
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGateway
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Ids = append(m.Ids, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipGateway(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthGateway
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *RefMap) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowGateway
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RefMap: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RefMap: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Refs", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGateway
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGateway
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Refs == nil {
+				m.Refs = make(map[string]*Ref)
+			}
+			var mapkey string
+			var mapvalue *Ref
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowGateway
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= (uint64(b) & 0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowGateway
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= (uint64(b) & 0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return ErrInvalidLengthGateway
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var mapmsglen int
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowGateway
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						mapmsglen |= (int(b) & 0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					if mapmsglen < 0 {
+						return ErrInvalidLengthGateway
+					}
+					postmsgIndex := iNdEx + mapmsglen
+					if mapmsglen < 0 {
+						return ErrInvalidLengthGateway
+					}
+					if postmsgIndex > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = &Ref{}
+					if err := mapvalue.Unmarshal(dAtA[iNdEx:postmsgIndex]); err != nil {
+						return err
+					}
+					iNdEx = postmsgIndex
 				} else {
 					iNdEx = entryPreIndex
 					skippy, err := skipGateway(dAtA[iNdEx:])
@@ -3767,6 +4445,26 @@ func (m *SolveRequest) Unmarshal(dAtA []byte) error {
 				}
 			}
 			m.AllowResultReturn = bool(v != 0)
+		case 6:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AllowResultArrayRef", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGateway
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.AllowResultArrayRef = bool(v != 0)
 		case 10:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Final", wireType)
@@ -5208,85 +5906,91 @@ var (
 	ErrIntOverflowGateway   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("gateway.proto", fileDescriptor_gateway_eff078cadb286ceb) }
+func init() { proto.RegisterFile("gateway.proto", fileDescriptor_gateway_f66b6a1c7ba3b979) }
 
-var fileDescriptor_gateway_eff078cadb286ceb = []byte{
-	// 1224 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x56, 0xcd, 0x6e, 0xdb, 0xc6,
-	0x13, 0x0f, 0x23, 0xc9, 0xb6, 0xc6, 0x72, 0xa2, 0x2c, 0xfe, 0xf8, 0x83, 0xe1, 0x21, 0x51, 0x89,
-	0xc2, 0x55, 0x12, 0x87, 0x44, 0x9d, 0x16, 0x4e, 0x93, 0x22, 0x69, 0x14, 0x27, 0x88, 0x5b, 0xbb,
-	0x11, 0x36, 0x05, 0x02, 0x04, 0x2d, 0xd0, 0x95, 0xb8, 0x62, 0x16, 0xa1, 0xb8, 0xec, 0x72, 0x15,
-	0xd7, 0xe8, 0xa5, 0xed, 0x2b, 0xf4, 0x45, 0xfa, 0x18, 0xb9, 0xb5, 0xe7, 0x1e, 0x82, 0xc2, 0xb7,
-	0x5e, 0xfa, 0x0c, 0xc5, 0x7e, 0x50, 0xa2, 0x3f, 0x44, 0x5b, 0x27, 0xee, 0x2c, 0xe7, 0x37, 0xf3,
-	0x9b, 0xd9, 0x99, 0xd9, 0x85, 0xb5, 0x98, 0x48, 0xba, 0x4f, 0x0e, 0x82, 0x4c, 0x70, 0xc9, 0xd1,
-	0xd5, 0x31, 0x1f, 0x1c, 0x04, 0x83, 0x09, 0x4b, 0xa2, 0x37, 0x4c, 0x06, 0x6f, 0x3f, 0x0e, 0x46,
-	0x82, 0xa7, 0x92, 0xa6, 0x91, 0x77, 0x3b, 0x66, 0xf2, 0xf5, 0x64, 0x10, 0x0c, 0xf9, 0x38, 0x8c,
-	0x79, 0xcc, 0x43, 0x8d, 0x18, 0x4c, 0x46, 0x5a, 0xd2, 0x82, 0x5e, 0x19, 0x4b, 0xde, 0xe6, 0x71,
-	0xf5, 0x98, 0xf3, 0x38, 0xa1, 0x24, 0x63, 0xb9, 0x5d, 0x86, 0x22, 0x1b, 0x86, 0xb9, 0x24, 0x72,
-	0x92, 0x5b, 0xcc, 0x46, 0x09, 0xa3, 0x88, 0x84, 0x05, 0x91, 0x30, 0xe7, 0xc9, 0x5b, 0x2a, 0xc2,
-	0x6c, 0x10, 0xf2, 0xac, 0xd0, 0x0e, 0xe7, 0x6a, 0x93, 0x8c, 0x85, 0xf2, 0x20, 0xa3, 0x79, 0xb8,
-	0xcf, 0xc5, 0x1b, 0x2a, 0x2c, 0xe0, 0xce, 0x5c, 0xc0, 0x44, 0xb2, 0x44, 0xa1, 0x86, 0x24, 0xcb,
-	0x95, 0x13, 0xf5, 0xb5, 0xa0, 0x72, 0xd8, 0x92, 0xa7, 0x2c, 0x97, 0x8c, 0xc5, 0x2c, 0x1c, 0xe5,
-	0x1a, 0x63, 0xbc, 0xa8, 0x20, 0x8c, 0xba, 0xff, 0x8f, 0x03, 0x4b, 0x98, 0xe6, 0x93, 0x44, 0x22,
-	0x04, 0x35, 0x41, 0x47, 0xae, 0xd3, 0x71, 0xba, 0xcd, 0x67, 0x17, 0xb0, 0x12, 0xd0, 0x16, 0xd4,
-	0x05, 0x1d, 0xe5, 0xee, 0xc5, 0x8e, 0xd3, 0x5d, 0xdd, 0xfc, 0x20, 0x98, 0x9b, 0xee, 0x00, 0xd3,
-	0xd1, 0x1e, 0xc9, 0x9e, 0x5d, 0xc0, 0x1a, 0x80, 0xbe, 0x82, 0x95, 0x31, 0x95, 0x24, 0x22, 0x92,
-	0xb8, 0xd0, 0xa9, 0x75, 0x57, 0x37, 0xc3, 0x4a, 0xb0, 0x62, 0x10, 0xec, 0x59, 0xc4, 0x93, 0x54,
-	0x8a, 0x03, 0x3c, 0x35, 0xe0, 0xdd, 0x87, 0xb5, 0x23, 0xbf, 0x50, 0x1b, 0x6a, 0x6f, 0xe8, 0x81,
-	0xa1, 0x8a, 0xd5, 0x12, 0xfd, 0x0f, 0x1a, 0x6f, 0x49, 0x32, 0xa1, 0x9a, 0x69, 0x0b, 0x1b, 0xe1,
-	0xde, 0xc5, 0xbb, 0x4e, 0x6f, 0x05, 0x96, 0x84, 0x36, 0xef, 0xff, 0xaa, 0x63, 0x55, 0x34, 0xd1,
-	0x43, 0x1b, 0x97, 0xa3, 0xa9, 0xdd, 0x3a, 0x33, 0x2e, 0xf5, 0xc9, 0x0d, 0x2d, 0x0d, 0xf4, 0xb6,
-	0xa0, 0x39, 0xdd, 0x3a, 0x8b, 0x4e, 0xb3, 0x44, 0xc7, 0x97, 0xb0, 0x86, 0xa9, 0x9c, 0x88, 0x14,
-	0xd3, 0x1f, 0x26, 0x34, 0x97, 0xe8, 0xb3, 0x82, 0x9f, 0xc6, 0x9f, 0x95, 0x64, 0xa5, 0x88, 0x2d,
-	0x00, 0x75, 0xa1, 0x41, 0x85, 0xe0, 0xc2, 0x1e, 0x0f, 0x0a, 0x4c, 0xa1, 0x06, 0x22, 0x1b, 0x06,
-	0x2f, 0x74, 0xa1, 0x62, 0xa3, 0xe0, 0xb7, 0xe1, 0x52, 0xe1, 0x35, 0xcf, 0x78, 0x9a, 0x53, 0xff,
-	0x37, 0x07, 0xae, 0x62, 0xaa, 0xeb, 0x74, 0x67, 0x4c, 0x62, 0xfa, 0x98, 0xa7, 0x23, 0x16, 0x17,
-	0xa4, 0xda, 0x50, 0xc3, 0x45, 0x2d, 0x60, 0xb5, 0x44, 0x5d, 0x58, 0xe9, 0x27, 0x44, 0x8e, 0xb8,
-	0x18, 0x5b, 0x77, 0xad, 0x20, 0x1b, 0x04, 0xc5, 0x1e, 0x9e, 0xfe, 0x45, 0x1d, 0x58, 0xb5, 0x86,
-	0xf7, 0x78, 0x44, 0xdd, 0x9a, 0xb6, 0x51, 0xde, 0x42, 0x2e, 0x2c, 0xef, 0xf2, 0xf8, 0x6b, 0x32,
-	0xa6, 0x6e, 0x5d, 0xff, 0x2d, 0x44, 0xff, 0x67, 0x07, 0xbc, 0xd3, 0x58, 0x19, 0xd2, 0xe8, 0x4b,
-	0x58, 0xda, 0x66, 0x31, 0xcd, 0x4d, 0xae, 0x9a, 0xbd, 0xcd, 0x77, 0xef, 0xaf, 0x5f, 0xf8, 0xeb,
-	0xfd, 0xf5, 0x9b, 0xa5, 0xa2, 0xe7, 0x19, 0x4d, 0x87, 0x3c, 0x95, 0x84, 0xa5, 0x54, 0xa8, 0xde,
-	0xbd, 0x1d, 0x69, 0x48, 0x60, 0x90, 0xd8, 0x5a, 0x40, 0xff, 0x87, 0x25, 0x63, 0xdd, 0x96, 0x8c,
-	0x95, 0xfc, 0x7f, 0x6b, 0xd0, 0x7a, 0xa1, 0x08, 0x14, 0xb9, 0x08, 0x00, 0xb6, 0xe9, 0x88, 0xa5,
-	0x4c, 0x32, 0x9e, 0xda, 0x43, 0xba, 0xa4, 0x62, 0x9f, 0xed, 0xe2, 0x92, 0x06, 0xf2, 0x60, 0xe5,
-	0xa9, 0x3d, 0x30, 0x7b, 0xfc, 0x53, 0x19, 0xbd, 0x82, 0xd5, 0x62, 0xfd, 0x3c, 0x93, 0x6e, 0x4d,
-	0x97, 0xdf, 0xdd, 0x8a, 0x13, 0x2f, 0x33, 0x09, 0x4a, 0x50, 0x53, 0x8b, 0x65, 0x63, 0xe8, 0x73,
-	0xb8, 0xba, 0x33, 0xce, 0xb8, 0x90, 0x8f, 0xc9, 0xf0, 0x35, 0x55, 0xd5, 0xb9, 0x4d, 0x33, 0x41,
-	0x87, 0x44, 0xd2, 0xc8, 0xad, 0x77, 0x6a, 0xdd, 0x26, 0x9e, 0xaf, 0x80, 0x36, 0xe0, 0x0a, 0x49,
-	0x12, 0xbe, 0x6f, 0x4b, 0x4c, 0x17, 0x8b, 0xdb, 0xe8, 0x38, 0xdd, 0x15, 0x7c, 0xf2, 0x87, 0xaa,
-	0xef, 0xa7, 0x2c, 0x25, 0x89, 0x0b, 0x5a, 0xc3, 0x08, 0xc8, 0x87, 0xd6, 0x93, 0x1f, 0x95, 0x03,
-	0x2a, 0x1e, 0x49, 0x29, 0xdc, 0x55, 0x9d, 0xd8, 0x23, 0x7b, 0xa8, 0x0f, 0x2d, 0xed, 0xde, 0x30,
-	0xc9, 0xdd, 0x96, 0x4e, 0xc1, 0x46, 0x45, 0x0a, 0xb4, 0xfa, 0xf3, 0x4c, 0xe5, 0xd6, 0xb6, 0xe0,
-	0x11, 0x0b, 0xde, 0x03, 0x68, 0x1f, 0x4f, 0xcc, 0x42, 0x1d, 0xf9, 0xbb, 0x03, 0x57, 0x4e, 0xf8,
-	0x40, 0x08, 0xea, 0xdf, 0x1c, 0x64, 0xd4, 0x9a, 0xd0, 0x6b, 0xb4, 0x07, 0x0d, 0x15, 0x83, 0x1a,
-	0x87, 0x8a, 0xf4, 0xd6, 0x22, 0xa4, 0x03, 0x8d, 0x34, 0xfc, 0x8d, 0x15, 0xef, 0x2e, 0xc0, 0x6c,
-	0x73, 0x21, 0xca, 0xdf, 0xc2, 0x9a, 0x2d, 0x0c, 0xdb, 0x18, 0xed, 0xd2, 0xec, 0x36, 0x93, 0x7b,
-	0x36, 0x56, 0x6a, 0x0b, 0x8e, 0x15, 0xff, 0x27, 0xb8, 0x8c, 0x29, 0x89, 0x9e, 0xb2, 0x84, 0xce,
-	0x9f, 0x07, 0xaa, 0xca, 0x59, 0x42, 0xfb, 0x44, 0xbe, 0x9e, 0x56, 0xb9, 0x95, 0xd1, 0x3d, 0x68,
-	0x60, 0x92, 0xc6, 0xd4, 0xba, 0xfe, 0xb0, 0xc2, 0xb5, 0x76, 0xa2, 0x74, 0xb1, 0x81, 0xf8, 0xf7,
-	0xa1, 0x39, 0xdd, 0x53, 0x3d, 0xfa, 0x7c, 0x34, 0xca, 0xa9, 0xe9, 0xf7, 0x1a, 0xb6, 0x92, 0xda,
-	0xdf, 0xa5, 0x69, 0x6c, 0x5d, 0xd7, 0xb0, 0x95, 0xfc, 0x75, 0x68, 0xcf, 0x98, 0xdb, 0xd4, 0x20,
-	0xa8, 0x6f, 0xab, 0x5b, 0xc8, 0xd1, 0xc5, 0xa8, 0xd7, 0x7e, 0xa4, 0xc6, 0x21, 0x89, 0xb6, 0x99,
-	0x98, 0x1f, 0xa0, 0x0b, 0xcb, 0xdb, 0x4c, 0x94, 0xe2, 0x2b, 0x44, 0xb4, 0x0e, 0x97, 0x76, 0xd2,
-	0x61, 0x32, 0x89, 0x54, 0xb4, 0x92, 0x8a, 0xd4, 0xce, 0xb8, 0x63, 0xbb, 0xfe, 0x43, 0x93, 0x47,
-	0xed, 0xc5, 0x92, 0xd9, 0x80, 0x65, 0x9a, 0x4a, 0xc1, 0x68, 0x71, 0xf5, 0xa0, 0xc0, 0xdc, 0xcc,
-	0x81, 0xbe, 0x99, 0xf5, 0xd4, 0xc6, 0x85, 0x8a, 0xbf, 0x05, 0x97, 0xd5, 0x46, 0xf5, 0x41, 0x20,
-	0xa8, 0x97, 0x48, 0xea, 0xb5, 0x7f, 0x0f, 0xda, 0x33, 0xa0, 0x75, 0xbd, 0x0e, 0x75, 0x75, 0xef,
-	0xdb, 0x01, 0x76, 0x9a, 0x5f, 0xfd, 0xdf, 0x5f, 0x83, 0xd5, 0x3e, 0x4b, 0x8b, 0x9b, 0xc0, 0x3f,
-	0x74, 0xa0, 0xd5, 0xe7, 0xe9, 0x6c, 0x06, 0xf7, 0xe1, 0x72, 0xd1, 0x6e, 0x8f, 0xfa, 0x3b, 0x8f,
-	0x49, 0x56, 0x84, 0xd2, 0x39, 0x79, 0xcc, 0xf6, 0x89, 0x12, 0x18, 0xc5, 0x5e, 0x5d, 0x8d, 0x6b,
-	0x7c, 0x1c, 0x8e, 0xbe, 0x80, 0xe5, 0xdd, 0xdd, 0x9e, 0xb6, 0x74, 0x71, 0x21, 0x4b, 0x05, 0x0c,
-	0x3d, 0x80, 0xe5, 0x97, 0xfa, 0xe5, 0x94, 0xdb, 0x91, 0x7a, 0x4a, 0xc9, 0x99, 0x40, 0x8d, 0x1a,
-	0xa6, 0x43, 0x2e, 0x22, 0x5c, 0x80, 0x36, 0xff, 0x68, 0x40, 0x73, 0x77, 0xb7, 0xd7, 0x13, 0x2c,
-	0x8a, 0x29, 0xfa, 0xc5, 0x01, 0x74, 0xf2, 0x12, 0x42, 0x9f, 0x54, 0x77, 0xd0, 0xe9, 0x37, 0xa9,
-	0xf7, 0xe9, 0x82, 0x28, 0x9b, 0xe5, 0x57, 0xd0, 0xd0, 0x1d, 0x8e, 0x3e, 0x3a, 0xe7, 0xe5, 0xe0,
-	0x75, 0xcf, 0x56, 0xb4, 0xb6, 0x87, 0xb0, 0x52, 0x74, 0x09, 0xba, 0x59, 0x49, 0xef, 0xc8, 0x10,
-	0xf0, 0x6e, 0x9d, 0x4b, 0xd7, 0x3a, 0xf9, 0x1e, 0x96, 0x6d, 0xf1, 0xa3, 0x1b, 0x67, 0xe0, 0x66,
-	0x6d, 0xe8, 0xdd, 0x3c, 0x8f, 0xea, 0x2c, 0x8c, 0xa2, 0xc8, 0x2b, 0xc3, 0x38, 0xd6, 0x42, 0x95,
-	0x61, 0x9c, 0xe8, 0x9a, 0x97, 0x50, 0x57, 0xdd, 0x80, 0xd6, 0x2b, 0x40, 0xa5, 0x76, 0xf1, 0xaa,
-	0x8e, 0xeb, 0x48, 0x1b, 0x7d, 0xa7, 0xde, 0xa2, 0xfa, 0x2e, 0xed, 0x56, 0xc6, 0x5c, 0x7a, 0x2a,
-	0x7a, 0x37, 0xce, 0xa1, 0x69, 0xcc, 0xf7, 0x5a, 0xef, 0x0e, 0xaf, 0x39, 0x7f, 0x1e, 0x5e, 0x73,
-	0xfe, 0x3e, 0xbc, 0xe6, 0x0c, 0x96, 0xf4, 0x63, 0xff, 0xce, 0x7f, 0x01, 0x00, 0x00, 0xff, 0xff,
-	0x7c, 0xf6, 0x53, 0x84, 0x3e, 0x0d, 0x00, 0x00,
+var fileDescriptor_gateway_f66b6a1c7ba3b979 = []byte{
+	// 1321 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x57, 0x5f, 0x6f, 0x1b, 0x45,
+	0x10, 0xcf, 0xc5, 0xce, 0x1f, 0x4f, 0x9c, 0xd4, 0x5d, 0x10, 0xb8, 0xf7, 0x90, 0x86, 0x13, 0x0a,
+	0x6e, 0x9b, 0xde, 0x41, 0xda, 0x2a, 0xa5, 0x45, 0x2d, 0x75, 0xd3, 0x2a, 0x81, 0x84, 0x5a, 0x5b,
+	0x50, 0xa5, 0x0a, 0x24, 0xce, 0xbe, 0xbd, 0xeb, 0xaa, 0xe7, 0xdb, 0x63, 0x6f, 0xdd, 0x62, 0xf1,
+	0x02, 0x6f, 0xbc, 0x23, 0xf1, 0x8c, 0xf8, 0x04, 0x7c, 0x8c, 0xbe, 0xc1, 0x33, 0x0f, 0x15, 0xca,
+	0x27, 0x41, 0xfb, 0xe7, 0xe2, 0xb3, 0x93, 0x9c, 0xe3, 0x27, 0xef, 0xce, 0xcd, 0x6f, 0xe6, 0x37,
+	0xb3, 0x33, 0xb3, 0x6b, 0x58, 0x8d, 0x7c, 0x41, 0x5e, 0xfb, 0x43, 0x37, 0xe5, 0x4c, 0x30, 0x74,
+	0xa9, 0xcf, 0xba, 0x43, 0xb7, 0x3b, 0xa0, 0x71, 0xf0, 0x92, 0x0a, 0xf7, 0xd5, 0x27, 0x6e, 0xc8,
+	0x59, 0x22, 0x48, 0x12, 0xd8, 0xd7, 0x23, 0x2a, 0x5e, 0x0c, 0xba, 0x6e, 0x8f, 0xf5, 0xbd, 0x88,
+	0x45, 0xcc, 0x53, 0x88, 0xee, 0x20, 0x54, 0x3b, 0xb5, 0x51, 0x2b, 0x6d, 0xc9, 0xde, 0x9e, 0x54,
+	0x8f, 0x18, 0x8b, 0x62, 0xe2, 0xa7, 0x34, 0x33, 0x4b, 0x8f, 0xa7, 0x3d, 0x2f, 0x13, 0xbe, 0x18,
+	0x64, 0x06, 0xb3, 0x55, 0xc0, 0x48, 0x22, 0x5e, 0x4e, 0xc4, 0xcb, 0x58, 0xfc, 0x8a, 0x70, 0x2f,
+	0xed, 0x7a, 0x2c, 0xcd, 0xb5, 0xbd, 0x33, 0xb5, 0xfd, 0x94, 0x7a, 0x62, 0x98, 0x92, 0xcc, 0x7b,
+	0xcd, 0xf8, 0x4b, 0xc2, 0x0d, 0xe0, 0xc6, 0x99, 0x80, 0x81, 0xa0, 0xb1, 0x44, 0xf5, 0xfc, 0x34,
+	0x93, 0x4e, 0xe4, 0xaf, 0x01, 0x15, 0xc3, 0x16, 0x2c, 0xa1, 0x99, 0xa0, 0x34, 0xa2, 0x5e, 0x98,
+	0x29, 0x8c, 0xf6, 0x22, 0x83, 0xd0, 0xea, 0xce, 0xaf, 0x15, 0x58, 0xc4, 0x24, 0x1b, 0xc4, 0x02,
+	0x6d, 0xc2, 0x2a, 0x27, 0xe1, 0x2e, 0x49, 0x39, 0xe9, 0xf9, 0x82, 0x04, 0x4d, 0x6b, 0xc3, 0x6a,
+	0xd5, 0xf6, 0xe6, 0xf0, 0xb8, 0x18, 0x7d, 0x03, 0x6b, 0x9c, 0x84, 0x59, 0x41, 0x71, 0x7e, 0xc3,
+	0x6a, 0xad, 0x6c, 0x5f, 0x73, 0xcf, 0x3c, 0x0c, 0x17, 0x93, 0xf0, 0xd0, 0x4f, 0x47, 0x90, 0xbd,
+	0x39, 0x3c, 0x61, 0x04, 0x6d, 0x43, 0x85, 0x93, 0xb0, 0x59, 0x51, 0xb6, 0xd6, 0xcb, 0x6d, 0xed,
+	0xcd, 0x61, 0xa9, 0x8c, 0x76, 0xa0, 0x2a, 0xad, 0x34, 0xab, 0x0a, 0xf4, 0xc1, 0x54, 0x02, 0x7b,
+	0x73, 0x58, 0x01, 0xd0, 0x97, 0xb0, 0xdc, 0x27, 0xc2, 0x0f, 0x7c, 0xe1, 0x37, 0x61, 0xa3, 0xd2,
+	0x5a, 0xd9, 0xf6, 0x4a, 0xc1, 0x32, 0x41, 0xee, 0xa1, 0x41, 0x3c, 0x4a, 0x04, 0x1f, 0xe2, 0x63,
+	0x03, 0xf6, 0x5d, 0x58, 0x1d, 0xfb, 0x84, 0x1a, 0x50, 0x79, 0x49, 0x86, 0x3a, 0x7f, 0x58, 0x2e,
+	0xd1, 0xbb, 0xb0, 0xf0, 0xca, 0x8f, 0x07, 0x44, 0xa5, 0xaa, 0x8e, 0xf5, 0xe6, 0xce, 0xfc, 0x6d,
+	0xab, 0xbd, 0x0c, 0x8b, 0x5c, 0x99, 0x77, 0x7e, 0xb7, 0xa0, 0x31, 0x99, 0x27, 0xb4, 0x6f, 0x22,
+	0xb4, 0x14, 0xc9, 0x5b, 0x33, 0xa4, 0x58, 0x0a, 0x32, 0x4d, 0x55, 0x99, 0xb0, 0x77, 0xa0, 0x76,
+	0x2c, 0x9a, 0x46, 0xb1, 0x56, 0xa0, 0xe8, 0xbc, 0x0f, 0x15, 0x4c, 0x42, 0x09, 0xa1, 0x81, 0x66,
+	0x52, 0xc3, 0x72, 0xe9, 0xfc, 0x69, 0xc9, 0xe2, 0x91, 0x6e, 0xd1, 0xfd, 0x31, 0x9e, 0xd3, 0x4b,
+	0xe1, 0x04, 0xbb, 0x67, 0xe5, 0xec, 0x6e, 0x16, 0xd9, 0x4d, 0xad, 0x8f, 0x22, 0x7b, 0x01, 0xab,
+	0x98, 0x88, 0x01, 0x4f, 0x30, 0xf9, 0x61, 0x40, 0x32, 0x81, 0x3e, 0xcd, 0x33, 0xae, 0xec, 0x4f,
+	0x2b, 0x1b, 0xa9, 0x88, 0x0d, 0x00, 0xb5, 0x60, 0x81, 0x70, 0xce, 0xb8, 0x61, 0x81, 0x5c, 0x3d,
+	0x19, 0x5c, 0x9e, 0xf6, 0xdc, 0xa7, 0x6a, 0x32, 0x60, 0xad, 0xe0, 0x34, 0x60, 0x2d, 0xf7, 0x9a,
+	0xa5, 0x2c, 0xc9, 0x88, 0xf3, 0x9b, 0x05, 0x97, 0x30, 0x51, 0x83, 0x61, 0xbf, 0xef, 0x47, 0xe4,
+	0x21, 0x4b, 0x42, 0x1a, 0xe5, 0xa4, 0x1a, 0x2a, 0xc7, 0x79, 0xc4, 0x32, 0xdd, 0x2d, 0x58, 0xee,
+	0xc4, 0xbe, 0x08, 0x19, 0xef, 0x1b, 0x77, 0x75, 0x37, 0xed, 0xba, 0xb9, 0x0c, 0x1f, 0x7f, 0x45,
+	0x1b, 0xb0, 0x62, 0x0c, 0x1f, 0xb2, 0x80, 0xa8, 0x0e, 0xaa, 0xe1, 0xa2, 0x08, 0x35, 0x61, 0xe9,
+	0x80, 0x45, 0x5f, 0xf9, 0x7d, 0xa2, 0x5a, 0xa5, 0x86, 0xf3, 0xad, 0xf3, 0xb3, 0x05, 0xf6, 0x69,
+	0xac, 0x34, 0x69, 0xf4, 0x05, 0x2c, 0xee, 0xd2, 0x88, 0x64, 0x3a, 0x57, 0xb5, 0xf6, 0xf6, 0x9b,
+	0xb7, 0x97, 0xe7, 0xfe, 0x7d, 0x7b, 0xf9, 0x6a, 0x61, 0xca, 0xb0, 0x94, 0x24, 0x3d, 0x96, 0x08,
+	0x9f, 0x26, 0x84, 0xcb, 0x61, 0x79, 0x3d, 0x50, 0x10, 0x57, 0x23, 0xb1, 0xb1, 0x80, 0xde, 0x83,
+	0x45, 0x6d, 0xdd, 0x34, 0x81, 0xd9, 0x39, 0x7f, 0x54, 0xa1, 0xfe, 0x54, 0x12, 0xc8, 0x73, 0xe1,
+	0x02, 0xec, 0x92, 0x90, 0x26, 0x54, 0x50, 0x96, 0x98, 0x43, 0x5a, 0x93, 0xb1, 0x8f, 0xa4, 0xb8,
+	0xa0, 0x81, 0x6c, 0x58, 0x7e, 0x6c, 0x0e, 0xcc, 0x14, 0xef, 0xf1, 0x1e, 0x3d, 0x87, 0x95, 0x7c,
+	0xfd, 0x24, 0x15, 0xcd, 0x8a, 0x2a, 0xcf, 0xdb, 0x25, 0x27, 0x5e, 0x64, 0xe2, 0x16, 0xa0, 0xba,
+	0x56, 0x8b, 0xc6, 0xd0, 0x67, 0x70, 0x69, 0xbf, 0x9f, 0x32, 0x2e, 0x1e, 0xfa, 0xbd, 0x17, 0x04,
+	0x8f, 0xcf, 0xc4, 0xaa, 0x6a, 0x93, 0xb3, 0x15, 0xd0, 0x16, 0x5c, 0xf4, 0xe3, 0x98, 0xbd, 0x36,
+	0x25, 0xa6, 0x8a, 0xa5, 0xb9, 0xb0, 0x61, 0xb5, 0x96, 0xf1, 0xc9, 0x0f, 0xe8, 0x63, 0x78, 0xa7,
+	0x20, 0x7c, 0xc0, 0xb9, 0x3f, 0x94, 0xf5, 0xb2, 0xa8, 0xf4, 0x4f, 0xfb, 0x24, 0xfb, 0xf9, 0x31,
+	0x4d, 0xfc, 0xb8, 0x09, 0x4a, 0x47, 0x6f, 0x90, 0x03, 0xf5, 0x47, 0x3f, 0x4a, 0x4a, 0x84, 0x3f,
+	0x10, 0x82, 0x37, 0x57, 0xd4, 0x51, 0x8c, 0xc9, 0x50, 0x07, 0xea, 0x8a, 0xb0, 0xe6, 0x9e, 0x35,
+	0xeb, 0x2a, 0x69, 0x5b, 0x25, 0x49, 0x53, 0xea, 0x4f, 0x52, 0x79, 0x1a, 0xa6, 0xa9, 0xc7, 0x2c,
+	0xd8, 0xf7, 0xa0, 0x31, 0x99, 0xca, 0x99, 0x26, 0xd0, 0x5f, 0x16, 0x5c, 0x3c, 0xe1, 0x03, 0x21,
+	0xa8, 0x7e, 0x3d, 0x4c, 0x89, 0x31, 0xa1, 0xd6, 0xe8, 0x10, 0x16, 0x64, 0x0c, 0x59, 0x73, 0x5e,
+	0x91, 0xde, 0x99, 0x85, 0xb4, 0xab, 0x90, 0x9a, 0xbf, 0xb6, 0x62, 0xdf, 0x06, 0x18, 0x09, 0x67,
+	0xa2, 0xfc, 0x2d, 0xac, 0x9a, 0x52, 0x32, 0xad, 0xd4, 0xd0, 0xf7, 0x9b, 0x01, 0xcb, 0xdb, 0x6b,
+	0x34, 0x88, 0x2a, 0x33, 0x0e, 0x22, 0xe7, 0x27, 0xb8, 0x80, 0x89, 0x1f, 0x3c, 0xa6, 0x31, 0x39,
+	0x7b, 0x82, 0xc8, 0xbe, 0xa0, 0x31, 0xe9, 0xf8, 0xe2, 0xc5, 0x71, 0x5f, 0x98, 0x3d, 0xba, 0x03,
+	0x0b, 0xd8, 0x4f, 0x22, 0x62, 0x5c, 0x7f, 0x58, 0xe2, 0x5a, 0x39, 0x91, 0xba, 0x58, 0x43, 0x9c,
+	0xbb, 0x50, 0x3b, 0x96, 0xc9, 0xae, 0x7e, 0x12, 0x86, 0x19, 0xd1, 0x13, 0xa2, 0x82, 0xcd, 0x4e,
+	0xca, 0x0f, 0x48, 0x12, 0x19, 0xd7, 0x15, 0x6c, 0x76, 0xce, 0xa6, 0xbc, 0xe4, 0x72, 0xe6, 0x26,
+	0x35, 0x08, 0xaa, 0xbb, 0xf2, 0x26, 0xb6, 0x54, 0x31, 0xaa, 0xb5, 0x13, 0xc8, 0x01, 0xea, 0x07,
+	0xbb, 0x94, 0x9f, 0x1d, 0x60, 0x13, 0x96, 0x76, 0x29, 0x2f, 0xc4, 0x97, 0x6f, 0xd1, 0x26, 0xac,
+	0xed, 0x27, 0xbd, 0x78, 0x10, 0xc8, 0x68, 0x05, 0xe1, 0x89, 0x99, 0x8a, 0x13, 0x52, 0xe7, 0xbe,
+	0xce, 0xa3, 0xf2, 0x62, 0xc8, 0x6c, 0xc1, 0x12, 0x49, 0x04, 0xa7, 0x24, 0xbf, 0xcc, 0x90, 0xab,
+	0x1f, 0x4f, 0xae, 0x7a, 0x3c, 0xa9, 0x39, 0x8f, 0x73, 0x15, 0x67, 0x07, 0x2e, 0x48, 0x41, 0xf9,
+	0x41, 0x20, 0xa8, 0x16, 0x48, 0xaa, 0xb5, 0x73, 0x07, 0x1a, 0x23, 0xa0, 0x71, 0xbd, 0x09, 0x55,
+	0xf9, 0x34, 0x33, 0x23, 0xef, 0x34, 0xbf, 0xea, 0xbb, 0xb3, 0x0a, 0x2b, 0x1d, 0x9a, 0xe4, 0x77,
+	0x87, 0x73, 0x64, 0x41, 0xbd, 0xc3, 0x92, 0xd1, 0xd4, 0xee, 0xc0, 0x85, 0xbc, 0xdd, 0x1e, 0x74,
+	0xf6, 0x1f, 0xfa, 0x69, 0x1e, 0xca, 0xc6, 0xc9, 0x63, 0x36, 0xaf, 0x48, 0x57, 0x2b, 0xb6, 0xab,
+	0x72, 0xc0, 0xe3, 0x49, 0x38, 0xfa, 0x1c, 0x96, 0x0e, 0x0e, 0xda, 0xca, 0xd2, 0xfc, 0x4c, 0x96,
+	0x72, 0x18, 0xba, 0x07, 0x4b, 0xcf, 0xd4, 0xe3, 0x36, 0x33, 0x43, 0xf8, 0x94, 0x92, 0xd3, 0x81,
+	0x6a, 0x35, 0x4c, 0x7a, 0x8c, 0x07, 0x38, 0x07, 0x6d, 0xff, 0xbd, 0x00, 0xb5, 0x83, 0x83, 0x76,
+	0x9b, 0xd3, 0x20, 0x22, 0xe8, 0x17, 0x0b, 0xd0, 0xc9, 0x6b, 0x0b, 0xdd, 0x2c, 0xef, 0xa0, 0xd3,
+	0xef, 0x5e, 0xfb, 0xd6, 0x8c, 0x28, 0x93, 0xe5, 0xe7, 0xb0, 0xa0, 0x3a, 0x1c, 0x7d, 0x74, 0xce,
+	0xeb, 0xc4, 0x6e, 0x4d, 0x57, 0x34, 0xb6, 0x7b, 0xb0, 0x9c, 0x77, 0x09, 0xba, 0x5a, 0x4a, 0x6f,
+	0x6c, 0x08, 0xd8, 0xd7, 0xce, 0xa5, 0x6b, 0x9c, 0x7c, 0x0f, 0x4b, 0xa6, 0xf8, 0xd1, 0x95, 0x29,
+	0xb8, 0x51, 0x1b, 0xda, 0x57, 0xcf, 0xa3, 0x3a, 0x0a, 0x23, 0x2f, 0xf2, 0xd2, 0x30, 0x26, 0x5a,
+	0xa8, 0x34, 0x8c, 0x13, 0x5d, 0xf3, 0x0c, 0xaa, 0xb2, 0x1b, 0xd0, 0x66, 0x09, 0xa8, 0xd0, 0x2e,
+	0x76, 0xd9, 0x71, 0x8d, 0xb5, 0xd1, 0x77, 0xf2, 0x75, 0xab, 0x6e, 0xdf, 0x56, 0x69, 0xcc, 0x85,
+	0xc7, 0xa5, 0x7d, 0xe5, 0x1c, 0x9a, 0xda, 0x7c, 0xbb, 0xfe, 0xe6, 0x68, 0xdd, 0xfa, 0xe7, 0x68,
+	0xdd, 0xfa, 0xef, 0x68, 0xdd, 0xea, 0x2e, 0xaa, 0xff, 0x63, 0x37, 0xfe, 0x0f, 0x00, 0x00, 0xff,
+	0xff, 0xbd, 0xb4, 0x1b, 0xf0, 0xe1, 0x0e, 0x00, 0x00,
 }

--- a/frontend/gateway/pb/gateway.proto
+++ b/frontend/gateway/pb/gateway.proto
@@ -30,14 +30,26 @@ service LLBBridge {
 
 message Result {
 	oneof result {
-		string ref = 1;
-		RefMap refs = 2;
+    		// Deprecated non-array refs.
+		string refDeprecated = 1;
+		RefMapDeprecated refsDeprecated = 2;
+
+		Ref ref = 3;
+		RefMap refs = 4;
 	}
 	map<string, bytes> metadata = 10;
 }
 
-message RefMap {
+message RefMapDeprecated {
 	map<string, string> refs = 1;
+}
+
+message Ref {
+	repeated string ids = 1;
+}
+
+message RefMap {
+	map<string, Ref> refs = 1;
 }
 
 message ReturnRequest {
@@ -70,6 +82,7 @@ message SolveRequest {
         // for each of the ImportCacheRefs entry to CacheImports for compatibility. (planned to be removed)
 	repeated string ImportCacheRefsDeprecated = 4;
 	bool allowResultReturn = 5;
+	bool allowResultArrayRef = 6;
 	
 	// apicaps.CapSolveInlineReturn deprecated
 	bool Final = 10;

--- a/frontend/gateway/pb/ref.go
+++ b/frontend/gateway/pb/ref.go
@@ -1,0 +1,9 @@
+package moby_buildkit_v1_frontend
+
+func NewRef(id string) *Ref {
+	var ref Ref
+	if id != "" {
+		ref.Ids = append(ref.Ids, id)
+	}
+	return &ref
+}


### PR DESCRIPTION
Partially fixes #871 

It moves non-array `ref` and `refs` map to array types while maintaining backwards compatibility. We need to detect clients without array ref capability (server need to detect client cap so `apicap` can't be used here), so `AllowResultArrayRef` was added.

Previous proto fields `Result_Ref` and `Result_RefMap` was moved to `Result_RefDeprecated` and `Result_RefMapDeprecated` respectively.

Some open questions:
1. Should we change the following struct/interfaces in this PR too?
https://github.com/moby/buildkit/blob/5c9365b6f4c2232a2d743a5792a2e708d7790fc4/frontend/result.go#L5-L9
https://github.com/moby/buildkit/blob/5c9365b6f4c2232a2d743a5792a2e708d7790fc4/frontend/gateway/client/result.go#L12-L17
2. In order to implement #751 after this PR, we need to add edge digests for each ref ID. Are you envisioning something like this?
```proto
message Ref {
	repeated string ids = 1;
	repeated string edgeDigests = 2;
}
```
3. Where should we write tests?