### PR TITLE
frontend/dockerfile: show original stagename in error-message

### DIFF
--- a/frontend/dockerfile/instructions/parse.go
+++ b/frontend/dockerfile/instructions/parse.go
@@ -297,7 +297,7 @@ func parseBuildStageName(args []string) (string, error) {
 	case len(args) == 3 && strings.EqualFold(args[1], "as"):
 		stageName = strings.ToLower(args[2])
 		if ok, _ := regexp.MatchString("^[a-z][a-z0-9-_\\.]*$", stageName); !ok {
-			return "", errors.Errorf("invalid name for build stage: %q, name can't start with a number or contain symbols", stageName)
+			return "", errors.Errorf("invalid name for build stage: %q, name can't start with a number or contain symbols", args[2])
 		}
 	case len(args) != 1:
 		return "", errors.New("FROM requires either one or three arguments")


### PR DESCRIPTION
Before this change, the error message would show the invalid name in lowercase:

    docker build -<<'EOF'
    FROM busybox AS foo:$BAR
    EOF

    [+] Building 0.2s (2/2) FINISHED
    => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                                                                             0.0s
    => => transferring dockerfile: 67B                                                                                                                                                                                                                                                                                                                              0.0s
    => [internal] load .dockerignore                                                                                                                                                                                                                                                                                                                                0.1s
    => => transferring context: 2B                                                                                                                                                                                                                                                                                                                                  0.0s
    failed to solve with frontend dockerfile.v0: failed to create LLB definition: Dockerfile parse error line 1: invalid name for build stage: "foo:$bar", name can't start with a number or contain symbols

With this patch, the invalid stagename is shown as-is
