### PR TITLE
exporter: support compression for layer blob data

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Keys supported by image output:
 * `unpack=true`: unpack image after creation (for use with containerd)
 * `dangling-name-prefix=[value]`: name image with `prefix@<digest>` , used for anonymous images
 * `name-canonical=true`: add additional canonical name `name@<digest>`
+* `compression=[uncompressed,gzip]`: choose compression type for layer, gzip is default value
 
 
 If credentials are required, `buildctl` will attempt to read Docker configuration file `$DOCKER_CONFIG/config.json`.

--- a/cache/blobs/compression.go
+++ b/cache/blobs/compression.go
@@ -1,0 +1,122 @@
+package blobs
+
+import (
+	"bytes"
+	"context"
+	"io"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/images"
+	"github.com/moby/buildkit/cache"
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+// CompressionType represents compression type for blob data.
+type CompressionType int
+
+const (
+	// Uncompressed indicates no compression.
+	Uncompressed CompressionType = iota
+
+	// Gzip is used for blob data.
+	Gzip
+
+	// UnknownCompression means not supported yet.
+	UnknownCompression CompressionType = -1
+)
+
+var DefaultCompression = Gzip
+
+func (ct CompressionType) String() string {
+	switch ct {
+	case Uncompressed:
+		return "uncompressed"
+	case Gzip:
+		return "gzip"
+	default:
+		return "unknown"
+	}
+}
+
+// DetectCompressionType returns media type from existing blob data.
+func DetectLayerMediaType(ctx context.Context, cs content.Store, id digest.Digest, oci bool) (string, error) {
+	ra, err := cs.ReaderAt(ctx, ocispec.Descriptor{Digest: id})
+	if err != nil {
+		return "", err
+	}
+	defer ra.Close()
+
+	ct, err := detectCompressionType(content.NewReader(ra))
+	if err != nil {
+		return "", err
+	}
+
+	switch ct {
+	case Uncompressed:
+		if oci {
+			return ocispec.MediaTypeImageLayer, nil
+		} else {
+			return images.MediaTypeDockerSchema2Layer, nil
+		}
+	case Gzip:
+		if oci {
+			return ocispec.MediaTypeImageLayerGzip, nil
+		} else {
+			return images.MediaTypeDockerSchema2LayerGzip, nil
+		}
+	default:
+		return "", errors.Errorf("failed to detect layer %v compression type", id)
+	}
+}
+
+// detectCompressionType detects compression type from real blob data.
+func detectCompressionType(cr io.Reader) (CompressionType, error) {
+	var buf [10]byte
+	var n int
+	var err error
+
+	if n, err = cr.Read(buf[:]); err != nil && err != io.EOF {
+		// Note: we'll ignore any io.EOF error because there are some
+		// odd cases where the layer.tar file will be empty (zero bytes)
+		// and we'll just treat it as a non-compressed stream and that
+		// means just create an empty layer.
+		//
+		// See issue docker/docker#18170
+		return UnknownCompression, err
+	}
+
+	for c, m := range map[CompressionType][]byte{
+		Gzip: {0x1F, 0x8B, 0x08},
+	} {
+		if n < len(m) {
+			continue
+		}
+		if bytes.Equal(m, buf[:len(m)]) {
+			return c, nil
+		}
+	}
+	return Uncompressed, nil
+}
+
+// GetMediaTypeForLayers retrieves media type for layer from ref information.
+func GetMediaTypeForLayers(diffPairs []DiffPair, ref cache.ImmutableRef) []string {
+	tref := ref
+
+	layerTypes := make([]string, 0, len(diffPairs))
+	for _, dp := range diffPairs {
+		if tref == nil {
+			return nil
+		}
+
+		info := tref.Info()
+		if !(info.DiffID == dp.DiffID && info.Blob == dp.Blobsum) {
+			return nil
+		}
+
+		layerTypes = append(layerTypes, info.MediaType)
+		tref = tref.Parent()
+	}
+	return layerTypes
+}

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -45,7 +45,7 @@ type ImageWriter struct {
 	opt WriterOpt
 }
 
-func (ic *ImageWriter) Commit(ctx context.Context, inp exporter.Source, oci bool) (*ocispec.Descriptor, error) {
+func (ic *ImageWriter) Commit(ctx context.Context, inp exporter.Source, oci bool, compression blobs.CompressionType) (*ocispec.Descriptor, error) {
 	platformsBytes, ok := inp.Metadata[exptypes.ExporterPlatformsKey]
 
 	if len(inp.Refs) > 0 && !ok {
@@ -53,7 +53,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp exporter.Source, oci bool
 	}
 
 	if len(inp.Refs) == 0 {
-		layers, err := ic.exportLayers(ctx, inp.Ref)
+		layers, err := ic.exportLayers(ctx, compression, inp.Ref)
 		if err != nil {
 			return nil, err
 		}
@@ -76,7 +76,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp exporter.Source, oci bool
 		refs = append(refs, r)
 	}
 
-	layers, err := ic.exportLayers(ctx, refs...)
+	layers, err := ic.exportLayers(ctx, compression, refs...)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +141,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp exporter.Source, oci bool
 	return &idxDesc, nil
 }
 
-func (ic *ImageWriter) exportLayers(ctx context.Context, refs ...cache.ImmutableRef) ([][]blobs.DiffPair, error) {
+func (ic *ImageWriter) exportLayers(ctx context.Context, compression blobs.CompressionType, refs ...cache.ImmutableRef) ([][]blobs.DiffPair, error) {
 	eg, ctx := errgroup.WithContext(ctx)
 	layersDone := oneOffProgress(ctx, "exporting layers")
 
@@ -150,7 +150,7 @@ func (ic *ImageWriter) exportLayers(ctx context.Context, refs ...cache.Immutable
 	for i, ref := range refs {
 		func(i int, ref cache.ImmutableRef) {
 			eg.Go(func() error {
-				diffPairs, err := blobs.GetDiffPairs(ctx, ic.opt.ContentStore, ic.opt.Differ, ref, true)
+				diffPairs, err := blobs.GetDiffPairs(ctx, ic.opt.ContentStore, ic.opt.Differ, ref, true, compression)
 				if err != nil {
 					return errors.Wrap(err, "failed calculating diff pairs for exported snapshot")
 				}
@@ -192,14 +192,12 @@ func (ic *ImageWriter) commitDistributionManifest(ctx context.Context, ref cache
 		configDigest = digest.FromBytes(config)
 		manifestType = ocispec.MediaTypeImageManifest
 		configType   = ocispec.MediaTypeImageConfig
-		layerType    = ocispec.MediaTypeImageLayerGzip
 	)
 
 	// Use docker media types for older Docker versions and registries
 	if !oci {
 		manifestType = images.MediaTypeDockerSchema2Manifest
 		configType = images.MediaTypeDockerSchema2Config
-		layerType = images.MediaTypeDockerSchema2LayerGzip
 	}
 
 	mfst := struct {
@@ -226,11 +224,31 @@ func (ic *ImageWriter) commitDistributionManifest(ctx context.Context, ref cache
 		"containerd.io/gc.ref.content.0": configDigest.String(),
 	}
 
+	layerMediaTypes := blobs.GetMediaTypeForLayers(diffPairs, ref)
+	cs := ic.opt.ContentStore
 	for i, dp := range diffPairs {
-		info, err := ic.opt.ContentStore.Info(ctx, dp.Blobsum)
+		info, err := cs.Info(ctx, dp.Blobsum)
 		if err != nil {
 			return nil, errors.Wrapf(err, "could not find blob %s from contentstore", dp.Blobsum)
 		}
+
+		var layerType string
+		if len(layerMediaTypes) > i {
+			layerType = layerMediaTypes[i]
+		}
+
+		// NOTE: The media type might be missing for some migrated ones
+		// from before lease based storage. If so, we should detect
+		// the media type from blob data.
+		//
+		// Discussion: https://github.com/moby/buildkit/pull/1277#discussion_r352795429
+		if layerType == "" {
+			layerType, err = blobs.DetectLayerMediaType(ctx, cs, dp.Blobsum, oci)
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		mfst.Layers = append(mfst.Layers, ocispec.Descriptor{
 			Digest:    dp.Blobsum,
 			Size:      info.Size,


### PR DESCRIPTION
Allow user to choose the compression type for layer data. Gzip is
default compression for layer exporter, which consume more Cpu resources
and take long time to export. With compression option, user can use
nocompressed option to export to save time. And future, zstd is one new
option for end-user.

Signed-off-by: Wei Fu <fuweid89@gmail.com>