### PR TITLE
Fix issue #1230 (add --oci-worker-binary)

### DIFF
--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -76,6 +76,8 @@ type OCIConfig struct {
 	// UserRemapUnsupported is unsupported key for testing. The feature is
 	// incomplete and the intention is to make it default without config.
 	UserRemapUnsupported string `toml:"userRemapUnsupported"`
+	// For use in storing the OCI worker binary name that will replace buildkit-runc
+	Binary        	 string            `toml:"binary"`
 }
 
 type ContainerdConfig struct {

--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -77,7 +77,7 @@ type OCIConfig struct {
 	// incomplete and the intention is to make it default without config.
 	UserRemapUnsupported string `toml:"userRemapUnsupported"`
 	// For use in storing the OCI worker binary name that will replace buildkit-runc
-	Binary        	 string            `toml:"binary"`
+	Binary string `toml:"binary"`
 }
 
 type ContainerdConfig struct {

--- a/cmd/buildkitd/main_oci_worker.go
+++ b/cmd/buildkitd/main_oci_worker.go
@@ -70,6 +70,11 @@ func init() {
 			Usage: "path of cni binary files",
 			Value: defaultConf.Workers.OCI.NetworkConfig.CNIBinaryPath,
 		},
+		cli.StringFlag{
+			Name:  "oci-worker-binary",
+			Usage: "name of specified oci worker binary",
+			Value: defaultConf.Workers.OCI.Binary,
+		},
 	}
 	n := "oci-worker-rootless"
 	u := "enable rootless mode"
@@ -180,6 +185,9 @@ func applyOCIFlags(c *cli.Context, cfg *config.Config) error {
 	if c.GlobalIsSet("oci-cni-binary-dir") {
 		cfg.Workers.OCI.NetworkConfig.CNIBinaryPath = c.GlobalString("oci-cni-binary-dir")
 	}
+	if c.GlobalIsSet("oci-worker-binary") {
+		cfg.Workers.OCI.Binary = c.GlobalString("oci-worker-binary")
+	}
 	return nil
 }
 
@@ -232,7 +240,7 @@ func ociWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([]worker
 		},
 	}
 
-	opt, err := runc.NewWorkerOpt(common.config.Root, snFactory, cfg.Rootless, processMode, cfg.Labels, idmapping, nc, dns)
+	opt, err := runc.NewWorkerOpt(common.config.Root, snFactory, cfg.Rootless, processMode, cfg.Labels, idmapping, nc, dns, cfg.Binary)
 	if err != nil {
 		return nil, err
 	}

--- a/docs/buildkitd.toml.md
+++ b/docs/buildkitd.toml.md
@@ -46,7 +46,9 @@ insecure-entitlements = [ "network.host", "security.insecure" ]
   noProcessSandbox = false
   gc = true
   gckeepstorage = 9000
-  binary = "" # OCI worker binary name, default binary is buildkit-runc
+  # alternate OCI worker binary name(example 'crun'), by default either 
+  # buildkit-runc or runc binary is used
+  binary = ""
   [worker.oci.labels]
     "foo" = "bar"
 

--- a/docs/buildkitd.toml.md
+++ b/docs/buildkitd.toml.md
@@ -46,6 +46,7 @@ insecure-entitlements = [ "network.host", "security.insecure" ]
   noProcessSandbox = false
   gc = true
   gckeepstorage = 9000
+  binary = "" # OCI worker binary name, default binary is buildkit-runc
   [worker.oci.labels]
     "foo" = "bar"
 

--- a/worker/runc/runc_test.go
+++ b/worker/runc/runc_test.go
@@ -40,7 +40,7 @@ func newWorkerOpt(t *testing.T, processMode oci.ProcessMode) (base.WorkerOpt, fu
 		},
 	}
 	rootless := false
-	workerOpt, err := NewWorkerOpt(tmpdir, snFactory, rootless, processMode, nil, nil, netproviders.Opt{Mode: "host"}, nil)
+	workerOpt, err := NewWorkerOpt(tmpdir, snFactory, rootless, processMode, nil, nil, netproviders.Opt{Mode: "host"}, nil, "")
 	require.NoError(t, err)
 
 	return workerOpt, cleanup


### PR DESCRIPTION
To support switching the OCI worker binary via buildkitd and without modifying the Dockerfile, an optional command-line flag was added to main_oci_worker.go that allowed for input the name of an OCI worker binary (ex. crun). This OCI worker binary would then replace the current buildkit-runc with a symbolic link to that binary. The above was done using the os/exec package's Command func.

fix #1230 

Signed-off-by: Jeffrey Huang <jeffreyhuang23@gmail.com>