### PR TITLE
Fixed issue #1200 (buildctl: add --tlsdir)

### DIFF
--- a/cmd/buildctl/common/common.go
+++ b/cmd/buildctl/common/common.go
@@ -3,10 +3,13 @@ package common
 import (
 	"context"
 	"net/url"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/moby/buildkit/client"
 	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
 
@@ -21,9 +24,41 @@ func ResolveClient(c *cli.Context) (*client.Client, error) {
 		}
 		serverName = uri.Hostname()
 	}
-	caCert := c.GlobalString("tlscacert")
-	cert := c.GlobalString("tlscert")
-	key := c.GlobalString("tlskey")
+
+	var caCert string
+	var cert string
+	var key string
+
+	tlsDir := c.GlobalString("tlsdir")
+
+	if tlsDir != "" {
+		// Look for ca.pem and, if it exists, set caCert to that
+		// Look for cert.pem and, if it exists, set key to that
+		// Look for key.pem and, if it exists, set tlsDir to that
+		for _, v := range [3]string{"ca.pem", "cert.pem", "key.pem"} {
+			file := filepath.Join(tlsDir, v)
+			if _, err := os.Stat(file); err == nil {
+				switch v {
+				case "ca.pem":
+					caCert = file
+				case "cert.pem":
+					cert = file
+				case "key.pem":
+					key = file
+				}
+			} else {
+				return nil, err
+			}
+		}
+
+		if c.GlobalString("tlscacert") != "" || c.GlobalString("tlscert") != "" || c.GlobalString("tlskey") != "" {
+			return nil, errors.New("cannot specify tlsdir and tlscacert/tlscert/tlskey at the same time")
+		}
+	} else {
+		caCert = c.GlobalString("tlscacert")
+		cert = c.GlobalString("tlscert")
+		key = c.GlobalString("tlskey")
+	}
 
 	opts := []client.ClientOpt{client.WithFailFast()}
 

--- a/cmd/buildctl/main.go
+++ b/cmd/buildctl/main.go
@@ -63,6 +63,11 @@ func main() {
 			Usage: "client key",
 			Value: "",
 		},
+		cli.StringFlag{
+			Name:  "tlsdir",
+			Usage: "directory containing CA certificate, client certificate, and client key",
+			Value: "",
+		},
 		cli.IntFlag{
 			Name:  "timeout",
 			Usage: "timeout backend connection after value seconds",


### PR DESCRIPTION
Added a command-line flag (tlsdir) to buildctl that allowed for specifying a directory that contains a ca.pem, cert.pem, and key.pem. This command-line flag acts an alias of --tlscacert, --tlscert, and --tlskey. --tlsdir cannot be used at the same time as those flags, and will cause an error if done. The pkg/errors package has been added to cmd/buildctl/common/common.go to allow for the creation of this error message.

fix #1200

Signed-off-by: Jeffrey Huang <jeffreyhuang23@gmail.com>