### PR TITLE
Fix issue #1240 (ignore non-existent local cache)

### DIFF
--- a/client/solve.go
+++ b/client/solve.go
@@ -414,7 +414,6 @@ func parseCacheOptions(opt SolveOpt) (*cacheOptions, error) {
 			}
 			contentStores["local:"+csDir] = cs
 
-			
 		}
 		if im.Type == "registry" {
 			legacyImportRef := attrs["ref"]

--- a/client/solve.go
+++ b/client/solve.go
@@ -407,10 +407,30 @@ func parseCacheOptions(opt SolveOpt) (*cacheOptions, error) {
 		attrs := im.Attrs
 		if im.Type == "local" {
 			csDir := im.Attrs["src"]
-			cs, err := loadLocalImportCacheStore(attrs)
+			if csDir == "" {
+				return nil, errors.New("local cache importer requires src")
+			}
+			cs, err := contentlocal.NewStore(csDir)
 			if err != nil {
 				logrus.Warning("local cache import at " + csDir + " not found due to err: " + err.Error())
 				continue
+			}
+			// if digest is not specified, load from "latest" tag
+			if attrs["digest"] == "" {
+				idx, err := ociindex.ReadIndexJSONFileLocked(filepath.Join(csDir, "index.json"))
+				if err != nil {
+					logrus.Warning("local cache import at " + csDir + " not found due to err: " + err.Error())
+					continue
+				}
+				for _, m := range idx.Manifests {
+					if m.Annotations[ocispec.AnnotationRefName] == "latest" {
+						attrs["digest"] = string(m.Digest)
+						break
+					}
+				}
+				if attrs["digest"] == "" {
+					return nil, errors.New("local cache importer requires either explicit digest or \"latest\" tag on index.json")
+				}
 			}
 			contentStores["local:"+csDir] = cs
 
@@ -454,32 +474,4 @@ func parseCacheOptions(opt SolveOpt) (*cacheOptions, error) {
 		frontendAttrs:   frontendAttrs,
 	}
 	return &res, nil
-}
-
-func loadLocalImportCacheStore(attrs map[string]string) (content.Store, error) {
-	csDir := attrs["src"]
-	if csDir == "" {
-		return nil, errors.New("local cache importer requires src")
-	}
-	cs, err := contentlocal.NewStore(csDir)
-	if err != nil {
-		return nil, err
-	}
-	// if digest is not specified, load from "latest" tag
-	if attrs["digest"] == "" {
-		idx, err := ociindex.ReadIndexJSONFileLocked(filepath.Join(csDir, "index.json"))
-		if err != nil {
-			return nil, err
-		}
-		for _, m := range idx.Manifests {
-			if m.Annotations[ocispec.AnnotationRefName] == "latest" {
-				attrs["digest"] = string(m.Digest)
-				break
-			}
-		}
-		if attrs["digest"] == "" {
-			return nil, errors.New("local cache importer requires either explicit digest or \"latest\" tag on index.json")
-		}
-	}
-	return cs, nil
 }


### PR DESCRIPTION
Allow build to run even if import cache of type=local is not found
Added an additional check in solve.go to catch errors thrown when
local import caches are not found. If none are found, continues as
if no import cache was specified.

fix #1240

Signed-off-by: Nikhil Pandeti <nikhil.pandeti@utexas.edu>