### PR TITLE
support specifying a custom tag using --import-cache type=local

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ The directory layout conforms to OCI Image Spec v1.0.
 -   `ref=docker.io/user/image:tag`: reference for `registry` cache importer
 -   `src=path/to/input-dir`: directory for `local` cache importer
 -   `digest=sha256:deadbeef`: digest of the manifest list to import for `local` cache importer.
+-   `tag=customtag`: custom tag of image for `local` cache importer.
     Defaults to the digest of "latest" tag in `index.json`
 
 ### Consistent hashing

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ The directory layout conforms to OCI Image Spec v1.0.
 -   `src=path/to/input-dir`: directory for `local` cache importer
 -   `digest=sha256:deadbeef`: digest of the manifest list to import for `local` cache importer.
 -   `tag=customtag`: custom tag of image for `local` cache importer.
-    Defaults to the digest of "latest" tag in `index.json`
+    Defaults to the digest of "latest" tag in `index.json` is for digest, not for tag
 
 ### Consistent hashing
 

--- a/client/solve.go
+++ b/client/solve.go
@@ -423,13 +423,13 @@ func parseCacheOptions(opt SolveOpt) (*cacheOptions, error) {
 					continue
 				}
 				for _, m := range idx.Manifests {
-					if m.Annotations[ocispec.AnnotationRefName] == "latest" {
+					if (m.Annotations[ocispec.AnnotationRefName] == "latest" && attrs["tag"] == "") || (attrs["tag"] != "" && m.Annotations[ocispec.AnnotationRefName] == attrs["tag"]) {
 						attrs["digest"] = string(m.Digest)
 						break
 					}
 				}
 				if attrs["digest"] == "" {
-					return nil, errors.New("local cache importer requires either explicit digest or \"latest\" tag on index.json")
+					return nil, errors.New("local cache importer requires either explicit digest, \"latest\" tag or custom tag on index.json")
 				}
 			}
 			contentStores["local:"+csDir] = cs


### PR DESCRIPTION
Fix #1242

When `--import-cache type = local` is specified, if a custom tag is included, the cache can be used.