### PR TITLE
Low-hanging Windows fruit

### DIFF
--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -173,7 +173,9 @@ func main() {
 	app.Flags = append(app.Flags, appFlags...)
 
 	app.Action = func(c *cli.Context) error {
-		if os.Geteuid() != 0 {
+		// TODO: On Windows this always returns -1. The actual "are you admin" check is very Windows-specific.
+		// See https://github.com/golang/go/issues/28804#issuecomment-505326268 for the "short" version.
+		if os.Geteuid() > 0 {
 			return errors.New("rootless mode requires to be executed as the mapped root in a user namespace; you may use RootlessKit for setting up the namespace")
 		}
 		ctx, cancel := context.WithCancel(appcontext.Context())

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -495,7 +495,7 @@ func getListener(addr string, uid, gid int, tlsConfig *tls.Config) (net.Listener
 	proto := addrSlice[0]
 	listenAddr := addrSlice[1]
 	switch proto {
-	case "unix":
+	case "unix", "npipe":
 		if tlsConfig != nil {
 			logrus.Warnf("TLS is disabled for %s", addr)
 		}
@@ -506,7 +506,6 @@ func getListener(addr string, uid, gid int, tlsConfig *tls.Config) (net.Listener
 		}
 		return sockets.NewTCPSocket(listenAddr, tlsConfig)
 	default:
-		// TODO: support npipe (with TLS?)
 		return nil, errors.Errorf("addr %s not supported", addr)
 	}
 }

--- a/executor/containerdexecutor/executor.go
+++ b/executor/containerdexecutor/executor.go
@@ -193,7 +193,12 @@ func (w containerdExecutor) Exec(ctx context.Context, meta executor.Meta, root c
 				cancel()
 			}
 			if status.ExitCode() != 0 {
-				err := errors.Errorf("process returned non-zero exit code: %d", status.ExitCode())
+				var err error
+				if status.ExitCode() == containerd.UnknownExitStatus && status.Error() != nil {
+					err = errors.Wrap(status.Error(), "failure waiting for process")
+				} else {
+					err = errors.Errorf("process returned non-zero exit code: %d", status.ExitCode())
+				}
 				select {
 				case <-ctx.Done():
 					err = errors.Wrap(ctx.Err(), err.Error())

--- a/util/appdefaults/appdefaults_windows.go
+++ b/util/appdefaults/appdefaults_windows.go
@@ -1,9 +1,17 @@
 package appdefaults
 
+import (
+	"os"
+	"path/filepath"
+)
+
 const (
-	Address   = "npipe:////./pipe/buildkitd"
-	Root      = ".buildstate"
-	ConfigDir = ""
+	Address = "npipe:////./pipe/buildkitd"
+)
+
+var (
+	Root      = filepath.Join(os.Getenv("ProgramData"), "buildkitd", ".buildstate")
+	ConfigDir = filepath.Join(os.Getenv("ProgramData"), "buildkitd")
 )
 
 func UserAddress() string {

--- a/worker/containerd/containerd.go
+++ b/worker/containerd/containerd.go
@@ -74,7 +74,7 @@ func newContainerd(root string, client *containerd.Client, snapshotterName, ns s
 		return base.WorkerOpt{}, errors.Wrap(err, "failed to list runtime plugin")
 	}
 	if len(resp.Plugins) == 0 {
-		return base.WorkerOpt{}, errors.Wrap(err, "failed to get runtime plugin")
+		return base.WorkerOpt{}, errors.New("failed to find any runtime plugins")
 	}
 
 	var platforms []specs.Platform

--- a/worker/containerd/containerd.go
+++ b/worker/containerd/containerd.go
@@ -69,7 +69,7 @@ func newContainerd(root string, client *containerd.Client, snapshotterName, ns s
 
 	cs := containerdsnapshot.NewContentStore(client.ContentStore(), ns)
 
-	resp, err := client.IntrospectionService().Plugins(context.TODO(), &introspection.PluginsRequest{Filters: []string{"type==io.containerd.runtime.v1"}})
+	resp, err := client.IntrospectionService().Plugins(context.TODO(), &introspection.PluginsRequest{Filters: []string{"type==io.containerd.runtime.v1", "type==io.containerd.runtime.v2"}})
 	if err != nil {
 		return base.WorkerOpt{}, errors.Wrap(err, "failed to list runtime plugin")
 	}


### PR DESCRIPTION
A bunch of small changes that fix blocking issue for supporting Buildkit on Windows against containerd.

This doesn't result in working Windows support, but the remaining areas of support are harder-to-solve, relating (so far) to either container spec generation, various aspects of network namespace handling, or various LLB commands that refuse to work if they cannot do user id mapping.

This is to advance #616, but does not complete it.