### PR TITLE
Exporter: Export metadata as json file in buildctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,13 @@ Keys supported by image output:
 * `dangling-name-prefix=[value]`: name image with `prefix@<digest>` , used for anonymous images
 * `name-canonical=true`: add additional canonical name `name@<digest>`
 * `compression=[uncompressed,gzip]`: choose compression type for layer, gzip is default value
-
+* `metadata-file=[value]`: export image metadata to a json file; the exported metadata json file:
+```
+{
+  "containerimage.digest": "sha256:xx", # image sha256
+  "image.name": "", # built image name
+}
+```
 
 If credentials are required, `buildctl` will attempt to read Docker configuration file `$DOCKER_CONFIG/config.json`.
 `$DOCKER_CONFIG` defaults to `~/.docker`.


### PR DESCRIPTION
write the metadata in resp.ExporterResponse to a json file which is defined in export metadata-file;

buildctl build --frontend dockerfile.v0 --opt filename=Dockerfile -local context=. --local dockerfile=. --output type=image,name=test:1,metadata-file=index.json

Related: #1158

Signed-off-by: genglu <genglu.gl@antfin.com>