### PR TITLE
fix baseimage with unknown application/octet-stream as config media type

### DIFF
--- a/util/imageutil/config.go
+++ b/util/imageutil/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/reference"
 	"github.com/containerd/containerd/remotes"
+	"github.com/containerd/containerd/remotes/docker"
 	"github.com/moby/buildkit/util/leaseutil"
 	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -152,7 +153,7 @@ func childrenConfigHandler(provider content.Provider, platform platforms.MatchCo
 			} else {
 				descs = append(descs, index.Manifests...)
 			}
-		case images.MediaTypeDockerSchema2Config, specs.MediaTypeImageConfig:
+		case images.MediaTypeDockerSchema2Config, specs.MediaTypeImageConfig, docker.LegacyConfigMediaType:
 			// childless data types.
 			return nil, nil
 		default:


### PR DESCRIPTION
When built image with Dockerfile and  the BaseImage was built and push by an older versions Docker which wrongly used application/octet-stream as the media type.
The build job will failed: 
`error: failed to solve: rpc error: code = Unknown desc = failed to solve with frontend dockerfile.v0: failed to build LLB: failed to load cache key: encountered unknown type application/octet-stream; children may not be fetched`

[docker distribution ##2243](https://github.com/docker/distribution/issues/2243)
[docker distribution ##1621](https://github.com/docker/distribution/issues/1621)

Signed-off-by: genglu <genglu.gl@antfin.com>