### PR TITLE
solver: avoid panic on combined cache load

### DIFF
--- a/solver/combinedcache.go
+++ b/solver/combinedcache.go
@@ -87,6 +87,9 @@ func (cm *combinedCacheManager) Load(ctx context.Context, rec *CacheRecord) (res
 			}
 		}
 	}
+	if len(results) == 0 { // TODO: handle gracefully
+		return nil, errors.Errorf("failed to load deleted cache")
+	}
 	return results[0].Result, nil
 }
 


### PR DESCRIPTION
fix #1319

Avoid panic on race from the combined cache. There is still an issue as the error should be handled gracefully but at least avoid panic atm.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>