### PR TITLE
Detect support for protobuf array ref on server on frontend return call

### DIFF
--- a/frontend/gateway/pb/caps.go
+++ b/frontend/gateway/pb/caps.go
@@ -19,6 +19,11 @@ const (
 	CapReadDir                 apicaps.CapID = "readdir"
 	CapStatFile                apicaps.CapID = "statfile"
 	CapImportCaches            apicaps.CapID = "importcaches"
+
+	// CapProtoRefArray is a capability to return arrays of refs instead of single
+	// refs. This capability is only for the wire format change and shouldn't be
+	// used in frontends for feature detection.
+	CapProtoRefArray apicaps.CapID = "proto.refarray"
 )
 
 func init() {
@@ -89,6 +94,13 @@ func init() {
 	Caps.Init(apicaps.Cap{
 		ID:      CapImportCaches,
 		Name:    "import caches",
+		Enabled: true,
+		Status:  apicaps.CapStatusExperimental,
+	})
+
+	Caps.Init(apicaps.Cap{
+		ID:      CapProtoRefArray,
+		Name:    "wire format ref arrays",
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})

--- a/solver/pb/caps.go
+++ b/solver/pb/caps.go
@@ -288,5 +288,4 @@ func init() {
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})
-
 }


### PR DESCRIPTION
Fixes #1327
Fixes #1321 
Regression introduced by: https://github.com/moby/buildkit/pull/1269

When using frontend built from regression commit and beyond, the frontend does not check for a server capability for ref arrays and sends ref arrays to the return API.

This PR, adds the apicap `CapProtoRefArray` and sends the appropriate ref/refarray to the return API depending on the apicap.

---

Reproduced with following steps:

Build the frontend from `master` of this repository:
```sh
$ DOCKER_BUILDKIT="1" docker build -t docker/dockerfile-upstream:regress -f ./frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile .
```

Then building an image using `Docker 19.03` (with an older buildkitd):
```Dockerfile
# syntax=docker/dockerfile-upstream:regress
FROM alpine
```

Inspecting the image:
```sh
$ docker inspect -f "{{.RootFS.Layers}}" reproduction:regress
[]
```

With the changes in this PR:
```sh
$ docker inspect -f "{{.RootFS.Layers}}" reproduction:regress
[sha256:77cae8ab23bf486355d1b3191259705374f4a11d483b24964d2f729dd8c076a0]
```