### PR TITLE
[v0.6 backport] vendor: update fsutil 0f039a052ca1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/sirupsen/logrus v1.3.0
 	github.com/stretchr/testify v1.3.0
 	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 // indirect
-	github.com/tonistiigi/fsutil v0.0.0-20190819224149-3d2716dd0a4d
+	github.com/tonistiigi/fsutil v0.0.0-20191018213012-0f039a052ca1
 	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea
 	github.com/uber/jaeger-client-go v0.0.0-20180103221425-e02c85f9069e
 	github.com/uber/jaeger-lib v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 h1:b6uOv7YOFK0TYG7HtkIgExQo+2RdLuwRft63jn2HWj8=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
-github.com/tonistiigi/fsutil v0.0.0-20190819224149-3d2716dd0a4d h1:HJg27yqwTV7vFG9dWPDbUi373o/bmSDYGN9mZgVwdH0=
-github.com/tonistiigi/fsutil v0.0.0-20190819224149-3d2716dd0a4d/go.mod h1:pzh7kdwkDRh+Bx8J30uqaKJ1M4QrSH/um8fcIXeM8rc=
+github.com/tonistiigi/fsutil v0.0.0-20191018213012-0f039a052ca1 h1:WRlNtJ2whFMKo95/e6uaNuAnn5TxLcMzczqMcfbIDxo=
+github.com/tonistiigi/fsutil v0.0.0-20191018213012-0f039a052ca1/go.mod h1:hP47OZfgT1aNVDJj28EnEKaKg6mjPEoS5Tb4BsWCTPs=
 github.com/tonistiigi/go-immutable-radix v0.0.0-20170803185627-826af9ccf0fe h1:pd7hrFSqUPxYS9IB+UMG1AB/8EXGXo17ssx0bSQ5L6Y=
 github.com/tonistiigi/go-immutable-radix v0.0.0-20170803185627-826af9ccf0fe/go.mod h1:/+MCh11CJf2oz0BXmlmqyopK/ad1rKkcOXPoYuPCJYU=
 github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea h1:SXhTLE6pb6eld/v/cCndK0AMpt1wiVFb/YYmqB3/QG0=
@@ -155,7 +155,6 @@ github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmF
 go.etcd.io/bbolt v1.3.2 h1:Z/90sZLPOeCy2PwprqkFa25PdkusRzaj9P8zm/KNyvk=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
-golang.org/x/crypto v0.0.0-20190129210102-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/vendor/github.com/tonistiigi/fsutil/diff.go
+++ b/vendor/github.com/tonistiigi/fsutil/diff.go
@@ -5,6 +5,7 @@ import (
 	"hash"
 	"os"
 
+	"github.com/pkg/errors"
 	"github.com/tonistiigi/fsutil/types"
 )
 
@@ -25,9 +26,14 @@ func GetWalkerFn(root string) walkerFn {
 				return err
 			}
 
+			stat, ok := f.Sys().(*types.Stat)
+			if !ok {
+				return errors.Errorf("%T invalid file without stat information", f.Sys())
+			}
+
 			p := &currentPath{
 				path: path,
-				f:    f,
+				stat: stat,
 			}
 
 			select {

--- a/vendor/github.com/tonistiigi/fsutil/diff_containerd.go
+++ b/vendor/github.com/tonistiigi/fsutil/diff_containerd.go
@@ -37,12 +37,12 @@ type ChangeFunc func(ChangeKind, string, os.FileInfo, error) error
 
 type currentPath struct {
 	path string
-	f    os.FileInfo
+	stat *types.Stat
 	//	fullPath string
 }
 
 // doubleWalkDiff walks both directories to create a diff
-func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b walkerFn) (err error) {
+func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b walkerFn, filter FilterFunc) (err error) {
 	g, ctx := errgroup.WithContext(ctx)
 
 	var (
@@ -86,14 +86,22 @@ func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b walkerFn) (er
 				continue
 			}
 
-			var f os.FileInfo
-			k, p := pathChange(f1, f2)
+			var f *types.Stat
+			var f2copy *currentPath
+			if f2 != nil {
+				statCopy := *f2.stat
+				if filter != nil {
+					filter(f2.path, &statCopy)
+				}
+				f2copy = &currentPath{path: f2.path, stat: &statCopy}
+			}
+			k, p := pathChange(f1, f2copy)
 			switch k {
 			case ChangeKindAdd:
 				if rmdir != "" {
 					rmdir = ""
 				}
-				f = f2.f
+				f = f2.stat
 				f2 = nil
 			case ChangeKindDelete:
 				// Check if this file is already removed by being
@@ -101,30 +109,30 @@ func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b walkerFn) (er
 				if rmdir != "" && strings.HasPrefix(f1.path, rmdir) {
 					f1 = nil
 					continue
-				} else if rmdir == "" && f1.f.IsDir() {
+				} else if rmdir == "" && f1.stat.IsDir() {
 					rmdir = f1.path + string(os.PathSeparator)
 				} else if rmdir != "" {
 					rmdir = ""
 				}
 				f1 = nil
 			case ChangeKindModify:
-				same, err := sameFile(f1, f2)
+				same, err := sameFile(f1, f2copy)
 				if err != nil {
 					return err
 				}
-				if f1.f.IsDir() && !f2.f.IsDir() {
+				if f1.stat.IsDir() && !f2copy.stat.IsDir() {
 					rmdir = f1.path + string(os.PathSeparator)
 				} else if rmdir != "" {
 					rmdir = ""
 				}
-				f = f2.f
+				f = f2.stat
 				f1 = nil
 				f2 = nil
 				if same {
 					continue loop0
 				}
 			}
-			if err := changeFn(k, p, f, nil); err != nil {
+			if err := changeFn(k, p, &StatInfo{f}, nil); err != nil {
 				return err
 			}
 		}
@@ -159,28 +167,17 @@ func pathChange(lower, upper *currentPath) (ChangeKind, string) {
 
 func sameFile(f1, f2 *currentPath) (same bool, retErr error) {
 	// If not a directory also check size, modtime, and content
-	if !f1.f.IsDir() {
-		if f1.f.Size() != f2.f.Size() {
+	if !f1.stat.IsDir() {
+		if f1.stat.Size_ != f2.stat.Size_ {
 			return false, nil
 		}
 
-		t1 := f1.f.ModTime()
-		t2 := f2.f.ModTime()
-		if t1.UnixNano() != t2.UnixNano() {
+		if f1.stat.ModTime != f2.stat.ModTime {
 			return false, nil
 		}
 	}
 
-	ls1, ok := f1.f.Sys().(*types.Stat)
-	if !ok {
-		return false, nil
-	}
-	ls2, ok := f2.f.Sys().(*types.Stat)
-	if !ok {
-		return false, nil
-	}
-
-	return compareStat(ls1, ls2)
+	return compareStat(f1.stat, f2.stat)
 }
 
 // compareStat returns whether the stats are equivalent,

--- a/vendor/github.com/tonistiigi/fsutil/diskwriter.go
+++ b/vendor/github.com/tonistiigi/fsutil/diskwriter.go
@@ -194,7 +194,7 @@ func (dw *DiskWriter) HandleChange(kind ChangeKind, p string, fi os.FileInfo, er
 
 	if isRegularFile {
 		if dw.opt.AsyncDataCb != nil {
-			dw.requestAsyncFileData(p, destPath, fi)
+			dw.requestAsyncFileData(p, destPath, fi, &statCopy)
 		}
 	} else {
 		return dw.processChange(kind, p, fi, nil)
@@ -203,7 +203,7 @@ func (dw *DiskWriter) HandleChange(kind ChangeKind, p string, fi os.FileInfo, er
 	return nil
 }
 
-func (dw *DiskWriter) requestAsyncFileData(p, dest string, fi os.FileInfo) {
+func (dw *DiskWriter) requestAsyncFileData(p, dest string, fi os.FileInfo, st *types.Stat) {
 	// todo: limit worker threads
 	dw.eg.Go(func() error {
 		if err := dw.processChange(ChangeKindAdd, p, fi, &lazyFileWriter{
@@ -211,7 +211,7 @@ func (dw *DiskWriter) requestAsyncFileData(p, dest string, fi os.FileInfo) {
 		}); err != nil {
 			return err
 		}
-		return chtimes(dest, fi.ModTime().UnixNano()) // TODO: parent dirs
+		return chtimes(dest, st.ModTime) // TODO: parent dirs
 	})
 }
 

--- a/vendor/github.com/tonistiigi/fsutil/go.mod
+++ b/vendor/github.com/tonistiigi/fsutil/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.0.3 // indirect
 	github.com/stretchr/testify v1.3.0
-	golang.org/x/crypto v0.0.0-20190129210102-0709b304e793 // indirect
+	golang.org/x/crypto v0.0.0-20180904163835-0709b304e793 // indirect
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
 	golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect

--- a/vendor/github.com/tonistiigi/fsutil/go.sum
+++ b/vendor/github.com/tonistiigi/fsutil/go.sum
@@ -45,8 +45,8 @@ github.com/sirupsen/logrus v1.0.3/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjM
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-golang.org/x/crypto v0.0.0-20190129210102-0709b304e793 h1:XN3FXXoqhpVVlj/6kSCqFXZoVfu18c8WGW7A8JPiOOk=
-golang.org/x/crypto v0.0.0-20190129210102-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20180904163835-0709b304e793 h1:u+LnwYTOOW7Ukr/fppxEb1Nwz0AtPflrblfvUudpo+I=
+golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd h1:nTDtHvHSdCn1m6ITfMRqtOd/9+7a3s8RBNOZ3eYZzJA=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=

--- a/vendor/github.com/tonistiigi/fsutil/receive.go
+++ b/vendor/github.com/tonistiigi/fsutil/receive.go
@@ -133,7 +133,7 @@ func (r *receiver) run(ctx context.Context) error {
 		if !r.merge {
 			destWalker = GetWalkerFn(r.dest)
 		}
-		err := doubleWalkDiff(ctx, dw.HandleChange, destWalker, w.fill)
+		err := doubleWalkDiff(ctx, dw.HandleChange, destWalker, w.fill, r.filter)
 		if err != nil {
 			return err
 		}
@@ -180,11 +180,11 @@ func (r *receiver) run(ctx context.Context) error {
 					r.mu.Unlock()
 				}
 				i++
-				cp := &currentPath{path: p.Stat.Path, f: &StatInfo{p.Stat}}
-				if err := r.orderValidator.HandleChange(ChangeKindAdd, cp.path, cp.f, nil); err != nil {
+				cp := &currentPath{path: p.Stat.Path, stat: p.Stat}
+				if err := r.orderValidator.HandleChange(ChangeKindAdd, cp.path, &StatInfo{cp.stat}, nil); err != nil {
 					return err
 				}
-				if err := r.hlValidator.HandleChange(ChangeKindAdd, cp.path, cp.f, nil); err != nil {
+				if err := r.hlValidator.HandleChange(ChangeKindAdd, cp.path, &StatInfo{cp.stat}, nil); err != nil {
 					return err
 				}
 				if err := w.update(cp); err != nil {

--- a/vendor/github.com/tonistiigi/fsutil/types/stat.go
+++ b/vendor/github.com/tonistiigi/fsutil/types/stat.go
@@ -1,0 +1,7 @@
+package types
+
+import "os"
+
+func (s Stat) IsDir() bool {
+	return os.FileMode(s.Mode).IsDir()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -233,7 +233,7 @@ github.com/stretchr/testify/require
 github.com/stretchr/testify/assert
 # github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
 github.com/syndtr/gocapability/capability
-# github.com/tonistiigi/fsutil v0.0.0-20190819224149-3d2716dd0a4d
+# github.com/tonistiigi/fsutil v0.0.0-20191018213012-0f039a052ca1
 github.com/tonistiigi/fsutil
 github.com/tonistiigi/fsutil/types
 github.com/tonistiigi/fsutil/copy


### PR DESCRIPTION
backport of https://github.com/moby/buildkit/pull/1317 for the v0.6.x release

full diff: https://github.com/tonistiigi/fsutil/compare/3d2716dd0a4d...0f039a052ca1

- tonistiigi/fsutil#68 fix gocrypto commit
- tonistiigi/fsutil#69 receive: use filter on receive diff
    - prevents incremental transfers with userns because the metadata
      on disk is always different than the one being transferred.
