### PR TITLE
[v0.6] cherry-picks for v0.6.4

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -345,9 +345,10 @@ func Dockerfile2LLB(ctx context.Context, dt []byte, opt ConvertOpt) (*llb.State,
 			opt.copyImage = DefaultCopyImage
 		}
 
-		if err = dispatchOnBuild(d, d.image.Config.OnBuild, opt); err != nil {
+		if err = dispatchOnBuildTriggers(d, d.image.Config.OnBuild, opt); err != nil {
 			return nil, nil, err
 		}
+		d.image.Config.OnBuild = nil
 
 		for _, cmd := range d.commands {
 			if err := dispatch(d, cmd, opt); err != nil {
@@ -586,7 +587,7 @@ type command struct {
 	sources []*dispatchState
 }
 
-func dispatchOnBuild(d *dispatchState, triggers []string, opt dispatchOpt) error {
+func dispatchOnBuildTriggers(d *dispatchState, triggers []string, opt dispatchOpt) error {
 	for _, trigger := range triggers {
 		ast, err := parser.Parse(strings.NewReader(trigger))
 		if err != nil {

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -92,6 +92,7 @@ var allTests = []integration.Test{
 	testDefaultEnvWithArgs,
 	testEnvEmptyFormatting,
 	testCacheMultiPlatformImportExport,
+	testOnBuildCleared,
 }
 
 var fileOpTests = []integration.Test{
@@ -3460,6 +3461,113 @@ LABEL foo=bar
 	v, ok = ociimg.Config.Labels["bar"]
 	require.True(t, ok)
 	require.Equal(t, "baz", v)
+}
+
+func testOnBuildCleared(t *testing.T, sb integration.Sandbox) {
+	f := getFrontend(t, sb)
+
+	registry, err := sb.NewRegistry()
+	if errors.Cause(err) == integration.ErrorRequirements {
+		t.Skip(err.Error())
+	}
+	require.NoError(t, err)
+
+	dockerfile := []byte(`
+FROM busybox
+ONBUILD RUN mkdir -p /out && echo -n 11 >> /out/foo
+`)
+
+	dir, err := tmpdir(
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+	)
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	c, err := client.New(context.TODO(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	target := registry + "/buildkit/testonbuild:base"
+
+	_, err = f.Solve(context.TODO(), c, client.SolveOpt{
+		Exports: []client.ExportEntry{
+			{
+				Type: client.ExporterImage,
+				Attrs: map[string]string{
+					"push": "true",
+					"name": target,
+				},
+			},
+		},
+		LocalDirs: map[string]string{
+			builder.DefaultLocalNameDockerfile: dir,
+			builder.DefaultLocalNameContext:    dir,
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	dockerfile = []byte(fmt.Sprintf(`
+	FROM %s 
+	`, target))
+
+	dir, err = tmpdir(
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+	)
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	target2 := registry + "/buildkit/testonbuild:child"
+
+	_, err = f.Solve(context.TODO(), c, client.SolveOpt{
+		Exports: []client.ExportEntry{
+			{
+				Type: client.ExporterImage,
+				Attrs: map[string]string{
+					"push": "true",
+					"name": target2,
+				},
+			},
+		},
+		LocalDirs: map[string]string{
+			builder.DefaultLocalNameDockerfile: dir,
+			builder.DefaultLocalNameContext:    dir,
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	dockerfile = []byte(fmt.Sprintf(`
+	FROM %s AS base
+	FROM scratch
+	COPY --from=base /out /
+	`, target2))
+
+	dir, err = tmpdir(
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+	)
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	destDir, err := ioutil.TempDir("", "buildkit")
+	require.NoError(t, err)
+	defer os.RemoveAll(destDir)
+
+	_, err = f.Solve(context.TODO(), c, client.SolveOpt{
+		Exports: []client.ExportEntry{
+			{
+				Type:      client.ExporterLocal,
+				OutputDir: destDir,
+			},
+		},
+		LocalDirs: map[string]string{
+			builder.DefaultLocalNameDockerfile: dir,
+			builder.DefaultLocalNameContext:    dir,
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	dt, err := ioutil.ReadFile(filepath.Join(destDir, "foo"))
+	require.NoError(t, err)
+	require.Equal(t, "11", string(dt))
 }
 
 func testCacheMultiPlatformImportExport(t *testing.T, sb integration.Sandbox) {

--- a/session/sshforward/sshprovider/agentprovider.go
+++ b/session/sshforward/sshprovider/agentprovider.go
@@ -178,7 +178,7 @@ type sock struct {
 }
 
 type readOnlyAgent struct {
-	agent.Agent
+	agent.ExtendedAgent
 }
 
 func (a *readOnlyAgent) Add(_ agent.AddedKey) error {

--- a/session/sshforward/sshprovider/agentprovider.go
+++ b/session/sshforward/sshprovider/agentprovider.go
@@ -196,3 +196,7 @@ func (a *readOnlyAgent) RemoveAll() error {
 func (a *readOnlyAgent) Lock(_ []byte) error {
 	return errors.Errorf("locking agent not allowed by buildkit")
 }
+
+func (a *readOnlyAgent) Extension(_ string, _ []byte) ([]byte, error) {
+	return nil, errors.Errorf("extensions not allowed by buildkit")
+}

--- a/solver/combinedcache.go
+++ b/solver/combinedcache.go
@@ -87,6 +87,9 @@ func (cm *combinedCacheManager) Load(ctx context.Context, rec *CacheRecord) (res
 			}
 		}
 	}
+	if len(results) == 0 { // TODO: handle gracefully
+		return nil, errors.Errorf("failed to load deleted cache")
+	}
 	return results[0].Result, nil
 }
 

--- a/util/flightcontrol/flightcontrol.go
+++ b/util/flightcontrol/flightcontrol.go
@@ -116,7 +116,9 @@ func newCall(fn func(ctx context.Context) (interface{}, error)) *call {
 
 func (c *call) run() {
 	defer c.closeProgressWriter()
-	v, err := c.fn(c.ctx)
+	ctx, cancel := context.WithCancel(c.ctx)
+	defer cancel()
+	v, err := c.fn(ctx)
 	c.mu.Lock()
 	c.result = v
 	c.err = err


### PR DESCRIPTION
https://github.com/moby/buildkit/pull/1202 buildkitd: disable TLS for UNIX sockets
https://github.com/moby/buildkit/pull/1270 Inherit extended agent so we get modern sign hashes
https://github.com/moby/buildkit/pull/1316 ensure context is cancelled to prevent goroutine leaks with containerd worker
https://github.com/moby/buildkit/pull/1328 solver: avoid panic on combined cache load
https://github.com/moby/buildkit/pull/1324 dockerfile: clear onbuild rules after triggering

@AkihiroSuda @thaJeztah 