### PR TITLE
Makefile: specify DOCKER_BUILDKIT when make images

### DIFF
--- a/hack/images
+++ b/hack/images
@@ -31,8 +31,8 @@ imageDocker() {
 		exit 1
 	fi
 	set -x
-	docker build $progressFlag --platform=$PLATFORMS -t $REPO:$TAG .
-	docker build $progressFlag --platform=$PLATFORMS -t $REPO:$TAG-rootless --target rootless .
+	DOCKER_BUILDKIT=1 docker build $progressFlag --platform=$PLATFORMS -t $REPO:$TAG .
+	DOCKER_BUILDKIT=1 docker build $progressFlag --platform=$PLATFORMS -t $REPO:$TAG-rootless --target rootless .
 	set +x
 
 	if [ "$PUSH" = "push" ]; then


### PR DESCRIPTION
When `make images` with buildmode docker-buildkit,
DOCKER_BUILDKIT=1 should be added to environments.

Signed-off-by: Lu Jingxiao <lujingxiao@huawei.com>

**What I met**
```bash
# make images
hack/images local moby/buildkit
+ docker build --platform=linux/amd64 -t moby/buildkit:local .
"--platform" is only supported on a Docker daemon with experimental features enabled
make: *** [images] Error 1
# git log -1
commit 8a267827cdfd672e4890f23f51c4153c6f0802b3
```

**With this patch**
```bash
# make images
hack/images local moby/buildkit
+ docker build --platform=linux/amd64 -t moby/buildkit:local .
[+] Building 19.6s (17/29)
 => [internal] load build definition from Dockerfile                                                                                                                                                         0.0s
 => => transferring dockerfile: 12.35kB                                                                                                                                                                      0.0s
 => [internal] load .dockerignore                                                                                                                                                                            0.0s
 => => transferring context: 56B                                                                                                                                                                             0.0s
...
```