### PR TITLE
Dockerfile: support Kubernetes runAsNonRoot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -274,7 +274,8 @@ FROM rootless-base AS rootless
 COPY --from=rootlesskit /rootlesskit /usr/bin/
 COPY --from=binaries / /usr/bin/
 COPY examples/buildctl-daemonless/buildctl-daemonless.sh /usr/bin/
-USER user
+# Kubernetes runAsNonRoot requires USER to be numeric
+USER 1000:1000
 ENV HOME /home/user
 ENV USER user
 ENV XDG_RUNTIME_DIR=/run/user/1000


### PR DESCRIPTION
Kubernetes runAsNonRoot requires `USER` in Dockerfile to be numeric:
https://github.com/kubernetes/kubernetes/blob/v1.18.0-alpha.2/pkg/kubelet/kuberuntime/security_context.go#L98
