### PR TITLE
Remove bashism from shared shell script

### DIFF
--- a/hack/util
+++ b/hack/util
@@ -28,7 +28,7 @@ fi
 
 cacheref=""
 currentref=""
-if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then
+if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then
   currentref="git://github.com/moby/buildkit#refs/pull/$TRAVIS_PULL_REQUEST/merge"
   cacheref="cicache.buildk.it/moby/buildkit/pr$TRAVIS_BUILD_ID"
 elif [ -n "$TRAVIS_BRANCH" ]; then


### PR DESCRIPTION
> All the other scripts in hack/ use bash, and this makes the lone `==` used in _hack/util_ work, rather than logging a complaint:
> > ./hack/validate-vendor: 31: [: pull_request: unexpected operator

Edit: Rewritten, above description no longer describes the change.