### PR TITLE
mount whitelist of devices on insecure security mode

### DIFF
--- a/executor/oci/spec_unix.go
+++ b/executor/oci/spec_unix.go
@@ -18,7 +18,7 @@ import (
 	"github.com/moby/buildkit/executor"
 	"github.com/moby/buildkit/snapshot"
 	"github.com/moby/buildkit/solver/pb"
-	"github.com/moby/buildkit/util/entitlements"
+	"github.com/moby/buildkit/util/entitlements/security"
 	"github.com/moby/buildkit/util/network"
 	"github.com/moby/buildkit/util/system"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -38,7 +38,7 @@ func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mou
 		ctx = namespaces.WithNamespace(ctx, "buildkit")
 	}
 	if meta.SecurityMode == pb.SecurityMode_INSECURE {
-		opts = append(opts, entitlements.WithInsecureSpec())
+		opts = append(opts, security.WithInsecureSpec())
 	} else if system.SeccompSupported() && meta.SecurityMode == pb.SecurityMode_SANDBOX {
 		opts = append(opts, seccomp.WithDefaultProfile())
 	}

--- a/frontend/dockerfile/dockerfile_runsecurity_test.go
+++ b/frontend/dockerfile/dockerfile_runsecurity_test.go
@@ -19,11 +19,74 @@ var runSecurityTests = []integration.Test{
 	testRunSecurityInsecure,
 	testRunSecuritySandbox,
 	testRunSecurityDefault,
+	testInsecureDevicesWhitelist,
 }
 
 func init() {
+	securityOpts = []integration.TestOpt{
+		integration.WithMirroredImages(integration.OfficialImages("alpine:latest")),
+		integration.WithMirroredImages(map[string]string{
+			"tonistiigi/hellofs:latest": "docker.io/tonistiigi/hellofs:latest",
+		}),
+	}
+
 	securityTests = append(securityTests, runSecurityTests...)
 
+}
+
+func testInsecureDevicesWhitelist(t *testing.T, sb integration.Sandbox) {
+	if sb.Rootless() {
+		t.SkipNow()
+	}
+
+	f := getFrontend(t, sb)
+
+	dockerfile := []byte(`
+FROM alpine
+RUN apk add --no-cache fuse e2fsprogs
+RUN [ ! -e /dev/fuse ] && [ ! -e /dev/loop-control ]
+# https://github.com/bazil/fuse/blob/master/examples/hellofs/hello.go#L91
+COPY --from=tonistiigi/hellofs /hellofs /bin/hellofs
+RUN --security=insecure [ -c /dev/fuse ] && [ -c /dev/loop-control ]
+RUN --security=insecure dmesg > /dev/null
+# testing fuse
+RUN --security=insecure hellofs /mnt & sleep 1 && ls -l /mnt && mount && cat /mnt/hello
+# testing loopbacks
+RUN --security=insecure ls -l /dev && dd if=/dev/zero of=disk.img bs=20M count=1 && \
+	mkfs.ext4 disk.img && \
+	mount -o loop disk.img /mnt && touch /mnt/foo \
+	umount /mnt && \
+	rm disk.img
+`)
+
+	dir, err := tmpdir(
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+	)
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	c, err := client.New(context.TODO(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = f.Solve(context.TODO(), c, client.SolveOpt{
+		LocalDirs: map[string]string{
+			builder.DefaultLocalNameDockerfile: dir,
+			builder.DefaultLocalNameContext:    dir,
+		},
+		AllowedEntitlements: []entitlements.Entitlement{entitlements.EntitlementSecurityInsecure},
+	}, nil)
+
+	secMode := sb.Value("security.insecure")
+	switch secMode {
+	case securityInsecureGranted:
+		require.NoError(t, err)
+	case securityInsecureDenied:
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "entitlement security.insecure is not allowed")
+	default:
+		require.Fail(t, "unexpected secmode")
+	}
 }
 
 func testRunSecurityInsecure(t *testing.T, sb integration.Sandbox) {

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -126,6 +126,7 @@ var securityTests = []integration.Test{}
 var networkTests = []integration.Test{}
 
 var opts []integration.TestOpt
+var securityOpts []integration.TestOpt
 
 type frontend interface {
 	Solve(context.Context, *client.Client, client.SolveOpt, chan *client.SolveStatus) (*client.SolveResponse, error)
@@ -166,7 +167,7 @@ func TestIntegration(t *testing.T) {
 		"true":  true,
 		"false": false,
 	}))...)
-	integration.Run(t, securityTests, append(opts,
+	integration.Run(t, securityTests, append(append(opts, securityOpts...),
 		integration.WithMatrix("security.insecure", map[string]interface{}{
 			"granted": securityInsecureGranted,
 			"denied":  securityInsecureDenied,

--- a/solver/pb/caps.go
+++ b/solver/pb/caps.go
@@ -45,6 +45,8 @@ const (
 	CapExecMountSSH                  apicaps.CapID = "exec.mount.ssh"
 	CapExecCgroupsMounted            apicaps.CapID = "exec.cgroup"
 
+	CapExecMetaSecurityDeviceWhitelistV1 apicaps.CapID = "exec.meta.security.devices.v1"
+
 	CapFileBase       apicaps.CapID = "file.base"
 	CapFileRmWildcard apicaps.CapID = "file.rm.wildcard"
 
@@ -185,6 +187,12 @@ func init() {
 
 	Caps.Init(apicaps.Cap{
 		ID:      CapExecMetaSecurity,
+		Enabled: true,
+		Status:  apicaps.CapStatusExperimental,
+	})
+
+	Caps.Init(apicaps.Cap{
+		ID:      CapExecMetaSecurityDeviceWhitelistV1,
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})


### PR DESCRIPTION
fixes https://github.com/docker/buildx/issues/220

Unlike `docker run --privileged` we don't mount all the devices from host because that would give inconsistent environments for different hosts that we would like to avoid (and later solve with constraints). But we can mount a whitelist of devices that are always created by regular distros and commonly used. Permissions are granted to users to read/write all the devices, for the missing ones you just need to `mknod` the device yourself.

Devices currently created with `--security=insecure`:
- kmsg
- fuse
- cuse
- loop-control + loopN
- net/tun
- kvm