### PR TITLE
solver: evaluate solve results lazily

### DIFF
--- a/frontend/result.go
+++ b/frontend/result.go
@@ -5,12 +5,12 @@ import (
 )
 
 type Result struct {
-	Ref      solver.CachedResult
-	Refs     map[string]solver.CachedResult
+	Ref      solver.ResultProxy
+	Refs     map[string]solver.ResultProxy
 	Metadata map[string][]byte
 }
 
-func (r *Result) EachRef(fn func(solver.CachedResult) error) (err error) {
+func (r *Result) EachRef(fn func(solver.ResultProxy) error) (err error) {
 	if r.Ref != nil {
 		err = fn(r.Ref)
 	}

--- a/solver/llbsolver/ops/build.go
+++ b/solver/llbsolver/ops/build.go
@@ -132,5 +132,10 @@ func (b *buildOp) Exec(ctx context.Context, inputs []solver.Result) (outputs []s
 		r.Release(context.TODO())
 	}
 
-	return []solver.Result{newRes.Ref}, err
+	r, err := newRes.Ref.Result(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return []solver.Result{r}, err
 }

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -22,6 +22,7 @@ import (
 	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 )
 
 const keyEntitlements = "llb.entitlements"
@@ -140,11 +141,23 @@ func (s *Solver) Solve(ctx context.Context, id string, req frontend.SolveRequest
 	}
 
 	defer func() {
-		res.EachRef(func(ref solver.CachedResult) error {
+		res.EachRef(func(ref solver.ResultProxy) error {
 			go ref.Release(context.TODO())
 			return nil
 		})
 	}()
+
+	eg, ctx2 := errgroup.WithContext(ctx)
+	res.EachRef(func(ref solver.ResultProxy) error {
+		eg.Go(func() error {
+			_, err := ref.Result(ctx2)
+			return err
+		})
+		return nil
+	})
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
 
 	var exporterResponse map[string]string
 	if e := exp.Exporter; e != nil {
@@ -155,13 +168,17 @@ func (s *Solver) Solve(ctx context.Context, id string, req frontend.SolveRequest
 			inp.Metadata = make(map[string][]byte)
 		}
 		if res := res.Ref; res != nil {
-			workerRef, ok := res.Sys().(*worker.WorkerRef)
+			r, err := res.Result(ctx)
+			if err != nil {
+				return nil, err
+			}
+			workerRef, ok := r.Sys().(*worker.WorkerRef)
 			if !ok {
-				return nil, errors.Errorf("invalid reference: %T", res.Sys())
+				return nil, errors.Errorf("invalid reference: %T", r.Sys())
 			}
 			inp.Ref = workerRef.ImmutableRef
 
-			dt, err := inlineCache(ctx, exp.CacheExporter, res)
+			dt, err := inlineCache(ctx, exp.CacheExporter, r)
 			if err != nil {
 				return nil, err
 			}
@@ -175,13 +192,17 @@ func (s *Solver) Solve(ctx context.Context, id string, req frontend.SolveRequest
 				if res == nil {
 					m[k] = nil
 				} else {
-					workerRef, ok := res.Sys().(*worker.WorkerRef)
+					r, err := res.Result(ctx)
+					if err != nil {
+						return nil, err
+					}
+					workerRef, ok := r.Sys().(*worker.WorkerRef)
 					if !ok {
-						return nil, errors.Errorf("invalid reference: %T", res.Sys())
+						return nil, errors.Errorf("invalid reference: %T", r.Sys())
 					}
 					m[k] = workerRef.ImmutableRef
 
-					dt, err := inlineCache(ctx, exp.CacheExporter, res)
+					dt, err := inlineCache(ctx, exp.CacheExporter, r)
 					if err != nil {
 						return nil, err
 					}
@@ -205,9 +226,13 @@ func (s *Solver) Solve(ctx context.Context, id string, req frontend.SolveRequest
 	if e := exp.CacheExporter; e != nil {
 		if err := inVertexContext(j.Context(ctx), "exporting cache", "", func(ctx context.Context) error {
 			prepareDone := oneOffProgress(ctx, "preparing build cache for export")
-			if err := res.EachRef(func(res solver.CachedResult) error {
+			if err := res.EachRef(func(res solver.ResultProxy) error {
+				r, err := res.Result(ctx)
+				if err != nil {
+					return err
+				}
 				// all keys have same export chain so exporting others is not needed
-				_, err := res.CacheKeys()[0].Exporter.ExportTo(ctx, e, solver.CacheExportOpt{
+				_, err = r.CacheKeys()[0].Exporter.ExportTo(ctx, e, solver.CacheExportOpt{
 					Convert: workerRefConverter,
 					Mode:    exp.CacheExportMode,
 				})

--- a/solver/types.go
+++ b/solver/types.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/content"
+	"github.com/moby/buildkit/solver/pb"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -65,6 +66,12 @@ type Result interface {
 type CachedResult interface {
 	Result
 	CacheKeys() []ExportableCacheKey
+}
+
+type ResultProxy interface {
+	Result(context.Context) (CachedResult, error)
+	Release(context.Context) error
+	Definition() *pb.Definition
 }
 
 // CacheExportMode is the type for setting cache exporting modes

--- a/worker/result.go
+++ b/worker/result.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/solver"
-	"github.com/moby/buildkit/solver/pb"
 )
 
 func NewWorkerRefResult(ref cache.ImmutableRef, worker Worker) solver.Result {
@@ -15,7 +14,6 @@ func NewWorkerRefResult(ref cache.ImmutableRef, worker Worker) solver.Result {
 type WorkerRef struct {
 	ImmutableRef cache.ImmutableRef
 	Worker       Worker
-	Definition   *pb.Definition
 }
 
 func (wr *WorkerRef) ID() string {


### PR DESCRIPTION
With https://github.com/moby/buildkit/pull/1286 previous solve results can be used as inputs for the new requests. One of the issues with the current implementation is that the main build is blocked and cannot start while the nested `Solve` request happens. This could be inefficient for parallelization and caching. Eg. buildkit supports caching even if you don't have the layer data for your whole cache chain(this is how inline remote cache works even with multi-stage builds), but the nested solve does not know that it may be just used for getting a future cache hit and needs to return local layers.

This PR changes the behavior of `Solve()` method for frontends. They now return results without actually starting the build. Results are evaluated only if the result ends up as the return value of the build or if files are accessed from it. This is quite a big behavior change(eg. the Dockerfile frontend now returns after it has computed the image config while previously it kept running for the full duration of the build) but I think all the existing frontends should still work as expected.

@hinshun 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>