### PR TITLE
dockerfile: update static base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ARG SHADOW_VERSION=4.8.1
 
 # git stage is used for checking out remote repository sources
 FROM --platform=$BUILDPLATFORM alpine AS git
-RUN apk add --no-cache git
+RUN apk add --no-cache git xz
 
 # xgo is a helper for golang cross-compilation
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:golang@sha256:6f7d999551dd471b58f70716754290495690efa8421e0a1fcf18eb11d0c0a537 AS xgo
@@ -124,7 +124,7 @@ RUN --mount=from=binaries \
 FROM scratch AS release
 COPY --from=releaser /out/ /
 
-FROM tonistiigi/git@sha256:704fcc24a17b40833625ee37c4a4acf0e4aa90d0aa276926d63847097134defd AS buildkit-export
+FROM tonistiigi/git@sha256:393483e1cef35f09e1a8fe0a0bd93a78b1b6ecec5b5afa5fa5d600fa3ab1fdd8 AS buildkit-export
 COPY examples/buildctl-daemonless/buildctl-daemonless.sh /usr/bin/
 VOLUME /var/lib/buildkit
 
@@ -251,7 +251,7 @@ RUN ./autogen.sh --disable-nls --disable-man --without-audit --without-selinux -
   && cp src/newuidmap src/newgidmap /usr/bin
 
 FROM alpine:3.11 AS rootless-base-internal
-RUN apk add --no-cache git
+RUN apk add --no-cache git xz
 COPY --from=idmap /usr/bin/newuidmap /usr/bin/newuidmap
 COPY --from=idmap /usr/bin/newgidmap /usr/bin/newgidmap
 # we could just set CAP_SETUID filecap rather than `chmod u+s`, but requires kernel >= 4.14
@@ -262,7 +262,7 @@ RUN chmod u+s /usr/bin/newuidmap /usr/bin/newgidmap \
   && echo user:100000:65536 | tee /etc/subuid | tee /etc/subgid
 
 # tonistiigi/buildkit:rootless-base is a pre-built multi-arch version of rootless-base-internal https://github.com/moby/buildkit/pull/666#pullrequestreview-161872350
-FROM tonistiigi/buildkit:rootless-base@sha256:7e87da0f64e4987b4b6620f7b27b62d7178fc27964fcc3afeb8412f4231aa425 AS rootless-base-external
+FROM tonistiigi/buildkit:rootless-base@sha256:0008b156dedd0220a5a0a1aa8840afe0ea0f01f44dfe1ae850b3970aaa1c5cec AS rootless-base-external
 FROM rootless-base-$ROOTLESS_BASE_MODE AS rootless-base
 
 # Rootless mode.


### PR DESCRIPTION
follow-up: https://github.com/moby/buildkit/pull/1343#issue-366707884
fixes: https://github.com/docker/buildx/issues/145

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>


```
 # docker buildx build --target git -o type=registry,name=tonistiigi/git --platform linux/amd64,linux/arm/v7,linux/arm/v6,linux/s390x,linux/ppc64le,linux/arm64 .
[+] Building 23.2s (23/23) FINISHED
 => [internal] load .dockerignore                                                                                                                                                                                       0.0s
 => => transferring context: 34B                                                                                                                                                                                        0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                                    0.0s
 => => transferring dockerfile: 11.93kB                                                                                                                                                                                 0.0s
 => resolve image config for docker.io/docker/dockerfile:1.1-experimental                                                                                                                                               1.1s
 => CACHED docker-image://docker.io/docker/dockerfile:1.1-experimental@sha256:888f21826273409b5ef5ff9ceb90c64a8f8ec7760da30d1ffbe6c3e2d323a7bd                                                                          0.0s
 => => resolve docker.io/docker/dockerfile:1.1-experimental@sha256:888f21826273409b5ef5ff9ceb90c64a8f8ec7760da30d1ffbe6c3e2d323a7bd                                                                                     0.0s
 => [linux/arm/v7 internal] load metadata for docker.io/library/alpine:latest                                                                                                                                           1.0s
 => [linux/s390x internal] load metadata for docker.io/library/alpine:latest                                                                                                                                            0.9s
 => [linux/arm64 internal] load metadata for docker.io/library/alpine:latest                                                                                                                                            0.9s
 => [linux/ppc64le internal] load metadata for docker.io/library/alpine:latest                                                                                                                                          1.0s
 => [linux/arm/v6 internal] load metadata for docker.io/library/alpine:latest                                                                                                                                           0.9s
 => [linux/amd64 internal] load metadata for docker.io/library/alpine:latest                                                                                                                                            0.7s
 => [linux/ppc64le git 1/2] FROM docker.io/library/alpine@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d                                                                                       0.9s
 => => sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d 1.64kB / 1.64kB                                                                                                                          0.0s
 => => sha256:ff8a6adf5859433869343296f1b06e0a7bdf4fc836b08d5854221e351baf6929 528B / 528B                                                                                                                              0.0s
 => => sha256:cd95c8a93e39dcaa0634a65d5b86a88bcd5c3092adb1f96504a7030faa165123 2.82MB / 2.82MB                                                                                                                          0.5s
 => => sha256:8ebf70746025b4e6b5bd434a1468b51a4278e88b29c08a0bb275f8b012066475 1.51kB / 1.51kB                                                                                                                          0.0s
 => => unpacking docker.io/library/alpine@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d                                                                                                       0.2s
 => [linux/amd64 git 1/2] FROM docker.io/library/alpine@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d                                                                                         0.0s
 => [linux/arm64 git 1/2] FROM docker.io/library/alpine@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d                                                                                         0.9s
 => => sha256:4d5c5951669588e23881c158629ae6bac4ab44866d5b4d150c3f15d91f26682b 528B / 528B                                                                                                                              0.0s
 => => sha256:8fa90b21c985a6fcfff966bdfbde81cdd088de0aa8af38110057f6ac408f4408 2.72MB / 2.72MB                                                                                                                          0.3s
 => => sha256:6e4716cdcf7a5a48d6e15b198b04caedc245dd2530204b02107fa3eadc71cb94 1.51kB / 1.51kB                                                                                                                          0.0s
 => => sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d 1.64kB / 1.64kB                                                                                                                          0.0s
 => => unpacking docker.io/library/alpine@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d                                                                                                       0.2s
 => CACHED [linux/amd64 git 2/2] RUN apk add --no-cache git xz                                                                                                                                                          0.0s
 => [linux/arm/v6 git 1/2] FROM docker.io/library/alpine@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d                                                                                        0.9s
 => => resolve docker.io/library/alpine@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d                                                                                                         0.0s
 => => sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d 1.64kB / 1.64kB                                                                                                                          0.0s
 => => sha256:401f030aa35e86bafd31c6cc292b01659cbde72d77e8c24737bd63283837f02c 528B / 528B                                                                                                                              0.0s
 => => sha256:832e07764099264ef96e50a1e5e41c52d6b0809bd054e29508a6878aa59d156d 2.62MB / 2.62MB                                                                                                                          0.3s
 => => sha256:8093515ca679e4cd8d56baf2ba7bd54b3728367d8640a211e26a6528e02c8f8e 1.51kB / 1.51kB                                                                                                                          0.0s
 => => unpacking docker.io/library/alpine@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d                                                                                                       0.3s
 => [linux/arm/v7 git 1/2] FROM docker.io/library/alpine@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d                                                                                        0.9s
 => => sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d 1.64kB / 1.64kB                                                                                                                          0.0s
 => => sha256:2c26a655f6e38294e859edac46230210bbed3591d6ff57060b8671cda09756d4 528B / 528B                                                                                                                              0.0s
 => => sha256:3a2c5e3c37b2e3d749405512ef3793aa45a2f5c11615d9e9efa80179262cdf27 2.42MB / 2.42MB                                                                                                                          0.4s
 => => sha256:b9cc225140e0790b9160876bb61c8e7516489325c0bf8e650eb8b6f975082c36 1.51kB / 1.51kB                                                                                                                          0.0s
 => => unpacking docker.io/library/alpine@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d                                                                                                       0.3s
 => [linux/s390x git 1/2] FROM docker.io/library/alpine@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d                                                                                         0.8s
 => => resolve docker.io/library/alpine@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d                                                                                                         0.0s
 => => sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d 1.64kB / 1.64kB                                                                                                                          0.0s
 => => sha256:ef20eb43010abda2d7944e0cd11ef00a961ff7a7f953671226fbf8747895417d 528B / 528B                                                                                                                              0.0s
 => => sha256:176bad61a3a435da03ec603d2bd8f7a69286d92f21f447b17f21f0bc4e085bde 2.58MB / 2.58MB                                                                                                                          0.3s
 => => sha256:d944d048f7287e69a141b3be4658e0735385852579e6e40ad1d2cceb49dce51b 1.51kB / 1.51kB                                                                                                                          0.0s
 => => unpacking docker.io/library/alpine@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d                                                                                                       0.3s
 => [linux/s390x git 2/2] RUN apk add --no-cache git xz                                                                                                                                                                 3.6s
 => [linux/arm/v6 git 2/2] RUN apk add --no-cache git xz                                                                                                                                                                3.4s
 => [linux/arm/v7 git 2/2] RUN apk add --no-cache git xz                                                                                                                                                                3.4s
 => [linux/ppc64le git 2/2] RUN apk add --no-cache git xz                                                                                                                                                               3.9s
 => [linux/arm64 git 2/2] RUN apk add --no-cache git xz                                                                                                                                                                 3.5s
 => exporting to image                                                                                                                                                                                                 15.8s
 => => exporting layers                                                                                                                                                                                                 1.5s
 => => exporting manifest sha256:3fb92f20384f36a68eaad60d212b219ddfb7050b72b84a4c2a141fcc8784377b                                                                                                                       0.5s
 => => exporting config sha256:9a50ef7cc18a89974865af58b9122c83b93cf87b8c3ae7fefeeda6c362ec82f9                                                                                                                         0.0s
 => => exporting manifest sha256:18d53ab39a4685176f423ad2485cdc9eee47a85a51a5d8124c62a05fea94855f                                                                                                                       0.0s
 => => exporting config sha256:0a8b2f32d18c5972932032ffab7338d88228a886a91e017a1832b9b338a76663                                                                                                                         0.0s
 => => exporting manifest sha256:abf9c47b08a93f2a7a0af93e40de351a0a24ff27ac77036581fd311064e77169                                                                                                                       0.0s
 => => exporting config sha256:5d9e752fb4e3f5cc37c461b104c36505239ce933443953aafaa2f81b7ee3263c                                                                                                                         0.0s
 => => exporting manifest sha256:219fd0332f9393282a2fb62d95675677e989a4fc6d4efa35d8cf1010b66904f9                                                                                                                       0.0s
 => => exporting config sha256:39a350ca8dfc72c7bdbf70c908648492677334239be2156a619c439bb1db5718                                                                                                                         0.0s
 => => exporting manifest sha256:42a379a52ba3f3b170bdefe816e4d99a6df6532a9be141375e91f04eb27fcc37                                                                                                                       0.0s
 => => exporting config sha256:63f48f6c1d601c09a984fd2d49635cb08a1b930cf77d7d67fd192f52669a1d78                                                                                                                         0.0s
 => => exporting manifest sha256:ff7bc13c0d2637663620fb4c6c89c55664eb653f764ff3f865b9e3654a7ed323                                                                                                                       0.0s
 => => exporting config sha256:130bf456ecddbae845fdde503c3449f97114ec036bf5b5b24f99df2cd714f884                                                                                                                         0.0s
 => => exporting manifest list sha256:393483e1cef35f09e1a8fe0a0bd93a78b1b6ecec5b5afa5fa5d600fa3ab1fdd8                                                                                                                  0.0s
 => => pushing layers                                                                                                                                                                                                  10.9s
 => => pushing manifest for docker.io/tonistiigi/git:latest                                                                                                                                                             2.7s
 # docker buildx imagetools inspect docker.io/tonistiigi/git:latest
Name:      docker.io/tonistiigi/git:latest
MediaType: application/vnd.docker.distribution.manifest.list.v2+json
Digest:    sha256:393483e1cef35f09e1a8fe0a0bd93a78b1b6ecec5b5afa5fa5d600fa3ab1fdd8

Manifests:
  Name:      docker.io/tonistiigi/git:latest@sha256:3fb92f20384f36a68eaad60d212b219ddfb7050b72b84a4c2a141fcc8784377b
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/amd64

  Name:      docker.io/tonistiigi/git:latest@sha256:18d53ab39a4685176f423ad2485cdc9eee47a85a51a5d8124c62a05fea94855f
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/arm/v7

  Name:      docker.io/tonistiigi/git:latest@sha256:abf9c47b08a93f2a7a0af93e40de351a0a24ff27ac77036581fd311064e77169
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/arm/v6

  Name:      docker.io/tonistiigi/git:latest@sha256:219fd0332f9393282a2fb62d95675677e989a4fc6d4efa35d8cf1010b66904f9
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/s390x

  Name:      docker.io/tonistiigi/git:latest@sha256:42a379a52ba3f3b170bdefe816e4d99a6df6532a9be141375e91f04eb27fcc37
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/ppc64le

  Name:      docker.io/tonistiigi/git:latest@sha256:ff7bc13c0d2637663620fb4c6c89c55664eb653f764ff3f865b9e3654a7ed323
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/arm64
  
  
  
 # docker buildx build --target rootless-base-internal -o type=registry -t tonistiigi/buildkit:rootless-base --platform linux/amd64,linux/arm/v7,linux/arm/v6,linux/s390x,linux/ppc64le,linux/arm64 .
[+] Building 25.3s (71/71) FINISHED
 => [internal] load .dockerignore                                                                                                                                                                                       0.1s
 => => transferring context: 34B                                                                                                                                                                                        0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                                    0.1s
 => => transferring dockerfile: 32B                                                                                                                                                                                     0.0s
 => resolve image config for docker.io/docker/dockerfile:1.1-experimental                                                                                                                                               0.3s
 => CACHED docker-image://docker.io/docker/dockerfile:1.1-experimental@sha256:888f21826273409b5ef5ff9ceb90c64a8f8ec7760da30d1ffbe6c3e2d323a7bd                                                                          0.0s
 => => resolve docker.io/docker/dockerfile:1.1-experimental@sha256:888f21826273409b5ef5ff9ceb90c64a8f8ec7760da30d1ffbe6c3e2d323a7bd                                                                                     0.0s
 => [linux/arm64 internal] load metadata for docker.io/library/alpine:3.11                                                                                                                                              0.3s
 => [linux/s390x internal] load metadata for docker.io/library/alpine:3.11                                                                                                                                              0.3s
 => [linux/arm/v7 internal] load metadata for docker.io/library/alpine:3.11                                                                                                                                             0.4s
 => [linux/ppc64le internal] load metadata for docker.io/library/alpine:3.11                                                                                                                                            0.4s
 => [linux/amd64 internal] load metadata for docker.io/library/alpine:3.11                                                                                                                                              0.4s
 => [linux/arm/v6 internal] load metadata for docker.io/library/alpine:3.11                                                                                                                                             0.4s
 => [linux/s390x rootless-base-internal 1/5] FROM docker.io/library/alpine:3.11@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d                                                                 0.0s
 => => resolve docker.io/library/alpine:3.11@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d                                                                                                    0.0s
 => [linux/arm/v6 idmap 1/6] FROM docker.io/library/alpine:3.11@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d                                                                                 0.0s
 => [linux/ppc64le idmap 1/6] FROM docker.io/library/alpine:3.11@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d                                                                                0.0s
 => => resolve docker.io/library/alpine:3.11@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d                                                                                                    0.0s
 => [linux/arm/v7 rootless-base-internal 1/5] FROM docker.io/library/alpine:3.11@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d                                                                0.0s
 => => resolve docker.io/library/alpine:3.11@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d                                                                                                    0.0s
 => [linux/arm64 idmap 1/6] FROM docker.io/library/alpine:3.11@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d                                                                                  0.0s
 => => resolve docker.io/library/alpine:3.11@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d                                                                                                    0.0s
 => [linux/amd64 rootless-base-internal 1/5] FROM docker.io/library/alpine:3.11@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d                                                                 0.0s
 => => resolve docker.io/library/alpine:3.11@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d                                                                                                    0.0s
 => CACHED [linux/arm64 rootless-base-internal 2/5] RUN apk add --no-cache git xz                                                                                                                                       0.0s
 => CACHED [linux/arm64 idmap 2/6] RUN apk add --no-cache autoconf automake build-base byacc gettext gettext-dev gcc git libcap-dev libtool libxslt                                                                     0.0s
 => CACHED [linux/arm64 idmap 3/6] RUN git clone https://github.com/shadow-maint/shadow.git /shadow                                                                                                                     0.0s
 => CACHED [linux/arm64 idmap 4/6] WORKDIR /shadow                                                                                                                                                                      0.0s
 => CACHED [linux/arm64 idmap 5/6] RUN git checkout 4.8.1                                                                                                                                                               0.0s
 => CACHED [linux/arm64 idmap 6/6] RUN ./autogen.sh --disable-nls --disable-man --without-audit --without-selinux --without-acl --without-attr --without-tcb --without-nscd   && make   && cp src/newuidmap src/newgid  0.0s
 => CACHED [linux/arm64 rootless-base-internal 3/5] COPY --from=idmap /usr/bin/newuidmap /usr/bin/newuidmap                                                                                                             0.0s
 => CACHED [linux/arm64 rootless-base-internal 4/5] COPY --from=idmap /usr/bin/newgidmap /usr/bin/newgidmap                                                                                                             0.0s
 => CACHED [linux/arm64 rootless-base-internal 5/5] RUN chmod u+s /usr/bin/newuidmap /usr/bin/newgidmap   && adduser -D -u 1000 user   && mkdir -p /run/user/1000 /home/user/.local/tmp /home/user/.local/share/buildk  0.0s
 => CACHED [linux/arm/v6 rootless-base-internal 2/5] RUN apk add --no-cache git xz                                                                                                                                      0.0s
 => CACHED [linux/arm/v6 idmap 2/6] RUN apk add --no-cache autoconf automake build-base byacc gettext gettext-dev gcc git libcap-dev libtool libxslt                                                                    0.0s
 => CACHED [linux/arm/v6 idmap 3/6] RUN git clone https://github.com/shadow-maint/shadow.git /shadow                                                                                                                    0.0s
 => CACHED [linux/arm/v6 idmap 4/6] WORKDIR /shadow                                                                                                                                                                     0.0s
 => CACHED [linux/arm/v6 idmap 5/6] RUN git checkout 4.8.1                                                                                                                                                              0.0s
 => CACHED [linux/arm/v6 idmap 6/6] RUN ./autogen.sh --disable-nls --disable-man --without-audit --without-selinux --without-acl --without-attr --without-tcb --without-nscd   && make   && cp src/newuidmap src/newgi  0.0s
 => CACHED [linux/arm/v6 rootless-base-internal 3/5] COPY --from=idmap /usr/bin/newuidmap /usr/bin/newuidmap                                                                                                            0.0s
 => CACHED [linux/arm/v6 rootless-base-internal 4/5] COPY --from=idmap /usr/bin/newgidmap /usr/bin/newgidmap                                                                                                            0.0s
 => CACHED [linux/arm/v6 rootless-base-internal 5/5] RUN chmod u+s /usr/bin/newuidmap /usr/bin/newgidmap   && adduser -D -u 1000 user   && mkdir -p /run/user/1000 /home/user/.local/tmp /home/user/.local/share/build  0.0s
 => CACHED [linux/s390x rootless-base-internal 2/5] RUN apk add --no-cache git xz                                                                                                                                       0.0s
 => CACHED [linux/s390x idmap 2/6] RUN apk add --no-cache autoconf automake build-base byacc gettext gettext-dev gcc git libcap-dev libtool libxslt                                                                     0.0s
 => CACHED [linux/s390x idmap 3/6] RUN git clone https://github.com/shadow-maint/shadow.git /shadow                                                                                                                     0.0s
 => CACHED [linux/s390x idmap 4/6] WORKDIR /shadow                                                                                                                                                                      0.0s
 => CACHED [linux/s390x idmap 5/6] RUN git checkout 4.8.1                                                                                                                                                               0.0s
 => CACHED [linux/s390x idmap 6/6] RUN ./autogen.sh --disable-nls --disable-man --without-audit --without-selinux --without-acl --without-attr --without-tcb --without-nscd   && make   && cp src/newuidmap src/newgid  0.0s
 => CACHED [linux/s390x rootless-base-internal 3/5] COPY --from=idmap /usr/bin/newuidmap /usr/bin/newuidmap                                                                                                             0.0s
 => CACHED [linux/s390x rootless-base-internal 4/5] COPY --from=idmap /usr/bin/newgidmap /usr/bin/newgidmap                                                                                                             0.0s
 => CACHED [linux/s390x rootless-base-internal 5/5] RUN chmod u+s /usr/bin/newuidmap /usr/bin/newgidmap   && adduser -D -u 1000 user   && mkdir -p /run/user/1000 /home/user/.local/tmp /home/user/.local/share/buildk  0.0s
 => CACHED [linux/ppc64le rootless-base-internal 2/5] RUN apk add --no-cache git xz                                                                                                                                     0.0s
 => CACHED [linux/ppc64le idmap 2/6] RUN apk add --no-cache autoconf automake build-base byacc gettext gettext-dev gcc git libcap-dev libtool libxslt                                                                   0.0s
 => CACHED [linux/ppc64le idmap 3/6] RUN git clone https://github.com/shadow-maint/shadow.git /shadow                                                                                                                   0.0s
 => CACHED [linux/ppc64le idmap 4/6] WORKDIR /shadow                                                                                                                                                                    0.0s
 => CACHED [linux/ppc64le idmap 5/6] RUN git checkout 4.8.1                                                                                                                                                             0.0s
 => CACHED [linux/ppc64le idmap 6/6] RUN ./autogen.sh --disable-nls --disable-man --without-audit --without-selinux --without-acl --without-attr --without-tcb --without-nscd   && make   && cp src/newuidmap src/newg  0.0s
 => CACHED [linux/ppc64le rootless-base-internal 3/5] COPY --from=idmap /usr/bin/newuidmap /usr/bin/newuidmap                                                                                                           0.0s
 => CACHED [linux/ppc64le rootless-base-internal 4/5] COPY --from=idmap /usr/bin/newgidmap /usr/bin/newgidmap                                                                                                           0.0s
 => CACHED [linux/ppc64le rootless-base-internal 5/5] RUN chmod u+s /usr/bin/newuidmap /usr/bin/newgidmap   && adduser -D -u 1000 user   && mkdir -p /run/user/1000 /home/user/.local/tmp /home/user/.local/share/buil  0.0s
 => CACHED [linux/amd64 rootless-base-internal 2/5] RUN apk add --no-cache git xz                                                                                                                                       0.0s
 => CACHED [linux/amd64 idmap 2/6] RUN apk add --no-cache autoconf automake build-base byacc gettext gettext-dev gcc git libcap-dev libtool libxslt                                                                     0.0s
 => CACHED [linux/amd64 idmap 3/6] RUN git clone https://github.com/shadow-maint/shadow.git /shadow                                                                                                                     0.0s
 => CACHED [linux/amd64 idmap 4/6] WORKDIR /shadow                                                                                                                                                                      0.0s
 => CACHED [linux/amd64 idmap 5/6] RUN git checkout 4.8.1                                                                                                                                                               0.0s
 => CACHED [linux/amd64 idmap 6/6] RUN ./autogen.sh --disable-nls --disable-man --without-audit --without-selinux --without-acl --without-attr --without-tcb --without-nscd   && make   && cp src/newuidmap src/newgid  0.0s
 => CACHED [linux/amd64 rootless-base-internal 3/5] COPY --from=idmap /usr/bin/newuidmap /usr/bin/newuidmap                                                                                                             0.0s
 => CACHED [linux/amd64 rootless-base-internal 4/5] COPY --from=idmap /usr/bin/newgidmap /usr/bin/newgidmap                                                                                                             0.0s
 => CACHED [linux/amd64 rootless-base-internal 5/5] RUN chmod u+s /usr/bin/newuidmap /usr/bin/newgidmap   && adduser -D -u 1000 user   && mkdir -p /run/user/1000 /home/user/.local/tmp /home/user/.local/share/buildk  0.0s
 => CACHED [linux/arm/v7 rootless-base-internal 2/5] RUN apk add --no-cache git xz                                                                                                                                      0.0s
 => CACHED [linux/arm/v7 idmap 2/6] RUN apk add --no-cache autoconf automake build-base byacc gettext gettext-dev gcc git libcap-dev libtool libxslt                                                                    0.0s
 => CACHED [linux/arm/v7 idmap 3/6] RUN git clone https://github.com/shadow-maint/shadow.git /shadow                                                                                                                    0.0s
 => CACHED [linux/arm/v7 idmap 4/6] WORKDIR /shadow                                                                                                                                                                     0.0s
 => CACHED [linux/arm/v7 idmap 5/6] RUN git checkout 4.8.1                                                                                                                                                              0.0s
 => CACHED [linux/arm/v7 idmap 6/6] RUN ./autogen.sh --disable-nls --disable-man --without-audit --without-selinux --without-acl --without-attr --without-tcb --without-nscd   && make   && cp src/newuidmap src/newgi  0.0s
 => CACHED [linux/arm/v7 rootless-base-internal 3/5] COPY --from=idmap /usr/bin/newuidmap /usr/bin/newuidmap                                                                                                            0.0s
 => CACHED [linux/arm/v7 rootless-base-internal 4/5] COPY --from=idmap /usr/bin/newgidmap /usr/bin/newgidmap                                                                                                            0.0s
 => CACHED [linux/arm/v7 rootless-base-internal 5/5] RUN chmod u+s /usr/bin/newuidmap /usr/bin/newgidmap   && adduser -D -u 1000 user   && mkdir -p /run/user/1000 /home/user/.local/tmp /home/user/.local/share/build  0.0s
 => exporting to image                                                                                                                                                                                                 23.6s
 => => exporting layers                                                                                                                                                                                                 0.0s
 => => exporting manifest sha256:e9bbd8ae01ed4e69de1e4255b41afebce174e72e7d15552bc3e4a48a36cb7b8e                                                                                                                       0.0s
 => => exporting config sha256:1183ddd9f07a2084b56010639517cc23e8af17e7d5123c1ddc9627ba7b8f1a66                                                                                                                         0.0s
 => => exporting manifest sha256:c8d873ea7f343839b51f2deb307ca074583852aaf891e73129eb73481b4aff45                                                                                                                       0.0s
 => => exporting config sha256:30f397f0bc12dc07685f30f9d7974c05e56f704e06575360d8088f1b0ae1861b                                                                                                                         0.0s
 => => exporting manifest sha256:5924875c65aeb2591ad859e6eae99f57ec29589b94f19cce9970559d3be89089                                                                                                                       0.0s
 => => exporting config sha256:fa8e480c9d75ad4c30ab591358ad0d916dccebabc54f893be494b1f836f44894                                                                                                                         0.0s
 => => exporting manifest sha256:f0ec9ee0f70ad92c200f99bf08a822c73e79341d81154f0a50754085fab1e923                                                                                                                       0.0s
 => => exporting config sha256:ce301fd4f0344a1110f6b627ac169382c6a2498b2550233999d25f854c2ce6a4                                                                                                                         0.0s
 => => exporting manifest sha256:b0b28e08cc356b79fb12b3982eb5b6d02b51430e31eb2adc4405da0a2fe6922d                                                                                                                       0.0s
 => => exporting config sha256:d86a64f1b5c11d359fed0f3e38ba982ea706f943b5c4e51e79a66751fa668a4a                                                                                                                         0.0s
 => => exporting manifest sha256:dcd110128a398567157497b8242f0d9a366db3271199718aa11963e3845b903b                                                                                                                       0.0s
 => => exporting config sha256:77caa6ed39ee6fc2c2faf01699958aeb30c2b290dfdd58c1f8b2646a2ec777a7                                                                                                                         0.0s
 => => exporting manifest list sha256:0008b156dedd0220a5a0a1aa8840afe0ea0f01f44dfe1ae850b3970aaa1c5cec                                                                                                                  0.0s
 => => pushing layers                                                                                                                                                                                                  20.5s
 => => pushing manifest for docker.io/tonistiigi/buildkit:rootless-base                                                                                                                                                 2.9s
 # docker buildx imagetools inspect docker.io/tonistiigi/buildkit:rootless-base
Name:      docker.io/tonistiigi/buildkit:rootless-base
MediaType: application/vnd.docker.distribution.manifest.list.v2+json
Digest:    sha256:0008b156dedd0220a5a0a1aa8840afe0ea0f01f44dfe1ae850b3970aaa1c5cec

Manifests:
  Name:      docker.io/tonistiigi/buildkit:rootless-base@sha256:e9bbd8ae01ed4e69de1e4255b41afebce174e72e7d15552bc3e4a48a36cb7b8e
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/amd64

  Name:      docker.io/tonistiigi/buildkit:rootless-base@sha256:c8d873ea7f343839b51f2deb307ca074583852aaf891e73129eb73481b4aff45
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/arm/v7

  Name:      docker.io/tonistiigi/buildkit:rootless-base@sha256:5924875c65aeb2591ad859e6eae99f57ec29589b94f19cce9970559d3be89089
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/arm/v6

  Name:      docker.io/tonistiigi/buildkit:rootless-base@sha256:f0ec9ee0f70ad92c200f99bf08a822c73e79341d81154f0a50754085fab1e923
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/s390x

  Name:      docker.io/tonistiigi/buildkit:rootless-base@sha256:b0b28e08cc356b79fb12b3982eb5b6d02b51430e31eb2adc4405da0a2fe6922d
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/ppc64le

  Name:      docker.io/tonistiigi/buildkit:rootless-base@sha256:dcd110128a398567157497b8242f0d9a366db3271199718aa11963e3845b903b
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/arm64
```
