### PR TITLE
solver: avoid recursive loop on cache-export

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -61,7 +61,7 @@ func TestIntegration(t *testing.T) {
 	mirrors := integration.WithMirroredImages(integration.OfficialImages("busybox:latest", "alpine:latest"))
 
 	integration.Run(t, []integration.Test{
-		testLocalCacheExport,
+		testCacheExportCacheKeyLoop,
 		testRelativeWorkDir,
 		testFileOpMkdirMkfile,
 		testFileOpCopyRm,
@@ -136,7 +136,8 @@ func newContainerd(cdAddress string) (*containerd.Client, error) {
 	return containerd.New(cdAddress, containerd.WithTimeout(60*time.Second), containerd.WithDefaultRuntime("io.containerd.runtime.v1.linux"))
 }
 
-func testLocalCacheExport(t *testing.T, sb integration.Sandbox) {
+// moby/buildkit#1336
+func testCacheExportCacheKeyLoop(t *testing.T, sb integration.Sandbox) {
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -148,27 +149,36 @@ func testLocalCacheExport(t *testing.T, sb integration.Sandbox) {
 	err = ioutil.WriteFile(filepath.Join(tmpdir, "foo"), []byte("foodata"), 0600)
 	require.NoError(t, err)
 
-	buildbase := llb.Image("alpine:latest").File(llb.Copy(llb.Local("mylocal"), "foo", "foo"))
-	intermed := llb.Image("alpine:latest").File(llb.Copy(buildbase, "foo", "foo"))
-	final := llb.Scratch().File(llb.Copy(intermed, "foo", "foooooo"))
+	for _, mode := range []bool{false, true} {
+		func(mode bool) {
+			t.Run(fmt.Sprintf("mode=%v", mode), func(t *testing.T) {
+				buildbase := llb.Image("alpine:latest").File(llb.Copy(llb.Local("mylocal"), "foo", "foo"))
+				if mode { // same cache keys with a separating node go to different code-path
+					buildbase = buildbase.Run(llb.Shlex("true")).Root()
+				}
+				intermed := llb.Image("alpine:latest").File(llb.Copy(buildbase, "foo", "foo"))
+				final := llb.Scratch().File(llb.Copy(intermed, "foo", "foooooo"))
 
-	def, err := final.Marshal()
-	require.NoError(t, err)
+				def, err := final.Marshal()
+				require.NoError(t, err)
 
-	_, err = c.Solve(context.TODO(), def, SolveOpt{
-		CacheExports: []CacheOptionsEntry{
-			{
-				Type: "local",
-				Attrs: map[string]string{
-					"dest": filepath.Join(tmpdir, "cache"),
-				},
-			},
-		},
-		LocalDirs: map[string]string{
-			"mylocal": tmpdir,
-		},
-	}, nil)
-	require.NoError(t, err)
+				_, err = c.Solve(context.TODO(), def, SolveOpt{
+					CacheExports: []CacheOptionsEntry{
+						{
+							Type: "local",
+							Attrs: map[string]string{
+								"dest": filepath.Join(tmpdir, "cache"),
+							},
+						},
+					},
+					LocalDirs: map[string]string{
+						"mylocal": tmpdir,
+					},
+				}, nil)
+				require.NoError(t, err)
+			})
+		}(mode)
+	}
 }
 
 func testBridgeNetworking(t *testing.T, sb integration.Sandbox) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -61,6 +61,7 @@ func TestIntegration(t *testing.T) {
 	mirrors := integration.WithMirroredImages(integration.OfficialImages("busybox:latest", "alpine:latest"))
 
 	integration.Run(t, []integration.Test{
+		testLocalCacheExport,
 		testRelativeWorkDir,
 		testFileOpMkdirMkfile,
 		testFileOpCopyRm,
@@ -133,6 +134,41 @@ func TestIntegration(t *testing.T) {
 
 func newContainerd(cdAddress string) (*containerd.Client, error) {
 	return containerd.New(cdAddress, containerd.WithTimeout(60*time.Second), containerd.WithDefaultRuntime("io.containerd.runtime.v1.linux"))
+}
+
+func testLocalCacheExport(t *testing.T, sb integration.Sandbox) {
+	c, err := New(context.TODO(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	tmpdir, err := ioutil.TempDir("", "buildkit-buildctl")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpdir)
+
+	err = ioutil.WriteFile(filepath.Join(tmpdir, "foo"), []byte("foodata"), 0600)
+	require.NoError(t, err)
+
+	buildbase := llb.Image("alpine:latest").File(llb.Copy(llb.Local("mylocal"), "foo", "foo"))
+	intermed := llb.Image("alpine:latest").File(llb.Copy(buildbase, "foo", "foo"))
+	final := llb.Scratch().File(llb.Copy(intermed, "foo", "foooooo"))
+
+	def, err := final.Marshal()
+	require.NoError(t, err)
+
+	_, err = c.Solve(context.TODO(), def, SolveOpt{
+		CacheExports: []CacheOptionsEntry{
+			{
+				Type: "local",
+				Attrs: map[string]string{
+					"dest": filepath.Join(tmpdir, "cache"),
+				},
+			},
+		},
+		LocalDirs: map[string]string{
+			"mylocal": tmpdir,
+		},
+	}, nil)
+	require.NoError(t, err)
 }
 
 func testBridgeNetworking(t *testing.T, sb integration.Sandbox) {


### PR DESCRIPTION
fixes #1336

@drodriguezhdez @aiordache  

This seems enough to fix the cycle issue (including a case with a longer cycle that doesn't appear with the original repro). But this area needs a bit more analysis, comments and maybe some debugging tooling to verify that the exported chain is still optimal, even in the cycle case. Also needs tests for the repros.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>