### PR TITLE
Edge case tests for build with cache export 

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -61,6 +61,7 @@ func TestIntegration(t *testing.T) {
 	mirrors := integration.WithMirroredImages(integration.OfficialImages("busybox:latest", "alpine:latest"))
 
 	integration.Run(t, []integration.Test{
+		testLocalCacheExport,
 		testRelativeWorkDir,
 		testFileOpMkdirMkfile,
 		testFileOpCopyRm,
@@ -133,6 +134,41 @@ func TestIntegration(t *testing.T) {
 
 func newContainerd(cdAddress string) (*containerd.Client, error) {
 	return containerd.New(cdAddress, containerd.WithTimeout(60*time.Second), containerd.WithDefaultRuntime("io.containerd.runtime.v1.linux"))
+}
+
+func testLocalCacheExport(t *testing.T, sb integration.Sandbox) {
+	c, err := New(context.TODO(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	tmpdir, err := ioutil.TempDir("", "buildkit-buildctl")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpdir)
+
+	err = ioutil.WriteFile(filepath.Join(tmpdir, "foo"), []byte("foodata"), 0600)
+	require.NoError(t, err)
+
+	buildbase := llb.Image("alpine:latest").File(llb.Copy(llb.Local("mylocal"), "foo", "foo"))
+	intermed := llb.Image("alpine:latest").File(llb.Copy(buildbase, "foo", "foo"))
+	final := llb.Scratch().File(llb.Copy(intermed, "foo", "foooooo"))
+
+	def, err := final.Marshal()
+	require.NoError(t, err)
+
+	_, err = c.Solve(context.TODO(), def, SolveOpt{
+		CacheExports: []CacheOptionsEntry{
+			{
+				Type: "local",
+				Attrs: map[string]string{
+					"dest": filepath.Join(tmpdir, "cache"),
+				},
+			},
+		},
+		LocalDirs: map[string]string{
+			"mylocal": tmpdir,
+		},
+	}, nil)
+	require.NoError(t, err)
 }
 
 func testBridgeNetworking(t *testing.T, sb integration.Sandbox) {

--- a/cmd/buildctl/buildctl_test.go
+++ b/cmd/buildctl/buildctl_test.go
@@ -16,6 +16,7 @@ func TestCLIIntegration(t *testing.T) {
 	integration.Run(t, []integration.Test{
 		testDiskUsage,
 		testBuildWithLocalFiles,
+		testBuildWithCacheExport,
 		testBuildLocalExporter,
 		testBuildContainerdExporter,
 		testPrune,


### PR DESCRIPTION
Should run into the recursive loop caused by some circular dependencies in solver's exporter. 

relates to https://github.com/moby/buildkit/issues/1313 and https://github.com/moby/buildkit/issues/1336

depends on https://github.com/moby/buildkit/pull/1382