### PR TITLE
WIP: Reactivate containerd 1.2 in the CI tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -220,7 +220,7 @@ RUN apt-get install -y --no-install-recommends uidmap sudo vim iptables \
   && chown -R user /run/user/1000 /home/user \
   && update-alternatives --set iptables /usr/sbin/iptables-legacy
 # musl is needed to directly use the registry binary that is built on alpine
-#ENV BUILDKIT_INTEGRATION_CONTAINERD_EXTRA="containerd-1.2=/opt/containerd-old/bin"
+ENV BUILDKIT_INTEGRATION_CONTAINERD_EXTRA="containerd-1.2=/opt/containerd-old/bin"
 COPY --from=rootlesskit /rootlesskit /usr/bin/
 COPY --from=containerd-old /out/containerd* /opt/containerd-old/bin/
 COPY --from=registry /bin/registry /usr/bin

--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -162,7 +162,7 @@ func Build(ctx context.Context, c client.Client) (*client.Result, error) {
 			},
 		})
 		if err != nil {
-			return nil, errors.Errorf("failed to read downloaded context")
+			return nil, errors.Wrapf(err, "failed to read downloaded context")
 		}
 		if isArchive(dt) {
 			if fileop {

--- a/hack/util
+++ b/hack/util
@@ -32,7 +32,7 @@ if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then
   currentref="git://github.com/moby/buildkit#refs/pull/$TRAVIS_PULL_REQUEST/merge"
   cacheref="cicache.buildk.it/moby/buildkit/pr$TRAVIS_BUILD_ID"
 elif [ -n "$TRAVIS_BRANCH" ]; then
-  currentref="git://github.com/moby/buildkit#$TRAVIS_BRANCH"
+  currentref="git://github.com/$TRAVIS_REPO_SLUG#$TRAVIS_BRANCH"
 fi
 
 

--- a/util/testutil/integration/oci.go
+++ b/util/testutil/integration/oci.go
@@ -1,8 +1,6 @@
 package integration
 
 import (
-	"bufio"
-	"bytes"
 	"fmt"
 	"log"
 	"os"
@@ -67,14 +65,4 @@ func (s *oci) New(cfg *BackendConfig) (Backend, func() error, error) {
 		address:  buildkitdSock,
 		rootless: s.uid != 0,
 	}, stop, nil
-}
-
-func printLogs(logs map[string]*bytes.Buffer, f func(args ...interface{})) {
-	for name, l := range logs {
-		f(name)
-		s := bufio.NewScanner(l)
-		for s.Scan() {
-			f(s.Text())
-		}
-	}
 }

--- a/util/testutil/integration/sandbox.go
+++ b/util/testutil/integration/sandbox.go
@@ -202,3 +202,13 @@ func rootlessSupported(uid int) bool {
 	}
 	return true
 }
+
+func printLogs(logs map[string]*bytes.Buffer, f func(args ...interface{})) {
+	for name, l := range logs {
+		f(name)
+		s := bufio.NewScanner(l)
+		for s.Scan() {
+			f(s.Text())
+		}
+	}
+}

--- a/util/testutil/integration/sandbox.go
+++ b/util/testutil/integration/sandbox.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"syscall"
@@ -44,6 +45,10 @@ type sandbox struct {
 
 func (sb *sandbox) PrintLogs(t *testing.T) {
 	printLogs(sb.logs, t.Log)
+}
+
+func (sb *sandbox) MatchLogs(matchRegexp *regexp.Regexp) bool {
+	return matchLogs(sb.logs, matchRegexp)
 }
 
 func (sb *sandbox) NewRegistry() (string, error) {
@@ -211,4 +216,16 @@ func printLogs(logs map[string]*bytes.Buffer, f func(args ...interface{})) {
 			f(s.Text())
 		}
 	}
+}
+
+func matchLogs(logs map[string]*bytes.Buffer, matchRegexp *regexp.Regexp) bool {
+	for _, l := range logs {
+		s := bufio.NewScanner(l)
+		for s.Scan() {
+			if matchRegexp.MatchString(s.Text()) {
+				return true
+			}
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This is a pre-requisite for #1348.

Per https://github.com/moby/buildkit/pull/1314#discussion_r364477958 and https://github.com/moby/buildkit/pull/1314#discussion_r365633635, containerd 1.2 is still supported, but CI testing was disabled in c4f0305.

Since that point, 200-something tests now fail due to calling a particular API `LeaseManager.AddResource` which was newly-added in containerd 1.3. (Two other APIs, `DeleteResource` and `ListResource` are unused in BuildKt.

The intention here is to skip those tests, as I don't understand enough about what `LeaseManager` does to actually do the surgery to make the tests pass, e.g., catching and ignoring the not-implemented failure in util/leaseutil/manager.go.