### PR TITLE
dockerfile build:  fix not exit when meet error in load config metadata

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert_test.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_test.go
@@ -26,7 +26,7 @@ func toEnvMap(args []instructions.KeyValuePairOptional, env []string) map[string
 
 func TestDockerfileParsing(t *testing.T) {
 	t.Parallel()
-	df := `FROM busybox
+	df := `FROM scratch
 ENV FOO bar
 COPY f1 f2 /sub/
 RUN ls -l
@@ -34,7 +34,7 @@ RUN ls -l
 	_, _, err := Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
 	assert.NoError(t, err)
 
-	df = `FROM busybox AS foo
+	df = `FROM scratch AS foo
 ENV FOO bar
 FROM foo
 COPY --from=foo f1 /
@@ -43,7 +43,7 @@ COPY --from=0 f2 /
 	_, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
 	assert.NoError(t, err)
 
-	df = `FROM busybox AS foo
+	df = `FROM scratch AS foo
 ENV FOO bar
 FROM foo
 COPY --from=foo f1 /
@@ -59,13 +59,13 @@ COPY --from=0 f2 /
 	})
 	assert.Error(t, err)
 
-	df = `FROM busybox
+	df = `FROM scratch
 	ADD http://github.com/moby/buildkit/blob/master/README.md /
 		`
 	_, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
 	assert.NoError(t, err)
 
-	df = `FROM busybox
+	df = `FROM scratch
 	COPY http://github.com/moby/buildkit/blob/master/README.md /
 		`
 	_, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})


### PR DESCRIPTION
 We have an unstable registry which sometimes cause the failure of fetching base-image manifest(config), but it didn't fail the build job. Then the built image will discard some run-time config defined in base-image(like ONBUILD, ENV...) 

logs like this:

> #3 [internal] load metadata for sofa-jdk8-4484-7u2:20200214_5...
> #3 ERROR: failed to fetch schema1 manifest: httpReaderSeeker: failed open: could not fetch content descriptor sha256:b659f107d54f2e1e746745be4252f0f7828b0ed10ff875256d8a1ebac58ef1d4 (application/vnd.docker.distribution.manifest.v1+prettyjws) from remote: not found
> 
> #4 [1/3] FROM sofa-jdk8-4484-7u2:20200214_5...
> #4 resolve acs-reg.alipay.com/image-mybank/sofa-jdk8-4484-7u2:20200214_56f781c 0.0s done
> #4 DONE 0.0s
Meet error but not exist 

I think we should return error  when we meet error in ResolveImageConfig. 

But I don't understand the note "// handle the error while builder is actually running"， not sure whether had other consideration. 

Signed-off-by: genglu <genglu.gl@antfin.com>