### PR TITLE
rootless: graduate from experimental

### DIFF
--- a/docs/rootless.md
+++ b/docs/rootless.md
@@ -1,4 +1,4 @@
-# Rootless mode (Experimental)
+# Rootless mode
 
 Rootless mode allows running BuildKit daemon as a non-root user.
 


### PR DESCRIPTION
The rootless mode is almost feature complete and now should be out of experimental.

(We still don't support cgroups, but it is not specific to rootless)