### PR TITLE
Support stargz snapshotter for dev stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ ARG ROOTLESSKIT_VERSION=v0.9.5
 ARG CNI_VERSION=v0.8.6
 ARG SHADOW_VERSION=4.8.1
 ARG FUSEOVERLAYFS_VERSION=v1.1.2
+ARG STARGZ_SNAPSHOTTER_VERSION=5aca593bd474015005b8832cf9763685d9d4db61
 
 # git stage is used for checking out remote repository sources
 FROM --platform=$BUILDPLATFORM alpine AS git
@@ -173,6 +174,15 @@ RUN  --mount=target=/root/.cache,type=cache \
   CGO_ENABLED=0 go build -o /rootlesskit ./cmd/rootlesskit && \
   file /rootlesskit | grep "statically linked"
 
+FROM gobuild-base AS stargz-snapshotter
+RUN git clone https://github.com/containerd/stargz-snapshotter.git /go/src/github.com/containerd/stargz-snapshotter
+WORKDIR /go/src/github.com/containerd/stargz-snapshotter
+ARG STARGZ_SNAPSHOTTER_VERSION
+RUN git checkout -q "$STARGZ_SNAPSHOTTER_VERSION"  && \
+  mkdir /out && CGO_ENABLED=0 PREFIX=/out/ make && \
+  file /out/containerd-stargz-grpc | grep "statically linked" && \
+  file /out/ctr-remote | grep "statically linked"
+
 FROM --platform=$BUILDPLATFORM alpine AS fuse-overlayfs
 RUN apk add --no-cache curl
 ARG FUSEOVERLAYFS_VERSION
@@ -225,7 +235,7 @@ RUN curl -Ls https://github.com/containernetworking/plugins/releases/download/$C
 
 FROM buildkit-base AS integration-tests-base
 ENV BUILDKIT_INTEGRATION_ROOTLESS_IDPAIR="1000:1000"
-RUN apt-get --no-install-recommends install -y uidmap sudo vim iptables \ 
+RUN apt-get --no-install-recommends install -y uidmap sudo vim iptables fuse \
   && useradd --create-home --home-dir /home/user --uid 1000 -s /bin/sh user \
   && echo "XDG_RUNTIME_DIR=/run/user/1000; export XDG_RUNTIME_DIR" >> /home/user/.profile \
   && mkdir -m 0700 -p /run/user/1000 \
@@ -233,6 +243,8 @@ RUN apt-get --no-install-recommends install -y uidmap sudo vim iptables \
   && update-alternatives --set iptables /usr/sbin/iptables-legacy
 # musl is needed to directly use the registry binary that is built on alpine
 ENV BUILDKIT_INTEGRATION_CONTAINERD_EXTRA="containerd-1.3=/opt/containerd-alt/bin"
+ENV BUILDKIT_INTEGRATION_CONTAINERD_STARGZ=1
+COPY --from=stargz-snapshotter /out/* /usr/bin/
 COPY --from=rootlesskit /rootlesskit /usr/bin/
 COPY --from=containerd-alt /out/containerd* /opt/containerd-alt/bin/
 COPY --from=registry /bin/registry /usr/bin

--- a/cache/opts.go
+++ b/cache/opts.go
@@ -9,8 +9,9 @@ import (
 )
 
 type DescHandler struct {
-	Provider content.Provider
-	Progress progress.Controller
+	Provider       content.Provider
+	Progress       progress.Controller
+	SnapshotLabels map[string]string
 }
 
 type DescHandlers map[digest.Digest]*DescHandler

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -15,6 +15,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -119,6 +120,7 @@ func TestIntegration(t *testing.T) {
 		testSourceMap,
 		testSourceMapFromRef,
 		testLazyImagePush,
+		testStargzLazyPull,
 	}, mirrors)
 
 	integration.Run(t, []integration.Test{
@@ -2047,6 +2049,112 @@ func testBuildPushAndValidate(t *testing.T, sb integration.Sandbox) {
 
 	_, ok = m["foo/sub/bar"]
 	require.False(t, ok)
+}
+
+func testStargzLazyPull(t *testing.T, sb integration.Sandbox) {
+	skipDockerd(t, sb)
+	requiresLinux(t)
+
+	cdAddress := sb.ContainerdAddress()
+	if cdAddress == "" || !sb.Stargz() {
+		t.Skip("test requires containerd worker with stargz snapshotter")
+	}
+
+	client, err := newContainerd(cdAddress)
+	require.NoError(t, err)
+	defer client.Close()
+	registry, err := sb.NewRegistry()
+	if errors.Is(err, integration.ErrorRequirements) {
+		t.Skip(err.Error())
+	}
+	require.NoError(t, err)
+
+	// Prepare stargz image
+	sgzImage := registry + "/stargz/alpine:latest"
+	err = exec.Command("ctr-remote", "image", "optimize",
+		"--period=1", "alpine:latest", sgzImage).Run()
+	require.NoError(t, err)
+
+	c, err := New(context.TODO(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	// stargz layers should be lazy even for executing something on them
+	def, err := llb.Image(sgzImage).
+		Run(llb.Args([]string{"/bin/touch", "/foo"})).
+		Marshal(context.TODO())
+	require.NoError(t, err)
+	target := registry + "/buildkit/testlazyimage:latest"
+	_, err = c.Solve(context.TODO(), def, SolveOpt{
+		Exports: []ExportEntry{
+			{
+				Type: ExporterImage,
+				Attrs: map[string]string{
+					"name": target,
+					"push": "true",
+				},
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	var (
+		imageService = client.ImageService()
+		contentStore = client.ContentStore()
+		ctx          = namespaces.WithNamespace(context.Background(), "buildkit")
+	)
+
+	img, err := imageService.Get(ctx, target)
+	require.NoError(t, err)
+
+	manifest, err := images.Manifest(ctx, contentStore, img.Target, nil)
+	require.NoError(t, err)
+
+	// Check if image layers are lazy.
+	// The topmost(last) layer created by `Run` isn't lazy so we skip the check for the layer.
+	var sgzLayers []ocispec.Descriptor
+	for _, layer := range manifest.Layers[:len(manifest.Layers)-1] {
+		_, err = contentStore.Info(ctx, layer.Digest)
+		require.True(t, errors.Is(err, ctderrdefs.ErrNotFound), "unexpected error %v", err)
+		sgzLayers = append(sgzLayers, layer)
+	}
+	require.NotEqual(t, 0, len(sgzLayers), "no layer can be used for checking lazypull")
+
+	// The topmost(last) layer created by `Run` shouldn't be lazy
+	_, err = contentStore.Info(ctx, manifest.Layers[len(manifest.Layers)-1].Digest)
+	require.NoError(t, err)
+
+	// clear all local state out
+	err = imageService.Delete(ctx, img.Name, images.SynchronousDelete())
+	require.NoError(t, err)
+	checkAllReleasable(t, c, sb, true)
+
+	// stargz layers should be exportable
+	destDir, err := ioutil.TempDir("", "buildkit")
+	require.NoError(t, err)
+	defer os.RemoveAll(destDir)
+	out := filepath.Join(destDir, "out.tar")
+	outW, err := os.Create(out)
+	require.NoError(t, err)
+	_, err = c.Solve(context.TODO(), def, SolveOpt{
+		Exports: []ExportEntry{
+			{
+				Type:   ExporterOCI,
+				Output: fixedWriteCloser(outW),
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	// Check if image layers are un-lazied
+	for _, layer := range sgzLayers {
+		_, err = contentStore.Info(ctx, layer.Digest)
+		require.NoError(t, err)
+	}
+
+	err = c.Prune(context.TODO(), nil, PruneAll)
+	require.NoError(t, err)
+	checkAllRemoved(t, c, sb)
 }
 
 func testLazyImagePush(t *testing.T, sb integration.Sandbox) {

--- a/cmd/buildctl/build_test.go
+++ b/cmd/buildctl/build_test.go
@@ -102,7 +102,11 @@ func testBuildContainerdExporter(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 
 	// NOTE: by default, it is overlayfs
-	ok, err := img.IsUnpacked(ctx, "overlayfs")
+	snapshotter := "overlayfs"
+	if sb.Stargz() {
+		snapshotter = "stargz"
+	}
+	ok, err := img.IsUnpacked(ctx, snapshotter)
 	require.NoError(t, err)
 	require.Equal(t, ok, true)
 }

--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -78,7 +78,8 @@ type OCIConfig struct {
 	// incomplete and the intention is to make it default without config.
 	UserRemapUnsupported string `toml:"userRemapUnsupported"`
 	// For use in storing the OCI worker binary name that will replace buildkit-runc
-	Binary string `toml:"binary"`
+	Binary               string `toml:"binary"`
+	ProxySnapshotterPath string `toml:"proxySnapshotterPath"`
 }
 
 type ContainerdConfig struct {
@@ -89,6 +90,7 @@ type ContainerdConfig struct {
 	Namespace string            `toml:"namespace"`
 	GCConfig
 	NetworkConfig
+	Snapshotter string `toml:"snapshotter"`
 }
 
 type GCPolicy struct {

--- a/cmd/buildkitd/main_containerd_worker.go
+++ b/cmd/buildkitd/main_containerd_worker.go
@@ -86,6 +86,11 @@ func init() {
 			Usage: "path of cni binary files",
 			Value: defaultConf.Workers.Containerd.NetworkConfig.CNIBinaryPath,
 		},
+		cli.StringFlag{
+			Name:  "containerd-worker-snapshotter",
+			Usage: "snapshotter name to use",
+			Value: ctd.DefaultSnapshotter,
+		},
 	}
 
 	if defaultConf.Workers.Containerd.GC == nil || *defaultConf.Workers.Containerd.GC {
@@ -184,6 +189,9 @@ func applyContainerdFlags(c *cli.Context, cfg *config.Config) error {
 	if c.GlobalIsSet("containerd-cni-binary-dir") {
 		cfg.Workers.Containerd.NetworkConfig.CNIBinaryPath = c.GlobalString("containerd-cni-binary-dir")
 	}
+	if c.GlobalIsSet("containerd-worker-snapshotter") {
+		cfg.Workers.Containerd.Snapshotter = c.GlobalString("containerd-worker-snapshotter")
+	}
 
 	return nil
 }
@@ -210,7 +218,11 @@ func containerdWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([
 		},
 	}
 
-	opt, err := containerd.NewWorkerOpt(common.config.Root, cfg.Address, ctd.DefaultSnapshotter, cfg.Namespace, cfg.Labels, dns, nc, ctd.WithTimeout(60*time.Second))
+	snapshotter := ctd.DefaultSnapshotter
+	if cfg.Snapshotter != "" {
+		snapshotter = cfg.Snapshotter
+	}
+	opt, err := containerd.NewWorkerOpt(common.config.Root, cfg.Address, snapshotter, cfg.Namespace, cfg.Labels, dns, nc, ctd.WithTimeout(60*time.Second))
 	if err != nil {
 		return nil, err
 	}

--- a/util/testutil/integration/sandbox.go
+++ b/util/testutil/integration/sandbox.go
@@ -24,6 +24,7 @@ type backend struct {
 	address           string
 	containerdAddress string
 	rootless          bool
+	stargz            bool
 }
 
 func (b backend) Address() string {
@@ -36,6 +37,10 @@ func (b backend) ContainerdAddress() string {
 
 func (b backend) Rootless() bool {
 	return b.rootless
+}
+
+func (b backend) Stargz() bool {
+	return b.stargz
 }
 
 type sandbox struct {


### PR DESCRIPTION
Related issues: 
- https://github.com/moby/buildkit/issues/1396
- https://github.com/containerd/stargz-snapshotter/pull/53

Throughout building steps, "pulling base image" is one of the time-consuming steps.

Recently, containerd community started "Stargz Snapshotter" (containerd/stargz-snapshotter) non-core subproject for speeding up image pulling. With this snapshotter, we can directly mount stargz-formatted (but still docker-compatible) image to nodes, which takes much shorter than downloading the whole of the image to nodes.

This commit solves the performance problem on pulling base images for "dev" stages using stargz snapshotter.

We introduced new RecordType "snapshot" for unexported base images. These images aren't guaranteed to have their whole contents in the content store but snapshots (possibly "remote" snapshots) are provided. Target (exported) base images don't have this type because its contents need to be fully available on the node for exportation.

We can test this patch with stargz snapshotter on [this branch](https://github.com/ktock/stargz-snapshotter/tree/buildkit) (Please also see [this instruction](https://github.com/ktock/stargz-snapshotter/blob/a4568426aff225bdc07718c53dc1a7dbf79e8f9e/script/buildkit/testing.md)).
We can see the benchmarking result with [sample image](https://github.com/ktock/stargz-snapshotter/blob/a4568426aff225bdc07718c53dc1a7dbf79e8f9e/script/buildkit/sample_sgz/Dockerfile) on https://github.com/containerd/stargz-snapshotter/pull/53#issuecomment-596995434.

This PR also intends to be a discussion thread for the design and implementation strategies of this feature so if there is a better one please tell us.