### PR TITLE
Add --force flag in git fetch command

### DIFF
--- a/source/git/gitsource.go
+++ b/source/git/gitsource.go
@@ -273,7 +273,8 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context) (out cache.ImmutableRe
 		args = append(args, "origin")
 		if !isCommitSHA(ref) {
 			args = append(args, "--force", ref+":tags/"+ref)
-			// local refs are needed so they would be advertised on next fetches
+			// local refs are needed so they would be advertised on next fetches. Force is used
+			// in case the ref is a branch and it now points to a different commit sha
 			// TODO: is there a better way to do this?
 		}
 		if _, err := gitWithinDir(ctx, gitDir, "", args...); err != nil {

--- a/source/git/gitsource.go
+++ b/source/git/gitsource.go
@@ -272,7 +272,7 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context) (out cache.ImmutableRe
 		}
 		args = append(args, "origin")
 		if !isCommitSHA(ref) {
-			args = append(args, ref+":tags/"+ref)
+			args = append(args, "--force", ref+":tags/"+ref)
 			// local refs are needed so they would be advertised on next fetches
 			// TODO: is there a better way to do this?
 		}


### PR DESCRIPTION
This fixes the following situation:

* The ref is a branch (eg `master`)
* The git source was previously used in another build, with the same URL and branch, but the branch was pointing to a different hash at the time
* The git fetch instruction throws an error, because locally the branch is tracked as a tag and tags are considered immutable. (As the git source had been previously used, the tag already exists locally.)

By using the `--force` flag, the git fetch forces the local tag update.

I've tested this in my own custom application. It fixes an error that looks like this:

```
rpc error: code = Unknown desc = failed to fetch remote git@github.com:vladaionescu/earthly.git: exit status 1
```

Buildkitd log:
```
time="2020-03-28T01:04:00Z" level=error msg="/moby.buildkit.v1.Control/Solve returned error: exit status 1\nfailed to fetch remote git@github.com:vladaionescu/earthly.git\ngithub.com/moby/buildkit/source/git.(*gitSourceHandler).Snapshot\n\t/src/source/git/gitsource.go:280\ngithub.com/moby/buildkit/solver/llbsolver/ops.(*sourceOp).Exec\n\t/src/solver/llbsolver/ops/source.go:87\ngithub.com/moby/buildkit/solver.(*sharedOp).Exec.func1\n\t/src/solver/jobs.go:688\ngithub.com/moby/buildkit/util/flightcontrol.(*call).run\n\t/src/util/flightcontrol/flightcontrol.go:121\nsync.(*Once).doSlow\n\t/usr/local/go/src/sync/once.go:66\nsync.(*Once).Do\n\t/usr/local/go/src/sync/once.go:57\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1357\ngithub.com/moby/buildkit/solver.(*edge).execOp\n\t/src/solver/edge.go:869\ngithub.com/moby/buildkit/solver/internal/pipe.NewWithFunction.func2\n\t/src/solver/internal/pipe/pipe.go:82\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1357"
```