### PR TITLE
llb: asyncronous llb graph generation support

### DIFF
--- a/client/build_test.go
+++ b/client/build_test.go
@@ -54,7 +54,7 @@ func testClientGatewaySolve(t *testing.T, sb integration.Sandbox) {
 		)
 		st := run.AddMount("/out", llb.Scratch())
 
-		def, err := st.Marshal()
+		def, err := st.Marshal(ctx)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to marshal state")
 		}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -161,7 +161,7 @@ func testCacheExportCacheKeyLoop(t *testing.T, sb integration.Sandbox) {
 				intermed := llb.Image("alpine:latest").File(llb.Copy(buildbase, "foo", "foo"))
 				final := llb.Scratch().File(llb.Copy(intermed, "foo", "foooooo"))
 
-				def, err := final.Marshal()
+				def, err := final.Marshal(context.TODO())
 				require.NoError(t, err)
 
 				_, err = c.Solve(context.TODO(), def, SolveOpt{
@@ -198,7 +198,7 @@ func testBridgeNetworking(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 	addrParts := strings.Split(s.Addr().String(), ":")
 
-	def, err := llb.Image("busybox").Run(llb.Shlexf("sh -c 'nc 127.0.0.1 %s | grep foo'", addrParts[len(addrParts)-1])).Marshal()
+	def, err := llb.Image("busybox").Run(llb.Shlexf("sh -c 'nc 127.0.0.1 %s | grep foo'", addrParts[len(addrParts)-1])).Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{}, nil)
@@ -221,7 +221,7 @@ func testHostNetworking(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 	addrParts := strings.Split(s.Addr().String(), ":")
 
-	def, err := llb.Image("busybox").Run(llb.Shlexf("sh -c 'nc 127.0.0.1 %s | grep foo'", addrParts[len(addrParts)-1]), llb.Network(llb.NetModeHost)).Marshal()
+	def, err := llb.Image("busybox").Run(llb.Shlexf("sh -c 'nc 127.0.0.1 %s | grep foo'", addrParts[len(addrParts)-1]), llb.Network(llb.NetModeHost)).Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{
@@ -240,7 +240,7 @@ func testExportBusyboxLocal(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 	defer c.Close()
 
-	def, err := llb.Image("busybox").Marshal()
+	def, err := llb.Image("busybox").Marshal(context.TODO())
 	require.NoError(t, err)
 
 	destDir, err := ioutil.TempDir("", "buildkit")
@@ -280,7 +280,7 @@ func testHostnameLookup(t *testing.T, sb integration.Sandbox) {
 
 	st := llb.Image("busybox:latest").Run(llb.Shlex(`sh -c "ping -c 1 $(hostname)"`))
 
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{}, nil)
@@ -295,7 +295,7 @@ func testStdinClosed(t *testing.T, sb integration.Sandbox) {
 
 	st := llb.Image("busybox:latest").Run(llb.Shlex("cat"))
 
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{}, nil)
@@ -326,7 +326,7 @@ func testSSHMount(t *testing.T, sb integration.Sandbox) {
 
 	// no ssh exposed
 	st := llb.Image("busybox:latest").Run(llb.Shlex(`nosuchcmd`), llb.AddSSHSocket())
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{}, nil)
@@ -335,7 +335,7 @@ func testSSHMount(t *testing.T, sb integration.Sandbox) {
 
 	// custom ID not exposed
 	st = llb.Image("busybox:latest").Run(llb.Shlex(`nosuchcmd`), llb.AddSSHSocket(llb.SSHID("customID")))
-	def, err = st.Marshal()
+	def, err = st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{
@@ -346,7 +346,7 @@ func testSSHMount(t *testing.T, sb integration.Sandbox) {
 
 	// missing custom ID ignored on optional
 	st = llb.Image("busybox:latest").Run(llb.Shlex(`ls`), llb.AddSSHSocket(llb.SSHID("customID"), llb.SSHOptional))
-	def, err = st.Marshal()
+	def, err = st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{
@@ -361,7 +361,7 @@ func testSSHMount(t *testing.T, sb integration.Sandbox) {
 			llb.AddSSHSocket())
 
 	out := st.AddMount("/out", llb.Scratch())
-	def, err = out.Marshal()
+	def, err = out.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	destDir, err := ioutil.TempDir("", "buildkit")
@@ -395,7 +395,7 @@ func testSSHMount(t *testing.T, sb integration.Sandbox) {
 			llb.AddSSHSocket())
 
 	out = st.AddMount("/out", llb.Scratch())
-	def, err = out.Marshal()
+	def, err = out.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	require.NoError(t, err)
@@ -422,7 +422,7 @@ func testSSHMount(t *testing.T, sb integration.Sandbox) {
 			llb.AddSSHSocket())
 
 	out = st.AddMount("/out", llb.Scratch())
-	def, err = out.Marshal()
+	def, err = out.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	k, err = rsa.GenerateKey(rand.Reader, 1024)
@@ -476,7 +476,7 @@ func testExtraHosts(t *testing.T, sb integration.Sandbox) {
 	st := llb.Image("busybox:latest").
 		Run(llb.Shlex(`sh -c 'cat /etc/hosts | grep myhost | grep 1.2.3.4'`), llb.AddExtraHost("myhost", net.ParseIP("1.2.3.4")))
 
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{}, nil)
@@ -491,7 +491,7 @@ func testNetworkMode(t *testing.T, sb integration.Sandbox) {
 	st := llb.Image("busybox:latest").
 		Run(llb.Shlex(`sh -c 'wget https://example.com 2>&1 | grep "wget: bad address"'`), llb.Network(llb.NetModeNone))
 
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{}, nil)
@@ -500,7 +500,7 @@ func testNetworkMode(t *testing.T, sb integration.Sandbox) {
 	st2 := llb.Image("busybox:latest").
 		Run(llb.Shlex(`ifconfig`), llb.Network(llb.NetModeHost))
 
-	def, err = st2.Marshal()
+	def, err = st2.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{
@@ -525,7 +525,7 @@ func testPushByDigest(t *testing.T, sb integration.Sandbox) {
 
 	st := llb.Scratch().File(llb.Mkfile("foo", 0600, []byte("data")))
 
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	name := registry + "/foo/bar"
@@ -590,7 +590,7 @@ func testSecurityMode(t *testing.T, sb integration.Sandbox) {
 		Run(llb.Shlex(command),
 			llb.Security(mode))
 
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{
@@ -624,7 +624,7 @@ func testSecurityModeSysfs(t *testing.T, sb integration.Sandbox) {
 		Run(llb.Shlex(command),
 			llb.Security(mode))
 
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{
@@ -651,7 +651,7 @@ func testSecurityModeErrors(t *testing.T, sb integration.Sandbox) {
 		st := llb.Image("busybox:latest").
 			Run(llb.Shlex(`sh -c 'echo sandbox'`))
 
-		def, err := st.Marshal()
+		def, err := st.Marshal(context.TODO())
 		require.NoError(t, err)
 
 		_, err = c.Solve(context.TODO(), def, SolveOpt{
@@ -664,7 +664,7 @@ func testSecurityModeErrors(t *testing.T, sb integration.Sandbox) {
 		st := llb.Image("busybox:latest").
 			Run(llb.Shlex(`sh -c 'echo insecure'`), llb.Security(llb.SecurityModeInsecure))
 
-		def, err := st.Marshal()
+		def, err := st.Marshal(context.TODO())
 		require.NoError(t, err)
 
 		_, err = c.Solve(context.TODO(), def, SolveOpt{}, nil)
@@ -834,7 +834,7 @@ func testSecretMounts(t *testing.T, sb integration.Sandbox) {
 	st := llb.Image("busybox:latest").
 		Run(llb.Shlex(`sh -c 'mount | grep mysecret | grep "type tmpfs" && [ "$(cat /run/secrets/mysecret)" = 'foo-secret' ]'`), llb.AddSecret("/run/secrets/mysecret"))
 
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{
@@ -848,7 +848,7 @@ func testSecretMounts(t *testing.T, sb integration.Sandbox) {
 	st = llb.Image("busybox:latest").
 		Run(llb.Shlex(`echo secret2`), llb.AddSecret("/run/secrets/mysecret2", llb.SecretOptional))
 
-	def, err = st.Marshal()
+	def, err = st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{
@@ -862,7 +862,7 @@ func testSecretMounts(t *testing.T, sb integration.Sandbox) {
 	st = llb.Image("busybox:latest").
 		Run(llb.Shlex(`echo secret3`), llb.AddSecret("/run/secrets/mysecret3"))
 
-	def, err = st.Marshal()
+	def, err = st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{
@@ -874,7 +874,7 @@ func testSecretMounts(t *testing.T, sb integration.Sandbox) {
 	st = llb.Image("busybox:latest").
 		Run(llb.Shlex(`sh -c '[ "$(stat -c "%u %g %f" /run/secrets/mysecret4)" = "1 1 81ff" ]' `), llb.AddSecret("/run/secrets/mysecret4", llb.SecretID("mysecret"), llb.SecretFileOpt(1, 1, 0777)))
 
-	def, err = st.Marshal()
+	def, err = st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{
@@ -894,7 +894,7 @@ func testTmpfsMounts(t *testing.T, sb integration.Sandbox) {
 	st := llb.Image("busybox:latest").
 		Run(llb.Shlex(`sh -c 'mount | grep /foobar | grep "type tmpfs" && touch /foobar/test'`), llb.AddMount("/foobar", llb.Scratch(), llb.Tmpfs()))
 
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{}, nil)
@@ -947,7 +947,7 @@ func testLocalSymlinkEscape(t *testing.T, sb integration.Sandbox) {
 	st := llb.Image("busybox:latest").
 		Run(llb.Shlex(`sh /mount/test.sh`), llb.AddMount("/mount", local, llb.Readonly))
 
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{
@@ -970,7 +970,7 @@ func testRelativeWorkDir(t *testing.T, sb integration.Sandbox) {
 		Run(llb.Shlex(`sh -c "pwd > /out/pwd"`)).
 		AddMount("/out", llb.Scratch())
 
-	def, err := pwd.Marshal()
+	def, err := pwd.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	destDir, err := ioutil.TempDir("", "buildkit")
@@ -1001,7 +1001,7 @@ func testFileOpMkdirMkfile(t *testing.T, sb integration.Sandbox) {
 	st := llb.Scratch().
 		File(llb.Mkdir("/foo", 0700).Mkfile("bar", 0600, []byte("contents")))
 
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	destDir, err := ioutil.TempDir("", "buildkit")
@@ -1055,7 +1055,7 @@ func testFileOpCopyRm(t *testing.T, sb integration.Sandbox) {
 				Rm("out/foo").
 				Copy(llb.Local("mylocal2"), "file2", "/"))
 
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	destDir, err := ioutil.TempDir("", "buildkit")
@@ -1119,7 +1119,7 @@ func testFileOpRmWildcard(t *testing.T, sb integration.Sandbox) {
 	).File(
 		llb.Rm("*/target", llb.WithAllowWildcard(true)),
 	)
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	destDir, err := ioutil.TempDir("", "buildkit")
@@ -1174,7 +1174,7 @@ func testBuildMultiMount(t *testing.T, sb integration.Sandbox) {
 	cp := ls.Run(llb.Shlex("/bin/cp -a /busybox/etc/passwd baz"))
 	cp.AddMount("/busybox", busybox)
 
-	def, err := cp.Marshal()
+	def, err := cp.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{}, nil)
@@ -1204,7 +1204,7 @@ func testBuildHTTPSource(t *testing.T, sb integration.Sandbox) {
 	// invalid URL first
 	st := llb.HTTP(server.URL + "/bar")
 
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{}, nil)
@@ -1214,7 +1214,7 @@ func testBuildHTTPSource(t *testing.T, sb integration.Sandbox) {
 	// first correct request
 	st = llb.HTTP(server.URL + "/foo")
 
-	def, err = st.Marshal()
+	def, err = st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{}, nil)
@@ -1247,7 +1247,7 @@ func testBuildHTTPSource(t *testing.T, sb integration.Sandbox) {
 	// test extra options
 	st = llb.HTTP(server.URL+"/foo", llb.Filename("bar"), llb.Chmod(0741), llb.Chown(1000, 1000))
 
-	def, err = st.Marshal()
+	def, err = st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{
@@ -1293,7 +1293,7 @@ func testResolveAndHosts(t *testing.T, sb integration.Sandbox) {
 	run(`sh -c "cp /etc/resolv.conf ."`)
 	run(`sh -c "cp /etc/hosts ."`)
 
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	destDir, err := ioutil.TempDir("", "buildkit")
@@ -1340,7 +1340,7 @@ func testUser(t *testing.T, sb integration.Sandbox) {
 	st = st.Run(llb.Shlex("cp -a /wd/. /out/"))
 	out := st.AddMount("/out", llb.Scratch())
 
-	def, err := out.Marshal()
+	def, err := out.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	destDir, err := ioutil.TempDir("", "buildkit")
@@ -1392,7 +1392,7 @@ func testOCIExporter(t *testing.T, sb integration.Sandbox) {
 	run(`sh -c "echo -n first > foo"`)
 	run(`sh -c "echo -n second > bar"`)
 
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	for _, exp := range []string{ExporterOCI, ExporterDocker} {
@@ -1521,7 +1521,7 @@ func testFrontendUseSolveResults(t *testing.T, sb integration.Sandbox) {
 			llb.Mkfile("foo", 0600, []byte("data")),
 		)
 
-		def, err := st.Marshal()
+		def, err := st.Marshal(context.TODO())
 		if err != nil {
 			return nil, err
 		}
@@ -1547,7 +1547,7 @@ func testFrontendUseSolveResults(t *testing.T, sb integration.Sandbox) {
 			llb.Copy(st2, "foo", "foo2"),
 		)
 
-		def, err = st.Marshal()
+		def, err = st.Marshal(context.TODO())
 		if err != nil {
 			return nil, err
 		}
@@ -1583,7 +1583,7 @@ func testExporterTargetExists(t *testing.T, sb integration.Sandbox) {
 	defer c.Close()
 
 	st := llb.Image("busybox:latest")
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	var mdDgst string
@@ -1613,7 +1613,7 @@ func testTarExporterWithSocket(t *testing.T, sb integration.Sandbox) {
 	defer c.Close()
 
 	alpine := llb.Image("docker.io/library/alpine:latest")
-	def, err := alpine.Run(llb.Args([]string{"sh", "-c", "nc -l -s local:/socket.sock & usleep 100000; kill %1"})).Marshal()
+	def, err := alpine.Run(llb.Args([]string{"sh", "-c", "nc -l -s local:/socket.sock & usleep 100000; kill %1"})).Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{
@@ -1646,7 +1646,7 @@ func testTarExporterSymlink(t *testing.T, sb integration.Sandbox) {
 
 	run(`sh -c "echo -n first > foo;ln -s foo bar"`)
 
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	var buf bytes.Buffer
@@ -1686,7 +1686,7 @@ func testBuildExportWithUncompressed(t *testing.T, sb integration.Sandbox) {
 	st := llb.Scratch()
 	st = busybox.Run(llb.Shlex(cmd), llb.Dir("/wd")).AddMount("/wd", st)
 
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	registry, err := sb.NewRegistry()
@@ -1806,7 +1806,7 @@ func testBuildPushAndValidate(t *testing.T, sb integration.Sandbox) {
 	run(`true`) // this doesn't create a layer
 	run(`sh -c "echo -n second > foo/sub/baz"`)
 
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	registry, err := sb.NewRegistry()
@@ -1833,7 +1833,7 @@ func testBuildPushAndValidate(t *testing.T, sb integration.Sandbox) {
 	// test existence of the image with next build
 	firstBuild := llb.Image(target)
 
-	def, err = firstBuild.Marshal()
+	def, err = firstBuild.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	destDir, err := ioutil.TempDir("", "buildkit")
@@ -2008,7 +2008,7 @@ func testBasicCacheImportExport(t *testing.T, sb integration.Sandbox, cacheOptio
 	run(`sh -c "echo -n foobar > const"`)
 	run(`sh -c "cat /dev/urandom | head -c 100 | sha256sum > unique"`)
 
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	destDir, err := ioutil.TempDir("", "buildkit")
@@ -2140,7 +2140,7 @@ func testBasicInlineCacheImportExport(t *testing.T, sb integration.Sandbox) {
 	run(`sh -c "echo -n foobar > const"`)
 	run(`sh -c "cat /dev/urandom | head -c 100 | sha256sum > unique"`)
 
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	target := registry + "/buildkit/testexportinline:latest"
@@ -2243,7 +2243,7 @@ func testBasicInlineCacheImportExport(t *testing.T, sb integration.Sandbox) {
 }
 
 func readFileInImage(c *Client, ref, path string) ([]byte, error) {
-	def, err := llb.Image(ref).Marshal()
+	def, err := llb.Image(ref).Marshal(context.TODO())
 	if err != nil {
 		return nil, err
 	}
@@ -2284,7 +2284,7 @@ func testCachedMounts(t *testing.T, sb integration.Sandbox) {
 	st.AddMount("/wd", llb.Scratch(), llb.AsPersistentCacheDir("mycache1", llb.CacheMountShared))
 	st.AddMount("/wd2", base, llb.AsPersistentCacheDir("mycache2", llb.CacheMountShared))
 
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{}, nil)
@@ -2304,7 +2304,7 @@ func testCachedMounts(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
-	def, err = out.Marshal()
+	def, err = out.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{
@@ -2349,7 +2349,7 @@ func testSharedCacheMounts(t *testing.T, sb integration.Sandbox) {
 	out.AddMount("/m1", st.Root())
 	out.AddMount("/m2", st2.Root())
 
-	def, err := out.Marshal()
+	def, err := out.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{}, nil)
@@ -2373,7 +2373,7 @@ func testLockedCacheMounts(t *testing.T, sb integration.Sandbox) {
 	out.AddMount("/m1", st.Root())
 	out.AddMount("/m2", st2.Root())
 
-	def, err := out.Marshal()
+	def, err := out.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{}, nil)
@@ -2392,7 +2392,7 @@ func testDuplicateCacheMount(t *testing.T, sb integration.Sandbox) {
 	out.AddMount("/m1", llb.Scratch(), llb.AsPersistentCacheDir("mycache1", llb.CacheMountLocked))
 	out.AddMount("/m2", llb.Scratch(), llb.AsPersistentCacheDir("mycache1", llb.CacheMountLocked))
 
-	def, err := out.Marshal()
+	def, err := out.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{}, nil)
@@ -2411,7 +2411,7 @@ func testCacheMountNoCache(t *testing.T, sb integration.Sandbox) {
 	out.AddMount("/m1", llb.Scratch(), llb.AsPersistentCacheDir("mycache1", llb.CacheMountLocked))
 	out.AddMount("/m2", llb.Scratch(), llb.AsPersistentCacheDir("mycache2", llb.CacheMountLocked))
 
-	def, err := out.Marshal()
+	def, err := out.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{}, nil)
@@ -2420,7 +2420,7 @@ func testCacheMountNoCache(t *testing.T, sb integration.Sandbox) {
 	out = busybox.Run(llb.Shlex(`sh -e -c "[[ ! -f /m1/foo ]]; touch /m1/foo2;"`), llb.IgnoreCache)
 	out.AddMount("/m1", llb.Scratch(), llb.AsPersistentCacheDir("mycache1", llb.CacheMountLocked))
 
-	def, err = out.Marshal()
+	def, err = out.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{}, nil)
@@ -2430,7 +2430,7 @@ func testCacheMountNoCache(t *testing.T, sb integration.Sandbox) {
 	out.AddMount("/m1", llb.Scratch(), llb.AsPersistentCacheDir("mycache1", llb.CacheMountLocked))
 	out.AddMount("/m2", llb.Scratch(), llb.AsPersistentCacheDir("mycache2", llb.CacheMountLocked))
 
-	def, err = out.Marshal()
+	def, err = out.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{}, nil)
@@ -2454,7 +2454,7 @@ func testDuplicateWhiteouts(t *testing.T, sb integration.Sandbox) {
 	run(`sh -e -c "mkdir -p d0 d1; echo -n first > d1/bar;"`)
 	run(`sh -c "rm -rf d0 d1"`)
 
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	destDir, err := ioutil.TempDir("", "buildkit")
@@ -2525,7 +2525,7 @@ func testWhiteoutParentDir(t *testing.T, sb integration.Sandbox) {
 	run(`sh -c "mkdir -p foo; echo -n first > foo/bar;"`)
 	run(`rm foo/bar`)
 
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	destDir, err := ioutil.TempDir("", "buildkit")
@@ -2582,7 +2582,7 @@ func testSchema1Image(t *testing.T, sb integration.Sandbox) {
 
 	st := llb.Image("gcr.io/google_containers/pause:3.0@sha256:0d093c962a6c2dd8bb8727b661e2b5f13e9df884af9945b4cc7088d9350cd3ee")
 
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{}, nil)
@@ -2611,7 +2611,7 @@ func testMountWithNoSource(t *testing.T, sb integration.Sandbox) {
 
 	st = run.AddMount("/mnt", st)
 
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{}, nil)
@@ -2635,7 +2635,7 @@ func testReadonlyRootFS(t *testing.T, sb integration.Sandbox) {
 		llb.Args([]string{"/bin/touch", "/foo"}))
 	st = run.AddMount("/mnt", st)
 
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, SolveOpt{}, nil)
@@ -2663,7 +2663,7 @@ func testProxyEnv(t *testing.T, sb integration.Sandbox) {
 	}))
 	out := st.AddMount("/out", llb.Scratch())
 
-	def, err := out.Marshal()
+	def, err := out.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	destDir, err := ioutil.TempDir("", "buildkit")
@@ -2691,7 +2691,7 @@ func testProxyEnv(t *testing.T, sb integration.Sandbox) {
 	}))
 	out = st.AddMount("/out", llb.Scratch())
 
-	def, err = out.Marshal()
+	def, err = out.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	destDir, err = ioutil.TempDir("", "buildkit")
@@ -2820,7 +2820,7 @@ func testInvalidExporter(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 	defer c.Close()
 
-	def, err := llb.Image("busybox:latest").Marshal()
+	def, err := llb.Image("busybox:latest").Marshal(context.TODO())
 	require.NoError(t, err)
 
 	destDir, err := ioutil.TempDir("", "buildkit")
@@ -2905,7 +2905,7 @@ func testParallelLocalBuilds(t *testing.T, sb integration.Sandbox) {
 				require.NoError(t, err)
 				defer os.RemoveAll(srcDir)
 
-				def, err := llb.Local("source").Marshal()
+				def, err := llb.Local("source").Marshal(context.TODO())
 				require.NoError(t, err)
 
 				destDir, err := ioutil.TempDir("", "buildkit")

--- a/client/llb/async.go
+++ b/client/llb/async.go
@@ -1,0 +1,98 @@
+package llb
+
+import (
+	"context"
+
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/util/flightcontrol"
+	digest "github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
+)
+
+type asyncState struct {
+	f      func(context.Context, State) (State, error)
+	prev   State
+	target State
+	set    bool
+	err    error
+	g      flightcontrol.Group
+}
+
+func (as *asyncState) Output() Output {
+	return as
+}
+
+func (as *asyncState) Vertex(ctx context.Context) Vertex {
+	err := as.Do(ctx)
+	if err != nil {
+		return &errVertex{err}
+	}
+	if as.set {
+		out := as.target.Output()
+		if out == nil {
+			return nil
+		}
+		return out.Vertex(ctx)
+	}
+	return nil
+}
+
+func (as *asyncState) ToInput(ctx context.Context, c *Constraints) (*pb.Input, error) {
+	err := as.Do(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if as.set {
+		out := as.target.Output()
+		if out == nil {
+			return nil, nil
+		}
+		return out.ToInput(ctx, c)
+	}
+	return nil, nil
+}
+
+func (as *asyncState) Do(ctx context.Context) error {
+	_, err := as.g.Do(ctx, "", func(ctx context.Context) (interface{}, error) {
+		if as.set {
+			return as.target, as.err
+		}
+		res, err := as.f(ctx, as.prev)
+		if err != nil {
+			select {
+			case <-ctx.Done():
+				if errors.Cause(err) == ctx.Err() {
+					return res, err
+				}
+			default:
+			}
+		}
+		as.target = res
+		as.err = err
+		as.set = true
+		return res, err
+	})
+	if err != nil {
+		return err
+	}
+	return as.err
+}
+
+type errVertex struct {
+	err error
+}
+
+func (v *errVertex) Validate(context.Context) error {
+	return v.err
+}
+func (v *errVertex) Marshal(context.Context, *Constraints) (digest.Digest, []byte, *pb.OpMetadata, error) {
+	return "", nil, nil, v.err
+}
+func (v *errVertex) Output() Output {
+	return nil
+}
+func (v *errVertex) Inputs() []Output {
+	return nil
+}
+
+var _ Vertex = &errVertex{}

--- a/client/llb/async_test.go
+++ b/client/llb/async_test.go
@@ -1,0 +1,46 @@
+package llb
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAsyncNonBlocking(t *testing.T) {
+	ctx := context.TODO()
+
+	wait := make(chan struct{})
+	ran := make(chan struct{})
+	st := Image("alpine").Dir("/foo").Async(func(ctx context.Context, st State) (State, error) {
+		close(ran)
+		<-wait // make sure callback doesn't block the chain
+		return st.Run(Shlex("cmd1")).Dir("sub"), nil
+	}).Run(Shlex("cmd2"))
+
+	close(wait)
+
+	select {
+	case <-time.After(100 * time.Millisecond):
+	case <-ran:
+		require.Fail(t, "callback should not have been called")
+	}
+
+	def, err := st.Marshal(ctx)
+	require.NoError(t, err)
+
+	m, arr := parseDef(t, def.Def)
+	require.Equal(t, 4, len(arr))
+
+	dgst, idx := last(t, arr)
+	require.Equal(t, 0, idx)
+	require.Equal(t, m[dgst], arr[2])
+
+	require.Equal(t, []string{"cmd1"}, arr[1].Op.(*pb.Op_Exec).Exec.Meta.Args)
+	require.Equal(t, "/foo", arr[1].Op.(*pb.Op_Exec).Exec.Meta.Cwd)
+
+	require.Equal(t, []string{"cmd2"}, arr[2].Op.(*pb.Op_Exec).Exec.Meta.Args)
+	require.Equal(t, "/foo/sub", arr[2].Op.(*pb.Op_Exec).Exec.Meta.Cwd)
+}

--- a/client/llb/definition.go
+++ b/client/llb/definition.go
@@ -1,6 +1,8 @@
 package llb
 
 import (
+	"context"
+
 	"github.com/moby/buildkit/solver/pb"
 	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -53,15 +55,15 @@ func NewDefinitionOp(def *pb.Definition) (*DefinitionOp, error) {
 	}, nil
 }
 
-func (d *DefinitionOp) ToInput(c *Constraints) (*pb.Input, error) {
-	return d.Output().ToInput(c)
+func (d *DefinitionOp) ToInput(ctx context.Context, c *Constraints) (*pb.Input, error) {
+	return d.Output().ToInput(ctx, c)
 }
 
-func (d *DefinitionOp) Vertex() Vertex {
+func (d *DefinitionOp) Vertex(context.Context) Vertex {
 	return d
 }
 
-func (d *DefinitionOp) Validate() error {
+func (d *DefinitionOp) Validate(context.Context) error {
 	// Scratch state has no digest, ops or metas.
 	if d.dgst == "" {
 		return nil
@@ -95,12 +97,12 @@ func (d *DefinitionOp) Validate() error {
 	return nil
 }
 
-func (d *DefinitionOp) Marshal(c *Constraints) (digest.Digest, []byte, *pb.OpMetadata, error) {
+func (d *DefinitionOp) Marshal(ctx context.Context, c *Constraints) (digest.Digest, []byte, *pb.OpMetadata, error) {
 	if d.dgst == "" {
 		return "", nil, nil, errors.Errorf("cannot marshal empty definition op")
 	}
 
-	if err := d.Validate(); err != nil {
+	if err := d.Validate(ctx); err != nil {
 		return "", nil, nil, err
 	}
 

--- a/client/llb/definition_test.go
+++ b/client/llb/definition_test.go
@@ -2,6 +2,7 @@ package llb
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/containerd/containerd/platforms"
@@ -27,18 +28,20 @@ func TestDefinitionEquivalence(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			def, err := tc.state.Marshal()
+			ctx := context.TODO()
+
+			def, err := tc.state.Marshal(context.TODO())
 			require.NoError(t, err)
 
 			op, err := NewDefinitionOp(def.ToPB())
 			require.NoError(t, err)
 
-			err = op.Validate()
+			err = op.Validate(ctx)
 			require.NoError(t, err)
 
 			st2 := NewState(op.Output())
 
-			def2, err := st2.Marshal()
+			def2, err := st2.Marshal(context.TODO())
 			require.NoError(t, err)
 			require.Equal(t, len(def.Def), len(def2.Def))
 			require.Equal(t, len(def.Metadata), len(def2.Metadata))
@@ -52,8 +55,10 @@ func TestDefinitionEquivalence(t *testing.T) {
 				require.Equal(t, def.Metadata[dgst], def2.Metadata[dgst])
 			}
 
-			expectedPlatform := tc.state.GetPlatform()
-			actualPlatform := st2.GetPlatform()
+			expectedPlatform, err := tc.state.GetPlatform(ctx)
+			require.NoError(t, err)
+			actualPlatform, err := st2.GetPlatform(ctx)
+			require.NoError(t, err)
 
 			if expectedPlatform == nil && actualPlatform != nil {
 				defaultPlatform := platforms.Normalize(platforms.DefaultSpec())

--- a/client/llb/exec.go
+++ b/client/llb/exec.go
@@ -1,6 +1,7 @@
 package llb
 
 import (
+	"context"
 	_ "crypto/sha256"
 	"fmt"
 	"net"
@@ -12,19 +13,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-type Meta struct {
-	Args       []string
-	Env        EnvList
-	Cwd        string
-	User       string
-	ProxyEnv   *ProxyEnv
-	ExtraHosts []HostIP
-	Network    pb.NetMode
-	Security   pb.SecurityMode
-}
-
-func NewExecOp(root Output, meta Meta, readOnly bool, c Constraints) *ExecOp {
-	e := &ExecOp{meta: meta, constraints: c}
+func NewExecOp(base State, proxyEnv *ProxyEnv, readOnly bool, c Constraints) *ExecOp {
+	e := &ExecOp{base: base, constraints: c, proxyEnv: proxyEnv}
+	root := base.Output()
 	rootMount := &mount{
 		target:   pb.RootMount,
 		source:   root,
@@ -58,9 +49,10 @@ type mount struct {
 
 type ExecOp struct {
 	MarshalCache
+	proxyEnv    *ProxyEnv
 	root        Output
 	mounts      []*mount
-	meta        Meta
+	base        State
 	constraints Constraints
 	isValidated bool
 	secrets     []SecretInfo
@@ -103,19 +95,27 @@ func (e *ExecOp) GetMount(target string) Output {
 	return nil
 }
 
-func (e *ExecOp) Validate() error {
+func (e *ExecOp) Validate(ctx context.Context) error {
 	if e.isValidated {
 		return nil
 	}
-	if len(e.meta.Args) == 0 {
+	args, err := getArgs(e.base)(ctx)
+	if err != nil {
+		return err
+	}
+	if len(args) == 0 {
 		return errors.Errorf("arguments are required")
 	}
-	if e.meta.Cwd == "" {
+	cwd, err := getDir(e.base)(ctx)
+	if err != nil {
+		return err
+	}
+	if cwd == "" {
 		return errors.Errorf("working directory is required")
 	}
 	for _, m := range e.mounts {
 		if m.source != nil {
-			if err := m.source.Vertex().Validate(); err != nil {
+			if err := m.source.Vertex(ctx).Validate(ctx); err != nil {
 				return err
 			}
 		}
@@ -124,11 +124,11 @@ func (e *ExecOp) Validate() error {
 	return nil
 }
 
-func (e *ExecOp) Marshal(c *Constraints) (digest.Digest, []byte, *pb.OpMetadata, error) {
+func (e *ExecOp) Marshal(ctx context.Context, c *Constraints) (digest.Digest, []byte, *pb.OpMetadata, error) {
 	if e.Cached(c) {
 		return e.Load()
 	}
-	if err := e.Validate(); err != nil {
+	if err := e.Validate(ctx); err != nil {
 		return "", nil, nil, err
 	}
 	// make sure mounts are sorted
@@ -136,52 +136,86 @@ func (e *ExecOp) Marshal(c *Constraints) (digest.Digest, []byte, *pb.OpMetadata,
 		return e.mounts[i].target < e.mounts[j].target
 	})
 
+	env, err := getEnv(e.base)(ctx)
+	if err != nil {
+		return "", nil, nil, err
+	}
+
 	if len(e.ssh) > 0 {
 		for i, s := range e.ssh {
 			if s.Target == "" {
 				e.ssh[i].Target = fmt.Sprintf("/run/buildkit/ssh_agent.%d", i)
 			}
 		}
-		if _, ok := e.meta.Env.Get("SSH_AUTH_SOCK"); !ok {
-			e.meta.Env = e.meta.Env.AddOrReplace("SSH_AUTH_SOCK", e.ssh[0].Target)
+		if _, ok := env.Get("SSH_AUTH_SOCK"); !ok {
+			env = env.AddOrReplace("SSH_AUTH_SOCK", e.ssh[0].Target)
 		}
 	}
 	if c.Caps != nil {
 		if err := c.Caps.Supports(pb.CapExecMetaSetsDefaultPath); err != nil {
-			e.meta.Env = e.meta.Env.SetDefault("PATH", system.DefaultPathEnv)
+			env = env.SetDefault("PATH", system.DefaultPathEnv)
 		} else {
 			addCap(&e.constraints, pb.CapExecMetaSetsDefaultPath)
 		}
 	}
 
-	meta := &pb.Meta{
-		Args: e.meta.Args,
-		Env:  e.meta.Env.ToArray(),
-		Cwd:  e.meta.Cwd,
-		User: e.meta.User,
+	args, err := getArgs(e.base)(ctx)
+	if err != nil {
+		return "", nil, nil, err
 	}
-	if len(e.meta.ExtraHosts) > 0 {
-		hosts := make([]*pb.HostIP, len(e.meta.ExtraHosts))
-		for i, h := range e.meta.ExtraHosts {
+
+	cwd, err := getDir(e.base)(ctx)
+	if err != nil {
+		return "", nil, nil, err
+	}
+
+	user, err := getUser(e.base)(ctx)
+	if err != nil {
+		return "", nil, nil, err
+	}
+
+	meta := &pb.Meta{
+		Args: args,
+		Env:  env.ToArray(),
+		Cwd:  cwd,
+		User: user,
+	}
+	extraHosts, err := getExtraHosts(e.base)(ctx)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	if len(extraHosts) > 0 {
+		hosts := make([]*pb.HostIP, len(extraHosts))
+		for i, h := range extraHosts {
 			hosts[i] = &pb.HostIP{Host: h.Host, IP: h.IP.String()}
 		}
 		meta.ExtraHosts = hosts
 	}
 
+	network, err := getNetwork(e.base)(ctx)
+	if err != nil {
+		return "", nil, nil, err
+	}
+
+	security, err := getSecurity(e.base)(ctx)
+	if err != nil {
+		return "", nil, nil, err
+	}
+
 	peo := &pb.ExecOp{
 		Meta:     meta,
-		Network:  e.meta.Network,
-		Security: e.meta.Security,
+		Network:  network,
+		Security: security,
 	}
-	if e.meta.Network != NetModeSandbox {
+	if network != NetModeSandbox {
 		addCap(&e.constraints, pb.CapExecMetaNetwork)
 	}
 
-	if e.meta.Security != SecurityModeSandbox {
+	if security != SecurityModeSandbox {
 		addCap(&e.constraints, pb.CapExecMetaSecurity)
 	}
 
-	if p := e.meta.ProxyEnv; p != nil {
+	if p := e.proxyEnv; p != nil {
 		peo.Meta.ProxyEnv = &pb.ProxyEnv{
 			HttpProxy:  p.HttpProxy,
 			HttpsProxy: p.HttpsProxy,
@@ -215,6 +249,14 @@ func (e *ExecOp) Marshal(c *Constraints) (digest.Digest, []byte, *pb.OpMetadata,
 		addCap(&e.constraints, pb.CapExecMountSSH)
 	}
 
+	if e.constraints.Platform == nil {
+		p, err := getPlatform(e.base)(ctx)
+		if err != nil {
+			return "", nil, nil, err
+		}
+		e.constraints.Platform = p
+	}
+
 	pop, md := MarshalConstraints(c, &e.constraints)
 	pop.Op = &pb.Op_Exec{
 		Exec: peo,
@@ -227,7 +269,7 @@ func (e *ExecOp) Marshal(c *Constraints) (digest.Digest, []byte, *pb.OpMetadata,
 			if m.tmpfs {
 				return "", nil, nil, errors.Errorf("tmpfs mounts must use scratch")
 			}
-			inp, err := m.source.ToInput(c)
+			inp, err := m.source.ToInput(ctx, c)
 			if err != nil {
 				return "", nil, nil, err
 			}

--- a/client/llb/exec_test.go
+++ b/client/llb/exec_test.go
@@ -1,6 +1,7 @@
 package llb
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,17 +11,17 @@ func TestTmpfsMountError(t *testing.T) {
 	t.Parallel()
 
 	st := Image("foo").Run(Shlex("args")).AddMount("/tmp", Scratch(), Tmpfs())
-	_, err := st.Marshal()
+	_, err := st.Marshal(context.TODO())
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "can't be used as a parent")
 
 	st = Image("foo").Run(Shlex("args"), AddMount("/tmp", Scratch(), Tmpfs())).Root()
-	_, err = st.Marshal()
+	_, err = st.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	st = Image("foo").Run(Shlex("args"), AddMount("/tmp", Image("bar"), Tmpfs())).Root()
-	_, err = st.Marshal()
+	_, err = st.Marshal(context.TODO())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "must use scratch")
 }

--- a/client/llb/fileop_test.go
+++ b/client/llb/fileop_test.go
@@ -1,6 +1,7 @@
 package llb
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -13,7 +14,7 @@ func TestFileMkdir(t *testing.T) {
 	t.Parallel()
 
 	st := Image("foo").File(Mkdir("/foo", 0700))
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 
 	require.NoError(t, err)
 
@@ -47,7 +48,7 @@ func TestFileMkdirChain(t *testing.T) {
 	t.Parallel()
 
 	st := Image("foo").Dir("/etc").File(Mkdir("/foo", 0700).Mkdir("bar", 0600, WithParents(true)).Mkdir("bar/baz", 0701, WithParents(false)))
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 
 	require.NoError(t, err)
 
@@ -100,7 +101,7 @@ func TestFileMkdirMkfile(t *testing.T) {
 	t.Parallel()
 
 	st := Scratch().File(Mkdir("/foo", 0700).Mkfile("bar", 0700, []byte("data")))
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 
 	require.NoError(t, err)
 
@@ -146,7 +147,7 @@ func TestFileMkfile(t *testing.T) {
 	t.Parallel()
 
 	st := Image("foo").File(Mkfile("/foo", 0700, []byte("data")))
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 
 	require.NoError(t, err)
 
@@ -181,7 +182,7 @@ func TestFileRm(t *testing.T) {
 	t.Parallel()
 
 	st := Image("foo").File(Rm("/foo"))
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 
 	require.NoError(t, err)
 
@@ -222,7 +223,7 @@ func TestFileSimpleChains(t *testing.T) {
 			Rm("foo").
 				Mkfile("/abc", 0701, []byte("d1")),
 		)
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 
 	require.NoError(t, err)
 
@@ -290,7 +291,7 @@ func TestFileCopy(t *testing.T) {
 	t.Parallel()
 
 	st := Image("foo").Dir("/tmp").File(Copy(Image("bar").Dir("/etc"), "foo", "bar"))
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 
 	require.NoError(t, err)
 
@@ -331,7 +332,7 @@ func TestFileCopyFromAction(t *testing.T) {
 				Mkfile("foo/bar", 0600, []byte("dt")).
 				WithState(Scratch().Dir("/tmp")),
 			"foo/bar", "baz"))
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 
 	require.NoError(t, err)
 
@@ -398,7 +399,7 @@ func TestFilePipeline(t *testing.T) {
 				Copy(Image("foo"), "in", "out").
 				Copy(Image("baz").Dir("/base"), "in2", "out2"),
 		)
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 
 	require.NoError(t, err)
 
@@ -500,7 +501,7 @@ func TestFileOwner(t *testing.T) {
 	t.Parallel()
 
 	st := Image("foo").File(Mkdir("/foo", 0700).Mkdir("bar", 0600, WithUIDGID(123, 456)).Mkdir("bar/baz", 0701, WithUser("foouser")))
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 
 	require.NoError(t, err)
 
@@ -546,7 +547,7 @@ func TestFileCopyOwner(t *testing.T) {
 				"src2", "dst", WithUser("user4")).
 			Copy(Image("foo"), "src3", "dst", WithUIDGID(1, 2)),
 		)
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 
 	require.NoError(t, err)
 
@@ -609,7 +610,7 @@ func TestFileCreatedTime(t *testing.T) {
 		Mkdir("/foo", 0700, WithCreatedTime(dt)).
 			Mkfile("bar", 0600, []byte{}, WithCreatedTime(dt2)).
 			Copy(Scratch(), "src", "dst", WithCreatedTime(dt3)))
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 
 	require.NoError(t, err)
 

--- a/client/llb/llbbuild/llbbuild.go
+++ b/client/llb/llbbuild/llbbuild.go
@@ -1,6 +1,8 @@
 package llbbuild
 
 import (
+	"context"
+
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/apicaps"
@@ -30,23 +32,23 @@ type build struct {
 	constraints    llb.Constraints
 }
 
-func (b *build) ToInput(c *llb.Constraints) (*pb.Input, error) {
-	dgst, _, _, err := b.Marshal(c)
+func (b *build) ToInput(ctx context.Context, c *llb.Constraints) (*pb.Input, error) {
+	dgst, _, _, err := b.Marshal(ctx, c)
 	if err != nil {
 		return nil, err
 	}
 	return &pb.Input{Digest: dgst, Index: pb.OutputIndex(0)}, nil
 }
 
-func (b *build) Vertex() llb.Vertex {
+func (b *build) Vertex(context.Context) llb.Vertex {
 	return b
 }
 
-func (b *build) Validate() error {
+func (b *build) Validate(context.Context) error {
 	return nil
 }
 
-func (b *build) Marshal(c *llb.Constraints) (digest.Digest, []byte, *pb.OpMetadata, error) {
+func (b *build) Marshal(ctx context.Context, c *llb.Constraints) (digest.Digest, []byte, *pb.OpMetadata, error) {
 	if b.Cached(c) {
 		return b.Load()
 	}
@@ -72,7 +74,7 @@ func (b *build) Marshal(c *llb.Constraints) (digest.Digest, []byte, *pb.OpMetada
 		Build: pbo,
 	}
 
-	inp, err := b.source.ToInput(c)
+	inp, err := b.source.ToInput(ctx, c)
 	if err != nil {
 		return "", nil, nil, err
 	}

--- a/client/llb/llbbuild/llbbuild_test.go
+++ b/client/llb/llbbuild/llbbuild_test.go
@@ -1,6 +1,7 @@
 package llbbuild
 
 import (
+	"context"
 	"testing"
 
 	"github.com/moby/buildkit/client/llb"
@@ -12,7 +13,7 @@ import (
 func TestMarshal(t *testing.T) {
 	t.Parallel()
 	b := NewBuildOp(newDummyOutput("foobar"), WithFilename("myfilename"))
-	dgst, dt, opMeta, err := b.Marshal(&llb.Constraints{})
+	dgst, dt, opMeta, err := b.Marshal(context.TODO(), &llb.Constraints{})
 	_ = opMeta
 	require.NoError(t, err)
 
@@ -42,12 +43,12 @@ type dummyOutput struct {
 	dgst digest.Digest
 }
 
-func (d *dummyOutput) ToInput(*llb.Constraints) (*pb.Input, error) {
+func (d *dummyOutput) ToInput(context.Context, *llb.Constraints) (*pb.Input, error) {
 	return &pb.Input{
 		Digest: d.dgst,
 		Index:  pb.OutputIndex(7), // random constant
 	}, nil
 }
-func (d *dummyOutput) Vertex() llb.Vertex {
+func (d *dummyOutput) Vertex(context.Context) llb.Vertex {
 	return nil
 }

--- a/client/llb/llbtest/platform_test.go
+++ b/client/llb/llbtest/platform_test.go
@@ -1,6 +1,7 @@
 package llbtest
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -22,7 +23,7 @@ func TestCustomPlatform(t *testing.T) {
 		Run(llb.Shlex("bax"), llb.Windows).
 		Run(llb.Shlex("bay"))
 
-	def, err := s.Marshal()
+	def, err := s.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	e, err := llbsolver.Load(def.ToPB())
@@ -51,7 +52,7 @@ func TestDefaultPlatform(t *testing.T) {
 
 	s := llb.Image("foo").Run(llb.Shlex("bar"))
 
-	def, err := s.Marshal()
+	def, err := s.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	e, err := llbsolver.Load(def.ToPB())
@@ -72,7 +73,7 @@ func TestPlatformOnMarshal(t *testing.T) {
 
 	s := llb.Image("image1").Run(llb.Shlex("bar"))
 
-	def, err := s.Marshal(llb.Windows)
+	def, err := s.Marshal(context.TODO(), llb.Windows)
 	require.NoError(t, err)
 
 	e, err := llbsolver.Load(def.ToPB())
@@ -92,7 +93,7 @@ func TestPlatformMixed(t *testing.T) {
 	s2 := llb.Image("image2", llb.LinuxArmel).Run(llb.Shlex("cmd-sub"))
 	s1.AddMount("/mnt", s2.Root())
 
-	def, err := s1.Marshal(llb.LinuxAmd64)
+	def, err := s1.Marshal(context.TODO(), llb.LinuxAmd64)
 	require.NoError(t, err)
 
 	e, err := llbsolver.Load(def.ToPB())
@@ -122,7 +123,7 @@ func TestFallbackPath(t *testing.T) {
 
 	// With no caps we expect no PATH but also no requirement for
 	// the cap.
-	def, err := llb.Scratch().Run(llb.Shlex("cmd")).Marshal(llb.LinuxAmd64)
+	def, err := llb.Scratch().Run(llb.Shlex("cmd")).Marshal(context.TODO(), llb.LinuxAmd64)
 	require.NoError(t, err)
 	e, err := llbsolver.Load(def.ToPB())
 	require.NoError(t, err)
@@ -134,7 +135,7 @@ func TestFallbackPath(t *testing.T) {
 	// no requirement for the cap.
 	cs := pb.Caps.CapSet(nil)
 	require.Error(t, cs.Supports(pb.CapExecMetaSetsDefaultPath))
-	def, err = llb.Scratch().Run(llb.Shlex("cmd")).Marshal(llb.LinuxAmd64, llb.WithCaps(cs))
+	def, err = llb.Scratch().Run(llb.Shlex("cmd")).Marshal(context.TODO(), llb.LinuxAmd64, llb.WithCaps(cs))
 	require.NoError(t, err)
 	e, err = llbsolver.Load(def.ToPB())
 	require.NoError(t, err)
@@ -148,7 +149,7 @@ func TestFallbackPath(t *testing.T) {
 	// present and empty), but also require the cap.
 	cs = pb.Caps.CapSet(pb.Caps.All())
 	require.NoError(t, cs.Supports(pb.CapExecMetaSetsDefaultPath))
-	def, err = llb.Scratch().Run(llb.Shlex("cmd")).Marshal(llb.LinuxAmd64, llb.WithCaps(cs))
+	def, err = llb.Scratch().Run(llb.Shlex("cmd")).Marshal(context.TODO(), llb.LinuxAmd64, llb.WithCaps(cs))
 	require.NoError(t, err)
 	e, err = llbsolver.Load(def.ToPB())
 	require.NoError(t, err)
@@ -164,7 +165,7 @@ func TestFallbackPath(t *testing.T) {
 		{llb.WithCaps(pb.Caps.CapSet(nil))},
 		{llb.WithCaps(pb.Caps.CapSet(pb.Caps.All()))},
 	} {
-		def, err = llb.Scratch().AddEnv("PATH", "foo").Run(llb.Shlex("cmd")).Marshal(append(cos, llb.LinuxAmd64)...)
+		def, err = llb.Scratch().AddEnv("PATH", "foo").Run(llb.Shlex("cmd")).Marshal(context.TODO(), append(cos, llb.LinuxAmd64)...)
 		require.NoError(t, err)
 		e, err = llbsolver.Load(def.ToPB())
 		require.NoError(t, err)

--- a/client/llb/meta.go
+++ b/client/llb/meta.go
@@ -1,6 +1,7 @@
 package llb
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"path"
@@ -29,7 +30,13 @@ func addEnvf(key, value string, replace bool, v ...interface{}) StateOption {
 		value = fmt.Sprintf(value, v...)
 	}
 	return func(s State) State {
-		return s.WithValue(keyEnv, getEnv(s).AddOrReplace(key, value))
+		return s.withValue(keyEnv, func(ctx context.Context) (interface{}, error) {
+			env, err := getEnv(s)(ctx)
+			if err != nil {
+				return nil, err
+			}
+			return env.AddOrReplace(key, value), nil
+		})
 	}
 }
 
@@ -42,14 +49,19 @@ func dirf(value string, replace bool, v ...interface{}) StateOption {
 		value = fmt.Sprintf(value, v...)
 	}
 	return func(s State) State {
-		if !path.IsAbs(value) {
-			prev := getDir(s)
-			if prev == "" {
-				prev = "/"
+		return s.withValue(keyDir, func(ctx context.Context) (interface{}, error) {
+			if !path.IsAbs(value) {
+				prev, err := getDir(s)(ctx)
+				if err != nil {
+					return nil, err
+				}
+				if prev == "" {
+					prev = "/"
+				}
+				value = path.Join(prev, value)
 			}
-			value = path.Join(prev, value)
-		}
-		return s.WithValue(keyDir, value)
+			return value, nil
+		})
 	}
 }
 
@@ -59,44 +71,64 @@ func user(str string) StateOption {
 	}
 }
 
-func reset(s_ State) StateOption {
+func reset(other State) StateOption {
 	return func(s State) State {
 		s = NewState(s.Output())
-		s.ctx = s_.ctx
+		s.prev = &other
 		return s
 	}
 }
 
-func getEnv(s State) EnvList {
-	v := s.Value(keyEnv)
-	if v != nil {
-		return v.(EnvList)
+func getEnv(s State) func(context.Context) (EnvList, error) {
+	return func(ctx context.Context) (EnvList, error) {
+		v, err := s.getValue(keyEnv)(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if v != nil {
+			return v.(EnvList), nil
+		}
+		return EnvList{}, nil
 	}
-	return EnvList{}
 }
 
-func getDir(s State) string {
-	v := s.Value(keyDir)
-	if v != nil {
-		return v.(string)
+func getDir(s State) func(context.Context) (string, error) {
+	return func(ctx context.Context) (string, error) {
+		v, err := s.getValue(keyDir)(ctx)
+		if err != nil {
+			return "", err
+		}
+		if v != nil {
+			return v.(string), nil
+		}
+		return "", nil
 	}
-	return ""
 }
 
-func getArgs(s State) []string {
-	v := s.Value(keyArgs)
-	if v != nil {
-		return v.([]string)
+func getArgs(s State) func(context.Context) ([]string, error) {
+	return func(ctx context.Context) ([]string, error) {
+		v, err := s.getValue(keyArgs)(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if v != nil {
+			return v.([]string), nil
+		}
+		return nil, nil
 	}
-	return nil
 }
 
-func getUser(s State) string {
-	v := s.Value(keyUser)
-	if v != nil {
-		return v.(string)
+func getUser(s State) func(context.Context) (string, error) {
+	return func(ctx context.Context) (string, error) {
+		v, err := s.getValue(keyUser)(ctx)
+		if err != nil {
+			return "", err
+		}
+		if v != nil {
+			return v.(string), nil
+		}
+		return "", nil
 	}
-	return ""
 }
 
 func args(args ...string) StateOption {
@@ -124,27 +156,43 @@ func platform(p specs.Platform) StateOption {
 	}
 }
 
-func getPlatform(s State) *specs.Platform {
-	v := s.Value(keyPlatform)
-	if v != nil {
-		p := v.(specs.Platform)
-		return &p
+func getPlatform(s State) func(context.Context) (*specs.Platform, error) {
+	return func(ctx context.Context) (*specs.Platform, error) {
+		v, err := s.getValue(keyPlatform)(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if v != nil {
+			p := v.(specs.Platform)
+			return &p, nil
+		}
+		return nil, nil
 	}
-	return nil
 }
 
 func extraHost(host string, ip net.IP) StateOption {
 	return func(s State) State {
-		return s.WithValue(keyExtraHost, append(getExtraHosts(s), HostIP{Host: host, IP: ip}))
+		return s.withValue(keyExtraHost, func(ctx context.Context) (interface{}, error) {
+			v, err := getExtraHosts(s)(ctx)
+			if err != nil {
+				return nil, err
+			}
+			return append(v, HostIP{Host: host, IP: ip}), nil
+		})
 	}
 }
 
-func getExtraHosts(s State) []HostIP {
-	v := s.Value(keyExtraHost)
-	if v != nil {
-		return v.([]HostIP)
+func getExtraHosts(s State) func(context.Context) ([]HostIP, error) {
+	return func(ctx context.Context) ([]HostIP, error) {
+		v, err := s.getValue(keyExtraHost)(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if v != nil {
+			return v.([]HostIP), nil
+		}
+		return nil, nil
 	}
-	return nil
 }
 
 type HostIP struct {
@@ -157,13 +205,18 @@ func network(v pb.NetMode) StateOption {
 		return s.WithValue(keyNetwork, v)
 	}
 }
-func getNetwork(s State) pb.NetMode {
-	v := s.Value(keyNetwork)
-	if v != nil {
-		n := v.(pb.NetMode)
-		return n
+func getNetwork(s State) func(context.Context) (pb.NetMode, error) {
+	return func(ctx context.Context) (pb.NetMode, error) {
+		v, err := s.getValue(keyNetwork)(ctx)
+		if err != nil {
+			return 0, err
+		}
+		if v != nil {
+			n := v.(pb.NetMode)
+			return n, nil
+		}
+		return NetModeSandbox, nil
 	}
-	return NetModeSandbox
 }
 
 func security(v pb.SecurityMode) StateOption {
@@ -171,13 +224,18 @@ func security(v pb.SecurityMode) StateOption {
 		return s.WithValue(keySecurity, v)
 	}
 }
-func getSecurity(s State) pb.SecurityMode {
-	v := s.Value(keySecurity)
-	if v != nil {
-		n := v.(pb.SecurityMode)
-		return n
+func getSecurity(s State) func(context.Context) (pb.SecurityMode, error) {
+	return func(ctx context.Context) (pb.SecurityMode, error) {
+		v, err := s.getValue(keySecurity)(ctx)
+		if err != nil {
+			return 0, err
+		}
+		if v != nil {
+			n := v.(pb.SecurityMode)
+			return n, nil
+		}
+		return SecurityModeSandbox, nil
 	}
-	return SecurityModeSandbox
 }
 
 type EnvList []KeyValue

--- a/client/llb/meta_test.go
+++ b/client/llb/meta_test.go
@@ -1,6 +1,7 @@
 package llb
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -8,17 +9,24 @@ import (
 
 func TestRelativeWd(t *testing.T) {
 	st := Scratch().Dir("foo")
-	require.Equal(t, st.GetDir(), "/foo")
+	require.Equal(t, getDirHelper(t, st), "/foo")
 
 	st = st.Dir("bar")
-	require.Equal(t, st.GetDir(), "/foo/bar")
+	require.Equal(t, getDirHelper(t, st), "/foo/bar")
 
 	st = st.Dir("..")
-	require.Equal(t, st.GetDir(), "/foo")
+	require.Equal(t, getDirHelper(t, st), "/foo")
 
 	st = st.Dir("/baz")
-	require.Equal(t, st.GetDir(), "/baz")
+	require.Equal(t, getDirHelper(t, st), "/baz")
 
 	st = st.Dir("../../..")
-	require.Equal(t, st.GetDir(), "/")
+	require.Equal(t, getDirHelper(t, st), "/")
+}
+
+func getDirHelper(t *testing.T, s State) string {
+	t.Helper()
+	v, err := s.GetDir(context.TODO())
+	require.NoError(t, err)
+	return v
 }

--- a/client/llb/source.go
+++ b/client/llb/source.go
@@ -34,7 +34,7 @@ func NewSource(id string, attrs map[string]string, c Constraints) *SourceOp {
 	return s
 }
 
-func (s *SourceOp) Validate() error {
+func (s *SourceOp) Validate(ctx context.Context) error {
 	if s.err != nil {
 		return s.err
 	}
@@ -44,11 +44,11 @@ func (s *SourceOp) Validate() error {
 	return nil
 }
 
-func (s *SourceOp) Marshal(constraints *Constraints) (digest.Digest, []byte, *pb.OpMetadata, error) {
+func (s *SourceOp) Marshal(ctx context.Context, constraints *Constraints) (digest.Digest, []byte, *pb.OpMetadata, error) {
 	if s.Cached(constraints) {
 		return s.Load()
 	}
-	if err := s.Validate(); err != nil {
+	if err := s.Validate(ctx); err != nil {
 		return "", nil, nil, err
 	}
 

--- a/client/llb/state.go
+++ b/client/llb/state.go
@@ -18,13 +18,13 @@ import (
 type StateOption func(State) State
 
 type Output interface {
-	ToInput(*Constraints) (*pb.Input, error)
-	Vertex() Vertex
+	ToInput(context.Context, *Constraints) (*pb.Input, error)
+	Vertex(context.Context) Vertex
 }
 
 type Vertex interface {
-	Validate() error
-	Marshal(*Constraints) (digest.Digest, []byte, *pb.OpMetadata, error)
+	Validate(context.Context) error
+	Marshal(context.Context, *Constraints) (digest.Digest, []byte, *pb.OpMetadata, error)
 	Output() Output
 	Inputs() []Output
 }
@@ -32,7 +32,6 @@ type Vertex interface {
 func NewState(o Output) State {
 	s := State{
 		out: o,
-		ctx: context.Background(),
 	}
 	s = dir("/")(s)
 	s = s.ensurePlatform()
@@ -40,9 +39,12 @@ func NewState(o Output) State {
 }
 
 type State struct {
-	out  Output
-	ctx  context.Context
-	opts []ConstraintsOpt
+	out   Output
+	prev  *State
+	key   interface{}
+	value func(context.Context) (interface{}, error)
+	opts  []ConstraintsOpt
+	async *asyncState
 }
 
 func (s State) ensurePlatform() State {
@@ -57,14 +59,48 @@ func (s State) ensurePlatform() State {
 }
 
 func (s State) WithValue(k, v interface{}) State {
+	return s.withValue(k, func(context.Context) (interface{}, error) {
+		return v, nil
+	})
+}
+
+func (s State) withValue(k interface{}, v func(context.Context) (interface{}, error)) State {
 	return State{
-		out: s.out,
-		ctx: context.WithValue(s.ctx, k, v),
+		out:   s.Output(),
+		prev:  &s, // doesn't need to be original pointer
+		key:   k,
+		value: v,
 	}
 }
 
-func (s State) Value(k interface{}) interface{} {
-	return s.ctx.Value(k)
+func (s State) Value(ctx context.Context, k interface{}) (interface{}, error) {
+	return s.getValue(k)(ctx)
+}
+
+func (s State) getValue(k interface{}) func(context.Context) (interface{}, error) {
+	if s.key == k {
+		return s.value
+	}
+	if s.async != nil {
+		return func(ctx context.Context) (interface{}, error) {
+			err := s.async.Do(ctx)
+			if err != nil {
+				return nil, err
+			}
+			return s.async.target.getValue(k)(ctx)
+		}
+	}
+	if s.prev == nil {
+		return nilValue
+	}
+	return s.prev.getValue(k)
+}
+
+func (s State) Async(f func(context.Context, State) (State, error)) State {
+	s2 := State{
+		async: &asyncState{f: f, prev: s},
+	}
+	return s2
 }
 
 func (s State) SetMarshalDefaults(co ...ConstraintsOpt) State {
@@ -72,11 +108,11 @@ func (s State) SetMarshalDefaults(co ...ConstraintsOpt) State {
 	return s
 }
 
-func (s State) Marshal(co ...ConstraintsOpt) (*Definition, error) {
+func (s State) Marshal(ctx context.Context, co ...ConstraintsOpt) (*Definition, error) {
 	def := &Definition{
 		Metadata: make(map[digest.Digest]pb.OpMetadata, 0),
 	}
-	if s.Output() == nil {
+	if s.Output() == nil || s.Output().Vertex(ctx) == nil {
 		return def, nil
 	}
 
@@ -89,11 +125,11 @@ func (s State) Marshal(co ...ConstraintsOpt) (*Definition, error) {
 		o.SetConstraintsOption(c)
 	}
 
-	def, err := marshal(s.Output().Vertex(), def, map[digest.Digest]struct{}{}, map[Vertex]struct{}{}, c)
+	def, err := marshal(ctx, s.Output().Vertex(ctx), def, map[digest.Digest]struct{}{}, map[Vertex]struct{}{}, c)
 	if err != nil {
 		return def, err
 	}
-	inp, err := s.Output().ToInput(c)
+	inp, err := s.Output().ToInput(ctx, c)
 	if err != nil {
 		return def, err
 	}
@@ -128,19 +164,19 @@ func (s State) Marshal(co ...ConstraintsOpt) (*Definition, error) {
 	return def, nil
 }
 
-func marshal(v Vertex, def *Definition, cache map[digest.Digest]struct{}, vertexCache map[Vertex]struct{}, c *Constraints) (*Definition, error) {
+func marshal(ctx context.Context, v Vertex, def *Definition, cache map[digest.Digest]struct{}, vertexCache map[Vertex]struct{}, c *Constraints) (*Definition, error) {
 	if _, ok := vertexCache[v]; ok {
 		return def, nil
 	}
 	for _, inp := range v.Inputs() {
 		var err error
-		def, err = marshal(inp.Vertex(), def, cache, vertexCache, c)
+		def, err = marshal(ctx, inp.Vertex(ctx), def, cache, vertexCache, c)
 		if err != nil {
 			return def, err
 		}
 	}
 
-	dgst, dt, opMeta, err := v.Marshal(c)
+	dgst, dt, opMeta, err := v.Marshal(ctx, c)
 	if err != nil {
 		return def, err
 	}
@@ -156,18 +192,22 @@ func marshal(v Vertex, def *Definition, cache map[digest.Digest]struct{}, vertex
 	return def, nil
 }
 
-func (s State) Validate() error {
-	return s.Output().Vertex().Validate()
+func (s State) Validate(ctx context.Context) error {
+	return s.Output().Vertex(ctx).Validate(ctx)
 }
 
 func (s State) Output() Output {
+	if s.async != nil {
+		return s.async.Output()
+	}
 	return s.out
 }
 
 func (s State) WithOutput(o Output) State {
+	prev := s
 	s = State{
-		out: o,
-		ctx: s.ctx,
+		out:  o,
+		prev: &prev,
 	}
 	s = s.ensurePlatform()
 	return s
@@ -200,24 +240,10 @@ func (s State) WithImageConfig(c []byte) (State, error) {
 
 func (s State) Run(ro ...RunOption) ExecState {
 	ei := &ExecInfo{State: s}
-	if p := s.GetPlatform(); p != nil {
-		ei.Constraints.Platform = p
-	}
 	for _, o := range ro {
 		o.SetRunOption(ei)
 	}
-	meta := Meta{
-		Args:       getArgs(ei.State),
-		Cwd:        getDir(ei.State),
-		Env:        getEnv(ei.State),
-		User:       getUser(ei.State),
-		ProxyEnv:   ei.ProxyEnv,
-		ExtraHosts: getExtraHosts(ei.State),
-		Network:    getNetwork(ei.State),
-		Security:   getSecurity(ei.State),
-	}
-
-	exec := NewExecOp(s.Output(), meta, ei.ReadonlyRootFS, ei.Constraints)
+	exec := NewExecOp(ei.State, ei.ProxyEnv, ei.ReadonlyRootFS, ei.Constraints)
 	for _, m := range ei.Mounts {
 		exec.AddMount(m.Target, m.Source, m.Opts...)
 	}
@@ -254,20 +280,29 @@ func (s State) Dirf(str string, v ...interface{}) State {
 	return dirf(str, true, v...)(s)
 }
 
-func (s State) GetEnv(key string) (string, bool) {
-	return getEnv(s).Get(key)
+func (s State) GetEnv(ctx context.Context, key string) (string, bool, error) {
+	env, err := getEnv(s)(ctx)
+	if err != nil {
+		return "", false, err
+	}
+	v, ok := env.Get(key)
+	return v, ok, nil
 }
 
-func (s State) Env() []string {
-	return getEnv(s).ToArray()
+func (s State) Env(ctx context.Context) ([]string, error) {
+	env, err := getEnv(s)(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return env.ToArray(), nil
 }
 
-func (s State) GetDir() string {
-	return getDir(s)
+func (s State) GetDir(ctx context.Context) (string, error) {
+	return getDir(s)(ctx)
 }
 
-func (s State) GetArgs() []string {
-	return getArgs(s)
+func (s State) GetArgs(ctx context.Context) ([]string, error) {
+	return getArgs(s)(ctx)
 }
 
 func (s State) Reset(s2 State) State {
@@ -282,23 +317,23 @@ func (s State) Platform(p specs.Platform) State {
 	return platform(p)(s)
 }
 
-func (s State) GetPlatform() *specs.Platform {
-	return getPlatform(s)
+func (s State) GetPlatform(ctx context.Context) (*specs.Platform, error) {
+	return getPlatform(s)(ctx)
 }
 
 func (s State) Network(n pb.NetMode) State {
 	return network(n)(s)
 }
 
-func (s State) GetNetwork() pb.NetMode {
-	return getNetwork(s)
+func (s State) GetNetwork(ctx context.Context) (pb.NetMode, error) {
+	return getNetwork(s)(ctx)
 }
 func (s State) Security(n pb.SecurityMode) State {
 	return security(n)(s)
 }
 
-func (s State) GetSecurity() pb.SecurityMode {
-	return getSecurity(s)
+func (s State) GetSecurity(ctx context.Context) (pb.SecurityMode, error) {
+	return getSecurity(s)(ctx)
 }
 
 func (s State) With(so ...StateOption) State {
@@ -321,7 +356,7 @@ type output struct {
 	platform *specs.Platform
 }
 
-func (o *output) ToInput(c *Constraints) (*pb.Input, error) {
+func (o *output) ToInput(ctx context.Context, c *Constraints) (*pb.Input, error) {
 	if o.err != nil {
 		return nil, o.err
 	}
@@ -333,14 +368,14 @@ func (o *output) ToInput(c *Constraints) (*pb.Input, error) {
 			return nil, err
 		}
 	}
-	dgst, _, _, err := o.vertex.Marshal(c)
+	dgst, _, _, err := o.vertex.Marshal(ctx, c)
 	if err != nil {
 		return nil, err
 	}
 	return &pb.Input{Digest: dgst, Index: index}, nil
 }
 
-func (o *output) Vertex() Vertex {
+func (o *output) Vertex(context.Context) Vertex {
 	return o.vertex
 }
 
@@ -512,4 +547,8 @@ func Require(filters ...string) ConstraintsOpt {
 			c.WorkerConstraints = append(c.WorkerConstraints, f)
 		}
 	})
+}
+
+func nilValue(context.Context) (interface{}, error) {
+	return nil, nil
 }

--- a/client/solve.go
+++ b/client/solve.go
@@ -192,7 +192,7 @@ func (c *Client) solve(ctx context.Context, def *llb.Definition, runGateway runG
 
 		frontendInputs := make(map[string]*pb.Definition)
 		for key, st := range opt.FrontendInputs {
-			def, err := st.Marshal()
+			def, err := st.Marshal(ctx)
 			if err != nil {
 				return err
 			}

--- a/cmd/buildctl/build_test.go
+++ b/cmd/buildctl/build_test.go
@@ -112,7 +112,7 @@ func testBuildContainerdExporter(t *testing.T, sb integration.Sandbox) {
 }
 
 func marshal(st llb.State) (io.Reader, error) {
-	def, err := st.Marshal()
+	def, err := st.Marshal(context.TODO())
 	if err != nil {
 		return nil, err
 	}

--- a/examples/buildkit0/buildkit.go
+++ b/examples/buildkit0/buildkit.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 
@@ -24,7 +25,7 @@ func main() {
 	bk := buildkit(opt)
 	out := bk.Run(llb.Shlex("ls -l /bin")) // debug output
 
-	dt, err := out.Marshal(llb.LinuxAmd64)
+	dt, err := out.Marshal(context.TODO(), llb.LinuxAmd64)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/buildkit1/buildkit.go
+++ b/examples/buildkit1/buildkit.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 
@@ -24,7 +25,7 @@ func main() {
 	bk := buildkit(opt)
 	out := bk.Run(llb.Shlex("ls -l /bin")) // debug output
 
-	dt, err := out.Marshal(llb.LinuxAmd64)
+	dt, err := out.Marshal(context.TODO(), llb.LinuxAmd64)
 	if err != nil {
 		panic(err)
 	}
@@ -88,7 +89,14 @@ func goFromGit(repo, tag string) llb.StateOption {
 		Dirf("/go/src/%s", repo).
 		Run(llb.Shlexf("git checkout -q %s", tag)).Root()
 	return func(s llb.State) llb.State {
-		return s.With(copyFrom(src, "/go", "/")).Reset(s).Dir(src.GetDir())
+		return s.With(copyFrom(src, "/go", "/")).Reset(s).Async(func(ctx context.Context, s llb.State) (llb.State, error) {
+			// TODO: add s.With(s2.DirValue) or s.With(llb.Dir(s2)) or s.Reset(s2, llb.DirMask)?
+			dir, err := src.GetDir(ctx)
+			if err != nil {
+				return llb.State{}, err
+			}
+			return s.Dir(dir), nil
+		})
 	}
 }
 

--- a/examples/buildkit2/buildkit.go
+++ b/examples/buildkit2/buildkit.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 
@@ -24,7 +25,7 @@ func main() {
 	bk := buildkit(opt)
 	out := bk.Run(llb.Shlex("ls -l /bin")) // debug output
 
-	dt, err := out.Marshal(llb.LinuxAmd64)
+	dt, err := out.Marshal(context.TODO(), llb.LinuxAmd64)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/buildkit3/buildkit.go
+++ b/examples/buildkit3/buildkit.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 
@@ -25,7 +26,7 @@ func main() {
 
 	bk := buildkit(opt)
 	out := bk
-	dt, err := out.Marshal(llb.LinuxAmd64)
+	dt, err := out.Marshal(context.TODO(), llb.LinuxAmd64)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/dockerfile2llb/main.go
+++ b/examples/dockerfile2llb/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"io/ioutil"
 	"log"
@@ -41,7 +42,7 @@ func main() {
 
 	_ = img
 
-	dt, err := state.Marshal()
+	dt, err := state.Marshal(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/examples/nested-llb/main.go
+++ b/examples/nested-llb/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	"github.com/moby/buildkit/client/llb"
@@ -23,7 +24,7 @@ func main() {
 
 	built := pb.With(llbbuild.Build())
 
-	dt, err := llb.Image("docker.io/library/alpine:latest").Run(llb.Shlex("ls -l /out"), llb.AddMount("/out", built, llb.Readonly)).Marshal(llb.LinuxAmd64)
+	dt, err := llb.Image("docker.io/library/alpine:latest").Run(llb.Shlex("ls -l /out"), llb.AddMount("/out", built, llb.Readonly)).Marshal(context.TODO(), llb.LinuxAmd64)
 	if err != nil {
 		panic(err)
 	}

--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -139,7 +139,7 @@ func Build(ctx context.Context, c client.Client) (*client.Result, error) {
 		buildContext = st
 	} else if httpPrefix.MatchString(opts[localNameContext]) {
 		httpContext := llb.HTTP(opts[localNameContext], llb.Filename("context"), dockerfile2llb.WithInternalName("load remote build context"))
-		def, err := httpContext.Marshal(marshalOpts...)
+		def, err := httpContext.Marshal(ctx, marshalOpts...)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to marshal httpcontext")
 		}
@@ -221,7 +221,7 @@ func Build(ctx context.Context, c client.Client) (*client.Result, error) {
 		}
 	}
 
-	def, err := src.Marshal(marshalOpts...)
+	def, err := src.Marshal(ctx, marshalOpts...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to marshal local source")
 	}
@@ -271,7 +271,7 @@ func Build(ctx context.Context, c client.Client) (*client.Result, error) {
 				)
 				dockerignoreState = &st
 			}
-			def, err := dockerignoreState.Marshal(marshalOpts...)
+			def, err := dockerignoreState.Marshal(ctx, marshalOpts...)
 			if err != nil {
 				return err
 			}
@@ -363,7 +363,7 @@ func Build(ctx context.Context, c client.Client) (*client.Result, error) {
 					return errors.Wrapf(err, "failed to create LLB definition")
 				}
 
-				def, err := st.Marshal()
+				def, err := st.Marshal(ctx)
 				if err != nil {
 					return errors.Wrapf(err, "failed to marshal LLB definition")
 				}
@@ -467,7 +467,7 @@ func forwardGateway(ctx context.Context, c client.Client, ref string, cmdline st
 
 		frontendInputs = make(map[string]*pb.Definition)
 		for name, state := range inputs {
-			def, err := state.Marshal()
+			def, err := state.Marshal(ctx)
 			if err != nil {
 				return nil, err
 			}

--- a/frontend/dockerfile/dockerfile2llb/convert_runmount.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_runmount.go
@@ -3,6 +3,7 @@
 package dockerfile2llb
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -132,7 +133,11 @@ func dispatchRunMounts(d *dispatchState, c *instructions.RunCommand, sources []*
 		}
 		target := mount.Target
 		if !filepath.IsAbs(filepath.Clean(mount.Target)) {
-			target = filepath.Join("/", d.state.GetDir(), mount.Target)
+			dir, err := d.state.GetDir(context.TODO())
+			if err != nil {
+				return nil, err
+			}
+			target = filepath.Join("/", dir, mount.Target)
 		}
 		if target == "/" {
 			return nil, errors.Errorf("invalid mount target %q", target)

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -1771,7 +1771,7 @@ COPY foo .
 		Run(llb.Shlex(`sh -c "echo -n foo0 > /empty/foo"`)).
 		AddMount("/empty", llb.Image("docker.io/moby/testpullscratch:latest"))
 
-	def, err := echo.Marshal()
+	def, err := echo.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	destDir, err := ioutil.TempDir("", "buildkit")
@@ -4442,7 +4442,7 @@ COPY foo foo2
 			llb.Copy(st2, "foo2", "foo3"),
 		)
 
-		def, err := st.Marshal()
+		def, err := st.Marshal(context.TODO())
 		if err != nil {
 			return nil, err
 		}
@@ -4490,7 +4490,7 @@ func testFrontendInputs(t *testing.T, sb integration.Sandbox) {
 		llb.Shlex(`sh -c "cat /dev/urandom | head -c 100 | sha256sum > /out/foo"`),
 	).AddMount("/out", llb.Scratch())
 
-	def, err := outMount.Marshal()
+	def, err := outMount.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	_, err = c.Solve(context.TODO(), def, client.SolveOpt{

--- a/frontend/frontend_test.go
+++ b/frontend/frontend_test.go
@@ -52,7 +52,7 @@ func testRefReadFile(t *testing.T, sb integration.Sandbox) {
 	defer os.RemoveAll(dir)
 
 	frontend := func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
-		def, err := llb.Local("mylocal").Marshal()
+		def, err := llb.Local("mylocal").Marshal(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -132,7 +132,7 @@ func testRefReadDir(t *testing.T, sb integration.Sandbox) {
 	})
 
 	frontend := func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
-		def, err := llb.Local("mylocal").Marshal()
+		def, err := llb.Local("mylocal").Marshal(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -236,7 +236,7 @@ func testRefStatFile(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 
 	frontend := func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
-		def, err := llb.Local("mylocal").Marshal()
+		def, err := llb.Local("mylocal").Marshal(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -135,7 +135,7 @@ func (gf *gatewayFrontend) Solve(ctx context.Context, llbBridge frontend.Fronten
 
 		src := llb.Image(sourceRef.String(), &markTypeFrontend{})
 
-		def, err := src.Marshal()
+		def, err := src.Marshal(ctx)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Adds new `llb.Async` method that can be used as a building block for adding callbacks to llb generation that can be resolved later. The DAG values are not evaluated until `Marshal()` or `Get*()` methods are called on a graph. These methods also now take context as an argument as these are the actually blocking functions.

Follow-up TODOs:

- Refactor image meta resolver to async callbacks. This may also require a new API feature that would make sure that resolving image config and pulling image snapshots always resolve to the same image on the same build if they now run completely in parallel. Eg. Dockerfile frontend atm appends a digest to the image ref after resolving a config for this. Could still use this method as well but then pull could only start after the config has been downloaded. @hinsun ideas?

- Refactor marshal method to allow returning partial input DAGs when the current node is blocked on a long-running job. Add a `Solve` method that can take `llb.State` directly and input and efficiently marshal and subbuild in that case.

- Provide helpers for doing things like frontend builds and turning image config returned in frontend metadata back into a state.

- Refactor dockerfile frontend to lazily evaluate and use `llb.State` for building up the final image configuration. Current `context.TODO()` hacks that I added to Dockerfile frontend should not actually be needed as the evaluation is not needed before `state.Marshal()` is called. Added the `context.TODO()` just to get the tests working before continuing.

- This should make the graph generation slower but not sure if it is meaningful. It could be easily optimized by adding memoized wrappers for cache but not sure where they would be most efficient without some benchmarking code. The old code is not super-optimized either in here, eg. could use something more efficient than a linked list for the values.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
