### PR TITLE
llb: make generic runoptions stateoptions

### DIFF
--- a/client/llb/exec.go
+++ b/client/llb/exec.go
@@ -456,17 +456,11 @@ func (fn runOptionFunc) SetRunOption(ei *ExecInfo) {
 	fn(ei)
 }
 
-func Network(n pb.NetMode) RunOption {
-	return runOptionFunc(func(ei *ExecInfo) {
-		ei.State = network(n)(ei.State)
-	})
+func (fn StateOption) SetRunOption(ei *ExecInfo) {
+	ei.State = ei.State.With(fn)
 }
 
-func Security(s pb.SecurityMode) RunOption {
-	return runOptionFunc(func(ei *ExecInfo) {
-		ei.State = security(s)(ei.State)
-	})
-}
+var _ RunOption = StateOption(func(_ State) State { return State{} })
 
 func Shlex(str string) RunOption {
 	return runOptionFunc(func(ei *ExecInfo) {
@@ -485,44 +479,9 @@ func Args(a []string) RunOption {
 	})
 }
 
-func AddEnv(key, value string) RunOption {
-	return runOptionFunc(func(ei *ExecInfo) {
-		ei.State = ei.State.AddEnv(key, value)
-	})
-}
-
-func AddEnvf(key, value string, v ...interface{}) RunOption {
-	return runOptionFunc(func(ei *ExecInfo) {
-		ei.State = ei.State.AddEnvf(key, value, v...)
-	})
-}
-
-func User(str string) RunOption {
-	return runOptionFunc(func(ei *ExecInfo) {
-		ei.State = ei.State.User(str)
-	})
-}
-
-func Dir(str string) RunOption {
-	return runOptionFunc(func(ei *ExecInfo) {
-		ei.State = ei.State.Dir(str)
-	})
-}
-func Dirf(str string, v ...interface{}) RunOption {
-	return runOptionFunc(func(ei *ExecInfo) {
-		ei.State = ei.State.Dirf(str, v...)
-	})
-}
-
 func AddExtraHost(host string, ip net.IP) RunOption {
 	return runOptionFunc(func(ei *ExecInfo) {
 		ei.State = ei.State.AddExtraHost(host, ip)
-	})
-}
-
-func Reset(s State) RunOption {
-	return runOptionFunc(func(ei *ExecInfo) {
-		ei.State = ei.State.Reset(s)
 	})
 }
 

--- a/client/llb/meta.go
+++ b/client/llb/meta.go
@@ -25,6 +25,14 @@ var (
 	keySecurity  = contextKeyT("llb.security")
 )
 
+func AddEnvf(key, value string, v ...interface{}) StateOption {
+	return addEnvf(key, value, true, v...)
+}
+
+func AddEnv(key, value string) StateOption {
+	return addEnvf(key, value, false)
+}
+
 func addEnvf(key, value string, replace bool, v ...interface{}) StateOption {
 	if replace {
 		value = fmt.Sprintf(value, v...)
@@ -40,8 +48,12 @@ func addEnvf(key, value string, replace bool, v ...interface{}) StateOption {
 	}
 }
 
-func dir(str string) StateOption {
+func Dir(str string) StateOption {
 	return dirf(str, false)
+}
+
+func Dirf(str string, v ...interface{}) StateOption {
+	return dirf(str, true, v...)
 }
 
 func dirf(value string, replace bool, v ...interface{}) StateOption {
@@ -65,13 +77,13 @@ func dirf(value string, replace bool, v ...interface{}) StateOption {
 	}
 }
 
-func user(str string) StateOption {
+func User(str string) StateOption {
 	return func(s State) State {
 		return s.WithValue(keyUser, str)
 	}
 }
 
-func reset(other State) StateOption {
+func Reset(other State) StateOption {
 	return func(s State) State {
 		s = NewState(s.Output())
 		s.prev = &other
@@ -200,7 +212,7 @@ type HostIP struct {
 	IP   net.IP
 }
 
-func network(v pb.NetMode) StateOption {
+func Network(v pb.NetMode) StateOption {
 	return func(s State) State {
 		return s.WithValue(keyNetwork, v)
 	}
@@ -219,7 +231,7 @@ func getNetwork(s State) func(context.Context) (pb.NetMode, error) {
 	}
 }
 
-func security(v pb.SecurityMode) StateOption {
+func Security(v pb.SecurityMode) StateOption {
 	return func(s State) State {
 		return s.WithValue(keySecurity, v)
 	}

--- a/client/llb/state.go
+++ b/client/llb/state.go
@@ -32,8 +32,7 @@ type Vertex interface {
 func NewState(o Output) State {
 	s := State{
 		out: o,
-	}
-	s = dir("/")(s)
+	}.Dir("/")
 	s = s.ensurePlatform()
 	return s
 }
@@ -266,18 +265,18 @@ func (s State) File(a *FileAction, opts ...ConstraintsOpt) State {
 }
 
 func (s State) AddEnv(key, value string) State {
-	return addEnvf(key, value, false)(s)
+	return AddEnv(key, value)(s)
 }
 
 func (s State) AddEnvf(key, value string, v ...interface{}) State {
-	return addEnvf(key, value, true, v...)(s)
+	return AddEnvf(key, value, v...)(s)
 }
 
 func (s State) Dir(str string) State {
-	return dirf(str, false)(s)
+	return Dir(str)(s)
 }
 func (s State) Dirf(str string, v ...interface{}) State {
-	return dirf(str, true, v...)(s)
+	return Dirf(str, v...)(s)
 }
 
 func (s State) GetEnv(ctx context.Context, key string) (string, bool, error) {
@@ -306,11 +305,11 @@ func (s State) GetArgs(ctx context.Context) ([]string, error) {
 }
 
 func (s State) Reset(s2 State) State {
-	return reset(s2)(s)
+	return Reset(s2)(s)
 }
 
 func (s State) User(v string) State {
-	return user(v)(s)
+	return User(v)(s)
 }
 
 func (s State) Platform(p specs.Platform) State {
@@ -322,14 +321,14 @@ func (s State) GetPlatform(ctx context.Context) (*specs.Platform, error) {
 }
 
 func (s State) Network(n pb.NetMode) State {
-	return network(n)(s)
+	return Network(n)(s)
 }
 
 func (s State) GetNetwork(ctx context.Context) (pb.NetMode, error) {
 	return getNetwork(s)(ctx)
 }
 func (s State) Security(n pb.SecurityMode) State {
-	return security(n)(s)
+	return Security(n)(s)
 }
 
 func (s State) GetSecurity(ctx context.Context) (pb.SecurityMode, error) {


### PR DESCRIPTION
@hinshun the suggestion in https://github.com/moby/buildkit/pull/1426#discussion_r403423877 doesn't really work because `llb.Dir()` already exists for the form `Run(llb.Dir(path))`. This PR generalizes these functions so they can be now also used in form `state.With(llb.Dir(path))`. Note that this does not solve the use-case in https://github.com/moby/buildkit/pull/1426#discussion_r403423877 though as the function takes a path and not another stage as an input so need a new syntax for that.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>