### PR TITLE
Allow sessions to hijack the connection outside of a solve

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -11,6 +11,8 @@ import (
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	controlapi "github.com/moby/buildkit/api/services/control"
 	"github.com/moby/buildkit/client/connhelper"
+	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/session/grpchijack"
 	"github.com/moby/buildkit/util/appdefaults"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -78,6 +80,10 @@ func New(ctx context.Context, address string, opts ...ClientOpt) (*Client, error
 
 func (c *Client) controlClient() controlapi.ControlClient {
 	return controlapi.NewControlClient(c.conn)
+}
+
+func (c *Client) Dialer() session.Dialer {
+	return grpchijack.Dialer(c.controlClient())
 }
 
 func (c *Client) Close() error {

--- a/client/solve.go
+++ b/client/solve.go
@@ -115,6 +115,12 @@ func (c *Client) solve(ctx context.Context, def *llb.Definition, runGateway runG
 	}
 
 	var ex ExportEntry
+	if len(opt.Exports) > 1 {
+		return nil, errors.New("currently only single Exports can be specified")
+	}
+	if len(opt.Exports) == 1 {
+		ex = opt.Exports[0]
+	}
 
 	if !opt.SessionPreInitialized {
 		if len(syncedDirs) > 0 {
@@ -123,13 +129,6 @@ func (c *Client) solve(ctx context.Context, def *llb.Definition, runGateway runG
 
 		for _, a := range opt.Session {
 			s.Allow(a)
-		}
-
-		if len(opt.Exports) > 1 {
-			return nil, errors.New("currently only single Exports can be specified")
-		}
-		if len(opt.Exports) == 1 {
-			ex = opt.Exports[0]
 		}
 
 		switch ex.Type {


### PR DESCRIPTION
Sessions need a way to run independently of a `Solve` and that isn't possible without being to hijack the underlying GRPC connection of a BuildKit client.

This a first step towards #1432, unblocking usage of shared sessions, but will require more design and  implementation to support multiple sessions.