### PR TITLE
progress: disable truncating by default when using --progress=plain

### DIFF
--- a/util/progress/progressui/printer.go
+++ b/util/progress/progressui/printer.go
@@ -57,11 +57,11 @@ func (p *textMux) printVtx(t *trace, dgst digest.Digest) {
 			p.notFirst = true
 		}
 
-		if os.Getenv("PROGRESS_NO_TRUNC") == "1" {
+		if os.Getenv("PROGRESS_NO_TRUNC") == "0" {
+			fmt.Fprintf(p.w, "#%d %s\n", v.index, limitString(v.Name, 72))
+		} else {
 			fmt.Fprintf(p.w, "#%d %s\n", v.index, v.Name)
 			fmt.Fprintf(p.w, "#%d %s\n", v.index, v.Digest)
-		} else {
-			fmt.Fprintf(p.w, "#%d %s\n", v.index, limitString(v.Name, 72))
 		}
 
 	}


### PR DESCRIPTION
fixes https://github.com/moby/buildkit/issues/1412

Currently, `docker build --progress=plain` truncates output, which makes it
difficult to debug problems during build (the step that failed may not be the
cause of the failure).

For example, in the following build, the output of the `RUN echo ...` is truncated:

    DOCKER_BUILDKIT=1 docker build --no-cache --progress=plain -t foo -<<EOF
    FROM busybox
    RUN echo "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas ut lorem nec leo euismod vestibulum. Donec tortor nisl, iaculis at vehicula vel, interdum eu orci. Integer velit lacus, congue id magna eu, mollis accumsan augue. Aliquam non venenatis risus, eu posuere libero. Vestibulum ante ipsum primis in faucibus orci luctus." > /somewhere
    RUN echo "something went wrong"; exit 1
    EOF

    #5 [2/3] RUN echo "Lorem ipsum dolor sit amet, consectetur adipiscing elit....
    #5 DONE 0.2s

    #6 [3/3] RUN echo "something went wrong"; exit 1
    #6 0.211 something went wrong
    #6 ERROR: executor failed running [/bin/sh -c echo "something went wrong"; exit 1]: runc did not terminate sucessfully
    ------
     > [3/3] RUN echo "something went wrong"; exit 1:
    ------
    failed to solve with frontend dockerfile.v0: failed to build LLB: executor failed running [/bin/sh -c echo "something went wrong"; exit 1]: runc did not terminate sucessfully

While there is an existing `PROGRESS_NO_TRUNC` environment variable, I think that
this should be the default if the user opted to use `--progress=plain` (or in
situations where no TTY is attached, which could be in CI).

This patch changes the default to disable truncating in those situations, but
allowing users to opt-out by setting `PROGRESS_NO_TRUNC=0`

With this change the same build looks like this:

    #5 [2/3] RUN echo "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas ut lorem nec leo euismod vestibulum. Donec tortor nisl, iaculis at vehicula vel, interdum eu orci. Integer velit lacus, congue id magna eu, mollis accumsan augue. Aliquam non venenatis risus, eu posuere libero. Vestibulum ante ipsum primis in faucibus orci luctus." > /somewhere
    #5 sha256:b2f0f47d63911ee55e7cf17c81007310e28190b5be84aa1a7869ba90786d5cee
    #5 DONE 0.2s

    #6 [3/3] RUN echo "something went wrong"; exit 1
    #6 sha256:c037b34bb998ae7d30572b489286da14df87e1478adf6d0c5c71c79b84b11bcc
    #6 0.293 something went wrong
    #6 ERROR: executor failed running [/bin/sh -c echo "something went wrong"; exit 1]: runc did not terminate sucessfully
    ------
     > [3/3] RUN echo "something went wrong"; exit 1:
    ------
    failed to solve with frontend dockerfile.v0: failed to build LLB: executor failed running [/bin/sh -c echo "something went wrong"; exit 1]: runc did not terminate sucessfully
