### PR TITLE
entitlements: separate daemon and client errors

### DIFF
--- a/util/entitlements/entitlements.go
+++ b/util/entitlements/entitlements.go
@@ -43,7 +43,7 @@ func WhiteList(allowed, supported []Entitlement) (Set, error) {
 		}
 		if supported != nil {
 			if !supm.Allowed(e) {
-				return nil, errors.Errorf("entitlement %s is not allowed", e)
+				return nil, errors.Errorf("granting entitlement %s is not allowed by build daemon configuration", e)
 			}
 		}
 		m[e] = struct{}{}


### PR DESCRIPTION
Make sure entitlement errors coming from missing daemon configuration and missing `--allow` on build are not the same.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>