### PR TITLE
Fix COPY --from=stage when running with user-namespaces

### DIFF
--- a/solver/llbsolver/file/backend.go
+++ b/solver/llbsolver/file/backend.go
@@ -179,14 +179,20 @@ func docopy(ctx context.Context, src, dest string, action pb.FileActionCopy, u *
 		return nil
 	}
 
-	ch, err := mapUserToChowner(u, idmap)
-	if err != nil {
-		return err
+	var ch copy.Chowner
+	if action.Owner != nil {
+		var err error
+		ch, err = mapUserToChowner(u, idmap)
+		if err != nil {
+			return err
+		}
 	}
 
 	opt := []copy.Opt{
 		func(ci *copy.CopyInfo) {
-			ci.Chown = ch
+			if ch != nil {
+				ci.Chown = ch
+			}
 			ci.Utime = timestampToTime(action.Timestamp)
 			if m := int(action.Mode); m != -1 {
 				ci.Mode = &m


### PR DESCRIPTION
Issue was reported in https://github.com/moby/moby/issues/34645#issuecomment-615173214, and relates to https://github.com/moby/moby/pull/38599, which addressed this issue for the classic builder.

When copying files between stages, file ownership should be preserved;

```dockerfile
FROM busybox:latest as build
RUN touch x && chown 1:1 x

FROM busybox:latest
RUN touch y && chown 1:1 y
COPY --from=build x ./
```

However, when running with user namespaces enabled:

```bash
# grep dockremap /etc/sub*id
/etc/subgid:dockremap:500000:65536
/etc/subuid:dockremap:500000:65536
```

A build would fail, because BuildKit is trying to map the container's UID/GID to the host:

    ERROR: failed to copy file info: failed to chown /var/lib/docker/500000.500000/overlay2/mu5zpgelkig84eo9rlbqdhnn9/merged/x: Container ID 500001 cannot be mapped to a host ID

When looking at the code, I found that `(fb *Backend) Copy()` takes a `action`
argument (`pb.FileActionCopy`), one of its options is wether or not the owner
should be overridden: https://github.com/moby/buildkit/blob/226a5db9ad3d3ce6ba9bf10fe6300ee635b70f3b/solver/pb/ops.pb.go#L1457-L1458

That argument is passed on to `docopy()` (which is called from `(fb *Backend) Copy()`), however inside `docopy()`, user-mapping is performed, irregardless if `Owner` was set or not: https://github.com/moby/buildkit/blob/226a5db9ad3d3ce6ba9bf10fe6300ee635b70f3b/solver/llbsolver/file/backend.go#L182-L189

This patch makes that step optional, and only performs `mapUserToChowner` if `action.Owner` is specified, hopefully addressing the issue.
