### PR TITLE
gateway: fix metadata getting lost on subsolve

### DIFF
--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -472,7 +472,9 @@ func (lbf *llbBridgeForwarder) Solve(ctx context.Context, req *pb.SolveRequest) 
 		return nil, errors.Errorf("solve did not return default result")
 	}
 
-	pbRes := &pb.Result{}
+	pbRes := &pb.Result{
+		Metadata: res.Metadata,
+	}
 	var defaultID string
 
 	lbf.mu.Lock()

--- a/frontend/gateway/pb/caps.go
+++ b/frontend/gateway/pb/caps.go
@@ -32,6 +32,9 @@ const (
 	// CapFrontendInputs is a capability to request frontend inputs from the
 	// LLBBridge GRPC server.
 	CapFrontendInputs apicaps.CapID = "frontend.inputs"
+
+	// CapGatewaySolveMetadata can be used to check if solve calls from gateway reliably return metadata
+	CapGatewaySolveMetadata apicaps.CapID = "gateway.solve.metadata"
 )
 
 func init() {
@@ -123,6 +126,13 @@ func init() {
 	Caps.Init(apicaps.Cap{
 		ID:      CapFrontendInputs,
 		Name:    "frontend inputs",
+		Enabled: true,
+		Status:  apicaps.CapStatusExperimental,
+	})
+
+	Caps.Init(apicaps.Cap{
+		ID:      CapGatewaySolveMetadata,
+		Name:    "gateway metadata",
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})


### PR DESCRIPTION
fixes #957

`Solve()` calls made from the gateway frontend do not reliably return metadata. Seems it wasn't really ever working properly but over commits it seemed to lost support even for some cases that worked before https://github.com/moby/buildkit/commit/303b5da7131cd11fb1934784fef61fb1a5c2a6a8#diff-35ffd957a392f33dd60921b3168d8fd9L391 . 

@hinshun Suprised you haven't hit this in hlb. It doesn't appear in dockerfile default path because subsolve for `#syntax` comes from builtin frontend usually. But as soon as we add nested builds capabilities this should be quite easy to hit, so I added a capability that allows this bug to be detected for cleaner errors.