### PR TITLE
upgrade errors checks to Is()

### DIFF
--- a/cache/contenthash/checksum_test.go
+++ b/cache/contenthash/checksum_test.go
@@ -242,11 +242,11 @@ func TestSymlinksNoFollow(t *testing.T) {
 
 	_, err = cc.ChecksumWildcard(context.TODO(), ref, "foo/ghi", true) // same because broken symlink
 	require.Error(t, err)
-	require.Equal(t, errNotFound, errors.Cause(err))
+	require.Equal(t, true, errors.Is(err, errNotFound))
 
 	_, err = cc.ChecksumWildcard(context.TODO(), ref, "y1", true)
 	require.Error(t, err)
-	require.Equal(t, errNotFound, errors.Cause(err))
+	require.Equal(t, true, errors.Is(err, errNotFound))
 
 	dgst, err = cc.Checksum(context.TODO(), ref, "sym", false)
 	require.NoError(t, err)
@@ -322,7 +322,7 @@ func TestChecksumBasicFile(t *testing.T) {
 
 	_, err = cc.Checksum(context.TODO(), ref, "d0/ghi", true)
 	require.Error(t, err)
-	require.Equal(t, errNotFound, errors.Cause(err))
+	require.Equal(t, true, errors.Is(err, errNotFound))
 
 	dgst, err = cc.Checksum(context.TODO(), ref, "/", true)
 	require.NoError(t, err)
@@ -478,11 +478,11 @@ func TestHandleChange(t *testing.T) {
 
 	_, err = cc.Checksum(context.TODO(), ref, "d0", true)
 	require.Error(t, err)
-	require.Equal(t, errNotFound, errors.Cause(err))
+	require.Equal(t, true, errors.Is(err, errNotFound))
 
 	_, err = cc.Checksum(context.TODO(), ref, "d0/abc", true)
 	require.Error(t, err)
-	require.Equal(t, errNotFound, errors.Cause(err))
+	require.Equal(t, true, errors.Is(err, errNotFound))
 
 	err = ref.Release(context.TODO())
 	require.NoError(t, err)

--- a/cache/contenthash/path.go
+++ b/cache/contenthash/path.go
@@ -1,9 +1,10 @@
 package contenthash
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
+
+	"github.com/pkg/errors"
 )
 
 var (
@@ -52,7 +53,7 @@ func walkLink(root, path string, linksWalked *int, cb onSymlinkFunc) (newpath st
 	fi, err := os.Lstat(realPath)
 	if err != nil {
 		// If path does not yet exist, treat as non-symlink
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return path, false, nil
 		}
 		return "", false, err

--- a/cache/manager.go
+++ b/cache/manager.go
@@ -143,7 +143,7 @@ func (cm *cacheManager) GetByBlob(ctx context.Context, desc ocispec.Descriptor, 
 
 	for _, si := range sis {
 		ref, err := cm.get(ctx, si.ID(), opts...)
-		if err != nil && errors.Cause(err) != errNotFound {
+		if err != nil && !IsNotFound(err) {
 			return nil, errors.Wrapf(err, "failed to get record %s by blobchainid", si.ID())
 		}
 		if p != nil {
@@ -160,7 +160,7 @@ func (cm *cacheManager) GetByBlob(ctx context.Context, desc ocispec.Descriptor, 
 	var link ImmutableRef
 	for _, si := range sis {
 		ref, err := cm.get(ctx, si.ID(), opts...)
-		if err != nil && errors.Cause(err) != errNotFound {
+		if err != nil && !IsNotFound(err) {
 			return nil, errors.Wrapf(err, "failed to get record %s by chainid", si.ID())
 		}
 		link = ref
@@ -338,7 +338,7 @@ func (cm *cacheManager) getRecord(ctx context.Context, id string, opts ...RefOpt
 		mutable, err := cm.getRecord(ctx, mutableID)
 		if err != nil {
 			// check loading mutable deleted record from disk
-			if errors.Cause(err) == errNotFound {
+			if IsNotFound(err) {
 				cm.md.Clear(id)
 			}
 			return nil, err
@@ -906,12 +906,8 @@ func (cm *cacheManager) DiskUsage(ctx context.Context, opt client.DiskUsageInfo)
 	return du, nil
 }
 
-func IsLocked(err error) bool {
-	return errors.Cause(err) == ErrLocked
-}
-
 func IsNotFound(err error) bool {
-	return errors.Cause(err) == errNotFound
+	return errors.Is(err, errNotFound)
 }
 
 type RefOption interface{}

--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -180,7 +180,7 @@ func TestManager(t *testing.T) {
 
 	_, err = cm.GetMutable(ctx, active.ID())
 	require.Error(t, err)
-	require.Equal(t, ErrLocked, errors.Cause(err))
+	require.Equal(t, true, errors.Is(err, ErrLocked))
 
 	checkDiskUsage(ctx, t, cm, 1, 0)
 
@@ -191,7 +191,7 @@ func TestManager(t *testing.T) {
 
 	_, err = cm.GetMutable(ctx, active.ID())
 	require.Error(t, err)
-	require.Equal(t, ErrLocked, errors.Cause(err))
+	require.Equal(t, true, errors.Is(err, ErrLocked))
 
 	err = snap.Release(ctx)
 	require.NoError(t, err)
@@ -216,11 +216,11 @@ func TestManager(t *testing.T) {
 
 	_, err = cm.GetMutable(ctx, active.ID())
 	require.Error(t, err)
-	require.Equal(t, errNotFound, errors.Cause(err))
+	require.Equal(t, true, errors.Is(err, errNotFound))
 
 	_, err = cm.GetMutable(ctx, snap.ID())
 	require.Error(t, err)
-	require.Equal(t, errInvalid, errors.Cause(err))
+	require.Equal(t, true, errors.Is(err, errInvalid))
 
 	snap, err = cm.Get(ctx, snap.ID())
 	require.NoError(t, err)
@@ -810,7 +810,7 @@ func TestLazyCommit(t *testing.T) {
 
 	_, err = cm.GetMutable(ctx, active.ID())
 	require.Error(t, err)
-	require.Equal(t, ErrLocked, errors.Cause(err))
+	require.Equal(t, true, errors.Is(err, ErrLocked))
 
 	// immutable refs still work
 	snap2, err := cm.Get(ctx, snap.ID())
@@ -831,7 +831,7 @@ func TestLazyCommit(t *testing.T) {
 	// active can't be get while immutable is held
 	_, err = cm.GetMutable(ctx, active.ID())
 	require.Error(t, err)
-	require.Equal(t, ErrLocked, errors.Cause(err))
+	require.Equal(t, true, errors.Is(err, ErrLocked))
 
 	err = snap.Release(ctx)
 	require.NoError(t, err)
@@ -844,7 +844,7 @@ func TestLazyCommit(t *testing.T) {
 	// because ref was took mutable old immutable are cleared
 	_, err = cm.Get(ctx, snap.ID())
 	require.Error(t, err)
-	require.Equal(t, errNotFound, errors.Cause(err))
+	require.Equal(t, true, errors.Is(err, errNotFound))
 
 	snap, err = active2.Commit(ctx)
 	require.NoError(t, err)
@@ -859,7 +859,7 @@ func TestLazyCommit(t *testing.T) {
 	// mutable is gone after finalize
 	_, err = cm.GetMutable(ctx, active2.ID())
 	require.Error(t, err)
-	require.Equal(t, errNotFound, errors.Cause(err))
+	require.Equal(t, true, errors.Is(err, errNotFound))
 
 	// immutable still works
 	snap2, err = cm.Get(ctx, snap.ID())
@@ -902,7 +902,7 @@ func TestLazyCommit(t *testing.T) {
 
 	_, err = cm.Get(ctx, snap.ID())
 	require.Error(t, err)
-	require.Equal(t, errNotFound, errors.Cause(err))
+	require.Equal(t, true, errors.Is(err, errNotFound))
 
 	snap, err = active.Commit(ctx)
 	require.NoError(t, err)
@@ -932,7 +932,7 @@ func TestLazyCommit(t *testing.T) {
 
 	active, err = cm.GetMutable(ctx, active.ID())
 	require.Error(t, err)
-	require.Equal(t, errNotFound, errors.Cause(err))
+	require.Equal(t, true, errors.Is(err, errNotFound))
 }
 
 func checkDiskUsage(ctx context.Context, t *testing.T, cm Manager, inuse, unused int) {

--- a/cache/migrate_v2.go
+++ b/cache/migrate_v2.go
@@ -56,7 +56,7 @@ func migrateChainID(si *metadata.StorageItem, all map[string]*metadata.StorageIt
 func MigrateV2(ctx context.Context, from, to string, cs content.Store, s snapshot.Snapshotter, lm leases.Manager) error {
 	_, err := os.Stat(to)
 	if err != nil {
-		if !os.IsNotExist(errors.Cause(err)) {
+		if !errors.Is(err, os.ErrNotExist) {
 			return errors.WithStack(err)
 		}
 	} else {
@@ -65,7 +65,7 @@ func MigrateV2(ctx context.Context, from, to string, cs content.Store, s snapsho
 
 	_, err = os.Stat(from)
 	if err != nil {
-		if !os.IsNotExist(errors.Cause(err)) {
+		if !errors.Is(err, os.ErrNotExist) {
 			return errors.WithStack(err)
 		}
 		return nil
@@ -180,7 +180,7 @@ func MigrateV2(ctx context.Context, from, to string, cs content.Store, s snapsho
 		})
 		if err != nil {
 			// if we are running the migration twice
-			if errdefs.IsAlreadyExists(err) {
+			if errors.Is(err, errdefs.ErrAlreadyExists) {
 				continue
 			}
 			return errors.Wrap(err, "failed to create lease")
@@ -208,7 +208,7 @@ func MigrateV2(ctx context.Context, from, to string, cs content.Store, s snapsho
 		if _, err := s.Update(ctx, snapshots.Info{
 			Name: getSnapshotID(item),
 		}, "labels.containerd.io/gc.root"); err != nil {
-			if !errdefs.IsNotFound(errors.Cause(err)) {
+			if !errors.Is(err, errdefs.ErrNotFound) {
 				return err
 			}
 		}
@@ -228,7 +228,7 @@ func MigrateV2(ctx context.Context, from, to string, cs content.Store, s snapsho
 			if _, err := s.Update(ctx, snapshots.Info{
 				Name: info.Name,
 			}, "labels.containerd.io/gc.root"); err != nil {
-				if !errdefs.IsNotFound(errors.Cause(err)) {
+				if !errors.Is(err, errdefs.ErrNotFound) {
 					return err
 				}
 			}

--- a/cache/refs.go
+++ b/cache/refs.go
@@ -160,7 +160,7 @@ func (cr *cacheRecord) Size(ctx context.Context) (int64, error) {
 				if isDead {
 					return int64(0), nil
 				}
-				if !errdefs.IsNotFound(err) {
+				if !errors.Is(err, errdefs.ErrNotFound) {
 					return s, errors.Wrapf(err, "failed to get usage for %s", cr.ID())
 				}
 			}
@@ -349,7 +349,7 @@ func (sr *immutableRef) Extract(ctx context.Context) error {
 			return nil, err
 		}
 		if err := sr.cm.Snapshotter.Commit(ctx, getSnapshotID(sr.md), key); err != nil {
-			if !errdefs.IsAlreadyExists(err) {
+			if !errors.Is(err, errdefs.ErrAlreadyExists) {
 				return nil, err
 			}
 		}
@@ -506,7 +506,7 @@ func (cr *cacheRecord) finalize(ctx context.Context, commit bool) error {
 		return nil
 	})
 	if err != nil {
-		if !errdefs.IsAlreadyExists(err) { // migrator adds leases for everything
+		if !errors.Is(err, errdefs.ErrAlreadyExists) { // migrator adds leases for everything
 			return errors.Wrap(err, "failed to create lease")
 		}
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -523,7 +523,7 @@ func testPushByDigest(t *testing.T, sb integration.Sandbox) {
 	defer c.Close()
 
 	registry, err := sb.NewRegistry()
-	if errors.Cause(err) == integration.ErrorRequirements {
+	if errors.Is(err, integration.ErrorRequirements) {
 		t.Skip(err.Error())
 	}
 	require.NoError(t, err)
@@ -688,7 +688,7 @@ func testFrontendImageNaming(t *testing.T, sb integration.Sandbox) {
 	defer c.Close()
 
 	registry, err := sb.NewRegistry()
-	if errors.Cause(err) == integration.ErrorRequirements {
+	if errors.Is(err, integration.ErrorRequirements) {
 		t.Skip(err.Error())
 	}
 	require.NoError(t, err)
@@ -1097,7 +1097,7 @@ func testFileOpCopyRm(t *testing.T, sb integration.Sandbox) {
 	require.Equal(t, []byte("bar0"), dt)
 
 	_, err = os.Stat(filepath.Join(destDir, "out/foo"))
-	require.Equal(t, true, os.IsNotExist(err))
+	require.Equal(t, true, errors.Is(err, os.ErrNotExist))
 
 	dt, err = ioutil.ReadFile(filepath.Join(destDir, "file2"))
 	require.NoError(t, err)
@@ -1156,10 +1156,10 @@ func testFileOpRmWildcard(t *testing.T, sb integration.Sandbox) {
 	require.Equal(t, true, fi.IsDir())
 
 	_, err = os.Stat(filepath.Join(destDir, "foo/target"))
-	require.Equal(t, true, os.IsNotExist(err))
+	require.Equal(t, true, errors.Is(err, os.ErrNotExist))
 
 	_, err = os.Stat(filepath.Join(destDir, "bar/target"))
-	require.Equal(t, true, os.IsNotExist(err))
+	require.Equal(t, true, errors.Is(err, os.ErrNotExist))
 }
 
 func testCallDiskUsage(t *testing.T, sb integration.Sandbox) {
@@ -1716,7 +1716,7 @@ func testBuildExportWithUncompressed(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 
 	registry, err := sb.NewRegistry()
-	if errors.Cause(err) == integration.ErrorRequirements {
+	if errors.Is(err, integration.ErrorRequirements) {
 		t.Skip(err.Error())
 	}
 	require.NoError(t, err)
@@ -1837,7 +1837,7 @@ func testBuildPushAndValidate(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 
 	registry, err := sb.NewRegistry()
-	if errors.Cause(err) == integration.ErrorRequirements {
+	if errors.Is(err, integration.ErrorRequirements) {
 		t.Skip(err.Error())
 	}
 	require.NoError(t, err)
@@ -2091,7 +2091,7 @@ func testBasicCacheImportExport(t *testing.T, sb integration.Sandbox, cacheOptio
 func testBasicRegistryCacheImportExport(t *testing.T, sb integration.Sandbox) {
 	skipDockerd(t, sb)
 	registry, err := sb.NewRegistry()
-	if errors.Cause(err) == integration.ErrorRequirements {
+	if errors.Is(err, integration.ErrorRequirements) {
 		t.Skip(err.Error())
 	}
 	require.NoError(t, err)
@@ -2108,7 +2108,7 @@ func testBasicRegistryCacheImportExport(t *testing.T, sb integration.Sandbox) {
 func testMultipleRegistryCacheImportExport(t *testing.T, sb integration.Sandbox) {
 	skipDockerd(t, sb)
 	registry, err := sb.NewRegistry()
-	if errors.Cause(err) == integration.ErrorRequirements {
+	if errors.Is(err, integration.ErrorRequirements) {
 		t.Skip(err.Error())
 	}
 	require.NoError(t, err)
@@ -2152,7 +2152,7 @@ func testBasicInlineCacheImportExport(t *testing.T, sb integration.Sandbox) {
 	skipDockerd(t, sb)
 	requiresLinux(t)
 	registry, err := sb.NewRegistry()
-	if errors.Cause(err) == integration.ErrorRequirements {
+	if errors.Is(err, integration.ErrorRequirements) {
 		t.Skip(err.Error())
 	}
 	require.NoError(t, err)

--- a/client/llb/async.go
+++ b/client/llb/async.go
@@ -61,7 +61,7 @@ func (as *asyncState) Do(ctx context.Context) error {
 		if err != nil {
 			select {
 			case <-ctx.Done():
-				if errors.Cause(err) == ctx.Err() {
+				if errors.Is(err, ctx.Err()) {
 					return res, err
 				}
 			default:

--- a/cmd/buildctl/build/output.go
+++ b/cmd/buildctl/build/output.go
@@ -103,7 +103,7 @@ func resolveExporterDest(exporter, dest string) (func(map[string]string) (io.Wri
 	case client.ExporterOCI, client.ExporterDocker, client.ExporterTar:
 		if dest != "" && dest != "-" {
 			fi, err := os.Stat(dest)
-			if err != nil && !os.IsNotExist(err) {
+			if err != nil && !errors.Is(err, os.ErrNotExist) {
 				return nil, "", errors.Wrapf(err, "invalid destination file: %s", dest)
 			}
 			if err == nil && fi.IsDir() {

--- a/cmd/buildctl/debug/dumpmetadata.go
+++ b/cmd/buildctl/debug/dumpmetadata.go
@@ -1,7 +1,6 @@
 package debug
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -9,6 +8,7 @@ import (
 	"time"
 
 	"github.com/moby/buildkit/util/appdefaults"
+	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 	bolt "go.etcd.io/bbolt"
 )
@@ -54,7 +54,7 @@ func findMetadataDBFiles(root string) ([]string, error) {
 		_, err := os.Stat(p)
 		if err == nil {
 			files = append(files, p)
-		} else if !os.IsNotExist(err) {
+		} else if !errors.Is(err, os.ErrNotExist) {
 			return nil, err
 		}
 	}

--- a/cmd/buildkitd/config.go
+++ b/cmd/buildkitd/config.go
@@ -21,7 +21,7 @@ func Load(r io.Reader) (config.Config, *toml.MetaData, error) {
 func LoadFile(fp string) (config.Config, *toml.MetaData, error) {
 	f, err := os.Open(fp)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return config.Config{}, nil, nil
 		}
 		return config.Config{}, nil, errors.Wrapf(err, "failed to load config from %s", fp)

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -339,7 +339,8 @@ func defaultConfigPath() string {
 func defaultConf() (config.Config, *toml.MetaData, error) {
 	cfg, md, err := LoadFile(defaultConfigPath())
 	if err != nil {
-		if _, ok := errors.Cause(err).(*os.PathError); !ok {
+		var pe *os.PathError
+		if !errors.As(err, pe) {
 			return config.Config{}, nil, err
 		}
 		return cfg, nil, nil

--- a/cmd/buildkitd/main_containerd_worker.go
+++ b/cmd/buildkitd/main_containerd_worker.go
@@ -237,7 +237,7 @@ func validContainerdSocket(socket string) bool {
 		return true
 	}
 	socketPath := strings.TrimPrefix(socket, "unix://")
-	if _, err := os.Stat(socketPath); os.IsNotExist(err) {
+	if _, err := os.Stat(socketPath); errors.Is(err, os.ErrNotExist) {
 		// FIXME(AkihiroSuda): add more conditions
 		logrus.Warnf("skipping containerd worker, as %q does not exist", socketPath)
 		return false

--- a/executor/oci/hosts.go
+++ b/executor/oci/hosts.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/moby/buildkit/executor"
 	"github.com/moby/buildkit/identity"
+	"github.com/pkg/errors"
 )
 
 const hostsContent = `
@@ -41,7 +42,7 @@ func makeHostsFile(stateDir string, extraHosts []executor.HostIP, idmap *idtools
 	if err == nil {
 		return "", func() {}, nil
 	}
-	if !os.IsNotExist(err) {
+	if !errors.Is(err, os.ErrNotExist) {
 		return "", nil, err
 	}
 

--- a/executor/oci/resolvconf.go
+++ b/executor/oci/resolvconf.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/libnetwork/resolvconf"
 	"github.com/docker/libnetwork/types"
 	"github.com/moby/buildkit/util/flightcontrol"
+	"github.com/pkg/errors"
 )
 
 var g flightcontrol.Group
@@ -34,7 +35,7 @@ func GetResolvConf(ctx context.Context, stateDir string, idmap *idtools.Identity
 		if !generate {
 			fi, err := os.Stat(p)
 			if err != nil {
-				if !os.IsNotExist(err) {
+				if !errors.Is(err, os.ErrNotExist) {
 					return "", err
 				}
 				generate = true
@@ -42,7 +43,7 @@ func GetResolvConf(ctx context.Context, stateDir string, idmap *idtools.Identity
 			if !generate {
 				fiMain, err := os.Stat(resolvconf.Path())
 				if err != nil {
-					if !os.IsNotExist(err) {
+					if !errors.Is(err, os.ErrNotExist) {
 						return nil, err
 					}
 					if lastNotEmpty {
@@ -64,7 +65,7 @@ func GetResolvConf(ctx context.Context, stateDir string, idmap *idtools.Identity
 		var dt []byte
 		f, err := resolvconfGet()
 		if err != nil {
-			if !os.IsNotExist(err) {
+			if !errors.Is(err, os.ErrNotExist) {
 				return "", err
 			}
 		} else {

--- a/executor/oci/user.go
+++ b/executor/oci/user.go
@@ -2,7 +2,6 @@ package oci
 
 import (
 	"context"
-	"errors"
 	"os"
 	"strconv"
 	"strings"
@@ -12,6 +11,7 @@ import (
 	"github.com/containerd/continuity/fs"
 	"github.com/opencontainers/runc/libcontainer/user"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
 )
 
 func GetUser(ctx context.Context, root, username string) (uint32, uint32, []uint32, error) {

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -219,7 +219,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source)
 				for _, sfx := range sfx {
 					img.Name = targetName + sfx
 					if _, err := e.opt.Images.Update(ctx, img); err != nil {
-						if !errdefs.IsNotFound(err) {
+						if !errors.Is(err, errdefs.ErrNotFound) {
 							return nil, tagDone(err)
 						}
 

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -2511,19 +2511,19 @@ Dockerfile
 
 	_, err = os.Stat(filepath.Join(destDir, ".dockerignore"))
 	require.Error(t, err)
-	require.True(t, os.IsNotExist(err))
+	require.True(t, errors.Is(err, os.ErrNotExist))
 
 	_, err = os.Stat(filepath.Join(destDir, "Dockerfile"))
 	require.Error(t, err)
-	require.True(t, os.IsNotExist(err))
+	require.True(t, errors.Is(err, os.ErrNotExist))
 
 	_, err = os.Stat(filepath.Join(destDir, "bar"))
 	require.Error(t, err)
-	require.True(t, os.IsNotExist(err))
+	require.True(t, errors.Is(err, os.ErrNotExist))
 
 	_, err = os.Stat(filepath.Join(destDir, "baz"))
 	require.Error(t, err)
-	require.True(t, os.IsNotExist(err))
+	require.True(t, errors.Is(err, os.ErrNotExist))
 
 	dt, err = ioutil.ReadFile(filepath.Join(destDir, "bay"))
 	require.NoError(t, err)
@@ -3202,7 +3202,7 @@ COPY --from=build foo bar2
 
 	_, err = os.Stat(filepath.Join(destDir, "bar2"))
 	require.Error(t, err)
-	require.True(t, os.IsNotExist(err))
+	require.True(t, errors.Is(err, os.ErrNotExist))
 
 	// second request from master branch contains both files
 	destDir, err = ioutil.TempDir("", "buildkit")
@@ -3504,7 +3504,7 @@ func testOnBuildCleared(t *testing.T, sb integration.Sandbox) {
 	f := getFrontend(t, sb)
 
 	registry, err := sb.NewRegistry()
-	if errors.Cause(err) == integration.ErrorRequirements {
+	if errors.Is(err, integration.ErrorRequirements) {
 		t.Skip(err.Error())
 	}
 	require.NoError(t, err)
@@ -3612,7 +3612,7 @@ func testCacheMultiPlatformImportExport(t *testing.T, sb integration.Sandbox) {
 	f := getFrontend(t, sb)
 
 	registry, err := sb.NewRegistry()
-	if errors.Cause(err) == integration.ErrorRequirements {
+	if errors.Is(err, integration.ErrorRequirements) {
 		t.Skip(err.Error())
 	}
 	require.NoError(t, err)
@@ -3738,7 +3738,7 @@ func testCacheImportExport(t *testing.T, sb integration.Sandbox) {
 	f := getFrontend(t, sb)
 
 	registry, err := sb.NewRegistry()
-	if errors.Cause(err) == integration.ErrorRequirements {
+	if errors.Is(err, integration.ErrorRequirements) {
 		t.Skip(err.Error())
 	}
 	require.NoError(t, err)
@@ -3923,7 +3923,7 @@ func testImportExportReproducibleIDs(t *testing.T, sb integration.Sandbox) {
 	f := getFrontend(t, sb)
 
 	registry, err := sb.NewRegistry()
-	if errors.Cause(err) == integration.ErrorRequirements {
+	if errors.Is(err, integration.ErrorRequirements) {
 		t.Skip(err.Error())
 	}
 	require.NoError(t, err)

--- a/frontend/dockerfile/instructions/commands.go
+++ b/frontend/dockerfile/instructions/commands.go
@@ -1,11 +1,11 @@
 package instructions
 
 import (
-	"errors"
 	"strings"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/strslice"
+	"github.com/pkg/errors"
 )
 
 // KeyValuePair represent an arbitrary named value (useful in slice instead of map[string] string to preserve ordering)

--- a/frontend/dockerfile/parser/line_parsers.go
+++ b/frontend/dockerfile/parser/line_parsers.go
@@ -8,11 +8,12 @@ package parser
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/pkg/errors"
 )
 
 var (

--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -218,7 +218,7 @@ func (gf *gatewayFrontend) Solve(ctx context.Context, llbBridge frontend.Fronten
 	err = llbBridge.Exec(ctx, meta, rootFS, lbf.Stdin, lbf.Stdout, os.Stderr)
 
 	if err != nil {
-		if errors.Cause(err) == context.Canceled && lbf.isErrServerClosed {
+		if errors.Is(err, context.Canceled) && lbf.isErrServerClosed {
 			err = errors.Errorf("frontend grpc server closed unexpectedly")
 		}
 		// An existing error (set via Return rpc) takes

--- a/session/filesync/diffcopy.go
+++ b/session/filesync/diffcopy.go
@@ -41,7 +41,7 @@ type streamWriterCloser struct {
 func (wc *streamWriterCloser) Write(dt []byte) (int, error) {
 	if err := wc.ClientStream.SendMsg(&BytesMessage{Data: dt}); err != nil {
 		// SendMsg return EOF on remote errors
-		if errors.Cause(err) == io.EOF {
+		if errors.Is(err, io.EOF) {
 			if err := errors.WithStack(wc.ClientStream.RecvMsg(struct{}{})); err != nil {
 				return 0, err
 			}
@@ -105,7 +105,7 @@ func writeTargetFile(ds grpc.Stream, wc io.WriteCloser) error {
 	for {
 		bm := BytesMessage{}
 		if err := ds.RecvMsg(&bm); err != nil {
-			if errors.Cause(err) == io.EOF {
+			if errors.Is(err, io.EOF) {
 				return nil
 			}
 			return errors.WithStack(err)

--- a/session/secrets/secretsprovider/secretsprovider.go
+++ b/session/secrets/secretsprovider/secretsprovider.go
@@ -31,7 +31,7 @@ func (sp *secretProvider) Register(server *grpc.Server) {
 func (sp *secretProvider) GetSecret(ctx context.Context, req *secrets.GetSecretRequest) (*secrets.GetSecretResponse, error) {
 	dt, err := sp.store.GetSecret(ctx, req.ID)
 	if err != nil {
-		if errors.Cause(err) == secrets.ErrNotFound {
+		if errors.Is(err, secrets.ErrNotFound) {
 			return nil, status.Errorf(codes.NotFound, err.Error())
 		}
 		return nil, err

--- a/solver/internal/pipe/pipe.go
+++ b/solver/internal/pipe/pipe.go
@@ -159,7 +159,7 @@ func (pw *sender) Finalize(v interface{}, err error) {
 	}
 	pw.status.Err = err
 	pw.status.Completed = true
-	if errors.Cause(err) == context.Canceled && pw.req.Canceled {
+	if errors.Is(err, context.Canceled) && pw.req.Canceled {
 		pw.status.Canceled = true
 	}
 	pw.sendChannel.Send(pw.status)

--- a/solver/llbsolver/file/backend.go
+++ b/solver/llbsolver/file/backend.go
@@ -82,7 +82,7 @@ func mkdir(ctx context.Context, d string, action pb.FileActionMkDir, user *copy.
 		}
 	} else {
 		if err := os.Mkdir(p, os.FileMode(action.Mode)&0777); err != nil {
-			if os.IsExist(err) {
+			if errors.Is(err, os.ErrExist) {
 				return nil
 			}
 			return err
@@ -151,7 +151,7 @@ func rmPath(root, src string, allowNotFound bool) error {
 	}
 
 	if err := os.RemoveAll(p); err != nil {
-		if os.IsNotExist(errors.Cause(err)) && allowNotFound {
+		if errors.Is(err, os.ErrNotExist) && allowNotFound {
 			return nil
 		}
 		return err

--- a/solver/llbsolver/ops/exec.go
+++ b/solver/llbsolver/ops/exec.go
@@ -293,7 +293,7 @@ func (g *cacheRefGetter) getRefCacheDirNoCache(ctx context.Context, key string, 
 			if mRef, err := g.cm.GetMutable(ctx, si.ID()); err == nil {
 				logrus.Debugf("reusing ref for cache dir: %s", mRef.ID())
 				return mRef, nil
-			} else if errors.Cause(err) == cache.ErrLocked {
+			} else if errors.Is(err, cache.ErrLocked) {
 				locked = true
 			}
 		}
@@ -447,7 +447,7 @@ func (e *execOp) getSecretMountable(ctx context.Context, m *pb.Mount) (cache.Mou
 
 	dt, err := secrets.GetSecret(ctx, caller, id)
 	if err != nil {
-		if errors.Cause(err) == secrets.ErrNotFound && m.SecretOpt.Optional {
+		if errors.Is(err, secrets.ErrNotFound) && m.SecretOpt.Optional {
 			return nil, nil
 		}
 		return nil, err

--- a/solver/scheduler_test.go
+++ b/solver/scheduler_test.go
@@ -504,7 +504,7 @@ func TestSingleCancelCache(t *testing.T) {
 
 	_, err = j0.Build(ctx, g0)
 	require.Error(t, err)
-	require.Equal(t, errors.Cause(err), context.Canceled)
+	require.Equal(t, true, errors.Is(err, context.Canceled))
 
 	require.Equal(t, *g0.Vertex.(*vertex).cacheCallCount, int64(1))
 	require.Equal(t, *g0.Vertex.(*vertex).execCallCount, int64(0))
@@ -547,7 +547,7 @@ func TestSingleCancelExec(t *testing.T) {
 
 	_, err = j1.Build(ctx, g1)
 	require.Error(t, err)
-	require.Equal(t, errors.Cause(err), context.Canceled)
+	require.Equal(t, true, errors.Is(err, context.Canceled))
 
 	require.Equal(t, *g1.Vertex.(*vertex).cacheCallCount, int64(1))
 	require.Equal(t, *g1.Vertex.(*vertex).execCallCount, int64(1))
@@ -601,7 +601,7 @@ func TestSingleCancelParallel(t *testing.T) {
 		_, err = j.Build(ctx, g)
 		close(firstErrored)
 		require.Error(t, err)
-		require.Equal(t, errors.Cause(err), context.Canceled)
+		require.Equal(t, true, errors.Is(err, context.Canceled))
 		return nil
 	})
 
@@ -1221,7 +1221,7 @@ func TestErrorReturns(t *testing.T) {
 
 	_, err = j0.Build(ctx, g0)
 	require.Error(t, err)
-	require.Contains(t, errors.Cause(err).Error(), "error-from-test")
+	require.Contains(t, err.Error(), "error-from-test")
 
 	require.NoError(t, j0.Discard())
 	j0 = nil
@@ -1262,7 +1262,7 @@ func TestErrorReturns(t *testing.T) {
 
 	_, err = j1.Build(ctx, g1)
 	require.Error(t, err)
-	require.Equal(t, errors.Cause(err), context.Canceled)
+	require.Equal(t, true, errors.Is(err, context.Canceled))
 
 	require.NoError(t, j1.Discard())
 	j1 = nil
@@ -1303,7 +1303,7 @@ func TestErrorReturns(t *testing.T) {
 
 	_, err = j2.Build(ctx, g2)
 	require.Error(t, err)
-	require.Contains(t, errors.Cause(err).Error(), "exec-error-from-test")
+	require.Contains(t, err.Error(), "exec-error-from-test")
 
 	require.NoError(t, j2.Discard())
 	j1 = nil

--- a/solver/testutil/cachestorage_testsuite.go
+++ b/solver/testutil/cachestorage_testsuite.go
@@ -94,11 +94,11 @@ func testResults(t *testing.T, st solver.CacheKeyStorage) {
 
 	_, err = st.Load("foo1", "foo1")
 	require.Error(t, err)
-	require.Equal(t, errors.Cause(err), solver.ErrNotFound)
+	require.Equal(t, true, errors.Is(err, solver.ErrNotFound))
 
 	_, err = st.Load("foo", "foo2")
 	require.Error(t, err)
-	require.Equal(t, errors.Cause(err), solver.ErrNotFound)
+	require.Equal(t, true, errors.Is(err, solver.ErrNotFound))
 }
 
 func testLinks(t *testing.T, st solver.CacheKeyStorage) {

--- a/source/git/gitsource.go
+++ b/source/git/gitsource.go
@@ -72,7 +72,7 @@ func (gs *gitSource) mountRemote(ctx context.Context, remote string) (target str
 	for _, si := range sis {
 		remoteRef, err = gs.cache.GetMutable(ctx, si.ID())
 		if err != nil {
-			if cache.IsLocked(err) {
+			if errors.Is(err, cache.ErrLocked) {
 				// should never really happen as no other function should access this metadata, but lets be graceful
 				logrus.Warnf("mutable ref for %s  %s was locked: %v", remote, si.ID(), err)
 				continue

--- a/source/git/gitsource_test.go
+++ b/source/git/gitsource_test.go
@@ -85,11 +85,11 @@ func testRepeatedFetch(t *testing.T, keepGitDir bool) {
 
 	_, err = os.Lstat(filepath.Join(dir, "ghi"))
 	require.Error(t, err)
-	require.True(t, os.IsNotExist(err))
+	require.True(t, errors.Is(err, os.ErrNotExist))
 
 	_, err = os.Lstat(filepath.Join(dir, "sub/subfile"))
 	require.Error(t, err)
-	require.True(t, os.IsNotExist(err))
+	require.True(t, errors.Is(err, os.ErrNotExist))
 
 	// second fetch returns same dir
 	id = &source.GitIdentifier{Remote: repodir, Ref: "master", KeepGitDir: keepGitDir}

--- a/util/contentutil/buffer_test.go
+++ b/util/contentutil/buffer_test.go
@@ -41,7 +41,7 @@ func TestReadWrite(t *testing.T) {
 
 	_, err = content.ReadBlob(ctx, b, ocispec.Descriptor{Digest: digest.FromBytes([]byte("foo3"))})
 	require.Error(t, err)
-	require.Equal(t, errors.Cause(err), errdefs.ErrNotFound)
+	require.Equal(t, true, errors.Is(err, errdefs.ErrNotFound))
 }
 
 func TestReaderAt(t *testing.T) {

--- a/util/contentutil/multiprovider_test.go
+++ b/util/contentutil/multiprovider_test.go
@@ -40,5 +40,5 @@ func TestMultiProvider(t *testing.T) {
 
 	_, err = content.ReadBlob(ctx, mp, ocispec.Descriptor{Digest: digest.FromBytes([]byte("foo2"))})
 	require.Error(t, err)
-	require.Equal(t, errors.Cause(err), errdefs.ErrNotFound)
+	require.Equal(t, true, errors.Is(err, errdefs.ErrNotFound))
 }

--- a/util/flightcontrol/flightcontrol.go
+++ b/util/flightcontrol/flightcontrol.go
@@ -35,7 +35,7 @@ func (g *Group) Do(ctx context.Context, key string, fn func(ctx context.Context)
 	var backoff time.Duration
 	for {
 		v, err = g.do(ctx, key, fn)
-		if err == nil || errors.Cause(err) != errRetry {
+		if err == nil || !errors.Is(err, errRetry) {
 			return v, err
 		}
 		// backoff logic

--- a/util/flightcontrol/flightcontrol_test.go
+++ b/util/flightcontrol/flightcontrol_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -52,7 +53,7 @@ func TestCancelOne(t *testing.T) {
 	eg.Go(func() error {
 		ret1, err := g.Do(ctx2, "foo", f)
 		assert.Error(t, err)
-		assert.Equal(t, errors.Cause(err), context.Canceled)
+		require.Equal(t, true, errors.Is(err, context.Canceled))
 		if err == nil {
 			r1 = ret1.(string)
 		}
@@ -94,7 +95,7 @@ func TestCancelBoth(t *testing.T) {
 	eg.Go(func() error {
 		ret1, err := g.Do(ctx2, "foo", f)
 		assert.Error(t, err)
-		assert.Equal(t, errors.Cause(err), context.Canceled)
+		require.Equal(t, true, errors.Is(err, context.Canceled))
 		if err == nil {
 			r1 = ret1.(string)
 		}
@@ -103,7 +104,7 @@ func TestCancelBoth(t *testing.T) {
 	eg.Go(func() error {
 		ret2, err := g.Do(ctx3, "foo", f)
 		assert.Error(t, err)
-		assert.Equal(t, errors.Cause(err), context.Canceled)
+		require.Equal(t, true, errors.Is(err, context.Canceled))
 		if err == nil {
 			r2 = ret2.(string)
 		}

--- a/util/network/cniprovider/cni.go
+++ b/util/network/cniprovider/cni.go
@@ -112,7 +112,7 @@ func (ns *cniNS) Close() error {
 			err = errors.Wrap(err1, "error unmounting network namespace")
 		}
 	}
-	if err1 := os.RemoveAll(filepath.Dir(ns.path)); err1 != nil && !os.IsNotExist(err1) && err == nil {
+	if err1 := os.RemoveAll(filepath.Dir(ns.path)); err1 != nil && !errors.Is(err1, os.ErrNotExist) && err == nil {
 		err = errors.Wrap(err, "error removing network namespace")
 	}
 

--- a/util/pull/pull.go
+++ b/util/pull/pull.go
@@ -299,7 +299,7 @@ func showProgress(ctx context.Context, ongoing *jobs, cs content.Store) {
 			if !j.done {
 				info, err := cs.Info(context.TODO(), j.Digest)
 				if err != nil {
-					if errdefs.IsNotFound(err) {
+					if errors.Is(err, errdefs.ErrNotFound) {
 						pw.Write(j.Digest.String(), progress.Status{
 							Action: "waiting",
 						})

--- a/util/resolver/resolver.go
+++ b/util/resolver/resolver.go
@@ -50,7 +50,7 @@ func fillInsecureOpts(host string, c config.RegistryConfig, h *docker.RegistryHo
 func loadTLSConfig(c config.RegistryConfig) (*tls.Config, error) {
 	for _, d := range c.TLSConfigDir {
 		fs, err := ioutil.ReadDir(d)
-		if err != nil && !os.IsNotExist(err) && !os.IsPermission(err) {
+		if err != nil && !errors.Is(err, os.ErrNotExist) && !errors.Is(err, os.ErrPermission) {
 			return nil, errors.WithStack(err)
 		}
 		for _, f := range fs {

--- a/util/testutil/integration/registry.go
+++ b/util/testutil/integration/registry.go
@@ -40,7 +40,7 @@ func NewRegistry(dir string) (url string, cl func() error, err error) {
 	}
 
 	if _, err := os.Stat(filepath.Join(dir, "config.yaml")); err != nil {
-		if !os.IsNotExist(err) {
+		if !errors.Is(err, os.ErrNotExist) {
 			return "", nil, err
 		}
 		template := fmt.Sprintf(`version: 0.1

--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -150,7 +150,7 @@ func Run(t *testing.T, testCases []Test, opt ...TestOpt) {
 						}
 						sb, closer, err := newSandbox(br, mirror, mv)
 						if err != nil {
-							if errors.Cause(err) == ErrorRequirements {
+							if errors.Is(err, ErrorRequirements) {
 								t.Skip(err.Error())
 							}
 							require.NoError(t, err)

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -521,7 +521,7 @@ func ID(root string) (string, error) {
 	f := filepath.Join(root, "workerid")
 	b, err := ioutil.ReadFile(f)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			id := identity.NewID()
 			err := ioutil.WriteFile(f, []byte(id), 0400)
 			return id, err


### PR DESCRIPTION
`errors.Is()` is the correct way to check error values since go1.13 . This is compatible with both `pkg/errors.Wrap` and error chains that implement `Unwrap()`.

Left out grpc errors. I think `grpc/status` package needs some refactoring for properly supporting `Is/As` as they have decided to hide the actual error type. The latest refactoring in master branch that puts most stuff under `internal` doesn't help either. Otherwise, we could define a helper function for checking grpc errors that understands the `Unwrap` chain.

Note that this does not mean any deprecation of `pkg/errors`. `Wrap/WithStack` remains preferred over defining custom `Unwrap` method for most cases, but `Cause()` shouldn't generally be needed anymore. To avoid mixing `errors` package we should continue importing `pkg/errors` and avoiding `stdlib/errors`. 

@thaJeztah 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>