### PR TITLE
dockerfile: include parser error location

### DIFF
--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -339,8 +339,8 @@ func defaultConfigPath() string {
 func defaultConf() (config.Config, *toml.MetaData, error) {
 	cfg, md, err := LoadFile(defaultConfigPath())
 	if err != nil {
-		var pe *os.PathError
-		if !errors.As(err, pe) {
+		var pe os.PathError
+		if !errors.As(err, &pe) {
 			return config.Config{}, nil, err
 		}
 		return cfg, nil, nil

--- a/frontend/dockerfile/instructions/commands.go
+++ b/frontend/dockerfile/instructions/commands.go
@@ -419,7 +419,7 @@ func IsCurrentStage(s []Stage, name string) bool {
 // CurrentStage return the last stage in a slice
 func CurrentStage(s []Stage) (*Stage, error) {
 	if len(s) == 0 {
-		return nil, errors.New("No build stage in current context")
+		return nil, errors.New("no build stage in current context")
 	}
 	return &s[len(s)-1], nil
 }

--- a/frontend/dockerfile/parser/errors.go
+++ b/frontend/dockerfile/parser/errors.go
@@ -25,6 +25,10 @@ func withLocation(err error, startLine, endLine int) error {
 	if err == nil {
 		return nil
 	}
+	var el ErrorLocation
+	if errors.As(err, &el) {
+		return err
+	}
 	return errors.WithStack(&ErrorLocation{
 		error:  err,
 		Ranges: toRanges(startLine, endLine),

--- a/frontend/dockerfile/parser/errors.go
+++ b/frontend/dockerfile/parser/errors.go
@@ -1,0 +1,42 @@
+package parser
+
+import "github.com/pkg/errors"
+
+type ErrorLocation struct {
+	Ranges []Range
+	error
+}
+
+func (e *ErrorLocation) Unwrap() error {
+	return e.error
+}
+
+type Range struct {
+	Start Position
+	End   Position
+}
+
+type Position struct {
+	Line      int
+	Character int
+}
+
+func withLocation(err error, startLine, endLine int) error {
+	if err == nil {
+		return nil
+	}
+	return errors.WithStack(&ErrorLocation{
+		error:  err,
+		Ranges: toRanges(startLine, endLine),
+	})
+}
+
+func toRanges(start, end int) (r []Range) {
+	if end <= start {
+		end = start
+	}
+	for i := start; i <= end; i++ {
+		r = append(r, Range{Start: Position{Line: i}, End: Position{Line: i}})
+	}
+	return
+}

--- a/frontend/dockerfile/parser/parser.go
+++ b/frontend/dockerfile/parser/parser.go
@@ -244,7 +244,7 @@ func Parse(rwc io.Reader) (*Result, error) {
 		}
 		bytesRead, err = processLine(d, bytesRead, true)
 		if err != nil {
-			return nil, err
+			return nil, withLocation(err, currentLine, 0)
 		}
 		currentLine++
 
@@ -258,7 +258,7 @@ func Parse(rwc io.Reader) (*Result, error) {
 		for !isEndOfLine && scanner.Scan() {
 			bytesRead, err := processLine(d, scanner.Bytes(), false)
 			if err != nil {
-				return nil, err
+				return nil, withLocation(err, currentLine, 0)
 			}
 			currentLine++
 
@@ -282,7 +282,7 @@ func Parse(rwc io.Reader) (*Result, error) {
 
 		child, err := newNodeFromLine(line, d)
 		if err != nil {
-			return nil, err
+			return nil, withLocation(err, startLine, currentLine)
 		}
 		root.AddChild(child, startLine, currentLine)
 	}
@@ -292,14 +292,14 @@ func Parse(rwc io.Reader) (*Result, error) {
 	}
 
 	if root.StartLine < 0 {
-		return nil, errors.New("file with no instructions")
+		return nil, withLocation(errors.New("file with no instructions"), currentLine, 0)
 	}
 
 	return &Result{
 		AST:         root,
 		Warnings:    warnings,
 		EscapeToken: d.escapeToken,
-	}, handleScannerError(scanner.Err())
+	}, withLocation(handleScannerError(scanner.Err()), currentLine, 0)
 }
 
 func trimComments(src []byte) []byte {

--- a/frontend/dockerfile/parser/parser.go
+++ b/frontend/dockerfile/parser/parser.go
@@ -63,6 +63,11 @@ func (node *Node) Dump() string {
 	return strings.TrimSpace(str)
 }
 
+// WrapError returns new error that implements ErrorLocation
+func (node *Node) WrapError(err error) error {
+	return withLocation(err, node.StartLine, node.EndLine)
+}
+
 func (node *Node) lines(start, end int) {
 	node.StartLine = start
 	node.EndLine = end


### PR DESCRIPTION
Allow any dockerfile parsing error from the token or instruction parser to be tracked to the causing source line.