### PR TITLE
file: fix double-remap of old uid value

### DIFF
--- a/solver/llbsolver/file/backend.go
+++ b/solver/llbsolver/file/backend.go
@@ -34,16 +34,17 @@ func mapUserToChowner(user *copy.User, idmap *idtools.IdentityMapping) (copy.Cho
 					return nil, nil
 				}
 				old = &copy.User{} // root
-			}
-			if idmap != nil {
-				identity, err := idmap.ToHost(idtools.Identity{
-					UID: old.Uid,
-					GID: old.Gid,
-				})
-				if err != nil {
-					return nil, err
+				// non-nil old is already mapped
+				if idmap != nil {
+					identity, err := idmap.ToHost(idtools.Identity{
+						UID: old.Uid,
+						GID: old.Gid,
+					})
+					if err != nil {
+						return nil, err
+					}
+					return &copy.User{Uid: identity.UID, Gid: identity.GID}, nil
 				}
-				return &copy.User{Uid: identity.UID, Gid: identity.GID}, nil
 			}
 			return old, nil
 		}, nil


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/34645#issuecomment-615173214
replaces https://github.com/moby/buildkit/pull/1448
regression from #1342

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>