### PR TITLE
CI: fix "--import-cache" deprecation warnings

### DIFF
--- a/hack/build_ci_first_pass
+++ b/hack/build_ci_first_pass
@@ -31,5 +31,5 @@ buildctl build $progressFlag --frontend=dockerfile.v0 \
 buildctl build $progressFlag --frontend=dockerfile.v0 \
   $currentcontextBuildctl \
   --opt target=integration-tests-base \
-  --import-cache cicache.buildk.it/moby/buildkit/master:integration-tests \
+  --import-cache type=registry,ref=cicache.buildk.it/moby/buildkit/master:integration-tests \
   $exportCacheFlags $exportFlags:integration-tests

--- a/hack/cross
+++ b/hack/cross
@@ -18,16 +18,16 @@ buildctl build $progressFlag --frontend=dockerfile.v0 \
   $currentcontextBuildctl \
   --opt target=binaries-linux-helper \
   --opt platform=$RUNC_PLATFORMS \
-  --import-cache cicache.buildk.it/moby/buildkit/master:binaries-cross-helper \
+  --import-cache type=registry,ref=cicache.buildk.it/moby/buildkit/master:binaries-cross-helper \
   --export-cache type=inline --output type=image,push=true,name=$repo:binaries-cross-helper
 fi
 
 buildctl build --progress=plain --frontend=dockerfile.v0 \
    $currentcontextBuildctl \
    --opt platform=$PLATFORMS \
-   --import-cache cicache.buildk.it/moby/buildkit/master:binaries-cross-helper
+   --import-cache type=registry,ref=cicache.buildk.it/moby/buildkit/master:binaries-cross-helper
 
 buildctl build --progress=plain --frontend=dockerfile.v0 \
    $currentcontextBuildctl \
    --opt platform=windows/amd64 --opt target=buildkit-buildkitd \
-   --import-cache cicache.buildk.it/moby/buildkit/master:binaries
+   --import-cache type=registry,ref=cicache.buildk.it/moby/buildkit/master:binaries


### PR DESCRIPTION
I noticed these warnings in CI logs;

    +buildctl build --progress=plain --frontend=dockerfile.v0 --opt context=git://github.com/moby/buildkit#refs/pull/1482/merge --opt build-arg:BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 --opt platform=linux/amd64,linux/arm/v7,linux/arm64,linux/s390x,linux/ppc64le,darwin/amd64,windows/amd64 --import-cache cicache.buildk.it/moby/buildkit/master:binaries-cross-helper
    WARN[0000] --import-cache <ref> is deprecated. Please use --import-cache type=registry,ref=<ref>,<opt>=<optval>[,<opt>=<optval>] instead.

