### PR TITLE
Fix goimports linting

### DIFF
--- a/cache/manager.go
+++ b/cache/manager.go
@@ -16,7 +16,7 @@ import (
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/snapshot"
-	"github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 	imagespecidentity "github.com/opencontainers/image-spec/identity"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"

--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/moby/buildkit/snapshot"
 	containerdsnapshot "github.com/moby/buildkit/snapshot/containerd"
 	"github.com/moby/buildkit/util/leaseutil"
-	"github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"

--- a/cache/migrate_v2.go
+++ b/cache/migrate_v2.go
@@ -13,7 +13,7 @@ import (
 	"github.com/containerd/containerd/snapshots"
 	"github.com/moby/buildkit/cache/metadata"
 	"github.com/moby/buildkit/snapshot"
-	"github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )

--- a/cache/refs.go
+++ b/cache/refs.go
@@ -17,7 +17,7 @@ import (
 	"github.com/moby/buildkit/snapshot"
 	"github.com/moby/buildkit/util/flightcontrol"
 	"github.com/moby/buildkit/util/leaseutil"
-	"github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 	imagespecidentity "github.com/opencontainers/image-spec/identity"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"

--- a/cache/remotecache/registry/registry.go
+++ b/cache/remotecache/registry/registry.go
@@ -10,7 +10,7 @@ import (
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/util/contentutil"
 	"github.com/moby/buildkit/util/resolver"
-	"github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"

--- a/cmd/buildctl/build.go
+++ b/cmd/buildctl/build.go
@@ -16,7 +16,7 @@ import (
 	"github.com/moby/buildkit/session/sshforward/sshprovider"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/progress/progressui"
-	"github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"

--- a/executor/oci/user.go
+++ b/executor/oci/user.go
@@ -10,7 +10,7 @@ import (
 	containerdoci "github.com/containerd/containerd/oci"
 	"github.com/containerd/continuity/fs"
 	"github.com/opencontainers/runc/libcontainer/user"
-	"github.com/opencontainers/runtime-spec/specs-go"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 )
 

--- a/session/content/content_test.go
+++ b/session/content/content_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/containerd/containerd/content/local"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/testutil"
-	"github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/snapshot/containerd/content.go
+++ b/snapshot/containerd/content.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/namespaces"
-	"github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )

--- a/solver/errdefs/vertex.go
+++ b/solver/errdefs/vertex.go
@@ -2,7 +2,7 @@ package errdefs
 
 import (
 	"github.com/moby/buildkit/util/grpcerrors"
-	"github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 )
 
 type VertexError struct {

--- a/util/network/cniprovider/cni.go
+++ b/util/network/cniprovider/cni.go
@@ -7,7 +7,7 @@ import (
 	"syscall"
 
 	"github.com/containerd/containerd/oci"
-	"github.com/containerd/go-cni"
+	cni "github.com/containerd/go-cni"
 	"github.com/gofrs/flock"
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/util/network"

--- a/util/rootless/specconv/specconv_linux.go
+++ b/util/rootless/specconv/specconv_linux.go
@@ -3,7 +3,7 @@ package specconv
 import (
 	"strings"
 
-	"github.com/opencontainers/runtime-spec/specs-go"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // ToRootless converts spec to be compatible with "rootless" runc.


### PR DESCRIPTION
```
[5/5] RUN --mount=target=/go/src/github.com/moby/buildkit 	gometalinter ...
0.435 util/rootless/specconv/specconv_linux.go:1::warning: file is not goimported (goimports)
1.320 cache/manager.go:1::warning: file is not goimported (goimports)
1.335 cache/manager_test.go:1::warning: file is not goimported (goimports)
1.337 cache/migrate_v2.go:1::warning: file is not goimported (goimports)
1.342 cache/refs.go:1::warning: file is not goimported (goimports)
1.454 cache/remotecache/registry/registry.go:1::warning: file is not goimported (goimports)
2.285 cmd/buildctl/build.go:1::warning: file is not goimported (goimports)
3.082 executor/oci/user.go:1::warning: file is not goimported (goimports)
4.333 session/content/content_test.go:1::warning: file is not goimported (goimports)
4.614 snapshot/containerd/content.go:1::warning: file is not goimported (goimports)
4.721 solver/errdefs/vertex.go:1::warning: file is not goimported (goimports)
6.066 util/network/cniprovider/cni.go:1::warning: file is not goimported (goimports)
ERROR: executor failed running [/bin/sh -c gometalinter --config=gometalinter.json ./...]: buildkit-runc did not terminate successfully
```
