### PR TITLE
dockerfile: add --chmod support for COPY/ADD command

### DIFF
--- a/frontend/dockerfile/instructions/commands.go
+++ b/frontend/dockerfile/instructions/commands.go
@@ -188,6 +188,7 @@ type AddCommand struct {
 	withNameAndCode
 	SourcesAndDest
 	Chown string
+	Chmod string
 }
 
 // Expand variables
@@ -209,6 +210,7 @@ type CopyCommand struct {
 	SourcesAndDest
 	From  string
 	Chown string
+	Chmod string
 }
 
 // Expand variables

--- a/frontend/dockerfile/instructions/parse.go
+++ b/frontend/dockerfile/instructions/parse.go
@@ -239,6 +239,7 @@ func parseAdd(req parseRequest) (*AddCommand, error) {
 		return nil, errNoDestinationArgument("ADD")
 	}
 	flChown := req.flags.AddString("chown", "")
+	flChmod := req.flags.AddString("chmod", "")
 	if err := req.flags.Parse(); err != nil {
 		return nil, err
 	}
@@ -246,6 +247,7 @@ func parseAdd(req parseRequest) (*AddCommand, error) {
 		SourcesAndDest:  SourcesAndDest(req.args),
 		withNameAndCode: newWithNameAndCode(req),
 		Chown:           flChown.Value,
+		Chmod:           flChmod.Value,
 	}, nil
 }
 
@@ -255,6 +257,7 @@ func parseCopy(req parseRequest) (*CopyCommand, error) {
 	}
 	flChown := req.flags.AddString("chown", "")
 	flFrom := req.flags.AddString("from", "")
+	flChmod := req.flags.AddString("chmod", "")
 	if err := req.flags.Parse(); err != nil {
 		return nil, err
 	}
@@ -263,6 +266,7 @@ func parseCopy(req parseRequest) (*CopyCommand, error) {
 		From:            flFrom.Value,
 		withNameAndCode: newWithNameAndCode(req),
 		Chown:           flChown.Value,
+		Chmod:           flChmod.Value,
 	}, nil
 }
 

--- a/solver/llbsolver/file/backend.go
+++ b/solver/llbsolver/file/backend.go
@@ -294,6 +294,7 @@ func (fb *Backend) Mkfile(ctx context.Context, m, user, group fileoptypes.Mount,
 
 	return mkfile(ctx, dir, action, u, mnt.m.IdentityMapping())
 }
+
 func (fb *Backend) Rm(ctx context.Context, m fileoptypes.Mount, action pb.FileActionRm) error {
 	mnt, ok := m.(*Mount)
 	if !ok {
@@ -309,6 +310,7 @@ func (fb *Backend) Rm(ctx context.Context, m fileoptypes.Mount, action pb.FileAc
 
 	return rm(ctx, dir, action)
 }
+
 func (fb *Backend) Copy(ctx context.Context, m1, m2, user, group fileoptypes.Mount, action pb.FileActionCopy) error {
 	mnt1, ok := m1.(*Mount)
 	if !ok {


### PR DESCRIPTION
I found that llb.CopyInfo already support mode option, but I'm not sure why there is no support for --chmod in COPY/ADD command. So I made little change to support it.

By the way, --chmod is really useful for us to make a smaller docker image in a easy way.

Signed-off-by: Chen Bin <chen.bin11@zte.com.cn>