### PR TITLE
Fix shell args expansion in buildctl-daemonless.sh

### DIFF
--- a/examples/buildctl-daemonless/buildctl-daemonless.sh
+++ b/examples/buildctl-daemonless/buildctl-daemonless.sh
@@ -54,4 +54,4 @@ waitForBuildkitd() {
 
 startBuildkitd
 waitForBuildkitd
-$BUILDCTL --addr=$(cat $tmp/addr) $@
+$BUILDCTL --addr=$(cat $tmp/addr) "$@"


### PR DESCRIPTION
When the special positional params character isn't enclosed in double quotes it prevents users from passing in arguments spanning multiple words. For example, `--opt build-arg:"word1 word2"` passes `word2` as a separate parameter to buildkit. Enclosing `$@` in double quotes treats each parameter as a separate word.

More here:
https://tiswww.case.edu/php/chet/bash/bashref.html#index-_0024_0040