### PR TITLE
cache: avoid nil dereference

### DIFF
--- a/cache/refs.go
+++ b/cache/refs.go
@@ -180,7 +180,10 @@ func (cr *cacheRecord) Size(ctx context.Context) (int64, error) {
 		cr.mu.Unlock()
 		return usage.Size, nil
 	})
-	return s.(int64), err
+	if err != nil {
+		return 0, err
+	}
+	return s.(int64), nil
 }
 
 func (cr *cacheRecord) Parent() ImmutableRef {


### PR DESCRIPTION
fixes #1510 

When one of the parallel requests is canceled error will be returned without the callback finishing. In that case, the value will be nil and type isn't controlled by the callback. 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>