### PR TITLE
[v0.6 backport] contenthash: ignore system and security xattrs in calculation

### DIFF
--- a/cache/contenthash/tarsum.go
+++ b/cache/contenthash/tarsum.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"sort"
 	"strconv"
+	"strings"
 )
 
 // WriteV1TarsumHeaders writes a tar header to a writer in V1 tarsum format.
@@ -38,7 +39,9 @@ func v1TarHeaderSelect(h *tar.Header) (orderedHeaders [][2]string) {
 	// Get extended attributes.
 	xAttrKeys := make([]string, len(h.Xattrs))
 	for k := range h.Xattrs {
-		xAttrKeys = append(xAttrKeys, k)
+		if !strings.HasPrefix(k, "security.") && !strings.HasPrefix(k, "system.") {
+			xAttrKeys = append(xAttrKeys, k)
+		}
 	}
 	sort.Strings(xAttrKeys)
 

--- a/cache/contenthash/tarsum.go
+++ b/cache/contenthash/tarsum.go
@@ -39,7 +39,7 @@ func v1TarHeaderSelect(h *tar.Header) (orderedHeaders [][2]string) {
 	// Get extended attributes.
 	xAttrKeys := make([]string, len(h.Xattrs))
 	for k := range h.Xattrs {
-		if !strings.HasPrefix(k, "security.") && !strings.HasPrefix(k, "system.") {
+		if k == "security.capability" || !strings.HasPrefix(k, "security.") && !strings.HasPrefix(k, "system.") {
 			xAttrKeys = append(xAttrKeys, k)
 		}
 	}


### PR DESCRIPTION
backport for the v0.6 / docker-19.03 branch

- https://github.com/moby/buildkit/pull/1393 contenthash: ignore system and security xattrs in calculation
    - fixes https://github.com/moby/buildkit/issues/1330 COPY cache not re-used depending on SELinux environment
    - addresses https://github.com/moby/moby/issues/39003#issuecomment-574615437
- https://github.com/moby/buildkit/pull/1526 contenthash: allow security.capability in cache checksum
