### PR TITLE
Introduced fuzzing by adding fuzzer for the jsonpath parser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ clean: FORCE
 test:
 	./hack/test integration gateway dockerfile
 
+fuzz:
+	./hack/fuzz
+
 lint:
 	./hack/lint
 

--- a/frontend/dockerfile/parser/fuzz.go
+++ b/frontend/dockerfile/parser/fuzz.go
@@ -1,0 +1,27 @@
+package parser
+
+import (
+	"os"
+)
+
+func Fuzz(data []byte) int {
+	f, err := os.Create("Dockerfile")
+	if err != nil {
+		return -1
+	}
+	defer f.Close()
+	defer os.Remove("Dockerfile")
+	_, err = f.Write(data)
+	if err != nil {
+		return -1
+	}
+	df, err := os.Open("Dockerfile")
+	if err != nil {
+		return 0
+	}
+	_, err = Parse(df)
+	if err != nil {
+		return 0
+	}
+	return 1
+}

--- a/frontend/dockerfile/parser/fuzz.go
+++ b/frontend/dockerfile/parser/fuzz.go
@@ -1,3 +1,5 @@
+// +build gofuzz
+
 package parser
 
 import (
@@ -15,11 +17,11 @@ func Fuzz(data []byte) int {
 	if err != nil {
 		return -1
 	}
-	df, err := os.Open("Dockerfile")
+	f, err = os.Open("Dockerfile")
 	if err != nil {
 		return 0
 	}
-	_, err = Parse(df)
+	_, err = Parse(f)
 	if err != nil {
 		return 0
 	}

--- a/frontend/dockerfile/parser/fuzz.go
+++ b/frontend/dockerfile/parser/fuzz.go
@@ -1,5 +1,3 @@
-// +build gofuzz
-
 package parser
 
 import (
@@ -17,10 +15,7 @@ func Fuzz(data []byte) int {
 	if err != nil {
 		return -1
 	}
-	f, err = os.Open("Dockerfile")
-	if err != nil {
-		return 0
-	}
+	f.Seek(0, 0)
 	_, err = Parse(f)
 	if err != nil {
 		return 0

--- a/hack/fuzz
+++ b/hack/fuzz
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+HACK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+BIN_DIR=$HACK_DIR/../../../../../bin
+
+go get -u github.com/dvyukov/go-fuzz/go-fuzz github.com/dvyukov/go-fuzz/go-fuzz-build
+
+cd $HACK_DIR/../frontend/dockerfile/parser
+$BIN_DIR/go-fuzz-build


### PR DESCRIPTION
This PR adds a fuzzer for the jsonpath parser.

The fuzzer can be run locally, integrated into regression testing, or we can setup continuous fuzzing. I can confirm that the fuzzer runs on oss-fuzz's infrastructure and will be happy to setup an integration application. This would mean that Google runs this and future fuzzers and notifies maintainers if a bug is found with a detailed bug report. It is a free service with an implied expectation that bugs are fixed. All I would need are the email addresses for potential bug reports. These will be added to a public list that can be changed at any time.

The fuzzer does not affect core functionality or tests.