### PR TITLE
skip tmpfs mounts when calculating indexes for llb.GetMount

### DIFF
--- a/client/llb/exec.go
+++ b/client/llb/exec.go
@@ -388,7 +388,7 @@ func (e *ExecOp) getMountIndexFn(m *mount) func() (pb.OutputIndex, error) {
 
 		i := 0
 		for _, m2 := range e.mounts {
-			if m2.noOutput || m2.readonly || m2.cacheID != "" {
+			if m2.noOutput || m2.readonly || m2.tmpfs || m2.cacheID != "" {
 				continue
 			}
 			if m == m2 {


### PR DESCRIPTION
fixes #1520 