### PR TITLE
increase test context timeouts

### DIFF
--- a/frontend/gateway/grpcclient/client.go
+++ b/frontend/gateway/grpcclient/client.go
@@ -32,7 +32,7 @@ type GrpcClient interface {
 }
 
 func New(ctx context.Context, opts map[string]string, session, product string, c pb.LLBBridgeClient, w []client.WorkerInfo) (GrpcClient, error) {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	resp, err := c.Ping(ctx, &pb.PingRequest{})
 	if err != nil {

--- a/util/testutil/integration/sandbox.go
+++ b/util/testutil/integration/sandbox.go
@@ -176,7 +176,7 @@ func runBuildkitd(conf *BackendConfig, args []string, logs map[string]*bytes.Buf
 		deferF.append(stop)
 	}
 
-	if err := waitUnix(address, 5*time.Second); err != nil {
+	if err := waitUnix(address, 10*time.Second); err != nil {
 		return "", nil, err
 	}
 


### PR DESCRIPTION
Looks like these timeouts can be hit under heavy load in integration tests.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>