### PR TITLE
git: support for token authentication

### DIFF
--- a/client/llb/source.go
+++ b/client/llb/source.go
@@ -215,7 +215,10 @@ func Git(remote, ref string, opts ...GitOption) State {
 		id += "#" + ref
 	}
 
-	gi := &GitInfo{}
+	gi := &GitInfo{
+		AuthHeaderSecret: "GIT_AUTH_HEADER",
+		AuthTokenSecret:  "GIT_AUTH_TOKEN",
+	}
 	for _, o := range opts {
 		o.SetGitOption(gi)
 	}
@@ -227,6 +230,14 @@ func Git(remote, ref string, opts ...GitOption) State {
 	if url != "" {
 		attrs[pb.AttrFullRemoteURL] = url
 		addCap(&gi.Constraints, pb.CapSourceGitFullURL)
+	}
+	if gi.AuthTokenSecret != "" {
+		attrs[pb.AttrAuthTokenSecret] = gi.AuthTokenSecret
+		addCap(&gi.Constraints, pb.CapSourceGitHttpAuth)
+	}
+	if gi.AuthHeaderSecret != "" {
+		attrs[pb.AttrAuthHeaderSecret] = gi.AuthHeaderSecret
+		addCap(&gi.Constraints, pb.CapSourceGitHttpAuth)
 	}
 
 	addCap(&gi.Constraints, pb.CapSourceGit)
@@ -246,12 +257,26 @@ func (fn gitOptionFunc) SetGitOption(gi *GitInfo) {
 
 type GitInfo struct {
 	constraintsWrapper
-	KeepGitDir bool
+	KeepGitDir       bool
+	AuthTokenSecret  string
+	AuthHeaderSecret string
 }
 
 func KeepGitDir() GitOption {
 	return gitOptionFunc(func(gi *GitInfo) {
 		gi.KeepGitDir = true
+	})
+}
+
+func AuthTokenSecret(v string) GitOption {
+	return gitOptionFunc(func(gi *GitInfo) {
+		gi.AuthTokenSecret = v
+	})
+}
+
+func AuthHeaderSecret(v string) GitOption {
+	return gitOptionFunc(func(gi *GitInfo) {
+		gi.AuthHeaderSecret = v
 	})
 }
 

--- a/solver/pb/attr.go
+++ b/solver/pb/attr.go
@@ -2,6 +2,8 @@ package pb
 
 const AttrKeepGitDir = "git.keepgitdir"
 const AttrFullRemoteURL = "git.fullurl"
+const AttrAuthHeaderSecret = "git.authheadersecret"
+const AttrAuthTokenSecret = "git.authtokensecret"
 const AttrLocalSessionID = "local.session"
 const AttrLocalUniqueID = "local.unique"
 const AttrIncludePatterns = "local.includepattern"

--- a/solver/pb/caps.go
+++ b/solver/pb/caps.go
@@ -19,9 +19,10 @@ const (
 	CapSourceLocalExcludePatterns apicaps.CapID = "source.local.excludepatterns"
 	CapSourceLocalSharedKeyHint   apicaps.CapID = "source.local.sharedkeyhint"
 
-	CapSourceGit        apicaps.CapID = "source.git"
-	CapSourceGitKeepDir apicaps.CapID = "source.git.keepgitdir"
-	CapSourceGitFullURL apicaps.CapID = "source.git.fullurl"
+	CapSourceGit         apicaps.CapID = "source.git"
+	CapSourceGitKeepDir  apicaps.CapID = "source.git.keepgitdir"
+	CapSourceGitFullURL  apicaps.CapID = "source.git.fullurl"
+	CapSourceGitHttpAuth apicaps.CapID = "source.git.httpauth"
 
 	CapSourceHTTP         apicaps.CapID = "source.http"
 	CapSourceHTTPChecksum apicaps.CapID = "source.http.checksum"
@@ -127,6 +128,12 @@ func init() {
 
 	Caps.Init(apicaps.Cap{
 		ID:      CapSourceGitFullURL,
+		Enabled: true,
+		Status:  apicaps.CapStatusExperimental,
+	})
+
+	Caps.Init(apicaps.Cap{
+		ID:      CapSourceGitHttpAuth,
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})

--- a/source/gitidentifier.go
+++ b/source/gitidentifier.go
@@ -8,10 +8,12 @@ import (
 )
 
 type GitIdentifier struct {
-	Remote     string
-	Ref        string
-	Subdir     string
-	KeepGitDir bool
+	Remote           string
+	Ref              string
+	Subdir           string
+	KeepGitDir       bool
+	AuthTokenSecret  string
+	AuthHeaderSecret string
 }
 
 func NewGitIdentifier(remoteURL string) (*GitIdentifier, error) {

--- a/source/identifier.go
+++ b/source/identifier.go
@@ -103,6 +103,10 @@ func FromLLB(op *pb.Op_Source, platform *pb.Platform) (Identifier, error) {
 				}
 			case pb.AttrFullRemoteURL:
 				id.Remote = v
+			case pb.AttrAuthHeaderSecret:
+				id.AuthHeaderSecret = v
+			case pb.AttrAuthTokenSecret:
+				id.AuthTokenSecret = v
 			}
 		}
 	}


### PR DESCRIPTION
Allow git to authorize with a http token. The value is pulled in with secrets. The secret names are configurable in LLB. Default names are `GIT_AUTH_HEADER` and `GIT_AUTH_HEADER.<host>` for raw authorization header and `GIT_AUTH_TOKEN` and `GIT_AUTH_TOKEN.<host>` for the `x-access-token` style basic auth value that github uses. Not sure if this is the best approach but want to make this simple to use for the default case. Could also add some hardcoded logic for common hosts like github/bitbucket.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>