### PR TITLE
client test: Fix check for whether sandbox has containerd

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -735,13 +735,9 @@ func testFrontendImageNaming(t *testing.T, sb integration.Sandbox) {
 			require.Equal(t, exporterResponse["image.name"], imageName)
 
 			// check if we can pull (requires containerd)
-			var cdAddress string
-			if cd, ok := sb.(interface {
-				ContainerdAddress() string
-			}); !ok {
+			cdAddress := sb.ContainerdAddress()
+			if cdAddress == "" {
 				return
-			} else {
-				cdAddress = cd.ContainerdAddress()
 			}
 
 			// TODO: make public pull helper function so this can be checked for standalone as well
@@ -1760,13 +1756,9 @@ func testBuildExportWithUncompressed(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	var cdAddress string
-	if cd, ok := sb.(interface {
-		ContainerdAddress() string
-	}); !ok {
-		return
-	} else {
-		cdAddress = cd.ContainerdAddress()
+	cdAddress := sb.ContainerdAddress()
+	if cdAddress == "" {
+		t.Skip("rest of test requires containerd worker")
 	}
 
 	client, err := newContainerd(cdAddress)
@@ -1896,13 +1888,9 @@ func testBuildPushAndValidate(t *testing.T, sb integration.Sandbox) {
 	checkAllReleasable(t, c, sb, false)
 
 	// examine contents of exported tars (requires containerd)
-	var cdAddress string
-	if cd, ok := sb.(interface {
-		ContainerdAddress() string
-	}); !ok {
-		return
-	} else {
-		cdAddress = cd.ContainerdAddress()
+	cdAddress := sb.ContainerdAddress()
+	if cdAddress == "" {
+		t.Skip("rest of test requires containerd worker")
 	}
 
 	// TODO: make public pull helper function so this can be checked for standalone as well
@@ -2916,13 +2904,9 @@ loop0:
 	require.Equal(t, 0, len(du))
 
 	// examine contents of exported tars (requires containerd)
-	var cdAddress string
-	if cd, ok := sb.(interface {
-		ContainerdAddress() string
-	}); !ok {
+	cdAddress := sb.ContainerdAddress()
+	if cdAddress == "" {
 		return
-	} else {
-		cdAddress = cd.ContainerdAddress()
 	}
 
 	// TODO: make public pull helper function so this can be checked for standalone as well

--- a/cmd/buildctl/build_test.go
+++ b/cmd/buildctl/build_test.go
@@ -68,13 +68,9 @@ func testBuildLocalExporter(t *testing.T, sb integration.Sandbox) {
 }
 
 func testBuildContainerdExporter(t *testing.T, sb integration.Sandbox) {
-	var cdAddress string
-	if cd, ok := sb.(interface {
-		ContainerdAddress() string
-	}); !ok {
-		t.Skip("only for containerd worker")
-	} else {
-		cdAddress = cd.ContainerdAddress()
+	cdAddress := sb.ContainerdAddress()
+	if cdAddress == "" {
+		t.Skip("test is only for containerd worker")
 	}
 
 	st := llb.Image("busybox").

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -1580,13 +1580,9 @@ COPY --from=0 /foo /foo
 func testCmdShell(t *testing.T, sb integration.Sandbox) {
 	f := getFrontend(t, sb)
 
-	var cdAddress string
-	if cd, ok := sb.(interface {
-		ContainerdAddress() string
-	}); !ok {
-		t.Skip("requires local image store")
-	} else {
-		cdAddress = cd.ContainerdAddress()
+	cdAddress := sb.ContainerdAddress()
+	if cdAddress == "" {
+		t.Skip("test is only for containerd worker")
 	}
 
 	dockerfile := []byte(`
@@ -1676,13 +1672,9 @@ ENTRYPOINT my entrypoint
 func testPullScratch(t *testing.T, sb integration.Sandbox) {
 	f := getFrontend(t, sb)
 
-	var cdAddress string
-	if cd, ok := sb.(interface {
-		ContainerdAddress() string
-	}); !ok {
-		t.Skip("requires local image store")
-	} else {
-		cdAddress = cd.ContainerdAddress()
+	cdAddress := sb.ContainerdAddress()
+	if cdAddress == "" {
+		t.Skip("test is only for containerd worker")
 	}
 
 	dockerfile := []byte(`
@@ -2345,13 +2337,9 @@ COPY foo /symlink/
 }
 
 func testDockerfileScratchConfig(t *testing.T, sb integration.Sandbox) {
-	var cdAddress string
-	if cd, ok := sb.(interface {
-		ContainerdAddress() string
-	}); !ok {
-		t.Skip("only for containerd worker")
-	} else {
-		cdAddress = cd.ContainerdAddress()
+	cdAddress := sb.ContainerdAddress()
+	if cdAddress == "" {
+		t.Skip("test requires containerd worker")
 	}
 
 	f := getFrontend(t, sb)
@@ -2454,13 +2442,9 @@ EXPOSE 5000
 	}, nil)
 	require.NoError(t, err)
 
-	var cdAddress string
-	if cd, ok := sb.(interface {
-		ContainerdAddress() string
-	}); !ok {
-		return
-	} else {
-		cdAddress = cd.ContainerdAddress()
+	cdAddress := sb.ContainerdAddress()
+	if cdAddress == "" {
+		t.Skip("rest of test requires containerd worker")
 	}
 
 	client, err := newContainerd(cdAddress)
@@ -2639,14 +2623,9 @@ RUN ["ls"]
 	require.NoError(t, cmd.Run())
 
 	// TODO: expose this test to OCI worker
-
-	var cdAddress string
-	if cd, ok := sb.(interface {
-		ContainerdAddress() string
-	}); !ok {
-		t.Skip("only for containerd worker")
-	} else {
-		cdAddress = cd.ContainerdAddress()
+	cdAddress := sb.ContainerdAddress()
+	if cdAddress == "" {
+		t.Skip("rest of test requires containerd worker")
 	}
 
 	client, err := newContainerd(cdAddress)
@@ -2817,13 +2796,9 @@ USER nobody
 	}, nil)
 	require.NoError(t, err)
 
-	var cdAddress string
-	if cd, ok := sb.(interface {
-		ContainerdAddress() string
-	}); !ok {
-		return
-	} else {
-		cdAddress = cd.ContainerdAddress()
+	cdAddress := sb.ContainerdAddress()
+	if cdAddress == "" {
+		t.Skip("rest of test requires containerd worker")
 	}
 
 	client, err := newContainerd(cdAddress)
@@ -3573,13 +3548,9 @@ LABEL foo=bar
 	}, nil)
 	require.NoError(t, err)
 
-	var cdAddress string
-	if cd, ok := sb.(interface {
-		ContainerdAddress() string
-	}); !ok {
-		t.Skip("only for containerd worker")
-	} else {
-		cdAddress = cd.ContainerdAddress()
+	cdAddress := sb.ContainerdAddress()
+	if cdAddress == "" {
+		t.Skip("rest of test requires containerd worker")
 	}
 
 	client, err := newContainerd(cdAddress)
@@ -3997,13 +3968,9 @@ RUN echo bar > bar
 	_, err = f.Solve(context.TODO(), c, opt, nil)
 	require.NoError(t, err)
 
-	var cdAddress string
-	if cd, ok := sb.(interface {
-		ContainerdAddress() string
-	}); !ok {
-		t.Skip("only for containerd worker")
-	} else {
-		cdAddress = cd.ContainerdAddress()
+	cdAddress := sb.ContainerdAddress()
+	if cdAddress == "" {
+		t.Skip("rest of test requires containerd worker")
 	}
 
 	client, err := newContainerd(cdAddress)
@@ -4021,13 +3988,9 @@ RUN echo bar > bar
 }
 
 func testImportExportReproducibleIDs(t *testing.T, sb integration.Sandbox) {
-	var cdAddress string
-	if cd, ok := sb.(interface {
-		ContainerdAddress() string
-	}); !ok {
-		t.Skip("only for containerd worker")
-	} else {
-		cdAddress = cd.ContainerdAddress()
+	cdAddress := sb.ContainerdAddress()
+	if cdAddress == "" {
+		t.Skip("test requires containerd worker")
 	}
 
 	f := getFrontend(t, sb)
@@ -4737,13 +4700,9 @@ loop0:
 	require.Equal(t, 0, len(du))
 
 	// examine contents of exported tars (requires containerd)
-	var cdAddress string
-	if cd, ok := sb.(interface {
-		ContainerdAddress() string
-	}); !ok {
+	cdAddress := sb.ContainerdAddress()
+	if cdAddress == "" {
 		return
-	} else {
-		cdAddress = cd.ContainerdAddress()
 	}
 
 	// TODO: make public pull helper function so this can be checked for standalone as well

--- a/util/testutil/integration/containerd.go
+++ b/util/testutil/integration/containerd.go
@@ -130,12 +130,11 @@ disabled_plugins = ["cri"]
 	}
 	deferF.append(stop)
 
-	return cdbackend{
+	return backend{
+		address:           buildkitdSock,
 		containerdAddress: address,
-		backend: backend{
-			address:  buildkitdSock,
-			rootless: false,
-		}}, cl, nil
+		rootless:          false,
+	}, cl, nil
 }
 
 func formatLogs(m map[string]*bytes.Buffer) string {
@@ -146,13 +145,4 @@ func formatLogs(m map[string]*bytes.Buffer) string {
 		}
 	}
 	return strings.Join(ss, ",")
-}
-
-type cdbackend struct {
-	backend
-	containerdAddress string
-}
-
-func (s cdbackend) ContainerdAddress() string {
-	return s.containerdAddress
 }

--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -29,6 +29,7 @@ import (
 // Backend is the minimal interface that describes a testing backend.
 type Backend interface {
 	Address() string
+	ContainerdAddress() string
 	Rootless() bool
 }
 

--- a/util/testutil/integration/sandbox.go
+++ b/util/testutil/integration/sandbox.go
@@ -22,12 +22,17 @@ import (
 const buildkitdConfigFile = "buildkitd.toml"
 
 type backend struct {
-	address  string
-	rootless bool
+	address           string
+	containerdAddress string
+	rootless          bool
 }
 
 func (b backend) Address() string {
 	return b.address
+}
+
+func (b backend) ContainerdAddress() string {
+	return b.containerdAddress
 }
 
 func (b backend) Rootless() bool {


### PR DESCRIPTION
Before this, the check was always returning that containerd wasn't running and
thus skipping the rest of several test cases.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

[Here's a go playground w/ a stripped down example that I believe shows the `interface{}` check wasn't working as expected.](https://play.golang.org/p/hUOwF6F31W7)