### PR TITLE
image export: Use correct media type when creating new layer blobs. 

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1737,6 +1737,22 @@ func testBuildExportWithUncompressed(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
+	ctx := namespaces.WithNamespace(context.Background(), "buildkit")
+	cdAddress := sb.ContainerdAddress()
+	var client *containerd.Client
+	if cdAddress != "" {
+		client, err = newContainerd(cdAddress)
+		require.NoError(t, err)
+		defer client.Close()
+
+		img, err := client.GetImage(ctx, target)
+		require.NoError(t, err)
+		mfst, err := images.Manifest(ctx, client.ContentStore(), img.Target(), nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(mfst.Layers))
+		require.Equal(t, images.MediaTypeDockerSchema2Layer, mfst.Layers[0].MediaType)
+	}
+
 	// new layer with gzip compression
 	targetImg := llb.Image(target)
 	cmd = `sh -e -c "echo -n gzip > data"`
@@ -1759,16 +1775,10 @@ func testBuildExportWithUncompressed(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	cdAddress := sb.ContainerdAddress()
 	if cdAddress == "" {
 		t.Skip("rest of test requires containerd worker")
 	}
 
-	client, err := newContainerd(cdAddress)
-	require.NoError(t, err)
-	defer client.Close()
-
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit")
 	err = client.ImageService().Delete(ctx, target, images.SynchronousDelete())
 	require.NoError(t, err)
 	err = client.ImageService().Delete(ctx, compressedTarget, images.SynchronousDelete())

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2921,6 +2921,7 @@ loop0:
 	// examine contents of exported tars (requires containerd)
 	cdAddress := sb.ContainerdAddress()
 	if cdAddress == "" {
+		t.Logf("checkAllReleasable: skipping check for exported tars in non-containerd test")
 		return
 	}
 


### PR DESCRIPTION
There are a few bugs in the image export related code being fixed here. GetMediaTypeForLayers was iterating over diffPairs in the wrong order, resulting in it always returning nil for images with more than one layer. This actually worked most of the time because it accidentally triggered a separate codepath meant to handle v0.6 migrations where mediatypes left empty get filled in. However, fixing that bug revealed another existing bug where the "oci" parameter in the image exporter was never passed to GetDiffPairs, resulting in newly created images to always have oci layer media types even when docker types are used for the rest of the image descriptors (manifests, config, etc.).

Due to the interaction between these various bugs, the only practical end effect previously was that single-layer images could incorrectly use oci layer media types when docker types were supposed to be used. An existing test has been expanded to cover that case in a previous commit.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

Note: This PR currently also includes the commits from #1538 so that tests can run in full. I'll rebase once #1538 is merged.
