### PR TITLE
Dockerfile: fix parsing of trailing backslash

### DIFF
--- a/frontend/dockerfile/parser/parser_test.go
+++ b/frontend/dockerfile/parser/parser_test.go
@@ -63,7 +63,7 @@ func TestParseCases(t *testing.T) {
 				// CRLF --> CR to match Unix behavior
 				content = bytes.Replace(content, []byte{'\x0d', '\x0a'}, []byte{'\x0a'}, -1)
 			}
-			require.Equal(t, result.AST.Dump()+"\n", string(content), dockerfile)
+			require.Equal(t, string(content), result.AST.Dump()+"\n", dockerfile)
 		})
 	}
 }

--- a/frontend/dockerfile/parser/testfiles/trailing-backslash/Dockerfile
+++ b/frontend/dockerfile/parser/testfiles/trailing-backslash/Dockerfile
@@ -1,0 +1,17 @@
+# https://github.com/docker/for-win/issues/5254
+
+FROM hello-world
+
+ENV A path
+ENV B another\\path
+ENV C trailing\\backslash\\
+ENV D This should not be appended to C
+ENV E hello\
+\
+world
+ENV F hello\
+ \
+world
+ENV G hello \
+\
+world

--- a/frontend/dockerfile/parser/testfiles/trailing-backslash/result
+++ b/frontend/dockerfile/parser/testfiles/trailing-backslash/result
@@ -1,0 +1,8 @@
+(from "hello-world")
+(env "A" "path")
+(env "B" "another\\\\path")
+(env "C" "trailing\\\\backslash\\\\")
+(env "D" "This should not be appended to C")
+(env "E" "helloworld")
+(env "F" "hello world")
+(env "G" "hello world")


### PR DESCRIPTION
fixes https://github.com/docker/for-win/issues/5254

If the line-continuation marker (`\`) is escaped, it should not be treated as such, but as a literal backslash, for example, the following should produce 5 `ENV` instructions:

```dockerfile
FROM hello-world

ENV A path
ENV B another\\path
ENV C trailing\\backslash\\
ENV D This gets appended to C
ENV E hello\
\
world
```
