### PR TITLE
Update Executor interface for Run and Exec

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -35,7 +35,7 @@ type ProcessInfo struct {
 }
 
 type Executor interface {
-	Run(ctx context.Context, id string, rootfs cache.Mountable, mounts []Mount, process ProcessInfo) error
+	Run(ctx context.Context, id string, rootfs cache.Mountable, mounts []Mount, process ProcessInfo, started chan<- struct{}) error
 	Exec(ctx context.Context, id string, process ProcessInfo) error
 }
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -35,7 +35,12 @@ type ProcessInfo struct {
 }
 
 type Executor interface {
+	// Run will start a container for the given process with rootfs, mounts.
+	// `id` is an optional name for the container so it can be referenced later via Exec.
+	// `started` is an optional channel that will be closed when the container setup completes and has started running.
 	Run(ctx context.Context, id string, rootfs cache.Mountable, mounts []Mount, process ProcessInfo, started chan<- struct{}) error
+	// Exec will start a process in container matching `id`. An error will be returned
+	// if the container failed to start (via Run) or has exited before Exec is called.
 	Exec(ctx context.Context, id string, process ProcessInfo) error
 }
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -28,9 +28,15 @@ type Mount struct {
 	Readonly bool
 }
 
+type ProcessInfo struct {
+	Meta           Meta
+	Stdin          io.ReadCloser
+	Stdout, Stderr io.WriteCloser
+}
+
 type Executor interface {
-	// TODO: add stdout/err
-	Exec(ctx context.Context, meta Meta, rootfs cache.Mountable, mounts []Mount, stdin io.ReadCloser, stdout, stderr io.WriteCloser) error
+	Run(ctx context.Context, id string, rootfs cache.Mountable, mounts []Mount, process ProcessInfo) error
+	Exec(ctx context.Context, id string, process ProcessInfo) error
 }
 
 type HostIP struct {

--- a/solver/llbsolver/ops/exec.go
+++ b/solver/llbsolver/ops/exec.go
@@ -381,6 +381,7 @@ func (sm *sshMountInstance) Mount() ([]mount.Mount, func() error, error) {
 			GID: gid,
 		})
 		if err != nil {
+			cancel()
 			return nil, nil, err
 		}
 		uid = identity.UID
@@ -731,7 +732,7 @@ func (e *execOp) Exec(ctx context.Context, g session.Group, inputs []solver.Resu
 	defer stdout.Close()
 	defer stderr.Close()
 
-	if err := e.exec.Exec(ctx, meta, root, mounts, nil, stdout, stderr); err != nil {
+	if err := e.exec.Run(ctx, "", root, mounts, executor.ProcessInfo{Meta: meta, Stdin: nil, Stdout: stdout, Stderr: stderr}); err != nil {
 		return nil, errors.Wrapf(err, "executor failed running %v", meta.Args)
 	}
 

--- a/solver/llbsolver/ops/exec.go
+++ b/solver/llbsolver/ops/exec.go
@@ -732,7 +732,7 @@ func (e *execOp) Exec(ctx context.Context, g session.Group, inputs []solver.Resu
 	defer stdout.Close()
 	defer stderr.Close()
 
-	if err := e.exec.Run(ctx, "", root, mounts, executor.ProcessInfo{Meta: meta, Stdin: nil, Stdout: stdout, Stderr: stderr}); err != nil {
+	if err := e.exec.Run(ctx, "", root, mounts, executor.ProcessInfo{Meta: meta, Stdin: nil, Stdout: stdout, Stderr: stderr}, nil); err != nil {
 		return nil, errors.Wrapf(err, "executor failed running %v", meta.Args)
 	}
 

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -297,7 +297,7 @@ func (w *Worker) Exec(ctx context.Context, meta executor.Meta, rootFS cache.Immu
 		return err
 	}
 	defer active.Release(context.TODO())
-	return w.Executor.Run(ctx, "", active, nil, executor.ProcessInfo{Meta: meta, Stdin: stdin, Stdout: stdout, Stderr: stderr})
+	return w.Executor.Run(ctx, "", active, nil, executor.ProcessInfo{Meta: meta, Stdin: stdin, Stdout: stdout, Stderr: stderr}, nil)
 }
 
 func (w *Worker) DiskUsage(ctx context.Context, opt client.DiskUsageInfo) ([]*client.UsageInfo, error) {

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -297,7 +297,7 @@ func (w *Worker) Exec(ctx context.Context, meta executor.Meta, rootFS cache.Immu
 		return err
 	}
 	defer active.Release(context.TODO())
-	return w.Executor.Exec(ctx, meta, active, nil, stdin, stdout, stderr)
+	return w.Executor.Run(ctx, "", active, nil, executor.ProcessInfo{Meta: meta, Stdin: stdin, Stdout: stdout, Stderr: stderr})
 }
 
 func (w *Worker) DiskUsage(ctx context.Context, opt client.DiskUsageInfo) ([]*client.UsageInfo, error) {

--- a/worker/containerd/containerd_test.go
+++ b/worker/containerd/containerd_test.go
@@ -1,0 +1,131 @@
+// +build linux,!no_containerd_worker
+
+package containerd
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/containerd/containerd/namespaces"
+	"github.com/moby/buildkit/cache"
+	"github.com/moby/buildkit/executor"
+	"github.com/moby/buildkit/identity"
+	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/source"
+	"github.com/moby/buildkit/util/network/netproviders"
+	"github.com/moby/buildkit/worker/base"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+const sockFile = "/run/containerd/containerd.sock"
+const ns = "buildkit-test"
+
+func newWorkerOpt(t *testing.T) (base.WorkerOpt, func()) {
+	tmpdir, err := ioutil.TempDir("", "workertest")
+	require.NoError(t, err)
+	cleanup := func() { os.RemoveAll(tmpdir) }
+	workerOpt, err := NewWorkerOpt(tmpdir, sockFile, "overlayfs", ns, nil, nil, netproviders.Opt{Mode: "host"})
+	require.NoError(t, err)
+	return workerOpt, cleanup
+}
+
+func checkRequirement(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("requires root")
+	}
+
+	fi, err := os.Stat(sockFile)
+	if err != nil {
+		t.Skipf("Failed to stat %s: %s", sockFile, err.Error())
+	}
+	if fi.Mode()&os.ModeSocket == 0 {
+		t.Skipf("%s is not a unix domain socket", sockFile)
+	}
+}
+
+func newCtx(s string) context.Context {
+	return namespaces.WithNamespace(context.Background(), s)
+}
+
+func newBusyboxSourceSnapshot(ctx context.Context, t *testing.T, w *base.Worker, sm *session.Manager) cache.ImmutableRef {
+	img, err := source.NewImageIdentifier("docker.io/library/busybox:latest")
+	require.NoError(t, err)
+	src, err := w.SourceManager.Resolve(ctx, img, sm)
+	require.NoError(t, err)
+	snap, err := src.Snapshot(ctx, nil)
+	require.NoError(t, err)
+	return snap
+}
+
+func TestContainerdWorkerExec(t *testing.T) {
+	t.Parallel()
+	checkRequirement(t)
+
+	workerOpt, cleanupWorkerOpt := newWorkerOpt(t)
+	defer cleanupWorkerOpt()
+	w, err := base.NewWorker(workerOpt)
+	require.NoError(t, err)
+
+	ctx := newCtx(ns)
+	ctx, cancel := context.WithCancel(ctx)
+	sm, err := session.NewManager()
+	require.NoError(t, err)
+
+	snap := newBusyboxSourceSnapshot(ctx, t, w, sm)
+	root, err := w.CacheManager.New(ctx, snap)
+	require.NoError(t, err)
+
+	id := identity.NewID()
+
+	// first start pid1 in the background
+	eg := errgroup.Group{}
+	eg.Go(func() error {
+		return w.Executor.Run(ctx, id, root, nil, executor.ProcessInfo{
+			Meta: executor.Meta{
+				Args: []string{"sleep", "10"},
+				Cwd:  "/",
+				Env:  []string{"PATH=/bin:/usr/bin:/sbin:/usr/sbin"},
+			},
+		})
+	})
+
+	stdout := bytes.NewBuffer(nil)
+	stderr := bytes.NewBuffer(nil)
+	err = w.Executor.Exec(ctx, id, executor.ProcessInfo{
+		Meta: executor.Meta{
+			Args: []string{"ps", "-o", "pid,comm"},
+		},
+		Stdout: &nopCloser{stdout},
+		Stderr: &nopCloser{stderr},
+	})
+	t.Logf("Stdout: %s", stdout.String())
+	t.Logf("Stderr: %s", stderr.String())
+	require.NoError(t, err)
+	// verify pid1 is sleep
+	require.Contains(t, stdout.String(), "1 sleep")
+	require.Empty(t, stderr.String())
+
+	// stop pid1
+	cancel()
+
+	err = eg.Wait()
+	// we expect this to get canceled after we test the exec
+	require.EqualError(t, errors.Cause(err), "context canceled")
+
+	err = snap.Release(ctx)
+	require.NoError(t, err)
+}
+
+type nopCloser struct {
+	io.Writer
+}
+
+func (n *nopCloser) Close() error {
+	return nil
+}

--- a/worker/containerd/containerd_test.go
+++ b/worker/containerd/containerd_test.go
@@ -3,34 +3,23 @@
 package containerd
 
 import (
-	"bytes"
-	"context"
-	"io"
 	"io/ioutil"
 	"os"
 	"testing"
 
-	"github.com/containerd/containerd/namespaces"
-	"github.com/moby/buildkit/cache"
-	"github.com/moby/buildkit/executor"
-	"github.com/moby/buildkit/identity"
-	"github.com/moby/buildkit/session"
-	"github.com/moby/buildkit/source"
 	"github.com/moby/buildkit/util/network/netproviders"
 	"github.com/moby/buildkit/worker/base"
-	"github.com/pkg/errors"
+	"github.com/moby/buildkit/worker/tests"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sync/errgroup"
 )
 
 const sockFile = "/run/containerd/containerd.sock"
-const ns = "buildkit-test"
 
 func newWorkerOpt(t *testing.T) (base.WorkerOpt, func()) {
 	tmpdir, err := ioutil.TempDir("", "workertest")
 	require.NoError(t, err)
 	cleanup := func() { os.RemoveAll(tmpdir) }
-	workerOpt, err := NewWorkerOpt(tmpdir, sockFile, "overlayfs", ns, nil, nil, netproviders.Opt{Mode: "host"})
+	workerOpt, err := NewWorkerOpt(tmpdir, sockFile, "overlayfs", "buildkit-test", nil, nil, netproviders.Opt{Mode: "host"})
 	require.NoError(t, err)
 	return workerOpt, cleanup
 }
@@ -49,20 +38,6 @@ func checkRequirement(t *testing.T) {
 	}
 }
 
-func newCtx(s string) context.Context {
-	return namespaces.WithNamespace(context.Background(), s)
-}
-
-func newBusyboxSourceSnapshot(ctx context.Context, t *testing.T, w *base.Worker, sm *session.Manager) cache.ImmutableRef {
-	img, err := source.NewImageIdentifier("docker.io/library/busybox:latest")
-	require.NoError(t, err)
-	src, err := w.SourceManager.Resolve(ctx, img, sm)
-	require.NoError(t, err)
-	snap, err := src.Snapshot(ctx, nil)
-	require.NoError(t, err)
-	return snap
-}
-
 func TestContainerdWorkerExec(t *testing.T) {
 	t.Parallel()
 	checkRequirement(t)
@@ -72,60 +47,16 @@ func TestContainerdWorkerExec(t *testing.T) {
 	w, err := base.NewWorker(workerOpt)
 	require.NoError(t, err)
 
-	ctx := newCtx(ns)
-	ctx, cancel := context.WithCancel(ctx)
-	sm, err := session.NewManager()
-	require.NoError(t, err)
-
-	snap := newBusyboxSourceSnapshot(ctx, t, w, sm)
-	root, err := w.CacheManager.New(ctx, snap)
-	require.NoError(t, err)
-
-	id := identity.NewID()
-
-	// first start pid1 in the background
-	eg := errgroup.Group{}
-	eg.Go(func() error {
-		return w.Executor.Run(ctx, id, root, nil, executor.ProcessInfo{
-			Meta: executor.Meta{
-				Args: []string{"sleep", "10"},
-				Cwd:  "/",
-				Env:  []string{"PATH=/bin:/usr/bin:/sbin:/usr/sbin"},
-			},
-		})
-	})
-
-	stdout := bytes.NewBuffer(nil)
-	stderr := bytes.NewBuffer(nil)
-	err = w.Executor.Exec(ctx, id, executor.ProcessInfo{
-		Meta: executor.Meta{
-			Args: []string{"ps", "-o", "pid,comm"},
-		},
-		Stdout: &nopCloser{stdout},
-		Stderr: &nopCloser{stderr},
-	})
-	t.Logf("Stdout: %s", stdout.String())
-	t.Logf("Stderr: %s", stderr.String())
-	require.NoError(t, err)
-	// verify pid1 is sleep
-	require.Contains(t, stdout.String(), "1 sleep")
-	require.Empty(t, stderr.String())
-
-	// stop pid1
-	cancel()
-
-	err = eg.Wait()
-	// we expect this to get canceled after we test the exec
-	require.EqualError(t, errors.Cause(err), "context canceled")
-
-	err = snap.Release(ctx)
-	require.NoError(t, err)
+	tests.TestWorkerExec(t, w)
 }
+func TestContainerdWorkerExecFailures(t *testing.T) {
+	t.Parallel()
+	checkRequirement(t)
 
-type nopCloser struct {
-	io.Writer
-}
+	workerOpt, cleanupWorkerOpt := newWorkerOpt(t)
+	defer cleanupWorkerOpt()
+	w, err := base.NewWorker(workerOpt)
+	require.NoError(t, err)
 
-func (n *nopCloser) Close() error {
-	return nil
+	tests.TestWorkerExecFailures(t, w)
 }

--- a/worker/runc/runc_test.go
+++ b/worker/runc/runc_test.go
@@ -4,7 +4,6 @@ package runc
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -13,22 +12,17 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/containerd/containerd/namespaces"
 	ctdsnapshot "github.com/containerd/containerd/snapshots"
 	"github.com/containerd/containerd/snapshots/overlay"
-	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/executor"
 	"github.com/moby/buildkit/executor/oci"
-	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/snapshot"
-	"github.com/moby/buildkit/source"
 	"github.com/moby/buildkit/util/network/netproviders"
 	"github.com/moby/buildkit/worker/base"
-	"github.com/pkg/errors"
+	"github.com/moby/buildkit/worker/tests"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sync/errgroup"
 )
 
 func newWorkerOpt(t *testing.T, processMode oci.ProcessMode) (base.WorkerOpt, func()) {
@@ -61,20 +55,6 @@ func checkRequirement(t *testing.T) {
 	}
 }
 
-func newCtx(s string) context.Context {
-	return namespaces.WithNamespace(context.Background(), s)
-}
-
-func newBusyboxSourceSnapshot(ctx context.Context, t *testing.T, w *base.Worker, sm *session.Manager) cache.ImmutableRef {
-	img, err := source.NewImageIdentifier("docker.io/library/busybox:latest")
-	require.NoError(t, err)
-	src, err := w.SourceManager.Resolve(ctx, img, sm)
-	require.NoError(t, err)
-	snap, err := src.Snapshot(ctx, nil)
-	require.NoError(t, err)
-	return snap
-}
-
 func TestRuncWorker(t *testing.T) {
 	t.Parallel()
 	checkRequirement(t)
@@ -84,10 +64,10 @@ func TestRuncWorker(t *testing.T) {
 	w, err := base.NewWorker(workerOpt)
 	require.NoError(t, err)
 
-	ctx := newCtx("buildkit-test")
+	ctx := tests.NewCtx("buildkit-test")
 	sm, err := session.NewManager()
 	require.NoError(t, err)
-	snap := newBusyboxSourceSnapshot(ctx, t, w, sm)
+	snap := tests.NewBusyboxSourceSnapshot(ctx, t, w, sm)
 
 	mounts, err := snap.Mount(ctx, false)
 	require.NoError(t, err)
@@ -127,7 +107,7 @@ func TestRuncWorker(t *testing.T) {
 	}
 
 	stderr := bytes.NewBuffer(nil)
-	err = w.Executor.Run(ctx, "", snap, nil, executor.ProcessInfo{Meta: meta, Stderr: &nopCloser{stderr}})
+	err = w.Executor.Run(ctx, "", snap, nil, executor.ProcessInfo{Meta: meta, Stderr: &nopCloser{stderr}}, nil)
 	require.Error(t, err) // Read-only root
 	// typical error is like `mkdir /.../rootfs/proc: read-only file system`.
 	// make sure the error is caused before running `echo foo > /bar`.
@@ -136,7 +116,7 @@ func TestRuncWorker(t *testing.T) {
 	root, err := w.CacheManager.New(ctx, snap)
 	require.NoError(t, err)
 
-	err = w.Executor.Run(ctx, "", root, nil, executor.ProcessInfo{Meta: meta, Stderr: &nopCloser{stderr}})
+	err = w.Executor.Run(ctx, "", root, nil, executor.ProcessInfo{Meta: meta, Stderr: &nopCloser{stderr}}, nil)
 	require.NoError(t, err)
 
 	meta = executor.Meta{
@@ -144,7 +124,7 @@ func TestRuncWorker(t *testing.T) {
 		Cwd:  "/",
 	}
 
-	err = w.Executor.Run(ctx, "", root, nil, executor.ProcessInfo{Meta: meta, Stderr: &nopCloser{stderr}})
+	err = w.Executor.Run(ctx, "", root, nil, executor.ProcessInfo{Meta: meta, Stderr: &nopCloser{stderr}}, nil)
 	require.NoError(t, err)
 
 	rf, err := root.Commit(ctx)
@@ -188,10 +168,10 @@ func TestRuncWorkerNoProcessSandbox(t *testing.T) {
 	w, err := base.NewWorker(workerOpt)
 	require.NoError(t, err)
 
-	ctx := newCtx("buildkit-test")
+	ctx := tests.NewCtx("buildkit-test")
 	sm, err := session.NewManager()
 	require.NoError(t, err)
-	snap := newBusyboxSourceSnapshot(ctx, t, w, sm)
+	snap := tests.NewBusyboxSourceSnapshot(ctx, t, w, sm)
 	root, err := w.CacheManager.New(ctx, snap)
 	require.NoError(t, err)
 
@@ -205,7 +185,7 @@ func TestRuncWorkerNoProcessSandbox(t *testing.T) {
 	}
 	stdout := bytes.NewBuffer(nil)
 	stderr := bytes.NewBuffer(nil)
-	err = w.Executor.Run(ctx, "", root, nil, executor.ProcessInfo{Meta: meta, Stdout: &nopCloser{stdout}, Stderr: &nopCloser{stderr}})
+	err = w.Executor.Run(ctx, "", root, nil, executor.ProcessInfo{Meta: meta, Stdout: &nopCloser{stdout}, Stderr: &nopCloser{stderr}}, nil)
 	require.NoError(t, err, fmt.Sprintf("stdout=%q, stderr=%q", stdout.String(), stderr.String()))
 	require.Equal(t, string(selfCmdline), stdout.String())
 }
@@ -219,55 +199,19 @@ func TestRuncWorkerExec(t *testing.T) {
 	w, err := base.NewWorker(workerOpt)
 	require.NoError(t, err)
 
-	ctx := newCtx("buildkit-test")
-	ctx, cancel := context.WithCancel(ctx)
-	sm, err := session.NewManager()
+	tests.TestWorkerExec(t, w)
+}
+
+func TestRuncWorkerExecFailures(t *testing.T) {
+	t.Parallel()
+	checkRequirement(t)
+
+	workerOpt, cleanupWorkerOpt := newWorkerOpt(t, oci.ProcessSandbox)
+	defer cleanupWorkerOpt()
+	w, err := base.NewWorker(workerOpt)
 	require.NoError(t, err)
 
-	snap := newBusyboxSourceSnapshot(ctx, t, w, sm)
-	root, err := w.CacheManager.New(ctx, snap)
-	require.NoError(t, err)
-
-	id := identity.NewID()
-
-	// first start pid1 in the background
-	eg := errgroup.Group{}
-	eg.Go(func() error {
-		return w.Executor.Run(ctx, id, root, nil, executor.ProcessInfo{
-			Meta: executor.Meta{
-				Args: []string{"sleep", "10"},
-				Cwd:  "/",
-				Env:  []string{"PATH=/bin:/usr/bin:/sbin:/usr/sbin"},
-			},
-		})
-	})
-
-	stdout := bytes.NewBuffer(nil)
-	stderr := bytes.NewBuffer(nil)
-	err = w.Executor.Exec(ctx, id, executor.ProcessInfo{
-		Meta: executor.Meta{
-			Args: []string{"ps", "-o", "pid,comm"},
-		},
-		Stdout: &nopCloser{stdout},
-		Stderr: &nopCloser{stderr},
-	})
-	t.Logf("Stdout: %s", stdout.String())
-	t.Logf("Stderr: %s", stderr.String())
-	require.NoError(t, err)
-	// verify pid1 is sleep
-	require.Contains(t, stdout.String(), "1 sleep")
-	require.Empty(t, stderr.String())
-
-	// stop pid1
-	cancel()
-
-	err = eg.Wait()
-	// we expect pid1 to get canceled after we test the exec
-	require.EqualError(t, errors.Cause(err), "context canceled")
-
-	err = snap.Release(ctx)
-	require.NoError(t, err)
-
+	tests.TestWorkerExecFailures(t, w)
 }
 
 type nopCloser struct {

--- a/worker/tests/common.go
+++ b/worker/tests/common.go
@@ -1,0 +1,201 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/containerd/containerd/namespaces"
+	"github.com/moby/buildkit/cache"
+	"github.com/moby/buildkit/executor"
+	"github.com/moby/buildkit/identity"
+	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/source"
+	"github.com/moby/buildkit/worker/base"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+func NewBusyboxSourceSnapshot(ctx context.Context, t *testing.T, w *base.Worker, sm *session.Manager) cache.ImmutableRef {
+	img, err := source.NewImageIdentifier("docker.io/library/busybox:latest")
+	require.NoError(t, err)
+	src, err := w.SourceManager.Resolve(ctx, img, sm)
+	require.NoError(t, err)
+	snap, err := src.Snapshot(ctx, nil)
+	require.NoError(t, err)
+	return snap
+}
+
+func NewCtx(s string) context.Context {
+	return namespaces.WithNamespace(context.Background(), s)
+}
+
+func TestWorkerExec(t *testing.T, w *base.Worker) {
+	ctx := NewCtx("buildkit-test")
+	ctx, cancel := context.WithCancel(ctx)
+	sm, err := session.NewManager()
+	require.NoError(t, err)
+
+	snap := NewBusyboxSourceSnapshot(ctx, t, w, sm)
+	root, err := w.CacheManager.New(ctx, snap)
+	require.NoError(t, err)
+
+	id := identity.NewID()
+
+	// first start pid1 in the background
+	eg := errgroup.Group{}
+	started := make(chan struct{})
+	eg.Go(func() error {
+		return w.Executor.Run(ctx, id, root, nil, executor.ProcessInfo{
+			Meta: executor.Meta{
+				Args: []string{"sleep", "10"},
+				Cwd:  "/",
+				Env:  []string{"PATH=/bin:/usr/bin:/sbin:/usr/sbin"},
+			},
+		}, started)
+	})
+
+	<-started
+
+	stdout := bytes.NewBuffer(nil)
+	stderr := bytes.NewBuffer(nil)
+
+	// verify pid1 is the sleep command via Exec
+	err = w.Executor.Exec(ctx, id, executor.ProcessInfo{
+		Meta: executor.Meta{
+			Args: []string{"ps", "-o", "pid,comm"},
+		},
+		Stdout: &nopCloser{stdout},
+		Stderr: &nopCloser{stderr},
+	})
+	t.Logf("Stdout: %s", stdout.String())
+	t.Logf("Stderr: %s", stderr.String())
+	require.NoError(t, err)
+	// verify pid1 is sleep
+	require.Contains(t, stdout.String(), "1 sleep")
+	require.Empty(t, stderr.String())
+
+	// simulate: echo -n "hello" | cat > /tmp/msg
+	stdin := bytes.NewReader([]byte("hello"))
+	stdout.Reset()
+	stderr.Reset()
+	err = w.Executor.Exec(ctx, id, executor.ProcessInfo{
+		Meta: executor.Meta{
+			Args: []string{"sh", "-c", "cat > /tmp/msg"},
+		},
+		Stdin:  &nopReadCloser{stdin},
+		Stdout: &nopCloser{stdout},
+		Stderr: &nopCloser{stderr},
+	})
+	require.NoError(t, err)
+	require.Empty(t, stdout.String())
+	require.Empty(t, stderr.String())
+
+	// verify contents of /tmp/msg
+	stdout.Reset()
+	stderr.Reset()
+	err = w.Executor.Exec(ctx, id, executor.ProcessInfo{
+		Meta: executor.Meta{
+			Args: []string{"cat", "/tmp/msg"},
+		},
+		Stdout: &nopCloser{stdout},
+		Stderr: &nopCloser{stderr},
+	})
+	t.Logf("Stdout: %s", stdout.String())
+	t.Logf("Stderr: %s", stderr.String())
+	require.NoError(t, err)
+	require.Equal(t, "hello", stdout.String())
+	require.Empty(t, stderr.String())
+
+	// stop pid1
+	cancel()
+
+	err = eg.Wait()
+	// we expect pid1 to get canceled after we test the exec
+	require.EqualError(t, errors.Cause(err), context.Canceled.Error())
+
+	err = snap.Release(ctx)
+	require.NoError(t, err)
+}
+
+func TestWorkerExecFailures(t *testing.T, w *base.Worker) {
+	ctx := NewCtx("buildkit-test")
+	sm, err := session.NewManager()
+	require.NoError(t, err)
+
+	snap := NewBusyboxSourceSnapshot(ctx, t, w, sm)
+	root, err := w.CacheManager.New(ctx, snap)
+	require.NoError(t, err)
+
+	id := identity.NewID()
+
+	// pid1 will start but only long enough for /bin/false to run
+	eg := errgroup.Group{}
+	started := make(chan struct{})
+	eg.Go(func() error {
+		return w.Executor.Run(ctx, id, root, nil, executor.ProcessInfo{
+			Meta: executor.Meta{
+				Args: []string{"/bin/false"},
+				Cwd:  "/",
+			},
+		}, started)
+	})
+
+	<-started
+
+	// this should fail since pid1 has already exited
+	err = w.Executor.Exec(ctx, id, executor.ProcessInfo{
+		Meta: executor.Meta{
+			Args: []string{"/bin/true"},
+		},
+	})
+	require.Error(t, err) // pid1 no longer running
+
+	err = eg.Wait()
+	require.Error(t, err) // process returned non-zero exit code: 1
+
+	// pid1 will not start, bogus pid1 command
+	eg = errgroup.Group{}
+	started = make(chan struct{})
+	eg.Go(func() error {
+		return w.Executor.Run(ctx, id, root, nil, executor.ProcessInfo{
+			Meta: executor.Meta{
+				Args: []string{"bogus"},
+			},
+		}, started)
+	})
+
+	<-started
+
+	// this should fail since pid1 never started
+	err = w.Executor.Exec(ctx, id, executor.ProcessInfo{
+		Meta: executor.Meta{
+			Args: []string{"/bin/true"},
+		},
+	})
+	require.Error(t, err) // container has exited with error
+
+	err = eg.Wait()
+	require.Error(t, err) // pid1 did not terminate successfully
+
+	err = snap.Release(ctx)
+	require.NoError(t, err)
+}
+
+type nopReadCloser struct {
+	io.Reader
+}
+
+func (n *nopReadCloser) Close() error {
+	return nil
+}
+
+type nopCloser struct {
+	io.Writer
+}
+
+func (n *nopCloser) Close() error {
+	return nil
+}


### PR DESCRIPTION
First step for #749 refactor Executor interface to allow for Run (pid1) vs Exec'ing into running containers.  Implements proposal outlined in: https://github.com/moby/buildkit/issues/749#issuecomment-655206042

