### PR TITLE
inline cache: fix handling of duplicate blobs

### DIFF
--- a/cache/remotecache/inline/inline.go
+++ b/cache/remotecache/inline/inline.go
@@ -72,7 +72,7 @@ func (ce *exporter) ExportForLayers(layers []digest.Digest) ([]byte, error) {
 		return nil, nil
 	}
 
-	cache := map[digest.Digest]int{}
+	cache := map[int]int{}
 
 	// reorder layers based on the order in the image
 	for i, r := range cfg.Records {
@@ -93,14 +93,14 @@ func (ce *exporter) ExportForLayers(layers []digest.Digest) ([]byte, error) {
 	return dt, nil
 }
 
-func getSortedLayerIndex(idx int, layers []v1.CacheLayer, cache map[digest.Digest]int) int {
+func getSortedLayerIndex(idx int, layers []v1.CacheLayer, cache map[int]int) int {
 	if idx == -1 {
 		return -1
 	}
 	l := layers[idx]
-	if i, ok := cache[l.Blob]; ok {
+	if i, ok := cache[idx]; ok {
 		return i
 	}
-	cache[l.Blob] = getSortedLayerIndex(l.ParentIndex, layers, cache) + 1
-	return cache[l.Blob]
+	cache[idx] = getSortedLayerIndex(l.ParentIndex, layers, cache) + 1
+	return cache[idx]
 }


### PR DESCRIPTION
fixes #1388

Blob digest shouldn't be used as a unique identifier as it may appear multiple times in the layer chain. Especially in moby where the digest is not compressed.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>