### PR TITLE
Use containerd's default runtime shim instead of hard-coded runtime v1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -145,7 +145,6 @@ RUN --mount=from=containerd-src,src=/usr/src/containerd,readwrite --mount=target
   git fetch origin \
   && git checkout -q "$CONTAINERD_VERSION" \
   && make bin/containerd \
-  && make bin/containerd-shim \
   && make bin/containerd-shim-runc-v2 \
   && make bin/ctr \
   && mv bin /out

--- a/Dockerfile
+++ b/Dockerfile
@@ -146,6 +146,7 @@ RUN --mount=from=containerd-src,src=/usr/src/containerd,readwrite --mount=target
   && git checkout -q "$CONTAINERD_VERSION" \
   && make bin/containerd \
   && make bin/containerd-shim \
+  && make bin/containerd-shim-runc-v2 \
   && make bin/ctr \
   && mv bin /out
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -143,7 +143,7 @@ func TestIntegration(t *testing.T) {
 }
 
 func newContainerd(cdAddress string) (*containerd.Client, error) {
-	return containerd.New(cdAddress, containerd.WithTimeout(60*time.Second), containerd.WithDefaultRuntime("io.containerd.runtime.v1.linux"))
+	return containerd.New(cdAddress, containerd.WithTimeout(60*time.Second))
 }
 
 // moby/buildkit#1336

--- a/cmd/buildctl/build_test.go
+++ b/cmd/buildctl/build_test.go
@@ -92,7 +92,7 @@ func testBuildContainerdExporter(t *testing.T, sb integration.Sandbox) {
 	err = cmd.Run()
 	require.NoError(t, err)
 
-	client, err := containerd.New(cdAddress, containerd.WithTimeout(60*time.Second), containerd.WithDefaultRuntime("io.containerd.runtime.v1.linux"))
+	client, err := containerd.New(cdAddress, containerd.WithTimeout(60*time.Second))
 	require.NoError(t, err)
 	defer client.Close()
 

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -4752,7 +4752,7 @@ loop0:
 }
 
 func newContainerd(cdAddress string) (*containerd.Client, error) {
-	return containerd.New(cdAddress, containerd.WithTimeout(60*time.Second), containerd.WithDefaultRuntime("io.containerd.runtime.v1.linux"))
+	return containerd.New(cdAddress, containerd.WithTimeout(60*time.Second))
 }
 
 func dfCmdArgs(ctx, dockerfile, args string) (string, string) {

--- a/worker/containerd/containerd.go
+++ b/worker/containerd/containerd.go
@@ -24,10 +24,7 @@ import (
 
 // NewWorkerOpt creates a WorkerOpt.
 func NewWorkerOpt(root string, address, snapshotterName, ns string, labels map[string]string, dns *oci.DNSConfig, nopt netproviders.Opt, opts ...containerd.ClientOpt) (base.WorkerOpt, error) {
-	opts = append(opts,
-		containerd.WithDefaultNamespace(ns),
-		containerd.WithDefaultRuntime("io.containerd.runtime.v1.linux"),
-	)
+	opts = append(opts, containerd.WithDefaultNamespace(ns))
 	client, err := containerd.New(address, opts...)
 	if err != nil {
 		return base.WorkerOpt{}, errors.Wrapf(err, "failed to connect client to %q . make sure containerd is running", address)


### PR DESCRIPTION
Per https://github.com/moby/buildkit/pull/1314#discussion_r364477958, this hard-coding was needed to support containerd 1.2, which as of BuildKit 0.7.0 is no longer supported for the containerd worker.

Contributes towards #616 