### PR TITLE
Make Travis usable for forks

### DIFF
--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -164,7 +164,7 @@ func Build(ctx context.Context, c client.Client) (*client.Result, error) {
 			},
 		})
 		if err != nil {
-			return nil, errors.Errorf("failed to read downloaded context")
+			return nil, errors.Wrapf(err, "failed to read downloaded context")
 		}
 		if isArchive(dt) {
 			if fileop {

--- a/hack/util
+++ b/hack/util
@@ -32,7 +32,7 @@ if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then
   currentref="git://github.com/moby/buildkit#refs/pull/$TRAVIS_PULL_REQUEST/merge"
   cacheref="cicache.buildk.it/moby/buildkit/pr$TRAVIS_BUILD_ID"
 elif [ -n "$TRAVIS_BRANCH" ]; then
-  currentref="git://github.com/moby/buildkit#$TRAVIS_BRANCH"
+  currentref="git://github.com/$TRAVIS_REPO_SLUG#$TRAVIS_BRANCH"
 fi
 
 

--- a/util/testutil/integration/oci.go
+++ b/util/testutil/integration/oci.go
@@ -1,8 +1,6 @@
 package integration
 
 import (
-	"bufio"
-	"bytes"
 	"fmt"
 	"log"
 	"os"
@@ -67,14 +65,4 @@ func (s *oci) New(cfg *BackendConfig) (Backend, func() error, error) {
 		address:  buildkitdSock,
 		rootless: s.uid != 0,
 	}, stop, nil
-}
-
-func printLogs(logs map[string]*bytes.Buffer, f func(args ...interface{})) {
-	for name, l := range logs {
-		f(name)
-		s := bufio.NewScanner(l)
-		for s.Scan() {
-			f(s.Text())
-		}
-	}
 }

--- a/util/testutil/integration/sandbox.go
+++ b/util/testutil/integration/sandbox.go
@@ -212,3 +212,13 @@ func rootlessSupported(uid int) bool {
 	}
 	return true
 }
+
+func printLogs(logs map[string]*bytes.Buffer, f func(args ...interface{})) {
+	for name, l := range logs {
+		f(name)
+		s := bufio.NewScanner(l)
+		for s.Scan() {
+			f(s.Text())
+		}
+	}
+}


### PR DESCRIPTION
Travis will now correctly build on branches in forks that do not exist in moby/buildkit, so I don't need to actually create the PR just to see if the build will pass. Or ignore the 'build failed' emails from Travis.

There's also a couple of other fixes that came up when I was working on #1387, iterating on the integration tests.