### PR TITLE
Use new containerd shim in integ tests; don't skip on requirement error.

### DIFF
--- a/util/testutil/integration/containerd.go
+++ b/util/testutil/integration/containerd.go
@@ -18,7 +18,7 @@ func InitContainerdWorker() {
 	Register(&containerd{
 		name:           "containerd",
 		containerd:     "containerd",
-		containerdShim: "containerd-shim",
+		containerdShim: "containerd-shim-runc-v2",
 	})
 	// defined in Dockerfile
 	// e.g. `containerd-1.1=/opt/containerd-1.1/bin,containerd-42.0=/opt/containerd-42.0/bin`

--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -21,7 +21,6 @@ import (
 	"github.com/containerd/containerd/content"
 	"github.com/moby/buildkit/util/contentutil"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -150,12 +149,7 @@ func Run(t *testing.T, testCases []Test, opt ...TestOpt) {
 							t.Parallel()
 						}
 						sb, closer, err := newSandbox(br, mirror, mv)
-						if err != nil {
-							if errors.Is(err, ErrorRequirements) {
-								t.Skip(err.Error())
-							}
-							require.NoError(t, err)
-						}
+						require.NoError(t, err)
 						defer func() {
 							assert.NoError(t, closer())
 							if t.Failed() {


### PR DESCRIPTION
A recent change updated the containerd shim built for integ tests to the newer
v2, but the integ test code itself was still hardcoded to look for the older
shim binary and, when that binary wasn't found, skip running the test. This
caused all containerd tests to be skipped.

The fix here updates the binary name to v2 and also removes the branch that
will skip a test when the requirements check fails.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

You can see the containerd tests getting skipped prior to this change by searching for "failed to lookup containerd-shim binary: missing requirements" here for example: https://travis-ci.org/github/moby/buildkit/jobs/708809890