### PR TITLE
hack: unblock master deploy

### DIFF
--- a/hack/images
+++ b/hack/images
@@ -15,7 +15,7 @@ progressFlag=""
 if [ "$CONTINUOUS_INTEGRATION" == "true" ]; then progressFlag="--progress=plain"; fi
 
 
-versionTag=$(git describe --tags --match "v[0-9]*")
+versionTag=$(git describe --always --tags --match "v[0-9]*")
 
 if [[ ! "$versionTag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 	versionTag=""


### PR DESCRIPTION
Since travis does checkouts with depth 50 we had to reach 50 commits from the last release for master deploy to start failing. Regression from #1404

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>