### PR TITLE
fix socket handling during copy

### DIFF
--- a/cache/contenthash/filehash.go
+++ b/cache/contenthash/filehash.go
@@ -40,6 +40,9 @@ func NewFileHash(path string, fi os.FileInfo) (hash.Hash, error) {
 }
 
 func NewFromStat(stat *fstypes.Stat) (hash.Hash, error) {
+	// Clear the socket bit since archive/tar.FileInfoHeader does not handle it
+	stat.Mode &^= uint32(os.ModeSocket)
+
 	fi := &statInfo{stat}
 	hdr, err := tar.FileInfoHeader(fi, stat.Linkname)
 	if err != nil {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -113,6 +113,7 @@ func TestIntegration(t *testing.T) {
 		testCacheMountNoCache,
 		testExporterTargetExists,
 		testTarExporterWithSocket,
+		testTarExporterWithSocketCopy,
 		testTarExporterSymlink,
 		testMultipleRegistryCacheImportExport,
 		testSourceMap,
@@ -1650,6 +1651,30 @@ func testTarExporterWithSocket(t *testing.T, sb integration.Sandbox) {
 			},
 		},
 	}, nil)
+	require.NoError(t, err)
+}
+
+func testTarExporterWithSocketCopy(t *testing.T, sb integration.Sandbox) {
+	if os.Getenv("TEST_DOCKERD") == "1" {
+		t.Skip("tar exporter is temporarily broken on dockerd")
+	}
+
+	requiresLinux(t)
+	c, err := New(context.TODO(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	alpine := llb.Image("docker.io/library/alpine:latest")
+	state := alpine.Run(llb.Args([]string{"sh", "-c", "nc -l -s local:/root/socket.sock & usleep 100000; kill %1"})).Root()
+
+	fa := llb.Copy(state, "/root", "/roo2", &llb.CopyInfo{})
+
+	scratchCopy := llb.Scratch().File(fa)
+
+	def, err := scratchCopy.Marshal(context.TODO())
+	require.NoError(t, err)
+
+	_, err = c.Solve(context.TODO(), def, SolveOpt{}, nil)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
This reproduces an error with tar trying to archive a socket, which is similar to the one that was fixed in https://github.com/moby/buildkit/pull/1144

```
        client_test.go:1696: 
            	Error Trace:	client_test.go:1696
            	            				run.go:165
            	Error:      	Received unexpected error:
            	            	rpc error: code = Unknown desc = failed to compute cache key: failed to create hash for /root/socket.sock: archive/tar: sockets not supported
            	            	github.com/moby/buildkit/util/stack.Enable
            	            		/src/util/stack/stack.go:51
            	            	github.com/moby/buildkit/util/grpcerrors.FromGRPC
            	            		/src/util/grpcerrors/grpcerrors.go:162
            	            	github.com/moby/buildkit/util/grpcerrors.UnaryClientInterceptor
            	            		/src/util/grpcerrors/intercept.go:22
            	            	google.golang.org/grpc.(*ClientConn).Invoke
            	            		/src/vendor/google.golang.org/grpc/call.go:35
            	            	github.com/moby/buildkit/api/services/control.(*controlClient).Solve
            	            		/src/api/services/control/control.pb.go:1321
            	            	github.com/moby/buildkit/client.(*Client).solve.func2
            	            		/src/client/solve.go:201
            	            	golang.org/x/sync/errgroup.(*Group).Go.func1
            	            		/src/vendor/golang.org/x/sync/errgroup/errgroup.go:57
            	            	runtime.goexit
            	            		/usr/local/go/src/runtime/asm_amd64.s:1357
            	            	failed to solve
            	            	github.com/moby/buildkit/client.(*Client).solve.func2
            	            		/src/client/solve.go:214
            	            	golang.org/x/sync/errgroup.(*Group).Go.func1
            	            		/src/vendor/golang.org/x/sync/errgroup/errgroup.go:57
            	            	runtime.goexit
            	            		/usr/local/go/src/runtime/asm_amd64.s:1357
            	Test:       	TestIntegration/TestTarExporterWithSocketCopy/worker=oci-rootless
        oci.go:74: stdout: /usr/bin/sudo
        oci.go:74: stderr: /usr/bin/sudo
        oci.go:77: time="2020-07-18T04:54:13Z" level=info msg="auto snapshotter: using overlayfs"
        oci.go:77: time="2020-07-18T04:54:13Z" level=debug msg="running in rootless mode"
        oci.go:77: time="2020-07-18T04:54:13Z" level=info msg="found worker \"0d7fqlw0dzm6coe47xuqsliqo\", labels=map[org.mobyproject.buildkit.worker.executor:oci org.mobyproject.buildkit.worker.hostname:5e9fae6f5c60 org.mobyproject.buildkit.worker.sandbox:true org.mobyproject.buildkit.worker.snapshotter:overlayfs], platforms=[linux/amd64 linux/386]"
        oci.go:77: time="2020-07-18T04:54:13Z" level=warning msg="rootless mode is not supported for containerd workers. disabling containerd worker."
        oci.go:77: time="2020-07-18T04:54:13Z" level=info msg="found 1 workers, default=\"0d7fqlw0dzm6coe47xuqsliqo\""
        oci.go:77: time="2020-07-18T04:54:13Z" level=warning msg="currently, only the default worker can be used."
        oci.go:77: time="2020-07-18T04:54:13Z" level=info msg="running server on /tmp/bktest_buildkitd003312146/buildkitd.sock"
        oci.go:77: time="2020-07-18T04:54:13Z" level=debug msg="session started"
        oci.go:77: time="2020-07-18T04:54:13Z" level=debug msg=resolving host="localhost:38005"
        oci.go:77: time="2020-07-18T04:54:13Z" level=debug msg="do request" host="localhost:38005" request.header.accept="application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.oci.image.index.v1+json, */*" request.header.user-agent=containerd/1.3.0+unknown request.method=HEAD url="http://localhost:38005/v2/library/alpine/manifests/latest"
        oci.go:77: time="2020-07-18T04:54:13Z" level=debug msg="fetch response received" host="localhost:38005" response.header.content-length=528 response.header.content-type=application/vnd.docker.distribution.manifest.v2+json response.header.date="Sat, 18 Jul 2020 04:54:13 GMT" response.header.docker-content-digest="sha256:a15790640a6690aa1730c38cf0a440e2aa44aaca9b0e8931a9f2b0d7cc90fd65" response.header.docker-distribution-api-version=registry/2.0 response.header.etag="\"sha256:a15790640a6690aa1730c38cf0a440e2aa44aaca9b0e8931a9f2b0d7cc90fd65\"" response.status="200 OK" url="http://localhost:38005/v2/library/alpine/manifests/latest"
        oci.go:77: time="2020-07-18T04:54:13Z" level=debug msg=resolved desc.digest="sha256:a15790640a6690aa1730c38cf0a440e2aa44aaca9b0e8931a9f2b0d7cc90fd65" host="localhost:38005"
        oci.go:77: time="2020-07-18T04:54:13Z" level=debug msg=resolving host="localhost:38005"
        oci.go:77: time="2020-07-18T04:54:13Z" level=debug msg="do request" host="localhost:38005" request.header.accept="application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.oci.image.index.v1+json, */*" request.header.user-agent=containerd/1.3.0+unknown request.method=HEAD url="http://localhost:38005/v2/library/alpine/manifests/sha256:a15790640a6690aa1730c38cf0a440e2aa44aaca9b0e8931a9f2b0d7cc90fd65"
        oci.go:77: time="2020-07-18T04:54:13Z" level=debug msg="fetch response received" host="localhost:38005" response.header.content-length=528 response.header.content-type=application/vnd.docker.distribution.manifest.v2+json response.header.date="Sat, 18 Jul 2020 04:54:13 GMT" response.header.docker-content-digest="sha256:a15790640a6690aa1730c38cf0a440e2aa44aaca9b0e8931a9f2b0d7cc90fd65" response.header.docker-distribution-api-version=registry/2.0 response.header.etag="\"sha256:a15790640a6690aa1730c38cf0a440e2aa44aaca9b0e8931a9f2b0d7cc90fd65\"" response.status="200 OK" url="http://localhost:38005/v2/library/alpine/manifests/sha256:a15790640a6690aa1730c38cf0a440e2aa44aaca9b0e8931a9f2b0d7cc90fd65"
        oci.go:77: time="2020-07-18T04:54:13Z" level=debug msg=resolved desc.digest="sha256:a15790640a6690aa1730c38cf0a440e2aa44aaca9b0e8931a9f2b0d7cc90fd65" host="localhost:38005"
        oci.go:77: time="2020-07-18T04:54:13Z" level=debug msg=fetch digest="sha256:a15790640a6690aa1730c38cf0a440e2aa44aaca9b0e8931a9f2b0d7cc90fd65" mediatype=application/vnd.docker.distribution.manifest.v2+json size=528
        oci.go:77: time="2020-07-18T04:54:13Z" level=debug msg="do request" digest="sha256:a15790640a6690aa1730c38cf0a440e2aa44aaca9b0e8931a9f2b0d7cc90fd65" mediatype=application/vnd.docker.distribution.manifest.v2+json request.header.accept="application/vnd.docker.distribution.manifest.v2+json, */*" request.header.user-agent=containerd/1.3.0+unknown request.method=GET size=528 url="http://localhost:38005/v2/library/alpine/manifests/sha256:a15790640a6690aa1730c38cf0a440e2aa44aaca9b0e8931a9f2b0d7cc90fd65"
        oci.go:77: time="2020-07-18T04:54:13Z" level=debug msg="fetch response received" digest="sha256:a15790640a6690aa1730c38cf0a440e2aa44aaca9b0e8931a9f2b0d7cc90fd65" mediatype=application/vnd.docker.distribution.manifest.v2+json response.header.content-length=528 response.header.content-type=application/vnd.docker.distribution.manifest.v2+json response.header.date="Sat, 18 Jul 2020 04:54:13 GMT" response.header.docker-content-digest="sha256:a15790640a6690aa1730c38cf0a440e2aa44aaca9b0e8931a9f2b0d7cc90fd65" response.header.docker-distribution-api-version=registry/2.0 response.header.etag="\"sha256:a15790640a6690aa1730c38cf0a440e2aa44aaca9b0e8931a9f2b0d7cc90fd65\"" response.status="200 OK" size=528 url="http://localhost:38005/v2/library/alpine/manifests/sha256:a15790640a6690aa1730c38cf0a440e2aa44aaca9b0e8931a9f2b0d7cc90fd65"
        oci.go:77: time="2020-07-18T04:54:13Z" level=debug msg=fetch digest="sha256:a24bb4013296f61e89ba57005a7b3e52274d8edd3ae2077d04395f806b63d83e" mediatype=application/vnd.docker.container.image.v1+json size=1509
        oci.go:77: time="2020-07-18T04:54:13Z" level=debug msg="do request" digest="sha256:a24bb4013296f61e89ba57005a7b3e52274d8edd3ae2077d04395f806b63d83e" mediatype=application/vnd.docker.container.image.v1+json request.header.accept="application/vnd.docker.container.image.v1+json, */*" request.header.user-agent=containerd/1.3.0+unknown request.method=GET size=1509 url="http://localhost:38005/v2/library/alpine/blobs/sha256:a24bb4013296f61e89ba57005a7b3e52274d8edd3ae2077d04395f806b63d83e"
        oci.go:77: time="2020-07-18T04:54:13Z" level=debug msg="fetch response received" digest="sha256:a24bb4013296f61e89ba57005a7b3e52274d8edd3ae2077d04395f806b63d83e" mediatype=application/vnd.docker.container.image.v1+json response.header.accept-ranges=bytes response.header.cache-control="max-age=31536000" response.header.content-length=1509 response.header.content-type=application/octet-stream response.header.date="Sat, 18 Jul 2020 04:54:13 GMT" response.header.docker-content-digest="sha256:a24bb4013296f61e89ba57005a7b3e52274d8edd3ae2077d04395f806b63d83e" response.header.docker-distribution-api-version=registry/2.0 response.header.etag="\"sha256:a24bb4013296f61e89ba57005a7b3e52274d8edd3ae2077d04395f806b63d83e\"" response.status="200 OK" size=1509 url="http://localhost:38005/v2/library/alpine/blobs/sha256:a24bb4013296f61e89ba57005a7b3e52274d8edd3ae2077d04395f806b63d83e"
        oci.go:77: time="2020-07-18T04:54:13Z" level=debug msg=fetch digest="sha256:a15790640a6690aa1730c38cf0a440e2aa44aaca9b0e8931a9f2b0d7cc90fd65" mediatype=application/vnd.docker.distribution.manifest.v2+json size=528
        oci.go:77: time="2020-07-18T04:54:13Z" level=debug msg=fetch digest="sha256:df20fa9351a15782c64e6dddb2d4a6f50bf6d3688060a34c4014b0d9a752eb4c" mediatype=application/vnd.docker.image.rootfs.diff.tar.gzip size=2797541
        oci.go:77: time="2020-07-18T04:54:13Z" level=debug msg=fetch digest="sha256:a24bb4013296f61e89ba57005a7b3e52274d8edd3ae2077d04395f806b63d83e" mediatype=application/vnd.docker.container.image.v1+json size=1509
        oci.go:77: time="2020-07-18T04:54:13Z" level=debug msg="do request" digest="sha256:df20fa9351a15782c64e6dddb2d4a6f50bf6d3688060a34c4014b0d9a752eb4c" mediatype=application/vnd.docker.image.rootfs.diff.tar.gzip request.header.accept="application/vnd.docker.image.rootfs.diff.tar.gzip, */*" request.header.user-agent=containerd/1.3.0+unknown request.method=GET size=2797541 url="http://localhost:38005/v2/library/alpine/blobs/sha256:df20fa9351a15782c64e6dddb2d4a6f50bf6d3688060a34c4014b0d9a752eb4c"
        oci.go:77: time="2020-07-18T04:54:13Z" level=debug msg="fetch response received" digest="sha256:df20fa9351a15782c64e6dddb2d4a6f50bf6d3688060a34c4014b0d9a752eb4c" mediatype=application/vnd.docker.image.rootfs.diff.tar.gzip response.header.accept-ranges=bytes response.header.cache-control="max-age=31536000" response.header.content-length=2797541 response.header.content-type=application/octet-stream response.header.date="Sat, 18 Jul 2020 04:54:13 GMT" response.header.docker-content-digest="sha256:df20fa9351a15782c64e6dddb2d4a6f50bf6d3688060a34c4014b0d9a752eb4c" response.header.docker-distribution-api-version=registry/2.0 response.header.etag="\"sha256:df20fa9351a15782c64e6dddb2d4a6f50bf6d3688060a34c4014b0d9a752eb4c\"" response.status="200 OK" size=2797541 url="http://localhost:38005/v2/library/alpine/blobs/sha256:df20fa9351a15782c64e6dddb2d4a6f50bf6d3688060a34c4014b0d9a752eb4c"
        oci.go:77: time="2020-07-18T04:54:13Z" level=debug msg="unpigz not found, falling back to go gzip" error="exec: \"unpigz\": executable file not found in $PATH"
        oci.go:77: time="2020-07-18T04:54:13Z" level=debug msg="diff applied" d=255.743209ms dgst="sha256:df20fa9351a15782c64e6dddb2d4a6f50bf6d3688060a34c4014b0d9a752eb4c" media=application/vnd.docker.image.rootfs.diff.tar.gzip size=0
        oci.go:77: time="2020-07-18T04:54:13Z" level=debug msg="> creating bmn7txh17f5go1zdf1dg57hk2 [sh -c nc -l -s local:/root/socket.sock & usleep 100000; kill %1]"
        oci.go:77: time="2020-07-18T04:54:14Z" level=error msg="/moby.buildkit.v1.Control/Solve returned error: rpc error: code = Unknown desc = failed to compute cache key: failed to create hash for /root/socket.sock: archive/tar: sockets not supported"
        oci.go:77: time="2020-07-18T04:54:14Z" level=debug msg="session finished: <nil>"
FAIL
```