### PR TITLE
Support not chowning files on all platforms

### DIFF
--- a/solver/llbsolver/file/user_nolinux.go
+++ b/solver/llbsolver/file/user_nolinux.go
@@ -10,5 +10,8 @@ import (
 )
 
 func readUser(chopt *pb.ChownOpt, mu, mg fileoptypes.Mount) (*copy.User, error) {
+	if chopt == nil {
+		return nil, nil
+	}
 	return nil, errors.New("only implemented in linux")
 }


### PR DESCRIPTION
chowning files still requires Linux.

Contributes towards #616 