### PR TITLE
Locally shortcut read-only bind mounts on Windows

### DIFF
--- a/snapshot/localmounter_windows.go
+++ b/snapshot/localmounter_windows.go
@@ -25,6 +25,19 @@ func (lm *localMounter) Mount() (string, error) {
 		return "", errors.Wrapf(errdefs.ErrNotImplemented, "request to mount %d layers, only 1 is supported", len(lm.mounts))
 	}
 
+	if lm.mounts[0].Type == "bind" || lm.mounts[0].Type == "rbind" {
+		ro := false
+		for _, opt := range lm.mounts[0].Options {
+			if opt == "ro" {
+				ro = true
+				break
+			}
+		}
+		if !ro {
+			return lm.mounts[0].Source, nil
+		}
+	}
+
 	// Windows mounts always activate in-place, so the target of the mount must be the source directory.
 	// See https://github.com/containerd/containerd/pull/2366
 	dir := lm.mounts[0].Source

--- a/snapshot/localmounter_windows.go
+++ b/snapshot/localmounter_windows.go
@@ -25,25 +25,27 @@ func (lm *localMounter) Mount() (string, error) {
 		return "", errors.Wrapf(errdefs.ErrNotImplemented, "request to mount %d layers, only 1 is supported", len(lm.mounts))
 	}
 
-	if lm.mounts[0].Type == "bind" || lm.mounts[0].Type == "rbind" {
+	m := lm.mounts[0]
+
+	if m.Type == "bind" || m.Type == "rbind" {
 		ro := false
-		for _, opt := range lm.mounts[0].Options {
+		for _, opt := range m.Options {
 			if opt == "ro" {
 				ro = true
 				break
 			}
 		}
 		if !ro {
-			return lm.mounts[0].Source, nil
+			return m.Source, nil
 		}
 	}
 
 	// Windows mounts always activate in-place, so the target of the mount must be the source directory.
 	// See https://github.com/containerd/containerd/pull/2366
-	dir := lm.mounts[0].Source
+	dir := m.Source
 
-	if err := lm.mounts[0].Mount(dir); err != nil {
-		return "", errors.Wrapf(err, "failed to mount in-place: %v", lm.mounts[0])
+	if err := m.Mount(dir); err != nil {
+		return "", errors.Wrapf(err, "failed to mount in-place: %v", m)
 	}
 	lm.target = dir
 	return lm.target, nil


### PR DESCRIPTION
This re-aligns this behaviour with the Unix localmounter.

containerd will not currently generate bind-mounts, but I have proposed this in https://github.com/containerd/containerd/pull/4419. In the meantime, this means that any BuildKit-created read-only bind-mounts will do the right thing.

Contributes to #616 