### PR TITLE
Unify OCI Spec generation across all host platforms

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -39,5 +39,5 @@ jobs:
       - name: Unit test
         env:
           SKIP_INTEGRATION_TESTS: 1
-        run: go test -mod=vendor -v ./cache/... ./client/... ./frontend/dockerfile/... ./session/... ./solver/... ./source/... ./util/...
+        run: go test -mod=vendor -v ./...
         working-directory: src/github.com/moby/buildkit

--- a/cmd/buildkitd/main_containerd_worker.go
+++ b/cmd/buildkitd/main_containerd_worker.go
@@ -1,4 +1,4 @@
-// +build linux,!no_containerd_worker
+// +build linux,!no_containerd_worker windows,!no_containerd_worker
 
 package main
 

--- a/executor/oci/mounts.go
+++ b/executor/oci/mounts.go
@@ -5,73 +5,48 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 )
 
-// MountOpts sets oci spec specific info for mount points
-type MountOpts func([]specs.Mount) ([]specs.Mount, error)
-
-//GetMounts returns default required for buildkit
-// https://github.com/moby/buildkit/issues/429
-func GetMounts(ctx context.Context, mountOpts ...MountOpts) ([]specs.Mount, error) {
-	mounts := []specs.Mount{
-		{
-			Destination: "/proc",
-			Type:        "proc",
-			Source:      "proc",
-		},
-		{
-			Destination: "/dev",
-			Type:        "tmpfs",
-			Source:      "tmpfs",
-			Options:     []string{"nosuid", "strictatime", "mode=755", "size=65536k"},
-		},
-		{
-			Destination: "/dev/pts",
-			Type:        "devpts",
-			Source:      "devpts",
-			Options:     []string{"nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620", "gid=5"},
-		},
-		{
-			Destination: "/dev/shm",
-			Type:        "tmpfs",
-			Source:      "shm",
-			Options:     []string{"nosuid", "noexec", "nodev", "mode=1777", "size=65536k"},
-		},
-		{
-			Destination: "/dev/mqueue",
-			Type:        "mqueue",
-			Source:      "mqueue",
-			Options:     []string{"nosuid", "noexec", "nodev"},
-		},
-		{
-			Destination: "/sys",
-			Type:        "sysfs",
-			Source:      "sysfs",
-			Options:     []string{"nosuid", "noexec", "nodev", "ro"},
-		},
-	}
-	var err error
-	for _, o := range mountOpts {
-		mounts, err = o(mounts)
-		if err != nil {
-			return nil, err
+func withRemovedMount(destination string) oci.SpecOpts {
+	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {
+		newMounts := []specs.Mount{}
+		for _, o := range s.Mounts {
+			if o.Destination != destination {
+				newMounts = append(newMounts, o)
+			}
 		}
+		s.Mounts = newMounts
+
+		return nil
 	}
-	return mounts, nil
 }
 
-func withROBind(src, dest string) func(m []specs.Mount) ([]specs.Mount, error) {
-	return func(m []specs.Mount) ([]specs.Mount, error) {
-		m = append(m, specs.Mount{
+func withROBind(src, dest string) oci.SpecOpts {
+	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {
+		s.Mounts = append(s.Mounts, specs.Mount{
 			Destination: dest,
 			Type:        "bind",
 			Source:      src,
 			Options:     []string{"nosuid", "noexec", "nodev", "rbind", "ro"},
 		})
-		return m, nil
+		return nil
 	}
+}
+
+func withCGroup() oci.SpecOpts {
+	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {
+		s.Mounts = append(s.Mounts, specs.Mount{
+			Destination: "/sys/fs/cgroup",
+			Type:        "cgroup",
+			Source:      "cgroup",
+			Options:     []string{"ro", "nosuid", "noexec", "nodev"},
+		})
+		return nil
+	}
+
 }
 
 func hasPrefix(p, prefixDir string) bool {
@@ -93,25 +68,35 @@ func removeMountsWithPrefix(mounts []specs.Mount, prefixDir string) []specs.Moun
 	return ret
 }
 
-func withProcessMode(processMode ProcessMode) func([]specs.Mount) ([]specs.Mount, error) {
-	return func(m []specs.Mount) ([]specs.Mount, error) {
-		switch processMode {
-		case ProcessSandbox:
-			// keep the default
-		case NoProcessSandbox:
-			m = removeMountsWithPrefix(m, "/proc")
-			procMount := specs.Mount{
-				Destination: "/proc",
-				Type:        "bind",
-				Source:      "/proc",
-				// NOTE: "rbind"+"ro" does not make /proc read-only recursively.
-				// So we keep maskedPath and readonlyPaths (although not mandatory for rootless mode)
-				Options: []string{"rbind"},
-			}
-			m = append([]specs.Mount{procMount}, m...)
-		default:
-			return nil, errors.Errorf("unknown process mode: %v", processMode)
+func withBoundProc() oci.SpecOpts {
+	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {
+		s.Mounts = removeMountsWithPrefix(s.Mounts, "/proc")
+		procMount := specs.Mount{
+			Destination: "/proc",
+			Type:        "bind",
+			Source:      "/proc",
+			// NOTE: "rbind"+"ro" does not make /proc read-only recursively.
+			// So we keep maskedPath and readonlyPaths (although not mandatory for rootless mode)
+			Options: []string{"rbind"},
 		}
-		return m, nil
+		s.Mounts = append([]specs.Mount{procMount}, s.Mounts...)
+
+		var maskedPaths []string
+		for _, s := range s.Linux.MaskedPaths {
+			if !hasPrefix(s, "/proc") {
+				maskedPaths = append(maskedPaths, s)
+			}
+		}
+		s.Linux.MaskedPaths = maskedPaths
+
+		var readonlyPaths []string
+		for _, s := range s.Linux.ReadonlyPaths {
+			if !hasPrefix(s, "/proc") {
+				readonlyPaths = append(readonlyPaths, s)
+			}
+		}
+		s.Linux.ReadonlyPaths = readonlyPaths
+
+		return nil
 	}
 }

--- a/executor/oci/mounts_test.go
+++ b/executor/oci/mounts_test.go
@@ -4,6 +4,9 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/containerd/containerd/oci"
+	"github.com/moby/buildkit/util/appcontext"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -93,4 +96,59 @@ func TestHasPrefix(t *testing.T) {
 		actual := hasPrefix(tc.path, tc.prefix)
 		assert.Equal(t, tc.expected, actual, "#%d: under(%q,%q)", i, tc.path, tc.prefix)
 	}
+}
+
+func TestWithRemovedMounts(t *testing.T) {
+	// The default mount-list from containerd
+	s := oci.Spec{
+		Mounts: []specs.Mount{
+			{
+				Destination: "/proc",
+				Type:        "proc",
+				Source:      "proc",
+				Options:     []string{"nosuid", "noexec", "nodev"},
+			},
+			{
+				Destination: "/dev",
+				Type:        "tmpfs",
+				Source:      "tmpfs",
+				Options:     []string{"nosuid", "strictatime", "mode=755", "size=65536k"},
+			},
+			{
+				Destination: "/dev/pts",
+				Type:        "devpts",
+				Source:      "devpts",
+				Options:     []string{"nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620", "gid=5"},
+			},
+			{
+				Destination: "/dev/shm",
+				Type:        "tmpfs",
+				Source:      "shm",
+				Options:     []string{"nosuid", "noexec", "nodev", "mode=1777", "size=65536k"},
+			},
+			{
+				Destination: "/dev/mqueue",
+				Type:        "mqueue",
+				Source:      "mqueue",
+				Options:     []string{"nosuid", "noexec", "nodev"},
+			},
+			{
+				Destination: "/sys",
+				Type:        "sysfs",
+				Source:      "sysfs",
+				Options:     []string{"nosuid", "noexec", "nodev", "ro"},
+			},
+			{
+				Destination: "/run",
+				Type:        "tmpfs",
+				Source:      "tmpfs",
+				Options:     []string{"nosuid", "strictatime", "mode=755", "size=65536k"},
+			},
+		},
+	}
+
+	oldLen := len(s.Mounts)
+	err := withRemovedMount("/run")(appcontext.Context(), nil, nil, &s)
+	assert.NoError(t, err)
+	assert.Equal(t, oldLen-1, len(s.Mounts))
 }

--- a/executor/oci/spec.go
+++ b/executor/oci/spec.go
@@ -1,5 +1,25 @@
 package oci
 
+import (
+	"context"
+	"path"
+	"sync"
+
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/oci"
+	"github.com/containerd/continuity/fs"
+	"github.com/docker/docker/pkg/idtools"
+	"github.com/mitchellh/hashstructure"
+	"github.com/moby/buildkit/executor"
+	"github.com/moby/buildkit/snapshot"
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/util/network"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+)
+
 // ProcMode configures PID namespaces
 type ProcessMode int
 
@@ -11,3 +31,233 @@ const (
 	// NoProcessSandbox should be enabled only when the BuildKit is running in a container as an unprivileged user.
 	NoProcessSandbox
 )
+
+// Ideally we don't have to import whole containerd just for the default spec
+
+// GenerateSpec generates spec using containerd functionality.
+// opts are ignored for s.Process, s.Hostname, and s.Mounts .
+func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mount, id, resolvConf, hostsFile string, namespace network.Namespace, processMode ProcessMode, idmap *idtools.IdentityMapping, opts ...oci.SpecOpts) (*specs.Spec, func(), error) {
+	c := &containers.Container{
+		ID: id,
+	}
+
+	// containerd/oci.GenerateSpec requires a namespace, which
+	// will be used to namespace specs.Linux.CgroupsPath if generated
+	if _, ok := namespaces.Namespace(ctx); !ok {
+		ctx = namespaces.WithNamespace(ctx, "buildkit")
+	}
+
+	if securityOpts, err := generateSecurityOpts(meta.SecurityMode); err == nil {
+		opts = append(opts, securityOpts...)
+	} else {
+		return nil, nil, err
+	}
+
+	if processModeOpts, err := generateProcessModeOpts(processMode); err == nil {
+		opts = append(opts, processModeOpts...)
+	} else {
+		return nil, nil, err
+	}
+
+	s, err := oci.GenerateSpec(ctx, nil, c, opts...)
+	if err != nil {
+		return nil, nil, err
+	}
+	// set the networking information on the spec
+	namespace.Set(s)
+
+	s.Process.Args = meta.Args
+	s.Process.Env = meta.Env
+	s.Process.Cwd = meta.Cwd
+	s.Process.Rlimits = nil           // reset open files limit
+	s.Process.NoNewPrivileges = false // reset nonewprivileges
+	s.Hostname = "buildkitsandbox"
+
+	// Setup for a Linux-based container (includes LCOW)
+	if s.Linux != nil {
+		s.Mounts, err = GetMounts(ctx,
+			withProcessMode(processMode),
+			withROBind(resolvConf, "/etc/resolv.conf"),
+			withROBind(hostsFile, "/etc/hosts"),
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		s.Mounts = append(s.Mounts, specs.Mount{
+			Destination: "/sys/fs/cgroup",
+			Type:        "cgroup",
+			Source:      "cgroup",
+			Options:     []string{"ro", "nosuid", "noexec", "nodev"},
+		})
+
+		if processMode == NoProcessSandbox {
+			var maskedPaths []string
+			for _, s := range s.Linux.MaskedPaths {
+				if !hasPrefix(s, "/proc") {
+					maskedPaths = append(maskedPaths, s)
+				}
+			}
+			s.Linux.MaskedPaths = maskedPaths
+			var readonlyPaths []string
+			for _, s := range s.Linux.ReadonlyPaths {
+				if !hasPrefix(s, "/proc") {
+					readonlyPaths = append(readonlyPaths, s)
+				}
+			}
+			s.Linux.ReadonlyPaths = readonlyPaths
+		}
+
+		if meta.SecurityMode == pb.SecurityMode_INSECURE {
+			if err = oci.WithWriteableCgroupfs(ctx, nil, c, s); err != nil {
+				return nil, nil, err
+			}
+			if err = oci.WithWriteableSysfs(ctx, nil, c, s); err != nil {
+				return nil, nil, err
+			}
+		}
+
+		if idmap != nil {
+			s.Linux.Namespaces = append(s.Linux.Namespaces, specs.LinuxNamespace{
+				Type: specs.UserNamespace,
+			})
+			s.Linux.UIDMappings = specMapping(idmap.UIDs())
+			s.Linux.GIDMappings = specMapping(idmap.GIDs())
+		}
+	}
+
+	sm := &submounts{}
+
+	var releasers []func() error
+	releaseAll := func() {
+		sm.cleanup()
+		for _, f := range releasers {
+			f()
+		}
+	}
+
+	for _, m := range mounts {
+		if m.Src == nil {
+			return nil, nil, errors.Errorf("mount %s has no source", m.Dest)
+		}
+		mountable, err := m.Src.Mount(ctx, m.Readonly)
+		if err != nil {
+			releaseAll()
+			return nil, nil, errors.Wrapf(err, "failed to mount %s", m.Dest)
+		}
+		mounts, release, err := mountable.Mount()
+		if err != nil {
+			releaseAll()
+			return nil, nil, errors.WithStack(err)
+		}
+		releasers = append(releasers, release)
+		for _, mount := range mounts {
+			mount, err = sm.subMount(mount, m.Selector)
+			if err != nil {
+				releaseAll()
+				return nil, nil, err
+			}
+			s.Mounts = append(s.Mounts, specs.Mount{
+				Destination: m.Dest,
+				Type:        mount.Type,
+				Source:      mount.Source,
+				Options:     mount.Options,
+			})
+		}
+	}
+
+	return s, releaseAll, nil
+}
+
+type mountRef struct {
+	mount   mount.Mount
+	unmount func() error
+}
+
+type submounts struct {
+	m map[uint64]mountRef
+}
+
+func (s *submounts) subMount(m mount.Mount, subPath string) (mount.Mount, error) {
+	if path.Join("/", subPath) == "/" {
+		return m, nil
+	}
+	if s.m == nil {
+		s.m = map[uint64]mountRef{}
+	}
+	h, err := hashstructure.Hash(m, nil)
+	if err != nil {
+		return mount.Mount{}, nil
+	}
+	if mr, ok := s.m[h]; ok {
+		sm, err := sub(mr.mount, subPath)
+		if err != nil {
+			return mount.Mount{}, nil
+		}
+		return sm, nil
+	}
+
+	lm := snapshot.LocalMounterWithMounts([]mount.Mount{m})
+
+	mp, err := lm.Mount()
+	if err != nil {
+		return mount.Mount{}, err
+	}
+
+	opts := []string{"rbind"}
+	for _, opt := range m.Options {
+		if opt == "ro" {
+			opts = append(opts, opt)
+		}
+	}
+
+	s.m[h] = mountRef{
+		mount: mount.Mount{
+			Source:  mp,
+			Type:    "bind",
+			Options: opts,
+		},
+		unmount: lm.Unmount,
+	}
+
+	sm, err := sub(s.m[h].mount, subPath)
+	if err != nil {
+		return mount.Mount{}, err
+	}
+	return sm, nil
+}
+
+func (s *submounts) cleanup() {
+	var wg sync.WaitGroup
+	wg.Add(len(s.m))
+	for _, m := range s.m {
+		func(m mountRef) {
+			go func() {
+				m.unmount()
+				wg.Done()
+			}()
+		}(m)
+	}
+	wg.Wait()
+}
+
+func sub(m mount.Mount, subPath string) (mount.Mount, error) {
+	src, err := fs.RootPath(m.Source, subPath)
+	if err != nil {
+		return mount.Mount{}, err
+	}
+	m.Source = src
+	return m, nil
+}
+
+func specMapping(s []idtools.IDMap) []specs.LinuxIDMapping {
+	var ids []specs.LinuxIDMapping
+	for _, item := range s {
+		ids = append(ids, specs.LinuxIDMapping{
+			HostID:      uint32(item.HostID),
+			ContainerID: uint32(item.ContainerID),
+			Size:        uint32(item.Size),
+		})
+	}
+	return ids
+}

--- a/executor/oci/spec.go
+++ b/executor/oci/spec.go
@@ -20,7 +20,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ProcMode configures PID namespaces
+// ProcessMode configures PID namespaces
 type ProcessMode int
 
 const (

--- a/executor/oci/spec.go
+++ b/executor/oci/spec.go
@@ -82,8 +82,11 @@ func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mou
 	if err != nil {
 		return nil, nil, err
 	}
+
 	// set the networking information on the spec
-	namespace.Set(s)
+	if err := namespace.Set(s); err != nil {
+		return nil, nil, err
+	}
 
 	s.Process.Rlimits = nil // reset open files limit
 

--- a/executor/oci/spec_unix.go
+++ b/executor/oci/spec_unix.go
@@ -5,26 +5,54 @@ package oci
 import (
 	"github.com/containerd/containerd/contrib/seccomp"
 	"github.com/containerd/containerd/oci"
+	"github.com/docker/docker/pkg/idtools"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/entitlements/security"
 	"github.com/moby/buildkit/util/system"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
+func generateMountOpts(resolvConf, hostsFile string) ([]oci.SpecOpts, error) {
+	return []oci.SpecOpts{
+		// https://github.com/moby/buildkit/issues/429
+		withRemovedMount("/run"),
+		withROBind(resolvConf, "/etc/resolv.conf"),
+		withROBind(hostsFile, "/etc/hosts"),
+		withCGroup(),
+	}, nil
+}
+
+// generateSecurityOpts may affect mounts, so must be called after generateMountOpts
 func generateSecurityOpts(mode pb.SecurityMode) ([]oci.SpecOpts, error) {
 	if mode == pb.SecurityMode_INSECURE {
-		return []oci.SpecOpts{security.WithInsecureSpec()}, nil
+		return []oci.SpecOpts{
+			security.WithInsecureSpec(),
+			oci.WithWriteableCgroupfs,
+			oci.WithWriteableSysfs,
+		}, nil
 	} else if system.SeccompSupported() && mode == pb.SecurityMode_SANDBOX {
 		return []oci.SpecOpts{seccomp.WithDefaultProfile()}, nil
 	}
 	return nil, nil
 }
 
+// generateProcessModeOpts may affect mounts, so must be called after generateMountOpts
 func generateProcessModeOpts(mode ProcessMode) ([]oci.SpecOpts, error) {
 	if mode == NoProcessSandbox {
-		// Mount for /proc is replaced in GetMounts() anyway
-		return []oci.SpecOpts{oci.WithHostNamespace(specs.PIDNamespace)}, nil
+		return []oci.SpecOpts{
+			oci.WithHostNamespace(specs.PIDNamespace),
+			withBoundProc(),
+		}, nil
 		// TODO(AkihiroSuda): Configure seccomp to disable ptrace (and prctl?) explicitly
 	}
 	return nil, nil
+}
+
+func generateIDmapOpts(idmap *idtools.IdentityMapping) ([]oci.SpecOpts, error) {
+	if idmap == nil {
+		return nil, nil
+	}
+	return []oci.SpecOpts{
+		oci.WithUserNamespace(specMapping(idmap.UIDs()), specMapping(idmap.GIDs())),
+	}, nil
 }

--- a/executor/oci/spec_windows.go
+++ b/executor/oci/spec_windows.go
@@ -5,11 +5,17 @@ package oci
 import (
 	"github.com/containerd/containerd/contrib/seccomp"
 	"github.com/containerd/containerd/oci"
+	"github.com/docker/docker/pkg/idtools"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/system"
 	"github.com/pkg/errors"
 )
 
+func generateMountOpts(resolvConf, hostsFile string) ([]oci.SpecOpts, error) {
+	return nil, nil
+}
+
+// generateSecurityOpts may affect mounts, so must be called after generateMountOpts
 func generateSecurityOpts(mode pb.SecurityMode) ([]oci.SpecOpts, error) {
 	if mode == pb.SecurityMode_INSECURE {
 		return nil, errors.New("no support for running in insecure mode on Windows")
@@ -20,9 +26,17 @@ func generateSecurityOpts(mode pb.SecurityMode) ([]oci.SpecOpts, error) {
 	return nil, nil
 }
 
+// generateProcessModeOpts may affect mounts, so must be called after generateMountOpts
 func generateProcessModeOpts(mode ProcessMode) ([]oci.SpecOpts, error) {
 	if mode == NoProcessSandbox {
 		return nil, errors.New("no support for NoProcessSandbox on Windows")
 	}
 	return nil, nil
+}
+
+func generateIDmapOpts(idmap *idtools.IdentityMapping) ([]oci.SpecOpts, error) {
+	if idmap == nil {
+		return nil, nil
+	}
+	return nil, errors.New("no support for IdentityMapping on Windows")
 }

--- a/executor/oci/spec_windows.go
+++ b/executor/oci/spec_windows.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build windows
 
 package oci
 
@@ -6,15 +6,15 @@ import (
 	"github.com/containerd/containerd/contrib/seccomp"
 	"github.com/containerd/containerd/oci"
 	"github.com/moby/buildkit/solver/pb"
-	"github.com/moby/buildkit/util/entitlements/security"
 	"github.com/moby/buildkit/util/system"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
 )
 
 func generateSecurityOpts(mode pb.SecurityMode) ([]oci.SpecOpts, error) {
 	if mode == pb.SecurityMode_INSECURE {
-		return []oci.SpecOpts{security.WithInsecureSpec()}, nil
+		return nil, errors.New("no support for running in insecure mode on Windows")
 	} else if system.SeccompSupported() && mode == pb.SecurityMode_SANDBOX {
+		// TODO: Can LCOW support seccomp? Does that even make sense?
 		return []oci.SpecOpts{seccomp.WithDefaultProfile()}, nil
 	}
 	return nil, nil
@@ -22,9 +22,7 @@ func generateSecurityOpts(mode pb.SecurityMode) ([]oci.SpecOpts, error) {
 
 func generateProcessModeOpts(mode ProcessMode) ([]oci.SpecOpts, error) {
 	if mode == NoProcessSandbox {
-		// Mount for /proc is replaced in GetMounts() anyway
-		return []oci.SpecOpts{oci.WithHostNamespace(specs.PIDNamespace)}, nil
-		// TODO(AkihiroSuda): Configure seccomp to disable ptrace (and prctl?) explicitly
+		return nil, errors.New("no support for NoProcessSandbox on Windows")
 	}
 	return nil, nil
 }


### PR DESCRIPTION
Contributes to #616

There's only a couple of things that are host-platform limited, i.e., security and process modes.

Everything else is specific to a target-platform. We can tell if we're targeting a Linux platform, either on Linux or LCOW, by the presence of the Linux key in the generated spec.

This doesn't introduce support for LCOW, as we'd need to plumb that down from the caller. It will probably also need massaging to work with LCOW, as some of the setup code here is probably incorrect for LCOW, e.g., the bind-mounts list may be incorrect.

----

It's actually a much smaller change than it looks, but a lot of code moved from _spec_unix.go_ to _spec.go_. If you compare old spec_unix.go to new _spec.go_, the changes in `GenerateSpec` and the lack of changes in the _other_ functions should be apparent, and more readable.