### PR TITLE
[v0.6] remotecache: only visit each item once when walking results

### DIFF
--- a/cache/remotecache/v1/cachestorage.go
+++ b/cache/remotecache/v1/cachestorage.go
@@ -220,6 +220,7 @@ func (cs *cacheResultStorage) LoadWithParents(ctx context.Context, res solver.Ca
 
 	m := map[string]solver.Result{}
 
+	visited := make(map[*item]struct{})
 	if err := v.walkAllResults(func(i *item) error {
 		if i.result == nil {
 			return nil
@@ -236,7 +237,7 @@ func (cs *cacheResultStorage) LoadWithParents(ctx context.Context, res solver.Ca
 			m[id] = worker.NewWorkerRefResult(ref, cs.w)
 		}
 		return nil
-	}); err != nil {
+	}, visited); err != nil {
 		for _, v := range m {
 			v.Release(context.TODO())
 		}

--- a/cache/remotecache/v1/chains.go
+++ b/cache/remotecache/v1/chains.go
@@ -128,13 +128,17 @@ func (c *item) LinkFrom(rec solver.CacheExporterRecord, index int, selector stri
 	c.links[index][link{src: src, selector: selector}] = struct{}{}
 }
 
-func (c *item) walkAllResults(fn func(i *item) error) error {
+func (c *item) walkAllResults(fn func(i *item) error, visited map[*item]struct{}) error {
+	if _, ok := visited[c]; ok {
+		return nil
+	}
+	visited[c] = struct{}{}
 	if err := fn(c); err != nil {
 		return err
 	}
 	for _, links := range c.links {
 		for l := range links {
-			if err := l.src.walkAllResults(fn); err != nil {
+			if err := l.src.walkAllResults(fn, visited); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
https://github.com/moby/buildkit/pull/1577

Missed this in the latest batch.