### PR TITLE
grpcerrors: use full typeurl registration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/containerd/fifo v0.0.0-20200410184934-f15a3290365b // indirect
 	github.com/containerd/go-cni v1.0.0
 	github.com/containerd/go-runc v0.0.0-20200220073739-7016d3ce2328
+	github.com/containerd/typeurl v1.0.1
 	github.com/coreos/go-systemd/v22 v22.1.0
 	github.com/docker/cli v0.0.0-20200227165822-2298e6a3fe24
 	github.com/docker/distribution v2.7.1+incompatible

--- a/solver/errdefs/vertex.go
+++ b/solver/errdefs/vertex.go
@@ -1,14 +1,14 @@
 package errdefs
 
 import (
-	proto "github.com/golang/protobuf/proto"
+	"github.com/containerd/typeurl"
 	"github.com/moby/buildkit/util/grpcerrors"
 	digest "github.com/opencontainers/go-digest"
 )
 
 func init() {
-	proto.RegisterType((*Vertex)(nil), "errdefs.Vertex")
-	proto.RegisterType((*Source)(nil), "errdefs.Source")
+	typeurl.Register((*Vertex)(nil), "github.com/moby/buildkit", "errdefs.Vertex+json")
+	typeurl.Register((*Source)(nil), "github.com/moby/buildkit", "errdefs.Source+json")
 }
 
 type VertexError struct {

--- a/util/grpcerrors/grpcerrors.go
+++ b/util/grpcerrors/grpcerrors.go
@@ -1,11 +1,15 @@
 package grpcerrors
 
 import (
+	"encoding/json"
+	"errors"
+
+	"github.com/containerd/typeurl"
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/moby/buildkit/util/stack"
+	"github.com/sirupsen/logrus"
 	spb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -47,12 +51,32 @@ func ToGRPC(err error) error {
 	})
 
 	if len(details) > 0 {
-		if st2, err := st.WithDetails(details...); err == nil {
+		if st2, err := withDetails(st, details...); err == nil {
 			st = st2
 		}
 	}
 
 	return st.Err()
+}
+
+func withDetails(s *status.Status, details ...proto.Message) (*status.Status, error) {
+	if s.Code() == codes.OK {
+		return nil, errors.New("no error details for status with code OK")
+	}
+	p := s.Proto()
+	for _, detail := range details {
+		url, err := typeurl.TypeURL(detail)
+		if err != nil {
+			logrus.Warnf("ignoring typed error %T: not registered", detail)
+			continue
+		}
+		dt, err := json.Marshal(detail)
+		if err != nil {
+			return nil, err
+		}
+		p.Details = append(p.Details, &any.Any{TypeUrl: url, Value: dt})
+	}
+	return status.FromProto(p), nil
 }
 
 func Code(err error) codes.Code {
@@ -123,17 +147,9 @@ func FromGRPC(err error) error {
 
 	// details that we don't understand are copied as proto
 	for _, d := range pb.Details {
-		var m interface{}
-		detail := &ptypes.DynamicAny{}
-		if err := ptypes.UnmarshalAny(d, detail); err != nil {
-			detail := &gogotypes.DynamicAny{}
-			if err := gogotypes.UnmarshalAny(gogoAny(d), detail); err != nil {
-				n.Details = append(n.Details, d)
-				continue
-			}
-			m = detail.Message
-		} else {
-			m = detail.Message
+		m, err := typeurl.UnmarshalAny(gogoAny(d))
+		if err != nil {
+			continue
 		}
 
 		switch v := m.(type) {
@@ -144,7 +160,6 @@ func FromGRPC(err error) error {
 		default:
 			n.Details = append(n.Details, d)
 		}
-
 	}
 
 	err = status.FromProto(n).Err()

--- a/util/stack/stack.go
+++ b/util/stack/stack.go
@@ -7,8 +7,13 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/containerd/typeurl"
 	"github.com/pkg/errors"
 )
+
+func init() {
+	typeurl.Register((*Stack)(nil), "github.com/moby/buildkit", "stack.Stack+json")
+}
 
 var version string
 var revision string


### PR DESCRIPTION
Also switches current types to json(default in containerd/typeurl).

Adds better future compatibility to typed errors that now have to be registered with full name and avoids depending on either google/protobuf or gogo when this library would be used. This makes sure the code can be moved around between repositories in the future if needed and new encoders added. Reused contained/typeurl package but in the future this should probably be switched to a custom implementation. These changes should not be breaking.

These changes are not compatible with current typed errors in master. No release version is affected.

@hinshun @AkihiroSuda 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>