### PR TITLE
update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,11 +127,6 @@ We are open to adding more backends.
 The buildkitd daemon listens gRPC API on `/run/buildkit/buildkitd.sock` by default, but you can also use TCP sockets.
 See [Expose BuildKit as a TCP service](#expose-buildkit-as-a-tcp-service).
 
-:information_source: Notice to Fedora 31 users:
-
-* As runc still does not work on cgroup v2 environment like Fedora 31, you need to substitute runc with crun. Run `buildkitd` with `--oci-worker-binary=crun`.
-* If you want to use runc, you need to configure the system to use cgroup v1. Run `sudo grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=0"` and reboot.
-
 ### Exploring LLB
 
 BuildKit builds are based on a binary intermediate format called LLB that is used for defining the dependency graph for processes running part of your build. tl;dr: LLB is to Dockerfile what LLVM IR is to C.

--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ Currently, the following high-level languages has been implemented for LLB:
 -   [Mockerfile](https://matt-rickard.com/building-a-new-dockerfile-frontend/)
 -   [Gockerfile](https://github.com/po3rin/gockerfile)
 -   [bldr (Pkgfile)](https://github.com/talos-systems/bldr/)
+-   [HLB](https://github.com/openllb/hlb)
+-   [Earthfile (Earthly)](https://github.com/earthly/earthly)
+-   [Cargo Wharf (Rust)](https://github.com/denzp/cargo-wharf)
 -   (open a PR to add your own language)
 
 ### Exploring Dockerfiles

--- a/docs/rootless.md
+++ b/docs/rootless.md
@@ -9,26 +9,18 @@ Using Ubuntu kernel is recommended.
 * No preparation is needed.
 * `overlayfs` snapshotter is used by default ([Ubuntu-specific kernel patch](https://kernel.ubuntu.com/git/ubuntu/ubuntu-bionic.git/commit/fs/overlayfs?id=3b7da90f28fe1ed4b79ef2d994c81efbc58f1144)).
 
-### Debian GNU/Linux 10
+### Debian GNU/Linux
 * Add `kernel.unprivileged_userns_clone=1` to `/etc/sysctl.conf` (or `/etc/sysctl.d`) and run `sudo sysctl -p`
 * `fuse-overlayfs` snapshotter is used by default.
 * To use `overlayfs` snapshotter (recommended), run `sudo modprobe overlay permit_mounts_in_userns=1` ([Debian-specific kernel patch, introduced in Debian 10](https://salsa.debian.org/kernel-team/linux/blob/283390e7feb21b47779b48e0c8eb0cc409d2c815/debian/patches/debian/overlayfs-permit-mounts-in-userns.patch)). Put the configuration to `/etc/modprobe.d` for persistence.
-
-### Debian GNU/Linux 9
-* Add `kernel.unprivileged_userns_clone=1` to `/etc/sysctl.conf` (or `/etc/sysctl.d`) and run `sudo sysctl -p`
-* Only `native` snapshotter can be used.
 
 ### Arch Linux
 * Add `kernel.unprivileged_userns_clone=1` to `/etc/sysctl.conf` (or `/etc/sysctl.d`) and run `sudo sysctl -p`
 * `fuse-overlayfs` snapshotter is used by default if running kernel >= 4.18.
   Otherwise only `native` snapshotter can be used.
 
-### Fedora 31
-* If you don't have the latest `runc` installed and you have `crun` instead, you need to run `buildkitd` with `--oci-worker-binary=crun`.
-* `fuse-overlayfs` snapshotter is used by default.
-
-### Fedora 30
-* No preparation is needed.
+### Fedora
+* If you don't have the latest `runc` (>= v1.0.0-rc91) installed and you have `crun` instead, you need to run `buildkitd` with `--oci-worker-binary=crun`.
 * `fuse-overlayfs` snapshotter is used by default.
 
 ### RHEL/CentOS 8


### PR DESCRIPTION
* README.md: drop cgroup v2 notes
* docs/rootless.md: drop support for Debian 9 and Fedora 30
* README.md: add HLB and Earthfile