### PR TITLE
Add initial GitHub Actions-based Windows CI

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,0 +1,43 @@
+# This workflow is for builds on Windows. We cannot use the existing
+# Travis-CI workflow as that depends on already having functioning
+# BuildKit to run the v1.1-experimental Dockerfile that builds BuildKit.
+name: Windows
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build BuildKit
+    runs-on: windows-2019
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.13
+      - name: Checkout
+        uses: actions/checkout@v2
+        # Is this needed? Didn't Go Modules fix this?
+        with:
+          path: src/github.com/moby/buildkit
+      - name: Compile
+        run: go install -mod=vendor ./cmd/...
+        working-directory: src/github.com/moby/buildkit
+
+  unit_tests:
+    name: Unit Tests
+    runs-on: windows-2019
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.13
+      - name: Checkout
+        uses: actions/checkout@v2
+        # Is this needed? Didn't Go Modules fix this?
+        with:
+          path: src/github.com/moby/buildkit
+      - name: Unit test
+        env:
+          SKIP_INTEGRATION_TESTS: 1
+        run: go test -mod=vendor -v ./frontend/dockerfile/.../... ./session/...
+        working-directory: src/github.com/moby/buildkit


### PR DESCRIPTION
Only a few tests are able to be run, because the integration test support code fails to compile on Windows, taking effect before the `SKIP_INTEGRATION_TESTS` env-var is handled.

NOTE: GitHub Actions are not currently enabled on moby/buildkit. You can see the results at https://github.com/TBBle/buildkit/tree/windows-CI-on-GitHub_Actions

Contributes towards: #616 