### PR TITLE
Fix test failures in unit tests on Windows

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -39,5 +39,5 @@ jobs:
       - name: Unit test
         env:
           SKIP_INTEGRATION_TESTS: 1
-        run: go test -mod=vendor -v ./frontend/dockerfile/... ./session/... ./util/...
+        run: go test -mod=vendor -v ./frontend/dockerfile/... ./session/... ./source/... ./util/...
         working-directory: src/github.com/moby/buildkit

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -39,5 +39,5 @@ jobs:
       - name: Unit test
         env:
           SKIP_INTEGRATION_TESTS: 1
-        run: go test -mod=vendor -v ./frontend/dockerfile/... ./session/...
+        run: go test -mod=vendor -v ./frontend/dockerfile/... ./session/... ./util/...
         working-directory: src/github.com/moby/buildkit

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -39,5 +39,5 @@ jobs:
       - name: Unit test
         env:
           SKIP_INTEGRATION_TESTS: 1
-        run: go test -mod=vendor -v ./frontend/dockerfile/.../... ./session/...
+        run: go test -mod=vendor -v ./frontend/dockerfile/... ./session/...
         working-directory: src/github.com/moby/buildkit

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -39,5 +39,5 @@ jobs:
       - name: Unit test
         env:
           SKIP_INTEGRATION_TESTS: 1
-        run: go test -mod=vendor -v ./client/... ./frontend/dockerfile/... ./session/... ./source/... ./util/...
+        run: go test -mod=vendor -v ./cache/... ./client/... ./frontend/dockerfile/... ./session/... ./source/... ./util/...
         working-directory: src/github.com/moby/buildkit

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -39,5 +39,5 @@ jobs:
       - name: Unit test
         env:
           SKIP_INTEGRATION_TESTS: 1
-        run: go test -mod=vendor -v ./frontend/dockerfile/... ./session/... ./source/... ./util/...
+        run: go test -mod=vendor -v ./client/... ./frontend/dockerfile/... ./session/... ./source/... ./util/...
         working-directory: src/github.com/moby/buildkit

--- a/cache/contenthash/checksum.go
+++ b/cache/contenthash/checksum.go
@@ -386,7 +386,7 @@ func (cc *cacheContext) ChecksumWildcard(ctx context.Context, mountable cache.Mo
 
 	wildcards, err := cc.wildcards(ctx, m, p)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 
 	if followLinks {

--- a/cache/contenthash/checksum_test.go
+++ b/cache/contenthash/checksum_test.go
@@ -202,6 +202,26 @@ func TestChecksumWildcard(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestChecksumWildcardWithBadMountable(t *testing.T) {
+	t.Parallel()
+	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpdir)
+
+	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
+	require.NoError(t, err)
+	cm, _ := setupCacheManager(t, tmpdir, "native", snapshotter)
+	defer cm.Close()
+
+	ref := createRef(t, cm, nil)
+
+	cc, err := newCacheContext(ref.Metadata(), nil)
+	require.NoError(t, err)
+
+	_, err = cc.ChecksumWildcard(context.TODO(), newBadMountable(), "*", false)
+	require.Error(t, err)
+}
+
 func TestSymlinksNoFollow(t *testing.T) {
 	t.Parallel()
 	tmpdir, err := ioutil.TempDir("", "buildkit-state")
@@ -911,6 +931,18 @@ func setupCacheManager(t *testing.T, tmpdir string, snapshotterName string, snap
 	return cm, func() {
 		db.Close()
 	}
+}
+
+type badMountable struct{}
+
+func (bm *badMountable) Mount(ctx context.Context, readonly bool) (snapshot.Mountable, error) {
+	return nil, errors.New("tried to mount bad mountable")
+}
+
+// newBadMountable returns a cache.Mountable that will fail to mount, for use in APIs
+// that require a Mountable, but which should never actually try to access the filesystem.
+func newBadMountable() cache.Mountable {
+	return &badMountable{}
 }
 
 // these test helpers are from tonistiigi/fsutil

--- a/cache/contenthash/checksum_test.go
+++ b/cache/contenthash/checksum_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -858,6 +859,11 @@ func TestPersistence(t *testing.T) {
 }
 
 func createRef(t *testing.T, cm cache.Manager, files []string) cache.ImmutableRef {
+	if runtime.GOOS == "windows" && len(files) > 0 {
+		// lm.Mount() will fail
+		t.Skip("Depends on unimplemented containerd bind-mount support on Windows")
+	}
+
 	mref, err := cm.New(context.TODO(), nil, cache.CachePolicyRetain)
 	require.NoError(t, err)
 

--- a/cache/contenthash/filehash.go
+++ b/cache/contenthash/filehash.go
@@ -49,7 +49,6 @@ func NewFromStat(stat *fstypes.Stat) (hash.Hash, error) {
 		return nil, err
 	}
 	hdr.Name = "" // note: empty name is different from current has in docker build. Name is added on recursive directory scan instead
-	hdr.Mode = int64(chmodWindowsTarEntry(os.FileMode(hdr.Mode)))
 	hdr.Devmajor = stat.Devmajor
 	hdr.Devminor = stat.Devminor
 

--- a/cache/contenthash/filehash_unix.go
+++ b/cache/contenthash/filehash_unix.go
@@ -12,10 +12,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func chmodWindowsTarEntry(perm os.FileMode) os.FileMode {
-	return perm
-}
-
 func setUnixOpt(path string, fi os.FileInfo, stat *fstypes.Stat) error {
 	s := fi.Sys().(*syscall.Stat_t)
 

--- a/cache/contenthash/filehash_windows.go
+++ b/cache/contenthash/filehash_windows.go
@@ -8,16 +8,6 @@ import (
 	fstypes "github.com/tonistiigi/fsutil/types"
 )
 
-// chmodWindowsTarEntry is used to adjust the file permissions used in tar
-// header based on the platform the archival is done.
-func chmodWindowsTarEntry(perm os.FileMode) os.FileMode {
-	perm &= 0755
-	// Add the x bit: make everything +x from windows
-	perm |= 0111
-
-	return perm
-}
-
 func setUnixOpt(path string, fi os.FileInfo, stat *fstypes.Stat) error {
 	return nil
 }

--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/containerd/containerd/content"
@@ -269,6 +270,10 @@ func TestManager(t *testing.T) {
 }
 
 func TestSnapshotExtract(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Depends on unimplemented containerd bind-mount support on Windows")
+	}
+
 	t.Parallel()
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
@@ -405,6 +410,10 @@ func TestSnapshotExtract(t *testing.T) {
 }
 
 func TestExtractOnMutable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Depends on unimplemented containerd bind-mount support on Windows")
+	}
+
 	t.Parallel()
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -18,7 +18,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
@@ -272,10 +271,7 @@ func testExportBusyboxLocal(t *testing.T, sb integration.Sandbox) {
 	fi2, err := os.Stat(filepath.Join(destDir, "bin/vi"))
 	require.NoError(t, err)
 
-	st1 := fi.Sys().(*syscall.Stat_t)
-	st2 := fi2.Sys().(*syscall.Stat_t)
-
-	require.Equal(t, st1.Ino, st2.Ino)
+	require.True(t, os.SameFile(fi, fi2))
 }
 
 func testHostnameLookup(t *testing.T, sb integration.Sandbox) {

--- a/client/llb/llbtest/platform_test.go
+++ b/client/llb/llbtest/platform_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/moby/buildkit/solver"
 	"github.com/moby/buildkit/solver/llbsolver"
 	"github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/util/system"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/require"
 )
@@ -131,7 +132,7 @@ func TestFallbackPath(t *testing.T) {
 	_, ok := getenv(e, "PATH")
 	require.False(t, ok)
 
-	// For an empty capset we expect a default non-empty PATH, and
+	// For an empty capset we expect a system-specific default PATH, and
 	// no requirement for the cap.
 	cs := pb.Caps.CapSet(nil)
 	require.Error(t, cs.Supports(pb.CapExecMetaSetsDefaultPath))
@@ -142,7 +143,7 @@ func TestFallbackPath(t *testing.T) {
 	require.False(t, def.Metadata[e.Vertex.Digest()].Caps[pb.CapExecMetaSetsDefaultPath])
 	v, ok := getenv(e, "PATH")
 	require.True(t, ok)
-	require.NotEqual(t, "", v)
+	require.Equal(t, system.DefaultPathEnv, v)
 
 	// All capabilities, including pb.CapExecMetaSetsDefaultPath,
 	// so should get no PATH (not present at all, rather than

--- a/executor/oci/mounts.go
+++ b/executor/oci/mounts.go
@@ -76,11 +76,11 @@ func withROBind(src, dest string) func(m []specs.Mount) ([]specs.Mount, error) {
 
 func hasPrefix(p, prefixDir string) bool {
 	prefixDir = filepath.Clean(prefixDir)
-	if prefixDir == "/" {
+	if filepath.Base(prefixDir) == string(filepath.Separator) {
 		return true
 	}
 	p = filepath.Clean(p)
-	return p == prefixDir || strings.HasPrefix(p, prefixDir+"/")
+	return p == prefixDir || strings.HasPrefix(p, prefixDir+string(filepath.Separator))
 }
 
 func removeMountsWithPrefix(mounts []specs.Mount, prefixDir string) []specs.Mount {

--- a/executor/oci/mounts_test.go
+++ b/executor/oci/mounts_test.go
@@ -3,7 +3,7 @@ package oci
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestHasPrefix(t *testing.T) {
@@ -51,6 +51,6 @@ func TestHasPrefix(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		actual := hasPrefix(tc.path, tc.prefix)
-		require.Equal(t, tc.expected, actual, "#%d: under(%q,%q)", i, tc.path, tc.prefix)
+		assert.Equal(t, tc.expected, actual, "#%d: under(%q,%q)", i, tc.path, tc.prefix)
 	}
 }

--- a/executor/oci/mounts_test.go
+++ b/executor/oci/mounts_test.go
@@ -1,6 +1,7 @@
 package oci
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,6 +49,45 @@ func TestHasPrefix(t *testing.T) {
 			prefix:   "/foo",
 			expected: false,
 		},
+	}
+	if runtime.GOOS == "windows" {
+		testCases = append(testCases,
+			testCase{
+				path:     "C:\\foo\\bar",
+				prefix:   "C:\\foo",
+				expected: true,
+			},
+			testCase{
+				path:     "C:\\foo\\bar",
+				prefix:   "C:\\foo\\",
+				expected: true,
+			},
+			testCase{
+				path:     "C:\\foo\\bar",
+				prefix:   "C:\\",
+				expected: true,
+			},
+			testCase{
+				path:     "C:\\foo",
+				prefix:   "C:\\foo",
+				expected: true,
+			},
+			testCase{
+				path:     "C:\\foo\\bar",
+				prefix:   "C:\\bar",
+				expected: false,
+			},
+			testCase{
+				path:     "C:\\foo\\bar",
+				prefix:   "foo",
+				expected: false,
+			},
+			testCase{
+				path:     "C:\\foobar",
+				prefix:   "C:\\foo",
+				expected: false,
+			},
+		)
 	}
 	for i, tc := range testCases {
 		actual := hasPrefix(tc.path, tc.prefix)

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -4651,7 +4651,12 @@ func tmpdir(appliers ...fstest.Applier) (string, error) {
 
 func runShell(dir string, cmds ...string) error {
 	for _, args := range cmds {
-		cmd := exec.Command("sh", "-c", args)
+		var cmd *exec.Cmd
+		if runtime.GOOS == "windows" {
+			cmd = exec.Command("powershell", "-command", args)
+		} else {
+			cmd = exec.Command("sh", "-c", args)
+		}
 		cmd.Dir = dir
 		if err := cmd.Run(); err != nil {
 			return errors.Wrapf(err, "error running %v", args)

--- a/source/git/gitsource_test.go
+++ b/source/git/gitsource_test.go
@@ -35,6 +35,10 @@ func TestRepeatedFetchKeepGitDir(t *testing.T) {
 }
 
 func testRepeatedFetch(t *testing.T, keepGitDir bool) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Depends on unimplemented containerd bind-mount support on Windows")
+	}
+
 	t.Parallel()
 	ctx := context.TODO()
 
@@ -149,6 +153,10 @@ func TestFetchBySHAKeepGitDir(t *testing.T) {
 }
 
 func testFetchBySHA(t *testing.T, keepGitDir bool) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Depends on unimplemented containerd bind-mount support on Windows")
+	}
+
 	t.Parallel()
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
@@ -222,6 +230,10 @@ func TestMultipleReposKeepGitDir(t *testing.T) {
 }
 
 func testMultipleRepos(t *testing.T, keepGitDir bool) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Depends on unimplemented containerd bind-mount support on Windows")
+	}
+
 	t.Parallel()
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 

--- a/source/git/gitsource_test.go
+++ b/source/git/gitsource_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -392,7 +393,12 @@ func setupGitRepo(dir string) (string, error) {
 
 func runShell(dir string, cmds ...string) error {
 	for _, args := range cmds {
-		cmd := exec.Command("sh", "-c", args)
+		var cmd *exec.Cmd
+		if runtime.GOOS == "windows" {
+			cmd = exec.Command("powershell", "-command", args)
+		} else {
+			cmd = exec.Command("sh", "-c", args)
+		}
 		cmd.Dir = dir
 		if err := cmd.Run(); err != nil {
 			return errors.Wrapf(err, "error running %v", args)

--- a/source/http/httpsource_test.go
+++ b/source/http/httpsource_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/containerd/containerd/content/local"
@@ -25,6 +26,10 @@ import (
 )
 
 func TestHTTPSource(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Depends on unimplemented containerd bind-mount support on Windows")
+	}
+
 	t.Parallel()
 	ctx := context.TODO()
 
@@ -139,6 +144,10 @@ func TestHTTPSource(t *testing.T) {
 }
 
 func TestHTTPDefaultName(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Depends on unimplemented containerd bind-mount support on Windows")
+	}
+
 	t.Parallel()
 	ctx := context.TODO()
 
@@ -212,6 +221,10 @@ func TestHTTPInvalidURL(t *testing.T) {
 }
 
 func TestHTTPChecksum(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Depends on unimplemented containerd bind-mount support on Windows")
+	}
+
 	t.Parallel()
 	ctx := context.TODO()
 

--- a/util/network/cniprovider/createns_windows.go
+++ b/util/network/cniprovider/createns_windows.go
@@ -12,7 +12,7 @@ func createNetNS(_ *cniProvider, id string) (string, error) {
 	nsTemplate := hcn.NewNamespace(hcn.NamespaceTypeGuest)
 	ns, err := nsTemplate.Create()
 	if err != nil {
-		return "", errors.Wrapf(err, "HostComputeNamespace.Create failed for %s", nsTemplate)
+		return "", errors.Wrapf(err, "HostComputeNamespace.Create failed for %s", nsTemplate.Id)
 	}
 
 	return ns.Id, nil

--- a/util/rootless/specconv/specconv_nonlinux.go
+++ b/util/rootless/specconv/specconv_nonlinux.go
@@ -1,0 +1,19 @@
+// +build !linux
+
+package specconv
+
+import (
+	"runtime"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+)
+
+// ToRootless converts spec to be compatible with "rootless" runc.
+// * Remove /sys mount
+// * Remove cgroups
+//
+// See docs/rootless.md for the supported runc revision.
+func ToRootless(spec *specs.Spec) error {
+	return errors.Errorf("not implemented on on %s", runtime.GOOS)
+}

--- a/util/system/path_windows_test.go
+++ b/util/system/path_windows_test.go
@@ -12,6 +12,8 @@ func TestCheckSystemDriveAndRemoveDriveLetter(t *testing.T) {
 		t.Fatalf("Expected error for d:")
 	}
 
+	var path string
+
 	// Single character is unchanged
 	if path, err = CheckSystemDriveAndRemoveDriveLetter("z"); err != nil {
 		t.Fatalf("Single character should pass")

--- a/util/testutil/integration/sandbox.go
+++ b/util/testutil/integration/sandbox.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
@@ -171,9 +170,7 @@ func runBuildkitd(conf *BackendConfig, args []string, logs map[string]*bytes.Buf
 	args = append(args, "--root", tmpdir, "--addr", address, "--debug")
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Env = append(os.Environ(), "BUILDKIT_DEBUG_EXEC_OUTPUT=1", "BUILDKIT_DEBUG_PANIC_ON_ERROR=1", "TMPDIR="+filepath.Join(tmpdir, "tmp"))
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setsid: true, // stretch sudo needs this for sigterm
-	}
+	cmd.SysProcAttr = getSysProcAttr()
 
 	stop, err := startCmd(cmd, logs)
 	if err != nil {

--- a/util/testutil/integration/sandbox_unix.go
+++ b/util/testutil/integration/sandbox_unix.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package integration
+
+import "syscall"
+
+func getSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		Setsid: true, // stretch sudo needs this for sigterm
+	}
+}

--- a/util/testutil/integration/sandbox_windows.go
+++ b/util/testutil/integration/sandbox_windows.go
@@ -1,0 +1,9 @@
+// +build windows
+
+package integration
+
+import "syscall"
+
+func getSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{}
+}


### PR DESCRIPTION
This makes

```PowerShell
${ENV:SKIP_INTEGRATION_TESTS}=1
go test ./...
```

only show test failures, rather than build failures, which puts us in a much better position to actually fix test failures and/or mark tests on not-for-Windows.

I've also skipped tests which fail due to missing support in containerd, to reduce the failing-test noise levels.

Apart from fixes in #1594, all unit tests now pass, but there's a couple of code changes that probably need close attention to confirm the fix was correct:
* 9b0c2906ee52b2992b8ee399d7f71a387bf86df8
* 8c31a337cd6918fb96e6a73a054c6870d141715d

Contributes towards: #616