### PR TITLE
[v0.6 backport] cache: avoid nil dereference

### DIFF
--- a/cache/refs.go
+++ b/cache/refs.go
@@ -123,7 +123,10 @@ func (cr *cacheRecord) Size(ctx context.Context) (int64, error) {
 		cr.mu.Unlock()
 		return usage.Size, nil
 	})
-	return s.(int64), err
+	if err != nil {
+		return 0, err
+	}
+	return s.(int64), nil
 }
 
 func (cr *cacheRecord) Parent() ImmutableRef {


### PR DESCRIPTION
backport of https://github.com/moby/buildkit/pull/1511
fixes https://github.com/moby/buildkit/issues/1510

This was seen on Docker Desktop "edge" (which switched to use BuildKit by default)