### PR TITLE
Ensure that time has passed between foo0 and foo1

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -39,5 +39,5 @@ jobs:
       - name: Unit test
         env:
           SKIP_INTEGRATION_TESTS: 1
-        run: go test -mod=vendor -v ./cache/... ./client/... ./frontend/dockerfile/... ./session/... ./source/... ./util/...
+        run: go test -mod=vendor -v ./cache/... ./client/... ./frontend/dockerfile/... ./session/... ./solver/... ./source/... ./util/...
         working-directory: src/github.com/moby/buildkit


### PR DESCRIPTION
On Windows, the resolution of time.Now() can be surprisingly low: 15ms according to the comments in the source of time.Now().