### PR TITLE
hack: use caching for master deploy

### DIFF
--- a/hack/images
+++ b/hack/images
@@ -78,6 +78,7 @@ image() {
     --local context=. --local dockerfile=. \
     --opt platform=$PLATFORMS \
     --export-cache type=inline \
+    --import-cache type=registry,ref=$REPO:$TAG$tagLatest \
     --output type=image,\"name=$REPO:$TAG$tagLatest\",$pushFlag
 
   buildctl build $progressFlag --frontend=dockerfile.v0 \
@@ -85,6 +86,7 @@ image() {
     --opt target=rootless \
     --opt platform=$PLATFORMS \
     --export-cache type=inline \
+    --import-cache type=registry,ref=$REPO:$TAG-rootless$tagLatestRootless \
     --output type=image,\"name=$REPO:$TAG-rootless$tagLatestRootless\",$pushFlag
 }
 


### PR DESCRIPTION
After rootless changes that rebuild from source deploy ci in master takes a lot of time (~40min). This should cut it down by reusing cache from previous master build.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>