### PR TITLE
buildctl: improve secret parsing

### DIFF
--- a/cmd/buildctl/build/secret.go
+++ b/cmd/buildctl/build/secret.go
@@ -61,7 +61,7 @@ func parseSecret(value string) (*secretsprovider.Source, error) {
 			return nil, errors.Errorf("unexpected key '%s' in '%s'", key, field)
 		}
 	}
-	if typ == "env" {
+	if typ == "env" && fs.Env == "" {
 		fs.Env = fs.FilePath
 		fs.FilePath = ""
 	}


### PR DESCRIPTION
`type=env,env=foo` would not work before

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>