### PR TITLE
executor/oci: correctly use user.GetExecUser interface

### DIFF
--- a/executor/oci/user.go
+++ b/executor/oci/user.go
@@ -63,7 +63,14 @@ func openUserFile(root, p string) (*os.File, error) {
 	if err != nil {
 		return nil, err
 	}
-	return os.Open(p)
+	fh, err := os.Open(p)
+	if err != nil {
+		// This is needed because a nil *os.File is different to a nil
+		// io.ReadCloser and this causes GetExecUser to not detect that the
+		// container file is missing.
+		return nil, err
+	}
+	return fh, nil
 }
 
 func parseUID(str string) (uint32, error) {


### PR DESCRIPTION
I noticed this repository had the same bug as in Moby (see https://github.com/moby/moby/pull/41288 / https://github.com/opencontainers/runc/pull/2275#issuecomment-665398607

A nil interface in Go is not the same as a nil pointer that satisfies
the interface. libcontainer/user has special handling for missing
/etc/{passwd,group} files but this is all based on nil interface checks,
which were broken by Docker's usage of the API.

When combined with some recent changes in runc that made read errors
actually be returned to the caller, this results in spurrious -EINVAL
errors when we should detect the situation as "there is no passwd file".
