### PR TITLE
executor/oci.GetUser(): remove unused context

### DIFF
--- a/executor/containerdexecutor/executor.go
+++ b/executor/containerdexecutor/executor.go
@@ -111,7 +111,7 @@ func (w *containerdExecutor) Run(ctx context.Context, id string, root cache.Moun
 		if err != nil {
 			return err
 		}
-		uid, gid, sgids, err = oci.GetUser(ctx, rootfsPath, meta.User)
+		uid, gid, sgids, err = oci.GetUser(rootfsPath, meta.User)
 		if err != nil {
 			lm.Unmount()
 			return err

--- a/executor/oci/user.go
+++ b/executor/oci/user.go
@@ -14,7 +14,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func GetUser(ctx context.Context, root, username string) (uint32, uint32, []uint32, error) {
+func GetUser(root, username string) (uint32, uint32, []uint32, error) {
 	// fast path from uid/gid
 	if uid, gid, err := ParseUIDGID(username); err == nil {
 		return uid, gid, nil, nil

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -212,7 +212,7 @@ func (w *runcExecutor) Run(ctx context.Context, id string, root cache.Mountable,
 	}
 	defer mount.Unmount(rootFSPath, 0)
 
-	uid, gid, sgids, err := oci.GetUser(ctx, rootFSPath, meta.User)
+	uid, gid, sgids, err := oci.GetUser(rootFSPath, meta.User)
 	if err != nil {
 		return err
 	}
@@ -385,7 +385,7 @@ func (w *runcExecutor) Exec(ctx context.Context, id string, process executor.Pro
 	}
 
 	if process.Meta.User != "" {
-		uid, gid, sgids, err := oci.GetUser(ctx, state.Rootfs, process.Meta.User)
+		uid, gid, sgids, err := oci.GetUser(state.Rootfs, process.Meta.User)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Noticed this was unused, but perhaps this was meant to be used at some point, in which case feel free to close