### PR TITLE
Clarify the gateway 'test' as a build-test

### DIFF
--- a/hack/test
+++ b/hack/test
@@ -81,10 +81,9 @@ if [ "$TEST_INTEGRATION" == 1 ]; then
 fi
 
 if [ "$TEST_GATEWAY" == 1 ]; then
-  cid=$(docker create --rm --volumes-from=$cacheVolume -e TEST_DOCKERD $iid go build -v ./frontend/gateway/client)
-  if [ "$TEST_DOCKERD" = "1" ]; then
-    docker cp "$TEST_DOCKERD_BINARY" $cid:/usr/bin/
-  fi
+  # Build-test "github.com/moby/buildkit/frontend/gateway/client", which isn't otherwise built by CI
+  # It really only needs buildkit-base. We have integration-tests in $iid, which is a direct child of buildkit-base.
+  cid=$(docker create --rm --volumes-from=$cacheVolume $iid go build -v ./frontend/gateway/client)
   docker start -a $cid
 fi
 


### PR DESCRIPTION
It also doesn't need dockerd added to its container when it builds.

Recording the clarification I received at https://github.com/moby/buildkit/pull/1606#issuecomment-664462494

I had looked at moving it into a build stage, adding it to the Dockerfile, but since it doesn't produce any artifacts, it sad weirdly there.