### PR TITLE
return exit status from executor Run/Exec

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net"
 
@@ -28,10 +29,18 @@ type Mount struct {
 	Readonly bool
 }
 
+type WinSize struct {
+	Rows   uint32
+	Cols   uint32
+	Xpixel uint32
+	Ypixel uint32
+}
+
 type ProcessInfo struct {
 	Meta           Meta
 	Stdin          io.ReadCloser
 	Stdout, Stderr io.WriteCloser
+	Resize         <-chan WinSize
 }
 
 type Executor interface {
@@ -47,4 +56,25 @@ type Executor interface {
 type HostIP struct {
 	Host string
 	IP   net.IP
+}
+
+// ExitError will be returned from Run and Exec when the container process exits with
+// a non-zero exit code.
+type ExitError struct {
+	ExitCode uint32
+	Err      error
+}
+
+func (err *ExitError) Error() string {
+	if err.Err != nil {
+		return err.Err.Error()
+	}
+	return fmt.Sprintf("exit code: %d", err.ExitCode)
+}
+
+func (err *ExitError) Unwrap() error {
+	if err.Err == nil {
+		return fmt.Errorf("exit code: %d", err.ExitCode)
+	}
+	return err.Err
 }

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -30,10 +30,8 @@ type Mount struct {
 }
 
 type WinSize struct {
-	Rows   uint32
-	Cols   uint32
-	Xpixel uint32
-	Ypixel uint32
+	Rows uint32
+	Cols uint32
 }
 
 type ProcessInfo struct {

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -332,13 +332,15 @@ func (w *runcExecutor) Run(ctx context.Context, id string, root cache.Mountable,
 	close(ended)
 
 	if status != 0 || err != nil {
-		err = &executor.ExitError{
+		exitErr := &executor.ExitError{
 			ExitCode: uint32(status),
 			Err:      err,
 		}
+		err = exitErr
 		select {
 		case <-ctx.Done():
-			return errors.Wrapf(ctx.Err(), err.Error())
+			exitErr.Err = errors.Wrapf(ctx.Err(), exitErr.Error())
+			return exitErr
 		default:
 			return stack.Enable(err)
 		}


### PR DESCRIPTION
More incremental work for #749 

This returns the process exit status from Run/Exec so we can send it in the ExitMessage.  This also plumbs in a Resize channel to handle resize events.

I will have another PR soon with the proto changes and server side changes for that, I just wanted to get these executor changes in to keep the PRs managable.   I have some questions about client side so I will add those questions/proposals to #749 

Through testing I found `runc` to be challenging since it will not create a pty like `containerd` does.  So for now I modified runc to just return "not implemnted" error when tty is requested.  I am trying to understand how `containerd` manages the pty with the console-socket option on `runc` so I hope to find a solution soon, but will likely be another follow up PR.
