### PR TITLE
introduce `--custom-authority-header` option in `buildctl` commad

### DIFF
--- a/cmd/buildctl/common/common.go
+++ b/cmd/buildctl/common/common.go
@@ -76,5 +76,11 @@ func ResolveClient(c *cli.Context) (*client.Client, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout*time.Second)
 	defer cancel()
 
+	customAuthorityHaeder := c.GlobalString("custom-authority-header")
+	if customAuthorityHaeder != "" {
+		opts = append(opts, client.WithCustomAuthorityHeader(customAuthorityHaeder))
+
+	}
+	
 	return client.New(ctx, c.GlobalString("addr"), opts...)
 }

--- a/cmd/buildctl/main.go
+++ b/cmd/buildctl/main.go
@@ -77,6 +77,11 @@ func main() {
 			Usage: "timeout backend connection after value seconds",
 			Value: 5,
 		},
+		cli.StringFlag{
+			Name:  "custom-authority-header",
+			Usage: "if set, it dials to addr with specified custom authority header",
+			Value: "",
+		},
 	}
 
 	app.Commands = []cli.Command{


### PR DESCRIPTION
fixes #1566

## What I've changed
This PR introduces `--custom-authority-header` in `buildctl` command.

### Note

I have already posted another PR(#1567) to fix #1566.  Although #1567 is breaking change, this approach does not break any previous `buildctl` behaviors because this just added cli options to override `:authority` header.
