### PR TITLE
Ensure Dockerfile WORKDIR C:\ becomes / in LLB

### DIFF
--- a/frontend/dockerfile/instructions/parse.go
+++ b/frontend/dockerfile/instructions/parse.go
@@ -6,6 +6,7 @@ package instructions
 
 import (
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -17,6 +18,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/command"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/moby/buildkit/util/suggest"
+	"github.com/moby/buildkit/util/system"
 	"github.com/pkg/errors"
 )
 
@@ -409,8 +411,14 @@ func parseWorkdir(req parseRequest) (*WorkdirCommand, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	path, err := system.CheckSystemDriveAndRemoveDriveLetter(req.args[0])
+	if err != nil {
+		return nil, err
+	}
+
 	return &WorkdirCommand{
-		Path:            req.args[0],
+		Path:            filepath.ToSlash(path),
 		withNameAndCode: newWithNameAndCode(req),
 	}, nil
 }


### PR DESCRIPTION
Putting this up for review as a first step towards implementing https://github.com/moby/buildkit/issues/616#issuecomment-663767944, to make sure we're happy with this approach. `parseAdd` will need similar fixes for its sources and destination arguments.

This change doesn't make `WORKDIR` actually work, as there are different issues when applying the LLB back to the filesystem, but those can be fixed separately.