### PR TITLE
resolver: fix resolver reuse

### DIFF
--- a/util/pull/resolver.go
+++ b/util/pull/resolver.go
@@ -54,7 +54,7 @@ func EnsureManifestRequested(ctx context.Context, res remotes.Resolver, ref stri
 	if !ok {
 		return
 	}
-	if atomic.LoadInt64(&cr.counter) == 0 {
+	if atomic.LoadInt64(cr.counter) == 0 {
 		res.Resolve(ctx, ref)
 	}
 }
@@ -114,14 +114,14 @@ type resolverCache struct {
 }
 
 type cachedResolver struct {
-	counter int64
+	counter *int64
 	timeout time.Time
 	remotes.Resolver
 	auth *resolver.SessionAuthenticator
 }
 
 func (cr *cachedResolver) Resolve(ctx context.Context, ref string) (name string, desc ocispec.Descriptor, err error) {
-	atomic.AddInt64(&cr.counter, 1)
+	atomic.AddInt64(cr.counter, 1)
 	return cr.Resolver.Resolve(ctx, ref)
 }
 
@@ -138,6 +138,8 @@ func (r *resolverCache) Add(ref string, resolver remotes.Resolver, auth *resolve
 		return &cr
 	}
 
+	var counter int64
+	cr.counter = &counter
 	cr.Resolver = resolver
 	cr.auth = auth
 	r.m[ref] = cr

--- a/util/resolver/resolver.go
+++ b/util/resolver/resolver.go
@@ -297,14 +297,12 @@ func newDefaultTransport() *http.Transport {
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-			DualStack: true,
+			KeepAlive: 60 * time.Second,
 		}).DialContext,
 		MaxIdleConns:          10,
 		IdleConnTimeout:       30 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 5 * time.Second,
-		DisableKeepAlives:     true,
 		TLSNextProto:          make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
 	}
 }


### PR DESCRIPTION
- Containerd config loading repeatedly calls hosts config callback, creating new authorizer. Now authorizer is cached. Also client was recreated if the host had a custom configuration.
- Keep-alive was disabled with HTTP2 but shouldn't have been. HTTP/2 remains disabled.
- EnsureManifestLoaded check (for gcr broken auth) had regressed and wasn't working because a struct was cloned

This should significantly improve performance for registry communication. Still a lot of things to improve but at least all regressions should be gone now. For further changes, I'd need to make more auth helper functions public in containerd to avoid copy-paste.

@sipsma @fuweid 