### PR TITLE
travis: replace after_failure with after_script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ install:
   - sudo docker cp buildkit:/usr/bin/buildctl /usr/bin/
   - export BUILDKIT_HOST=tcp://0.0.0.0:1234
 
-after_failure:
-  - docker ps -a && docker logs buildkit
-  - sudo dmesg
+after_script:
+  - if [[ "$TRAVIS_TEST_RESULT" == 1 ]]; then docker ps -a && docker logs buildkit && sudo dmesg; fi
 
 env:
   global:


### PR DESCRIPTION
after_failure does not get triggered after deploy failure. 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>