### PR TITLE
client: fix connhelper context canceling

### DIFF
--- a/client/connhelper/dockercontainer/dockercontainer.go
+++ b/client/connhelper/dockercontainer/dockercontainer.go
@@ -28,7 +28,8 @@ func Helper(u *url.URL) (*connhelper.ConnectionHelper, error) {
 			if sp.Context != "" {
 				ctxFlags = append(ctxFlags, "--context="+sp.Context)
 			}
-			return commandconn.New(ctx, "docker", append(ctxFlags, []string{"exec", "-i", sp.Container, "buildctl", "dial-stdio"}...)...)
+			// using background context because context remains active for the duration of the process, after dial has completed
+			return commandconn.New(context.Background(), "docker", append(ctxFlags, []string{"exec", "-i", sp.Container, "buildctl", "dial-stdio"}...)...)
 		},
 	}, nil
 }

--- a/client/connhelper/kubepod/kubepod.go
+++ b/client/connhelper/kubepod/kubepod.go
@@ -25,7 +25,8 @@ func Helper(u *url.URL) (*connhelper.ConnectionHelper, error) {
 	}
 	return &connhelper.ConnectionHelper{
 		ContextDialer: func(ctx context.Context, addr string) (net.Conn, error) {
-			return commandconn.New(ctx, "kubectl", "--context="+sp.Context, "--namespace="+sp.Namespace,
+			// using background context because context remains active for the duration of the process, after dial has completed
+			return commandconn.New(context.Background(), "kubectl", "--context="+sp.Context, "--namespace="+sp.Namespace,
 				"exec", "--container="+sp.Container, "-i", sp.Pod, "--", "buildctl", "dial-stdio")
 		},
 	}, nil


### PR DESCRIPTION
fixes #1626 

Dial context is canceled after connection is
established so can’t be used for a long running process.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>