### PR TITLE
new connection helper: podman-container://<CONTAINER>

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ You don't need to read this document unless you want to use the full-featured st
 - [Expose BuildKit as a TCP service](#expose-buildkit-as-a-tcp-service)
   - [Load balancing](#load-balancing)
 - [Containerizing BuildKit](#containerizing-buildkit)
+  - [Podman](#podman)
   - [Kubernetes](#kubernetes)
   - [Daemonless](#daemonless)
 - [Opentracing support](#opentracing-support)
@@ -415,6 +416,16 @@ docker run -d --name buildkitd --privileged moby/buildkit:latest
 export BUILDKIT_HOST=docker-container://buildkitd
 buildctl build --help
 ```
+
+### Podman
+To connect to a BuildKit daemon running in a Podman container, use `podman-container://` instead of `docker-container://` .
+
+```bash
+podman run -d --name buildkitd --privileged moby/buildkit:latest
+buildctl --addr=podman-container://buildkitd build --frontend dockerfile.v0 --local context=. --local dockerfile=. --output type=oci | podman load foo
+```
+
+`sudo` is not required.
 
 ### Kubernetes
 

--- a/client/connhelper/podmancontainer/podmancontainer.go
+++ b/client/connhelper/podmancontainer/podmancontainer.go
@@ -1,0 +1,49 @@
+// Package podmancontainer provides connhelper for podman-container://<container>
+package podmancontainer
+
+import (
+	"context"
+	"net"
+	"net/url"
+
+	"github.com/docker/cli/cli/connhelper/commandconn"
+	"github.com/moby/buildkit/client/connhelper"
+	"github.com/pkg/errors"
+)
+
+func init() {
+	connhelper.Register("podman-container", Helper)
+}
+
+// Helper returns helper for connecting to a Podman container.
+// Requires BuildKit v0.5.0 or later in the container.
+func Helper(u *url.URL) (*connhelper.ConnectionHelper, error) {
+	sp, err := SpecFromURL(u)
+	if err != nil {
+		return nil, err
+	}
+	return &connhelper.ConnectionHelper{
+		ContextDialer: func(ctx context.Context, addr string) (net.Conn, error) {
+			// using background context because context remains active for the duration of the process, after dial has completed
+			return commandconn.New(context.Background(), "podman", "exec", "-i", sp.Container, "buildctl", "dial-stdio")
+		},
+	}, nil
+}
+
+// Spec
+type Spec struct {
+	Container string
+}
+
+// SpecFromURL creates Spec from URL.
+// URL is like podman-container://<container>
+// The <container> part is mandatory.
+func SpecFromURL(u *url.URL) (*Spec, error) {
+	sp := Spec{
+		Container: u.Hostname(),
+	}
+	if sp.Container == "" {
+		return nil, errors.New("url lacks container name")
+	}
+	return &sp, nil
+}

--- a/client/connhelper/podmancontainer/podmancontainer_test.go
+++ b/client/connhelper/podmancontainer/podmancontainer_test.go
@@ -1,0 +1,30 @@
+package podmancontainer
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSpecFromURL(t *testing.T) {
+	cases := map[string]*Spec{
+		"podman-container://containername": {
+			Container: "containername",
+		},
+		"podman-container://": nil,
+	}
+	for s, expected := range cases {
+		u, err := url.Parse(s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err := SpecFromURL(u)
+		if expected != nil {
+			require.NoError(t, err)
+			require.EqualValues(t, expected, got, s)
+		} else {
+			require.Error(t, err, s)
+		}
+	}
+}

--- a/cmd/buildctl/main.go
+++ b/cmd/buildctl/main.go
@@ -6,6 +6,7 @@ import (
 
 	_ "github.com/moby/buildkit/client/connhelper/dockercontainer"
 	_ "github.com/moby/buildkit/client/connhelper/kubepod"
+	_ "github.com/moby/buildkit/client/connhelper/podmancontainer"
 	bccommon "github.com/moby/buildkit/cmd/buildctl/common"
 	"github.com/moby/buildkit/solver/errdefs"
 	"github.com/moby/buildkit/util/apicaps"


### PR DESCRIPTION
Similar to `docker-container://` but for Podman containers.