### PR TITLE
add sipsma and coryb as maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -151,8 +151,10 @@ made through a pull request.
 
 		people = [
 			"akihirosuda",
+			"coryb",
 			"hinshun",
 			"ijc",
+			"sipsma",
 			"tiborvass",
 			"tonistiigi",
 		]
@@ -184,6 +186,11 @@ made through a pull request.
 	Email = "akihiro.suda.cz@hco.ntt.co.jp"
 	GitHub = "AkihiroSuda"
 
+	[people.coryb]
+	Name = "Cory Bennett"
+	Email = "github@corybennett.org"
+	GitHub = "coryb"
+
 	[people.hinshun]
 	Name = "Edgar Lee"
 	Email = "edgarhinshunlee@gmail.com"
@@ -193,6 +200,11 @@ made through a pull request.
 	Name = "Ian Campbell"
 	Email = "ian.campbell@docker.com"
 	GitHub = "ijc"
+
+	[people.sipsma]
+	Name = "Erik Sipsma"
+	Email = "erik@sipsma.dev"
+	GitHub = "sipsma"
 
 	[people.thajeztah]
 	Name = "Sebastiaan van Stijn"


### PR DESCRIPTION
Thanks for all the great contributions to BuildKit you have done so far @coryb @sipsma . Welcome to maintainers.

Already agreed with the vote in Slack, but feel free to check the e-mails are correct etc.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>