### PR TITLE
cni: remove duplicate error check

### DIFF
--- a/util/network/cniprovider/cni.go
+++ b/util/network/cniprovider/cni.go
@@ -42,10 +42,6 @@ func New(opt Opt) (network.Provider, error) {
 		return nil, err
 	}
 
-	if err != nil {
-		return nil, err
-	}
-
 	cp := &cniProvider{CNI: cniHandle, root: opt.Root}
 	if err := cp.initNetwork(); err != nil {
 		return nil, err


### PR DESCRIPTION
This PR removes a dangling `if err != nil {}` check that was already done right above. I tried to follow contribution guidelines, but let me know if I missed something.

Signed-off-by: Miguel Ángel Jimeno <miguelangel4b@gmail.com>