### PR TITLE
auth: fetch tokens from client side

### DIFF
--- a/session/auth/auth.go
+++ b/session/auth/auth.go
@@ -2,11 +2,28 @@ package auth
 
 import (
 	"context"
+	"crypto/subtle"
+	"math/rand"
+	"sync"
 
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/util/grpcerrors"
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/nacl/sign"
 	"google.golang.org/grpc/codes"
 )
+
+var salt []byte
+var saltOnce sync.Once
+
+// getSalt returns unique component per daemon restart to avoid persistent keys
+func getSalt() []byte {
+	saltOnce.Do(func() {
+		salt = make([]byte, 32)
+		rand.Read(salt)
+	})
+	return salt
+}
 
 func CredentialsFunc(sm *session.Manager, g session.Group) func(string) (session, username, secret string, err error) {
 	return func(host string) (string, string, string, error) {
@@ -33,4 +50,81 @@ func CredentialsFunc(sm *session.Manager, g session.Group) func(string) (session
 		}
 		return sessionID, user, secret, nil
 	}
+}
+
+func FetchToken(req *FetchTokenRequest, sm *session.Manager, g session.Group) (resp *FetchTokenResponse, err error) {
+	err = sm.Any(context.TODO(), g, func(ctx context.Context, id string, c session.Caller) error {
+		client := NewAuthClient(c.Conn())
+
+		resp, err = client.FetchToken(ctx, req)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func VerifyTokenAuthority(host string, pubKey *[32]byte, sm *session.Manager, g session.Group) (sessionID string, ok bool, err error) {
+	var verified bool
+	err = sm.Any(context.TODO(), g, func(ctx context.Context, id string, c session.Caller) error {
+		client := NewAuthClient(c.Conn())
+
+		payload := make([]byte, 32)
+		rand.Read(payload)
+		resp, err := client.VerifyTokenAuthority(ctx, &VerifyTokenAuthorityRequest{
+			Host:    host,
+			Salt:    getSalt(),
+			Payload: payload,
+		})
+		if err != nil {
+			if grpcerrors.Code(err) == codes.Unimplemented {
+				return nil
+			}
+			return err
+		}
+		var dt []byte
+		dt, ok = sign.Open(nil, resp.Signed, pubKey)
+		if ok && subtle.ConstantTimeCompare(dt, payload) == 1 {
+			verified = true
+		}
+		sessionID = id
+		return nil
+	})
+	if err != nil {
+		return "", false, err
+	}
+	return sessionID, verified, nil
+}
+
+func GetTokenAuthority(host string, sm *session.Manager, g session.Group) (sessionID string, pubKey *[32]byte, err error) {
+	err = sm.Any(context.TODO(), g, func(ctx context.Context, id string, c session.Caller) error {
+		client := NewAuthClient(c.Conn())
+
+		resp, err := client.GetTokenAuthority(ctx, &GetTokenAuthorityRequest{
+			Host: host,
+			Salt: getSalt(),
+		})
+		if err != nil {
+			if grpcerrors.Code(err) == codes.Unimplemented || grpcerrors.Code(err) == codes.Unavailable {
+				return nil
+			}
+			return err
+		}
+		if len(resp.PublicKey) != 32 {
+			return errors.Errorf("invalid pubkey length %d", len(pubKey))
+		}
+
+		sessionID = id
+		pubKey = new([32]byte)
+		copy((*pubKey)[:], resp.PublicKey)
+		return nil
+	})
+	if err != nil {
+		return "", nil, err
+	}
+	return sessionID, pubKey, nil
 }

--- a/session/auth/auth.pb.go
+++ b/session/auth/auth.pb.go
@@ -4,6 +4,7 @@
 package auth
 
 import (
+	bytes "bytes"
 	context "context"
 	fmt "fmt"
 	proto "github.com/gogo/protobuf/proto"
@@ -122,30 +123,384 @@ func (m *CredentialsResponse) GetSecret() string {
 	return ""
 }
 
+type FetchTokenRequest struct {
+	ClientID string   `protobuf:"bytes,1,opt,name=ClientID,proto3" json:"ClientID,omitempty"`
+	Host     string   `protobuf:"bytes,2,opt,name=Host,proto3" json:"Host,omitempty"`
+	Realm    string   `protobuf:"bytes,3,opt,name=Realm,proto3" json:"Realm,omitempty"`
+	Service  string   `protobuf:"bytes,4,opt,name=Service,proto3" json:"Service,omitempty"`
+	Scopes   []string `protobuf:"bytes,5,rep,name=Scopes,proto3" json:"Scopes,omitempty"`
+}
+
+func (m *FetchTokenRequest) Reset()      { *m = FetchTokenRequest{} }
+func (*FetchTokenRequest) ProtoMessage() {}
+func (*FetchTokenRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_8bbd6f3875b0e874, []int{2}
+}
+func (m *FetchTokenRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *FetchTokenRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_FetchTokenRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *FetchTokenRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FetchTokenRequest.Merge(m, src)
+}
+func (m *FetchTokenRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *FetchTokenRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_FetchTokenRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_FetchTokenRequest proto.InternalMessageInfo
+
+func (m *FetchTokenRequest) GetClientID() string {
+	if m != nil {
+		return m.ClientID
+	}
+	return ""
+}
+
+func (m *FetchTokenRequest) GetHost() string {
+	if m != nil {
+		return m.Host
+	}
+	return ""
+}
+
+func (m *FetchTokenRequest) GetRealm() string {
+	if m != nil {
+		return m.Realm
+	}
+	return ""
+}
+
+func (m *FetchTokenRequest) GetService() string {
+	if m != nil {
+		return m.Service
+	}
+	return ""
+}
+
+func (m *FetchTokenRequest) GetScopes() []string {
+	if m != nil {
+		return m.Scopes
+	}
+	return nil
+}
+
+type FetchTokenResponse struct {
+	Token     string `protobuf:"bytes,1,opt,name=Token,proto3" json:"Token,omitempty"`
+	ExpiresIn int64  `protobuf:"varint,2,opt,name=ExpiresIn,proto3" json:"ExpiresIn,omitempty"`
+	IssuedAt  int64  `protobuf:"varint,3,opt,name=IssuedAt,proto3" json:"IssuedAt,omitempty"`
+}
+
+func (m *FetchTokenResponse) Reset()      { *m = FetchTokenResponse{} }
+func (*FetchTokenResponse) ProtoMessage() {}
+func (*FetchTokenResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_8bbd6f3875b0e874, []int{3}
+}
+func (m *FetchTokenResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *FetchTokenResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_FetchTokenResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *FetchTokenResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FetchTokenResponse.Merge(m, src)
+}
+func (m *FetchTokenResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *FetchTokenResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_FetchTokenResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_FetchTokenResponse proto.InternalMessageInfo
+
+func (m *FetchTokenResponse) GetToken() string {
+	if m != nil {
+		return m.Token
+	}
+	return ""
+}
+
+func (m *FetchTokenResponse) GetExpiresIn() int64 {
+	if m != nil {
+		return m.ExpiresIn
+	}
+	return 0
+}
+
+func (m *FetchTokenResponse) GetIssuedAt() int64 {
+	if m != nil {
+		return m.IssuedAt
+	}
+	return 0
+}
+
+type GetTokenAuthorityRequest struct {
+	Host string `protobuf:"bytes,1,opt,name=Host,proto3" json:"Host,omitempty"`
+	Salt []byte `protobuf:"bytes,2,opt,name=Salt,proto3" json:"Salt,omitempty"`
+}
+
+func (m *GetTokenAuthorityRequest) Reset()      { *m = GetTokenAuthorityRequest{} }
+func (*GetTokenAuthorityRequest) ProtoMessage() {}
+func (*GetTokenAuthorityRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_8bbd6f3875b0e874, []int{4}
+}
+func (m *GetTokenAuthorityRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *GetTokenAuthorityRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_GetTokenAuthorityRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *GetTokenAuthorityRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetTokenAuthorityRequest.Merge(m, src)
+}
+func (m *GetTokenAuthorityRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *GetTokenAuthorityRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetTokenAuthorityRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GetTokenAuthorityRequest proto.InternalMessageInfo
+
+func (m *GetTokenAuthorityRequest) GetHost() string {
+	if m != nil {
+		return m.Host
+	}
+	return ""
+}
+
+func (m *GetTokenAuthorityRequest) GetSalt() []byte {
+	if m != nil {
+		return m.Salt
+	}
+	return nil
+}
+
+type GetTokenAuthorityResponse struct {
+	PublicKey []byte `protobuf:"bytes,1,opt,name=PublicKey,proto3" json:"PublicKey,omitempty"`
+}
+
+func (m *GetTokenAuthorityResponse) Reset()      { *m = GetTokenAuthorityResponse{} }
+func (*GetTokenAuthorityResponse) ProtoMessage() {}
+func (*GetTokenAuthorityResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_8bbd6f3875b0e874, []int{5}
+}
+func (m *GetTokenAuthorityResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *GetTokenAuthorityResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_GetTokenAuthorityResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *GetTokenAuthorityResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetTokenAuthorityResponse.Merge(m, src)
+}
+func (m *GetTokenAuthorityResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *GetTokenAuthorityResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetTokenAuthorityResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GetTokenAuthorityResponse proto.InternalMessageInfo
+
+func (m *GetTokenAuthorityResponse) GetPublicKey() []byte {
+	if m != nil {
+		return m.PublicKey
+	}
+	return nil
+}
+
+type VerifyTokenAuthorityRequest struct {
+	Host    string `protobuf:"bytes,1,opt,name=Host,proto3" json:"Host,omitempty"`
+	Payload []byte `protobuf:"bytes,2,opt,name=Payload,proto3" json:"Payload,omitempty"`
+	Salt    []byte `protobuf:"bytes,3,opt,name=Salt,proto3" json:"Salt,omitempty"`
+}
+
+func (m *VerifyTokenAuthorityRequest) Reset()      { *m = VerifyTokenAuthorityRequest{} }
+func (*VerifyTokenAuthorityRequest) ProtoMessage() {}
+func (*VerifyTokenAuthorityRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_8bbd6f3875b0e874, []int{6}
+}
+func (m *VerifyTokenAuthorityRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *VerifyTokenAuthorityRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_VerifyTokenAuthorityRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *VerifyTokenAuthorityRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_VerifyTokenAuthorityRequest.Merge(m, src)
+}
+func (m *VerifyTokenAuthorityRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *VerifyTokenAuthorityRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_VerifyTokenAuthorityRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_VerifyTokenAuthorityRequest proto.InternalMessageInfo
+
+func (m *VerifyTokenAuthorityRequest) GetHost() string {
+	if m != nil {
+		return m.Host
+	}
+	return ""
+}
+
+func (m *VerifyTokenAuthorityRequest) GetPayload() []byte {
+	if m != nil {
+		return m.Payload
+	}
+	return nil
+}
+
+func (m *VerifyTokenAuthorityRequest) GetSalt() []byte {
+	if m != nil {
+		return m.Salt
+	}
+	return nil
+}
+
+type VerifyTokenAuthorityResponse struct {
+	Signed []byte `protobuf:"bytes,1,opt,name=Signed,proto3" json:"Signed,omitempty"`
+}
+
+func (m *VerifyTokenAuthorityResponse) Reset()      { *m = VerifyTokenAuthorityResponse{} }
+func (*VerifyTokenAuthorityResponse) ProtoMessage() {}
+func (*VerifyTokenAuthorityResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_8bbd6f3875b0e874, []int{7}
+}
+func (m *VerifyTokenAuthorityResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *VerifyTokenAuthorityResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_VerifyTokenAuthorityResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *VerifyTokenAuthorityResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_VerifyTokenAuthorityResponse.Merge(m, src)
+}
+func (m *VerifyTokenAuthorityResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *VerifyTokenAuthorityResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_VerifyTokenAuthorityResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_VerifyTokenAuthorityResponse proto.InternalMessageInfo
+
+func (m *VerifyTokenAuthorityResponse) GetSigned() []byte {
+	if m != nil {
+		return m.Signed
+	}
+	return nil
+}
+
 func init() {
 	proto.RegisterType((*CredentialsRequest)(nil), "moby.filesync.v1.CredentialsRequest")
 	proto.RegisterType((*CredentialsResponse)(nil), "moby.filesync.v1.CredentialsResponse")
+	proto.RegisterType((*FetchTokenRequest)(nil), "moby.filesync.v1.FetchTokenRequest")
+	proto.RegisterType((*FetchTokenResponse)(nil), "moby.filesync.v1.FetchTokenResponse")
+	proto.RegisterType((*GetTokenAuthorityRequest)(nil), "moby.filesync.v1.GetTokenAuthorityRequest")
+	proto.RegisterType((*GetTokenAuthorityResponse)(nil), "moby.filesync.v1.GetTokenAuthorityResponse")
+	proto.RegisterType((*VerifyTokenAuthorityRequest)(nil), "moby.filesync.v1.VerifyTokenAuthorityRequest")
+	proto.RegisterType((*VerifyTokenAuthorityResponse)(nil), "moby.filesync.v1.VerifyTokenAuthorityResponse")
 }
 
 func init() { proto.RegisterFile("auth.proto", fileDescriptor_8bbd6f3875b0e874) }
 
 var fileDescriptor_8bbd6f3875b0e874 = []byte{
-	// 233 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0xe2, 0x4a, 0x2c, 0x2d, 0xc9,
-	0xd0, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x12, 0xc8, 0xcd, 0x4f, 0xaa, 0xd4, 0x4b, 0xcb, 0xcc,
-	0x49, 0x2d, 0xae, 0xcc, 0x4b, 0xd6, 0x2b, 0x33, 0x54, 0xd2, 0xe0, 0x12, 0x72, 0x2e, 0x4a, 0x4d,
-	0x49, 0xcd, 0x2b, 0xc9, 0x4c, 0xcc, 0x29, 0x0e, 0x4a, 0x2d, 0x2c, 0x4d, 0x2d, 0x2e, 0x11, 0x12,
-	0xe2, 0x62, 0xf1, 0xc8, 0x2f, 0x2e, 0x91, 0x60, 0x54, 0x60, 0xd4, 0xe0, 0x0c, 0x02, 0xb3, 0x95,
-	0x3c, 0xb9, 0x84, 0x51, 0x54, 0x16, 0x17, 0xe4, 0xe7, 0x15, 0xa7, 0x0a, 0x49, 0x71, 0x71, 0x84,
-	0x16, 0xa7, 0x16, 0xe5, 0x25, 0xe6, 0xa6, 0x42, 0x95, 0xc3, 0xf9, 0x42, 0x62, 0x5c, 0x6c, 0xc1,
-	0xa9, 0xc9, 0x45, 0xa9, 0x25, 0x12, 0x4c, 0x60, 0x19, 0x28, 0xcf, 0x28, 0x89, 0x8b, 0xc5, 0xb1,
-	0xb4, 0x24, 0x43, 0x28, 0x8a, 0x8b, 0x1b, 0xc9, 0x48, 0x21, 0x15, 0x3d, 0x74, 0xe7, 0xe9, 0x61,
-	0xba, 0x4d, 0x4a, 0x95, 0x80, 0x2a, 0x88, 0xbb, 0x9c, 0xac, 0x2e, 0x3c, 0x94, 0x63, 0xb8, 0xf1,
-	0x50, 0x8e, 0xe1, 0xc3, 0x43, 0x39, 0xc6, 0x86, 0x47, 0x72, 0x8c, 0x2b, 0x1e, 0xc9, 0x31, 0x9e,
-	0x78, 0x24, 0xc7, 0x78, 0xe1, 0x91, 0x1c, 0xe3, 0x83, 0x47, 0x72, 0x8c, 0x2f, 0x1e, 0xc9, 0x31,
-	0x7c, 0x78, 0x24, 0xc7, 0x38, 0xe1, 0xb1, 0x1c, 0xc3, 0x85, 0xc7, 0x72, 0x0c, 0x37, 0x1e, 0xcb,
-	0x31, 0x44, 0xb1, 0x80, 0x02, 0x2b, 0x89, 0x0d, 0x1c, 0x5a, 0xc6, 0x80, 0x00, 0x00, 0x00, 0xff,
-	0xff, 0x64, 0x61, 0x71, 0x59, 0x3b, 0x01, 0x00, 0x00,
+	// 513 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x94, 0xcd, 0x6e, 0xd3, 0x40,
+	0x10, 0xc7, 0xbd, 0x75, 0xd2, 0x36, 0x43, 0x0f, 0x74, 0x89, 0x90, 0x31, 0xd1, 0xaa, 0x32, 0x45,
+	0xaa, 0x40, 0x58, 0x02, 0x24, 0x24, 0xb8, 0xb5, 0xe5, 0x2b, 0xe2, 0x52, 0x39, 0x7c, 0x48, 0xbd,
+	0x20, 0xc7, 0x9e, 0x12, 0x0b, 0xc7, 0x0e, 0xde, 0x75, 0x85, 0x6f, 0xdc, 0xb9, 0xf0, 0x08, 0x1c,
+	0x79, 0x14, 0x8e, 0x39, 0xf6, 0x48, 0x9c, 0x0b, 0xc7, 0x3c, 0x02, 0xf2, 0x66, 0x9d, 0x04, 0x1c,
+	0xd2, 0xdc, 0xfc, 0x1f, 0xff, 0x77, 0xe6, 0xb7, 0x33, 0xa3, 0x05, 0x70, 0x53, 0xd1, 0xb3, 0x07,
+	0x49, 0x2c, 0x62, 0x7a, 0xb5, 0x1f, 0x77, 0x33, 0xfb, 0x2c, 0x08, 0x91, 0x67, 0x91, 0x67, 0x9f,
+	0xdf, 0xb7, 0x0e, 0x80, 0x1e, 0x27, 0xe8, 0x63, 0x24, 0x02, 0x37, 0xe4, 0x0e, 0x7e, 0x4a, 0x91,
+	0x0b, 0x4a, 0xa1, 0xf6, 0x32, 0xe6, 0xc2, 0x20, 0x7b, 0xe4, 0xa0, 0xe1, 0xc8, 0x6f, 0xab, 0x0d,
+	0xd7, 0xfe, 0x72, 0xf2, 0x41, 0x1c, 0x71, 0xa4, 0x26, 0x6c, 0xbf, 0xe1, 0x98, 0x44, 0x6e, 0x1f,
+	0x95, 0x7d, 0xa6, 0xe9, 0x75, 0xd8, 0xec, 0xa0, 0x97, 0xa0, 0x30, 0x36, 0xe4, 0x1f, 0xa5, 0xac,
+	0xaf, 0x04, 0x76, 0x9f, 0xa3, 0xf0, 0x7a, 0xaf, 0xe3, 0x8f, 0x18, 0x95, 0x45, 0x4d, 0xd8, 0x3e,
+	0x0e, 0x03, 0x8c, 0x44, 0xfb, 0x69, 0x99, 0xa9, 0xd4, 0x33, 0xa0, 0x8d, 0x39, 0x10, 0x6d, 0x42,
+	0xdd, 0x41, 0x37, 0xec, 0x1b, 0xba, 0x0c, 0x4e, 0x05, 0x35, 0x60, 0xab, 0x83, 0xc9, 0x79, 0xe0,
+	0xa1, 0x51, 0x93, 0xf1, 0x52, 0x4a, 0x1a, 0x2f, 0x1e, 0x20, 0x37, 0xea, 0x7b, 0xba, 0xa4, 0x91,
+	0xca, 0xf2, 0x81, 0x2e, 0xc2, 0xa8, 0x7b, 0x35, 0xa1, 0x2e, 0x03, 0x0a, 0x65, 0x2a, 0x68, 0x0b,
+	0x1a, 0xcf, 0x3e, 0x0f, 0x82, 0x04, 0x79, 0x3b, 0x92, 0x30, 0xba, 0x33, 0x0f, 0x14, 0x37, 0x68,
+	0x73, 0x9e, 0xa2, 0x7f, 0x28, 0x24, 0x94, 0xee, 0xcc, 0xb4, 0x75, 0x04, 0xc6, 0x0b, 0x14, 0x32,
+	0xcb, 0x61, 0x2a, 0x7a, 0x71, 0x12, 0x88, 0x6c, 0x45, 0xbb, 0x8b, 0x58, 0xc7, 0x0d, 0xa7, 0x37,
+	0xde, 0x71, 0xe4, 0xb7, 0xf5, 0x18, 0x6e, 0x2c, 0xc9, 0xa1, 0x80, 0x5b, 0xd0, 0x38, 0x49, 0xbb,
+	0x61, 0xe0, 0xbd, 0xc2, 0x4c, 0x66, 0xda, 0x71, 0xe6, 0x01, 0xeb, 0x3d, 0xdc, 0x7c, 0x8b, 0x49,
+	0x70, 0x96, 0xad, 0x4f, 0x60, 0xc0, 0xd6, 0x89, 0x9b, 0x85, 0xb1, 0xeb, 0x2b, 0x88, 0x52, 0xce,
+	0xd8, 0xf4, 0x05, 0xb6, 0x47, 0xd0, 0x5a, 0x5e, 0x40, 0xe1, 0x15, 0xdd, 0x0f, 0x3e, 0x44, 0xe8,
+	0x2b, 0x36, 0xa5, 0x1e, 0x7c, 0xd7, 0xa1, 0x56, 0xb8, 0xe9, 0x29, 0x5c, 0x59, 0xd8, 0x2f, 0xba,
+	0x6f, 0xff, 0xbb, 0xab, 0x76, 0x75, 0x51, 0xcd, 0xdb, 0x97, 0xb8, 0x54, 0xf1, 0x77, 0x00, 0xf3,
+	0x11, 0xd3, 0x5b, 0xd5, 0x43, 0x95, 0x6d, 0x34, 0xf7, 0x57, 0x9b, 0x54, 0xe2, 0x10, 0x76, 0x2b,
+	0x13, 0xa1, 0x77, 0xaa, 0x47, 0xff, 0x37, 0x7a, 0xf3, 0xee, 0x5a, 0x5e, 0x55, 0x2d, 0x85, 0xe6,
+	0xb2, 0x1e, 0xd3, 0x7b, 0xd5, 0x24, 0x2b, 0x86, 0x6d, 0xda, 0xeb, 0xda, 0xa7, 0x65, 0x8f, 0x9e,
+	0x0c, 0x47, 0x4c, 0xbb, 0x18, 0x31, 0x6d, 0x32, 0x62, 0xe4, 0x4b, 0xce, 0xc8, 0x8f, 0x9c, 0x91,
+	0x9f, 0x39, 0x23, 0xc3, 0x9c, 0x91, 0x5f, 0x39, 0x23, 0xbf, 0x73, 0xa6, 0x4d, 0x72, 0x46, 0xbe,
+	0x8d, 0x99, 0x36, 0x1c, 0x33, 0xed, 0x62, 0xcc, 0xb4, 0xd3, 0x5a, 0xf1, 0xee, 0x74, 0x37, 0xe5,
+	0xc3, 0xf3, 0xf0, 0x4f, 0x00, 0x00, 0x00, 0xff, 0xff, 0xba, 0xb3, 0x18, 0x70, 0x86, 0x04, 0x00,
+	0x00,
 }
 
 func (this *CredentialsRequest) Equal(that interface{}) bool {
@@ -199,6 +554,182 @@ func (this *CredentialsResponse) Equal(that interface{}) bool {
 	}
 	return true
 }
+func (this *FetchTokenRequest) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*FetchTokenRequest)
+	if !ok {
+		that2, ok := that.(FetchTokenRequest)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.ClientID != that1.ClientID {
+		return false
+	}
+	if this.Host != that1.Host {
+		return false
+	}
+	if this.Realm != that1.Realm {
+		return false
+	}
+	if this.Service != that1.Service {
+		return false
+	}
+	if len(this.Scopes) != len(that1.Scopes) {
+		return false
+	}
+	for i := range this.Scopes {
+		if this.Scopes[i] != that1.Scopes[i] {
+			return false
+		}
+	}
+	return true
+}
+func (this *FetchTokenResponse) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*FetchTokenResponse)
+	if !ok {
+		that2, ok := that.(FetchTokenResponse)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Token != that1.Token {
+		return false
+	}
+	if this.ExpiresIn != that1.ExpiresIn {
+		return false
+	}
+	if this.IssuedAt != that1.IssuedAt {
+		return false
+	}
+	return true
+}
+func (this *GetTokenAuthorityRequest) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*GetTokenAuthorityRequest)
+	if !ok {
+		that2, ok := that.(GetTokenAuthorityRequest)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Host != that1.Host {
+		return false
+	}
+	if !bytes.Equal(this.Salt, that1.Salt) {
+		return false
+	}
+	return true
+}
+func (this *GetTokenAuthorityResponse) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*GetTokenAuthorityResponse)
+	if !ok {
+		that2, ok := that.(GetTokenAuthorityResponse)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if !bytes.Equal(this.PublicKey, that1.PublicKey) {
+		return false
+	}
+	return true
+}
+func (this *VerifyTokenAuthorityRequest) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*VerifyTokenAuthorityRequest)
+	if !ok {
+		that2, ok := that.(VerifyTokenAuthorityRequest)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Host != that1.Host {
+		return false
+	}
+	if !bytes.Equal(this.Payload, that1.Payload) {
+		return false
+	}
+	if !bytes.Equal(this.Salt, that1.Salt) {
+		return false
+	}
+	return true
+}
+func (this *VerifyTokenAuthorityResponse) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*VerifyTokenAuthorityResponse)
+	if !ok {
+		that2, ok := that.(VerifyTokenAuthorityResponse)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if !bytes.Equal(this.Signed, that1.Signed) {
+		return false
+	}
+	return true
+}
 func (this *CredentialsRequest) GoString() string {
 	if this == nil {
 		return "nil"
@@ -217,6 +748,75 @@ func (this *CredentialsResponse) GoString() string {
 	s = append(s, "&auth.CredentialsResponse{")
 	s = append(s, "Username: "+fmt.Sprintf("%#v", this.Username)+",\n")
 	s = append(s, "Secret: "+fmt.Sprintf("%#v", this.Secret)+",\n")
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *FetchTokenRequest) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 9)
+	s = append(s, "&auth.FetchTokenRequest{")
+	s = append(s, "ClientID: "+fmt.Sprintf("%#v", this.ClientID)+",\n")
+	s = append(s, "Host: "+fmt.Sprintf("%#v", this.Host)+",\n")
+	s = append(s, "Realm: "+fmt.Sprintf("%#v", this.Realm)+",\n")
+	s = append(s, "Service: "+fmt.Sprintf("%#v", this.Service)+",\n")
+	s = append(s, "Scopes: "+fmt.Sprintf("%#v", this.Scopes)+",\n")
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *FetchTokenResponse) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 7)
+	s = append(s, "&auth.FetchTokenResponse{")
+	s = append(s, "Token: "+fmt.Sprintf("%#v", this.Token)+",\n")
+	s = append(s, "ExpiresIn: "+fmt.Sprintf("%#v", this.ExpiresIn)+",\n")
+	s = append(s, "IssuedAt: "+fmt.Sprintf("%#v", this.IssuedAt)+",\n")
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *GetTokenAuthorityRequest) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 6)
+	s = append(s, "&auth.GetTokenAuthorityRequest{")
+	s = append(s, "Host: "+fmt.Sprintf("%#v", this.Host)+",\n")
+	s = append(s, "Salt: "+fmt.Sprintf("%#v", this.Salt)+",\n")
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *GetTokenAuthorityResponse) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 5)
+	s = append(s, "&auth.GetTokenAuthorityResponse{")
+	s = append(s, "PublicKey: "+fmt.Sprintf("%#v", this.PublicKey)+",\n")
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *VerifyTokenAuthorityRequest) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 7)
+	s = append(s, "&auth.VerifyTokenAuthorityRequest{")
+	s = append(s, "Host: "+fmt.Sprintf("%#v", this.Host)+",\n")
+	s = append(s, "Payload: "+fmt.Sprintf("%#v", this.Payload)+",\n")
+	s = append(s, "Salt: "+fmt.Sprintf("%#v", this.Salt)+",\n")
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *VerifyTokenAuthorityResponse) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 5)
+	s = append(s, "&auth.VerifyTokenAuthorityResponse{")
+	s = append(s, "Signed: "+fmt.Sprintf("%#v", this.Signed)+",\n")
 	s = append(s, "}")
 	return strings.Join(s, "")
 }
@@ -242,6 +842,9 @@ const _ = grpc.SupportPackageIsVersion4
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type AuthClient interface {
 	Credentials(ctx context.Context, in *CredentialsRequest, opts ...grpc.CallOption) (*CredentialsResponse, error)
+	FetchToken(ctx context.Context, in *FetchTokenRequest, opts ...grpc.CallOption) (*FetchTokenResponse, error)
+	GetTokenAuthority(ctx context.Context, in *GetTokenAuthorityRequest, opts ...grpc.CallOption) (*GetTokenAuthorityResponse, error)
+	VerifyTokenAuthority(ctx context.Context, in *VerifyTokenAuthorityRequest, opts ...grpc.CallOption) (*VerifyTokenAuthorityResponse, error)
 }
 
 type authClient struct {
@@ -261,9 +864,39 @@ func (c *authClient) Credentials(ctx context.Context, in *CredentialsRequest, op
 	return out, nil
 }
 
+func (c *authClient) FetchToken(ctx context.Context, in *FetchTokenRequest, opts ...grpc.CallOption) (*FetchTokenResponse, error) {
+	out := new(FetchTokenResponse)
+	err := c.cc.Invoke(ctx, "/moby.filesync.v1.Auth/FetchToken", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *authClient) GetTokenAuthority(ctx context.Context, in *GetTokenAuthorityRequest, opts ...grpc.CallOption) (*GetTokenAuthorityResponse, error) {
+	out := new(GetTokenAuthorityResponse)
+	err := c.cc.Invoke(ctx, "/moby.filesync.v1.Auth/GetTokenAuthority", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *authClient) VerifyTokenAuthority(ctx context.Context, in *VerifyTokenAuthorityRequest, opts ...grpc.CallOption) (*VerifyTokenAuthorityResponse, error) {
+	out := new(VerifyTokenAuthorityResponse)
+	err := c.cc.Invoke(ctx, "/moby.filesync.v1.Auth/VerifyTokenAuthority", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // AuthServer is the server API for Auth service.
 type AuthServer interface {
 	Credentials(context.Context, *CredentialsRequest) (*CredentialsResponse, error)
+	FetchToken(context.Context, *FetchTokenRequest) (*FetchTokenResponse, error)
+	GetTokenAuthority(context.Context, *GetTokenAuthorityRequest) (*GetTokenAuthorityResponse, error)
+	VerifyTokenAuthority(context.Context, *VerifyTokenAuthorityRequest) (*VerifyTokenAuthorityResponse, error)
 }
 
 // UnimplementedAuthServer can be embedded to have forward compatible implementations.
@@ -272,6 +905,15 @@ type UnimplementedAuthServer struct {
 
 func (*UnimplementedAuthServer) Credentials(ctx context.Context, req *CredentialsRequest) (*CredentialsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Credentials not implemented")
+}
+func (*UnimplementedAuthServer) FetchToken(ctx context.Context, req *FetchTokenRequest) (*FetchTokenResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method FetchToken not implemented")
+}
+func (*UnimplementedAuthServer) GetTokenAuthority(ctx context.Context, req *GetTokenAuthorityRequest) (*GetTokenAuthorityResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetTokenAuthority not implemented")
+}
+func (*UnimplementedAuthServer) VerifyTokenAuthority(ctx context.Context, req *VerifyTokenAuthorityRequest) (*VerifyTokenAuthorityResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method VerifyTokenAuthority not implemented")
 }
 
 func RegisterAuthServer(s *grpc.Server, srv AuthServer) {
@@ -296,6 +938,60 @@ func _Auth_Credentials_Handler(srv interface{}, ctx context.Context, dec func(in
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Auth_FetchToken_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(FetchTokenRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AuthServer).FetchToken(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/moby.filesync.v1.Auth/FetchToken",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AuthServer).FetchToken(ctx, req.(*FetchTokenRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Auth_GetTokenAuthority_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetTokenAuthorityRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AuthServer).GetTokenAuthority(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/moby.filesync.v1.Auth/GetTokenAuthority",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AuthServer).GetTokenAuthority(ctx, req.(*GetTokenAuthorityRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Auth_VerifyTokenAuthority_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(VerifyTokenAuthorityRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AuthServer).VerifyTokenAuthority(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/moby.filesync.v1.Auth/VerifyTokenAuthority",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AuthServer).VerifyTokenAuthority(ctx, req.(*VerifyTokenAuthorityRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Auth_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "moby.filesync.v1.Auth",
 	HandlerType: (*AuthServer)(nil),
@@ -303,6 +999,18 @@ var _Auth_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Credentials",
 			Handler:    _Auth_Credentials_Handler,
+		},
+		{
+			MethodName: "FetchToken",
+			Handler:    _Auth_FetchToken_Handler,
+		},
+		{
+			MethodName: "GetTokenAuthority",
+			Handler:    _Auth_GetTokenAuthority_Handler,
+		},
+		{
+			MethodName: "VerifyTokenAuthority",
+			Handler:    _Auth_VerifyTokenAuthority_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -376,6 +1084,247 @@ func (m *CredentialsResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *FetchTokenRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *FetchTokenRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *FetchTokenRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Scopes) > 0 {
+		for iNdEx := len(m.Scopes) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Scopes[iNdEx])
+			copy(dAtA[i:], m.Scopes[iNdEx])
+			i = encodeVarintAuth(dAtA, i, uint64(len(m.Scopes[iNdEx])))
+			i--
+			dAtA[i] = 0x2a
+		}
+	}
+	if len(m.Service) > 0 {
+		i -= len(m.Service)
+		copy(dAtA[i:], m.Service)
+		i = encodeVarintAuth(dAtA, i, uint64(len(m.Service)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.Realm) > 0 {
+		i -= len(m.Realm)
+		copy(dAtA[i:], m.Realm)
+		i = encodeVarintAuth(dAtA, i, uint64(len(m.Realm)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.Host) > 0 {
+		i -= len(m.Host)
+		copy(dAtA[i:], m.Host)
+		i = encodeVarintAuth(dAtA, i, uint64(len(m.Host)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.ClientID) > 0 {
+		i -= len(m.ClientID)
+		copy(dAtA[i:], m.ClientID)
+		i = encodeVarintAuth(dAtA, i, uint64(len(m.ClientID)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *FetchTokenResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *FetchTokenResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *FetchTokenResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.IssuedAt != 0 {
+		i = encodeVarintAuth(dAtA, i, uint64(m.IssuedAt))
+		i--
+		dAtA[i] = 0x18
+	}
+	if m.ExpiresIn != 0 {
+		i = encodeVarintAuth(dAtA, i, uint64(m.ExpiresIn))
+		i--
+		dAtA[i] = 0x10
+	}
+	if len(m.Token) > 0 {
+		i -= len(m.Token)
+		copy(dAtA[i:], m.Token)
+		i = encodeVarintAuth(dAtA, i, uint64(len(m.Token)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GetTokenAuthorityRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetTokenAuthorityRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *GetTokenAuthorityRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Salt) > 0 {
+		i -= len(m.Salt)
+		copy(dAtA[i:], m.Salt)
+		i = encodeVarintAuth(dAtA, i, uint64(len(m.Salt)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Host) > 0 {
+		i -= len(m.Host)
+		copy(dAtA[i:], m.Host)
+		i = encodeVarintAuth(dAtA, i, uint64(len(m.Host)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GetTokenAuthorityResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetTokenAuthorityResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *GetTokenAuthorityResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.PublicKey) > 0 {
+		i -= len(m.PublicKey)
+		copy(dAtA[i:], m.PublicKey)
+		i = encodeVarintAuth(dAtA, i, uint64(len(m.PublicKey)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *VerifyTokenAuthorityRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *VerifyTokenAuthorityRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *VerifyTokenAuthorityRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Salt) > 0 {
+		i -= len(m.Salt)
+		copy(dAtA[i:], m.Salt)
+		i = encodeVarintAuth(dAtA, i, uint64(len(m.Salt)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.Payload) > 0 {
+		i -= len(m.Payload)
+		copy(dAtA[i:], m.Payload)
+		i = encodeVarintAuth(dAtA, i, uint64(len(m.Payload)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Host) > 0 {
+		i -= len(m.Host)
+		copy(dAtA[i:], m.Host)
+		i = encodeVarintAuth(dAtA, i, uint64(len(m.Host)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *VerifyTokenAuthorityResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *VerifyTokenAuthorityResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *VerifyTokenAuthorityResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Signed) > 0 {
+		i -= len(m.Signed)
+		copy(dAtA[i:], m.Signed)
+		i = encodeVarintAuth(dAtA, i, uint64(len(m.Signed)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintAuth(dAtA []byte, offset int, v uint64) int {
 	offset -= sovAuth(v)
 	base := offset
@@ -417,6 +1366,120 @@ func (m *CredentialsResponse) Size() (n int) {
 	return n
 }
 
+func (m *FetchTokenRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.ClientID)
+	if l > 0 {
+		n += 1 + l + sovAuth(uint64(l))
+	}
+	l = len(m.Host)
+	if l > 0 {
+		n += 1 + l + sovAuth(uint64(l))
+	}
+	l = len(m.Realm)
+	if l > 0 {
+		n += 1 + l + sovAuth(uint64(l))
+	}
+	l = len(m.Service)
+	if l > 0 {
+		n += 1 + l + sovAuth(uint64(l))
+	}
+	if len(m.Scopes) > 0 {
+		for _, s := range m.Scopes {
+			l = len(s)
+			n += 1 + l + sovAuth(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *FetchTokenResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Token)
+	if l > 0 {
+		n += 1 + l + sovAuth(uint64(l))
+	}
+	if m.ExpiresIn != 0 {
+		n += 1 + sovAuth(uint64(m.ExpiresIn))
+	}
+	if m.IssuedAt != 0 {
+		n += 1 + sovAuth(uint64(m.IssuedAt))
+	}
+	return n
+}
+
+func (m *GetTokenAuthorityRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Host)
+	if l > 0 {
+		n += 1 + l + sovAuth(uint64(l))
+	}
+	l = len(m.Salt)
+	if l > 0 {
+		n += 1 + l + sovAuth(uint64(l))
+	}
+	return n
+}
+
+func (m *GetTokenAuthorityResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.PublicKey)
+	if l > 0 {
+		n += 1 + l + sovAuth(uint64(l))
+	}
+	return n
+}
+
+func (m *VerifyTokenAuthorityRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Host)
+	if l > 0 {
+		n += 1 + l + sovAuth(uint64(l))
+	}
+	l = len(m.Payload)
+	if l > 0 {
+		n += 1 + l + sovAuth(uint64(l))
+	}
+	l = len(m.Salt)
+	if l > 0 {
+		n += 1 + l + sovAuth(uint64(l))
+	}
+	return n
+}
+
+func (m *VerifyTokenAuthorityResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Signed)
+	if l > 0 {
+		n += 1 + l + sovAuth(uint64(l))
+	}
+	return n
+}
+
 func sovAuth(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
@@ -440,6 +1503,75 @@ func (this *CredentialsResponse) String() string {
 	s := strings.Join([]string{`&CredentialsResponse{`,
 		`Username:` + fmt.Sprintf("%v", this.Username) + `,`,
 		`Secret:` + fmt.Sprintf("%v", this.Secret) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *FetchTokenRequest) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&FetchTokenRequest{`,
+		`ClientID:` + fmt.Sprintf("%v", this.ClientID) + `,`,
+		`Host:` + fmt.Sprintf("%v", this.Host) + `,`,
+		`Realm:` + fmt.Sprintf("%v", this.Realm) + `,`,
+		`Service:` + fmt.Sprintf("%v", this.Service) + `,`,
+		`Scopes:` + fmt.Sprintf("%v", this.Scopes) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *FetchTokenResponse) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&FetchTokenResponse{`,
+		`Token:` + fmt.Sprintf("%v", this.Token) + `,`,
+		`ExpiresIn:` + fmt.Sprintf("%v", this.ExpiresIn) + `,`,
+		`IssuedAt:` + fmt.Sprintf("%v", this.IssuedAt) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *GetTokenAuthorityRequest) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&GetTokenAuthorityRequest{`,
+		`Host:` + fmt.Sprintf("%v", this.Host) + `,`,
+		`Salt:` + fmt.Sprintf("%v", this.Salt) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *GetTokenAuthorityResponse) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&GetTokenAuthorityResponse{`,
+		`PublicKey:` + fmt.Sprintf("%v", this.PublicKey) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *VerifyTokenAuthorityRequest) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&VerifyTokenAuthorityRequest{`,
+		`Host:` + fmt.Sprintf("%v", this.Host) + `,`,
+		`Payload:` + fmt.Sprintf("%v", this.Payload) + `,`,
+		`Salt:` + fmt.Sprintf("%v", this.Salt) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *VerifyTokenAuthorityResponse) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&VerifyTokenAuthorityResponse{`,
+		`Signed:` + fmt.Sprintf("%v", this.Signed) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -629,6 +1761,788 @@ func (m *CredentialsResponse) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Secret = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipAuth(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthAuth
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthAuth
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *FetchTokenRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowAuth
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: FetchTokenRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: FetchTokenRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ClientID", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAuth
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthAuth
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthAuth
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ClientID = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Host", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAuth
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthAuth
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthAuth
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Host = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Realm", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAuth
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthAuth
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthAuth
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Realm = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Service", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAuth
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthAuth
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthAuth
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Service = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Scopes", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAuth
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthAuth
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthAuth
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Scopes = append(m.Scopes, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipAuth(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthAuth
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthAuth
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *FetchTokenResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowAuth
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: FetchTokenResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: FetchTokenResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Token", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAuth
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthAuth
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthAuth
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Token = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ExpiresIn", wireType)
+			}
+			m.ExpiresIn = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAuth
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.ExpiresIn |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field IssuedAt", wireType)
+			}
+			m.IssuedAt = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAuth
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.IssuedAt |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipAuth(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthAuth
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthAuth
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetTokenAuthorityRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowAuth
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetTokenAuthorityRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetTokenAuthorityRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Host", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAuth
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthAuth
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthAuth
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Host = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Salt", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAuth
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthAuth
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthAuth
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Salt = append(m.Salt[:0], dAtA[iNdEx:postIndex]...)
+			if m.Salt == nil {
+				m.Salt = []byte{}
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipAuth(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthAuth
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthAuth
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetTokenAuthorityResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowAuth
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetTokenAuthorityResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetTokenAuthorityResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PublicKey", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAuth
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthAuth
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthAuth
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.PublicKey = append(m.PublicKey[:0], dAtA[iNdEx:postIndex]...)
+			if m.PublicKey == nil {
+				m.PublicKey = []byte{}
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipAuth(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthAuth
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthAuth
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *VerifyTokenAuthorityRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowAuth
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: VerifyTokenAuthorityRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: VerifyTokenAuthorityRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Host", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAuth
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthAuth
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthAuth
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Host = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Payload", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAuth
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthAuth
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthAuth
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Payload = append(m.Payload[:0], dAtA[iNdEx:postIndex]...)
+			if m.Payload == nil {
+				m.Payload = []byte{}
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Salt", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAuth
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthAuth
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthAuth
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Salt = append(m.Salt[:0], dAtA[iNdEx:postIndex]...)
+			if m.Salt == nil {
+				m.Salt = []byte{}
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipAuth(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthAuth
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthAuth
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *VerifyTokenAuthorityResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowAuth
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: VerifyTokenAuthorityResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: VerifyTokenAuthorityResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Signed", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAuth
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthAuth
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthAuth
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Signed = append(m.Signed[:0], dAtA[iNdEx:postIndex]...)
+			if m.Signed == nil {
+				m.Signed = []byte{}
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/session/auth/auth.proto
+++ b/session/auth/auth.proto
@@ -6,8 +6,10 @@ option go_package = "auth";
 
 service Auth{
   rpc Credentials(CredentialsRequest) returns (CredentialsResponse);
+  rpc FetchToken(FetchTokenRequest) returns (FetchTokenResponse);
+  rpc GetTokenAuthority(GetTokenAuthorityRequest) returns (GetTokenAuthorityResponse);
+  rpc VerifyTokenAuthority(VerifyTokenAuthorityRequest) returns (VerifyTokenAuthorityResponse);
 }
-
 
 message CredentialsRequest {
 	string Host = 1;
@@ -16,4 +18,37 @@ message CredentialsRequest {
 message CredentialsResponse {
 	string Username = 1;
 	string Secret = 2;
+}
+
+message FetchTokenRequest {
+	string ClientID = 1;
+	string Host = 2;
+	string Realm = 3;
+	string Service = 4;
+	repeated string Scopes = 5;
+}
+
+message FetchTokenResponse {
+	string Token = 1;
+	int64 ExpiresIn = 2; // seconds
+	int64 IssuedAt = 3; // timestamp
+}
+
+message GetTokenAuthorityRequest {
+	string Host = 1;
+	bytes Salt = 2;
+}
+
+message GetTokenAuthorityResponse {
+	bytes PublicKey = 1;
+}
+
+message VerifyTokenAuthorityRequest {
+	string Host = 1;
+	bytes Payload = 2;
+	bytes Salt = 3;
+}
+
+message VerifyTokenAuthorityResponse {
+	bytes Signed = 1;
 }

--- a/session/auth/authprovider/authprovider.go
+++ b/session/auth/authprovider/authprovider.go
@@ -2,24 +2,46 @@ package authprovider
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
 	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
 	"sync"
+	"time"
 
+	authutil "github.com/containerd/containerd/remotes/docker/auth"
+	remoteserrors "github.com/containerd/containerd/remotes/errors"
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/auth"
+	"github.com/moby/buildkit/util/progress/progresswriter"
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/nacl/sign"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func NewDockerAuthProvider(stderr io.Writer) session.Attachable {
 	return &authProvider{
-		config: config.LoadDefaultConfigFile(stderr),
+		config:      config.LoadDefaultConfigFile(stderr),
+		seeds:       &tokenSeeds{dir: config.Dir()},
+		loggerCache: map[string]struct{}{},
 	}
 }
 
 type authProvider struct {
-	config *configfile.ConfigFile
+	config      *configfile.ConfigFile
+	seeds       *tokenSeeds
+	logger      progresswriter.Logger
+	loggerCache map[string]struct{}
 
 	// The need for this mutex is not well understood.
 	// Without it, the docker cli on OS X hangs when
@@ -28,17 +50,80 @@ type authProvider struct {
 	mu sync.Mutex
 }
 
+func (ap *authProvider) SetLogger(l progresswriter.Logger) {
+	ap.mu.Lock()
+	ap.logger = l
+	ap.mu.Unlock()
+}
+
 func (ap *authProvider) Register(server *grpc.Server) {
 	auth.RegisterAuthServer(server, ap)
 }
 
-func (ap *authProvider) Credentials(ctx context.Context, req *auth.CredentialsRequest) (*auth.CredentialsResponse, error) {
+func (ap *authProvider) FetchToken(ctx context.Context, req *auth.FetchTokenRequest) (rr *auth.FetchTokenResponse, err error) {
+	creds, err := ap.credentials(req.Host)
+	if err != nil {
+		return nil, err
+	}
+
+	to := authutil.TokenOptions{
+		Realm:    req.Realm,
+		Service:  req.Service,
+		Scopes:   req.Scopes,
+		Username: creds.Username,
+		Secret:   creds.Secret,
+	}
+
+	if creds.Secret != "" {
+		done := func(progresswriter.SubLogger) error {
+			return err
+		}
+		defer func() {
+			err = errors.Wrap(err, "failed to fetch oauth token")
+		}()
+		ap.mu.Lock()
+		name := fmt.Sprintf("[auth] %v token for %s", strings.Join(trimScopePrefix(req.Scopes), " "), req.Host)
+		if _, ok := ap.loggerCache[name]; !ok {
+			progresswriter.Wrap(name, ap.logger, done)
+		}
+		ap.mu.Unlock()
+		// try GET first because Docker Hub does not support POST
+		// switch once support has landed
+		resp, err := authutil.FetchToken(ctx, http.DefaultClient, nil, to)
+		if err != nil {
+			var errStatus remoteserrors.ErrUnexpectedStatus
+			if errors.As(err, &errStatus) {
+				// retry with POST request
+				// As of September 2017, GCR is known to return 404.
+				// As of February 2018, JFrog Artifactory is known to return 401.
+				if (errStatus.StatusCode == 405 && to.Username != "") || errStatus.StatusCode == 404 || errStatus.StatusCode == 401 {
+					resp, err := authutil.FetchTokenWithOAuth(ctx, http.DefaultClient, nil, "buildkit-client", to)
+					if err != nil {
+						return nil, err
+					}
+
+					return toTokenResponse(resp.AccessToken, resp.IssuedAt, resp.ExpiresIn), nil
+				}
+			}
+			return nil, err
+		}
+		return toTokenResponse(resp.Token, resp.IssuedAt, resp.ExpiresIn), nil
+	}
+	// do request anonymously
+	resp, err := authutil.FetchToken(ctx, http.DefaultClient, nil, to)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to fetch anonymous token")
+	}
+	return toTokenResponse(resp.Token, resp.IssuedAt, resp.ExpiresIn), nil
+}
+
+func (ap *authProvider) credentials(host string) (*auth.CredentialsResponse, error) {
 	ap.mu.Lock()
 	defer ap.mu.Unlock()
-	if req.Host == "registry-1.docker.io" {
-		req.Host = "https://index.docker.io/v1/"
+	if host == "registry-1.docker.io" {
+		host = "https://index.docker.io/v1/"
 	}
-	ac, err := ap.config.GetAuthConfig(req.Host)
+	ac, err := ap.config.GetAuthConfig(host)
 	if err != nil {
 		return nil, err
 	}
@@ -50,4 +135,86 @@ func (ap *authProvider) Credentials(ctx context.Context, req *auth.CredentialsRe
 		res.Secret = ac.Password
 	}
 	return res, nil
+}
+
+func (ap *authProvider) Credentials(ctx context.Context, req *auth.CredentialsRequest) (*auth.CredentialsResponse, error) {
+	resp, err := ap.credentials(req.Host)
+	if err != nil || resp.Secret != "" {
+		ap.mu.Lock()
+		defer ap.mu.Unlock()
+		_, ok := ap.loggerCache[req.Host]
+		ap.loggerCache[req.Host] = struct{}{}
+		if !ok {
+			return resp, progresswriter.Wrap(fmt.Sprintf("[auth] sharing credentials for %s", req.Host), ap.logger, func(progresswriter.SubLogger) error {
+				return err
+			})
+		}
+	}
+	return resp, err
+}
+
+func (ap *authProvider) GetTokenAuthority(ctx context.Context, req *auth.GetTokenAuthorityRequest) (*auth.GetTokenAuthorityResponse, error) {
+	key, err := ap.getAuthorityKey(req.Host, req.Salt)
+	if err != nil {
+		return nil, err
+	}
+
+	return &auth.GetTokenAuthorityResponse{PublicKey: key[32:]}, nil
+}
+
+func (ap *authProvider) VerifyTokenAuthority(ctx context.Context, req *auth.VerifyTokenAuthorityRequest) (*auth.VerifyTokenAuthorityResponse, error) {
+	key, err := ap.getAuthorityKey(req.Host, req.Salt)
+	if err != nil {
+		return nil, err
+	}
+
+	priv := new([64]byte)
+	copy((*priv)[:], key)
+
+	return &auth.VerifyTokenAuthorityResponse{Signed: sign.Sign(nil, req.Payload, priv)}, nil
+}
+
+func (ap *authProvider) getAuthorityKey(host string, salt []byte) (ed25519.PrivateKey, error) {
+	if v, err := strconv.ParseBool(os.Getenv("BUILDKIT_NO_CLIENT_TOKEN")); err == nil && v {
+		return nil, status.Errorf(codes.Unavailable, "client side tokens disabled")
+	}
+
+	creds, err := ap.credentials(host)
+	if err != nil {
+		return nil, err
+	}
+	seed, err := ap.seeds.getSeed(host)
+	if err != nil {
+		return nil, err
+	}
+
+	mac := hmac.New(sha256.New, salt)
+	if creds.Secret != "" {
+		mac.Write(seed)
+		enc := json.NewEncoder(mac)
+		enc.Encode(creds)
+	}
+
+	sum := mac.Sum(nil)
+
+	return ed25519.NewKeyFromSeed(sum[:ed25519.SeedSize]), nil
+}
+
+func toTokenResponse(token string, issuedAt time.Time, expires int) *auth.FetchTokenResponse {
+	resp := &auth.FetchTokenResponse{
+		Token:     token,
+		ExpiresIn: int64(expires),
+	}
+	if !issuedAt.IsZero() {
+		resp.IssuedAt = issuedAt.Unix()
+	}
+	return resp
+}
+
+func trimScopePrefix(scopes []string) []string {
+	out := make([]string, len(scopes))
+	for i, s := range scopes {
+		out[i] = strings.TrimPrefix(s, "repository:")
+	}
+	return out
 }

--- a/session/auth/authprovider/tokenseed.go
+++ b/session/auth/authprovider/tokenseed.go
@@ -1,0 +1,73 @@
+package authprovider
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/gofrs/flock"
+	"github.com/pkg/errors"
+)
+
+type tokenSeeds struct {
+	mu  sync.Mutex
+	dir string
+}
+
+type seed struct {
+	Seed []byte
+}
+
+func (ts *tokenSeeds) getSeed(host string) ([]byte, error) {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	if err := os.MkdirAll(ts.dir, 0755); err != nil {
+		return nil, err
+	}
+
+	l := flock.New(filepath.Join(ts.dir, ".token_seed.lock"))
+	if err := l.Lock(); err != nil {
+		return nil, err
+	}
+	defer l.Unlock()
+
+	// we include client side randomness to avoid chosen plaintext attack from the daemon side
+	fp := filepath.Join(ts.dir, ".token_seed")
+	dt, err := ioutil.ReadFile(fp)
+	m := map[string]seed{}
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+	} else {
+		if err := json.Unmarshal(dt, &m); err != nil {
+			return nil, errors.Wrapf(err, "failed to parse %s", fp)
+		}
+	}
+	v, ok := m[host]
+	if !ok {
+		v = seed{Seed: newSeed()}
+	}
+
+	m[host] = v
+
+	dt, err = json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := ioutil.WriteFile(fp, dt, 0600); err != nil {
+		return nil, err
+	}
+	return v.Seed, nil
+}
+
+func newSeed() []byte {
+	b := make([]byte, 16)
+	rand.Read(b)
+	return b
+}

--- a/util/progress/progresswriter/multiwriter.go
+++ b/util/progress/progresswriter/multiwriter.go
@@ -1,0 +1,106 @@
+package progresswriter
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/moby/buildkit/client"
+	"golang.org/x/sync/errgroup"
+)
+
+type MultiWriter struct {
+	w     Writer
+	eg    *errgroup.Group
+	once  sync.Once
+	ready chan struct{}
+}
+
+func (mw *MultiWriter) WithPrefix(pfx string, force bool) Writer {
+	in := make(chan *client.SolveStatus)
+	out := mw.w.Status()
+	p := &prefixed{
+		main: mw.w,
+		in:   in,
+	}
+	mw.eg.Go(func() error {
+		mw.once.Do(func() {
+			close(mw.ready)
+		})
+		for {
+			select {
+			case v, ok := <-in:
+				if ok {
+					if force {
+						for _, v := range v.Vertexes {
+							v.Name = addPrefix(pfx, v.Name)
+						}
+					}
+					out <- v
+				} else {
+					return nil
+				}
+			case <-mw.Done():
+				return mw.Err()
+			}
+		}
+	})
+	return p
+}
+
+func (mw *MultiWriter) Done() <-chan struct{} {
+	return mw.w.Done()
+}
+
+func (mw *MultiWriter) Err() error {
+	return mw.w.Err()
+}
+
+func (mw *MultiWriter) Status() chan *client.SolveStatus {
+	return nil
+}
+
+type prefixed struct {
+	main Writer
+	in   chan *client.SolveStatus
+}
+
+func (p *prefixed) Done() <-chan struct{} {
+	return p.main.Done()
+}
+
+func (p *prefixed) Err() error {
+	return p.main.Err()
+}
+
+func (p *prefixed) Status() chan *client.SolveStatus {
+	return p.in
+}
+
+func NewMultiWriter(pw Writer) *MultiWriter {
+	if pw == nil {
+		return nil
+	}
+	eg, _ := errgroup.WithContext(context.TODO())
+
+	ready := make(chan struct{})
+
+	go func() {
+		<-ready
+		eg.Wait()
+		close(pw.Status())
+	}()
+
+	return &MultiWriter{
+		w:     pw,
+		eg:    eg,
+		ready: ready,
+	}
+}
+
+func addPrefix(pfx, name string) string {
+	if strings.HasPrefix(name, "[") {
+		return "[" + pfx + " " + name[1:]
+	}
+	return "[" + pfx + "] " + name
+}

--- a/util/progress/progresswriter/printer.go
+++ b/util/progress/progresswriter/printer.go
@@ -1,0 +1,94 @@
+package progresswriter
+
+import (
+	"context"
+	"os"
+
+	"github.com/containerd/console"
+	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/util/progress/progressui"
+	"github.com/pkg/errors"
+)
+
+type printer struct {
+	status chan *client.SolveStatus
+	done   <-chan struct{}
+	err    error
+}
+
+func (p *printer) Done() <-chan struct{} {
+	return p.done
+}
+
+func (p *printer) Err() error {
+	return p.err
+}
+
+func (p *printer) Status() chan *client.SolveStatus {
+	if p == nil {
+		return nil
+	}
+	return p.status
+}
+
+type tee struct {
+	Writer
+	status chan *client.SolveStatus
+}
+
+func (t *tee) Status() chan *client.SolveStatus {
+	return t.status
+}
+
+func Tee(w Writer, ch chan *client.SolveStatus) Writer {
+	st := make(chan *client.SolveStatus)
+	t := &tee{
+		status: st,
+		Writer: w,
+	}
+	go func() {
+		for v := range st {
+			w.Status() <- v
+			ch <- v
+		}
+		close(w.Status())
+		close(ch)
+	}()
+	return t
+}
+
+func NewPrinter(ctx context.Context, out console.File, mode string) (Writer, error) {
+	statusCh := make(chan *client.SolveStatus)
+	doneCh := make(chan struct{})
+
+	pw := &printer{
+		status: statusCh,
+		done:   doneCh,
+	}
+
+	if v := os.Getenv("BUILDKIT_PROGRESS"); v != "" && mode == "auto" {
+		mode = v
+	}
+
+	var c console.Console
+	switch mode {
+	case "auto", "tty", "":
+		if cons, err := console.ConsoleFromFile(out); err == nil {
+			c = cons
+		} else {
+			if mode == "tty" {
+				return nil, errors.Wrap(err, "failed to get console")
+			}
+		}
+	case "plain":
+	default:
+		return nil, errors.Errorf("invalid progress mode %s", mode)
+	}
+
+	go func() {
+		// not using shared context to not disrupt display but let is finish reporting errors
+		pw.err = progressui.DisplaySolveStatus(ctx, "", c, out, statusCh)
+		close(doneCh)
+	}()
+	return pw, nil
+}

--- a/util/progress/progresswriter/progress.go
+++ b/util/progress/progresswriter/progress.go
@@ -1,0 +1,93 @@
+package progresswriter
+
+import (
+	"time"
+
+	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/identity"
+	"github.com/opencontainers/go-digest"
+)
+
+type Logger func(*client.SolveStatus)
+
+type SubLogger interface {
+	Wrap(name string, fn func() error) error
+	Log(stream int, dt []byte)
+}
+
+func Wrap(name string, l Logger, fn func(SubLogger) error) (err error) {
+	if l == nil {
+		return nil
+	}
+	dgst := digest.FromBytes([]byte(identity.NewID()))
+	tm := time.Now()
+	l(&client.SolveStatus{
+		Vertexes: []*client.Vertex{{
+			Digest:  dgst,
+			Name:    name,
+			Started: &tm,
+		}},
+	})
+
+	defer func() {
+		tm2 := time.Now()
+		errMsg := ""
+		if err != nil {
+			errMsg = err.Error()
+		}
+		l(&client.SolveStatus{
+			Vertexes: []*client.Vertex{{
+				Digest:    dgst,
+				Name:      name,
+				Started:   &tm,
+				Completed: &tm2,
+				Error:     errMsg,
+			}},
+		})
+	}()
+
+	return fn(&subLogger{dgst, l})
+}
+
+type subLogger struct {
+	dgst   digest.Digest
+	logger Logger
+}
+
+func (sl *subLogger) Wrap(name string, fn func() error) (err error) {
+	tm := time.Now()
+	sl.logger(&client.SolveStatus{
+		Statuses: []*client.VertexStatus{{
+			Vertex:    sl.dgst,
+			ID:        name,
+			Timestamp: time.Now(),
+			Started:   &tm,
+		}},
+	})
+
+	defer func() {
+		tm2 := time.Now()
+		sl.logger(&client.SolveStatus{
+			Statuses: []*client.VertexStatus{{
+				Vertex:    sl.dgst,
+				ID:        name,
+				Timestamp: time.Now(),
+				Started:   &tm,
+				Completed: &tm2,
+			}},
+		})
+	}()
+
+	return fn()
+}
+
+func (sl *subLogger) Log(stream int, dt []byte) {
+	sl.logger(&client.SolveStatus{
+		Logs: []*client.VertexLog{{
+			Vertex:    sl.dgst,
+			Stream:    stream,
+			Data:      dt,
+			Timestamp: time.Now(),
+		}},
+	})
+}

--- a/util/progress/progresswriter/reset.go
+++ b/util/progress/progresswriter/reset.go
@@ -1,0 +1,71 @@
+package progresswriter
+
+import (
+	"time"
+
+	"github.com/moby/buildkit/client"
+)
+
+func ResetTime(in Writer) Writer {
+	w := &pw{Writer: in, status: make(chan *client.SolveStatus), tm: time.Now()}
+	go func() {
+		for {
+			select {
+			case <-in.Done():
+				return
+			case st, ok := <-w.status:
+				if !ok {
+					close(in.Status())
+					return
+				}
+				if w.diff == nil {
+					for _, v := range st.Vertexes {
+						if v.Started != nil {
+							d := v.Started.Sub(w.tm)
+							w.diff = &d
+						}
+					}
+				}
+				if w.diff != nil {
+					for _, v := range st.Vertexes {
+						if v.Started != nil {
+							d := v.Started.Add(-*w.diff)
+							v.Started = &d
+						}
+						if v.Completed != nil {
+							d := v.Completed.Add(-*w.diff)
+							v.Completed = &d
+						}
+					}
+					for _, v := range st.Statuses {
+						if v.Started != nil {
+							d := v.Started.Add(-*w.diff)
+							v.Started = &d
+						}
+						if v.Completed != nil {
+							d := v.Completed.Add(-*w.diff)
+							v.Completed = &d
+						}
+						v.Timestamp = v.Timestamp.Add(-*w.diff)
+					}
+					for _, v := range st.Logs {
+						v.Timestamp = v.Timestamp.Add(-*w.diff)
+					}
+				}
+				in.Status() <- st
+			}
+		}
+	}()
+	return w
+}
+
+type pw struct {
+	Writer
+	tm     time.Time
+	diff   *time.Duration
+	status chan *client.SolveStatus
+}
+
+func (p *pw) Status() chan *client.SolveStatus {
+	return p.status
+}

--- a/util/progress/progresswriter/writer.go
+++ b/util/progress/progresswriter/writer.go
@@ -1,0 +1,46 @@
+package progresswriter
+
+import (
+	"time"
+
+	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/identity"
+	"github.com/opencontainers/go-digest"
+)
+
+type Writer interface {
+	Done() <-chan struct{}
+	Err() error
+	Status() chan *client.SolveStatus
+}
+
+func Write(w Writer, name string, f func() error) {
+	status := w.Status()
+	dgst := digest.FromBytes([]byte(identity.NewID()))
+	tm := time.Now()
+
+	vtx := client.Vertex{
+		Digest:  dgst,
+		Name:    name,
+		Started: &tm,
+	}
+
+	status <- &client.SolveStatus{
+		Vertexes: []*client.Vertex{&vtx},
+	}
+
+	var err error
+	if f != nil {
+		err = f()
+	}
+
+	tm2 := time.Now()
+	vtx2 := vtx
+	vtx2.Completed = &tm2
+	if err != nil {
+		vtx2.Error = err.Error()
+	}
+	status <- &client.SolveStatus{
+		Vertexes: []*client.Vertex{&vtx2},
+	}
+}

--- a/util/resolver/authorizer.go
+++ b/util/resolver/authorizer.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -63,12 +64,21 @@ func (a *authHandlerNS) get(host string, sm *session.Manager, g session.Group) *
 			continue
 		}
 		if parts[0] == host {
-			session, username, password, err := sessionauth.CredentialsFunc(sm, g)(host)
-			if err == nil {
-				if username == h.common.Username && password == h.common.Secret {
+			if h.authority != nil {
+				session, ok, err := sessionauth.VerifyTokenAuthority(host, h.authority, sm, g)
+				if err == nil && ok {
 					a.handlers[host+"/"+session] = h
 					h.lastUsed = time.Now()
 					return h
+				}
+			} else {
+				session, username, password, err := sessionauth.CredentialsFunc(sm, g)(host)
+				if err == nil {
+					if username == h.common.Username && password == h.common.Secret {
+						a.handlers[host+"/"+session] = h
+						h.lastUsed = time.Now()
+						return h
+					}
 				}
 			}
 		}
@@ -117,7 +127,7 @@ func (a *dockerAuthorizer) Authorize(ctx context.Context, req *http.Request) err
 		return nil
 	}
 
-	auth, err := ah.authorize(ctx, a.session)
+	auth, err := ah.authorize(ctx, a.sm, a.session)
 	if err != nil {
 		return err
 	}
@@ -141,17 +151,17 @@ func (a *dockerAuthorizer) AddResponses(ctx context.Context, responses []*http.R
 
 	for _, c := range auth.ParseAuthHeader(last.Header) {
 		if c.Scheme == auth.BearerAuth {
+			var oldScopes []string
 			if err := invalidAuthorization(c, responses); err != nil {
 				a.handlers.delete(handler)
 
-				oldScope := ""
 				if handler != nil {
-					oldScope = strings.Join(handler.common.Scopes, " ")
+					oldScopes = handler.common.Scopes
 				}
 				handler = nil
 
 				// this hacky way seems to be best method to detect that error is fatal and should not be retried with a new token
-				if c.Parameters["error"] == "insufficient_scope" && c.Parameters["scope"] == oldScope {
+				if c.Parameters["error"] == "insufficient_scope" && parseScopes(oldScopes).contains(parseScopes(strings.Split(c.Parameters["scope"], " "))) {
 					return err
 				}
 			}
@@ -166,17 +176,25 @@ func (a *dockerAuthorizer) AddResponses(ctx context.Context, responses []*http.R
 				return nil
 			}
 
-			session, username, secret, err := a.getCredentials(host)
+			var username, secret string
+			session, pubKey, err := sessionauth.GetTokenAuthority(host, a.sm, a.session)
 			if err != nil {
 				return err
+			}
+			if pubKey == nil {
+				session, username, secret, err = a.getCredentials(host)
+				if err != nil {
+					return err
+				}
 			}
 
 			common, err := auth.GenerateTokenOptions(ctx, host, username, secret, c)
 			if err != nil {
 				return err
 			}
+			common.Scopes = parseScopes(append(common.Scopes, oldScopes...)).normalize()
 
-			a.handlers.set(host, session, newAuthHandler(a.client, c.Scheme, common))
+			a.handlers.set(host, session, newAuthHandler(host, a.client, c.Scheme, pubKey, common))
 
 			return nil
 		} else if c.Scheme == auth.BasicAuth {
@@ -191,7 +209,7 @@ func (a *dockerAuthorizer) AddResponses(ctx context.Context, responses []*http.R
 					Secret:   secret,
 				}
 
-				a.handlers.set(host, session, newAuthHandler(a.client, c.Scheme, common))
+				a.handlers.set(host, session, newAuthHandler(host, a.client, c.Scheme, nil, common))
 
 				return nil
 			}
@@ -225,24 +243,30 @@ type authHandler struct {
 	scopedTokens map[string]*authResult
 
 	lastUsed time.Time
+
+	host string
+
+	authority *[32]byte
 }
 
-func newAuthHandler(client *http.Client, scheme auth.AuthenticationScheme, opts auth.TokenOptions) *authHandler {
+func newAuthHandler(host string, client *http.Client, scheme auth.AuthenticationScheme, authority *[32]byte, opts auth.TokenOptions) *authHandler {
 	return &authHandler{
+		host:         host,
 		client:       client,
 		scheme:       scheme,
 		common:       opts,
 		scopedTokens: map[string]*authResult{},
 		lastUsed:     time.Now(),
+		authority:    authority,
 	}
 }
 
-func (ah *authHandler) authorize(ctx context.Context, g session.Group) (string, error) {
+func (ah *authHandler) authorize(ctx context.Context, sm *session.Manager, g session.Group) (string, error) {
 	switch ah.scheme {
 	case auth.BasicAuth:
 		return ah.doBasicAuth(ctx)
 	case auth.BearerAuth:
-		return ah.doBearerAuth(ctx)
+		return ah.doBearerAuth(ctx, sm, g)
 	default:
 		return "", errors.Wrapf(errdefs.ErrNotImplemented, "failed to find supported auth scheme: %s", string(ah.scheme))
 	}
@@ -259,11 +283,11 @@ func (ah *authHandler) doBasicAuth(ctx context.Context) (string, error) {
 	return fmt.Sprintf("Basic %s", auth), nil
 }
 
-func (ah *authHandler) doBearerAuth(ctx context.Context) (token string, err error) {
+func (ah *authHandler) doBearerAuth(ctx context.Context, sm *session.Manager, g session.Group) (token string, err error) {
 	// copy common tokenOptions
 	to := ah.common
 
-	to.Scopes = docker.GetTokenScopes(ctx, to.Scopes)
+	to.Scopes = parseScopes(docker.GetTokenScopes(ctx, to.Scopes)).normalize()
 
 	// Docs: https://docs.docker.com/registry/spec/auth/scope
 	scoped := strings.Join(to.Scopes, " ")
@@ -300,6 +324,21 @@ func (ah *authHandler) doBearerAuth(ctx context.Context) (token string, err erro
 		r.Done()
 	}()
 
+	if ah.authority != nil {
+		resp, err := sessionauth.FetchToken(&sessionauth.FetchTokenRequest{
+			ClientID: "buildkit-client",
+			Host:     ah.host,
+			Realm:    to.Realm,
+			Service:  to.Service,
+			Scopes:   to.Scopes,
+		}, sm, g)
+		if err != nil {
+			return "", err
+		}
+		issuedAt, expires = time.Unix(resp.IssuedAt, 0), int(resp.ExpiresIn)
+		return resp.Token, nil
+	}
+
 	// fetch token for the resource scope
 	if to.Secret != "" {
 		defer func() {
@@ -315,7 +354,7 @@ func (ah *authHandler) doBearerAuth(ctx context.Context) (token string, err erro
 				// As of September 2017, GCR is known to return 404.
 				// As of February 2018, JFrog Artifactory is known to return 401.
 				if (errStatus.StatusCode == 405 && to.Username != "") || errStatus.StatusCode == 404 || errStatus.StatusCode == 401 {
-					resp, err := auth.FetchTokenWithOAuth(ctx, ah.client, nil, "containerd-client", to)
+					resp, err := auth.FetchTokenWithOAuth(ctx, ah.client, nil, "buildkit-client", to)
 					if err != nil {
 						return "", err
 					}
@@ -362,6 +401,71 @@ func sameRequest(r1, r2 *http.Request) bool {
 	}
 	if *r1.URL != *r2.URL {
 		return false
+	}
+	return true
+}
+
+type scopes map[string]map[string]struct{}
+
+func parseScopes(s []string) scopes {
+	// https://docs.docker.com/registry/spec/auth/scope/
+	m := map[string]map[string]struct{}{}
+	for _, scope := range s {
+		parts := strings.SplitN(scope, ":", 3)
+		names := []string{parts[0]}
+		if len(parts) > 1 {
+			names = append(names, parts[1])
+		}
+		var actions []string
+		if len(parts) == 3 {
+			actions = append(actions, strings.Split(parts[2], ",")...)
+		}
+		name := strings.Join(names, ":")
+		ma, ok := m[name]
+		if !ok {
+			ma = map[string]struct{}{}
+			m[name] = ma
+		}
+
+		for _, a := range actions {
+			ma[a] = struct{}{}
+		}
+	}
+	return m
+}
+
+func (s scopes) normalize() []string {
+	names := make([]string, 0, len(s))
+	for n := range s {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	out := make([]string, 0, len(s))
+
+	for _, n := range names {
+		actions := make([]string, 0, len(s[n]))
+		for a := range s[n] {
+			actions = append(actions, a)
+		}
+		sort.Strings(actions)
+
+		out = append(out, n+":"+strings.Join(actions, ","))
+	}
+	return out
+}
+
+func (s scopes) contains(s2 scopes) bool {
+	for n := range s2 {
+		v, ok := s[n]
+		if !ok {
+			return false
+		}
+		for a := range s2[n] {
+			if _, ok := v[a]; !ok {
+				return false
+			}
+		}
 	}
 	return true
 }

--- a/vendor/golang.org/x/crypto/nacl/sign/sign.go
+++ b/vendor/golang.org/x/crypto/nacl/sign/sign.go
@@ -1,0 +1,90 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package sign signs small messages using public-key cryptography.
+//
+// Sign uses Ed25519 to sign messages. The length of messages is not hidden.
+// Messages should be small because:
+// 1. The whole message needs to be held in memory to be processed.
+// 2. Using large messages pressures implementations on small machines to process
+// plaintext without verifying the signature. This is very dangerous, and this API
+// discourages it, but a protocol that uses excessive message sizes might present
+// some implementations with no other choice.
+// 3. Performance may be improved by working with messages that fit into data caches.
+// Thus large amounts of data should be chunked so that each message is small.
+//
+// This package is not interoperable with the current release of NaCl
+// (https://nacl.cr.yp.to/sign.html), which does not support Ed25519 yet. However,
+// it is compatible with the NaCl fork libsodium (https://www.libsodium.org), as well
+// as TweetNaCl (https://tweetnacl.cr.yp.to/).
+package sign
+
+import (
+	"io"
+
+	"golang.org/x/crypto/ed25519"
+	"golang.org/x/crypto/internal/subtle"
+)
+
+// Overhead is the number of bytes of overhead when signing a message.
+const Overhead = 64
+
+// GenerateKey generates a new public/private key pair suitable for use with
+// Sign and Open.
+func GenerateKey(rand io.Reader) (publicKey *[32]byte, privateKey *[64]byte, err error) {
+	pub, priv, err := ed25519.GenerateKey(rand)
+	if err != nil {
+		return nil, nil, err
+	}
+	publicKey, privateKey = new([32]byte), new([64]byte)
+	copy((*publicKey)[:], pub)
+	copy((*privateKey)[:], priv)
+	return publicKey, privateKey, nil
+}
+
+// Sign appends a signed copy of message to out, which will be Overhead bytes
+// longer than the original and must not overlap it.
+func Sign(out, message []byte, privateKey *[64]byte) []byte {
+	sig := ed25519.Sign(ed25519.PrivateKey((*privateKey)[:]), message)
+	ret, out := sliceForAppend(out, Overhead+len(message))
+	if subtle.AnyOverlap(out, message) {
+		panic("nacl: invalid buffer overlap")
+	}
+	copy(out, sig)
+	copy(out[Overhead:], message)
+	return ret
+}
+
+// Open verifies a signed message produced by Sign and appends the message to
+// out, which must not overlap the signed message. The output will be Overhead
+// bytes smaller than the signed message.
+func Open(out, signedMessage []byte, publicKey *[32]byte) ([]byte, bool) {
+	if len(signedMessage) < Overhead {
+		return nil, false
+	}
+	if !ed25519.Verify(ed25519.PublicKey((*publicKey)[:]), signedMessage[Overhead:], signedMessage[:Overhead]) {
+		return nil, false
+	}
+	ret, out := sliceForAppend(out, len(signedMessage)-Overhead)
+	if subtle.AnyOverlap(out, signedMessage) {
+		panic("nacl: invalid buffer overlap")
+	}
+	copy(out, signedMessage[Overhead:])
+	return ret, true
+}
+
+// sliceForAppend takes a slice and a requested number of bytes. It returns a
+// slice with the contents of the given slice followed by that many bytes and a
+// second slice that aliases into it and contains only the extra bytes. If the
+// original slice has sufficient capacity then no allocation is performed.
+func sliceForAppend(in []byte, n int) (head, tail []byte) {
+	if total := len(in) + n; cap(in) >= total {
+		head = in[:total]
+	} else {
+		head = make([]byte, total)
+		copy(head, in)
+	}
+	tail = head[len(in):]
+	return
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -342,6 +342,7 @@ golang.org/x/crypto/curve25519
 golang.org/x/crypto/ed25519
 golang.org/x/crypto/ed25519/internal/edwards25519
 golang.org/x/crypto/internal/subtle
+golang.org/x/crypto/nacl/sign
 golang.org/x/crypto/poly1305
 golang.org/x/crypto/ssh
 golang.org/x/crypto/ssh/agent


### PR DESCRIPTION
Instead of sharing credentials with the daemon use session to request temporary tokens requested from the cli side. The tokens are still reused with resolvers like before and efficiency shouldn't suffer. @sipsma 

~Marking wip to add client-side progress injection making token requests visible. This turned out to be more complicated and I'm moving code from buildx to buildkit to achieve it.~

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>