### PR TITLE
ensure containerd is running for worker tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ jobs:
       script: 
         - TESTPKGS=./client ./hack/test integration
         - TESTPKGS=./cmd/buildctl ./hack/test integration
+        - TESTPKGS=./worker/containerd ./hack/test integration
     - script:
        - ./hack/lint
        - SKIP_INTEGRATION_TESTS=1 ./hack/test integration gateway


### PR DESCRIPTION
fixes issue #1637, containerd worker tests now running as integration tests:
https://travis-ci.org/github/moby/buildkit/jobs/722986753#L2677