### PR TITLE
Expand BUILD_ARG in "COPY --from=$BUILD_ARG source destination"

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -225,6 +225,15 @@ func Dockerfile2LLB(ctx context.Context, dt []byte, opt ConvertOpt) (*llb.State,
 			}
 			func(i int, d *dispatchState) {
 				eg.Go(func() error {
+					name, err := shlex.ProcessWordWithMap(d.stage.BaseName, metaArgsToMap(optMetaArgs))
+					if err != nil {
+						return parser.WithLocation(err, d.stage.Location)
+					}
+					if name == "" {
+						return parser.WithLocation(errors.Errorf("base name (%s) should not be blank", d.stage.BaseName), d.stage.Location)
+					}
+					d.stage.BaseName = name
+
 					ref, err := reference.ParseNormalizedNamed(d.stage.BaseName)
 					if err != nil {
 						return parser.WithLocation(errors.Wrapf(err, "failed to parse stage name %q", d.stage.BaseName), d.stage.Location)

--- a/frontend/dockerfile/dockerfile2llb/convert_test.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_test.go
@@ -43,6 +43,18 @@ COPY --from=0 f2 /
 	_, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
 	assert.NoError(t, err)
 
+	df = `ARG ARGUMENT
+FROM busybox AS foo
+ENV FOO bar
+FROM foo
+COPY --from=$ARGUMENT f1 /
+COPY --from=0 f2 /
+	`
+	buildArgs := make(map[string]string)
+	buildArgs["ARGUMENT"] = "foo"
+	_, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{BuildArgs: buildArgs})
+	assert.NoError(t, err)
+
 	df = `FROM busybox AS foo
 ENV FOO bar
 FROM foo

--- a/frontend/dockerfile/instructions/commands.go
+++ b/frontend/dockerfile/instructions/commands.go
@@ -220,6 +220,13 @@ func (c *CopyCommand) Expand(expander SingleWordExpander) error {
 		return err
 	}
 	c.Chown = expandedChown
+
+	expandedFrom, err := expander(c.From)
+	if err != nil {
+		return err
+	}
+	c.From = expandedFrom
+
 	return expandSliceInPlace(c.SourcesAndDest, expander)
 }
 


### PR DESCRIPTION
I assume this one hasn't been implemented for some reasons, according to https://github.com/moby/moby/issues/34482 🤔 

Signed-off-by: Tobias Gesellchen <tobias@gesellix.de>
