### PR TITLE
[v0.6 backport] progressui: fix panic on terminals with zero height

### DIFF
--- a/util/progress/progressui/display.go
+++ b/util/progress/progressui/display.go
@@ -548,6 +548,9 @@ func align(l, r string, w int) string {
 }
 
 func wrapHeight(j []*job, limit int) []*job {
+	if limit < 0 {
+		return nil
+	}
 	var wrapped []*job
 	wrapped = append(wrapped, j...)
 	if len(j) > limit {


### PR DESCRIPTION
backport of https://github.com/moby/buildkit/pull/1486
addresses https://github.com/moby/buildkit/issues/1479