### PR TITLE
fix tests after busybox update

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1343,7 +1343,7 @@ func testUser(t *testing.T, sb integration.Sandbox) {
 
 	run("daemon", `sh -c "id -nu > user"`)
 	run("daemon:daemon", `sh -c "id -ng > group"`)
-	run("daemon:nogroup", `sh -c "id -ng > nogroup"`)
+	run("daemon:nobody", `sh -c "id -ng > nobody"`)
 	run("1:1", `sh -c "id -g > userone"`)
 
 	st = st.Run(llb.Shlex("cp -a /wd/. /out/"))
@@ -1374,9 +1374,9 @@ func testUser(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 	require.Contains(t, string(dt), "daemon")
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "nogroup"))
+	dt, err = ioutil.ReadFile(filepath.Join(destDir, "nobody"))
 	require.NoError(t, err)
-	require.Contains(t, string(dt), "nogroup")
+	require.Contains(t, string(dt), "nobody")
 
 	dt, err = ioutil.ReadFile(filepath.Join(destDir, "userone"))
 	require.NoError(t, err)

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -2262,7 +2262,7 @@ FROM busybox
 ARG group
 ENV owner 1000
 ADD --chown=${owner}:${group} foo /
-RUN [ "$(stat -c "%u %G" /foo)" == "1000 nogroup" ]
+RUN [ "$(stat -c "%u %G" /foo)" == "1000 nobody" ]
 `)
 
 	dir, err := tmpdir(
@@ -2279,7 +2279,7 @@ RUN [ "$(stat -c "%u %G" /foo)" == "1000 nogroup" ]
 	_, err = f.Solve(context.TODO(), c, client.SolveOpt{
 		FrontendAttrs: map[string]string{
 			"build-arg:BUILDKIT_DISABLE_FILEOP": strconv.FormatBool(!isFileOp),
-			"build-arg:group":                   "nogroup",
+			"build-arg:group":                   "nobody",
 		},
 		LocalDirs: map[string]string{
 			builder.DefaultLocalNameDockerfile: dir,
@@ -2832,7 +2832,7 @@ FROM busybox AS base
 ENV owner 1000
 RUN mkdir -m 0777 /out
 COPY --chown=daemon foo /
-COPY --chown=1000:nogroup bar /baz
+COPY --chown=1000:nobody bar /baz
 ARG group
 COPY --chown=${owner}:${group} foo /foobis
 RUN stat -c "%U %G" /foo  > /out/fooowner
@@ -2868,7 +2868,7 @@ COPY --from=base /out /
 		},
 		FrontendAttrs: map[string]string{
 			"build-arg:BUILDKIT_DISABLE_FILEOP": strconv.FormatBool(!isFileOp),
-			"build-arg:group":                   "nogroup",
+			"build-arg:group":                   "nobody",
 		},
 		LocalDirs: map[string]string{
 			builder.DefaultLocalNameDockerfile: dir,
@@ -2883,11 +2883,11 @@ COPY --from=base /out /
 
 	dt, err = ioutil.ReadFile(filepath.Join(destDir, "subowner"))
 	require.NoError(t, err)
-	require.Equal(t, "1000 nogroup\n", string(dt))
+	require.Equal(t, "1000 nobody\n", string(dt))
 
 	dt, err = ioutil.ReadFile(filepath.Join(destDir, "foobisowner"))
 	require.NoError(t, err)
-	require.Equal(t, "1000 nogroup\n", string(dt))
+	require.Equal(t, "1000 nobody\n", string(dt))
 }
 
 func testCopyChmod(t *testing.T, sb integration.Sandbox) {


### PR DESCRIPTION
CI is broken and the issue seems to be not a buildkit change but a change in busybox image used in test.

```
 # docker run -it --rm busybox:1.31 cat /etc/group | grep no
nogroup:x:65534:
 # docker run -it --rm busybox:1.32 cat /etc/group | grep no
nobody:x:65534:
```

We should probably also pin to a specific version to avoid this. But corrected the tests atm.

@tianon I assume this change was intentional and we don't expect a rollback.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>