### PR TITLE
[v0.7 backport] fix tests after busybox update

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1335,7 +1335,7 @@ func testUser(t *testing.T, sb integration.Sandbox) {
 
 	run("daemon", `sh -c "id -nu > user"`)
 	run("daemon:daemon", `sh -c "id -ng > group"`)
-	run("daemon:nogroup", `sh -c "id -ng > nogroup"`)
+	run("daemon:nobody", `sh -c "id -ng > nobody"`)
 	run("1:1", `sh -c "id -g > userone"`)
 
 	st = st.Run(llb.Shlex("cp -a /wd/. /out/"))
@@ -1366,9 +1366,9 @@ func testUser(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 	require.Contains(t, string(dt), "daemon")
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "nogroup"))
+	dt, err = ioutil.ReadFile(filepath.Join(destDir, "nobody"))
 	require.NoError(t, err)
-	require.Contains(t, string(dt), "nogroup")
+	require.Contains(t, string(dt), "nobody")
 
 	dt, err = ioutil.ReadFile(filepath.Join(destDir, "userone"))
 	require.NoError(t, err)

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -2795,7 +2795,7 @@ FROM busybox AS base
 ENV owner 1000
 RUN mkdir -m 0777 /out
 COPY --chown=daemon foo /
-COPY --chown=1000:nogroup bar /baz
+COPY --chown=1000:nobody bar /baz
 ARG group
 COPY --chown=${owner}:${group} foo /foobis
 RUN stat -c "%U %G" /foo  > /out/fooowner
@@ -2831,7 +2831,7 @@ COPY --from=base /out /
 		},
 		FrontendAttrs: map[string]string{
 			"build-arg:BUILDKIT_DISABLE_FILEOP": strconv.FormatBool(!isFileOp),
-			"build-arg:group":                   "nogroup",
+			"build-arg:group":                   "nobody",
 		},
 		LocalDirs: map[string]string{
 			builder.DefaultLocalNameDockerfile: dir,
@@ -2846,11 +2846,11 @@ COPY --from=base /out /
 
 	dt, err = ioutil.ReadFile(filepath.Join(destDir, "subowner"))
 	require.NoError(t, err)
-	require.Equal(t, "1000 nogroup\n", string(dt))
+	require.Equal(t, "1000 nobody\n", string(dt))
 
 	dt, err = ioutil.ReadFile(filepath.Join(destDir, "foobisowner"))
 	require.NoError(t, err)
-	require.Equal(t, "1000 nogroup\n", string(dt))
+	require.Equal(t, "1000 nobody\n", string(dt))
 }
 
 func testCopyOverrideFiles(t *testing.T, sb integration.Sandbox) {


### PR DESCRIPTION
backport of https://github.com/moby/buildkit/pull/1681

cherry-pick wasn't clean, because `testDockerfileAddChownExpand()` is not yet in this branch (was added in https://github.com/moby/buildkit/pull/1473)