### PR TITLE
dockerfile: allow multiple values for ARG

### DIFF
--- a/frontend/dockerfile/instructions/commands.go
+++ b/frontend/dockerfile/instructions/commands.go
@@ -380,22 +380,25 @@ func (c *StopSignalCommand) CheckPlatform(platform string) error {
 // Dockerfile author may optionally set a default value of this variable.
 type ArgCommand struct {
 	withNameAndCode
-	KeyValuePairOptional
+	Args []KeyValuePairOptional
 }
 
 // Expand variables
 func (c *ArgCommand) Expand(expander SingleWordExpander) error {
-	p, err := expander(c.Key)
-	if err != nil {
-		return err
-	}
-	c.Key = p
-	if c.Value != nil {
-		p, err = expander(*c.Value)
+	for i, v := range c.Args {
+		p, err := expander(v.Key)
 		if err != nil {
 			return err
 		}
-		c.Value = &p
+		v.Key = p
+		if v.Value != nil {
+			p, err = expander(*v.Value)
+			if err != nil {
+				return err
+			}
+			v.Value = &p
+		}
+		c.Args[i] = v
 	}
 	return nil
 }

--- a/frontend/dockerfile/instructions/parse_test.go
+++ b/frontend/dockerfile/instructions/parse_test.go
@@ -164,11 +164,6 @@ func TestErrorCases(t *testing.T) {
 			expectedError: "MAINTAINER isn't allowed as an ONBUILD trigger",
 		},
 		{
-			name:          "ARG two arguments",
-			dockerfile:    "ARG foo bar",
-			expectedError: "ARG requires exactly one argument",
-		},
-		{
 			name:          "MAINTAINER unknown flag",
 			dockerfile:    "MAINTAINER --boo joe@example.com",
 			expectedError: "Unknown flag: boo",

--- a/frontend/dockerfile/parser/testfiles/args/Dockerfile
+++ b/frontend/dockerfile/parser/testfiles/args/Dockerfile
@@ -1,0 +1,3 @@
+ARG foo bar=baz
+FROM ubuntu
+ARG abc="123 456" def

--- a/frontend/dockerfile/parser/testfiles/args/result
+++ b/frontend/dockerfile/parser/testfiles/args/result
@@ -1,0 +1,3 @@
+(arg "foo" "bar=baz")
+(from "ubuntu")
+(arg "abc=\"123 456\"" "def")


### PR DESCRIPTION
`ENV` accepts multiple definitions with a single command, no reason why `ARG` should behave any differently.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>