### PR TITLE
Make HTTP/2 authority pseudo-header spec-compliant

### DIFF
--- a/frontend/gateway/grpcclient/client.go
+++ b/frontend/gateway/grpcclient/client.go
@@ -509,7 +509,7 @@ func grpcClientConn(ctx context.Context) (context.Context, *grpc.ClientConn, err
 		return stdioConn(), nil
 	})
 
-	cc, err := grpc.DialContext(ctx, "", dialOpt, grpc.WithInsecure(), grpc.WithUnaryInterceptor(grpcerrors.UnaryClientInterceptor), grpc.WithStreamInterceptor(grpcerrors.StreamClientInterceptor))
+	cc, err := grpc.DialContext(ctx, "localhost", dialOpt, grpc.WithInsecure(), grpc.WithUnaryInterceptor(grpcerrors.UnaryClientInterceptor), grpc.WithStreamInterceptor(grpcerrors.StreamClientInterceptor))
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to create grpc client")
 	}

--- a/session/grpc.go
+++ b/session/grpc.go
@@ -64,7 +64,7 @@ func grpcClientConn(ctx context.Context, conn net.Conn) (context.Context, *grpc.
 		dialOpts = append(dialOpts, grpc.WithStreamInterceptor(grpc_middleware.ChainStreamClient(stream...)))
 	}
 
-	cc, err := grpc.DialContext(ctx, "", dialOpts...)
+	cc, err := grpc.DialContext(ctx, "localhost", dialOpts...)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to create grpc client")
 	}


### PR DESCRIPTION
The dockerfile frontend is sending an invalid value (`""`, empty string) for the HTTP/2 "authority" pseudo-header. As per https://github.com/grpc/grpc-go/issues/3854, it seems this can be fixed in Buildkit by specifying a non-empty target when creating the DialContext.

I have verified that with this change the authority header now indicates "localhost".