### PR TITLE
client: Solve: remove delay before cancelling status context

### DIFF
--- a/client/solve.go
+++ b/client/solve.go
@@ -177,10 +177,7 @@ func (c *Client) solve(ctx context.Context, def *llb.Definition, runGateway runG
 		defer cancelSolve()
 
 		defer func() { // make sure the Status ends cleanly on build errors
-			go func() {
-				<-time.After(3 * time.Second)
-				cancelStatus()
-			}()
+			cancelStatus()
 			logrus.Debugf("stopping session")
 			s.Close()
 		}()


### PR DESCRIPTION
This fixes an apparent bug where the client package `Solve()` method does not respect context cancellation.

Specifically, when the client cancels the context while Solve is executing, the internal [status-handling goroutine](https://github.com/moby/buildkit/blob/19c4cba4b3c1fdc0335b664c6b6e59720b9dc8a8/client/solve.go#L244) (one of the errgroup participants) does not return but hangs indefinitely, causing the errgroup `Wait()` call to hang forever.

It's not clear to me why the three second delay causes this issue. When debugging, I see the delay and then the context is cancelled as expected, but somehow the status goroutine does not get signaled to exit. When the delay is removed, all goroutines exit as expected.