### PR TITLE
Prevent context canceled errors from being permanent in authorizer

### DIFF
--- a/util/resolver/authorizer.go
+++ b/util/resolver/authorizer.go
@@ -269,13 +269,31 @@ func (ah *authHandler) doBearerAuth(ctx context.Context) (token string, err erro
 	scoped := strings.Join(to.Scopes, " ")
 
 	ah.Lock()
-	if r, exist := ah.scopedTokens[scoped]; exist {
+	for {
+		r, exist := ah.scopedTokens[scoped]
+		if !exist {
+			// no entry cached
+			break
+		}
 		ah.Unlock()
 		r.Wait()
-		if r.expires.IsZero() || r.expires.After(time.Now()) {
+		if r.err != nil {
+			select {
+			case <-ctx.Done():
+				return "", r.err
+			default:
+			}
+		}
+		if !errors.Is(r.err, context.Canceled) &&
+			(r.expires.IsZero() || r.expires.After(time.Now())) {
 			return r.token, r.err
 		}
+		// r.err is canceled or token expired. Get rid of it and try again
 		ah.Lock()
+		r2, exist := ah.scopedTokens[scoped]
+		if exist && r == r2 {
+			delete(ah.scopedTokens, scoped)
+		}
 	}
 
 	// only one fetch token job


### PR DESCRIPTION
In [Earthly](https://github.com/earthly/earthly), we've seen errors that look like these:

```
rpc error: code = Canceled desc = failed to load cache key: failed to authorize: failed to fetch oauth token: context canceled
```

```
rpc error: code = Canceled desc = failed to load cache key: failed to authorize: failed to fetch anonymous token: context canceled
```

When these are encountered, new builds stop working altogether, because the error remains cached permanently in buildkitd. Restarting buildkitd fixes the problem.

The change in this PR prevents context.Canceled errors from being cached at all.

Related issue in Earthly: https://github.com/earthly/earthly/issues/245
CC @alexcb @agbell