### PR TITLE
clear file mount stubs and fix empty layer cases

### DIFF
--- a/cache/remotecache/v1/utils.go
+++ b/cache/remotecache/v1/utils.go
@@ -4,13 +4,10 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/solver"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
-)
-
-const (
-	emptyGZLayer = digest.Digest("sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1")
 )
 
 // sortConfig sorts the config structure to make sure it is deterministic
@@ -242,7 +239,7 @@ func marshalRemote(r *solver.Remote, state *marshalState) string {
 	}
 	desc := r.Descriptors[len(r.Descriptors)-1]
 
-	if desc.Digest == emptyGZLayer {
+	if desc.Digest == exptypes.EmptyGZLayer {
 		return parentID
 	}
 

--- a/cache/remotecache/v1/utils.go
+++ b/cache/remotecache/v1/utils.go
@@ -9,6 +9,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	emptyGZLayer = digest.Digest("sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1")
+)
+
 // sortConfig sorts the config structure to make sure it is deterministic
 func sortConfig(cc *CacheConfig) {
 	type indexedLayer struct {
@@ -237,6 +241,10 @@ func marshalRemote(r *solver.Remote, state *marshalState) string {
 		parentID = marshalRemote(r2, state)
 	}
 	desc := r.Descriptors[len(r.Descriptors)-1]
+
+	if desc.Digest == emptyGZLayer {
+		return parentID
+	}
 
 	state.descriptors[desc.Digest] = DescriptorProviderPair{
 		Descriptor: desc,

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -213,6 +213,8 @@ func (w *runcExecutor) Run(ctx context.Context, id string, root cache.Mountable,
 	}
 	defer mount.Unmount(rootFSPath, 0)
 
+	defer executor.MountStubsCleaner(rootFSPath, mounts)()
+
 	uid, gid, sgids, err := oci.GetUser(rootFSPath, meta.User)
 	if err != nil {
 		return err

--- a/executor/stubs.go
+++ b/executor/stubs.go
@@ -1,0 +1,49 @@
+package executor
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/containerd/continuity/fs"
+)
+
+func MountStubsCleaner(dir string, mounts []Mount) func() {
+	names := []string{"/etc/resolv.conf", "/etc/hosts"}
+
+	for _, m := range mounts {
+		names = append(names, m.Dest)
+	}
+
+	paths := make([]string, 0, len(names))
+
+	for _, p := range names {
+		p = filepath.Join("/", p)
+		if p == "/" {
+			continue
+		}
+		realPath, err := fs.RootPath(dir, p)
+		if err != nil {
+			continue
+		}
+
+		_, err = os.Lstat(realPath)
+		if errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ENOTDIR) {
+			paths = append(paths, realPath)
+		}
+	}
+
+	return func() {
+		for _, p := range paths {
+			st, err := os.Lstat(p)
+			if err != nil {
+				continue
+			}
+			if st.Size() != 0 {
+				continue
+			}
+			os.Remove(p)
+		}
+	}
+}

--- a/exporter/containerimage/exptypes/types.go
+++ b/exporter/containerimage/exptypes/types.go
@@ -1,10 +1,15 @@
 package exptypes
 
-import specs "github.com/opencontainers/image-spec/specs-go/v1"
+import (
+	"github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+)
 
 const ExporterImageConfigKey = "containerimage.config"
 const ExporterInlineCache = "containerimage.inlinecache"
 const ExporterPlatformsKey = "refs.platforms"
+
+const EmptyGZLayer = digest.Digest("sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1")
 
 type Platforms struct {
 	Platforms []Platform

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -413,13 +413,13 @@ func normalizeLayersAndHistory(remote *solver.Remote, history []ocispec.History,
 	var layerIndex int
 	for i, h := range history {
 		if !h.EmptyLayer {
-			if h.Created == nil {
-				h.Created = refMeta[layerIndex].createdAt
-			}
 			if remote.Descriptors[layerIndex].Digest == emptyGZLayer {
 				h.EmptyLayer = true
 				remote.Descriptors = append(remote.Descriptors[:layerIndex], remote.Descriptors[layerIndex+1:]...)
 			} else {
+				if h.Created == nil {
+					h.Created = refMeta[layerIndex].createdAt
+				}
 				layerIndex++
 			}
 		}

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -27,10 +27,6 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const (
-	emptyGZLayer = digest.Digest("sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1")
-)
-
 type WriterOpt struct {
 	Snapshotter  snapshot.Snapshotter
 	ContentStore content.Store
@@ -413,7 +409,7 @@ func normalizeLayersAndHistory(remote *solver.Remote, history []ocispec.History,
 	var layerIndex int
 	for i, h := range history {
 		if !h.EmptyLayer {
-			if remote.Descriptors[layerIndex].Digest == emptyGZLayer {
+			if remote.Descriptors[layerIndex].Digest == exptypes.EmptyGZLayer {
 				h.EmptyLayer = true
 				remote.Descriptors = append(remote.Descriptors[:layerIndex], remote.Descriptors[layerIndex+1:]...)
 			} else {

--- a/frontend/dockerfile/dockerfile_secrets_test.go
+++ b/frontend/dockerfile/dockerfile_secrets_test.go
@@ -28,6 +28,7 @@ func testSecretFileParams(t *testing.T, sb integration.Sandbox) {
 	dockerfile := []byte(`
 FROM busybox
 RUN --mount=type=secret,required=false,mode=741,uid=100,gid=102,target=/mysecret [ "$(stat -c "%u %g %f" /mysecret)" = "100 102 81e1" ]
+RUN [ ! -f /mysecret ] # check no stub left behind
 `)
 
 	dir, err := tmpdir(

--- a/snapshot/imagerefchecker/checker.go
+++ b/snapshot/imagerefchecker/checker.go
@@ -9,13 +9,10 @@ import (
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
 	"github.com/moby/buildkit/cache"
+	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
-)
-
-const (
-	emptyGZLayer = digest.Digest("sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1")
 )
 
 type Opt struct {
@@ -93,7 +90,7 @@ func toDigests(layers []specs.Descriptor) []digest.Digest {
 func layerKey(layers []digest.Digest) string {
 	b := &strings.Builder{}
 	for _, l := range layers {
-		if l != emptyGZLayer {
+		if l != exptypes.EmptyGZLayer {
 			b.Write([]byte(l))
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/moby/moby/issues/38667 by removing the empty files that were created for the mountpoints. Otherwise, paths used for secrets or `/etc/resolv.conf` would remain in the image as empty files.

While testing with the fix I discovered cases where empty layers were not handled properly for cache export. Extra commits fix these cases. After that, the example case in https://github.com/moby/buildkit/issues/1727 now produces reproducible digests.