### PR TITLE
stack: remove helper functions from error stack traces

### DIFF
--- a/util/grpcerrors/grpcerrors.go
+++ b/util/grpcerrors/grpcerrors.go
@@ -181,6 +181,10 @@ func FromGRPC(err error) error {
 		err = d.WrapError(err)
 	}
 
+	if err != nil {
+		stack.Helper()
+	}
+
 	return stack.Enable(err)
 }
 


### PR DESCRIPTION
Mark some common functions as helpers so they don't show up on top of (almost all) stack traces.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>