### PR TITLE
update go-runc  module, use runc.ExitError for container exec status

### DIFF
--- a/executor/runcexecutor/executor_common.go
+++ b/executor/runcexecutor/executor_common.go
@@ -4,9 +4,7 @@ package runcexecutor
 
 import (
 	"context"
-	"os/exec"
 
-	"github.com/containerd/containerd"
 	runc "github.com/containerd/go-runc"
 	"github.com/moby/buildkit/executor"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -15,30 +13,24 @@ import (
 
 var unsupportedConsoleError = errors.New("tty for runc is only supported on linux")
 
-func (w *runcExecutor) run(ctx context.Context, id, bundle string, process executor.ProcessInfo) (int, error) {
+func updateRuncFieldsForHostOS(runtime *runc.Runc) {}
+
+func (w *runcExecutor) run(ctx context.Context, id, bundle string, process executor.ProcessInfo) error {
 	if process.Meta.Tty {
-		return 0, unsupportedConsoleError
+		return unsupportedConsoleError
 	}
-	return w.runc.Run(ctx, id, bundle, &runc.CreateOpts{
+	_, err := w.runc.Run(ctx, id, bundle, &runc.CreateOpts{
 		IO:      &forwardIO{stdin: process.Stdin, stdout: process.Stdout, stderr: process.Stderr},
 		NoPivot: w.noPivot,
 	})
+	return err
 }
 
-func (w *runcExecutor) exec(ctx context.Context, id, bundle string, specsProcess *specs.Process, process executor.ProcessInfo) (int, error) {
+func (w *runcExecutor) exec(ctx context.Context, id, bundle string, specsProcess *specs.Process, process executor.ProcessInfo) error {
 	if process.Meta.Tty {
-		return 0, unsupportedConsoleError
+		return unsupportedConsoleError
 	}
-	err := w.runc.Exec(ctx, id, *specsProcess, &runc.ExecOpts{
+	return w.runc.Exec(ctx, id, *specsProcess, &runc.ExecOpts{
 		IO: &forwardIO{stdin: process.Stdin, stdout: process.Stdout, stderr: process.Stderr},
 	})
-
-	var exitError *exec.ExitError
-	if errors.As(err, &exitError) {
-		return exitError.ExitCode(), err
-	}
-	if err != nil {
-		return containerd.UnknownExitStatus, err
-	}
-	return 0, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containerd/containerd v1.4.1-0.20200903181227-d4e78200d6da
 	github.com/containerd/continuity v0.0.0-20200710164510-efbc4488d8fe
 	github.com/containerd/go-cni v1.0.1
-	github.com/containerd/go-runc v0.0.0-20200220073739-7016d3ce2328
+	github.com/containerd/go-runc v0.0.0-20201017060547-8c4be61c2e34
 	github.com/containerd/stargz-snapshotter v0.0.0-20200903042824-2ee75e91f8f9
 	github.com/containerd/typeurl v1.0.1
 	github.com/coreos/go-systemd/v22 v22.1.0

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,8 @@ github.com/containerd/go-cni v1.0.1/go.mod h1:+vUpYxKvAF72G9i1WoDOiPGRtQpqsNW/ZH
 github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3/go.mod h1:IV7qH3hrUgRmyYrtgEeGWJfWbgcHL9CSRruz2Vqcph0=
 github.com/containerd/go-runc v0.0.0-20200220073739-7016d3ce2328 h1:PRTagVMbJcCezLcHXe8UJvR1oBzp2lG3CEumeFOLOds=
 github.com/containerd/go-runc v0.0.0-20200220073739-7016d3ce2328/go.mod h1:PpyHrqVs8FTi9vpyHwPwiNEGaACDxT/N/pLcvMSRA9g=
+github.com/containerd/go-runc v0.0.0-20201017060547-8c4be61c2e34 h1:jFRg/hwx0DPpcg23MNusAppCDJa5nndN3/RAxSblN58=
+github.com/containerd/go-runc v0.0.0-20201017060547-8c4be61c2e34/go.mod h1:1CDPys/h0SMZoki7dv3bPQ1wJWnmaeZIO026WPts2xM=
 github.com/containerd/stargz-snapshotter v0.0.0-20200903042824-2ee75e91f8f9 h1:JEcj3rNCg0Ho5t9kiOa4LV/vaNXbRQ9l2PIRzz2LWCQ=
 github.com/containerd/stargz-snapshotter v0.0.0-20200903042824-2ee75e91f8f9/go.mod h1:f+gZLtYcuNQWxucWyfVEQXSBoGbXNpQ76+XWVMgp+34=
 github.com/containerd/ttrpc v0.0.0-20190828154514-0e0f228740de/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=

--- a/vendor/github.com/containerd/go-runc/.travis.yml
+++ b/vendor/github.com/containerd/go-runc/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 go:
-    - 1.12.x
     - 1.13.x
+    - 1.14.x
+    - 1.15.x
 
 install:
   - go get -t ./...

--- a/vendor/github.com/containerd/go-runc/go.mod
+++ b/vendor/github.com/containerd/go-runc/go.mod
@@ -6,5 +6,6 @@ require (
 	github.com/containerd/console v0.0.0-20191206165004-02ecf6a7291e
 	github.com/opencontainers/runtime-spec v1.0.1
 	github.com/pkg/errors v0.8.1
+	github.com/sirupsen/logrus v1.6.0
 	golang.org/x/sys v0.0.0-20191210023423-ac6580df4449
 )

--- a/vendor/github.com/containerd/go-runc/go.sum
+++ b/vendor/github.com/containerd/go-runc/go.sum
@@ -1,9 +1,16 @@
 github.com/containerd/console v0.0.0-20191206165004-02ecf6a7291e h1:GdiIYd8ZDOrT++e1NjhSD4rGt9zaJukHm4rt5F4mRQc=
 github.com/containerd/console v0.0.0-20191206165004-02ecf6a7291e/go.mod h1:8Pf4gM6VEbTNRIT26AyyU7hxdQU3MvAvxVI0sc00XBE=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/opencontainers/runtime-spec v1.0.1 h1:wY4pOY8fBdSIvs9+IDHC55thBuEulhzfSgKeC1yFvzQ=
 github.com/opencontainers/runtime-spec v1.0.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
+github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191210023423-ac6580df4449 h1:gSbV7h1NRL2G1xTg/owz62CST1oJBmxy4QpMMregXVQ=
 golang.org/x/sys v0.0.0-20191210023423-ac6580df4449/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/vendor/github.com/containerd/go-runc/io_unix.go
+++ b/vendor/github.com/containerd/go-runc/io_unix.go
@@ -20,7 +20,9 @@ package runc
 
 import (
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
+	"runtime"
 )
 
 // NewPipeIO creates pipe pairs to be used with runc
@@ -47,7 +49,13 @@ func NewPipeIO(uid, gid int, opts ...IOOpt) (i IO, err error) {
 		}
 		pipes = append(pipes, stdin)
 		if err = unix.Fchown(int(stdin.r.Fd()), uid, gid); err != nil {
-			return nil, errors.Wrap(err, "failed to chown stdin")
+			// TODO: revert with proper darwin solution, skipping for now
+			// as darwin chown is returning EINVAL on anonymous pipe
+			if runtime.GOOS == "darwin" {
+				logrus.WithError(err).Debug("failed to chown stdin, ignored")
+			} else {
+				return nil, errors.Wrap(err, "failed to chown stdin")
+			}
 		}
 	}
 	if option.OpenStdout {
@@ -56,7 +64,13 @@ func NewPipeIO(uid, gid int, opts ...IOOpt) (i IO, err error) {
 		}
 		pipes = append(pipes, stdout)
 		if err = unix.Fchown(int(stdout.w.Fd()), uid, gid); err != nil {
-			return nil, errors.Wrap(err, "failed to chown stdout")
+			// TODO: revert with proper darwin solution, skipping for now
+			// as darwin chown is returning EINVAL on anonymous pipe
+			if runtime.GOOS == "darwin" {
+				logrus.WithError(err).Debug("failed to chown stdout, ignored")
+			} else {
+				return nil, errors.Wrap(err, "failed to chown stdout")
+			}
 		}
 	}
 	if option.OpenStderr {
@@ -65,7 +79,13 @@ func NewPipeIO(uid, gid int, opts ...IOOpt) (i IO, err error) {
 		}
 		pipes = append(pipes, stderr)
 		if err = unix.Fchown(int(stderr.w.Fd()), uid, gid); err != nil {
-			return nil, errors.Wrap(err, "failed to chown stderr")
+			// TODO: revert with proper darwin solution, skipping for now
+			// as darwin chown is returning EINVAL on anonymous pipe
+			if runtime.GOOS == "darwin" {
+				logrus.WithError(err).Debug("failed to chown stderr, ignored")
+			} else {
+				return nil, errors.Wrap(err, "failed to chown stderr")
+			}
 		}
 	}
 	return &pipeIO{

--- a/vendor/github.com/containerd/go-runc/runc_unix.go
+++ b/vendor/github.com/containerd/go-runc/runc_unix.go
@@ -1,0 +1,38 @@
+//+build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package runc
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// Runc is the client to the runc cli
+type Runc struct {
+	//If command is empty, DefaultCommand is used
+	Command       string
+	Root          string
+	Debug         bool
+	Log           string
+	LogFormat     Format
+	PdeathSignal  unix.Signal
+	Setpgid       bool
+	Criu          string
+	SystemdCgroup bool
+	Rootless      *bool // nil stands for "auto"
+}

--- a/vendor/github.com/containerd/go-runc/runc_windows.go
+++ b/vendor/github.com/containerd/go-runc/runc_windows.go
@@ -1,0 +1,31 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package runc
+
+// Runc is the client to the runc cli
+type Runc struct {
+	//If command is empty, DefaultCommand is used
+	Command       string
+	Root          string
+	Debug         bool
+	Log           string
+	LogFormat     Format
+	Setpgid       bool
+	Criu          string
+	SystemdCgroup bool
+	Rootless      *bool // nil stands for "auto"
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -117,7 +117,7 @@ github.com/containerd/continuity/sysx
 github.com/containerd/fifo
 # github.com/containerd/go-cni v1.0.1
 github.com/containerd/go-cni
-# github.com/containerd/go-runc v0.0.0-20200220073739-7016d3ce2328
+# github.com/containerd/go-runc v0.0.0-20201017060547-8c4be61c2e34
 github.com/containerd/go-runc
 # github.com/containerd/stargz-snapshotter v0.0.0-20200903042824-2ee75e91f8f9
 github.com/containerd/stargz-snapshotter/cache


### PR DESCRIPTION
This fixes status error handling for runc exec, also makes status error messages common between runc and containerd executors.

Pulls in latest go-runc mod.  `Runc.PdeathSignal`  has been moved upstream to be `unix` only, so I have made the corresponding fix for the runc executor also.