### PR TITLE
Delay decoding stargz config for avoiding extra dependency for config pkg

### DIFF
--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-import sgzconf "github.com/containerd/stargz-snapshotter/stargz/config"
+import "github.com/BurntSushi/toml"
 
 // Config provides containerd configuration data for the server
 type Config struct {
@@ -80,9 +80,13 @@ type OCIConfig struct {
 	// incomplete and the intention is to make it default without config.
 	UserRemapUnsupported string `toml:"userRemapUnsupported"`
 	// For use in storing the OCI worker binary name that will replace buildkit-runc
-	Binary                  string         `toml:"binary"`
-	ProxySnapshotterPath    string         `toml:"proxySnapshotterPath"`
-	StargzSnapshotterConfig sgzconf.Config `toml:"stargzSnapshotter"`
+	Binary               string `toml:"binary"`
+	ProxySnapshotterPath string `toml:"proxySnapshotterPath"`
+
+	// StargzSnapshotterConfig is configuration for stargz snapshotter.
+	// Decoding this is delayed in order to remove the dependency from this
+	// config pkg to stargz snapshotter's config pkg.
+	StargzSnapshotterConfig toml.Primitive `toml:"stargzSnapshotter"`
 }
 
 type ContainerdConfig struct {

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -67,7 +67,8 @@ func init() {
 }
 
 type workerInitializerOpt struct {
-	config *config.Config
+	config         *config.Config
+	configMetaData *toml.MetaData
 }
 
 type workerInitializer struct {
@@ -236,7 +237,7 @@ func main() {
 			os.RemoveAll(lockPath)
 		}()
 
-		controller, err := newController(c, &cfg)
+		controller, err := newController(c, &cfg, md)
 		if err != nil {
 			return err
 		}
@@ -581,13 +582,14 @@ func serverCredentials(cfg config.TLSConfig) (*tls.Config, error) {
 	return tlsConf, nil
 }
 
-func newController(c *cli.Context, cfg *config.Config) (*control.Controller, error) {
+func newController(c *cli.Context, cfg *config.Config, md *toml.MetaData) (*control.Controller, error) {
 	sessionManager, err := session.NewManager()
 	if err != nil {
 		return nil, err
 	}
 	wc, err := newWorkerController(c, workerInitializerOpt{
-		config: cfg,
+		config:         cfg,
+		configMetaData: md,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
https://github.com/moby/moby/pull/41601#issuecomment-718730085

`cmd/buildkitd/config` pkg is imported and used by other packages including moby/moby.

Though stargz snapshotter configuration is currently effective only with buildkitd + OCI worker, `cmd/buildkitd/config` consumer needs to introduce an indirect dependency to stargz snapshotter's config pkg (`github.com/containerd/stargz-snapshotter/stargz/config`), which is too much.

This commit solves this by delaying decoding the stargz config until OCI worker's initialization phase.
