### PR TITLE
Add fuse dependency to moby/buildkit image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -129,6 +129,7 @@ FROM scratch AS release
 COPY --from=releaser /out/ /
 
 FROM tonistiigi/git@sha256:393483e1cef35f09e1a8fe0a0bd93a78b1b6ecec5b5afa5fa5d600fa3ab1fdd8 AS buildkit-export
+RUN apk add --no-cache fuse3 && ln -s fusermount3 /usr/bin/fusermount
 COPY examples/buildctl-daemonless/buildctl-daemonless.sh /usr/bin/
 VOLUME /var/lib/buildkit
 


### PR DESCRIPTION
Following-up: https://github.com/moby/buildkit/issues/1663

Currently moby/buildkit image misses fuse dependency (fusermount) so currently stargz support doesn't work on that image. 
This commit fixes this issue.

