### PR TITLE
add retry handlers to push/pull

### DIFF
--- a/cache/remote.go
+++ b/cache/remote.go
@@ -9,14 +9,12 @@ import (
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/reference"
-	"github.com/moby/buildkit/client"
-	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver"
 	"github.com/moby/buildkit/util/compression"
 	"github.com/moby/buildkit/util/contentutil"
 	"github.com/moby/buildkit/util/leaseutil"
-	"github.com/moby/buildkit/util/progress"
+	"github.com/moby/buildkit/util/progress/logs"
 	"github.com/moby/buildkit/util/pull/pullprogress"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -183,7 +181,7 @@ func (p lazyRefProvider) Unlazy(ctx context.Context) error {
 		err := contentutil.Copy(ctx, p.ref.cm.ContentStore, &pullprogress.ProviderWithProgress{
 			Provider: p.dh.Provider(p.session),
 			Manager:  p.ref.cm.ContentStore,
-		}, p.desc, loggerFromContext(ctx))
+		}, p.desc, logs.LoggerFromContext(ctx))
 		if err != nil {
 			return nil, err
 		}
@@ -202,14 +200,4 @@ func (p lazyRefProvider) Unlazy(ctx context.Context) error {
 		return nil, err
 	})
 	return err
-}
-
-func loggerFromContext(ctx context.Context) func([]byte) {
-	return func(dt []byte) {
-		pw, _, _ := progress.FromContext(ctx)
-		pw.Write(identity.NewID(), client.VertexLog{
-			Stream: 2,
-			Data:   []byte(dt),
-		})
-	}
 }

--- a/cache/remotecache/export.go
+++ b/cache/remotecache/export.go
@@ -10,13 +10,12 @@ import (
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
 	v1 "github.com/moby/buildkit/cache/remotecache/v1"
-	"github.com/moby/buildkit/client"
-	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver"
 	"github.com/moby/buildkit/util/compression"
 	"github.com/moby/buildkit/util/contentutil"
 	"github.com/moby/buildkit/util/progress"
+	"github.com/moby/buildkit/util/progress/logs"
 	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -96,7 +95,7 @@ func (ce *contentCacheExporter) Finalize(ctx context.Context) (map[string]string
 			return nil, errors.Errorf("missing blob %s", l.Blob)
 		}
 		layerDone := oneOffProgress(ctx, fmt.Sprintf("writing layer %s", l.Blob))
-		if err := contentutil.Copy(ctx, ce.ingester, dgstPair.Provider, dgstPair.Descriptor, loggerFromContext(ctx)); err != nil {
+		if err := contentutil.Copy(ctx, ce.ingester, dgstPair.Provider, dgstPair.Descriptor, logs.LoggerFromContext(ctx)); err != nil {
 			return nil, layerDone(errors.Wrap(err, "error writing layer blob"))
 		}
 		layerDone(nil)
@@ -145,14 +144,4 @@ func (ce *contentCacheExporter) Finalize(ctx context.Context) (map[string]string
 	res[ExporterResponseManifestDesc] = string(descJSON)
 	mfstDone(nil)
 	return res, nil
-}
-
-func loggerFromContext(ctx context.Context) func([]byte) {
-	return func(dt []byte) {
-		pw, _, _ := progress.FromContext(ctx)
-		pw.Write(identity.NewID(), client.VertexLog{
-			Stream: 2,
-			Data:   []byte(dt),
-		})
-	}
 }

--- a/util/contentutil/copy.go
+++ b/util/contentutil/copy.go
@@ -13,8 +13,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-func Copy(ctx context.Context, ingester content.Ingester, provider content.Provider, desc ocispec.Descriptor) error {
-	if _, err := retryhandler.New(remotes.FetchHandler(ingester, &localFetcher{provider}))(ctx, desc); err != nil {
+func Copy(ctx context.Context, ingester content.Ingester, provider content.Provider, desc ocispec.Descriptor, logger func([]byte)) error {
+	if _, err := retryhandler.New(remotes.FetchHandler(ingester, &localFetcher{provider}), logger)(ctx, desc); err != nil {
 		return err
 	}
 	return nil
@@ -65,7 +65,7 @@ func CopyChain(ctx context.Context, ingester content.Ingester, provider content.
 	handlers := []images.Handler{
 		images.ChildrenHandler(provider),
 		filterHandler,
-		retryhandler.New(remotes.FetchHandler(ingester, &localFetcher{provider})),
+		retryhandler.New(remotes.FetchHandler(ingester, &localFetcher{provider}), nil),
 	}
 
 	if err := images.Dispatch(ctx, images.Handlers(handlers...), nil, desc); err != nil {
@@ -73,7 +73,7 @@ func CopyChain(ctx context.Context, ingester content.Ingester, provider content.
 	}
 
 	for i := len(manifestStack) - 1; i >= 0; i-- {
-		if err := Copy(ctx, ingester, provider, manifestStack[i]); err != nil {
+		if err := Copy(ctx, ingester, provider, manifestStack[i], nil); err != nil {
 			return errors.WithStack(err)
 		}
 	}

--- a/util/contentutil/copy_test.go
+++ b/util/contentutil/copy_test.go
@@ -21,7 +21,7 @@ func TestCopy(t *testing.T) {
 	err := content.WriteBlob(ctx, b0, "foo", bytes.NewBuffer([]byte("foobar")), ocispec.Descriptor{Size: -1})
 	require.NoError(t, err)
 
-	err = Copy(ctx, b1, b0, ocispec.Descriptor{Digest: digest.FromBytes([]byte("foobar")), Size: -1})
+	err = Copy(ctx, b1, b0, ocispec.Descriptor{Digest: digest.FromBytes([]byte("foobar")), Size: -1}, nil)
 	require.NoError(t, err)
 
 	dt, err := content.ReadBlob(ctx, b1, ocispec.Descriptor{Digest: digest.FromBytes([]byte("foobar"))})

--- a/util/contentutil/fetcher_test.go
+++ b/util/contentutil/fetcher_test.go
@@ -26,7 +26,7 @@ func TestFetcher(t *testing.T) {
 	p := FromFetcher(f)
 
 	b1 := NewBuffer()
-	err = Copy(ctx, b1, p, ocispec.Descriptor{Digest: digest.FromBytes([]byte("foobar")), Size: -1})
+	err = Copy(ctx, b1, p, ocispec.Descriptor{Digest: digest.FromBytes([]byte("foobar")), Size: -1}, nil)
 	require.NoError(t, err)
 
 	dt, err := content.ReadBlob(ctx, b1, ocispec.Descriptor{Digest: digest.FromBytes([]byte("foobar"))})

--- a/util/imageutil/config.go
+++ b/util/imageutil/config.go
@@ -101,7 +101,7 @@ func Config(ctx context.Context, str string, resolver remotes.Resolver, cache Co
 	children := childrenConfigHandler(cache, platform)
 
 	handlers := []images.Handler{
-		retryhandler.New(remotes.FetchHandler(cache, fetcher)),
+		retryhandler.New(remotes.FetchHandler(cache, fetcher), nil),
 		children,
 	}
 	if err := images.Dispatch(ctx, images.Handlers(handlers...), nil, desc); err != nil {

--- a/util/imageutil/config.go
+++ b/util/imageutil/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/moby/buildkit/util/leaseutil"
+	"github.com/moby/buildkit/util/resolver/retryhandler"
 	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -100,7 +101,7 @@ func Config(ctx context.Context, str string, resolver remotes.Resolver, cache Co
 	children := childrenConfigHandler(cache, platform)
 
 	handlers := []images.Handler{
-		remotes.FetchHandler(cache, fetcher),
+		retryhandler.New(remotes.FetchHandler(cache, fetcher)),
 		children,
 	}
 	if err := images.Dispatch(ctx, images.Handlers(handlers...), nil, desc); err != nil {

--- a/util/pull/pull.go
+++ b/util/pull/pull.go
@@ -17,6 +17,7 @@ import (
 	"github.com/moby/buildkit/util/imageutil"
 	"github.com/moby/buildkit/util/pull/pullprogress"
 	"github.com/moby/buildkit/util/resolver"
+	"github.com/moby/buildkit/util/resolver/retryhandler"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -146,7 +147,7 @@ func (p *Puller) PullManifests(ctx context.Context) (*PulledManifests, error) {
 		}
 		handlers = append(handlers,
 			filterLayerBlobs(metadata, &mu),
-			remotes.FetchHandler(p.ContentStore, fetcher),
+			retryhandler.New(remotes.FetchHandler(p.ContentStore, fetcher)),
 			childrenHandler,
 			dslHandler,
 		)

--- a/util/pull/pull.go
+++ b/util/pull/pull.go
@@ -11,13 +11,11 @@ import (
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/containerd/containerd/remotes/docker/schema1"
-	"github.com/moby/buildkit/client"
-	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/util/contentutil"
 	"github.com/moby/buildkit/util/flightcontrol"
 	"github.com/moby/buildkit/util/imageutil"
-	"github.com/moby/buildkit/util/progress"
+	"github.com/moby/buildkit/util/progress/logs"
 	"github.com/moby/buildkit/util/pull/pullprogress"
 	"github.com/moby/buildkit/util/resolver"
 	"github.com/moby/buildkit/util/resolver/retryhandler"
@@ -150,7 +148,7 @@ func (p *Puller) PullManifests(ctx context.Context) (*PulledManifests, error) {
 		}
 		handlers = append(handlers,
 			filterLayerBlobs(metadata, &mu),
-			retryhandler.New(remotes.FetchHandler(p.ContentStore, fetcher), loggerFromContext(ctx)),
+			retryhandler.New(remotes.FetchHandler(p.ContentStore, fetcher), logs.LoggerFromContext(ctx)),
 			childrenHandler,
 			dslHandler,
 		)
@@ -262,14 +260,4 @@ func getLayers(ctx context.Context, provider content.Provider, desc ocispec.Desc
 		layers[i] = desc
 	}
 	return layers, nil
-}
-
-func loggerFromContext(ctx context.Context) func([]byte) {
-	return func(dt []byte) {
-		pw, _, _ := progress.FromContext(ctx)
-		pw.Write(identity.NewID(), client.VertexLog{
-			Stream: 2,
-			Data:   []byte(dt),
-		})
-	}
 }

--- a/util/push/push.go
+++ b/util/push/push.go
@@ -20,6 +20,7 @@ import (
 	"github.com/moby/buildkit/util/imageutil"
 	"github.com/moby/buildkit/util/progress"
 	"github.com/moby/buildkit/util/resolver"
+	"github.com/moby/buildkit/util/resolver/retryhandler"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -80,7 +81,7 @@ func Push(ctx context.Context, sm *session.Manager, sid string, provider content
 		}
 	})
 
-	pushHandler := remotes.PushHandler(pusher, provider)
+	pushHandler := retryhandler.New(remotes.PushHandler(pusher, provider))
 	pushUpdateSourceHandler, err := updateDistributionSourceHandler(manager, pushHandler, ref)
 	if err != nil {
 		return err

--- a/util/push/push.go
+++ b/util/push/push.go
@@ -14,13 +14,12 @@ import (
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/docker/distribution/reference"
-	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/cmd/buildkitd/config"
-	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/util/flightcontrol"
 	"github.com/moby/buildkit/util/imageutil"
 	"github.com/moby/buildkit/util/progress"
+	"github.com/moby/buildkit/util/progress/logs"
 	"github.com/moby/buildkit/util/resolver"
 	"github.com/moby/buildkit/util/resolver/retryhandler"
 	digest "github.com/opencontainers/go-digest"
@@ -83,7 +82,7 @@ func Push(ctx context.Context, sm *session.Manager, sid string, provider content
 		}
 	})
 
-	pushHandler := retryhandler.New(remotes.PushHandler(pusher, provider), loggerFromContext(ctx))
+	pushHandler := retryhandler.New(remotes.PushHandler(pusher, provider), logs.LoggerFromContext(ctx))
 	pushUpdateSourceHandler, err := updateDistributionSourceHandler(manager, pushHandler, ref)
 	if err != nil {
 		return err
@@ -311,14 +310,4 @@ func dedupeHandler(h images.HandlerFunc) images.HandlerFunc {
 		}
 		return res.([]ocispec.Descriptor), nil
 	})
-}
-
-func loggerFromContext(ctx context.Context) func([]byte) {
-	return func(dt []byte) {
-		pw, _, _ := progress.FromContext(ctx)
-		pw.Write(identity.NewID(), client.VertexLog{
-			Stream: 2,
-			Data:   []byte(dt),
-		})
-	}
 }

--- a/util/resolver/retryhandler/retry.go
+++ b/util/resolver/retryhandler/retry.go
@@ -1,0 +1,73 @@
+package retryhandler
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/containerd/containerd/images"
+	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/identity"
+	"github.com/moby/buildkit/util/progress"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+func New(f images.HandlerFunc) images.HandlerFunc {
+	return func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		backoff := time.Second
+		var pw progress.Writer
+		for {
+			descs, err := f(ctx, desc)
+			if err != nil {
+				select {
+				case <-ctx.Done():
+					return nil, err
+				default:
+					if !retryError(err) {
+						return nil, err
+					}
+				}
+				if pw == nil {
+					pw, _, _ = progress.FromContext(ctx)
+				}
+				pw.Write(identity.NewID(), client.VertexLog{
+					Stream: 2,
+					Data:   []byte(fmt.Sprintf("error: %v\n", err.Error())),
+				})
+			} else {
+				return descs, nil
+			}
+			// backoff logic
+			if backoff >= 8*time.Second {
+				return nil, err
+			}
+			pw.Write(identity.NewID(), client.VertexLog{
+				Stream: 2,
+				Data:   []byte(fmt.Sprintf("retrying in %v\n", backoff)),
+			})
+			time.Sleep(backoff)
+			backoff *= 2
+		}
+	}
+}
+
+func retryError(err error) bool {
+	if errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) {
+		return true
+	}
+	// https://github.com/containerd/containerd/pull/4724
+	if errors.Cause(err).Error() == "no response" {
+		return true
+	}
+
+	// net.ErrClosed exposed in go1.16
+	if strings.Contains(err.Error(), "use of closed network connection") {
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
Unlike docker, containerd does not perform retries on dropped connections. This adds basic retry backoff mechanisms for certain errors while logging them instead. Note that chunk based resume is still missing on push.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>