### PR TITLE
Use standard Makefile install variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-DESTDIR=/usr/local
+prefix=/usr/local
+bindir=$(prefix)/bin
 
 binaries: FORCE
 	hack/binaries
@@ -8,8 +9,8 @@ images: FORCE
 	hack/images local moby/buildkit
 
 install: FORCE
-	mkdir -p $(DESTDIR)/bin
-	install bin/* $(DESTDIR)/bin
+	mkdir -p $(DESTDIR)$(bindir)
+	install bin/* $(DESTDIR)$(bindir)
 
 clean: FORCE
 	rm -rf ./bin


### PR DESCRIPTION
The DESTDIR is supposed to be an optional staging location,
while the prefix says where software is going to be installed.

https://www.gnu.org/prep/standards/html_node/Directory-Variables.html
https://www.gnu.org/prep/standards/html_node/DESTDIR.html

Using standard variables make it easier to package (works out-of-the-box)

From #1794