### PR TITLE
Allow worker to override GetRemote(), needed in moby integration

### DIFF
--- a/cache/remote.go
+++ b/cache/remote.go
@@ -24,6 +24,8 @@ type Unlazier interface {
 	Unlazy(ctx context.Context) error
 }
 
+// GetRemote gets a *solver.Remote from content store for this ref (potentially pulling lazily).
+// Note: Use WorkerRef.GetRemote instead as moby integration requires custom GetRemote implementation.
 func (sr *immutableRef) GetRemote(ctx context.Context, createIfNeeded bool, compressionType compression.Type, s session.Group) (*solver.Remote, error) {
 	ctx, done, err := leaseutil.WithLease(ctx, sr.cm.LeaseManager, leaseutil.MakeTemporary)
 	if err != nil {

--- a/solver/llbsolver/result.go
+++ b/solver/llbsolver/result.go
@@ -82,6 +82,6 @@ func workerRefConverter(g session.Group) func(ctx context.Context, res solver.Re
 			return nil, errors.Errorf("invalid result: %T", res.Sys())
 		}
 
-		return ref.ImmutableRef.GetRemote(ctx, true, compression.Default, g)
+		return ref.GetRemote(ctx, true, compression.Default, g)
 	}
 }

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -270,7 +270,7 @@ func inlineCache(ctx context.Context, e remotecache.Exporter, res solver.CachedR
 			return nil, errors.Errorf("invalid reference: %T", res.Sys())
 		}
 
-		remote, err := workerRef.ImmutableRef.GetRemote(ctx, true, compression.Default, g)
+		remote, err := workerRef.GetRemote(ctx, true, compression.Default, g)
 		if err != nil || remote == nil {
 			return nil, nil
 		}

--- a/worker/cacheresult.go
+++ b/worker/cacheresult.go
@@ -78,7 +78,8 @@ func (s *cacheResultStorage) LoadRemote(ctx context.Context, res solver.CacheRes
 		return nil, err
 	}
 	defer ref.Release(context.TODO())
-	remote, err := ref.GetRemote(ctx, false, compression.Default, g)
+	wref := WorkerRef{ref, w}
+	remote, err := wref.GetRemote(ctx, false, compression.Default, g)
 	if err != nil {
 		return nil, nil // ignore error. loadRemote is best effort
 	}

--- a/worker/result.go
+++ b/worker/result.go
@@ -4,7 +4,9 @@ import (
 	"context"
 
 	"github.com/moby/buildkit/cache"
+	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/util/compression"
 )
 
 func NewWorkerRefResult(ref cache.ImmutableRef, worker Worker) solver.Result {
@@ -22,6 +24,18 @@ func (wr *WorkerRef) ID() string {
 		refID = wr.ImmutableRef.ID()
 	}
 	return wr.Worker.ID() + "::" + refID
+}
+
+// GetRemote method abstracts ImmutableRef's GetRemote to allow a Worker to override.
+// This is needed for moby integration.
+// Use this method instead of calling ImmutableRef.GetRemote() directly.
+func (wr *WorkerRef) GetRemote(ctx context.Context, createIfNeeded bool, compressionType compression.Type, g session.Group) (*solver.Remote, error) {
+	if w, ok := wr.Worker.(interface {
+		GetRemote(context.Context, cache.ImmutableRef, bool, compression.Type, session.Group) (*solver.Remote, error)
+	}); ok {
+		return w.GetRemote(ctx, wr.ImmutableRef, createIfNeeded, compressionType, g)
+	}
+	return wr.ImmutableRef.GetRemote(ctx, createIfNeeded, compressionType, g)
 }
 
 type workerRefResult struct {


### PR DESCRIPTION
This fixes panics in the moby integration of buildkit when using cache.
Panics come from nil Differ in computeBlobChain which is called in GetRemote().

GetRemote() got moved from Worker to ImmutableRef during the lazy-pull refactor.
However, the ability to easily override GetRemote() got lost with that refactor.

This patch attempts to allow for the override while keeping changes minimal.

Signed-off-by: Tibor Vass <tibor@docker.com>