### PR TITLE
copy  containerd.UnknownExitStatus to local const

### DIFF
--- a/executor/containerdexecutor/executor.go
+++ b/executor/containerdexecutor/executor.go
@@ -380,7 +380,7 @@ func (w *containerdExecutor) runProcess(ctx context.Context, p containerd.Proces
 					ExitCode: status.ExitCode(),
 					Err:      status.Error(),
 				}
-				if status.ExitCode() == containerd.UnknownExitStatus && status.Error() != nil {
+				if status.ExitCode() == errdefs.ContainerdUnknownExitStatus && status.Error() != nil {
 					exitErr.Err = errors.Wrap(status.Error(), "failure waiting for process")
 				}
 				select {

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -12,7 +12,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/mount"
 	containerdoci "github.com/containerd/containerd/oci"
 	"github.com/containerd/continuity/fs"
@@ -335,7 +334,7 @@ func (w *runcExecutor) Run(ctx context.Context, id string, root executor.Mount, 
 func exitError(ctx context.Context, err error) error {
 	if err != nil {
 		exitErr := &errdefs.ExitError{
-			ExitCode: containerd.UnknownExitStatus,
+			ExitCode: errdefs.ContainerdUnknownExitStatus,
 			Err:      err,
 		}
 		var runcExitError *runc.ExitError

--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/containerd/containerd"
 	"github.com/docker/distribution/reference"
 	"github.com/gogo/googleapis/google/rpc"
 	gogotypes "github.com/gogo/protobuf/types"
@@ -1170,7 +1169,7 @@ func (lbf *llbBridgeForwarder) ExecProcess(srv pb.LLBBridge_ExecProcessServer) e
 					var exitError *errdefs.ExitError
 					var statusError *rpc.Status
 					if err != nil {
-						statusCode = containerd.UnknownExitStatus
+						statusCode = errdefs.ContainerdUnknownExitStatus
 						st, _ := status.FromError(grpcerrors.ToGRPC(err))
 						stp := st.Proto()
 						statusError = &rpc.Status{

--- a/frontend/gateway/grpcclient/client.go
+++ b/frontend/gateway/grpcclient/client.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/containerd/containerd"
 	"github.com/gogo/googleapis/google/rpc"
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/golang/protobuf/ptypes/any"
@@ -883,7 +882,7 @@ func (ctr *container) Start(ctx context.Context, req client.StartRequest) (clien
 					Message: exit.Error.Message,
 					Details: convertGogoAny(exit.Error.Details),
 				}))
-				if exit.Code != containerd.UnknownExitStatus {
+				if exit.Code != errdefs.ContainerdUnknownExitStatus {
 					exitError = &errdefs.ExitError{ExitCode: exit.Code, Err: exitError}
 				}
 			} else if serverDone := msg.GetDone(); serverDone != nil {

--- a/solver/errdefs/exit.go
+++ b/solver/errdefs/exit.go
@@ -2,6 +2,16 @@ package errdefs
 
 import "fmt"
 
+const (
+	// ContainerdUnknownExitStatus is returned when containerd is unable to
+	// determine the exit status of a process. This can happen if the process never starts
+	// or if an error was encountered when obtaining the exit status, it is set to 255.
+	//
+	// This const is defined here to prevent importing github.com/containerd/containerd
+	// and corresponds with https://github.com/containerd/containerd/blob/40b22ef0741028917761d8c5d5d29e0d19038836/task.go#L52-L55
+	ContainerdUnknownExitStatus = 255
+)
+
 // ExitError will be returned when the container process exits with a non-zero
 // exit code.
 type ExitError struct {


### PR DESCRIPTION
relates to https://github.com/docker/cli/pull/2843

Copy this const to a local constant to prevent importing the containerd client in the front-end.

For consistency, I also updated the executor code to use the same const, although not strictly needed.
