### PR TITLE
cache: handle nil result from flightcontrol

### DIFF
--- a/cache/refs.go
+++ b/cache/refs.go
@@ -454,6 +454,9 @@ func (sr *immutableRef) prepareRemoteSnapshots(ctx context.Context, dhs DescHand
 		// This layer cannot be prepared without unlazying.
 		return false, nil
 	})
+	if err != nil {
+		return false, err
+	}
 	return ok.(bool), err
 }
 


### PR DESCRIPTION
Otherwise the error result may cause a panic.

@ktock Looking at the code I'm not sure why this function gets called at all on non-stargz. If it is not needed it makes the default path slower and should be avoided.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>