### PR TITLE
Check remote snapshot availability only for stargz

### DIFF
--- a/cache/refs.go
+++ b/cache/refs.go
@@ -399,8 +399,10 @@ func (sr *immutableRef) Extract(ctx context.Context, s session.Group) (rerr erro
 		ctx = winlayers.UseWindowsLayerMode(ctx)
 	}
 
-	if _, err := sr.prepareRemoteSnapshots(ctx, sr.descHandlers); err != nil {
-		return err
+	if sr.cm.Snapshotter.Name() == "stargz" {
+		if _, err := sr.prepareRemoteSnapshots(ctx, sr.descHandlers); err != nil {
+			return err
+		}
 	}
 
 	return sr.extract(ctx, sr.descHandlers, s)


### PR DESCRIPTION
Following-up: https://github.com/moby/buildkit/pull/1825
> Looking at the code I'm not sure why this function gets called at all on non-stargz. If it is not needed it makes the default path slower and should be avoided.

Since this patch, checking logic is enabled only for the configuration with "stargz" snapshotter. Currently this is done by checking the name of the snapshotter but we should find more generic way when more implementations of remote snapshotters are supported by BuildKit.

cc: @tonistiigi