### PR TITLE
move UnknownExitStatus to executor package from errdefs

### DIFF
--- a/client/build_test.go
+++ b/client/build_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/frontend/gateway/client"
+	gwerrdefs "github.com/moby/buildkit/frontend/gateway/errdefs"
 	gatewayapi "github.com/moby/buildkit/frontend/gateway/pb"
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/session"
@@ -450,7 +451,7 @@ func testClientGatewayContainerPID1Fail(t *testing.T, sb integration.Sandbox) {
 		defer ctr.Release(ctx)
 		err = pid1.Wait()
 
-		var exitError *errdefs.ExitError
+		var exitError *gwerrdefs.ExitError
 		require.True(t, errors.As(err, &exitError))
 		require.Equal(t, uint32(99), exitError.ExitCode)
 
@@ -775,7 +776,7 @@ func testClientGatewayContainerPID1Tty(t *testing.T, sb integration.Sandbox) {
 		prompt.SendExit(99)
 
 		err = pid1.Wait()
-		var exitError *errdefs.ExitError
+		var exitError *gwerrdefs.ExitError
 		require.True(t, errors.As(err, &exitError))
 		require.Equal(t, uint32(99), exitError.ExitCode)
 
@@ -919,7 +920,7 @@ func testClientGatewayContainerExecTty(t *testing.T, sb integration.Sandbox) {
 		prompt.SendExit(99)
 
 		err = pid2.Wait()
-		var exitError *errdefs.ExitError
+		var exitError *gwerrdefs.ExitError
 		require.True(t, errors.As(err, &exitError))
 		require.Equal(t, uint32(99), exitError.ExitCode)
 

--- a/executor/containerdexecutor/executor.go
+++ b/executor/containerdexecutor/executor.go
@@ -19,9 +19,9 @@ import (
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/moby/buildkit/executor"
 	"github.com/moby/buildkit/executor/oci"
+	"github.com/moby/buildkit/frontend/gateway/errdefs"
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/snapshot"
-	"github.com/moby/buildkit/solver/errdefs"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/network"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -380,7 +380,7 @@ func (w *containerdExecutor) runProcess(ctx context.Context, p containerd.Proces
 					ExitCode: status.ExitCode(),
 					Err:      status.Error(),
 				}
-				if status.ExitCode() == errdefs.ContainerdUnknownExitStatus && status.Error() != nil {
+				if status.ExitCode() == errdefs.UnknownExitStatus && status.Error() != nil {
 					exitErr.Err = errors.Wrap(status.Error(), "failure waiting for process")
 				}
 				select {

--- a/executor/containerdexecutor/executor_test.go
+++ b/executor/containerdexecutor/executor_test.go
@@ -1,0 +1,16 @@
+package containerdexecutor
+
+import (
+	"testing"
+
+	"github.com/containerd/containerd"
+	"github.com/moby/buildkit/frontend/gateway/errdefs"
+)
+
+func TestContainerdUnknownExitStatus(t *testing.T) {
+	// There are assumptions in the containerd executor that the UnknownExitStatus
+	// used in errdefs.ExitError matches the variable in the containerd package.
+	if containerd.UnknownExitStatus != errdefs.UnknownExitStatus {
+		t.Fatalf("containerd.UnknownExitStatus != errdefs.UnknownExitStatus")
+	}
+}

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -19,8 +19,8 @@ import (
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/moby/buildkit/executor"
 	"github.com/moby/buildkit/executor/oci"
+	"github.com/moby/buildkit/frontend/gateway/errdefs"
 	"github.com/moby/buildkit/identity"
-	"github.com/moby/buildkit/solver/errdefs"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/network"
 	rootlessspecconv "github.com/moby/buildkit/util/rootless/specconv"
@@ -334,7 +334,7 @@ func (w *runcExecutor) Run(ctx context.Context, id string, root executor.Mount, 
 func exitError(ctx context.Context, err error) error {
 	if err != nil {
 		exitErr := &errdefs.ExitError{
-			ExitCode: errdefs.ContainerdUnknownExitStatus,
+			ExitCode: errdefs.UnknownExitStatus,
 			Err:      err,
 		}
 		var runcExitError *runc.ExitError

--- a/frontend/gateway/errdefs/exit.go
+++ b/frontend/gateway/errdefs/exit.go
@@ -3,13 +3,13 @@ package errdefs
 import "fmt"
 
 const (
-	// ContainerdUnknownExitStatus is returned when containerd is unable to
-	// determine the exit status of a process. This can happen if the process never starts
+	// UnknownExitStatus might be returned in (*ExitError).ExitCode via
+	// ContainerProcess.Wait.  This can happen if the process never starts
 	// or if an error was encountered when obtaining the exit status, it is set to 255.
 	//
 	// This const is defined here to prevent importing github.com/containerd/containerd
 	// and corresponds with https://github.com/containerd/containerd/blob/40b22ef0741028917761d8c5d5d29e0d19038836/task.go#L52-L55
-	ContainerdUnknownExitStatus = 255
+	UnknownExitStatus = 255
 )
 
 // ExitError will be returned when the container process exits with a non-zero

--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -25,6 +25,7 @@ import (
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/frontend"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	gwerrdefs "github.com/moby/buildkit/frontend/gateway/errdefs"
 	pb "github.com/moby/buildkit/frontend/gateway/pb"
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/session"
@@ -1166,10 +1167,10 @@ func (lbf *llbBridgeForwarder) ExecProcess(srv pb.LLBBridge_ExecProcessServer) e
 					err := proc.Wait()
 
 					var statusCode uint32
-					var exitError *errdefs.ExitError
+					var exitError *gwerrdefs.ExitError
 					var statusError *rpc.Status
 					if err != nil {
-						statusCode = errdefs.ContainerdUnknownExitStatus
+						statusCode = gwerrdefs.UnknownExitStatus
 						st, _ := status.FromError(grpcerrors.ToGRPC(err))
 						stp := st.Proto()
 						statusError = &rpc.Status{

--- a/frontend/gateway/grpcclient/client.go
+++ b/frontend/gateway/grpcclient/client.go
@@ -16,9 +16,9 @@ import (
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/frontend/gateway/errdefs"
 	pb "github.com/moby/buildkit/frontend/gateway/pb"
 	"github.com/moby/buildkit/identity"
-	"github.com/moby/buildkit/solver/errdefs"
 	opspb "github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/apicaps"
 	"github.com/moby/buildkit/util/grpcerrors"
@@ -882,7 +882,7 @@ func (ctr *container) Start(ctx context.Context, req client.StartRequest) (clien
 					Message: exit.Error.Message,
 					Details: convertGogoAny(exit.Error.Details),
 				}))
-				if exit.Code != errdefs.ContainerdUnknownExitStatus {
+				if exit.Code != errdefs.UnknownExitStatus {
 					exitError = &errdefs.ExitError{ExitCode: exit.Code, Err: exitError}
 				}
 			} else if serverDone := msg.GetDone(); serverDone != nil {


### PR DESCRIPTION
resolves #1811

moved the variable from errdefs to be next to the executor interfaces

also renaming the variable since it is returned from both runc and container executor