### PR TITLE
Fix `make images` and GHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -317,7 +317,9 @@ jobs:
       -
         name: Build ${{ needs.release-base.outputs.tag }}
         run: |
-          ./hack/images "${{ needs.release-base.outputs.tag }}" "$REPO_SLUG_TARGET" "${{ needs.release-base.outputs.push }}"
+          tag="${{ needs.release-base.outputs.tag }}"
+          if [ -n "${{ matrix.target-stage }}" ]; then tag="$tag-${{ matrix.target-stage }}"; fi
+          ./hack/images "$tag" "$REPO_SLUG_TARGET" "${{ needs.release-base.outputs.push }}"
         env:
           TARGET: ${{ matrix.target-stage }}
           CACHE_DIR: /tmp/.buildkit-cache/${{ env.CACHEKEY_CROSS }} /tmp/.buildkit-cache/image${{ matrix.target-stage }}

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ binaries: FORCE
 images: FORCE
 # moby/buildkit:local and moby/buildkit:local-rootless are created on Docker
 	hack/images local moby/buildkit
+	TARGET=rootless hack/images local-rootless moby/buildkit
 
 install: FORCE
 	mkdir -p $(DESTDIR)$(bindir)

--- a/hack/images
+++ b/hack/images
@@ -25,9 +25,21 @@ if [ -z "$TAG" ] || [ -z "$REPO" ]; then
   usage
 fi
 
-pushFlag="push=false"
+localmode=""
+if [[ "$TAG" == local* ]]; then
+  localmode="1"
+  if [ "$PUSH" = "push" ]; then
+    echo >&2 "local images cannot be pushed"
+    exit 1
+  fi
+fi
+
+outputFlag="--output=type=image,push=false"
 if [ "$PUSH" = "push" ]; then
-  pushFlag="push=true"
+  outputFlag="--output=type=image,push=true"
+fi
+if [ -n "$localmode" ]; then
+  outputFlag="--output=type=docker"
 fi
 
 targetFlag=""
@@ -50,14 +62,16 @@ if [[ -n "$cacheref" ]] && [[ "$cachetype" = "local" ]]; then
     importCacheFlags="$importCacheFlags--cache-from=type=local,src=$ref "
   done
 fi
+if [ -n "$localmode" ]; then
+  importCacheFlags=""
+fi
 
 exportCacheFlags=""
 if [ "$PUSH" = "push" ]; then
   exportCacheFlags="--cache-to=type=inline "
 fi
 
-buildxCmd build $targetFlag $importCacheFlags $exportCacheFlags \
+buildxCmd build $targetFlag $importCacheFlags $exportCacheFlags $outputFlag \
   --platform "$PLATFORMS" \
   --tag "$REPO:$TAG$tagLatest" \
-  --output "type=image,$pushFlag" \
-  $currentref
+  $currentcontext


### PR DESCRIPTION
`make images` had been broken since d56ddccf0aeb96e56d72af28b7eb8589cf27f31f: (https://github.com/moby/buildkit/pull/1835)
- The context path was not specified in `docker buildx build`
- Registry cache was always specified even for local builds
- Rootless image was not built

Also, GHA didn't build the rootless image with a correct tag.
