### PR TITLE
hack/util: install buildx when not installed

### DIFF
--- a/hack/bootstrap-buildx
+++ b/hack/bootstrap-buildx
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+if [ "$#" -ne 1 ]; then
+  echo >&2 "usage: $0 <name>"
+  exit 1
+fi
+NAME="$1"
+echo "Bootstrapping buildx builder \"${NAME}\""
+
+topdir="$(realpath "$(dirname "$0")/..")"
+cd "${topdir}"
+buildx="./bin/buildx"
+if ! "${buildx}" inspect "${NAME}" >/dev/null 2>&1; then
+  set -x
+  "${buildx}" create --driver docker-container --name "${NAME}"
+fi
+
+set -x
+"${buildx}" inspect --bootstrap "${NAME}"

--- a/hack/install-buildx
+++ b/hack/install-buildx
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+topdir="$(realpath $(dirname "$0")/..)"
+cd "${topdir}"
+
+VERSION="v0.5.1"
+BINDIR="$(pwd)/bin"
+DEST="${BINDIR}/buildx"
+
+os=""
+case "$(uname)" in
+  Linux)
+    os="linux"
+    ;;
+  Darwin)
+    os="darwin"
+    ;;
+  *)
+    echo >&2 "unknown OS"
+    exit 1
+    ;;
+esac
+
+arch="$(uname -m)"
+case "${arch}" in
+  x86_64)
+    arch="amd64"
+    ;;
+  aarch64)
+    arch="arm64"
+    ;;
+  armv7l)
+    arch="arm-v7"
+    ;;
+  armv6l)
+    arch="arm-v6"
+    ;;
+esac
+
+url="https://github.com/docker/buildx/releases/download/${VERSION}/buildx-${VERSION}.${os}-${arch}"
+
+echo "Installing buildx ${VERSION} as ${DEST}"
+set -x
+mkdir -p "${BINDIR}"
+rm -f "${DEST}.download"
+curl -f -L -o "${DEST}.download" "${url}"
+chmod +x "${DEST}.download"
+mv "${DEST}.download" "${DEST}"

--- a/hack/util
+++ b/hack/util
@@ -28,11 +28,8 @@ buildxCmd() {
   elif buildx version >/dev/null 2>&1; then
     set -x
     buildx "$@" $progressFlag
-  elif docker version >/dev/null 2>&1; then
-    set -x
-    DOCKER_BUILDKIT=1 docker "$@" $progressFlag
   else
-    echo >&2 "ERROR: Please enable DOCKER_BUILDKIT or install standalone buildx"
+    echo >&2 "ERROR: Please install buildx"
     exit 1
   fi
 }

--- a/hack/util
+++ b/hack/util
@@ -29,8 +29,15 @@ buildxCmd() {
     set -x
     buildx "$@" $progressFlag
   else
-    echo >&2 "ERROR: Please install buildx"
-    exit 1
+    topdir="$(realpath $(dirname "$0")/..)"
+    if [ ! -x "${topdir}/bin/buildx" ]; then
+      set -x
+      "${topdir}/hack/install-buildx"
+    fi
+    set -x
+    bootstrapName="moby-buildkit"
+    "${topdir}/hack/bootstrap-buildx" "${bootstrapName}"
+    BUILDX_BUILDER="${bootstrapName}" "${topdir}/bin/buildx" "$@" $progressFlag
   fi
 }
 


### PR DESCRIPTION
DOCKER_BUILDKIT CLI is slightly different from buildx.
It is hard to maintain DOCKER_BUILDKIT as a buildx alternative.
