### PR TITLE
client: temporarily skip testClientSlowRootfsRef for containerd

### DIFF
--- a/client/build_test.go
+++ b/client/build_test.go
@@ -941,6 +941,11 @@ func testClientSlowCacheRootfsRef(t *testing.T, sb integration.Sandbox) {
 
 	ctx := context.TODO()
 
+	// https://github.com/moby/buildkit/issues/1820
+	if sb.ContainerdAddress() != "" {
+		t.Skip()
+	}
+
 	c, err := New(ctx, sb.Address())
 	require.NoError(t, err)
 	defer c.Close()


### PR DESCRIPTION
tracked in #1820

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>