### PR TITLE
fix invalid cancellation errors on pull

### DIFF
--- a/client/build_test.go
+++ b/client/build_test.go
@@ -941,11 +941,6 @@ func testClientSlowCacheRootfsRef(t *testing.T, sb integration.Sandbox) {
 
 	ctx := context.TODO()
 
-	// https://github.com/moby/buildkit/issues/1820
-	if sb.ContainerdAddress() != "" {
-		t.Skip()
-	}
-
 	c, err := New(ctx, sb.Address())
 	require.NoError(t, err)
 	defer c.Close()

--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -255,7 +255,7 @@ func (gf *gatewayFrontend) Solve(ctx context.Context, llbBridge frontend.Fronten
 	err = w.Executor().Run(ctx, "", mountWithSession(rootFS, session.NewGroup(sid)), nil, executor.ProcessInfo{Meta: meta, Stdin: lbf.Stdin, Stdout: lbf.Stdout, Stderr: os.Stderr}, nil)
 
 	if err != nil {
-		if errors.Is(err, context.Canceled) && lbf.isErrServerClosed {
+		if errdefs.IsCanceled(err) && lbf.isErrServerClosed {
 			err = errors.Errorf("frontend grpc server closed unexpectedly")
 		}
 		// An existing error (set via Return rpc) takes

--- a/solver/errdefs/context.go
+++ b/solver/errdefs/context.go
@@ -1,0 +1,13 @@
+package errdefs
+
+import (
+	"context"
+	"errors"
+
+	"github.com/moby/buildkit/util/grpcerrors"
+	"google.golang.org/grpc/codes"
+)
+
+func IsCanceled(err error) bool {
+	return errors.Is(err, context.Canceled) || grpcerrors.Code(err) == codes.Canceled
+}


### PR DESCRIPTION
fixes #1820

Cancellation errors should not be stored but when cancel error came from containerd client it was not matched by regular `errors.Is` check. This would not have happened if containerd used the same wrapped typed errors as buildkit but current containerd API does not allow me to add buildkit rpc wrapping to containerd calls. So instead use a special cancellation detection.

Also fix clearing the temporary leases so they could not accidentally cancel the context as well.

@crazy-max 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>