### PR TITLE
docs/rootless.md: add instruction for isolating netns

### DIFF
--- a/docs/rootless.md
+++ b/docs/rootless.md
@@ -52,6 +52,11 @@ $ rootlesskit buildkitd
 $ buildctl --addr unix:///run/user/$UID/buildkit/buildkitd.sock build ...
 ```
 
+To isolate BuildKit daemon's network namespace from the host (recommended):
+```console
+$ rootlesskit --net=slirp4netns --copy-up=/etc --disable-host-loopback buildkitd
+```
+
 ## Troubleshooting
 If facing an error related to `fuse-overlayfs`, try running `buildkitd` with `--oci-worker-snapshotter=native`:
 


### PR DESCRIPTION
Isolating network namespace with `rootlesskit --net=slirp4netns` is recommended for protecting localhost sockets and abstract sockets on the host.

This is not meaningful for running rootless buildkitd inside a container (because netns is already isolated), so slirp4netns is not added in Dockerfile.
