### PR TITLE
Ensure ENTRYPOINT command has at least one argument

### DIFF
--- a/frontend/dockerfile/instructions/parse.go
+++ b/frontend/dockerfile/instructions/parse.go
@@ -400,6 +400,10 @@ func parseCmd(req parseRequest) (*CmdCommand, error) {
 }
 
 func parseEntrypoint(req parseRequest) (*EntrypointCommand, error) {
+	if len(req.args) == 0 {
+		return nil, errAtLeastOneArgument("ENTRYPOINT")
+	}
+
 	if err := req.flags.Parse(); err != nil {
 		return nil, err
 	}

--- a/frontend/dockerfile/instructions/parse_test.go
+++ b/frontend/dockerfile/instructions/parse_test.go
@@ -34,6 +34,7 @@ func TestCommandsAtLeastOneArgument(t *testing.T) {
 		"HEALTHCHECK",
 		"EXPOSE",
 		"VOLUME",
+		"ENTRYPOINT",
 	}
 
 	for _, cmd := range commands {


### PR DESCRIPTION
Addressing issue #1119.

Added check to `parseEntrypoint` ensuring at least one argument is provided. Added ENTRYPOINT to the list of commands requiring at least one argument in `parse_test.go` as well.


Signed-off-by: Andrew Chang <chang331006@gmail.com>