### PR TITLE
Revert "Ensure ENTRYPOINT command has at least one argument"

### DIFF
--- a/frontend/dockerfile/instructions/parse.go
+++ b/frontend/dockerfile/instructions/parse.go
@@ -400,10 +400,6 @@ func parseCmd(req parseRequest) (*CmdCommand, error) {
 }
 
 func parseEntrypoint(req parseRequest) (*EntrypointCommand, error) {
-	if len(req.args) == 0 {
-		return nil, errAtLeastOneArgument("ENTRYPOINT")
-	}
-
 	if err := req.flags.Parse(); err != nil {
 		return nil, err
 	}

--- a/frontend/dockerfile/instructions/parse_test.go
+++ b/frontend/dockerfile/instructions/parse_test.go
@@ -34,7 +34,6 @@ func TestCommandsAtLeastOneArgument(t *testing.T) {
 		"HEALTHCHECK",
 		"EXPOSE",
 		"VOLUME",
-		"ENTRYPOINT",
 	}
 
 	for _, cmd := range commands {


### PR DESCRIPTION
This reverts commit 174bcf85efbd65ffdc19acfb7d0cab653e78a979 (https://github.com/moby/buildkit/pull/1862),

This commit attempted to fix a situation where an empty entrypoint was specified, causing a confusing error when running the image (https://github.com/moby/buildkit/issues/1119), however, allowing the entrypoint to be reset should be a valid use-case, and running such image on docker 20.10 at least produces an informative error;

    docker build -t foo -<<'EOF'
    FROM busybox
    ENTRYPOINT []
    EOF

Or, to reset a previously set entrypoint:

    docker build -t foo -<<'EOF'
    FROM busybox AS one
    ENTRYPOINT ["/bin/busybox"]

    FROM one AS two
    ENTRYPOINT []
    EOF

If no command is specified for the image above:

    docker run -it --rm foo
    docker: Error response from daemon: No command specified.
    See 'docker run --help'.

Passing a command to run:

    docker run -it --rm foo sh
    /#

Given that this commit resulted in a regression/breaking change this reverts the commit. (see https://github.com/moby/moby/pull/41745)
