### PR TITLE
handle foreign mediatypes on push

### DIFF
--- a/util/compression/compression.go
+++ b/util/compression/compression.go
@@ -99,17 +99,21 @@ func detectCompressionType(cr io.Reader) (Type, error) {
 }
 
 var toDockerLayerType = map[string]string{
-	ocispec.MediaTypeImageLayer:            images.MediaTypeDockerSchema2Layer,
-	images.MediaTypeDockerSchema2Layer:     images.MediaTypeDockerSchema2Layer,
-	ocispec.MediaTypeImageLayerGzip:        images.MediaTypeDockerSchema2LayerGzip,
-	images.MediaTypeDockerSchema2LayerGzip: images.MediaTypeDockerSchema2LayerGzip,
+	ocispec.MediaTypeImageLayer:                   images.MediaTypeDockerSchema2Layer,
+	images.MediaTypeDockerSchema2Layer:            images.MediaTypeDockerSchema2Layer,
+	ocispec.MediaTypeImageLayerGzip:               images.MediaTypeDockerSchema2LayerGzip,
+	images.MediaTypeDockerSchema2LayerGzip:        images.MediaTypeDockerSchema2LayerGzip,
+	images.MediaTypeDockerSchema2LayerForeign:     images.MediaTypeDockerSchema2Layer,
+	images.MediaTypeDockerSchema2LayerForeignGzip: images.MediaTypeDockerSchema2LayerGzip,
 }
 
 var toOCILayerType = map[string]string{
-	ocispec.MediaTypeImageLayer:            ocispec.MediaTypeImageLayer,
-	images.MediaTypeDockerSchema2Layer:     ocispec.MediaTypeImageLayer,
-	ocispec.MediaTypeImageLayerGzip:        ocispec.MediaTypeImageLayerGzip,
-	images.MediaTypeDockerSchema2LayerGzip: ocispec.MediaTypeImageLayerGzip,
+	ocispec.MediaTypeImageLayer:                   ocispec.MediaTypeImageLayer,
+	images.MediaTypeDockerSchema2Layer:            ocispec.MediaTypeImageLayer,
+	ocispec.MediaTypeImageLayerGzip:               ocispec.MediaTypeImageLayerGzip,
+	images.MediaTypeDockerSchema2LayerGzip:        ocispec.MediaTypeImageLayerGzip,
+	images.MediaTypeDockerSchema2LayerForeign:     ocispec.MediaTypeImageLayer,
+	images.MediaTypeDockerSchema2LayerForeignGzip: ocispec.MediaTypeImageLayerGzip,
 }
 
 func convertLayerMediaType(mediaType string, oci bool) string {


### PR DESCRIPTION
fixes #1877

Using the original mediatype for compression detection tried to push with a foreign mediatypes that is not always allowed by registries.

The current logic doesn't support other compressions than gzip. Future change should allow storing multiple blobs with different compressions/no-compression and convert from one compression to other if needed.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>