### PR TITLE
docs: add readme used for registry images

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ buildctl build \
 
 #### Building a Dockerfile using external frontend:
 
-External versions of the Dockerfile frontend are pushed to https://hub.docker.com/r/docker/dockerfile-upstream and https://hub.docker.com/r/docker/dockerfile and can be used with the gateway frontend. The source for the external frontend is currently located in `./frontend/dockerfile/cmd/dockerfile-frontend` but will move out of this repository in the future ([#163](https://github.com/moby/buildkit/issues/163)). For automatic build from master branch of this repository `docker/dockerfile-upsteam:master` or `docker/dockerfile-upstream:master-experimental` image can be used.
+External versions of the Dockerfile frontend are pushed to https://hub.docker.com/r/docker/dockerfile-upstream and https://hub.docker.com/r/docker/dockerfile and can be used with the gateway frontend. The source for the external frontend is currently located in `./frontend/dockerfile/cmd/dockerfile-frontend` but will move out of this repository in the future ([#163](https://github.com/moby/buildkit/issues/163)). For automatic build from master branch of this repository `docker/dockerfile-upstream:master` or `docker/dockerfile-upstream:master-labs` image can be used.
 
 ```bash
 buildctl build \
@@ -435,7 +435,7 @@ For Kubernetes deployments, see [`examples/kubernetes`](./examples/kubernetes).
 
 ### Daemonless
 
-To run client and an ephemeral daemon in a single container ("daemonless mode"):
+To run the client and an ephemeral daemon in a single container ("daemonless mode"):
 
 ```bash
 docker run \

--- a/docs/images-readme.md
+++ b/docs/images-readme.md
@@ -1,0 +1,94 @@
+# BuildKit
+
+BuildKit is a concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit.
+
+Report issues at https://github.com/moby/buildkit
+
+Join `#buildkit` channel on [Docker Community Slack](http://dockr.ly/slack)
+
+# Tags
+
+### Latest stable release
+
+- [`v0.8.0`, `latest`](https://github.com/moby/buildkit/blob/v0.8.0/Dockerfile)
+
+- [`v0.8.0-rootless`, `rootless`](https://github.com/moby/buildkit/blob/v0.8.0/Dockerfile) (see [`docs/rootless.md`](https://github.com/moby/buildkit/blob/master/docs/rootless.md) for usage)
+
+### Development build from master branch
+
+- [`master`](https://github.com/moby/buildkit/blob/master/Dockerfile)
+
+- [`master-rootless`](https://github.com/moby/buildkit/blob/master/Dockerfile)
+
+
+Binary releases and changelog can be found from https://github.com/moby/buildkit/releases
+
+# Usage
+
+
+To run daemon in a container:
+
+```bash
+docker run -d --name buildkitd --privileged moby/buildkit:latest
+export BUILDKIT_HOST=docker-container://buildkitd
+buildctl build --help
+```
+
+See https://github.com/moby/buildkit#buildkit for general BuildKit usage instructions
+
+
+## Docker Buildx
+
+[Buildx](https://github.com/docker/buildx) uses the latest stable image by default. To set a custom BuildKit image version use `--driver-opt`:
+
+```bash
+docker buildx create --driver-opt image=moby/buildkit:master --use
+```
+
+
+## Rootless
+
+For Rootless deployments, see [`docs/rootless.md`](https://github.com/moby/buildkit/blob/master/docs/rootless.md)
+
+
+## Kubernetes
+
+For Kubernetes deployments, see [`examples/kubernetes`](https://github.com/moby/buildkit/tree/master/examples/kubernetes)
+
+
+## Daemonless
+
+To run the client and an ephemeral daemon in a single container ("daemonless mode"):
+
+```bash
+docker run \
+    -it \
+    --rm \
+    --privileged \
+    -v /path/to/dir:/tmp/work \
+    --entrypoint buildctl-daemonless.sh \
+    moby/buildkit:master \
+        build \
+        --frontend dockerfile.v0 \
+        --local context=/tmp/work \
+        --local dockerfile=/tmp/work
+```
+
+Rootless mode:
+
+```bash
+docker run \
+    -it \
+    --rm \
+    --security-opt seccomp=unconfined \
+    --security-opt apparmor=unconfined \
+    -e BUILDKITD_FLAGS=--oci-worker-no-process-sandbox \
+    -v /path/to/dir:/tmp/work \
+    --entrypoint buildctl-daemonless.sh \
+    moby/buildkit:master-rootless \
+        build \
+        --frontend \
+        dockerfile.v0 \
+        --local context=/tmp/work \
+        --local dockerfile=/tmp/work
+```


### PR DESCRIPTION
This is the base for readme at https://hub.docker.com/r/moby/buildkit . Maybe in the future, this can be automated so tags don't need to be modified manually.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>