### PR TITLE
solver: delay before discarding job

### DIFF
--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -527,7 +527,13 @@ func (j *Job) Discard() error {
 		st.mu.Unlock()
 	}
 
-	delete(j.list.jobs, j.id)
+	go func() {
+		// don't clear job right away. there might still be a status request coming to read progress
+		time.Sleep(10 * time.Second)
+		j.list.mu.Lock()
+		defer j.list.mu.Unlock()
+		delete(j.list.jobs, j.id)
+	}()
 	return nil
 }
 


### PR DESCRIPTION
Previous versions of buildkit leaked job IDs. Cleanup was added in #1752 but it is too agressive. As `Solve()` and `Status()` requests are made in parallel, `Solve()` could finish up before `Status()` arrives and receives " job ID not found".

Saw this failing in an integration test.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>