### PR TITLE
llb: make sure fileop uses the platform for current state

### DIFF
--- a/client/llb/fileop.go
+++ b/client/llb/fileop.go
@@ -661,6 +661,14 @@ func (f *FileOp) Marshal(ctx context.Context, c *Constraints) (digest.Digest, []
 
 	pfo := &pb.FileOp{}
 
+	if f.constraints.Platform == nil {
+		p, err := getPlatform(*f.action.state)(ctx)
+		if err != nil {
+			return "", nil, nil, nil, err
+		}
+		f.constraints.Platform = p
+	}
+
 	pop, md := MarshalConstraints(c, &f.constraints)
 	pop.Op = &pb.Op_File{
 		File: pfo,


### PR DESCRIPTION
If source root sets the platform for a state, vertexes should
keep that instead of using the global value passed on marshal.
Already worked properly for exec, but not for file.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>