### PR TITLE
exporter: return config digest when exporting single-arch image

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1649,6 +1649,8 @@ func testExporterTargetExists(t *testing.T, sb integration.Sandbox) {
 
 	require.True(t, strings.HasPrefix(dgst, "sha256:"))
 	require.Equal(t, dgst, mdDgst)
+
+	require.True(t, strings.HasPrefix(res.ExporterResponse["containerimage.config.digest"], "sha256:"))
 }
 
 func testTarExporterWithSocket(t *testing.T, sb integration.Sandbox) {

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -273,6 +273,9 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source,
 	}
 
 	resp["containerimage.digest"] = desc.Digest.String()
+	if v, ok := desc.Annotations["config.digest"]; ok {
+		resp["containerimage.config.digest"] = v
+	}
 	return resp, nil
 }
 

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -139,6 +139,10 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source,
 
 	resp := make(map[string]string)
 	resp["containerimage.digest"] = desc.Digest.String()
+	if v, ok := desc.Annotations["config.digest"]; ok {
+		resp["containerimage.config.digest"] = v
+		delete(desc.Annotations, "config.digeest")
+	}
 
 	if n, ok := src.Metadata["image.name"]; e.name == "*" && ok {
 		e.name = string(n)


### PR DESCRIPTION
Accessing config digest is important when exporting to Docker where manifests digests are not yet supported. 

Related https://github.com/docker/buildx/issues/420

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>