### PR TITLE
allow nil return from frontend

### DIFF
--- a/frontend/frontend_test.go
+++ b/frontend/frontend_test.go
@@ -32,7 +32,34 @@ func TestFrontendIntegration(t *testing.T) {
 		testRefReadFile,
 		testRefReadDir,
 		testRefStatFile,
+		testReturnNil,
 	})
+}
+
+func testReturnNil(t *testing.T, sb integration.Sandbox) {
+	ctx := context.TODO()
+
+	c, err := client.New(ctx, sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	destDir, err := ioutil.TempDir("", "buildkit")
+	require.NoError(t, err)
+	defer os.RemoveAll(destDir)
+
+	frontend := func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
+		return nil, nil
+	}
+
+	_, err = c.Build(ctx, client.SolveOpt{}, "", frontend, nil)
+	require.NoError(t, err)
+
+	frontend = func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
+		return gateway.NewResult(), nil
+	}
+
+	_, err = c.Build(ctx, client.SolveOpt{}, "", frontend, nil)
+	require.NoError(t, err)
 }
 
 func testRefReadFile(t *testing.T, sb integration.Sandbox) {

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -131,6 +131,10 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 		}
 	}
 
+	if res == nil {
+		res = &frontend.Result{}
+	}
+
 	defer func() {
 		res.EachRef(func(ref solver.ResultProxy) error {
 			go ref.Release(context.TODO())


### PR DESCRIPTION
Returning `nil,nil` from frontend could result in a `nil dereference panic`.

The added test actually does not catch this as the client gateway has no issue, but added for future safety. Testing frontends via a gateway is kind of complicated outside of dockerfile atm.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>