### PR TITLE
cache: retain layer annotations

### DIFF
--- a/cache/blobs.go
+++ b/cache/blobs.go
@@ -219,6 +219,7 @@ func (sr *immutableRef) setBlob(ctx context.Context, desc ocispec.Descriptor) er
 	queueBlobChainID(sr.md, blobChainID.String())
 	queueMediaType(sr.md, desc.MediaType)
 	queueBlobSize(sr.md, desc.Size)
+	queueAnnotations(sr.md, desc.Annotations)
 	if err := sr.md.Commit(); err != nil {
 		return err
 	}

--- a/cache/manager.go
+++ b/cache/manager.go
@@ -250,6 +250,7 @@ func (cm *cacheManager) GetByBlob(ctx context.Context, desc ocispec.Descriptor, 
 	queueBlobOnly(rec.md, blobOnly)
 	queueMediaType(rec.md, desc.MediaType)
 	queueBlobSize(rec.md, desc.Size)
+	queueAnnotations(rec.md, desc.Annotations)
 	queueCommitted(rec.md)
 
 	if err := rec.md.Commit(); err != nil {

--- a/cache/refs.go
+++ b/cache/refs.go
@@ -57,6 +57,7 @@ type RefInfo struct {
 	Blob        digest.Digest
 	MediaType   string
 	Extracted   bool
+	Annotations map[string]string
 }
 
 type MutableRef interface {
@@ -333,6 +334,7 @@ func (sr *immutableRef) Info() RefInfo {
 		BlobChainID: digest.Digest(getBlobChainID(sr.md)),
 		SnapshotID:  getSnapshotID(sr.md),
 		Extracted:   !getBlobOnly(sr.md),
+		Annotations: getAnnotations(sr.md),
 	}
 }
 
@@ -341,7 +343,7 @@ func (sr *immutableRef) ociDesc() (ocispec.Descriptor, error) {
 		Digest:      digest.Digest(getBlob(sr.md)),
 		Size:        getBlobSize(sr.md),
 		MediaType:   getMediaType(sr.md),
-		Annotations: make(map[string]string),
+		Annotations: getAnnotations(sr.md),
 	}
 
 	diffID := getDiffID(sr.md)


### PR DESCRIPTION
This allows retaining layer annotations returned from the differ.

The current differ implementation does not create any annotation, but future implementation may.