### PR TITLE
Dispatch workflow for buildx image

### DIFF
--- a/.github/workflows/buildx-image.yml
+++ b/.github/workflows/buildx-image.yml
@@ -1,0 +1,73 @@
+# source  latest
+# dest    buildx-stable-1
+# result  moby/buildkit:latest   > moby/buildkit:buildx-stable-1
+#         moby/buildkit:rootless > moby/buildkit:buildx-stable-1-rootless
+#
+# source  v0.8.1
+# dest    buildx-stable-1
+# result  moby/buildkit:v0.8.1          > moby/buildkit:buildx-stable-1
+#         moby/buildkit:v0.8.1-rootless > moby/buildkit:buildx-stable-1-rootless
+name: buildx-image
+
+on:
+  workflow_dispatch:
+    inputs:
+      source-tag:
+        description: 'BuildKit source Docker tag'
+        required: true
+        default: 'latest'
+      dest-tag:
+        description: 'Default BuildKit Docker tag for buildx'
+        required: true
+        default: 'buildx-stable-1'
+      dry-run:
+        description: 'Dry run'
+        required: false
+        default: 'true'
+
+env:
+  REPO_SLUG_TARGET: "moby/buildkit"
+
+jobs:
+  create:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor:
+          - ''
+          - 'rootless'
+    steps:
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        if: inputs.dry-run != 'true'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Create
+        run: |
+          DRYRUN_FLAG=""
+          if [ "${{ inputs.dry-run }}" = "true" ]; then
+            DRYRUN_FLAG="--dry-run"
+          fi
+
+          SOURCE_TAG="${{ inputs.source-tag }}"
+          DEST_TAG="${{ inputs.dest-tag }}"
+          if [ "${{ matrix.flavor }}" != "" ]; then
+            if [ "$SOURCE_TAG" = "latest" ]; then
+              SOURCE_TAG="${{ matrix.flavor }}"
+            else
+              SOURCE_TAG="${SOURCE_TAG}-${{ matrix.flavor }}"
+            fi
+            DEST_TAG="${DEST_TAG}-${{ matrix.flavor }}"
+          fi
+
+          set -x
+          docker buildx imagetools create ${DRYRUN_FLAG} --tag \
+            "${{ env.REPO_SLUG_TARGET }}:${DEST_TAG}" \
+            "${{ env.REPO_SLUG_TARGET }}:${SOURCE_TAG}"


### PR DESCRIPTION
Ref. docker/buildx#479 docker/buildx#419

Simple workflow to be able to create/update the buildkit tag for [buildx docker-container driver](https://github.com/docker/buildx/blob/master/driver/bkimage/bkimage.go). Only members with `write` access to this repo are allowed to trigger this workflow.

We could also add more restrictions:
* Specific users that can trigger the workflow: `if: contains('["AkihiroSuda","tonistiigi"]', github.actor)`
* Specific prefix to avoid tag corruption (`buildx-`?)
* Immutability?

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>