### PR TITLE
Add support for fd:// for socket activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ You don't need to read this document unless you want to use the full-featured st
     - [`--export-cache` options](#--export-cache-options)
     - [`--import-cache` options](#--import-cache-options)
   - [Consistent hashing](#consistent-hashing)
+- [Systemd socket activation](#systemd-socket-activation)
 - [Expose BuildKit as a TCP service](#expose-buildkit-as-a-tcp-service)
   - [Load balancing](#load-balancing)
 - [Containerizing BuildKit](#containerizing-buildkit)
@@ -125,6 +126,9 @@ The buildkitd daemon supports two worker backends: OCI (runc) and containerd.
 By default, the OCI (runc) worker is used. You can set `--oci-worker=false --containerd-worker=true` to use the containerd worker.
 
 We are open to adding more backends.
+
+To start the buildkitd daemon using systemd socket activiation, you can install the buildkit systemd unit files.
+See [Systemd socket activation](#systemd-socket-activation)
 
 The buildkitd daemon listens gRPC API on `/run/buildkit/buildkitd.sock` by default, but you can also use TCP sockets.
 See [Expose BuildKit as a TCP service](#expose-buildkit-as-a-tcp-service).
@@ -370,6 +374,10 @@ consider client-side load balancing using consistent hashing.
 
 See [`./examples/kubernetes/consistenthash`](./examples/kubernetes/consistenthash).
 
+## Systemd socket activation
+
+On Systemd based systems, you can communicate with the daemon via [Systemd socket activation](http://0pointer.de/blog/projects/socket-activation.html), use `buildkitd --addr fd://`.
+You can find examples of using Systemd socket activation with BuildKit and Systemd in [`./examples/systemd`](./examples/systemd).
 ## Expose BuildKit as a TCP service
 
 The `buildkitd` daemon can listen the gRPC API on a TCP socket.

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -512,6 +512,8 @@ func getListener(addr string, uid, gid int, tlsConfig *tls.Config) (net.Listener
 			logrus.Warnf("TLS is disabled for %s", addr)
 		}
 		return sys.GetLocalListener(listenAddr, uid, gid)
+	case "fd":
+		return listenFD(listenAddr, tlsConfig)
 	case "tcp":
 		if tlsConfig == nil {
 			logrus.Warnf("TLS is not enabled for %s. enabling mutual TLS authentication is highly recommended", addr)

--- a/cmd/buildkitd/main_unix.go
+++ b/cmd/buildkitd/main_unix.go
@@ -3,9 +3,42 @@
 package main
 
 import (
+	"crypto/tls"
+	"net"
 	"syscall"
+
+	"github.com/coreos/go-systemd/v22/activation"
+	"github.com/pkg/errors"
 )
 
 func init() {
 	syscall.Umask(0)
+}
+
+func listenFD(addr string, tlsConfig *tls.Config) (net.Listener, error) {
+	var (
+		err       error
+		listeners []net.Listener
+	)
+	// socket activation
+	if tlsConfig != nil {
+		listeners, err = activation.TLSListeners(tlsConfig)
+	} else {
+		listeners, err = activation.Listeners()
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if len(listeners) == 0 {
+		return nil, errors.New("no sockets found via socket activation: make sure the service was started by systemd")
+	}
+
+	// default to first fd
+	if addr == "" {
+		return listeners[0], nil
+	}
+
+	//TODO: systemd fd selection (default is 3)
+	return nil, errors.New("not supported yet")
 }

--- a/cmd/buildkitd/main_windows.go
+++ b/cmd/buildkitd/main_windows.go
@@ -3,5 +3,13 @@
 package main
 
 import (
+	"crypto/tls"
+	"net"
+
 	_ "github.com/moby/buildkit/solver/llbsolver/ops"
+	"github.com/pkg/errors"
 )
+
+func listenFD(addr string, tlsConfig *tls.Config) (net.Listener, error) {
+	return nil, errors.New("listening server on fd not supported on windows")
+}

--- a/examples/systemd/buildkit.service
+++ b/examples/systemd/buildkit.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=BuildKit
+Requires=buildkit.socket
+After=buildkit.socket
+Documentation=https://github.com/moby/buildkit
+
+[Service]
+ExecStart=/usr/local/bin/buildkitd --addr fd://
+
+[Install]
+WantedBy=multi-user.target

--- a/examples/systemd/buildkit.socket
+++ b/examples/systemd/buildkit.socket
@@ -1,0 +1,9 @@
+[Unit]
+Description=BuildKit
+Documentation=https://github.com/moby/buildkit
+
+[Socket]
+ListenStream=%t/buildkit/buildkitd.sock
+
+[Install]
+WantedBy=sockets.target

--- a/vendor/github.com/coreos/go-systemd/v22/activation/files.go
+++ b/vendor/github.com/coreos/go-systemd/v22/activation/files.go
@@ -1,0 +1,67 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package activation implements primitives for systemd socket activation.
+package activation
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+const (
+	// listenFdsStart corresponds to `SD_LISTEN_FDS_START`.
+	listenFdsStart = 3
+)
+
+// Files returns a slice containing a `os.File` object for each
+// file descriptor passed to this process via systemd fd-passing protocol.
+//
+// The order of the file descriptors is preserved in the returned slice.
+// `unsetEnv` is typically set to `true` in order to avoid clashes in
+// fd usage and to avoid leaking environment flags to child processes.
+func Files(unsetEnv bool) []*os.File {
+	if unsetEnv {
+		defer os.Unsetenv("LISTEN_PID")
+		defer os.Unsetenv("LISTEN_FDS")
+		defer os.Unsetenv("LISTEN_FDNAMES")
+	}
+
+	pid, err := strconv.Atoi(os.Getenv("LISTEN_PID"))
+	if err != nil || pid != os.Getpid() {
+		return nil
+	}
+
+	nfds, err := strconv.Atoi(os.Getenv("LISTEN_FDS"))
+	if err != nil || nfds == 0 {
+		return nil
+	}
+
+	names := strings.Split(os.Getenv("LISTEN_FDNAMES"), ":")
+
+	files := make([]*os.File, 0, nfds)
+	for fd := listenFdsStart; fd < listenFdsStart+nfds; fd++ {
+		syscall.CloseOnExec(fd)
+		name := "LISTEN_FD_" + strconv.Itoa(fd)
+		offset := fd - listenFdsStart
+		if offset < len(names) && len(names[offset]) > 0 {
+			name = names[offset]
+		}
+		files = append(files, os.NewFile(uintptr(fd), name))
+	}
+
+	return files
+}

--- a/vendor/github.com/coreos/go-systemd/v22/activation/listeners.go
+++ b/vendor/github.com/coreos/go-systemd/v22/activation/listeners.go
@@ -1,0 +1,103 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package activation
+
+import (
+	"crypto/tls"
+	"net"
+)
+
+// Listeners returns a slice containing a net.Listener for each matching socket type
+// passed to this process.
+//
+// The order of the file descriptors is preserved in the returned slice.
+// Nil values are used to fill any gaps. For example if systemd were to return file descriptors
+// corresponding with "udp, tcp, tcp", then the slice would contain {nil, net.Listener, net.Listener}
+func Listeners() ([]net.Listener, error) {
+	files := Files(true)
+	listeners := make([]net.Listener, len(files))
+
+	for i, f := range files {
+		if pc, err := net.FileListener(f); err == nil {
+			listeners[i] = pc
+			f.Close()
+		}
+	}
+	return listeners, nil
+}
+
+// ListenersWithNames maps a listener name to a set of net.Listener instances.
+func ListenersWithNames() (map[string][]net.Listener, error) {
+	files := Files(true)
+	listeners := map[string][]net.Listener{}
+
+	for _, f := range files {
+		if pc, err := net.FileListener(f); err == nil {
+			current, ok := listeners[f.Name()]
+			if !ok {
+				listeners[f.Name()] = []net.Listener{pc}
+			} else {
+				listeners[f.Name()] = append(current, pc)
+			}
+			f.Close()
+		}
+	}
+	return listeners, nil
+}
+
+// TLSListeners returns a slice containing a net.listener for each matching TCP socket type
+// passed to this process.
+// It uses default Listeners func and forces TCP sockets handlers to use TLS based on tlsConfig.
+func TLSListeners(tlsConfig *tls.Config) ([]net.Listener, error) {
+	listeners, err := Listeners()
+
+	if listeners == nil || err != nil {
+		return nil, err
+	}
+
+	if tlsConfig != nil {
+		for i, l := range listeners {
+			// Activate TLS only for TCP sockets
+			if l.Addr().Network() == "tcp" {
+				listeners[i] = tls.NewListener(l, tlsConfig)
+			}
+		}
+	}
+
+	return listeners, err
+}
+
+// TLSListenersWithNames maps a listener name to a net.Listener with
+// the associated TLS configuration.
+func TLSListenersWithNames(tlsConfig *tls.Config) (map[string][]net.Listener, error) {
+	listeners, err := ListenersWithNames()
+
+	if listeners == nil || err != nil {
+		return nil, err
+	}
+
+	if tlsConfig != nil {
+		for _, ll := range listeners {
+			// Activate TLS only for TCP sockets
+			for i, l := range ll {
+				if l.Addr().Network() == "tcp" {
+					ll[i] = tls.NewListener(l, tlsConfig)
+				}
+			}
+		}
+	}
+
+	return listeners, err
+}

--- a/vendor/github.com/coreos/go-systemd/v22/activation/packetconns.go
+++ b/vendor/github.com/coreos/go-systemd/v22/activation/packetconns.go
@@ -1,0 +1,38 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package activation
+
+import (
+	"net"
+)
+
+// PacketConns returns a slice containing a net.PacketConn for each matching socket type
+// passed to this process.
+//
+// The order of the file descriptors is preserved in the returned slice.
+// Nil values are used to fill any gaps. For example if systemd were to return file descriptors
+// corresponding with "udp, tcp, udp", then the slice would contain {net.PacketConn, nil, net.PacketConn}
+func PacketConns() ([]net.PacketConn, error) {
+	files := Files(true)
+	conns := make([]net.PacketConn, len(files))
+
+	for i, f := range files {
+		if pc, err := net.FilePacketConn(f); err == nil {
+			conns[i] = pc
+			f.Close()
+		}
+	}
+	return conns, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -145,6 +145,7 @@ github.com/containernetworking/cni/pkg/types/current
 github.com/containernetworking/cni/pkg/utils
 github.com/containernetworking/cni/pkg/version
 # github.com/coreos/go-systemd/v22 v22.1.0
+github.com/coreos/go-systemd/v22/activation
 github.com/coreos/go-systemd/v22/daemon
 # github.com/cpuguy83/go-md2man/v2 v2.0.0
 github.com/cpuguy83/go-md2man/v2/md2man


### PR DESCRIPTION
Used go-systemd code from moby/moby daemon

Only added `buildkitd --addr fd://` for now.

Closes #1923