### PR TITLE
allow cache export to execute on build failure

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -266,9 +266,11 @@ func (c *Controller) Solve(ctx context.Context, req *controlapi.SolveRequest) (*
 			return nil, err
 		}
 		cacheExportMode = parseCacheExportMode(e.Attrs["mode"])
-		cacheExportOnFailure, err = strconv.ParseBool(e.Attrs["onfailure"])
-		if err != nil {
-			return nil, err
+		if onfailure, ok := e.Attrs["onfailure"]; ok {
+			cacheExportOnFailure, err = strconv.ParseBool(onfailure)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	for _, im := range req.Cache.Imports {

--- a/solver/internal/pipe/pipe.go
+++ b/solver/internal/pipe/pipe.go
@@ -80,11 +80,7 @@ func NewWithFunction(f func(context.Context) (interface{}, error)) (*Pipe, func(
 
 	return p, func() {
 		res, err := f(ctx)
-		if err != nil {
-			p.Sender.Finalize(nil, err)
-			return
-		}
-		p.Sender.Finalize(res, nil)
+		p.Sender.Finalize(res, err)
 	}
 }
 

--- a/solver/llbsolver/bridge.go
+++ b/solver/llbsolver/bridge.go
@@ -103,7 +103,7 @@ func (b *llbBridge) loadResult(ctx context.Context, def *pb.Definition, cacheImp
 
 	res, err := b.builder.Build(ctx, edge)
 	if err != nil {
-		return nil, err
+		return res, err
 	}
 	wr, ok := res.Sys().(*worker.WorkerRef)
 	if !ok {
@@ -261,7 +261,7 @@ func (rp *resultProxy) Result(ctx context.Context) (res solver.CachedResult, err
 		return v, err
 	})
 	if r != nil {
-		return r.(solver.CachedResult), nil
+		return r.(solver.CachedResult), err
 	}
 	return nil, err
 }

--- a/solver/scheduler.go
+++ b/solver/scheduler.go
@@ -241,10 +241,11 @@ func (s *scheduler) build(ctx context.Context, edge Edge) (CachedResult, error) 
 
 	<-wait
 
-	if err := p.Receiver.Status().Err; err != nil {
-		return nil, err
+	st := p.Receiver.Status()
+	if es, ok := st.Value.(*edgeState); ok && es.result != nil {
+		return es.result.Clone(), st.Err
 	}
-	return p.Receiver.Status().Value.(*edgeState).result.Clone(), nil
+	return nil, st.Err
 }
 
 // newPipe creates a new request pipe between two edges

--- a/solver/types.go
+++ b/solver/types.go
@@ -97,6 +97,8 @@ type CacheExportOpt struct {
 	Mode CacheExportMode
 	// Session is the session group to client (for auth credentials etc)
 	Session session.Group
+	// OnFailure specifies whether caching should still occur post build failure
+	OnFailure bool
 }
 
 // CacheExporter can export the artifacts of the build chain


### PR DESCRIPTION
For ephemeral buildkit instances where a local, shared disk cache isn't necessarily feasible, it seems like it'd be helpful to export the external build cache for all completed steps even if the entire build itself has failed. This implements a new option for the export cache `onfailure` that will export the cached layers even if the build fails or errors.

This is my first delve into the internals, so I'm not sure this is the best approach to the solution. Especially as returning a value _and_ error seems anti-Go, but I was hesitant to undergo a larger refactoring unless this is a desirable feature.