### PR TITLE
Fix reference count issues on typed errors with mount references

### DIFF
--- a/frontend/gateway/container.go
+++ b/frontend/gateway/container.go
@@ -127,6 +127,7 @@ type MountRef struct {
 type MountMutableRef struct {
 	Ref        cache.MutableRef
 	MountIndex int
+	NoCommit   bool
 }
 
 type MakeMutable func(m *opspb.Mount, ref cache.ImmutableRef) (cache.MutableRef, error)
@@ -196,6 +197,7 @@ func PrepareMounts(ctx context.Context, mm *mounts.MountManager, cm cache.Manage
 			p.Actives = append(p.Actives, MountMutableRef{
 				MountIndex: i,
 				Ref:        active,
+				NoCommit:   true,
 			})
 			if m.Output != opspb.SkipOutput && ref != nil {
 				p.OutputRefs = append(p.OutputRefs, MountRef{

--- a/solver/llbsolver/errdefs/exec.go
+++ b/solver/llbsolver/errdefs/exec.go
@@ -21,10 +21,15 @@ func (e *ExecError) Unwrap() error {
 }
 
 func (e *ExecError) EachRef(fn func(solver.Result) error) (err error) {
+	m := map[solver.Result]struct{}{}
 	for _, res := range e.Inputs {
 		if res == nil {
 			continue
 		}
+		if _, ok := m[res]; ok {
+			continue
+		}
+		m[res] = struct{}{}
 		if err1 := fn(res); err1 != nil && err == nil {
 			err = err1
 		}
@@ -33,6 +38,10 @@ func (e *ExecError) EachRef(fn func(solver.Result) error) (err error) {
 		if res == nil {
 			continue
 		}
+		if _, ok := m[res]; ok {
+			continue
+		}
+		m[res] = struct{}{}
 		if err1 := fn(res); err1 != nil && err == nil {
 			err = err1
 		}

--- a/solver/llbsolver/ops/exec.go
+++ b/solver/llbsolver/ops/exec.go
@@ -235,7 +235,7 @@ func (e *execOp) Exec(ctx context.Context, g session.Group, inputs []solver.Resu
 				if m.Input == -1 {
 					continue
 				}
-				execInputs[i] = inputs[m.Input]
+				execInputs[i] = inputs[m.Input].Clone()
 			}
 			execMounts := make([]solver.Result, len(e.op.Mounts))
 			copy(execMounts, execInputs)

--- a/solver/llbsolver/ops/exec.go
+++ b/solver/llbsolver/ops/exec.go
@@ -243,12 +243,16 @@ func (e *execOp) Exec(ctx context.Context, g session.Group, inputs []solver.Resu
 				execMounts[p.OutputRefs[i].MountIndex] = res
 			}
 			for _, active := range p.Actives {
-				ref, cerr := active.Ref.Commit(ctx)
-				if cerr != nil {
-					err = errors.Wrapf(err, "error committing %s: %s", active.Ref.ID(), cerr)
-					continue
+				if active.NoCommit {
+					active.Ref.Release(context.TODO())
+				} else {
+					ref, cerr := active.Ref.Commit(ctx)
+					if cerr != nil {
+						err = errors.Wrapf(err, "error committing %s: %s", active.Ref.ID(), cerr)
+						continue
+					}
+					execMounts[active.MountIndex] = worker.NewWorkerRefResult(ref, e.w)
 				}
-				execMounts[active.MountIndex] = worker.NewWorkerRefResult(ref, e.w)
 			}
 			err = errdefs.WithExecError(err, execInputs, execMounts)
 		} else {

--- a/solver/llbsolver/ops/file.go
+++ b/solver/llbsolver/ops/file.go
@@ -421,7 +421,6 @@ func (s *FileOpSolver) getInput(ctx context.Context, idx int, inputs []fileoptyp
 					if cerr == nil {
 						outputRes[idx-len(inputs)] = worker.NewWorkerRefResult(ref.(cache.ImmutableRef), s.w)
 					}
-					inpMount.Release(context.TODO())
 				}
 
 				// If the action has a secondary input, commit it and set the ref on

--- a/solver/result.go
+++ b/solver/result.go
@@ -47,7 +47,7 @@ type splitResult struct {
 
 func (r *splitResult) Release(ctx context.Context) error {
 	if atomic.AddInt64(&r.released, 1) > 1 {
-		err := errors.Errorf("releasing already released reference")
+		err := errors.Errorf("releasing already released reference %+v", r.Result.ID())
 		logrus.Error(err)
 		return err
 	}
@@ -78,8 +78,12 @@ func NewSharedCachedResult(res CachedResult) *SharedCachedResult {
 	}
 }
 
-func (r *SharedCachedResult) Clone() CachedResult {
+func (r *SharedCachedResult) CloneCachedResult() CachedResult {
 	return &clonedCachedResult{Result: r.SharedResult.Clone(), cr: r.CachedResult}
+}
+
+func (r *SharedCachedResult) Clone() Result {
+	return r.CloneCachedResult()
 }
 
 func (r *SharedCachedResult) Release(ctx context.Context) error {

--- a/solver/scheduler.go
+++ b/solver/scheduler.go
@@ -244,7 +244,7 @@ func (s *scheduler) build(ctx context.Context, edge Edge) (CachedResult, error) 
 	if err := p.Receiver.Status().Err; err != nil {
 		return nil, err
 	}
-	return p.Receiver.Status().Value.(*edgeState).result.Clone(), nil
+	return p.Receiver.Status().Value.(*edgeState).result.CloneCachedResult(), nil
 }
 
 // newPipe creates a new request pipe between two edges

--- a/solver/scheduler_test.go
+++ b/solver/scheduler_test.go
@@ -3640,6 +3640,7 @@ type dummyResult struct {
 func (r *dummyResult) ID() string                    { return r.id }
 func (r *dummyResult) Release(context.Context) error { return nil }
 func (r *dummyResult) Sys() interface{}              { return r }
+func (r *dummyResult) Clone() Result                 { return r }
 
 func testOpResolver(v Vertex, b Builder) (Op, error) {
 	if op, ok := v.Sys().(Op); ok {

--- a/solver/types.go
+++ b/solver/types.go
@@ -61,6 +61,7 @@ type Result interface {
 	ID() string
 	Release(context.Context) error
 	Sys() interface{}
+	Clone() Result
 }
 
 // CachedResult is a result connected with its cache key

--- a/worker/result.go
+++ b/worker/result.go
@@ -52,3 +52,11 @@ func (r *workerRefResult) Release(ctx context.Context) error {
 func (r *workerRefResult) Sys() interface{} {
 	return r.WorkerRef
 }
+
+func (r *workerRefResult) Clone() solver.Result {
+	r2 := *r
+	if r.ImmutableRef != nil {
+		r.ImmutableRef = r.ImmutableRef.Clone()
+	}
+	return &r2
+}


### PR DESCRIPTION
fix #1958
fixes / addresses https://github.com/docker/for-linux/issues/1203

Issues:

- Cache mount may not be committed because it is shared between multiple vertexes and multiple builds. I think we should make it more type-safe, eg. if `ExecError` dealt with `cache.Ref` instead of `Result` it would have been clear that you can get an object like this from a cache mount. Or any operation with a mutable reference that has been committed should fail right away. We could try a more complicated approach later, eg try to wait for error handler to get full ownership of mount ref by checking that everything else has released it. In practical cases, I think the current is ok and when a debug container creates a cache mount it comes back with the same state anyway if nothing else is changing the data in parallel.
- The input refs returned from failed `ExecOp` directly with `ExecError` need to be cloned. Otherwise, they get released twice. But I don't understand why the same issue does not appear on `FileOp`.
- ExecError may contain duplicates of the same ref for different positions in the mounts array. That should not result in a double release. 