### PR TITLE
Refactor Connection Helper to interface and allow helpers to provide grpc.DialOptions

### DIFF
--- a/client/client_unix.go
+++ b/client/client_unix.go
@@ -7,14 +7,26 @@ import (
 	"net"
 	"strings"
 
+	"github.com/moby/buildkit/client/connhelper"
 	"github.com/pkg/errors"
+	"google.golang.org/grpc"
 )
 
-func dialer(ctx context.Context, address string) (net.Conn, error) {
+func defaultConnhelper() connhelper.ConnectionHelper {
+	return &platformConnhelper{}
+}
+
+type platformConnhelper struct{}
+
+func (c *platformConnhelper) ContextDialer(ctx context.Context, address string) (net.Conn, error) {
 	addrParts := strings.SplitN(address, "://", 2)
 	if len(addrParts) != 2 {
 		return nil, errors.Errorf("invalid address %s", address)
 	}
 	var d net.Dialer
 	return d.DialContext(ctx, addrParts[0], addrParts[1])
+}
+
+func (c *platformConnhelper) DialOptions(addr string) ([]grpc.DialOption, error) {
+	return nil, nil
 }

--- a/client/client_windows.go
+++ b/client/client_windows.go
@@ -6,10 +6,18 @@ import (
 	"strings"
 
 	winio "github.com/Microsoft/go-winio"
+	"github.com/moby/buildkit/client/connhelper"
 	"github.com/pkg/errors"
+	"google.golang.org/grpc"
 )
 
-func dialer(ctx context.Context, address string) (net.Conn, error) {
+func defaultConnhelper() connhelper.ConnectionHelper {
+	return &platformConnhelper{}
+}
+
+type platformConnhelper struct{}
+
+func (c *platformConnhelper) ContextDialer(ctx context.Context, address string) (net.Conn, error) {
 	addrParts := strings.SplitN(address, "://", 2)
 	if len(addrParts) != 2 {
 		return nil, errors.Errorf("invalid address %s", address)
@@ -22,4 +30,8 @@ func dialer(ctx context.Context, address string) (net.Conn, error) {
 		var d net.Dialer
 		return d.DialContext(ctx, addrParts[0], addrParts[1])
 	}
+}
+
+func (c *platformConnhelper) DialOptions(addr string) ([]grpc.DialOption, error) {
+	return nil, nil
 }

--- a/client/connhelper/dockercontainer/dockercontainer.go
+++ b/client/connhelper/dockercontainer/dockercontainer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/cli/cli/connhelper/commandconn"
 	"github.com/moby/buildkit/client/connhelper"
 	"github.com/pkg/errors"
+	"google.golang.org/grpc"
 )
 
 func init() {
@@ -17,21 +18,29 @@ func init() {
 
 // Helper returns helper for connecting to a Docker container.
 // Requires BuildKit v0.5.0 or later in the container.
-func Helper(u *url.URL) (*connhelper.ConnectionHelper, error) {
+func Helper(u *url.URL) (connhelper.ConnectionHelper, error) {
 	sp, err := SpecFromURL(u)
 	if err != nil {
 		return nil, err
 	}
-	return &connhelper.ConnectionHelper{
-		ContextDialer: func(ctx context.Context, addr string) (net.Conn, error) {
-			ctxFlags := []string{}
-			if sp.Context != "" {
-				ctxFlags = append(ctxFlags, "--context="+sp.Context)
-			}
-			// using background context because context remains active for the duration of the process, after dial has completed
-			return commandconn.New(context.Background(), "docker", append(ctxFlags, []string{"exec", "-i", sp.Container, "buildctl", "dial-stdio"}...)...)
-		},
-	}, nil
+	return &dockerContainerHelper{sp}, nil
+}
+
+type dockerContainerHelper struct {
+	sp *Spec
+}
+
+func (c *dockerContainerHelper) ContextDialer(ctx context.Context, addr string) (net.Conn, error) {
+	ctxFlags := []string{}
+	if c.sp.Context != "" {
+		ctxFlags = append(ctxFlags, "--context="+c.sp.Context)
+	}
+	// using background context because context remains active for the duration of the process, after dial has completed
+	return commandconn.New(context.Background(), "docker", append(ctxFlags, []string{"exec", "-i", c.sp.Container, "buildctl", "dial-stdio"}...)...)
+}
+
+func (c *dockerContainerHelper) DialOptions(addr string) ([]grpc.DialOption, error) {
+	return nil, nil
 }
 
 // Spec


### PR DESCRIPTION
I've found the need to provide `grpc.DialOption` when trying to implement a `connhelper.ConnectionHelper`. This PR refactors it to an interface and adds an additional `DialOptions` method.

Happy to change how the interface looks.