### PR TITLE
[v0.8 backport] update qemu emulators

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,8 +105,8 @@ RUN --mount=target=. --mount=target=/root/.cache,type=cache \
 
 FROM scratch AS binaries-linux-helper
 COPY --from=runc /usr/bin/runc /buildkit-runc
-# built from https://github.com/tonistiigi/binfmt/runs/1488746859
-COPY --from=tonistiigi/binfmt:buildkit@sha256:4f7bf8fdf34ca4df118e099666b664c4cc8f054446dc71ff54117150ef1a2800 / /
+# built from https://github.com/tonistiigi/binfmt/runs/1743699129
+COPY --from=tonistiigi/binfmt:buildkit@sha256:75583ce1cf4a7166fd2592f45e4ff3f53727eee6edcd3a3e804f749b1f214a39 / /
 FROM binaries-linux-helper AS binaries-linux
 COPY --from=buildctl /usr/bin/buildctl /
 COPY --from=buildkitd /usr/bin/buildkitd /

--- a/solver/llbsolver/ops/exec_binfmt.go
+++ b/solver/llbsolver/ops/exec_binfmt.go
@@ -27,6 +27,7 @@ var qemuArchMap = map[string]string{
 	"arm":     "arm",
 	"s390x":   "s390x",
 	"ppc64le": "ppc64le",
+	"386":     "i386",
 }
 
 type emulator struct {


### PR DESCRIPTION
backport of https://github.com/moby/buildkit/pull/1953

Fixes bugs with executing scripts with shebang and adds 386 emulator.

https://github.com/tonistiigi/binfmt/compare/2e0b0261e390a974d419c163039865d89919738b...e78b54eb5a1a00538a003acd431df71b9e4c97e6
