### PR TITLE
Support BUILDKIT_MULTI_PLATFORM arg in Dockerfile

### DIFF
--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -54,6 +54,7 @@ const (
 	keyContextSubDir           = "contextsubdir"
 	keyContextKeepGitDir       = "build-arg:BUILDKIT_CONTEXT_KEEP_GIT_DIR"
 	keySyntax                  = "build-arg:BUILDKIT_SYNTAX"
+	keyMultiPlatformArg        = "build-arg:BUILDKIT_MULTI_PLATFORM"
 	keyHostname                = "hostname"
 )
 
@@ -369,6 +370,9 @@ func Build(ctx context.Context, c client.Client) (*client.Result, error) {
 
 	exportMap := len(targetPlatforms) > 1
 
+	if v := opts[keyMultiPlatformArg]; v != "" {
+		opts[keyMultiPlatform] = v
+	}
 	if v := opts[keyMultiPlatform]; v != "" {
 		b, err := strconv.ParseBool(v)
 		if err != nil {


### PR DESCRIPTION
This sets the platform prefix based on the `BUILDKIT_MULTI_PLATFORM`
value (if set).  This is similar to the changes here in
docker/buildx@7f58ad45fab9ab0e8c961cac6599ce0e8b100ad2

This is in relation to @tonistiigi's comment here https://github.com/docker/buildx/pull/467#issuecomment-744088189
I'm not sure if this is the right place.