### PR TITLE
resolver: fix tcp connections limit

### DIFF
--- a/util/resolver/resolver.go
+++ b/util/resolver/resolver.go
@@ -43,7 +43,7 @@ func fillInsecureOpts(host string, c config.RegistryConfig, h docker.RegistryHos
 	}
 	if c.Insecure != nil && *c.Insecure {
 		h2 := h
-		transport := newDefaultTransport()
+		transport := newTransport()
 		transport.TLSClientConfig = tc
 		h2.Client = &http.Client{
 			Transport: tracing.NewTransport(transport),
@@ -53,7 +53,7 @@ func fillInsecureOpts(host string, c config.RegistryConfig, h docker.RegistryHos
 	}
 
 	if len(hosts) == 0 {
-		transport := newDefaultTransport()
+		transport := newTransport()
 		transport.TLSClientConfig = tc
 
 		h.Client = &http.Client{
@@ -172,18 +172,20 @@ func NewRegistryConfig(m map[string]config.RegistryConfig) docker.RegistryHosts 
 
 func newDefaultClient() *http.Client {
 	return &http.Client{
-		Transport: tracing.NewTransport(newDefaultTransport()),
+		Transport: tracing.NewTransport(defaultTransport),
 	}
 }
 
-// newDefaultTransport is for pull or push client
+var defaultTransport = newTransport()
+
+// newTransport is for pull or push client
 //
 // NOTE: For push, there must disable http2 for https because the flow control
 // will limit data transfer. The net/http package doesn't provide http2 tunable
 // settings which limits push performance.
 //
 // REF: https://github.com/golang/go/issues/14077
-func newDefaultTransport() *http.Transport {
+func newTransport() *http.Transport {
 	return &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
@@ -194,6 +196,7 @@ func newDefaultTransport() *http.Transport {
 		IdleConnTimeout:       30 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 5 * time.Second,
+		MaxConnsPerHost:       6,
 		TLSNextProto:          make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
 	}
 }


### PR DESCRIPTION
partly fixes #1984

Make sure to always use the same tcp connection pool. Otherwise, if some builds pull tens of images in parallel client/server can't handle that.

This should also be capped in the higher level because currently still all layers start showing progress instantly, even if most are waiting on the connection pool. Ideally, we could start showing progress from the first byte but not sure how easy/clean that is to implement.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>