### PR TITLE
[v0.8 backport] Fix reference count issues on typed errors, docs: fix frontend image tags 

### DIFF
--- a/frontend/dockerfile/docs/syntax.md
+++ b/frontend/dockerfile/docs/syntax.md
@@ -12,7 +12,7 @@ If you are using Docker v18.09 or later, BuildKit mode can be enabled by setting
 
 BuildKit supports loading frontends dynamically from container images. Images for Dockerfile frontends are available at [`docker/dockerfile`](https://hub.docker.com/r/docker/dockerfile/tags/) repository.
 
-To use the external frontend, the first line of your Dockerfile needs to be `# syntax=docker/dockerfile:v1.2` pointing to the
+To use the external frontend, the first line of your Dockerfile needs to be `# syntax=docker/dockerfile:1.2` pointing to the
 specific image you want to use.
 
 BuildKit also ships with Dockerfile frontend builtin but it is recommended to use an external image to make sure that all
@@ -73,7 +73,7 @@ it if more storage space is needed.
 #### Example: cache Go packages
 
 ```dockerfile
-# syntax = docker/dockerfile:experimental
+# syntax = docker/dockerfile:1.2
 FROM golang
 ...
 RUN --mount=type=cache,target=/root/.cache/go-build go build ...
@@ -82,7 +82,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build go build ...
 #### Example: cache apt packages
 
 ```dockerfile
-# syntax = docker/dockerfile:experimental
+# syntax = docker/dockerfile:1.2
 FROM ubuntu
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
@@ -115,7 +115,7 @@ This mount type allows the build container to access secure files such as privat
 #### Example: access to S3
 
 ```dockerfile
-# syntax = docker/dockerfile:experimental
+# syntax = docker/dockerfile:1.2
 FROM python:3
 RUN pip install awscli
 RUN --mount=type=secret,id=aws,target=/root/.aws/credentials aws s3 cp s3://... ...
@@ -147,7 +147,7 @@ This mount type allows the build container to access SSH keys via SSH agents, wi
 #### Example: access to Gitlab
 
 ```dockerfile
-# syntax = docker/dockerfile:experimental
+# syntax = docker/dockerfile:1.2
 FROM alpine
 RUN apk add --no-cache openssh-client
 RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan gitlab.com >> ~/.ssh/known_hosts
@@ -193,7 +193,7 @@ Default sandbox mode can be activated via `--security=sandbox`, but that is no-o
 #### Example: check entitlements
 
 ```dockerfile
-# syntax = docker/dockerfile:experimental
+# syntax = docker/dockerfile:1.2-labs
 FROM ubuntu
 RUN --security=insecure cat /proc/self/status | grep CapEff
 ```
@@ -229,7 +229,7 @@ which needs to be enabled when starting the buildkitd daemon
 #### Example: isolating external effects
 
 ```dockerfile
-# syntax = docker/dockerfile:experimental
+# syntax = docker/dockerfile:1.2-labs
 FROM python:3.6
 ADD mypackage.tgz wheels/
 RUN --network=none pip install --find-links wheels mypackage

--- a/frontend/gateway/container.go
+++ b/frontend/gateway/container.go
@@ -127,6 +127,7 @@ type MountRef struct {
 type MountMutableRef struct {
 	Ref        cache.MutableRef
 	MountIndex int
+	NoCommit   bool
 }
 
 type MakeMutable func(m *opspb.Mount, ref cache.ImmutableRef) (cache.MutableRef, error)
@@ -196,6 +197,7 @@ func PrepareMounts(ctx context.Context, mm *mounts.MountManager, cm cache.Manage
 			p.Actives = append(p.Actives, MountMutableRef{
 				MountIndex: i,
 				Ref:        active,
+				NoCommit:   true,
 			})
 			if m.Output != opspb.SkipOutput && ref != nil {
 				p.OutputRefs = append(p.OutputRefs, MountRef{

--- a/solver/llbsolver/errdefs/exec.go
+++ b/solver/llbsolver/errdefs/exec.go
@@ -21,10 +21,15 @@ func (e *ExecError) Unwrap() error {
 }
 
 func (e *ExecError) EachRef(fn func(solver.Result) error) (err error) {
+	m := map[solver.Result]struct{}{}
 	for _, res := range e.Inputs {
 		if res == nil {
 			continue
 		}
+		if _, ok := m[res]; ok {
+			continue
+		}
+		m[res] = struct{}{}
 		if err1 := fn(res); err1 != nil && err == nil {
 			err = err1
 		}
@@ -33,6 +38,10 @@ func (e *ExecError) EachRef(fn func(solver.Result) error) (err error) {
 		if res == nil {
 			continue
 		}
+		if _, ok := m[res]; ok {
+			continue
+		}
+		m[res] = struct{}{}
 		if err1 := fn(res); err1 != nil && err == nil {
 			err = err1
 		}

--- a/solver/llbsolver/ops/exec.go
+++ b/solver/llbsolver/ops/exec.go
@@ -235,7 +235,7 @@ func (e *execOp) Exec(ctx context.Context, g session.Group, inputs []solver.Resu
 				if m.Input == -1 {
 					continue
 				}
-				execInputs[i] = inputs[m.Input]
+				execInputs[i] = inputs[m.Input].Clone()
 			}
 			execMounts := make([]solver.Result, len(e.op.Mounts))
 			copy(execMounts, execInputs)

--- a/solver/llbsolver/ops/exec.go
+++ b/solver/llbsolver/ops/exec.go
@@ -243,12 +243,16 @@ func (e *execOp) Exec(ctx context.Context, g session.Group, inputs []solver.Resu
 				execMounts[p.OutputRefs[i].MountIndex] = res
 			}
 			for _, active := range p.Actives {
-				ref, cerr := active.Ref.Commit(ctx)
-				if cerr != nil {
-					err = errors.Wrapf(err, "error committing %s: %s", active.Ref.ID(), cerr)
-					continue
+				if active.NoCommit {
+					active.Ref.Release(context.TODO())
+				} else {
+					ref, cerr := active.Ref.Commit(ctx)
+					if cerr != nil {
+						err = errors.Wrapf(err, "error committing %s: %s", active.Ref.ID(), cerr)
+						continue
+					}
+					execMounts[active.MountIndex] = worker.NewWorkerRefResult(ref, e.w)
 				}
-				execMounts[active.MountIndex] = worker.NewWorkerRefResult(ref, e.w)
 			}
 			err = errdefs.WithExecError(err, execInputs, execMounts)
 		} else {

--- a/solver/llbsolver/ops/file.go
+++ b/solver/llbsolver/ops/file.go
@@ -430,7 +430,6 @@ func (s *FileOpSolver) getInput(ctx context.Context, idx int, inputs []fileoptyp
 					if cerr == nil {
 						outputRes[idx-len(inputs)] = worker.NewWorkerRefResult(ref.(cache.ImmutableRef), s.w)
 					}
-					inpMount.Release(context.TODO())
 				}
 
 				// If the action has a secondary input, commit it and set the ref on

--- a/solver/result.go
+++ b/solver/result.go
@@ -47,7 +47,7 @@ type splitResult struct {
 
 func (r *splitResult) Release(ctx context.Context) error {
 	if atomic.AddInt64(&r.released, 1) > 1 {
-		err := errors.Errorf("releasing already released reference")
+		err := errors.Errorf("releasing already released reference %+v", r.Result.ID())
 		logrus.Error(err)
 		return err
 	}
@@ -78,8 +78,12 @@ func NewSharedCachedResult(res CachedResult) *SharedCachedResult {
 	}
 }
 
-func (r *SharedCachedResult) Clone() CachedResult {
+func (r *SharedCachedResult) CloneCachedResult() CachedResult {
 	return &clonedCachedResult{Result: r.SharedResult.Clone(), cr: r.CachedResult}
+}
+
+func (r *SharedCachedResult) Clone() Result {
+	return r.CloneCachedResult()
 }
 
 func (r *SharedCachedResult) Release(ctx context.Context) error {

--- a/solver/scheduler.go
+++ b/solver/scheduler.go
@@ -244,7 +244,7 @@ func (s *scheduler) build(ctx context.Context, edge Edge) (CachedResult, error) 
 	if err := p.Receiver.Status().Err; err != nil {
 		return nil, err
 	}
-	return p.Receiver.Status().Value.(*edgeState).result.Clone(), nil
+	return p.Receiver.Status().Value.(*edgeState).result.CloneCachedResult(), nil
 }
 
 // newPipe creates a new request pipe between two edges

--- a/solver/scheduler_test.go
+++ b/solver/scheduler_test.go
@@ -3640,6 +3640,7 @@ type dummyResult struct {
 func (r *dummyResult) ID() string                    { return r.id }
 func (r *dummyResult) Release(context.Context) error { return nil }
 func (r *dummyResult) Sys() interface{}              { return r }
+func (r *dummyResult) Clone() Result                 { return r }
 
 func testOpResolver(v Vertex, b Builder) (Op, error) {
 	if op, ok := v.Sys().(Op); ok {

--- a/solver/types.go
+++ b/solver/types.go
@@ -61,6 +61,7 @@ type Result interface {
 	ID() string
 	Release(context.Context) error
 	Sys() interface{}
+	Clone() Result
 }
 
 // CachedResult is a result connected with its cache key

--- a/worker/result.go
+++ b/worker/result.go
@@ -52,3 +52,11 @@ func (r *workerRefResult) Release(ctx context.Context) error {
 func (r *workerRefResult) Sys() interface{} {
 	return r.WorkerRef
 }
+
+func (r *workerRefResult) Clone() solver.Result {
+	r2 := *r
+	if r.ImmutableRef != nil {
+		r.ImmutableRef = r.ImmutableRef.Clone()
+	}
+	return &r2
+}


### PR DESCRIPTION
backports of:


- https://github.com/moby/buildkit/pull/1916 dockerfile/docs: fix frontend image tags
    - fixes https://github.com/moby/buildkit/issues/1907
- ~https://github.com/moby/buildkit/pull/1986 resolver: fix tcp connections limit~ (see https://github.com/moby/buildkit/issues/1988#issuecomment-782508241 and https://github.com/moby/buildkit/pull/1989)
- https://github.com/moby/buildkit/pull/1963 Fix reference count issues on typed errors with mount references
    - fixes https://github.com/moby/buildkit/issues/1958 errors on releasing mounts with typed execerror refs
    - fixes / addresses https://github.com/docker/for-linux/issues/1203 invalid mutable ref when using shared cache mounts

```
# https://github.com/moby/buildkit/pull/1916 dockerfile/docs: fix frontend image tags
git cherry-pick -s -S -x 1218e37c239c1d6d27446d748a49abc6434e7dee

# https://github.com/moby/buildkit/pull/1963 Fix reference count issues on typed errors with mount references
git cherry-pick -s -S -x 3660e5f9c8efe4bd8d2e61c684c950863abae2ee b4b0ece384cbd1bc62335d1716556ed43169260f 42fb2a877164cca5103354a529e7e68f6acc1136
```
