### PR TITLE
allow skipping empty layer detection on cache export

### DIFF
--- a/cache/remotecache/v1/utils.go
+++ b/cache/remotecache/v1/utils.go
@@ -10,6 +10,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+// EmptyLayerRemovalSupported defines if implementation supports removal of empty layers. Buildkit image exporter
+// removes empty layers, but moby layerstore based implementation does not.
+var EmptyLayerRemovalSupported = true
+
 // sortConfig sorts the config structure to make sure it is deterministic
 func sortConfig(cc *CacheConfig) {
 	type indexedLayer struct {
@@ -239,7 +243,7 @@ func marshalRemote(r *solver.Remote, state *marshalState) string {
 	}
 	desc := r.Descriptors[len(r.Descriptors)-1]
 
-	if desc.Digest == exptypes.EmptyGZLayer {
+	if desc.Digest == exptypes.EmptyGZLayer && EmptyLayerRemovalSupported {
 		return parentID
 	}
 


### PR DESCRIPTION
fix #1992

Moby image exporter does not remove empty layers causing inline cache to go out of sync. This allows behavior to be configured so it can be turned off in moby.

Regression from 85dd12d875f98e2e2fac819b0eb8abdbf0d35f77

There is still an issue that empty layers (ones optimized after differ, not metadata commands) can get out of sync in the history array of the image after cache import. Don't really know what to do about it as there is no information to determine that a `RUN` command didn't create a layer without running it.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>