### PR TITLE
[v0.8] allow skipping empty layer detection on cache export

### DIFF
--- a/cache/remotecache/v1/utils.go
+++ b/cache/remotecache/v1/utils.go
@@ -10,6 +10,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+// EmptyLayerRemovalSupported defines if implementation supports removal of empty layers. Buildkit image exporter
+// removes empty layers, but moby layerstore based implementation does not.
+var EmptyLayerRemovalSupported = true
+
 // sortConfig sorts the config structure to make sure it is deterministic
 func sortConfig(cc *CacheConfig) {
 	type indexedLayer struct {
@@ -239,7 +243,7 @@ func marshalRemote(r *solver.Remote, state *marshalState) string {
 	}
 	desc := r.Descriptors[len(r.Descriptors)-1]
 
-	if desc.Digest == exptypes.EmptyGZLayer {
+	if desc.Digest == exptypes.EmptyGZLayer && EmptyLayerRemovalSupported {
 		return parentID
 	}
 


### PR DESCRIPTION
Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
(cherry picked from commit 29af1397e204096b4b1a9e4a6dcf86f47028d573)
Signed-off-by: Tibor Vass <tibor@docker.com>

Backport of #1993 