### PR TITLE
Automatically detect default git branch

### DIFF
--- a/source/gitidentifier.go
+++ b/source/gitidentifier.go
@@ -2,8 +2,6 @@ package source
 
 import (
 	"net/url"
-	"os/exec"
-	"regexp"
 	"strings"
 
 	"github.com/moby/buildkit/util/sshutil"
@@ -20,8 +18,6 @@ type GitIdentifier struct {
 	MountSSHSock     string
 	KnownSSHHosts    string
 }
-
-var defaultBranch = regexp.MustCompile(`refs/heads/(\S+)`)
 
 func NewGitIdentifier(remoteURL string) (*GitIdentifier, error) {
 	repo := GitIdentifier{}
@@ -55,14 +51,6 @@ func NewGitIdentifier(remoteURL string) (*GitIdentifier, error) {
 		return nil, errors.Errorf("subdir not supported yet")
 	}
 
-	if repo.Ref == "" {
-		var err error
-		repo.Ref, err = getDefaultBranch(repo.Remote)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	return &repo, nil
 }
 
@@ -86,18 +74,4 @@ func getRefAndSubdir(fragment string) (ref string, subdir string) {
 		subdir = refAndDir[1]
 	}
 	return
-}
-
-// getDefaultBranch gets the default branch of a repository using ls-remote
-func getDefaultBranch(remoteURL string) (string, error) {
-	out, err := exec.Command("git", "ls-remote", "--symref", remoteURL, "HEAD").CombinedOutput()
-	if err != nil {
-		return "", errors.Errorf("error fetching default branch for repository %s: %v", remoteURL, err)
-	}
-
-	ss := defaultBranch.FindAllStringSubmatch(string(out), -1)
-	if len(ss) == 0 || len(ss[0]) != 2 {
-		return "", errors.Errorf("could not find default branch for repository: %s", remoteURL)
-	}
-	return ss[0][1], nil
 }

--- a/source/gitidentifier_test.go
+++ b/source/gitidentifier_test.go
@@ -7,19 +7,13 @@ import (
 )
 
 func TestNewGitIdentifier(t *testing.T) {
-	gi, err := NewGitIdentifier("ssh://root@subdomain.example.hostname:2222/root/my/really/weird/path/foo.git")
-	require.Nil(t, err)
-	require.Equal(t, "ssh://root@subdomain.example.hostname:2222/root/my/really/weird/path/foo.git", gi.Remote)
-	require.Equal(t, "master", gi.Ref)
-	require.Equal(t, "", gi.Subdir)
-
-	gi, err = NewGitIdentifier("ssh://root@subdomain.example.hostname:2222/root/my/really/weird/path/foo.git#main")
+	gi, err := NewGitIdentifier("ssh://root@subdomain.example.hostname:2222/root/my/really/weird/path/foo.git#main")
 	require.Nil(t, err)
 	require.Equal(t, "ssh://root@subdomain.example.hostname:2222/root/my/really/weird/path/foo.git", gi.Remote)
 	require.Equal(t, "main", gi.Ref)
 	require.Equal(t, "", gi.Subdir)
 
-	gi, err = NewGitIdentifier("git@github.com:moby/buildkit.git")
+	gi, err = NewGitIdentifier("git@github.com:moby/buildkit.git#master")
 	require.Nil(t, err)
 	require.Equal(t, "git@github.com:moby/buildkit.git", gi.Remote)
 	require.Equal(t, "master", gi.Ref)

--- a/source/gitidentifier_test.go
+++ b/source/gitidentifier_test.go
@@ -13,16 +13,16 @@ func TestNewGitIdentifier(t *testing.T) {
 	require.Equal(t, "main", gi.Ref)
 	require.Equal(t, "", gi.Subdir)
 
-	gi, err = NewGitIdentifier("git@github.com:moby/buildkit.git#master")
+	gi, err = NewGitIdentifier("git@github.com:moby/buildkit.git#main")
 	require.Nil(t, err)
 	require.Equal(t, "git@github.com:moby/buildkit.git", gi.Remote)
-	require.Equal(t, "master", gi.Ref)
+	require.Equal(t, "main", gi.Ref)
 	require.Equal(t, "", gi.Subdir)
 
-	gi, err = NewGitIdentifier("github.com/moby/buildkit.git")
+	gi, err = NewGitIdentifier("github.com/moby/buildkit.git#main")
 	require.Nil(t, err)
 	require.Equal(t, "https://github.com/moby/buildkit.git", gi.Remote)
-	require.Equal(t, "master", gi.Ref)
+	require.Equal(t, "main", gi.Ref)
 	require.Equal(t, "", gi.Subdir)
 
 }


### PR DESCRIPTION
**- What I did**

I added functionality to find the true default branch of a git repository, whereas previously it was hardcoded to master.

Further fixes [moby#41914](https://github.com/moby/moby/issues/41914), follow up to [moby#42095](https://github.com/moby/moby/pull/42095)

**- How I did it**

I added a function that uses `ls-remote` to find the default branch, and then wrote a regex to parse the result.

**- How to verify it**

```
buildctl build --frontend=dockerfile.v0 --opt context=https://github.com/docker/compose-cli.git
```