### PR TITLE
remotecache: make sure local writer commits close grpc stream

### DIFF
--- a/vendor/github.com/containerd/containerd/content/proxy/content_writer.go
+++ b/vendor/github.com/containerd/containerd/content/proxy/content_writer.go
@@ -125,7 +125,8 @@ func (rw *remoteWriter) Commit(ctx context.Context, size int64, expected digest.
 
 	rw.digest = resp.Digest
 	rw.offset = resp.Offset
-	return nil
+
+	return rw.Close()
 }
 
 func (rw *remoteWriter) Truncate(size int64) error {


### PR DESCRIPTION
@AkihiroSuda I randomly get 

```
ERRO[0004] (*service).Write failed                       error="rpc error: code = Canceled desc = context canceled" expected="sha256:418cf4f2671cfbe7391c3bc89ba9e9b34c3209a742ab0527c08bf6efc4d83bc7" ref="sha256:418cf4f2671cfbe7391c3bc89ba9e9b34c3209a742ab0527c08bf6efc4d83bc7" total=563
```

on client side while exporting to the local cache. iiuc this is because the exporter doesn't cleanly close the grpc writer and so the loop that reads from it in the client side might close with cancellation error after build has completed and `session.Close` has been called.

As this is in vendored code I'm not sure how it is supposed to work or if this change is really missing in upstream.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>