### PR TITLE
Disable GitHub Checks Patch Annotations

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,3 +6,6 @@ coverage:
       default:
         target: auto  # auto % coverage target
         threshold: 1%  # allow for 1% reduction of coverage without failing
+
+github_checks:
+  annotations: false


### PR DESCRIPTION
Disable Codecov [annotations](https://docs.codecov.io/docs/github-checks-beta#yaml-configuration-for-github-checks-and-codecov).

cc @tonistiigi 

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>