### PR TITLE
caps: add contains method

### DIFF
--- a/util/apicaps/caps.go
+++ b/util/apicaps/caps.go
@@ -122,6 +122,13 @@ func (s *CapSet) Supports(id CapID) error {
 	return nil
 }
 
+// Contains checks if cap set contains cap. Note that unlike Supports() this
+// function only checks capability existence in remote set, not if cap has been initialized.
+func (s *CapSet) Contains(id CapID) bool {
+	_, ok := s.set[string(id)]
+	return ok
+}
+
 // CapError is an error for unsupported capability
 type CapError struct {
 	ID         CapID


### PR DESCRIPTION
This is needed for https://github.com/docker/buildx/pull/535 so that client can check for a cap in remote set even if it has not been initialized in the vendored code.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>