### PR TITLE
Retry on temporary network failures

### DIFF
--- a/util/resolver/retryhandler/retry.go
+++ b/util/resolver/retryhandler/retry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"strings"
 	"syscall"
 	"time"
@@ -48,6 +49,10 @@ func New(f images.HandlerFunc, logger func([]byte)) images.HandlerFunc {
 
 func retryError(err error) bool {
 	if errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) {
+		return true
+	}
+	// catches TLS timeout or other network-related temporary errors
+	if ne, ok := errors.Cause(err).(net.Error); ok && ne.Temporary() {
 		return true
 	}
 	// https://github.com/containerd/containerd/pull/4724


### PR DESCRIPTION
In Earthly, we are seeing frequent errors [like these](https://github.com/earthly/earthly/runs/2179559918#step:6:2759) in large builds. This change helps reduce such instances.

```
Error: failed to load cache key: failed to do request: Head https://registry-1.docker.io/v2/alpine/git/manifests/v2.30.1: net/http: TLS handshake timeout
```

This is the net/http error type produced in such instances: https://golang.org/src/net/http/transport.go#L2835, which implements the `net.Error` interface. This catches other similar situations too, by matching on `net.Error`.

Signed-off-by: Vlad A. Ionescu <vladaionescu@users.noreply.github.com>