### PR TITLE
Remove duplicate "not found" from some error messages

### DIFF
--- a/cache/contenthash/checksum.go
+++ b/cache/contenthash/checksum.go
@@ -610,7 +610,7 @@ func (cc *cacheContext) checksum(ctx context.Context, root *iradix.Node, txn *ir
 		return nil, false, err
 	}
 	if cr == nil {
-		return nil, false, errors.Wrapf(errNotFound, "%q not found", convertKeyToPath(origk))
+		return nil, false, errors.Wrapf(errNotFound, "%q", convertKeyToPath(origk))
 	}
 	if cr.Digest != "" {
 		return cr, false, nil

--- a/cache/manager.go
+++ b/cache/manager.go
@@ -375,7 +375,7 @@ func (cm *cacheManager) getRecord(ctx context.Context, id string, opts ...RefOpt
 
 	md, ok := cm.md.Get(id)
 	if !ok {
-		return nil, errors.Wrapf(errNotFound, "%s not found", id)
+		return nil, errors.Wrap(errNotFound, id)
 	}
 	if mutableID := getEqualMutable(md); mutableID != "" {
 		mutable, err := cm.getRecord(ctx, mutableID)

--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -669,7 +669,7 @@ func (lbf *llbBridgeForwarder) getImmutableRef(ctx context.Context, id, path str
 		return nil, errors.Errorf("no such ref: %v", id)
 	}
 	if ref == nil {
-		return nil, errors.Wrapf(os.ErrNotExist, "%s not found", path)
+		return nil, errors.Wrap(os.ErrNotExist, path)
 	}
 
 	r, err := ref.Result(ctx)

--- a/session/secrets/secrets.go
+++ b/session/secrets/secrets.go
@@ -22,7 +22,7 @@ func GetSecret(ctx context.Context, c session.Caller, id string) ([]byte, error)
 	})
 	if err != nil {
 		if code := grpcerrors.Code(err); code == codes.Unimplemented || code == codes.NotFound {
-			return nil, errors.Wrapf(ErrNotFound, "secret %s not found", id)
+			return nil, errors.Wrapf(ErrNotFound, "secret %s", id)
 		}
 		return nil, err
 	}


### PR DESCRIPTION
I noticed this when building a Dockerfile that failed because a file didn't
exist, so went through error messages that looked like they had a duplicate
"not found" in the output;

    [+] Building 0.9s (6/9)
     => [internal] load build definition from Dockerfile                0.2s
     => => transferring dockerfile: 306B                                0.0s
     => [internal] load .dockerignore                                   0.1s
     => => transferring context: 2B                                     0.0s
     => [internal] load metadata for docker.io/library/alpine:latest    0.0s
     => CACHED [1/5] FROM docker.io/library/alpine                      0.0s
     => [internal] load build context                                   0.6s
     => => transferring context: 701B                                   0.5s
     => ERROR [2/5] ADD no-such-file.txt /                              0.0s
    ------
     > [2/5] ADD no-such-file.txt /:
    ------
    failed to compute cache key: "/no-such-file.txt" not found: not found

