### PR TITLE
solve: remove duplicate filepath.Join

### DIFF
--- a/solver/llbsolver/file/backend.go
+++ b/solver/llbsolver/file/backend.go
@@ -67,7 +67,7 @@ func mapUserToChowner(user *copy.User, idmap *idtools.IdentityMapping) (copy.Cho
 }
 
 func mkdir(ctx context.Context, d string, action pb.FileActionMkDir, user *copy.User, idmap *idtools.IdentityMapping) error {
-	p, err := fs.RootPath(d, filepath.Join(filepath.Join("/", action.Path)))
+	p, err := fs.RootPath(d, filepath.Join("/", action.Path))
 	if err != nil {
 		return err
 	}
@@ -100,7 +100,7 @@ func mkdir(ctx context.Context, d string, action pb.FileActionMkDir, user *copy.
 }
 
 func mkfile(ctx context.Context, d string, action pb.FileActionMkFile, user *copy.User, idmap *idtools.IdentityMapping) error {
-	p, err := fs.RootPath(d, filepath.Join(filepath.Join("/", action.Path)))
+	p, err := fs.RootPath(d, filepath.Join("/", action.Path))
 	if err != nil {
 		return err
 	}
@@ -146,7 +146,7 @@ func rm(ctx context.Context, d string, action pb.FileActionRm) error {
 }
 
 func rmPath(root, src string, allowNotFound bool) error {
-	p, err := fs.RootPath(root, filepath.Join(filepath.Join("/", src)))
+	p, err := fs.RootPath(root, filepath.Join("/", src))
 	if err != nil {
 		return err
 	}
@@ -166,7 +166,7 @@ func docopy(ctx context.Context, src, dest string, action pb.FileActionCopy, u *
 	destPath := cleanPath(action.Dest)
 
 	if !action.CreateDestPath {
-		p, err := fs.RootPath(dest, filepath.Join(filepath.Join("/", action.Dest)))
+		p, err := fs.RootPath(dest, filepath.Join("/", action.Dest))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
I saw these, and there was no comment in the code explaining if there was a reason for this; these were added in 2be999ba52ec6c3e75d3514b4228b23f67bc34c7 (https://github.com/moby/buildkit/pull/809), but couldn't find a mention about these particular lines in the review comments, and I couldn't think of a special reason for it ':-)
