### PR TITLE
authprovider: allow errors on seed unmarshal

### DIFF
--- a/session/auth/authprovider/tokenseed.go
+++ b/session/auth/authprovider/tokenseed.go
@@ -53,9 +53,8 @@ func (ts *tokenSeeds) getSeed(host string) ([]byte, error) {
 			return nil, err
 		}
 	} else {
-		if err := json.Unmarshal(dt, &ts.m); err != nil {
-			return nil, errors.Wrapf(err, "failed to parse %s", fp)
-		}
+		// ignore error in case of crash during previous marshal
+		_ = json.Unmarshal(dt, &ts.m)
 	}
 	v, ok := ts.m[host]
 	if !ok {


### PR DESCRIPTION
docker/buildx#547

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>