### PR TITLE
metadata: clone external data

### DIFF
--- a/cache/metadata/metadata.go
+++ b/cache/metadata/metadata.go
@@ -280,10 +280,13 @@ func (s *StorageItem) GetExternal(k string) ([]byte, error) {
 		if b == nil {
 			return errors.WithStack(errNotFound)
 		}
-		dt = b.Get([]byte(k))
-		if dt == nil {
+		dt2 := b.Get([]byte(k))
+		if dt2 == nil {
 			return errors.WithStack(errNotFound)
 		}
+		// data needs to be copied as boltdb can reuse the buffer after View returns
+		dt = make([]byte, len(dt2))
+		copy(dt, dt2)
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
fix https://github.com/moby/buildkit/issues/1913

Mentioned in https://github.com/moby/buildkit/issues/1913#issuecomment-751909103 that this may require pooling but since atm it is only used in contentcache that already has own lru cache, extra pooling isn't needed for this case.

@vladaionescu 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>