### PR TITLE
Remove potentially expired tokens

### DIFF
--- a/util/resolver/authorizer.go
+++ b/util/resolver/authorizer.go
@@ -400,6 +400,11 @@ func (ah *authHandler) fetchToken(ctx context.Context, sm *session.Manager, g se
 }
 
 func invalidAuthorization(c auth.Challenge, responses []*http.Response) error {
+	lastResponse := responses[len(responses)-1]
+	if lastResponse.StatusCode == http.StatusUnauthorized {
+		return errors.Wrapf(docker.ErrInvalidAuthorization, "authorization status: %v", lastResponse.StatusCode)
+	}
+
 	errStr := c.Parameters["error"]
 	if errStr == "" {
 		return nil


### PR DESCRIPTION
Some registries (notably Quay) issue tokens that expire without providing an `expires in` value in the authorization payload. Therefore, if a token produces a 401, we should remove it and re-fetch.

I admit this is a hack... likely incomplete and/or the wrong way to approach it. Any guidance would be great. The point is that we need to avoid using tokens that may have expired.

This (or a better approach) should resolve https://github.com/moby/buildkit/issues/2055 (and also thereby resolve https://github.com/earthly/earthly/issues/890, too)