### PR TITLE
[Carry 2001] Dockerfile: update containerd to 1.4.3  + fix testutil

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1.2
 
 ARG RUNC_VERSION=v1.0.0-rc93
-ARG CONTAINERD_VERSION=v1.4.2
+ARG CONTAINERD_VERSION=v1.4.3
 # containerd v1.3 for integration tests
 ARG CONTAINERD_ALT_VERSION=v1.3.7
 # available targets: buildkitd, buildkitd.oci_only, buildkitd.containerd_only

--- a/util/testutil/integration/oci.go
+++ b/util/testutil/integration/oci.go
@@ -67,7 +67,7 @@ func (s *oci) New(cfg *BackendConfig) (Backend, func() error, error) {
 		buildkitdArgs = append([]string{"sudo", "-u", fmt.Sprintf("#%d", s.uid), "-i", "--", "exec", "rootlesskit"}, buildkitdArgs...)
 	}
 
-	buildkitdSock, stop, err := runBuildkitd(cfg, buildkitdArgs, cfg.Logs, s.uid, s.gid)
+	buildkitdSock, stop, err := runBuildkitd(cfg, buildkitdArgs, cfg.Logs, s.uid, s.gid, nil)
 	if err != nil {
 		printLogs(cfg.Logs, log.Println)
 		return nil, nil, err

--- a/util/testutil/integration/sandbox.go
+++ b/util/testutil/integration/sandbox.go
@@ -139,7 +139,7 @@ func getBuildkitdAddr(tmpdir string) string {
 	return address
 }
 
-func runBuildkitd(conf *BackendConfig, args []string, logs map[string]*bytes.Buffer, uid, gid int) (address string, cl func() error, err error) {
+func runBuildkitd(conf *BackendConfig, args []string, logs map[string]*bytes.Buffer, uid, gid int, extraEnv []string) (address string, cl func() error, err error) {
 	deferF := &multiCloser{}
 	cl = deferF.F()
 
@@ -175,6 +175,7 @@ func runBuildkitd(conf *BackendConfig, args []string, logs map[string]*bytes.Buf
 	args = append(args, "--root", tmpdir, "--addr", address, "--debug")
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Env = append(os.Environ(), "BUILDKIT_DEBUG_EXEC_OUTPUT=1", "BUILDKIT_DEBUG_PANIC_ON_ERROR=1", "TMPDIR="+filepath.Join(tmpdir, "tmp"))
+	cmd.Env = append(cmd.Env, extraEnv...)
 	cmd.SysProcAttr = getSysProcAttr()
 
 	stop, err := startCmd(cmd, logs)


### PR DESCRIPTION
Carry https://github.com/moby/buildkit/pull/2001 , with testutil fix (https://github.com/moby/buildkit/pull/2017#issuecomment-797302456)
