### PR TITLE
worker/containerd: expose namespace and UUID as labels

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -46,8 +46,10 @@ type Infos interface {
 
 // Pre-defined label keys
 const (
-	labelPrefix      = "org.mobyproject.buildkit.worker."
-	LabelExecutor    = labelPrefix + "executor"    // "oci" or "containerd"
-	LabelSnapshotter = labelPrefix + "snapshotter" // containerd snapshotter name ("overlay", "native", ...)
-	LabelHostname    = labelPrefix + "hostname"
+	labelPrefix              = "org.mobyproject.buildkit.worker."
+	LabelExecutor            = labelPrefix + "executor"    // "oci" or "containerd"
+	LabelSnapshotter         = labelPrefix + "snapshotter" // containerd snapshotter name ("overlay", "native", ...)
+	LabelHostname            = labelPrefix + "hostname"
+	LabelContainerdUUID      = labelPrefix + "containerd.uuid"      // containerd worker: containerd UUID
+	LabelContainerdNamespace = labelPrefix + "containerd.namespace" // containerd worker: containerd namespace
 )


### PR DESCRIPTION
e.g.,
```
Labels:
        org.mobyproject.buildkit.worker.containerd.namespace:   buildkit
        org.mobyproject.buildkit.worker.containerd.uuid:        343cfb49-cce9-453f-b21c-e5d22ca2cb47
        org.mobyproject.buildkit.worker.executor:               containerd
        org.mobyproject.buildkit.worker.hostname:               suda-ws01
        org.mobyproject.buildkit.worker.snapshotter:            overlayfs
```

Planned to be used by nerdctl to detect whether containerd exporter can be used
