### PR TITLE
api/services/control: move out of experimental

### DIFF
--- a/api/services/control/control.proto
+++ b/api/services/control/control.proto
@@ -2,9 +2,6 @@ syntax = "proto3";
 
 package moby.buildkit.v1;
 
-// The control API is currently considered experimental and may break in a backwards
-// incompatible way.
-
 import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 import "google/protobuf/timestamp.proto";
 import "github.com/moby/buildkit/solver/pb/ops.proto";


### PR DESCRIPTION
Lots of client implementations have been already depending on the
current controller API, so the API should not be considered experimental.
