### PR TITLE
[WIP] buildctl --worker=<WORKER> build

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ To run `buildkitd` as a non-root user, see [`docs/rootless.md`](docs/rootless.md
 The buildkitd daemon supports two worker backends: OCI (runc) and containerd.
 
 By default, the OCI (runc) worker is used. You can set `--oci-worker=false --containerd-worker=true` to use the containerd worker.
+Starting with BuildKit 0.9, the worker can be also chosen with `buildctl --worker=(oci|containerd)`.
 
 We are open to adding more backends.
 

--- a/client/llb/source.go
+++ b/client/llb/source.go
@@ -13,6 +13,7 @@ import (
 	"github.com/moby/buildkit/util/apicaps"
 	"github.com/moby/buildkit/util/gitutil"
 	"github.com/moby/buildkit/util/sshutil"
+	"github.com/moby/buildkit/worker/workercontext"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
@@ -141,7 +142,8 @@ func Image(ref string, opts ...ImageOption) State {
 			if p == nil {
 				p = c.Platform
 			}
-			dgst, dt, err := info.metaResolver.ResolveImageConfig(context.TODO(), ref, ResolveImageConfigOpt{
+			ctx2 := workercontext.WithWorker(context.TODO(), workercontext.Worker(ctx))
+			dgst, dt, err := info.metaResolver.ResolveImageConfig(ctx2, ref, ResolveImageConfigOpt{
 				Platform:    p,
 				ResolveMode: info.resolveMode.String(),
 			})

--- a/client/solve.go
+++ b/client/solve.go
@@ -21,6 +21,7 @@ import (
 	"github.com/moby/buildkit/session/grpchijack"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/entitlements"
+	"github.com/moby/buildkit/worker/workercontext"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -93,6 +94,7 @@ func (c *Client) solve(ctx context.Context, def *llb.Definition, runGateway runG
 	statusContext, cancelStatus := context.WithCancel(context.Background())
 	defer cancelStatus()
 
+	statusContext = workercontext.WithWorker(statusContext, workercontext.Worker(ctx))
 	if span := trace.SpanFromContext(ctx); span.SpanContext().IsValid() {
 		statusContext = trace.ContextWithSpan(statusContext, span)
 	}

--- a/cmd/buildctl/common/common.go
+++ b/cmd/buildctl/common/common.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/util/tracing/detect"
+	"github.com/moby/buildkit/worker/workercontext"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 	"go.opentelemetry.io/otel/trace"
@@ -85,6 +86,10 @@ func ResolveClient(c *cli.Context) (*client.Client, error) {
 	timeout := time.Duration(c.GlobalInt("timeout"))
 	ctx, cancel := context.WithTimeout(ctx, timeout*time.Second)
 	defer cancel()
+
+	if worker := c.GlobalString("worker"); worker != "" {
+		ctx = workercontext.WithWorker(ctx, worker)
+	}
 
 	return client.New(ctx, c.GlobalString("addr"), opts...)
 }

--- a/cmd/buildctl/common/trace.go
+++ b/cmd/buildctl/common/trace.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/moby/buildkit/util/appcontext"
 	"github.com/moby/buildkit/util/tracing/detect"
+	"github.com/moby/buildkit/worker/workercontext"
 	"github.com/urfave/cli"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -66,5 +67,9 @@ func AttachAppContext(app *cli.App) error {
 }
 
 func CommandContext(c *cli.Context) context.Context {
-	return c.App.Metadata["context"].(context.Context)
+	ctx := c.App.Metadata["context"].(context.Context)
+	if worker := c.GlobalString("worker"); worker != "" {
+		ctx = workercontext.WithWorker(ctx, worker)
+	}
+	return ctx
 }

--- a/cmd/buildctl/main.go
+++ b/cmd/buildctl/main.go
@@ -56,6 +56,10 @@ func main() {
 			Value: defaultAddress,
 		},
 		cli.StringFlag{
+			Name:  "worker",
+			Usage: "worker ID or executor name (e.g., \"oci\", \"containerd\"), defaults is determined by the daemon",
+		},
+		cli.StringFlag{
 			Name:  "tlsservername",
 			Usage: "buildkitd server name for certificate validation",
 			Value: "",

--- a/control/control.go
+++ b/control/control.go
@@ -247,9 +247,8 @@ func (c *Controller) Solve(ctx context.Context, req *controlapi.SolveRequest) (*
 	}()
 
 	var expi exporter.ExporterInstance
-	// TODO: multiworker
 	// This is actually tricky, as the exporter should come from the worker that has the returned reference. We may need to delay this so that the solver loads this.
-	w, err := c.opt.WorkerController.GetDefault()
+	w, err := c.opt.WorkerController.GetFromContext(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/frontend/gateway/forwarder/forward.go
+++ b/frontend/gateway/forwarder/forward.go
@@ -272,7 +272,7 @@ func (c *bridgeClient) NewContainer(ctx context.Context, req client.NewContainer
 		return nil, err
 	}
 
-	w, err := c.workers.GetDefault()
+	w, err := c.workers.GetFromContext(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/frontend/gateway/grpcclient/client.go
+++ b/frontend/gateway/grpcclient/client.go
@@ -69,12 +69,12 @@ func New(ctx context.Context, opts map[string]string, session, product string, c
 	}, nil
 }
 
-func current() (GrpcClient, error) {
+func current(ctx context.Context) (GrpcClient, error) {
 	if ep := product(); ep != "" {
 		apicaps.ExportedProduct = ep
 	}
 
-	ctx, conn, err := grpcClientConn(context.Background())
+	ctx, conn, err := grpcClientConn(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +94,7 @@ func convertRef(ref client.Reference) (*pb.Ref, error) {
 }
 
 func RunFromEnvironment(ctx context.Context, f client.BuildFunc) error {
-	client, err := current()
+	client, err := current(ctx)
 	if err != nil {
 		return errors.Wrapf(err, "failed to initialize client from environment")
 	}

--- a/solver/internal/pipe/pipe.go
+++ b/solver/internal/pipe/pipe.go
@@ -70,6 +70,7 @@ type Status struct {
 func NewWithFunction(f func(context.Context) (interface{}, error)) (*Pipe, func()) {
 	p := New(Request{})
 
+	// we create a new ctx here, so worker ID is not propagated here
 	ctx, cancel := context.WithCancel(context.TODO())
 
 	p.OnReceiveCompletion = func() {

--- a/solver/scheduler_test.go
+++ b/solver/scheduler_test.go
@@ -3658,7 +3658,7 @@ func (r *dummyResult) Release(context.Context) error { return nil }
 func (r *dummyResult) Sys() interface{}              { return r }
 func (r *dummyResult) Clone() Result                 { return r }
 
-func testOpResolver(v Vertex, b Builder) (Op, error) {
+func testOpResolver(_ context.Context, v Vertex, b Builder) (Op, error) {
 	if op, ok := v.Sys().(Op); ok {
 		if vtx, ok := op.(*vertexSubBuild); ok {
 			vtx.b = b

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -40,7 +40,7 @@ type Worker interface {
 }
 
 type Infos interface {
-	GetDefault() (Worker, error)
+	GetFromContext(ctx context.Context) (Worker, error)
 	WorkerInfos() []client.WorkerInfo
 }
 

--- a/worker/workercontext/workercontext.go
+++ b/worker/workercontext/workercontext.go
@@ -1,0 +1,30 @@
+package workercontext
+
+import (
+	"context"
+
+	"google.golang.org/grpc/metadata"
+)
+
+const metadataKey = "buildkit-worker"
+
+func WithWorker(ctx context.Context, id string) context.Context {
+	if id != "" {
+		return metadata.AppendToOutgoingContext(ctx, metadataKey, id)
+	}
+	return ctx
+}
+
+func Worker(ctx context.Context) string {
+	if md, ok := metadata.FromOutgoingContext(ctx); ok {
+		if ss := md[metadataKey]; len(ss) > 0 && ss[0] != "" {
+			return ss[0]
+		}
+	}
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		if ss := md[metadataKey]; len(ss) > 0 && ss[0] != "" {
+			return ss[0]
+		}
+	}
+	return ""
+}

--- a/worker/workercontroller.go
+++ b/worker/workercontroller.go
@@ -1,9 +1,13 @@
 package worker
 
 import (
+	"context"
+
 	"github.com/containerd/containerd/filters"
 	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/worker/workercontext"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // Controller holds worker instances.
@@ -52,6 +56,33 @@ func (c *Controller) Get(id string) (Worker, error) {
 		}
 	}
 	return nil, errors.Errorf("worker %s not found", id)
+}
+
+func (c *Controller) GetFromContext(ctx context.Context) (Worker, error) {
+	if selector := workercontext.Worker(ctx); selector != "" {
+		logrus.Debugf("worker selector %q is specified via context", selector)
+		workers, err := c.List()
+		if err != nil {
+			return nil, nil
+		}
+		for _, w := range workers {
+			id := w.ID()
+			if selector == id {
+				logrus.Debugf("worker selector %q matches ID %q", selector, id)
+				return w, nil
+			}
+			executorName := w.Labels()[LabelExecutor]
+			if selector == executorName {
+				logrus.Debugf("worker selector %q matches ID %q (%q=%q)", selector, id,
+					LabelExecutor, executorName)
+				return w, nil
+			}
+		}
+		return nil, errors.Errorf("invalid worker selector %q", selector)
+	}
+	logrus.Debug("no worker was specified via context")
+	// Hint for debugging: Add panic() here to verify that the worker ID is passed to every ctx.
+	return c.GetDefault()
 }
 
 // TODO: add Get(Constraint) (*Worker, error)


### PR DESCRIPTION
Usage: `buildctl --worker=<WORKER> build`.

`<WORKER>` is a worker ID, or an worker executor name ("oci", "containerd").

WIP: error after switching worker:
```
error: failed to solve: rpc error: code = Unknown desc = failed to prepare q9b7oc9p5jbd4hsu22yax6ivj: parent snapshot l42deemkhuc5f4v2id6wnc56t does not exist: not found
```

Implementation details:
- the worker selector is stored in `context.Context` as gRPC metadata. See `./worker/workercontext` pkg
- the solver stores the worker selector to `Job` via `j.SetValue`

