### PR TITLE
Fix missing mounts in execOp cache map

### DIFF
--- a/solver/llbsolver/ops/exec.go
+++ b/solver/llbsolver/ops/exec.go
@@ -69,8 +69,8 @@ func cloneExecOp(old *pb.ExecOp) pb.ExecOp {
 	}
 	n.Meta = &meta
 	n.Mounts = nil
-	for i := range n.Mounts {
-		m := *n.Mounts[i]
+	for i := range old.Mounts {
+		m := *old.Mounts[i]
 		n.Mounts = append(n.Mounts, &m)
 	}
 	return n


### PR DESCRIPTION
A bug in `cloneExecOp` prevented mounts from being included in the digest
computed for the `execOp` cache map. This could lead to an exec being
wrongly cached when a different mount was used for a subsequent
execution.

Repro case:
https://gist.github.com/aaronlehmann/cfeaefc028df8127fb85b9b5f9125f2d

In this example, pass2 should generate an empty diff because the /from
and /to mounts are the same busybox image. But before the fix, it uses
the cached result from pass1 (with different mounts) instead.

Signed-off-by: Aaron Lehmann <alehmann@netflix.com>