### PR TITLE
Fix potential crash on nil value

### DIFF
--- a/source/git/gitsource.go
+++ b/source/git/gitsource.go
@@ -140,10 +140,10 @@ func (gs *gitSource) mountRemote(ctx context.Context, remote string, auth []stri
 		// same new remote metadata
 		si, _ := gs.md.Get(remoteRef.ID())
 		v, err := metadata.NewValue(remoteKey)
-		v.Index = remoteKey
 		if err != nil {
 			return "", nil, err
 		}
+		v.Index = remoteKey
 
 		if err := si.Update(func(b *bolt.Bucket) error {
 			return si.SetValue(b, "git-remote", v)
@@ -551,10 +551,11 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context, g session.Group) (out 
 
 	si, _ := gs.md.Get(snap.ID())
 	v, err := metadata.NewValue(snapshotKey)
-	v.Index = snapshotKey
 	if err != nil {
 		return nil, err
 	}
+	v.Index = snapshotKey
+
 	if err := si.Update(func(b *bolt.Bucket) error {
 		return si.SetValue(b, "git-snapshot", v)
 	}); err != nil {


### PR DESCRIPTION
As reported on https://lgtm.com/projects/g/moby/buildkit/alerts/?mode=list https://lgtm.com/projects/g/moby/buildkit/rev/c47972dc5a9e2f4fc0a58d299b6f096161203fbb (can't seem to get a permalink)

![Screenshot from 2021-04-15 14-58-27](https://user-images.githubusercontent.com/278727/114872978-1cc5a880-9dfb-11eb-98aa-de37c73e0480.png)

Makes sure to never assign to a `nil` `v` (possible if `err != nil`).