### PR TITLE
Allow none differ on local source to avoid false Dockerfile matches

### DIFF
--- a/client/llb/source.go
+++ b/client/llb/source.go
@@ -442,7 +442,6 @@ type DiffType string
 
 const DiffNone DiffType = pb.AttrLocalDifferNone
 const DiffMetadata DiffType = pb.AttrLocalDifferMetadata
-const DiffContent DiffType = pb.AttrLocalDifferContent
 
 type DifferInfo struct {
 	Type     DiffType

--- a/client/llb/source.go
+++ b/client/llb/source.go
@@ -440,8 +440,15 @@ func Differ(t DiffType, required bool) LocalOption {
 
 type DiffType string
 
-const DiffNone DiffType = pb.AttrLocalDifferNone
-const DiffMetadata DiffType = pb.AttrLocalDifferMetadata
+const (
+	// DiffNone will do no file comparisons, all files in the Local source will
+	// be retransmitted.
+	DiffNone DiffType = pb.AttrLocalDifferNone
+	// DiffMetadata will compare file metadata (size, modified time, mode, owner,
+	// group, device and link name) to determine if the files in the Local source need
+	// to be retransmitted.  This is the default behavior.
+	DiffMetadata DiffType = pb.AttrLocalDifferMetadata
+)
 
 type DifferInfo struct {
 	Type     DiffType

--- a/client/llb/source.go
+++ b/client/llb/source.go
@@ -361,6 +361,12 @@ func Local(name string, opts ...LocalOption) State {
 		attrs[pb.AttrSharedKeyHint] = gi.SharedKeyHint
 		addCap(&gi.Constraints, pb.CapSourceLocalSharedKeyHint)
 	}
+	if gi.Differ.Type != "" {
+		attrs[pb.AttrLocalDiffer] = string(gi.Differ.Type)
+		if gi.Differ.Required {
+			addCap(&gi.Constraints, pb.CapSourceLocalDiffer)
+		}
+	}
 
 	addCap(&gi.Constraints, pb.CapSourceLocal)
 
@@ -423,6 +429,26 @@ func SharedKeyHint(h string) LocalOption {
 	})
 }
 
+func Differ(t DiffType, required bool) LocalOption {
+	return localOptionFunc(func(li *LocalInfo) {
+		li.Differ = DifferInfo{
+			Type:     t,
+			Required: required,
+		}
+	})
+}
+
+type DiffType string
+
+const DiffNone DiffType = pb.AttrLocalDifferNone
+const DiffMetadata DiffType = pb.AttrLocalDifferMetadata
+const DiffContent DiffType = pb.AttrLocalDifferContent
+
+type DifferInfo struct {
+	Type     DiffType
+	Required bool
+}
+
 type LocalInfo struct {
 	constraintsWrapper
 	SessionID       string
@@ -430,6 +456,7 @@ type LocalInfo struct {
 	ExcludePatterns string
 	FollowPaths     string
 	SharedKeyHint   string
+	Differ          DifferInfo
 }
 
 func HTTP(url string, opts ...HTTPOption) State {

--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -143,6 +143,7 @@ func Build(ctx context.Context, c client.Client) (*client.Result, error) {
 		llb.SessionID(c.BuildOpts().SessionID),
 		llb.SharedKeyHint(localNameDockerfile),
 		dockerfile2llb.WithInternalName(name),
+		llb.Differ(llb.DiffNone, false),
 	)
 
 	fileop := useFileOp(opts, &caps)
@@ -302,6 +303,7 @@ func Build(ctx context.Context, c client.Client) (*client.Result, error) {
 					llb.FollowPaths([]string{dockerignoreFilename}),
 					llb.SharedKeyHint(localNameContext+"-"+dockerignoreFilename),
 					dockerfile2llb.WithInternalName("load "+dockerignoreFilename),
+					llb.Differ(llb.DiffNone, false),
 				)
 				dockerignoreState = &st
 			}

--- a/session/filesync/diffcopy.go
+++ b/session/filesync/diffcopy.go
@@ -70,7 +70,7 @@ func (wc *streamWriterCloser) Close() error {
 	return nil
 }
 
-func recvDiffCopy(ds grpc.ClientStream, dest string, cu CacheUpdater, progress progressCb, filter func(string, *fstypes.Stat) bool) (err error) {
+func recvDiffCopy(ds grpc.ClientStream, dest string, cu CacheUpdater, progress progressCb, differ fsutil.DiffType, filter func(string, *fstypes.Stat) bool) (err error) {
 	st := time.Now()
 	defer func() {
 		logrus.Debugf("diffcopy took: %v", time.Since(st))
@@ -93,6 +93,7 @@ func recvDiffCopy(ds grpc.ClientStream, dest string, cu CacheUpdater, progress p
 		ContentHasher: ch,
 		ProgressCb:    progress,
 		Filter:        fsutil.FilterFunc(filter),
+		Differ:        differ,
 	}))
 }
 

--- a/session/filesync/filesync.go
+++ b/session/filesync/filesync.go
@@ -24,6 +24,7 @@ const (
 	keyFollowPaths        = "followpaths"
 	keyDirName            = "dir-name"
 	keyExporterMetaPrefix = "exporter-md-"
+	keyDiffer             = "differ"
 )
 
 type fsSyncProvider struct {
@@ -130,7 +131,7 @@ type progressCb func(int, bool)
 type protocol struct {
 	name   string
 	sendFn func(stream Stream, fs fsutil.FS, progress progressCb) error
-	recvFn func(stream grpc.ClientStream, destDir string, cu CacheUpdater, progress progressCb, mapFunc func(string, *fstypes.Stat) bool) error
+	recvFn func(stream grpc.ClientStream, destDir string, cu CacheUpdater, progress progressCb, differ fsutil.DiffType, mapFunc func(string, *fstypes.Stat) bool) error
 }
 
 func isProtoSupported(p string) bool {
@@ -160,6 +161,7 @@ type FSSendRequestOpt struct {
 	CacheUpdater     CacheUpdater
 	ProgressCb       func(int, bool)
 	Filter           func(string, *fstypes.Stat) bool
+	Differ           fsutil.DiffType
 }
 
 // CacheUpdater is an object capable of sending notifications for the cache hash changes
@@ -227,7 +229,7 @@ func FSSync(ctx context.Context, c session.Caller, opt FSSendRequestOpt) error {
 		panic(fmt.Sprintf("invalid protocol: %q", pr.name))
 	}
 
-	return pr.recvFn(stream, opt.DestDir, opt.CacheUpdater, opt.ProgressCb, opt.Filter)
+	return pr.recvFn(stream, opt.DestDir, opt.CacheUpdater, opt.ProgressCb, opt.Differ, opt.Filter)
 }
 
 // NewFSSyncTargetDir allows writing into a directory

--- a/session/filesync/filesync.go
+++ b/session/filesync/filesync.go
@@ -24,7 +24,6 @@ const (
 	keyFollowPaths        = "followpaths"
 	keyDirName            = "dir-name"
 	keyExporterMetaPrefix = "exporter-md-"
-	keyDiffer             = "differ"
 )
 
 type fsSyncProvider struct {

--- a/solver/pb/attr.go
+++ b/solver/pb/attr.go
@@ -30,6 +30,5 @@ const AttrImageRecordType = "image.recordtype"
 const AttrLocalDiffer = "local.differ"
 const AttrLocalDifferNone = "none"
 const AttrLocalDifferMetadata = "metadata"
-const AttrLocalDifferContent = "content"
 
 type IsFileAction = isFileAction_Action

--- a/solver/pb/attr.go
+++ b/solver/pb/attr.go
@@ -12,6 +12,7 @@ const AttrIncludePatterns = "local.includepattern"
 const AttrFollowPaths = "local.followpaths"
 const AttrExcludePatterns = "local.excludepatterns"
 const AttrSharedKeyHint = "local.sharedkeyhint"
+
 const AttrLLBDefinitionFilename = "llbbuild.filename"
 
 const AttrHTTPChecksum = "http.checksum"
@@ -25,5 +26,10 @@ const AttrImageResolveModeDefault = "default"
 const AttrImageResolveModeForcePull = "pull"
 const AttrImageResolveModePreferLocal = "local"
 const AttrImageRecordType = "image.recordtype"
+
+const AttrLocalDiffer = "local.differ"
+const AttrLocalDifferNone = "none"
+const AttrLocalDifferMetadata = "metadata"
+const AttrLocalDifferContent = "content"
 
 type IsFileAction = isFileAction_Action

--- a/solver/pb/caps.go
+++ b/solver/pb/caps.go
@@ -18,6 +18,7 @@ const (
 	CapSourceLocalFollowPaths     apicaps.CapID = "source.local.followpaths"
 	CapSourceLocalExcludePatterns apicaps.CapID = "source.local.excludepatterns"
 	CapSourceLocalSharedKeyHint   apicaps.CapID = "source.local.sharedkeyhint"
+	CapSourceLocalDiffer          apicaps.CapID = "source.local.differ"
 
 	CapSourceGit              apicaps.CapID = "source.git"
 	CapSourceGitKeepDir       apicaps.CapID = "source.git.keepgitdir"
@@ -118,6 +119,13 @@ func init() {
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})
+
+	Caps.Init(apicaps.Cap{
+		ID:      CapSourceLocalDiffer,
+		Enabled: true,
+		Status:  apicaps.CapStatusExperimental,
+	})
+
 	Caps.Init(apicaps.Cap{
 		ID:      CapSourceGit,
 		Enabled: true,

--- a/source/identifier.go
+++ b/source/identifier.go
@@ -11,6 +11,7 @@ import (
 	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+	"github.com/tonistiigi/fsutil"
 )
 
 var (
@@ -146,6 +147,15 @@ func FromLLB(op *pb.Op_Source, platform *pb.Platform) (Identifier, error) {
 				id.FollowPaths = paths
 			case pb.AttrSharedKeyHint:
 				id.SharedKeyHint = v
+			case pb.AttrLocalDiffer:
+				switch v {
+				case pb.AttrLocalDifferMetadata, "":
+					id.Differ = fsutil.DiffMetadata
+				case pb.AttrLocalDifferNone:
+					id.Differ = fsutil.DiffNone
+				case pb.AttrLocalDifferContent:
+					id.Differ = fsutil.DiffContent
+				}
 			}
 		}
 	}
@@ -214,6 +224,7 @@ type LocalIdentifier struct {
 	ExcludePatterns []string
 	FollowPaths     []string
 	SharedKeyHint   string
+	Differ          fsutil.DiffType
 }
 
 func NewLocalIdentifier(str string) (*LocalIdentifier, error) {

--- a/source/identifier.go
+++ b/source/identifier.go
@@ -153,8 +153,6 @@ func FromLLB(op *pb.Op_Source, platform *pb.Platform) (Identifier, error) {
 					id.Differ = fsutil.DiffMetadata
 				case pb.AttrLocalDifferNone:
 					id.Differ = fsutil.DiffNone
-				case pb.AttrLocalDifferContent:
-					id.Differ = fsutil.DiffContent
 				}
 			}
 		}

--- a/source/local/local.go
+++ b/source/local/local.go
@@ -178,6 +178,7 @@ func (ls *localSourceHandler) snapshot(ctx context.Context, s session.Group, cal
 		DestDir:          dest,
 		CacheUpdater:     &cacheUpdater{cc, mount.IdentityMapping()},
 		ProgressCb:       newProgressHandler(ctx, "transferring "+ls.src.Name+":"),
+		Differ:           ls.src.Differ,
 	}
 
 	if idmap := mount.IdentityMapping(); idmap != nil {


### PR DESCRIPTION
fixes #1368

Allows new `llb.Differ` property to configure what algorithm should be used when transferring file changes. Dockerfile frontend is updated to not trust metadata comparison for Dockerfile/dockerignore transfer. This can be extended in the future with some content-based comparison for better precision.