### PR TITLE
feat(run-mount): add support for variable expansion

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert_runmount.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_runmount.go
@@ -20,12 +20,14 @@ func detectRunMount(cmd *command, allDispatchStates *dispatchStates) bool {
 		mounts := instructions.GetMounts(c)
 		sources := make([]*dispatchState, len(mounts))
 		for i, mount := range mounts {
-			if mount.From == "" && mount.Type == instructions.MountTypeCache {
-				mount.From = emptyImageName
-			}
-			from := mount.From
-			if from == "" || mount.Type == instructions.MountTypeTmpfs {
-				continue
+			var from string
+			if mount.From == "" {
+				// this might not be accurate because the type might not have a real source (tmpfs for instance),
+				// but since this is just for creating the sources map it should be ok (we don't want to check the value of
+				// mount.Type because it might be a variable)
+				from = emptyImageName
+			} else {
+				from = mount.From
 			}
 			stn, ok := allDispatchStates.findStateByName(from)
 			if !ok {

--- a/frontend/dockerfile/instructions/commands.go
+++ b/frontend/dockerfile/instructions/commands.go
@@ -272,6 +272,13 @@ type RunCommand struct {
 	FlagsUsed []string
 }
 
+func (c *RunCommand) Expand(expander SingleWordExpander) error {
+	if err := setMountState(c, expander); err != nil {
+		return err
+	}
+	return nil
+}
+
 // CmdCommand : CMD foo
 //
 // Set the default command to run in the container (which may be empty).


### PR DESCRIPTION
This PR adds support for variable expansion in RUN mounts.
Resolves https://github.com/moby/buildkit/issues/815

Caveats:
- `from` expansion is not supported.
- Expansion is not supported in `ONBUILD RUN` commands (I don't even think mounts work there).