### PR TITLE
Add --metadata-file flag to output build metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,20 @@ consider client-side load balancing using consistent hashing.
 
 See [`./examples/kubernetes/consistenthash`](./examples/kubernetes/consistenthash).
 
+## Metadata
+
+To output build metadata such as the image digest, pass the `--metadata-file` flag.
+The metadata will be written as a JSON object to the specified file.
+The directory of the specified file must already exist and be writable.
+
+```
+buildctl build ... --metadata-file metadata.json
+```
+
+```
+{"containerimage.digest": "sha256:ea0cfb27fd41ea0405d3095880c1efa45710f5bcdddb7d7d5a7317ad4825ae14",...}
+```
+
 ## Systemd socket activation
 
 On Systemd based systems, you can communicate with the daemon via [Systemd socket activation](http://0pointer.de/blog/projects/socket-activation.html), use `buildkitd --addr fd://`.

--- a/cmd/buildctl/buildctl_test.go
+++ b/cmd/buildctl/buildctl_test.go
@@ -18,6 +18,7 @@ func TestCLIIntegration(t *testing.T) {
 		testBuildWithLocalFiles,
 		testBuildLocalExporter,
 		testBuildContainerdExporter,
+		testBuildMetadataFile,
 		testPrune,
 		testUsage,
 	},


### PR DESCRIPTION
Output build metadata (such as image digest) to a file based on a flag to `buildctl`.
Fixes #1158.

```
buildctl build --frontend=dockerfile.v0 --metadata-file meta.json --local context=. --local dockerfile=.. --output type=image,name=foo:latest,push=false
```

```
{"containerimage.config.digest":"sha256:9ba453cfcf085ebe34d7e3bc0cd13e02038361693a53d8663ddca8f83e26447d","containerimage.digest":"sha256:475f3a5ec8513c157acc20aacf3c872afb3b508ed40f9e9fb519d31897b7a3f0","image.name":"foo:latest"}
```

@tonistiigi @AkihiroSuda This is based on the comments from #1315.