### PR TITLE
Dockerfile: don't use wrong tag for xx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ FROM --platform=$BUILDPLATFORM alpine:${ALPINE_VERSION} AS git
 RUN apk add --no-cache git
 
 # xx is a helper for cross-compilation
-FROM --platform=$BUILDPLATFORM tonistiigi/xx:golang@sha256:810dc54d5144f133a218e88e319184bf8b9ce01d37d46ddb37573e90decd9eef AS xx
+FROM --platform=$BUILDPLATFORM tonistiigi/xx@sha256:810dc54d5144f133a218e88e319184bf8b9ce01d37d46ddb37573e90decd9eef AS xx
 
 FROM --platform=$BUILDPLATFORM golang:1.13-alpine AS gostable
 FROM --platform=$BUILDPLATFORM golang:1.16-alpine AS golatest


### PR DESCRIPTION
Golang wrapper tag is not being used anymore and was replaced with regular xx v2

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>