### PR TITLE
hack/install-buildx: allow overriding variables

### DIFF
--- a/hack/install-buildx
+++ b/hack/install-buildx
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
-topdir="$(realpath $(dirname "$0")/..)"
-cd "${topdir}"
 
-VERSION="v0.5.1"
-BINDIR="$(pwd)/bin"
-DEST="${BINDIR}/buildx"
+if [ -z "${BINDIR}" ] && [ -z "${PREFIX}" ]; then
+  PREFIX="$(realpath "$(dirname "$0")"/..)"
+fi
+
+: "${VERSION:=v0.5.1}"
+: "${BINDIR:="${PREFIX}/bin"}"
+: "${DEST:="${BINDIR}/buildx"}"
 
 os=""
 case "$(uname)" in


### PR DESCRIPTION
relates to https://github.com/moby/moby/pull/41949 https://github.com/moby/moby/pull/41949#discussion_r566371210

With this patch:

    PREFIX=$(pwd)/foo/bar VERSION=v0.5.0 sh -c ./install-buildx
    Installing buildx v0.5.0 as /Users/sebastiaan/Projects/test/test_buildx_install/foo/bar/bin/buildx
    + mkdir -p /Users/sebastiaan/Projects/test/test_buildx_install/foo/bar/bin
    + rm -f /Users/sebastiaan/Projects/test/test_buildx_install/foo/bar/bin/buildx.download
    + curl -f -L -o /Users/sebastiaan/Projects/test/test_buildx_install/foo/bar/bin/buildx.download https://github.com/docker/buildx/releases/download/v0.5.0/buildx-v0.5.0.darwin-amd64
      % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                     Dload  Upload   Total   Spent    Left  Speed
    100   634  100   634    0     0   2313      0 --:--:-- --:--:-- --:--:--  2305
    100 58.5M  100 58.5M    0     0  5721k      0  0:00:10  0:00:10 --:--:-- 5947k
    + chmod +x /Users/sebastiaan/Projects/test/test_buildx_install/foo/bar/bin/buildx.download
    + mv /Users/sebastiaan/Projects/test/test_buildx_install/foo/bar/bin/buildx.download /Users/sebastiaan/Projects/test/test_buildx_install/foo/bar/bin/buildx

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>