### PR TITLE
git: support subdir component

### DIFF
--- a/solver/pb/caps.go
+++ b/solver/pb/caps.go
@@ -25,6 +25,7 @@ const (
 	CapSourceGitHTTPAuth      apicaps.CapID = "source.git.httpauth"
 	CapSourceGitKnownSSHHosts apicaps.CapID = "source.git.knownsshhosts"
 	CapSourceGitMountSSHSock  apicaps.CapID = "source.git.mountsshsock"
+	CapSourceGitSubdir        apicaps.CapID = "source.git.subdir"
 
 	CapSourceHTTP         apicaps.CapID = "source.http"
 	CapSourceHTTPChecksum apicaps.CapID = "source.http.checksum"
@@ -148,6 +149,12 @@ func init() {
 
 	Caps.Init(apicaps.Cap{
 		ID:      CapSourceGitMountSSHSock,
+		Enabled: true,
+		Status:  apicaps.CapStatusExperimental,
+	})
+
+	Caps.Init(apicaps.Cap{
+		ID:      CapSourceGitSubdir,
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})

--- a/source/gitidentifier.go
+++ b/source/gitidentifier.go
@@ -2,10 +2,10 @@ package source
 
 import (
 	"net/url"
+	"path"
 	"strings"
 
 	"github.com/moby/buildkit/util/sshutil"
-	"github.com/pkg/errors"
 )
 
 type GitIdentifier struct {
@@ -46,8 +46,8 @@ func NewGitIdentifier(remoteURL string) (*GitIdentifier, error) {
 		u.Fragment = ""
 		repo.Remote = u.String()
 	}
-	if repo.Subdir != "" {
-		return nil, errors.Errorf("subdir not supported yet")
+	if sd := path.Clean(repo.Subdir); sd == "/" || sd == "." {
+		repo.Subdir = ""
 	}
 	return &repo, nil
 }


### PR DESCRIPTION
fixes #1684

wip: trying to see if I can also add backward compatibility to support old buildkit versions in https://github.com/moby/buildkit/compare/tonistiigi:git-subdir-wip. Looks tricky but may be possible.

@crazy-max @chris-crone

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>