### PR TITLE
Transform relative mountpoints for exec mounts in the executor

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -124,6 +124,7 @@ func TestIntegration(t *testing.T) {
 		testLazyImagePush,
 		testStargzLazyPull,
 		testFileOpInputSwap,
+		testRelativeMountpoint,
 	}, mirrors)
 
 	integration.Run(t, []integration.Test{
@@ -3456,6 +3457,44 @@ func testParallelLocalBuilds(t *testing.T, sb integration.Sandbox) {
 
 	err = eg.Wait()
 	require.NoError(t, err)
+}
+
+// testRelativeMountpoint is a test that relative paths for mountpoints don't
+// fail when runc is upgraded to at least rc95, which introduces an error when
+// mountpoints are not absolute. Relative paths should be transformed to
+// absolute points based on the llb.State's current working directory.
+func testRelativeMountpoint(t *testing.T, sb integration.Sandbox) {
+	requiresLinux(t)
+	c, err := New(context.TODO(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	id := identity.NewID()
+
+	st := llb.Image("busybox:latest").Dir("/root").Run(
+		llb.Shlexf("sh -c 'echo -n %s > /root/relpath/data'", id),
+	).AddMount("relpath", llb.Scratch())
+
+	def, err := st.Marshal(context.TODO())
+	require.NoError(t, err)
+
+	destDir, err := ioutil.TempDir("", "buildkit")
+	require.NoError(t, err)
+	defer os.RemoveAll(destDir)
+
+	_, err = c.Solve(context.TODO(), def, SolveOpt{
+		Exports: []ExportEntry{
+			{
+				Type:      ExporterLocal,
+				OutputDir: destDir,
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	dt, err := ioutil.ReadFile(filepath.Join(destDir, "data"))
+	require.NoError(t, err)
+	require.Equal(t, dt, []byte(id))
 }
 
 func tmpdir(appliers ...fstest.Applier) (string, error) {

--- a/solver/llbsolver/ops/exec.go
+++ b/solver/llbsolver/ops/exec.go
@@ -240,7 +240,7 @@ func (e *execOp) Exec(ctx context.Context, g session.Group, inputs []solver.Resu
 		}
 	}
 
-	p, err := gateway.PrepareMounts(ctx, e.mm, e.cm, g, e.op.Mounts, refs, func(m *pb.Mount, ref cache.ImmutableRef) (cache.MutableRef, error) {
+	p, err := gateway.PrepareMounts(ctx, e.mm, e.cm, g, e.op.Meta.Cwd, e.op.Mounts, refs, func(m *pb.Mount, ref cache.ImmutableRef) (cache.MutableRef, error) {
 		desc := fmt.Sprintf("mount %s from exec %s", m.Dest, strings.Join(e.op.Meta.Args, " "))
 		return e.cm.New(ctx, ref, g, cache.WithDescription(desc))
 	})


### PR DESCRIPTION
- Currently buildkit & containerd depend on runc rc93
- Runc rc94 brings in commit: https://github.com/opencontainers/runc/commit/2192670a2430054c1e539ca7a3bf0ddc43b0bc3d
- Relative mountpoints used to be treated as relative to root, but now fails at runtime
- Dockerfile frontend handles relative path mountpoints for the runmount
- Buildkit doesn't handle in the executor which means other frontends may encounter the `mount destination not absolute` error in runc rc94
- Executor should respect the execop cwd for relative mountpoints