### PR TITLE
progressui: don't print vertex digest

### DIFF
--- a/util/progress/progressui/printer.go
+++ b/util/progress/progressui/printer.go
@@ -61,7 +61,6 @@ func (p *textMux) printVtx(t *trace, dgst digest.Digest) {
 			fmt.Fprintf(p.w, "#%d %s\n", v.index, limitString(v.Name, 72))
 		} else {
 			fmt.Fprintf(p.w, "#%d %s\n", v.index, v.Name)
-			fmt.Fprintf(p.w, "#%d %s\n", v.index, v.Digest)
 		}
 
 	}


### PR DESCRIPTION
This doesn't carry much information unless debugging LLB layer and is confusing.

@thaJeztah 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>