### PR TITLE
[v0.8] Transform relative mountpoints for exec mounts in the executor

### DIFF
--- a/solver/llbsolver/ops/exec.go
+++ b/solver/llbsolver/ops/exec.go
@@ -240,7 +240,7 @@ func (e *execOp) Exec(ctx context.Context, g session.Group, inputs []solver.Resu
 		}
 	}
 
-	p, err := gateway.PrepareMounts(ctx, e.mm, e.cm, g, e.op.Mounts, refs, func(m *pb.Mount, ref cache.ImmutableRef) (cache.MutableRef, error) {
+	p, err := gateway.PrepareMounts(ctx, e.mm, e.cm, g, e.op.Meta.Cwd, e.op.Mounts, refs, func(m *pb.Mount, ref cache.ImmutableRef) (cache.MutableRef, error) {
 		desc := fmt.Sprintf("mount %s from exec %s", m.Dest, strings.Join(e.op.Meta.Args, " "))
 		return e.cm.New(ctx, ref, g, cache.WithDescription(desc))
 	})


### PR DESCRIPTION
pick #2123

There will probably not be another v0.8 release (runc security issue does not apply to buildkit directly) but pick for possible vendor update in Docker.

Signed-off-by: Edgar Lee <edgarl@netflix.com>
(cherry picked from commit a57ae2746fe679e8678d6ab5f61d19366b4c7b70)