### PR TITLE
update to go 1.16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,7 +169,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.13
+          go-version: 1.16
       -
         name: Cache Go modules
         uses: actions/cache@v2

--- a/examples/buildkit0/buildkit.go
+++ b/examples/buildkit0/buildkit.go
@@ -33,7 +33,7 @@ func main() {
 }
 
 func goBuildBase() llb.State {
-	goAlpine := llb.Image("docker.io/library/golang:1.13-alpine")
+	goAlpine := llb.Image("docker.io/library/golang:1.16-alpine")
 	return goAlpine.
 		AddEnv("PATH", "/usr/local/go/bin:"+system.DefaultPathEnvUnix).
 		AddEnv("GOPATH", "/go").

--- a/examples/buildkit1/buildkit.go
+++ b/examples/buildkit1/buildkit.go
@@ -33,7 +33,7 @@ func main() {
 }
 
 func goBuildBase() llb.State {
-	goAlpine := llb.Image("docker.io/library/golang:1.13-alpine")
+	goAlpine := llb.Image("docker.io/library/golang:1.16-alpine")
 	return goAlpine.
 		AddEnv("PATH", "/usr/local/go/bin:"+system.DefaultPathEnvUnix).
 		AddEnv("GOPATH", "/go").

--- a/examples/buildkit2/buildkit.go
+++ b/examples/buildkit2/buildkit.go
@@ -33,7 +33,7 @@ func main() {
 }
 
 func goBuildBase() llb.State {
-	goAlpine := llb.Image("docker.io/library/golang:1.13-alpine")
+	goAlpine := llb.Image("docker.io/library/golang:1.16-alpine")
 	return goAlpine.
 		AddEnv("PATH", "/usr/local/go/bin:"+system.DefaultPathEnvUnix).
 		AddEnv("GOPATH", "/go").

--- a/examples/buildkit3/buildkit.go
+++ b/examples/buildkit3/buildkit.go
@@ -34,7 +34,7 @@ func main() {
 }
 
 func goBuildBase() llb.State {
-	goAlpine := llb.Image("docker.io/library/golang:1.13-alpine")
+	goAlpine := llb.Image("docker.io/library/golang:1.16-alpine")
 	return goAlpine.
 		AddEnv("PATH", "/usr/local/go/bin:"+system.DefaultPathEnvUnix).
 		AddEnv("GOPATH", "/go").

--- a/examples/nested-llb/main.go
+++ b/examples/nested-llb/main.go
@@ -32,7 +32,7 @@ func main() {
 }
 
 func goBuildBase() llb.State {
-	goAlpine := llb.Image("docker.io/library/golang:1.13-alpine")
+	goAlpine := llb.Image("docker.io/library/golang:1.16-alpine")
 	return goAlpine.
 		AddEnv("PATH", "/usr/local/go/bin:"+system.DefaultPathEnvUnix).
 		AddEnv("GOPATH", "/go").

--- a/frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile
+++ b/frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile
@@ -3,7 +3,7 @@
 # xx is a helper for cross-compilation
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:golang@sha256:810dc54d5144f133a218e88e319184bf8b9ce01d37d46ddb37573e90decd9eef AS xx
 
-FROM --platform=$BUILDPLATFORM golang:1.13-alpine AS base
+FROM --platform=$BUILDPLATFORM golang:1.16-alpine AS base
 COPY --from=xx / /
 WORKDIR /src
 ENV GOFLAGS=-mod=vendor

--- a/hack/dockerfiles/generated-files.Dockerfile
+++ b/hack/dockerfiles/generated-files.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.2
 
 # protoc is dynamically linked to glibc to can't use golang:1.10-alpine
-FROM golang:1.13-buster AS gobuild-base
+FROM golang:1.16-buster AS gobuild-base
 # https://github.com/golang/protobuf/blob/v1.3.5/.travis.yml#L15
 ARG PROTOC_VERSION=3.11.4
 ARG GOGO_VERSION=v1.3.2

--- a/hack/dockerfiles/lint.Dockerfile
+++ b/hack/dockerfiles/lint.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.2
 
-FROM golang:1.13-alpine
+FROM golang:1.16-alpine
 RUN apk add --no-cache gcc musl-dev yamllint
 RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.39.0
 WORKDIR /go/src/github.com/moby/buildkit

--- a/hack/dockerfiles/vendor.Dockerfile
+++ b/hack/dockerfiles/vendor.Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.2
-FROM golang:1.13-alpine AS vendored
+FROM golang:1.16-alpine AS vendored
 RUN  apk add --no-cache git
 WORKDIR /src
 RUN --mount=target=/src,rw \

--- a/source/git/redact_credentials_go114.go
+++ b/source/git/redact_credentials_go114.go
@@ -1,4 +1,4 @@
-// +build go1.15
+// +build !go1.15
 
 package git
 
@@ -13,5 +13,18 @@ func redactCredentials(s string) string {
 		return s // string is not a URL, just return it
 	}
 
-	return u.Redacted()
+	return urlRedacted(u)
+}
+
+// urlRedacted comes from go's url.Redacted() which isn't available on go < 1.15
+func urlRedacted(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+
+	ru := *u
+	if _, has := ru.User.Password(); has {
+		ru.User = url.UserPassword(ru.User.Username(), "xxxxx")
+	}
+	return ru.String()
 }

--- a/util/archutil/Dockerfile
+++ b/util/archutil/Dockerfile
@@ -49,7 +49,7 @@ FROM base AS exit-mips64
 COPY fixtures/exit.mips64.s .
 RUN mips64-linux-gnuabi64-as --noexecstack -o exit.o exit.mips64.s && mips64-linux-gnuabi64-ld -o exit -s exit.o
 
-FROM golang:1.13-alpine AS generate
+FROM golang:1.16-alpine AS generate
 WORKDIR /src
 COPY --from=exit-amd64 /src/exit amd64
 COPY --from=exit-386 /src/exit 386


### PR DESCRIPTION
depends on https://github.com/moby/buildkit/pull/2146

relates to https://github.com/moby/moby/pull/40353 https://github.com/moby/moby/pull/40353#issuecomment-849982605

This updates all occurrences of Go 1.13 to Go 1.16; also updated the code that's used to redact credentials in URLs to use the Go implementation (based on https://github.com/golang/go/commit/e3323f57df1f4a44093a2d25fee33513325cbb86, it's available in Go 1.15 and up).
