### PR TITLE
generated files: update google/protobuf v1.3.5, protoc v3.14.0 and fix install for go modules

### DIFF
--- a/hack/dockerfiles/generated-files.Dockerfile
+++ b/hack/dockerfiles/generated-files.Dockerfile
@@ -2,7 +2,8 @@
 
 # protoc is dynamically linked to glibc to can't use golang:1.10-alpine
 FROM golang:1.13-buster AS gobuild-base
-ARG PROTOC_VERSION=3.1.0
+# https://github.com/golang/protobuf/blob/v1.3.5/.travis.yml#L15
+ARG PROTOC_VERSION=3.11.4
 ARG GOGO_VERSION=v1.3.2
 RUN apt-get update && apt-get --no-install-recommends install -y \
 	unzip \

--- a/hack/dockerfiles/generated-files.Dockerfile
+++ b/hack/dockerfiles/generated-files.Dockerfile
@@ -3,20 +3,19 @@
 # protoc is dynamically linked to glibc to can't use golang:1.10-alpine
 FROM golang:1.13-buster AS gobuild-base
 ARG PROTOC_VERSION=3.1.0
-ARG GOGO_VERSION=master
+ARG GOGO_VERSION=v1.3.2
 RUN apt-get update && apt-get --no-install-recommends install -y \
-	git \
 	unzip \
 	&& true
 RUN wget -q https://github.com/google/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip && unzip protoc-${PROTOC_VERSION}-linux-x86_64.zip -d /usr/local
 
-RUN go get -d github.com/gogo/protobuf/protoc-gen-gogofaster \
+RUN git clone https://github.com/gogo/protobuf.git /go/src/github.com/gogo/protobuf \
 	&& cd /go/src/github.com/gogo/protobuf \
 	&& git checkout -q $GOGO_VERSION \
 	&& go install ./protoc-gen-gogo ./protoc-gen-gogofaster ./protoc-gen-gogoslick
 
-ARG PROTOBUF_VERSION=v1.3.3
-RUN go get -d github.com/golang/protobuf/protoc-gen-go \
+ARG PROTOBUF_VERSION=v1.3.5
+RUN git clone https://github.com/golang/protobuf.git /go/src/github.com/golang/protobuf \
 	&& cd /go/src/github.com/golang/protobuf \
 	&& git checkout -q $PROTOBUF_VERSION \
 	&& go install ./protoc-gen-go

--- a/hack/update-generated-files
+++ b/hack/update-generated-files
@@ -4,11 +4,13 @@
 set -eu
 
 gogo_version=$(awk '$1 == "github.com/gogo/protobuf" { print $2 }' go.mod)
+protobuf_version=$(awk '$3 == "github.com/golang/protobuf" { print $4 }' go.mod)
 output=$(mktemp -d -t buildctl-output.XXXXXXXXXX)
 
 buildxCmd build \
   --target "update" \
   --build-arg "GOGO_VERSION=$gogo_version" \
+  --build-arg "PROTOBUF_VERSION=$protobuf_version" \
   --output "type=local,dest=$output" \
   --file "./hack/dockerfiles/generated-files.Dockerfile" \
   .

--- a/util/stack/stack.pb.go
+++ b/util/stack/stack.pb.go
@@ -151,7 +151,9 @@ func init() {
 	proto.RegisterType((*Frame)(nil), "stack.Frame")
 }
 
-func init() { proto.RegisterFile("stack.proto", fileDescriptor_b44c07feb2ca0a5a) }
+func init() {
+	proto.RegisterFile("stack.proto", fileDescriptor_b44c07feb2ca0a5a)
+}
 
 var fileDescriptor_b44c07feb2ca0a5a = []byte{
 	// 185 bytes of a gzipped FileDescriptorProto


### PR DESCRIPTION
### generated files: update google/protobuf v1.3.5, and fix install for go modules

This patch updates the script and Dockerfile to prevent issues when using go
modules.

The first change is to use a plain `git clone` instead of `go get -d` to download
the source. While (like "pre go-modules") `go get -d` won't *build* the binaries
when go modules are used, it *will* use go modules to download the package
(and dependencies); as a result:

- no git repository will be cloned in gopath
- go modules will be downloaded for "master" (not the version that we specify
  to build)

Note: Once we update to Go 1.16, this script could be updated to use `go install <repo>@version`

The second change is an update to the `update-generated-files` script to detect
the correct version of google/protobuf to use from the `go.mod`'s  `replace` rule,
to make sure we generate (and verify) using the correct version.

The Dockerfile was also updated to update the default versions specified in the
PROTOBUF_VERSION and GOGO_VERSION build-args (although not strictly necessary).

Regenerating the files with this version resulted in a minor formatting change.


### generated-files: update protoc to v3.11.4 to match google/protobuf

see https://github.com/golang/protobuf/blob/v1.3.5/.travis.yml#L15

Note that gogo/protobuf v1.3.2 updated protoc to v3.14.0; https://github.com/gogo/protobuf/releases/tag/v1.3.2
however, regenerating protobufs with this switched an import to use
google.golang.org/protobuf/types/known/timestamppb instead of
github.com/golang/protobuf/ptypes/timestamp, so using the older
version for now