### PR TITLE
go.mod: update docker and docker cli to v20.10.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,11 +16,11 @@ require (
 	github.com/containerd/stargz-snapshotter v0.5.0
 	github.com/containerd/typeurl v1.0.2
 	github.com/coreos/go-systemd/v22 v22.1.0
-	github.com/docker/cli v20.10.5+incompatible
+	github.com/docker/cli v20.10.7+incompatible
 	github.com/docker/distribution v2.7.1+incompatible
-	github.com/docker/docker v20.10.5+incompatible
+	github.com/docker/docker v20.10.7+incompatible
 	github.com/docker/go-connections v0.4.0
-	github.com/docker/libnetwork v0.8.0-dev.2.0.20201215162534-fa125a3512ee
+	github.com/docker/libnetwork v0.8.0-dev.2.0.20210525090646-64b7a4574d14
 	github.com/gofrs/flock v0.7.3
 	github.com/gogo/googleapis v1.4.0
 	github.com/gogo/protobuf v1.3.2
@@ -34,7 +34,7 @@ require (
 	github.com/hashicorp/go-immutable-radix v1.0.0
 	github.com/hashicorp/golang-lru v0.5.3
 	github.com/hashicorp/uuid v0.0.0-20160311170451-ebb0a03e909c // indirect
-	github.com/ishidawataru/sctp v0.0.0-20191218070446-00ab2ac2db07 // indirect
+	github.com/ishidawataru/sctp v0.0.0-20210226210310-f2269e66cdee // indirect
 	github.com/jaguilar/vt100 v0.0.0-20150826170717-2703a27b14ea
 	github.com/mitchellh/hashstructure v1.0.0
 	github.com/moby/locker v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -236,8 +236,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
-github.com/docker/cli v20.10.5+incompatible h1:bjflayQbWg+xOkF2WPEAOi4Y7zWhR7ptoPhV/VqLVDE=
-github.com/docker/cli v20.10.5+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v20.10.7+incompatible h1:pv/3NqibQKphWZiAskMzdz8w0PRbtTaEB+f6NwdU7Is=
+github.com/docker/cli v20.10.7+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v0.0.0-20190905152932-14b96e55d84c/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
@@ -245,6 +245,8 @@ github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4Kfc
 github.com/docker/docker v17.12.0-ce-rc1.0.20200730172259-9f28837c1d93+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v20.10.5+incompatible h1:o5WL5onN4awYGwrW7+oTn5x9AF2prw7V0Ox8ZEkoCdg=
 github.com/docker/docker v20.10.5+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v20.10.7+incompatible h1:Z6O9Nhsjv+ayUEeI1IojKbYcsGdgYSNqxe1s2MYzUhQ=
+github.com/docker/docker v20.10.7+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.3 h1:zI2p9+1NQYdnG6sMU26EX4aVGlqbInSQxQXLvzJ4RPQ=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
@@ -257,8 +259,8 @@ github.com/docker/go-metrics v0.0.1 h1:AgB/0SvBxihN0X8OR4SjsblXkbMvalQ8cjmtKQ2rQ
 github.com/docker/go-metrics v0.0.1/go.mod h1:cG1hvH2utMXtqgqqYE9plW6lDxS3/5ayHzueweSI3Vw=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/docker/libnetwork v0.8.0-dev.2.0.20201215162534-fa125a3512ee h1:VQGPaek8TO9sRNRVNXmjzrya1SmleN0cMf/vvyjjJHo=
-github.com/docker/libnetwork v0.8.0-dev.2.0.20201215162534-fa125a3512ee/go.mod h1:93m0aTqz6z+g32wla4l4WxTrdtvBRmVzYRkYvasA5Z8=
+github.com/docker/libnetwork v0.8.0-dev.2.0.20210525090646-64b7a4574d14 h1:GZvuJOpa10/Yl2EinacWoMqJ+XtNPbikclDZvNXBNO8=
+github.com/docker/libnetwork v0.8.0-dev.2.0.20210525090646-64b7a4574d14/go.mod h1:93m0aTqz6z+g32wla4l4WxTrdtvBRmVzYRkYvasA5Z8=
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
@@ -398,8 +400,8 @@ github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/ishidawataru/sctp v0.0.0-20191218070446-00ab2ac2db07 h1:rw3IAne6CDuVFlZbPOkA7bhxlqawFh7RJJ+CejfMaxE=
-github.com/ishidawataru/sctp v0.0.0-20191218070446-00ab2ac2db07/go.mod h1:co9pwDoBCm1kGxawmb4sPq0cSIOOWNPT4KnHotMP1Zg=
+github.com/ishidawataru/sctp v0.0.0-20210226210310-f2269e66cdee h1:PAXLXk1heNZ5yokbMBpVLZQxo43wCZxRwl00mX+dd44=
+github.com/ishidawataru/sctp v0.0.0-20210226210310-f2269e66cdee/go.mod h1:co9pwDoBCm1kGxawmb4sPq0cSIOOWNPT4KnHotMP1Zg=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/vendor/github.com/docker/docker/client/client.go
+++ b/vendor/github.com/docker/docker/client/client.go
@@ -2,7 +2,7 @@
 Package client is a Go client for the Docker Engine API.
 
 For more information about the Engine API, see the documentation:
-https://docs.docker.com/engine/reference/api/
+https://docs.docker.com/engine/api/
 
 Usage
 

--- a/vendor/github.com/docker/docker/pkg/archive/archive_linux.go
+++ b/vendor/github.com/docker/docker/pkg/archive/archive_linux.go
@@ -2,29 +2,26 @@ package archive // import "github.com/docker/docker/pkg/archive"
 
 import (
 	"archive/tar"
-	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 
-	"github.com/containerd/continuity/fs"
 	"github.com/docker/docker/pkg/system"
-	"github.com/moby/sys/mount"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 
-func getWhiteoutConverter(format WhiteoutFormat, inUserNS bool) tarWhiteoutConverter {
+func getWhiteoutConverter(format WhiteoutFormat, inUserNS bool) (tarWhiteoutConverter, error) {
 	if format == OverlayWhiteoutFormat {
-		return overlayWhiteoutConverter{inUserNS: inUserNS}
+		if inUserNS {
+			return nil, errors.New("specifying OverlayWhiteoutFormat is not allowed in userns")
+		}
+		return overlayWhiteoutConverter{}, nil
 	}
-	return nil
+	return nil, nil
 }
 
 type overlayWhiteoutConverter struct {
-	inUserNS bool
 }
 
 func (overlayWhiteoutConverter) ConvertWrite(hdr *tar.Header, path string, fi os.FileInfo) (wo *tar.Header, err error) {
@@ -77,13 +74,7 @@ func (c overlayWhiteoutConverter) ConvertRead(hdr *tar.Header, path string) (boo
 	if base == WhiteoutOpaqueDir {
 		err := unix.Setxattr(dir, "trusted.overlay.opaque", []byte{'y'}, 0)
 		if err != nil {
-			if c.inUserNS {
-				if err = replaceDirWithOverlayOpaque(dir); err != nil {
-					return false, errors.Wrapf(err, "replaceDirWithOverlayOpaque(%q) failed", dir)
-				}
-			} else {
-				return false, errors.Wrapf(err, "setxattr(%q, trusted.overlay.opaque=y)", dir)
-			}
+			return false, errors.Wrapf(err, "setxattr(%q, trusted.overlay.opaque=y)", dir)
 		}
 		// don't write the file itself
 		return false, err
@@ -95,19 +86,7 @@ func (c overlayWhiteoutConverter) ConvertRead(hdr *tar.Header, path string) (boo
 		originalPath := filepath.Join(dir, originalBase)
 
 		if err := unix.Mknod(originalPath, unix.S_IFCHR, 0); err != nil {
-			if c.inUserNS {
-				// Ubuntu and a few distros support overlayfs in userns.
-				//
-				// Although we can't call mknod directly in userns (at least on bionic kernel 4.15),
-				// we can still create 0,0 char device using mknodChar0Overlay().
-				//
-				// NOTE: we don't need this hack for the containerd snapshotter+unpack model.
-				if err := mknodChar0Overlay(originalPath); err != nil {
-					return false, errors.Wrapf(err, "failed to mknodChar0UserNS(%q)", originalPath)
-				}
-			} else {
-				return false, errors.Wrapf(err, "failed to mknod(%q, S_IFCHR, 0)", originalPath)
-			}
+			return false, errors.Wrapf(err, "failed to mknod(%q, S_IFCHR, 0)", originalPath)
 		}
 		if err := os.Chown(originalPath, hdr.Uid, hdr.Gid); err != nil {
 			return false, err
@@ -118,147 +97,4 @@ func (c overlayWhiteoutConverter) ConvertRead(hdr *tar.Header, path string) (boo
 	}
 
 	return true, nil
-}
-
-// mknodChar0Overlay creates 0,0 char device by mounting overlayfs and unlinking.
-// This function can be used for creating 0,0 char device in userns on Ubuntu.
-//
-// Steps:
-// * Mkdir lower,upper,merged,work
-// * Create lower/dummy
-// * Mount overlayfs
-// * Unlink merged/dummy
-// * Unmount overlayfs
-// * Make sure a 0,0 char device is created as upper/dummy
-// * Rename upper/dummy to cleansedOriginalPath
-func mknodChar0Overlay(cleansedOriginalPath string) error {
-	dir := filepath.Dir(cleansedOriginalPath)
-	tmp, err := ioutil.TempDir(dir, "mc0o")
-	if err != nil {
-		return errors.Wrapf(err, "failed to create a tmp directory under %s", dir)
-	}
-	defer os.RemoveAll(tmp)
-	lower := filepath.Join(tmp, "l")
-	upper := filepath.Join(tmp, "u")
-	work := filepath.Join(tmp, "w")
-	merged := filepath.Join(tmp, "m")
-	for _, s := range []string{lower, upper, work, merged} {
-		if err := os.MkdirAll(s, 0700); err != nil {
-			return errors.Wrapf(err, "failed to mkdir %s", s)
-		}
-	}
-	dummyBase := "d"
-	lowerDummy := filepath.Join(lower, dummyBase)
-	if err := ioutil.WriteFile(lowerDummy, []byte{}, 0600); err != nil {
-		return errors.Wrapf(err, "failed to create a dummy lower file %s", lowerDummy)
-	}
-	// lowerdir needs ":" to be escaped: https://github.com/moby/moby/issues/40939#issuecomment-627098286
-	lowerEscaped := strings.ReplaceAll(lower, ":", "\\:")
-	mOpts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lowerEscaped, upper, work)
-	if err := mount.Mount("overlay", merged, "overlay", mOpts); err != nil {
-		return err
-	}
-	mergedDummy := filepath.Join(merged, dummyBase)
-	if err := os.Remove(mergedDummy); err != nil {
-		syscall.Unmount(merged, 0)
-		return errors.Wrapf(err, "failed to unlink %s", mergedDummy)
-	}
-	if err := syscall.Unmount(merged, 0); err != nil {
-		return errors.Wrapf(err, "failed to unmount %s", merged)
-	}
-	upperDummy := filepath.Join(upper, dummyBase)
-	if err := isChar0(upperDummy); err != nil {
-		return err
-	}
-	if err := os.Rename(upperDummy, cleansedOriginalPath); err != nil {
-		return errors.Wrapf(err, "failed to rename %s to %s", upperDummy, cleansedOriginalPath)
-	}
-	return nil
-}
-
-func isChar0(path string) error {
-	osStat, err := os.Stat(path)
-	if err != nil {
-		return errors.Wrapf(err, "failed to stat %s", path)
-	}
-	st, ok := osStat.Sys().(*syscall.Stat_t)
-	if !ok {
-		return errors.Errorf("got unsupported stat for %s", path)
-	}
-	if os.FileMode(st.Mode)&syscall.S_IFMT != syscall.S_IFCHR {
-		return errors.Errorf("%s is not a character device, got mode=%d", path, st.Mode)
-	}
-	if st.Rdev != 0 {
-		return errors.Errorf("%s is not a 0,0 character device, got Rdev=%d", path, st.Rdev)
-	}
-	return nil
-}
-
-// replaceDirWithOverlayOpaque replaces path with a new directory with trusted.overlay.opaque
-// xattr. The contents of the directory are preserved.
-func replaceDirWithOverlayOpaque(path string) error {
-	if path == "/" {
-		return errors.New("replaceDirWithOverlayOpaque: path must not be \"/\"")
-	}
-	dir := filepath.Dir(path)
-	tmp, err := ioutil.TempDir(dir, "rdwoo")
-	if err != nil {
-		return errors.Wrapf(err, "failed to create a tmp directory under %s", dir)
-	}
-	defer os.RemoveAll(tmp)
-	// newPath is a new empty directory crafted with trusted.overlay.opaque xattr.
-	// we copy the content of path into newPath, remove path, and rename newPath to path.
-	newPath, err := createDirWithOverlayOpaque(tmp)
-	if err != nil {
-		return errors.Wrapf(err, "createDirWithOverlayOpaque(%q) failed", tmp)
-	}
-	if err := fs.CopyDir(newPath, path); err != nil {
-		return errors.Wrapf(err, "CopyDir(%q, %q) failed", newPath, path)
-	}
-	if err := os.RemoveAll(path); err != nil {
-		return err
-	}
-	return os.Rename(newPath, path)
-}
-
-// createDirWithOverlayOpaque creates a directory with trusted.overlay.opaque xattr,
-// without calling setxattr, so as to allow creating opaque dir in userns on Ubuntu.
-func createDirWithOverlayOpaque(tmp string) (string, error) {
-	lower := filepath.Join(tmp, "l")
-	upper := filepath.Join(tmp, "u")
-	work := filepath.Join(tmp, "w")
-	merged := filepath.Join(tmp, "m")
-	for _, s := range []string{lower, upper, work, merged} {
-		if err := os.MkdirAll(s, 0700); err != nil {
-			return "", errors.Wrapf(err, "failed to mkdir %s", s)
-		}
-	}
-	dummyBase := "d"
-	lowerDummy := filepath.Join(lower, dummyBase)
-	if err := os.MkdirAll(lowerDummy, 0700); err != nil {
-		return "", errors.Wrapf(err, "failed to create a dummy lower directory %s", lowerDummy)
-	}
-	// lowerdir needs ":" to be escaped: https://github.com/moby/moby/issues/40939#issuecomment-627098286
-	lowerEscaped := strings.ReplaceAll(lower, ":", "\\:")
-	mOpts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lowerEscaped, upper, work)
-	if err := mount.Mount("overlay", merged, "overlay", mOpts); err != nil {
-		return "", err
-	}
-	mergedDummy := filepath.Join(merged, dummyBase)
-	if err := os.Remove(mergedDummy); err != nil {
-		syscall.Unmount(merged, 0)
-		return "", errors.Wrapf(err, "failed to rmdir %s", mergedDummy)
-	}
-	// upperDummy becomes a 0,0-char device file here
-	if err := os.Mkdir(mergedDummy, 0700); err != nil {
-		syscall.Unmount(merged, 0)
-		return "", errors.Wrapf(err, "failed to mkdir %s", mergedDummy)
-	}
-	// upperDummy becomes a directory with trusted.overlay.opaque xattr
-	// (but can't be verified in userns)
-	if err := syscall.Unmount(merged, 0); err != nil {
-		return "", errors.Wrapf(err, "failed to unmount %s", merged)
-	}
-	upperDummy := filepath.Join(upper, dummyBase)
-	return upperDummy, nil
 }

--- a/vendor/github.com/docker/docker/pkg/archive/archive_other.go
+++ b/vendor/github.com/docker/docker/pkg/archive/archive_other.go
@@ -2,6 +2,6 @@
 
 package archive // import "github.com/docker/docker/pkg/archive"
 
-func getWhiteoutConverter(format WhiteoutFormat, inUserNS bool) tarWhiteoutConverter {
-	return nil
+func getWhiteoutConverter(format WhiteoutFormat, inUserNS bool) (tarWhiteoutConverter, error) {
+	return nil, nil
 }

--- a/vendor/github.com/docker/docker/pkg/signal/signal.go
+++ b/vendor/github.com/docker/docker/pkg/signal/signal.go
@@ -12,9 +12,16 @@ import (
 )
 
 // CatchAll catches all signals and relays them to the specified channel.
+// SIGURG is not handled, as it's used by the Go runtime to support
+// preemptable system calls.
 func CatchAll(sigc chan os.Signal) {
 	var handledSigs []os.Signal
-	for _, s := range SignalMap {
+	for n, s := range SignalMap {
+		if n == "URG" {
+			// Do not handle SIGURG, as in go1.14+, the go runtime issues
+			// SIGURG as an interrupt to support preemptable system calls on Linux.
+			continue
+		}
 		handledSigs = append(handledSigs, s)
 	}
 	signal.Notify(sigc, handledSigs...)

--- a/vendor/github.com/ishidawataru/sctp/.travis.yml
+++ b/vendor/github.com/ishidawataru/sctp/.travis.yml
@@ -1,10 +1,20 @@
 language: go
+arch:
+    - amd64
+    - ppc64le
 go:
  - 1.9.x
  - 1.10.x
  - 1.11.x
  - 1.12.x
  - 1.13.x
+# allowing test cases to fail  for the versions were not suppotred by ppc64le 
+matrix:
+  allow_failures:
+                - go: 1.9.x
+                - go: 1.10.x
+                - go: 1.13.x
+
 
 script:
  - go test -v -race ./...
@@ -12,6 +22,7 @@ script:
  - GOOS=linux   GOARCH=arm     go build .
  - GOOS=linux   GOARCH=arm64   go build .
  - GOOS=linux   GOARCH=ppc64le go build .
+ - GOOS=linux   GOARCH=mips64le go build .
  - (go version | grep go1.6 > /dev/null) || GOOS=linux   GOARCH=s390x   go build .
 # can be compiled but not functional:
  - GOOS=linux   GOARCH=386     go build .

--- a/vendor/github.com/ishidawataru/sctp/sctp_linux.go
+++ b/vendor/github.com/ishidawataru/sctp/sctp_linux.go
@@ -212,7 +212,7 @@ func listenSCTPExtConfig(network string, laddr *SCTPAddr, options InitMsg, contr
 				laddr.IPAddrs = append(laddr.IPAddrs, net.IPAddr{IP: net.IPv6zero})
 			}
 		}
-		err := SCTPBind(sock, laddr, SCTP_BINDX_ADD_ADDR)
+		err = SCTPBind(sock, laddr, SCTP_BINDX_ADD_ADDR)
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -165,7 +165,7 @@ github.com/coreos/go-systemd/v22/daemon
 github.com/cpuguy83/go-md2man/v2/md2man
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/docker/cli v20.10.5+incompatible
+# github.com/docker/cli v20.10.7+incompatible
 github.com/docker/cli/cli/config
 github.com/docker/cli/cli/config/configfile
 github.com/docker/cli/cli/config/credentials
@@ -175,7 +175,7 @@ github.com/docker/cli/cli/connhelper/commandconn
 github.com/docker/distribution/digestset
 github.com/docker/distribution/reference
 github.com/docker/distribution/registry/api/errcode
-# github.com/docker/docker v20.10.5+incompatible
+# github.com/docker/docker v20.10.7+incompatible
 github.com/docker/docker/api
 github.com/docker/docker/api/types
 github.com/docker/docker/api/types/blkiodev
@@ -226,7 +226,7 @@ github.com/docker/go-events
 github.com/docker/go-metrics
 # github.com/docker/go-units v0.4.0
 github.com/docker/go-units
-# github.com/docker/libnetwork v0.8.0-dev.2.0.20201215162534-fa125a3512ee
+# github.com/docker/libnetwork v0.8.0-dev.2.0.20210525090646-64b7a4574d14
 github.com/docker/libnetwork/ipamutils
 github.com/docker/libnetwork/resolvconf
 github.com/docker/libnetwork/resolvconf/dns
@@ -275,7 +275,7 @@ github.com/hanwen/go-fuse/v2/splice
 github.com/hashicorp/go-immutable-radix
 # github.com/hashicorp/golang-lru v0.5.3
 github.com/hashicorp/golang-lru/simplelru
-# github.com/ishidawataru/sctp v0.0.0-20191218070446-00ab2ac2db07
+# github.com/ishidawataru/sctp v0.0.0-20210226210310-f2269e66cdee
 github.com/ishidawataru/sctp
 # github.com/jaguilar/vt100 v0.0.0-20150826170717-2703a27b14ea => github.com/tonistiigi/vt100 v0.0.0-20190402012908-ad4c4a574305
 github.com/jaguilar/vt100


### PR DESCRIPTION
- pkg/signal: ignore SIGURG on all platforms
- pkg/archive: use v2 capabilities in layer archives
- update ishidawataru/sctp to fix possible socket leak when bind fails

docker/cli:

- config: print deprecation warning when falling back to ~/.dockercfg
