### PR TITLE
move RegistryConfig to resolver package

### DIFF
--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -1,6 +1,9 @@
 package config
 
-import "github.com/BurntSushi/toml"
+import (
+	"github.com/BurntSushi/toml"
+	"github.com/moby/buildkit/util/resolver"
+)
 
 // Config provides containerd configuration data for the server
 type Config struct {
@@ -9,7 +12,7 @@ type Config struct {
 	// Root is the path to a directory where buildkit will store persistent data
 	Root string `toml:"root"`
 
-	//Entitlements e.g. security.insecure, network.host
+	// Entitlements e.g. security.insecure, network.host
 	Entitlements []string `toml:"insecure-entitlements"`
 	// GRPC configuration settings
 	GRPC GRPCConfig `toml:"grpc"`
@@ -19,7 +22,7 @@ type Config struct {
 		Containerd ContainerdConfig `toml:"containerd"`
 	} `toml:"worker"`
 
-	Registries map[string]RegistryConfig `toml:"registry"`
+	Registries map[string]resolver.RegistryConfig `toml:"registry"`
 
 	DNS *DNSConfig `toml:"dns"`
 }
@@ -33,20 +36,6 @@ type GRPCConfig struct {
 	TLS TLSConfig `toml:"tls"`
 	// MaxRecvMsgSize int    `toml:"max_recv_message_size"`
 	// MaxSendMsgSize int    `toml:"max_send_message_size"`
-}
-
-type RegistryConfig struct {
-	Mirrors      []string     `toml:"mirrors"`
-	PlainHTTP    *bool        `toml:"http"`
-	Insecure     *bool        `toml:"insecure"`
-	RootCAs      []string     `toml:"ca"`
-	KeyPairs     []TLSKeyPair `toml:"keypair"`
-	TLSConfigDir []string     `toml:"tlsconfigdir"`
-}
-
-type TLSKeyPair struct {
-	Key         string `toml:"key"`
-	Certificate string `toml:"cert"`
 }
 
 type TLSConfig struct {

--- a/util/push/push.go
+++ b/util/push/push.go
@@ -14,7 +14,6 @@ import (
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/docker/distribution/reference"
-	"github.com/moby/buildkit/cmd/buildkitd/config"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/util/flightcontrol"
 	"github.com/moby/buildkit/util/imageutil"
@@ -55,7 +54,7 @@ func Push(ctx context.Context, sm *session.Manager, sid string, provider content
 	if insecure {
 		insecureTrue := true
 		httpTrue := true
-		hosts = resolver.NewRegistryConfig(map[string]config.RegistryConfig{
+		hosts = resolver.NewRegistryConfig(map[string]resolver.RegistryConfig{
 			reference.Domain(parsed): {
 				Insecure:  &insecureTrue,
 				PlainHTTP: &httpTrue,


### PR DESCRIPTION
relates to https://github.com/moby/moby/pull/42465#issuecomment-855086782

This allows using the resolver package without having to import the buildkit daemon configuration.

~Aliasses were added in the config package for backward compatibility, and to allow for the config package to diverge / extend the internal type if needed.~
