### PR TITLE
cache: fix possible nil dereferences

### DIFF
--- a/cache/manager.go
+++ b/cache/manager.go
@@ -150,10 +150,13 @@ func (cm *cacheManager) GetByBlob(ctx context.Context, desc ocispec.Descriptor, 
 		return nil, err
 	}
 
-	if len(sis) > 0 {
-		ref, err := cm.get(ctx, sis[0].ID(), opts...)
+	for _, si := range sis {
+		ref, err := cm.get(ctx, si.ID(), opts...)
 		if err != nil && !IsNotFound(err) {
 			return nil, errors.Wrapf(err, "failed to get record %s by blobchainid", sis[0].ID())
+		}
+		if ref == nil {
+			continue
 		}
 		if p != nil {
 			releaseParent = true
@@ -170,12 +173,15 @@ func (cm *cacheManager) GetByBlob(ctx context.Context, desc ocispec.Descriptor, 
 	}
 
 	var link ImmutableRef
-	if len(sis) > 0 {
-		ref, err := cm.get(ctx, sis[0].ID(), opts...)
+	for _, si := range sis {
+		ref, err := cm.get(ctx, si.ID(), opts...)
 		if err != nil && !IsNotFound(err) {
 			return nil, errors.Wrapf(err, "failed to get record %s by chainid", sis[0].ID())
 		}
-		link = ref
+		if ref != nil {
+			link = ref
+			break
+		}
 	}
 
 	id := identity.NewID()


### PR DESCRIPTION
Fix #2153

It should be possible for this to happen when gc/prune runs in the middle of `Search` and `Get` calls. Not found error was already handled but not cleanly. The code that causes the panic was added later, previously there was no panic for this case but if there was a fallback option only one search result was tried.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>