### PR TITLE
add current tracing context detection and exec propagation

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/url"
+	"strings"
 
 	"github.com/containerd/containerd/defaults"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
@@ -16,9 +17,12 @@ import (
 	"github.com/moby/buildkit/session/grpchijack"
 	"github.com/moby/buildkit/util/appdefaults"
 	"github.com/moby/buildkit/util/grpcerrors"
+	"github.com/moby/buildkit/util/tracing/otlptracegrpc"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -60,7 +64,6 @@ func New(ctx context.Context, address string, opts ...ClientOpt) (*Client, error
 		if wt, ok := o.(*withTracer); ok {
 			customTracer = true
 			tracerProvider = wt.tp
-
 		}
 		if wd, ok := o.(*withDialer); ok {
 			gopts = append(gopts, grpc.WithContextDialer(wd.dialer))
@@ -76,7 +79,7 @@ func New(ctx context.Context, address string, opts ...ClientOpt) (*Client, error
 
 	if tracerProvider != nil {
 		var propagators = propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{})
-		unary = append(unary, otelgrpc.UnaryClientInterceptor(otelgrpc.WithTracerProvider(tracerProvider), otelgrpc.WithPropagators(propagators)))
+		unary = append(unary, filterInterceptor(otelgrpc.UnaryClientInterceptor(otelgrpc.WithTracerProvider(tracerProvider), otelgrpc.WithPropagators(propagators))))
 		stream = append(stream, otelgrpc.StreamClientInterceptor(otelgrpc.WithTracerProvider(tracerProvider), otelgrpc.WithPropagators(propagators)))
 	}
 
@@ -122,10 +125,41 @@ func New(ctx context.Context, address string, opts ...ClientOpt) (*Client, error
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to dial %q . make sure buildkitd is running", address)
 	}
+
 	c := &Client{
 		conn: conn,
 	}
+
+	_ = c.setupDelegatedTracing(ctx) // ignore error
+
 	return c, nil
+}
+
+func (c *Client) setupDelegatedTracing(ctx context.Context) error {
+	span := trace.SpanFromContext(ctx)
+	if !span.SpanContext().IsValid() {
+		return nil
+	}
+
+	exp, ok := span.TracerProvider().(interface {
+		SpanExporter() sdktrace.SpanExporter
+	})
+	if !ok || exp == nil {
+		return nil
+	}
+	del, ok := exp.(interface {
+		SetDelegate(context.Context, sdktrace.SpanExporter) error
+	})
+	if !ok {
+		return nil
+	}
+
+	pd := otlptracegrpc.NewClient(c.conn)
+	e, err := otlptrace.New(ctx, pd)
+	if err != nil {
+		return nil
+	}
+	return del.SetDelegate(ctx, e)
 }
 
 func (c *Client) controlClient() controlapi.ControlClient {
@@ -218,4 +252,13 @@ func resolveDialer(address string) (func(context.Context, string) (net.Conn, err
 	}
 	// basic dialer
 	return dialer, nil
+}
+
+func filterInterceptor(intercept grpc.UnaryClientInterceptor) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		if strings.HasSuffix(method, "opentelemetry.proto.collector.trace.v1.TraceService/Export") {
+			return invoker(ctx, method, req, reply, cc, opts...)
+		}
+		return intercept(ctx, method, req, reply, cc, invoker, opts...)
+	}
 }

--- a/cmd/buildctl/main.go
+++ b/cmd/buildctl/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/moby/buildkit/util/appdefaults"
 	"github.com/moby/buildkit/util/profiler"
 	"github.com/moby/buildkit/util/stack"
+	_ "github.com/moby/buildkit/util/tracing/detect/delegated"
 	_ "github.com/moby/buildkit/util/tracing/detect/jaeger"
 	"github.com/moby/buildkit/version"
 	"github.com/sirupsen/logrus"

--- a/cmd/buildctl/main.go
+++ b/cmd/buildctl/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/moby/buildkit/util/stack"
 	_ "github.com/moby/buildkit/util/tracing/detect/delegated"
 	_ "github.com/moby/buildkit/util/tracing/detect/jaeger"
+	_ "github.com/moby/buildkit/util/tracing/env"
 	"github.com/moby/buildkit/version"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"

--- a/cmd/buildkitd/main_containerd_worker.go
+++ b/cmd/buildkitd/main_containerd_worker.go
@@ -235,7 +235,7 @@ func containerdWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([
 	if cfg.Snapshotter != "" {
 		snapshotter = cfg.Snapshotter
 	}
-	opt, err := containerd.NewWorkerOpt(common.config.Root, cfg.Address, snapshotter, cfg.Namespace, cfg.Labels, dns, nc, common.config.Workers.Containerd.ApparmorProfile, parallelismSem, ctd.WithTimeout(60*time.Second))
+	opt, err := containerd.NewWorkerOpt(common.config.Root, cfg.Address, snapshotter, cfg.Namespace, cfg.Labels, dns, nc, common.config.Workers.Containerd.ApparmorProfile, parallelismSem, common.traceSocket, ctd.WithTimeout(60*time.Second))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/buildkitd/main_oci_worker.go
+++ b/cmd/buildkitd/main_oci_worker.go
@@ -287,7 +287,7 @@ func ociWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([]worker
 		parallelismSem = semaphore.NewWeighted(int64(cfg.MaxParallelism))
 	}
 
-	opt, err := runc.NewWorkerOpt(common.config.Root, snFactory, cfg.Rootless, processMode, cfg.Labels, idmapping, nc, dns, cfg.Binary, cfg.ApparmorProfile, parallelismSem)
+	opt, err := runc.NewWorkerOpt(common.config.Root, snFactory, cfg.Rootless, processMode, cfg.Labels, idmapping, nc, dns, cfg.Binary, cfg.ApparmorProfile, parallelismSem, common.traceSocket)
 	if err != nil {
 		return nil, err
 	}

--- a/control/control.go
+++ b/control/control.go
@@ -29,6 +29,8 @@ import (
 	v1 "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type Opt struct {
@@ -193,6 +195,9 @@ func (c *Controller) Prune(req *controlapi.PruneRequest, stream controlapi.Contr
 }
 
 func (c *Controller) Export(ctx context.Context, req *tracev1.ExportTraceServiceRequest) (*tracev1.ExportTraceServiceResponse, error) {
+	if c.opt.TraceCollector == nil {
+		return nil, status.Errorf(codes.Unavailable, "trace collector not configured")
+	}
 	err := c.opt.TraceCollector.ExportSpans(ctx, transform.Spans(req.GetResourceSpans()))
 	if err != nil {
 		return nil, err

--- a/executor/oci/spec.go
+++ b/executor/oci/spec.go
@@ -15,6 +15,7 @@ import (
 	"github.com/moby/buildkit/executor"
 	"github.com/moby/buildkit/snapshot"
 	"github.com/moby/buildkit/util/network"
+	traceexec "github.com/moby/buildkit/util/tracing/exec"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/pkg/errors"
@@ -75,6 +76,8 @@ func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mou
 	if meta.Hostname != "" {
 		hostname = meta.Hostname
 	}
+
+	meta.Env = append(meta.Env, traceexec.Environ(ctx)...)
 
 	opts = append(opts,
 		oci.WithProcessArgs(meta.Args...),

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -46,6 +46,7 @@ type Opt struct {
 	DNS             *oci.DNSConfig
 	OOMScoreAdj     *int
 	ApparmorProfile string
+	TracingSocket   string
 }
 
 var defaultCommandCandidates = []string{"buildkit-runc", "runc"}
@@ -64,6 +65,7 @@ type runcExecutor struct {
 	running          map[string]chan error
 	mu               sync.Mutex
 	apparmorProfile  string
+	tracingSocket    string
 }
 
 func New(opt Opt, networkProviders map[pb.NetMode]network.Provider) (executor.Executor, error) {
@@ -127,6 +129,7 @@ func New(opt Opt, networkProviders map[pb.NetMode]network.Provider) (executor.Ex
 		oomScoreAdj:      opt.OOMScoreAdj,
 		running:          make(map[string]chan error),
 		apparmorProfile:  opt.ApparmorProfile,
+		tracingSocket:    opt.TracingSocket,
 	}
 	return w, nil
 }
@@ -256,7 +259,7 @@ func (w *runcExecutor) Run(ctx context.Context, id string, root executor.Mount, 
 		}
 		opts = append(opts, containerdoci.WithCgroup(cgroupsPath))
 	}
-	spec, cleanup, err := oci.GenerateSpec(ctx, meta, mounts, id, resolvConf, hostsFile, namespace, w.processMode, w.idmap, w.apparmorProfile, opts...)
+	spec, cleanup, err := oci.GenerateSpec(ctx, meta, mounts, id, resolvConf, hostsFile, namespace, w.processMode, w.idmap, w.apparmorProfile, w.tracingSocket, opts...)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.0.0-RC1
 	go.opentelemetry.io/otel/sdk v1.0.0-RC1
 	go.opentelemetry.io/otel/trace v1.0.0-RC1
+	go.opentelemetry.io/proto/otlp v0.9.0
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c

--- a/util/appcontext/appcontext.go
+++ b/util/appcontext/appcontext.go
@@ -22,7 +22,12 @@ func Context() context.Context {
 		const exitLimit = 3
 		retries := 0
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx := context.Background()
+		for _, f := range inits {
+			ctx = f(ctx)
+		}
+
+		ctx, cancel := context.WithCancel(ctx)
 		appContextCache = ctx
 
 		go func() {

--- a/util/appcontext/register.go
+++ b/util/appcontext/register.go
@@ -1,0 +1,14 @@
+package appcontext
+
+import (
+	"context"
+)
+
+type Initializer func(context.Context) context.Context
+
+var inits []Initializer
+
+// Register stores a new context initializer that runs on app context creation
+func Register(f Initializer) {
+	inits = append(inits, f)
+}

--- a/util/tracing/detect/delegated/delegated.go
+++ b/util/tracing/detect/delegated/delegated.go
@@ -1,0 +1,66 @@
+package jaeger
+
+import (
+	"context"
+	"sync"
+
+	"github.com/moby/buildkit/util/tracing/detect"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+const maxBuffer = 128
+
+var exp = &Exporter{}
+
+func init() {
+	detect.Register("delegated", func() (sdktrace.SpanExporter, error) {
+		return exp, nil
+	})
+}
+
+type Exporter struct {
+	mu       sync.Mutex
+	delegate sdktrace.SpanExporter
+	buffer   []sdktrace.ReadOnlySpan
+}
+
+var _ sdktrace.SpanExporter = &Exporter{}
+
+func (e *Exporter) ExportSpans(ctx context.Context, ss []sdktrace.ReadOnlySpan) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.delegate != nil {
+		return e.delegate.ExportSpans(ctx, ss)
+	}
+
+	if len(e.buffer) > maxBuffer {
+		return nil
+	}
+
+	e.buffer = append(e.buffer, ss...)
+	return nil
+}
+
+func (e *Exporter) Shutdown(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.delegate != nil {
+		return e.delegate.Shutdown(ctx)
+	}
+
+	return nil
+}
+
+func (e *Exporter) SetDelegate(ctx context.Context, del sdktrace.SpanExporter) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.delegate = del
+
+	if len(e.buffer) > 0 {
+		return e.delegate.ExportSpans(ctx, e.buffer)
+	}
+	return nil
+}

--- a/util/tracing/detect/delegated/delegated.go
+++ b/util/tracing/detect/delegated/delegated.go
@@ -15,7 +15,7 @@ var exp = &Exporter{}
 func init() {
 	detect.Register("delegated", func() (sdktrace.SpanExporter, error) {
 		return exp, nil
-	})
+	}, 100)
 }
 
 type Exporter struct {
@@ -60,7 +60,9 @@ func (e *Exporter) SetDelegate(ctx context.Context, del sdktrace.SpanExporter) e
 	e.delegate = del
 
 	if len(e.buffer) > 0 {
-		return e.delegate.ExportSpans(ctx, e.buffer)
+		err := e.delegate.ExportSpans(ctx, e.buffer)
+		e.buffer = nil
+		return err
 	}
 	return nil
 }

--- a/util/tracing/detect/detect.go
+++ b/util/tracing/detect/detect.go
@@ -78,7 +78,11 @@ func detect() error {
 
 	sdktp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sp), sdktrace.WithResource(res))
 	closers = append(closers, sdktp.Shutdown)
-	tp = sdktp
+
+	tp = &tracerProviderWithExporter{
+		TracerProvider: sdktp,
+		exp:            exp,
+	}
 
 	return nil
 }
@@ -121,4 +125,13 @@ func (serviceNameDetector) Detect(ctx context.Context) (*resource.Resource, erro
 			return filepath.Base(os.Args[0]), nil
 		},
 	).Detect(ctx)
+}
+
+type tracerProviderWithExporter struct {
+	trace.TracerProvider
+	exp sdktrace.SpanExporter
+}
+
+func (t *tracerProviderWithExporter) SpanExporter() sdktrace.SpanExporter {
+	return t.exp
 }

--- a/util/tracing/detect/jaeger/jaeger.go
+++ b/util/tracing/detect/jaeger/jaeger.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	detect.Register("jaeger", jaegerExporter)
+	detect.Register("jaeger", jaegerExporter, 11)
 }
 
 func jaegerExporter() (sdktrace.SpanExporter, error) {

--- a/util/tracing/detect/otlp.go
+++ b/util/tracing/detect/otlp.go
@@ -12,7 +12,7 @@ import (
 )
 
 func init() {
-	Register("otlp", otlpExporter)
+	Register("otlp", otlpExporter, 10)
 }
 
 func otlpExporter() (sdktrace.SpanExporter, error) {

--- a/util/tracing/env/traceenv.go
+++ b/util/tracing/env/traceenv.go
@@ -1,0 +1,54 @@
+package detect
+
+import (
+	"context"
+	"os"
+
+	"github.com/moby/buildkit/util/appcontext"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+const (
+	traceparentHeader = "traceparent"
+	tracestateHeader  = "tracestate"
+)
+
+func init() {
+	appcontext.Register(initContext)
+}
+
+func initContext(ctx context.Context) context.Context {
+	// previously defined in https://github.com/open-telemetry/opentelemetry-swift/blob/4ea467ed4b881d7329bf2254ca7ed7f2d9d6e1eb/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift#L14-L15
+	parent := os.Getenv("OTEL_TRACE_PARENT")
+	state := os.Getenv("OTEL_TRACE_STATE")
+
+	if parent == "" {
+		return ctx
+	}
+
+	tc := propagation.TraceContext{}
+	return tc.Extract(ctx, &textMap{parent: parent, state: state})
+}
+
+type textMap struct {
+	parent string
+	state  string
+}
+
+func (tm *textMap) Get(key string) string {
+	switch key {
+	case traceparentHeader:
+		return tm.parent
+	case tracestateHeader:
+		return tm.state
+	default:
+		return ""
+	}
+}
+
+func (tm *textMap) Set(key string, value string) {
+}
+
+func (tm *textMap) Keys() []string {
+	return []string{traceparentHeader, tracestateHeader}
+}

--- a/util/tracing/exec/traceexec.go
+++ b/util/tracing/exec/traceexec.go
@@ -1,0 +1,68 @@
+package detect
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/propagation"
+)
+
+const (
+	traceparentHeader = "traceparent"
+	tracestateHeader  = "tracestate"
+)
+
+// Environ returns list of environment variables that need to be sent to the child process
+// in order for it to pick up cross-process tracing from same state.
+func Environ(ctx context.Context) []string {
+	var tm textMap
+	tc := propagation.TraceContext{}
+	tc.Inject(ctx, &tm)
+
+	var env []string
+
+	// previously defined in https://github.com/open-telemetry/opentelemetry-swift/blob/4ea467ed4b881d7329bf2254ca7ed7f2d9d6e1eb/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift#L14-L15
+	if tm.parent != "" {
+		env = append(env, "OTEL_TRACE_PARENT="+tm.parent)
+	}
+	if tm.state != "" {
+		env = append(env, "OTEL_TRACE_STATE="+tm.state)
+	}
+
+	return env
+}
+
+type textMap struct {
+	parent string
+	state  string
+}
+
+func (tm *textMap) Get(key string) string {
+	switch key {
+	case traceparentHeader:
+		return tm.parent
+	case tracestateHeader:
+		return tm.state
+	default:
+		return ""
+	}
+}
+
+func (tm *textMap) Set(key string, value string) {
+	switch key {
+	case traceparentHeader:
+		tm.parent = value
+	case tracestateHeader:
+		tm.state = value
+	}
+}
+
+func (tm *textMap) Keys() []string {
+	var k []string
+	if tm.parent != "" {
+		k = append(k, traceparentHeader)
+	}
+	if tm.state != "" {
+		k = append(k, tracestateHeader)
+	}
+	return k
+}

--- a/util/tracing/otlptracegrpc/client.go
+++ b/util/tracing/otlptracegrpc/client.go
@@ -1,0 +1,101 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlptracegrpc // import "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
+
+	"google.golang.org/grpc"
+
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+type client struct {
+	connection *Connection
+
+	lock         sync.Mutex
+	tracesClient coltracepb.TraceServiceClient
+}
+
+var _ otlptrace.Client = (*client)(nil)
+
+var (
+	errNoClient = errors.New("no client")
+)
+
+// NewClient creates a new gRPC trace client.
+func NewClient(cc *grpc.ClientConn) otlptrace.Client {
+	c := &client{}
+	c.connection = NewConnection(cc, c.handleNewConnection)
+
+	return c
+}
+
+func (c *client) handleNewConnection(cc *grpc.ClientConn) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if cc != nil {
+		c.tracesClient = coltracepb.NewTraceServiceClient(cc)
+	} else {
+		c.tracesClient = nil
+	}
+}
+
+// Start establishes a connection to the collector.
+func (c *client) Start(ctx context.Context) error {
+	return c.connection.StartConnection(ctx)
+}
+
+// Stop shuts down the connection to the collector.
+func (c *client) Stop(ctx context.Context) error {
+	return c.connection.Shutdown(ctx)
+}
+
+// UploadTraces sends a batch of spans to the collector.
+func (c *client) UploadTraces(ctx context.Context, protoSpans []*tracepb.ResourceSpans) error {
+	if !c.connection.Connected() {
+		return fmt.Errorf("traces exporter is disconnected from the server: %w", c.connection.LastConnectError())
+	}
+
+	ctx, cancel := c.connection.ContextWithStop(ctx)
+	defer cancel()
+	ctx, tCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer tCancel()
+
+	ctx = c.connection.ContextWithMetadata(ctx)
+	err := func() error {
+		c.lock.Lock()
+		defer c.lock.Unlock()
+		if c.tracesClient == nil {
+			return errNoClient
+		}
+
+		_, err := c.tracesClient.Export(ctx, &coltracepb.ExportTraceServiceRequest{
+			ResourceSpans: protoSpans,
+		})
+		return err
+	}()
+	if err != nil {
+		c.connection.SetStateDisconnected(err)
+	}
+	return err
+}

--- a/util/tracing/otlptracegrpc/connection.go
+++ b/util/tracing/otlptracegrpc/connection.go
@@ -1,0 +1,219 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlptracegrpc
+
+import (
+	"context"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unsafe"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+type Connection struct {
+	// Ensure pointer is 64-bit aligned for atomic operations on both 32 and 64 bit machines.
+	lastConnectErrPtr unsafe.Pointer
+
+	// mu protects the Connection as it is accessed by the
+	// exporter goroutines and background Connection goroutine
+	mu sync.Mutex
+	cc *grpc.ClientConn
+
+	// these fields are read-only after constructor is finished
+	metadata             metadata.MD
+	newConnectionHandler func(cc *grpc.ClientConn)
+
+	// these channels are created once
+	disconnectedCh             chan bool
+	backgroundConnectionDoneCh chan struct{}
+	stopCh                     chan struct{}
+
+	// this is for tests, so they can replace the closing
+	// routine without a worry of modifying some global variable
+	// or changing it back to original after the test is done
+	closeBackgroundConnectionDoneCh func(ch chan struct{})
+}
+
+func NewConnection(cc *grpc.ClientConn, handler func(cc *grpc.ClientConn)) *Connection {
+	c := new(Connection)
+	c.newConnectionHandler = handler
+	c.cc = cc
+	c.closeBackgroundConnectionDoneCh = func(ch chan struct{}) {
+		close(ch)
+	}
+	return c
+}
+
+func (c *Connection) StartConnection(ctx context.Context) error {
+	c.stopCh = make(chan struct{})
+	c.disconnectedCh = make(chan bool, 1)
+	c.backgroundConnectionDoneCh = make(chan struct{})
+
+	if err := c.connect(ctx); err == nil {
+		c.setStateConnected()
+	} else {
+		c.SetStateDisconnected(err)
+	}
+	go c.indefiniteBackgroundConnection()
+
+	// TODO: proper error handling when initializing connections.
+	// We can report permanent errors, e.g., invalid settings.
+	return nil
+}
+
+func (c *Connection) LastConnectError() error {
+	errPtr := (*error)(atomic.LoadPointer(&c.lastConnectErrPtr))
+	if errPtr == nil {
+		return nil
+	}
+	return *errPtr
+}
+
+func (c *Connection) saveLastConnectError(err error) {
+	var errPtr *error
+	if err != nil {
+		errPtr = &err
+	}
+	atomic.StorePointer(&c.lastConnectErrPtr, unsafe.Pointer(errPtr))
+}
+
+func (c *Connection) SetStateDisconnected(err error) {
+	c.saveLastConnectError(err)
+	select {
+	case c.disconnectedCh <- true:
+	default:
+	}
+	c.newConnectionHandler(nil)
+}
+
+func (c *Connection) setStateConnected() {
+	c.saveLastConnectError(nil)
+}
+
+func (c *Connection) Connected() bool {
+	return c.LastConnectError() == nil
+}
+
+const defaultConnReattemptPeriod = 10 * time.Second
+
+func (c *Connection) indefiniteBackgroundConnection() {
+	defer func() {
+		c.closeBackgroundConnectionDoneCh(c.backgroundConnectionDoneCh)
+	}()
+
+	connReattemptPeriod := defaultConnReattemptPeriod
+
+	// No strong seeding required, nano time can
+	// already help with pseudo uniqueness.
+	rng := rand.New(rand.NewSource(time.Now().UnixNano() + rand.Int63n(1024)))
+
+	// maxJitterNanos: 70% of the connectionReattemptPeriod
+	maxJitterNanos := int64(0.7 * float64(connReattemptPeriod))
+
+	for {
+		// Otherwise these will be the normal scenarios to enable
+		// reconnection if we trip out.
+		// 1. If we've stopped, return entirely
+		// 2. Otherwise block until we are disconnected, and
+		//    then retry connecting
+		select {
+		case <-c.stopCh:
+			return
+
+		case <-c.disconnectedCh:
+			// Quickly check if we haven't stopped at the
+			// same time.
+			select {
+			case <-c.stopCh:
+				return
+
+			default:
+			}
+
+			// Normal scenario that we'll wait for
+		}
+
+		if err := c.connect(context.Background()); err == nil {
+			c.setStateConnected()
+		} else {
+			// this code is unreachable in most cases
+			// c.connect does not establish Connection
+			c.SetStateDisconnected(err)
+		}
+
+		// Apply some jitter to avoid lockstep retrials of other
+		// collector-exporters. Lockstep retrials could result in an
+		// innocent DDOS, by clogging the machine's resources and network.
+		jitter := time.Duration(rng.Int63n(maxJitterNanos))
+		select {
+		case <-c.stopCh:
+			return
+		case <-time.After(connReattemptPeriod + jitter):
+		}
+	}
+}
+
+func (c *Connection) connect(ctx context.Context) error {
+	c.newConnectionHandler(c.cc)
+	return nil
+}
+
+func (c *Connection) ContextWithMetadata(ctx context.Context) context.Context {
+	if c.metadata.Len() > 0 {
+		return metadata.NewOutgoingContext(ctx, c.metadata)
+	}
+	return ctx
+}
+
+func (c *Connection) Shutdown(ctx context.Context) error {
+	close(c.stopCh)
+	// Ensure that the backgroundConnector returns
+	select {
+	case <-c.backgroundConnectionDoneCh:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	c.mu.Lock()
+	cc := c.cc
+	c.cc = nil
+	c.mu.Unlock()
+
+	if cc != nil {
+		return cc.Close()
+	}
+
+	return nil
+}
+
+func (c *Connection) ContextWithStop(ctx context.Context) (context.Context, context.CancelFunc) {
+	// Unify the parent context Done signal with the Connection's
+	// stop channel.
+	ctx, cancel := context.WithCancel(ctx)
+	go func(ctx context.Context, cancel context.CancelFunc) {
+		select {
+		case <-ctx.Done():
+			// Nothing to do, either cancelled or deadline
+			// happened.
+		case <-c.stopCh:
+			cancel()
+		}
+	}(ctx, cancel)
+	return ctx, cancel
+}

--- a/util/tracing/tracetransform/attribute.go
+++ b/util/tracing/tracetransform/attribute.go
@@ -1,0 +1,141 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracetransform
+
+import (
+	"reflect"
+
+	"go.opentelemetry.io/otel/attribute"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+// Attributes transforms a slice of KeyValues into a slice of OTLP attribute key-values.
+func Attributes(attrs []attribute.KeyValue) []*commonpb.KeyValue {
+	if len(attrs) == 0 {
+		return nil
+	}
+
+	out := make([]*commonpb.KeyValue, 0, len(attrs))
+	for _, kv := range attrs {
+		out = append(out, toAttribute(kv))
+	}
+	return out
+}
+
+// ResourceAttributes transforms a Resource into a slice of OTLP attribute key-values.
+func ResourceAttributes(resource *resource.Resource) []*commonpb.KeyValue {
+	if resource.Len() == 0 {
+		return nil
+	}
+
+	out := make([]*commonpb.KeyValue, 0, resource.Len())
+	for iter := resource.Iter(); iter.Next(); {
+		out = append(out, toAttribute(iter.Attribute()))
+	}
+
+	return out
+}
+
+func toAttribute(v attribute.KeyValue) *commonpb.KeyValue {
+	result := &commonpb.KeyValue{
+		Key:   string(v.Key),
+		Value: new(commonpb.AnyValue),
+	}
+	switch v.Value.Type() {
+	case attribute.BOOL:
+		result.Value.Value = &commonpb.AnyValue_BoolValue{
+			BoolValue: v.Value.AsBool(),
+		}
+	case attribute.INT64:
+		result.Value.Value = &commonpb.AnyValue_IntValue{
+			IntValue: v.Value.AsInt64(),
+		}
+	case attribute.FLOAT64:
+		result.Value.Value = &commonpb.AnyValue_DoubleValue{
+			DoubleValue: v.Value.AsFloat64(),
+		}
+	case attribute.STRING:
+		result.Value.Value = &commonpb.AnyValue_StringValue{
+			StringValue: v.Value.AsString(),
+		}
+	case attribute.ARRAY:
+		result.Value.Value = &commonpb.AnyValue_ArrayValue{
+			ArrayValue: &commonpb.ArrayValue{
+				Values: arrayValues(v),
+			},
+		}
+	default:
+		result.Value.Value = &commonpb.AnyValue_StringValue{
+			StringValue: "INVALID",
+		}
+	}
+	return result
+}
+
+func arrayValues(kv attribute.KeyValue) []*commonpb.AnyValue {
+	a := kv.Value.AsArray()
+	aType := reflect.TypeOf(a)
+	var valueFunc func(reflect.Value) *commonpb.AnyValue
+	switch aType.Elem().Kind() {
+	case reflect.Bool:
+		valueFunc = func(v reflect.Value) *commonpb.AnyValue {
+			return &commonpb.AnyValue{
+				Value: &commonpb.AnyValue_BoolValue{
+					BoolValue: v.Bool(),
+				},
+			}
+		}
+	case reflect.Int, reflect.Int64:
+		valueFunc = func(v reflect.Value) *commonpb.AnyValue {
+			return &commonpb.AnyValue{
+				Value: &commonpb.AnyValue_IntValue{
+					IntValue: v.Int(),
+				},
+			}
+		}
+	case reflect.Uintptr:
+		valueFunc = func(v reflect.Value) *commonpb.AnyValue {
+			return &commonpb.AnyValue{
+				Value: &commonpb.AnyValue_IntValue{
+					IntValue: int64(v.Uint()),
+				},
+			}
+		}
+	case reflect.Float64:
+		valueFunc = func(v reflect.Value) *commonpb.AnyValue {
+			return &commonpb.AnyValue{
+				Value: &commonpb.AnyValue_DoubleValue{
+					DoubleValue: v.Float(),
+				},
+			}
+		}
+	case reflect.String:
+		valueFunc = func(v reflect.Value) *commonpb.AnyValue {
+			return &commonpb.AnyValue{
+				Value: &commonpb.AnyValue_StringValue{
+					StringValue: v.String(),
+				},
+			}
+		}
+	}
+
+	results := make([]*commonpb.AnyValue, aType.Len())
+	for i, aValue := 0, reflect.ValueOf(a); i < aValue.Len(); i++ {
+		results[i] = valueFunc(aValue.Index(i))
+	}
+	return results
+}

--- a/util/tracing/tracetransform/instrumentation.go
+++ b/util/tracing/tracetransform/instrumentation.go
@@ -1,0 +1,31 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracetransform
+
+import (
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+
+	"go.opentelemetry.io/otel/sdk/instrumentation"
+)
+
+func InstrumentationLibrary(il instrumentation.Library) *commonpb.InstrumentationLibrary {
+	if il == (instrumentation.Library{}) {
+		return nil
+	}
+	return &commonpb.InstrumentationLibrary{
+		Name:    il.Name,
+		Version: il.Version,
+	}
+}

--- a/util/tracing/tracetransform/resource.go
+++ b/util/tracing/tracetransform/resource.go
@@ -1,0 +1,29 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracetransform
+
+import (
+	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
+
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+// Resource transforms a Resource into an OTLP Resource.
+func Resource(r *resource.Resource) *resourcepb.Resource {
+	if r == nil {
+		return nil
+	}
+	return &resourcepb.Resource{Attributes: ResourceAttributes(r)}
+}

--- a/util/tracing/tracetransform/span.go
+++ b/util/tracing/tracetransform/span.go
@@ -1,0 +1,218 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracetransform
+
+import (
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+
+	"go.opentelemetry.io/otel/sdk/instrumentation"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	maxEventsPerSpan = 128
+)
+
+// Spans transforms a slice of OpenTelemetry spans into a slice of OTLP
+// ResourceSpans.
+func Spans(sdl []tracesdk.ReadOnlySpan) []*tracepb.ResourceSpans {
+	if len(sdl) == 0 {
+		return nil
+	}
+
+	rsm := make(map[attribute.Distinct]*tracepb.ResourceSpans)
+
+	type ilsKey struct {
+		r  attribute.Distinct
+		il instrumentation.Library
+	}
+	ilsm := make(map[ilsKey]*tracepb.InstrumentationLibrarySpans)
+
+	var resources int
+	for _, sd := range sdl {
+		if sd == nil {
+			continue
+		}
+
+		rKey := sd.Resource().Equivalent()
+		iKey := ilsKey{
+			r:  rKey,
+			il: sd.InstrumentationLibrary(),
+		}
+		ils, iOk := ilsm[iKey]
+		if !iOk {
+			// Either the resource or instrumentation library were unknown.
+			ils = &tracepb.InstrumentationLibrarySpans{
+				InstrumentationLibrary: InstrumentationLibrary(sd.InstrumentationLibrary()),
+				Spans:                  []*tracepb.Span{},
+			}
+		}
+		ils.Spans = append(ils.Spans, span(sd))
+		ilsm[iKey] = ils
+
+		rs, rOk := rsm[rKey]
+		if !rOk {
+			resources++
+			// The resource was unknown.
+			rs = &tracepb.ResourceSpans{
+				Resource:                    Resource(sd.Resource()),
+				InstrumentationLibrarySpans: []*tracepb.InstrumentationLibrarySpans{ils},
+			}
+			rsm[rKey] = rs
+			continue
+		}
+
+		// The resource has been seen before. Check if the instrumentation
+		// library lookup was unknown because if so we need to add it to the
+		// ResourceSpans. Otherwise, the instrumentation library has already
+		// been seen and the append we did above will be included it in the
+		// InstrumentationLibrarySpans reference.
+		if !iOk {
+			rs.InstrumentationLibrarySpans = append(rs.InstrumentationLibrarySpans, ils)
+		}
+	}
+
+	// Transform the categorized map into a slice
+	rss := make([]*tracepb.ResourceSpans, 0, resources)
+	for _, rs := range rsm {
+		rss = append(rss, rs)
+	}
+	return rss
+}
+
+// span transforms a Span into an OTLP span.
+func span(sd tracesdk.ReadOnlySpan) *tracepb.Span {
+	if sd == nil {
+		return nil
+	}
+
+	tid := sd.SpanContext().TraceID()
+	sid := sd.SpanContext().SpanID()
+
+	s := &tracepb.Span{
+		TraceId:                tid[:],
+		SpanId:                 sid[:],
+		TraceState:             sd.SpanContext().TraceState().String(),
+		Status:                 status(sd.Status().Code, sd.Status().Description),
+		StartTimeUnixNano:      uint64(sd.StartTime().UnixNano()),
+		EndTimeUnixNano:        uint64(sd.EndTime().UnixNano()),
+		Links:                  links(sd.Links()),
+		Kind:                   spanKind(sd.SpanKind()),
+		Name:                   sd.Name(),
+		Attributes:             Attributes(sd.Attributes()),
+		Events:                 spanEvents(sd.Events()),
+		DroppedAttributesCount: uint32(sd.DroppedAttributes()),
+		DroppedEventsCount:     uint32(sd.DroppedEvents()),
+		DroppedLinksCount:      uint32(sd.DroppedLinks()),
+	}
+
+	if psid := sd.Parent().SpanID(); psid.IsValid() {
+		s.ParentSpanId = psid[:]
+	}
+
+	return s
+}
+
+// status transform a span code and message into an OTLP span status.
+func status(status codes.Code, message string) *tracepb.Status {
+	var c tracepb.Status_StatusCode
+	switch status {
+	case codes.Error:
+		c = tracepb.Status_STATUS_CODE_ERROR
+	default:
+		c = tracepb.Status_STATUS_CODE_OK
+	}
+	return &tracepb.Status{
+		Code:    c,
+		Message: message,
+	}
+}
+
+// links transforms span Links to OTLP span links.
+func links(links []trace.Link) []*tracepb.Span_Link {
+	if len(links) == 0 {
+		return nil
+	}
+
+	sl := make([]*tracepb.Span_Link, 0, len(links))
+	for _, otLink := range links {
+		// This redefinition is necessary to prevent otLink.*ID[:] copies
+		// being reused -- in short we need a new otLink per iteration.
+		otLink := otLink
+
+		tid := otLink.SpanContext.TraceID()
+		sid := otLink.SpanContext.SpanID()
+
+		sl = append(sl, &tracepb.Span_Link{
+			TraceId:    tid[:],
+			SpanId:     sid[:],
+			Attributes: Attributes(otLink.Attributes),
+		})
+	}
+	return sl
+}
+
+// spanEvents transforms span Events to an OTLP span events.
+func spanEvents(es []tracesdk.Event) []*tracepb.Span_Event {
+	if len(es) == 0 {
+		return nil
+	}
+
+	evCount := len(es)
+	if evCount > maxEventsPerSpan {
+		evCount = maxEventsPerSpan
+	}
+	events := make([]*tracepb.Span_Event, 0, evCount)
+	nEvents := 0
+
+	// Transform message events
+	for _, e := range es {
+		if nEvents >= maxEventsPerSpan {
+			break
+		}
+		nEvents++
+		events = append(events,
+			&tracepb.Span_Event{
+				Name:         e.Name,
+				TimeUnixNano: uint64(e.Time.UnixNano()),
+				Attributes:   Attributes(e.Attributes),
+				// TODO (rghetia) : Add Drop Counts when supported.
+			},
+		)
+	}
+
+	return events
+}
+
+// spanKind transforms a SpanKind to an OTLP span kind.
+func spanKind(kind trace.SpanKind) tracepb.Span_SpanKind {
+	switch kind {
+	case trace.SpanKindInternal:
+		return tracepb.Span_SPAN_KIND_INTERNAL
+	case trace.SpanKindClient:
+		return tracepb.Span_SPAN_KIND_CLIENT
+	case trace.SpanKindServer:
+		return tracepb.Span_SPAN_KIND_SERVER
+	case trace.SpanKindProducer:
+		return tracepb.Span_SPAN_KIND_PRODUCER
+	case trace.SpanKindConsumer:
+		return tracepb.Span_SPAN_KIND_CONSUMER
+	default:
+		return tracepb.Span_SPAN_KIND_UNSPECIFIED
+	}
+}

--- a/util/tracing/tracing.go
+++ b/util/tracing/tracing.go
@@ -18,7 +18,7 @@ import (
 func StartSpan(ctx context.Context, operationName string, opts ...trace.SpanStartOption) (trace.Span, context.Context) {
 	parent := trace.SpanFromContext(ctx)
 	tracer := trace.NewNoopTracerProvider().Tracer("")
-	if parent.SpanContext().IsValid() {
+	if parent != nil && parent.SpanContext().IsValid() {
 		tracer = parent.TracerProvider().Tracer("")
 	}
 	ctx, span := tracer.Start(ctx, operationName, opts...)
@@ -47,7 +47,7 @@ func ContextWithSpanFromContext(ctx, ctx2 context.Context) context.Context {
 	if span := trace.SpanFromContext(ctx); span.SpanContext().IsValid() {
 		return ctx
 	}
-	if span := trace.SpanFromContext(ctx2); span != nil {
+	if span := trace.SpanFromContext(ctx2); span != nil && span.SpanContext().IsValid() {
 		return trace.ContextWithSpan(ctx, span)
 	}
 	return ctx

--- a/util/tracing/transform/attribute.go
+++ b/util/tracing/transform/attribute.go
@@ -1,0 +1,91 @@
+package transform
+
+import (
+	"go.opentelemetry.io/otel/attribute"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+)
+
+// Attributes transforms a slice of OTLP attribute key-values into a slice of KeyValues
+func Attributes(attrs []*commonpb.KeyValue) []attribute.KeyValue {
+	if len(attrs) == 0 {
+		return nil
+	}
+
+	out := make([]attribute.KeyValue, 0, len(attrs))
+	for _, a := range attrs {
+		kv := attribute.KeyValue{
+			Key:   attribute.Key(a.Key),
+			Value: toValue(a.Value),
+		}
+		out = append(out, kv)
+	}
+	return out
+}
+
+func toValue(v *commonpb.AnyValue) attribute.Value {
+	switch vv := v.Value.(type) {
+	case *commonpb.AnyValue_BoolValue:
+		return attribute.BoolValue(vv.BoolValue)
+	case *commonpb.AnyValue_IntValue:
+		return attribute.Int64Value(vv.IntValue)
+	case *commonpb.AnyValue_DoubleValue:
+		return attribute.Float64Value(vv.DoubleValue)
+	case *commonpb.AnyValue_StringValue:
+		return attribute.StringValue(vv.StringValue)
+	case *commonpb.AnyValue_ArrayValue:
+		return arrayValues(vv.ArrayValue.Values)
+	default:
+		return attribute.StringValue("INVALID")
+	}
+}
+
+func boolArray(kv []*commonpb.AnyValue) attribute.Value {
+	arr := make([]bool, len(kv))
+	for i, v := range kv {
+		arr[i] = v.GetBoolValue()
+	}
+	return attribute.ArrayValue(arr)
+}
+
+func intArray(kv []*commonpb.AnyValue) attribute.Value {
+	arr := make([]int64, len(kv))
+	for i, v := range kv {
+		arr[i] = v.GetIntValue()
+	}
+	return attribute.ArrayValue(arr)
+}
+
+func doubleArray(kv []*commonpb.AnyValue) attribute.Value {
+	arr := make([]float64, len(kv))
+	for i, v := range kv {
+		arr[i] = v.GetDoubleValue()
+	}
+	return attribute.ArrayValue(arr)
+}
+
+func stringArray(kv []*commonpb.AnyValue) attribute.Value {
+	arr := make([]string, len(kv))
+	for i, v := range kv {
+		arr[i] = v.GetStringValue()
+	}
+	return attribute.ArrayValue(arr)
+}
+
+func arrayValues(kv []*commonpb.AnyValue) attribute.Value {
+	if len(kv) == 0 {
+		return attribute.ArrayValue([]string{})
+	}
+
+	switch kv[0].Value.(type) {
+	case *commonpb.AnyValue_BoolValue:
+		return boolArray(kv)
+	case *commonpb.AnyValue_IntValue:
+		return intArray(kv)
+	case *commonpb.AnyValue_DoubleValue:
+		return doubleArray(kv)
+	case *commonpb.AnyValue_StringValue:
+		return stringArray(kv)
+	default:
+		return attribute.ArrayValue([]string{})
+	}
+}

--- a/util/tracing/transform/instrumentation.go
+++ b/util/tracing/transform/instrumentation.go
@@ -1,0 +1,17 @@
+package transform
+
+import (
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+
+	"go.opentelemetry.io/otel/sdk/instrumentation"
+)
+
+func instrumentationLibrary(il *commonpb.InstrumentationLibrary) instrumentation.Library {
+	if il == nil {
+		return instrumentation.Library{}
+	}
+	return instrumentation.Library{
+		Name:    il.Name,
+		Version: il.Version,
+	}
+}

--- a/util/tracing/transform/span.go
+++ b/util/tracing/transform/span.go
@@ -1,0 +1,254 @@
+package transform
+
+import (
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
+	"go.opentelemetry.io/otel/sdk/resource"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+	v11 "go.opentelemetry.io/proto/otlp/common/v1"
+	v1 "go.opentelemetry.io/proto/otlp/resource/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+const (
+	maxMessageEventsPerSpan = 128
+)
+
+// Spans transforms slice of OTLP ResourceSpan into a slice of SpanSnapshots.
+func Spans(sdl []*tracepb.ResourceSpans) []tracesdk.ReadOnlySpan {
+	if len(sdl) == 0 {
+		return nil
+	}
+
+	var out []tracesdk.ReadOnlySpan
+
+	for _, sd := range sdl {
+		if sd == nil {
+			continue
+		}
+
+		for _, sdi := range sd.InstrumentationLibrarySpans {
+			sda := make([]tracesdk.ReadOnlySpan, len(sdi.Spans))
+			for i, s := range sdi.Spans {
+				sda[i] = &readOnlySpan{
+					pb:        s,
+					il:        sdi.InstrumentationLibrary,
+					resource:  sd.Resource,
+					schemaURL: sd.SchemaUrl,
+				}
+			}
+			out = append(out, sda...)
+		}
+	}
+
+	return out
+}
+
+type readOnlySpan struct {
+	// Embed the interface to implement the private method.
+	tracesdk.ReadOnlySpan
+
+	pb        *tracepb.Span
+	il        *v11.InstrumentationLibrary
+	resource  *v1.Resource
+	schemaURL string
+}
+
+func (s *readOnlySpan) Name() string {
+	return s.pb.Name
+}
+
+func (s *readOnlySpan) SpanContext() trace.SpanContext {
+	var tid trace.TraceID
+	copy(tid[:], s.pb.TraceId)
+	var sid trace.SpanID
+	copy(sid[:], s.pb.SpanId)
+
+	st, _ := trace.ParseTraceState(s.pb.TraceState)
+
+	return trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    tid,
+		SpanID:     sid,
+		TraceState: st,
+	})
+}
+
+func (s *readOnlySpan) Parent() trace.SpanContext {
+	if len(s.pb.ParentSpanId) == 0 {
+		return trace.SpanContext{}
+	}
+	var tid trace.TraceID
+	copy(tid[:], s.pb.TraceId)
+	var psid trace.SpanID
+	copy(psid[:], s.pb.ParentSpanId)
+	return trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: tid,
+		SpanID:  psid,
+	})
+}
+
+func (s *readOnlySpan) SpanKind() trace.SpanKind {
+	return spanKind(s.pb.Kind)
+}
+
+func (s *readOnlySpan) StartTime() time.Time {
+	return time.Unix(0, int64(s.pb.StartTimeUnixNano))
+}
+
+func (s *readOnlySpan) EndTime() time.Time {
+	return time.Unix(0, int64(s.pb.EndTimeUnixNano))
+}
+
+func (s *readOnlySpan) Attributes() []attribute.KeyValue {
+	return Attributes(s.pb.Attributes)
+}
+
+func (s *readOnlySpan) Links() []trace.Link {
+	return links(s.pb.Links)
+}
+
+func (s *readOnlySpan) Events() []tracesdk.Event {
+	return spanEvents(s.pb.Events)
+}
+
+func (s *readOnlySpan) Status() tracesdk.Status {
+	return tracesdk.Status{
+		Code:        statusCode(s.pb.Status),
+		Description: s.pb.Status.GetMessage(),
+	}
+}
+
+func (s *readOnlySpan) InstrumentationLibrary() instrumentation.Library {
+	return instrumentationLibrary(s.il)
+}
+
+// Resource returns information about the entity that produced the span.
+func (s *readOnlySpan) Resource() *resource.Resource {
+	if s.resource == nil {
+		return nil
+	}
+	if s.schemaURL != "" {
+		return resource.NewWithAttributes(s.schemaURL, Attributes(s.resource.Attributes)...)
+	}
+	return resource.NewSchemaless(Attributes(s.resource.Attributes)...)
+}
+
+// DroppedAttributes returns the number of attributes dropped by the span
+// due to limits being reached.
+func (s *readOnlySpan) DroppedAttributes() int {
+	return int(s.pb.DroppedAttributesCount)
+}
+
+// DroppedLinks returns the number of links dropped by the span due to
+// limits being reached.
+func (s *readOnlySpan) DroppedLinks() int {
+	return int(s.pb.DroppedLinksCount)
+}
+
+// DroppedEvents returns the number of events dropped by the span due to
+// limits being reached.
+func (s *readOnlySpan) DroppedEvents() int {
+	return int(s.pb.DroppedEventsCount)
+}
+
+// ChildSpanCount returns the count of spans that consider the span a
+// direct parent.
+func (s *readOnlySpan) ChildSpanCount() int {
+	return 0
+}
+
+var _ tracesdk.ReadOnlySpan = &readOnlySpan{}
+
+// status transform a OTLP span status into span code.
+func statusCode(st *tracepb.Status) codes.Code {
+	switch st.Code {
+	case tracepb.Status_STATUS_CODE_ERROR:
+		return codes.Error
+	default:
+		return codes.Ok
+	}
+}
+
+// links transforms OTLP span links to span Links.
+func links(links []*tracepb.Span_Link) []trace.Link {
+	if len(links) == 0 {
+		return nil
+	}
+
+	sl := make([]trace.Link, 0, len(links))
+	for _, otLink := range links {
+		// This redefinition is necessary to prevent otLink.*ID[:] copies
+		// being reused -- in short we need a new otLink per iteration.
+		otLink := otLink
+
+		var tid trace.TraceID
+		copy(tid[:], otLink.TraceId)
+		var sid trace.SpanID
+		copy(sid[:], otLink.SpanId)
+
+		sctx := trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID: tid,
+			SpanID:  sid,
+		})
+
+		sl = append(sl, trace.Link{
+			SpanContext: sctx,
+			Attributes:  Attributes(otLink.Attributes),
+		})
+	}
+	return sl
+}
+
+// spanEvents transforms OTLP span events to span Events.
+func spanEvents(es []*tracepb.Span_Event) []tracesdk.Event {
+	if len(es) == 0 {
+		return nil
+	}
+
+	evCount := len(es)
+	if evCount > maxMessageEventsPerSpan {
+		evCount = maxMessageEventsPerSpan
+	}
+	events := make([]tracesdk.Event, 0, evCount)
+	messageEvents := 0
+
+	// Transform message events
+	for _, e := range es {
+		if messageEvents >= maxMessageEventsPerSpan {
+			break
+		}
+		messageEvents++
+		events = append(events,
+			tracesdk.Event{
+				Name:                  e.Name,
+				Time:                  time.Unix(0, int64(e.TimeUnixNano)),
+				Attributes:            Attributes(e.Attributes),
+				DroppedAttributeCount: int(e.DroppedAttributesCount),
+			},
+		)
+	}
+
+	return events
+}
+
+// spanKind transforms a an OTLP span kind to SpanKind.
+func spanKind(kind tracepb.Span_SpanKind) trace.SpanKind {
+	switch kind {
+	case tracepb.Span_SPAN_KIND_INTERNAL:
+		return trace.SpanKindInternal
+	case tracepb.Span_SPAN_KIND_CLIENT:
+		return trace.SpanKindClient
+	case tracepb.Span_SPAN_KIND_SERVER:
+		return trace.SpanKindServer
+	case tracepb.Span_SPAN_KIND_PRODUCER:
+		return trace.SpanKindProducer
+	case tracepb.Span_SPAN_KIND_CONSUMER:
+		return trace.SpanKindConsumer
+	default:
+		return trace.SpanKindUnspecified
+	}
+}

--- a/worker/containerd/containerd.go
+++ b/worker/containerd/containerd.go
@@ -26,16 +26,16 @@ import (
 )
 
 // NewWorkerOpt creates a WorkerOpt.
-func NewWorkerOpt(root string, address, snapshotterName, ns string, labels map[string]string, dns *oci.DNSConfig, nopt netproviders.Opt, apparmorProfile string, parallelismSem *semaphore.Weighted, opts ...containerd.ClientOpt) (base.WorkerOpt, error) {
+func NewWorkerOpt(root string, address, snapshotterName, ns string, labels map[string]string, dns *oci.DNSConfig, nopt netproviders.Opt, apparmorProfile string, parallelismSem *semaphore.Weighted, traceSocket string, opts ...containerd.ClientOpt) (base.WorkerOpt, error) {
 	opts = append(opts, containerd.WithDefaultNamespace(ns))
 	client, err := containerd.New(address, opts...)
 	if err != nil {
 		return base.WorkerOpt{}, errors.Wrapf(err, "failed to connect client to %q . make sure containerd is running", address)
 	}
-	return newContainerd(root, client, snapshotterName, ns, labels, dns, nopt, apparmorProfile, parallelismSem)
+	return newContainerd(root, client, snapshotterName, ns, labels, dns, nopt, apparmorProfile, parallelismSem, traceSocket)
 }
 
-func newContainerd(root string, client *containerd.Client, snapshotterName, ns string, labels map[string]string, dns *oci.DNSConfig, nopt netproviders.Opt, apparmorProfile string, parallelismSem *semaphore.Weighted) (base.WorkerOpt, error) {
+func newContainerd(root string, client *containerd.Client, snapshotterName, ns string, labels map[string]string, dns *oci.DNSConfig, nopt netproviders.Opt, apparmorProfile string, parallelismSem *semaphore.Weighted, traceSocket string) (base.WorkerOpt, error) {
 	if strings.Contains(snapshotterName, "/") {
 		return base.WorkerOpt{}, errors.Errorf("bad snapshotter name: %q", snapshotterName)
 	}
@@ -115,7 +115,7 @@ func newContainerd(root string, client *containerd.Client, snapshotterName, ns s
 		ID:             id,
 		Labels:         xlabels,
 		MetadataStore:  md,
-		Executor:       containerdexecutor.New(client, root, "", np, dns, apparmorProfile),
+		Executor:       containerdexecutor.New(client, root, "", np, dns, apparmorProfile, traceSocket),
 		Snapshotter:    snap,
 		ContentStore:   cs,
 		Applier:        winlayers.NewFileSystemApplierWithWindows(cs, df),

--- a/worker/containerd/containerd_test.go
+++ b/worker/containerd/containerd_test.go
@@ -30,7 +30,7 @@ func newWorkerOpt(t *testing.T, addr string) (base.WorkerOpt, func()) {
 	tmpdir, err := ioutil.TempDir("", "workertest")
 	require.NoError(t, err)
 	cleanup := func() { os.RemoveAll(tmpdir) }
-	workerOpt, err := NewWorkerOpt(tmpdir, addr, "overlayfs", "buildkit-test", nil, nil, netproviders.Opt{Mode: "host"}, "", nil)
+	workerOpt, err := NewWorkerOpt(tmpdir, addr, "overlayfs", "buildkit-test", nil, nil, netproviders.Opt{Mode: "host"}, "", nil, "")
 	require.NoError(t, err)
 	return workerOpt, cleanup
 }

--- a/worker/runc/runc.go
+++ b/worker/runc/runc.go
@@ -33,7 +33,7 @@ type SnapshotterFactory struct {
 }
 
 // NewWorkerOpt creates a WorkerOpt.
-func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, processMode oci.ProcessMode, labels map[string]string, idmap *idtools.IdentityMapping, nopt netproviders.Opt, dns *oci.DNSConfig, binary, apparmorProfile string, parallelismSem *semaphore.Weighted) (base.WorkerOpt, error) {
+func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, processMode oci.ProcessMode, labels map[string]string, idmap *idtools.IdentityMapping, nopt netproviders.Opt, dns *oci.DNSConfig, binary, apparmorProfile string, parallelismSem *semaphore.Weighted, traceSocket string) (base.WorkerOpt, error) {
 	var opt base.WorkerOpt
 	name := "runc-" + snFactory.Name
 	root = filepath.Join(root, name)
@@ -64,6 +64,7 @@ func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, proc
 		IdentityMapping: idmap,
 		DNS:             dns,
 		ApparmorProfile: apparmorProfile,
+		TracingSocket:   traceSocket,
 	}, np)
 	if err != nil {
 		return opt, err

--- a/worker/runc/runc_test.go
+++ b/worker/runc/runc_test.go
@@ -40,7 +40,7 @@ func newWorkerOpt(t *testing.T, processMode oci.ProcessMode) (base.WorkerOpt, fu
 		},
 	}
 	rootless := false
-	workerOpt, err := NewWorkerOpt(tmpdir, snFactory, rootless, processMode, nil, nil, netproviders.Opt{Mode: "host"}, nil, "", "", nil)
+	workerOpt, err := NewWorkerOpt(tmpdir, snFactory, rootless, processMode, nil, nil, netproviders.Opt{Mode: "host"}, nil, "", "", nil, "")
 	require.NoError(t, err)
 
 	return workerOpt, cleanup


### PR DESCRIPTION
~depends on #2152~

Allows current tracing context to be detected from the environment and pass it to child processes, eg. `llb.Exec`.