### PR TITLE
Compute diff from the upper directory of overlayfs-based snapshotter

### DIFF
--- a/cache/blobs_linux.go
+++ b/cache/blobs_linux.go
@@ -1,0 +1,423 @@
+// +build linux
+
+package cache
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/containerd/containerd/archive"
+	ctdcompression "github.com/containerd/containerd/archive/compression"
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/continuity/devices"
+	"github.com/containerd/continuity/fs"
+	"github.com/containerd/continuity/sysx"
+	digest "github.com/opencontainers/go-digest"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+var emptyDesc = ocispecs.Descriptor{}
+
+// computeOverlayBlob provides overlayfs-specialized method to compute
+// diff between lower and upper snapshot. If the passed mounts cannot
+// be computed (e.g. because the mounts aren't overlayfs), it returns
+// an error.
+func (sr *immutableRef) tryComputeOverlayBlob(ctx context.Context, lower, upper []mount.Mount, mediaType string, ref string, compressorFunc compressor) (_ ocispecs.Descriptor, ok bool, err error) {
+
+	// Get upperdir location if mounts are overlayfs that can be processed by this differ.
+	upperdir, err := getOverlayUpperdir(lower, upper)
+	if err != nil {
+		// This is not an overlayfs snapshot. This is not an error so don't return error here
+		// and let the caller fallback to another differ.
+		return emptyDesc, false, nil
+	}
+
+	if compressorFunc == nil {
+		switch mediaType {
+		case ocispecs.MediaTypeImageLayer:
+		case ocispecs.MediaTypeImageLayerGzip:
+			compressorFunc = func(dest io.Writer, requiredMediaType string) (io.WriteCloser, error) {
+				return ctdcompression.CompressStream(dest, ctdcompression.Gzip)
+			}
+		default:
+			return emptyDesc, false, errors.Errorf("unsupported diff media type: %v", mediaType)
+		}
+	}
+
+	cw, err := sr.cm.ContentStore.Writer(ctx,
+		content.WithRef(ref),
+		content.WithDescriptor(ocispecs.Descriptor{
+			MediaType: mediaType, // most contentstore implementations just ignore this
+		}))
+	if err != nil {
+		return emptyDesc, false, errors.Wrap(err, "failed to open writer")
+	}
+	defer func() {
+		if err != nil {
+			cw.Close()
+		}
+	}()
+
+	var labels map[string]string
+	if compressorFunc != nil {
+		dgstr := digest.SHA256.Digester()
+		compressed, err := compressorFunc(cw, mediaType)
+		if err != nil {
+			return emptyDesc, false, errors.Wrap(err, "failed to get compressed stream")
+		}
+		err = writeOverlayUpperdir(ctx, io.MultiWriter(compressed, dgstr.Hash()), upperdir, lower)
+		compressed.Close()
+		if err != nil {
+			return emptyDesc, false, errors.Wrap(err, "failed to write compressed diff")
+		}
+		if labels == nil {
+			labels = map[string]string{}
+		}
+		labels[containerdUncompressed] = dgstr.Digest().String()
+	} else {
+		if err = writeOverlayUpperdir(ctx, cw, upperdir, lower); err != nil {
+			return emptyDesc, false, errors.Wrap(err, "failed to write diff")
+		}
+	}
+
+	var commitopts []content.Opt
+	if labels != nil {
+		commitopts = append(commitopts, content.WithLabels(labels))
+	}
+	dgst := cw.Digest()
+	if err := cw.Commit(ctx, 0, dgst, commitopts...); err != nil {
+		if !errdefs.IsAlreadyExists(err) {
+			return emptyDesc, false, errors.Wrap(err, "failed to commit")
+		}
+	}
+	cinfo, err := sr.cm.ContentStore.Info(ctx, dgst)
+	if err != nil {
+		return emptyDesc, false, errors.Wrap(err, "failed to get info from content store")
+	}
+	if cinfo.Labels == nil {
+		cinfo.Labels = make(map[string]string)
+	}
+	// Set uncompressed label if digest already existed without label
+	if _, ok := cinfo.Labels[containerdUncompressed]; !ok {
+		cinfo.Labels[containerdUncompressed] = labels[containerdUncompressed]
+		if _, err := sr.cm.ContentStore.Update(ctx, cinfo, "labels."+containerdUncompressed); err != nil {
+			return emptyDesc, false, errors.Wrap(err, "error setting uncompressed label")
+		}
+	}
+
+	return ocispecs.Descriptor{
+		MediaType: mediaType,
+		Size:      cinfo.Size,
+		Digest:    cinfo.Digest,
+	}, true, nil
+}
+
+// getOverlayUpperdir parses the passed mounts and identifies the directory
+// that contains diff between upper and lower.
+func getOverlayUpperdir(lower, upper []mount.Mount) (string, error) {
+	var upperdir string
+	if len(lower) == 0 && len(upper) == 1 { // upper is the bottommost snpashot
+		// Get layer directories of upper snapshot
+		upperM := upper[0]
+		if upperM.Type != "bind" {
+			return "", errors.Errorf("bottommost upper must be bind mount but %q", upperM.Type)
+		}
+		upperdir = upperM.Source
+	} else if len(lower) == 1 && len(upper) == 1 {
+		// Get layer directories of lower snapshot
+		var lowerlayers []string
+		lowerM := lower[0]
+		switch lowerM.Type {
+		case "bind":
+			// lower snapshot is a bind mount of one layer
+			lowerlayers = []string{lowerM.Source}
+		case "overlay":
+			// lower snapshot is an overlay mount of multiple layers
+			var err error
+			lowerlayers, err = getOverlayLayers(lowerM)
+			if err != nil {
+				return "", err
+			}
+		default:
+			return "", errors.Errorf("cannot get layer information from mount option (type = %q)", lowerM.Type)
+		}
+
+		// Get layer directories of upper snapshot
+		upperM := upper[0]
+		if upperM.Type != "overlay" {
+			return "", errors.Errorf("upper snapshot isn't overlay mounted (type = %q)", upperM.Type)
+		}
+		upperlayers, err := getOverlayLayers(upperM)
+		if err != nil {
+			return "", err
+		}
+
+		// Check if the diff directory can be determined
+		if len(upperlayers) != len(lowerlayers)+1 {
+			return "", errors.Errorf("cannot determine diff of more than one upper directories")
+		}
+		for i := 0; i < len(lowerlayers); i++ {
+			if upperlayers[i] != lowerlayers[i] {
+				return "", errors.Errorf("layer %d must be common between upper and lower snapshots", i)
+			}
+		}
+		upperdir = upperlayers[len(upperlayers)-1] // get the topmost layer that indicates diff
+	} else {
+		return "", errors.Errorf("multiple mount configurations are not supported")
+	}
+	if upperdir == "" {
+		return "", errors.Errorf("cannot determine upperdir from mount option")
+	}
+	return upperdir, nil
+}
+
+// getOverlayLayers returns all layer directories of an overlayfs mount.
+func getOverlayLayers(m mount.Mount) ([]string, error) {
+	var u string
+	var uFound bool
+	var l []string // l[0] = bottommost
+	for _, o := range m.Options {
+		if strings.HasPrefix(o, "upperdir=") {
+			u, uFound = strings.TrimPrefix(o, "upperdir="), true
+		} else if strings.HasPrefix(o, "lowerdir=") {
+			l = strings.Split(strings.TrimPrefix(o, "lowerdir="), ":")
+			for i, j := 0, len(l)-1; i < j; i, j = i+1, j-1 {
+				l[i], l[j] = l[j], l[i] // make l[0] = bottommost
+			}
+		} else if strings.HasPrefix(o, "workdir=") || o == "index=off" || o == "userxattr" {
+			// these options are possible to specfied by the snapshotter but not indicate dir locations.
+			continue
+		} else {
+			// encountering an unknown option. return error and fallback to walking differ
+			// to avoid unexpected diff.
+			return nil, errors.Errorf("unknown option %q specified by snapshotter", o)
+		}
+	}
+	if uFound {
+		return append(l, u), nil
+	}
+	return l, nil
+}
+
+// writeOverlayUpperdir writes a layer tar archive into the specified writer, based on
+// the diff information stored in the upperdir.
+func writeOverlayUpperdir(ctx context.Context, w io.Writer, upperdir string, lower []mount.Mount) error {
+	emptyLower, err := ioutil.TempDir("", "buildkit") // empty directory used for the lower of diff view
+	if err != nil {
+		return errors.Wrapf(err, "failed to create temp dir")
+	}
+	defer os.Remove(emptyLower)
+	upperView := []mount.Mount{
+		{
+			Type:    "overlay",
+			Source:  "overlay",
+			Options: []string{fmt.Sprintf("lowerdir=%s", strings.Join([]string{upperdir, emptyLower}, ":"))},
+		},
+	}
+	return mount.WithTempMount(ctx, lower, func(lowerRoot string) error {
+		return mount.WithTempMount(ctx, upperView, func(upperViewRoot string) error {
+			cw := archive.NewChangeWriter(w, upperViewRoot)
+			if err := overlayChanges(ctx, cw.HandleChange, upperdir, upperViewRoot, lowerRoot); err != nil {
+				if err2 := cw.Close(); err2 != nil {
+					return errors.Wrapf(err, "failed torecord upperdir changes (close error: %v)", err2)
+				}
+				return errors.Wrapf(err, "failed torecord upperdir changes")
+			}
+			return cw.Close()
+		})
+	})
+}
+
+// overlayChanges is continuty's `fs.Change`-like method but leverages overlayfs's
+// "upperdir" for computing the diff. "upperdirView" is overlayfs mounted view of
+// the upperdir that doesn't contain whiteouts. This is used for computing
+// changes under opaque directories.
+func overlayChanges(ctx context.Context, changeFn fs.ChangeFunc, upperdir, upperdirView, base string) error {
+	return filepath.Walk(upperdir, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Rebase path
+		path, err = filepath.Rel(upperdir, path)
+		if err != nil {
+			return err
+		}
+		path = filepath.Join(string(os.PathSeparator), path)
+
+		// Skip root
+		if path == string(os.PathSeparator) {
+			return nil
+		}
+
+		// Check if this is a deleted entry
+		isDelete, skip, err := checkDelete(upperdir, path, base, f)
+		if err != nil {
+			return err
+		} else if skip {
+			return nil
+		}
+
+		var kind fs.ChangeKind
+		var skipRecord bool
+		if isDelete {
+			// This is a deleted entry.
+			kind = fs.ChangeKindDelete
+			f = nil
+		} else if baseF, err := os.Lstat(filepath.Join(base, path)); err == nil {
+			// File exists in the base layer. Thus this is modified.
+			kind = fs.ChangeKindModify
+			// Avoid including directory that hasn't been modified. If /foo/bar/baz is modified,
+			// then /foo will apper here even if it's not been modified because it's the parent of bar.
+			if same, err := sameDir(baseF, f, filepath.Join(base, path), filepath.Join(upperdirView, path)); same {
+				skipRecord = true // Both are the same, don't record the change
+			} else if err != nil {
+				return err
+			}
+		} else if os.IsNotExist(err) {
+			// File doesn't exist in the base layer. Thus this is added.
+			kind = fs.ChangeKindAdd
+		} else if err != nil {
+			return err
+		}
+
+		if !skipRecord {
+			if err := changeFn(kind, path, f, nil); err != nil {
+				return err
+			}
+		}
+
+		if f != nil {
+			if isOpaque, err := checkOpaque(upperdir, path, base, f); err != nil {
+				return err
+			} else if isOpaque {
+				// This is an opaque directory. Start a new walking differ to get adds/deletes of
+				// this directory. We use "upperdirView" directory which doesn't contain whiteouts.
+				if err := fs.Changes(ctx, filepath.Join(base, path), filepath.Join(upperdirView, path),
+					func(k fs.ChangeKind, p string, f os.FileInfo, err error) error {
+						return changeFn(k, filepath.Join(path, p), f, err) // rebase path to be based on the opaque dir
+					},
+				); err != nil {
+					return err
+				}
+				return filepath.SkipDir // We completed this directory. Do not walk files under this directory anymore.
+			}
+		}
+		return nil
+	})
+}
+
+// checkDelete checks if the specified file is a whiteout
+func checkDelete(upperdir string, path string, base string, f os.FileInfo) (delete, skip bool, _ error) {
+	if f.Mode()&os.ModeCharDevice != 0 {
+		if _, ok := f.Sys().(*syscall.Stat_t); ok {
+			maj, min, err := devices.DeviceInfo(f)
+			if err != nil {
+				return false, false, errors.Wrapf(err, "failed to get device info")
+			}
+			if maj == 0 && min == 0 {
+				// This file is a whiteout (char 0/0) that indicates this is deleted from the base
+				if _, err := os.Lstat(filepath.Join(base, path)); err != nil {
+					if !os.IsNotExist(err) {
+						return false, false, errors.Wrapf(err, "failed to lstat")
+					}
+					// This file doesn't exist even in the base dir.
+					// We don't need whiteout. Just skip this file.
+					return false, true, nil
+				}
+				return true, false, nil
+			}
+		}
+	}
+	return false, false, nil
+}
+
+// checkDelete checks if the specified file is an opaque directory
+func checkOpaque(upperdir string, path string, base string, f os.FileInfo) (isOpaque bool, _ error) {
+	if f.IsDir() {
+		for _, oKey := range []string{"trusted.overlay.opaque", "user.overlay.opaque"} {
+			opaque, err := sysx.LGetxattr(filepath.Join(upperdir, path), oKey)
+			if err != nil && err != unix.ENODATA {
+				return false, errors.Wrapf(err, "failed to retrieve %s attr", oKey)
+			} else if len(opaque) == 1 && opaque[0] == 'y' {
+				// This is an opaque whiteout directory.
+				if _, err := os.Lstat(filepath.Join(base, path)); err != nil {
+					if !os.IsNotExist(err) {
+						return false, errors.Wrapf(err, "failed to lstat")
+					}
+					// This file doesn't exist even in the base dir. We don't need treat this as an opaque.
+					return false, nil
+				}
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// sameDir performs continity-compatible comparison of directories.
+// https://github.com/containerd/continuity/blob/v0.1.0/fs/path.go#L91-L133
+// This doesn't compare files because it requires to compare their contents.
+// This is what we want to avoid by this overlayfs-specialized differ.
+func sameDir(f1, f2 os.FileInfo, f1fullPath, f2fullPath string) (bool, error) {
+	if !f1.IsDir() || !f2.IsDir() {
+		return false, nil
+	}
+
+	if os.SameFile(f1, f2) {
+		return true, nil
+	}
+
+	equalStat, err := compareSysStat(f1.Sys(), f2.Sys())
+	if err != nil || !equalStat {
+		return equalStat, err
+	}
+
+	if eq, err := compareCapabilities(f1fullPath, f2fullPath); err != nil || !eq {
+		return eq, err
+	}
+
+	return true, nil
+}
+
+// Ported from continuity project
+// https://github.com/containerd/continuity/blob/v0.1.0/fs/diff_unix.go#L43-L54
+// Copyright The containerd Authors.
+func compareSysStat(s1, s2 interface{}) (bool, error) {
+	ls1, ok := s1.(*syscall.Stat_t)
+	if !ok {
+		return false, nil
+	}
+	ls2, ok := s2.(*syscall.Stat_t)
+	if !ok {
+		return false, nil
+	}
+
+	return ls1.Mode == ls2.Mode && ls1.Uid == ls2.Uid && ls1.Gid == ls2.Gid && ls1.Rdev == ls2.Rdev, nil
+}
+
+// Ported from continuity project
+// https://github.com/containerd/continuity/blob/v0.1.0/fs/diff_unix.go#L56-L66
+// Copyright The containerd Authors.
+func compareCapabilities(p1, p2 string) (bool, error) {
+	c1, err := sysx.LGetxattr(p1, "security.capability")
+	if err != nil && err != sysx.ENODATA {
+		return false, errors.Wrapf(err, "failed to get xattr for %s", p1)
+	}
+	c2, err := sysx.LGetxattr(p2, "security.capability")
+	if err != nil && err != sysx.ENODATA {
+		return false, errors.Wrapf(err, "failed to get xattr for %s", p2)
+	}
+	return bytes.Equal(c1, c2), nil
+}

--- a/cache/blobs_linux_test.go
+++ b/cache/blobs_linux_test.go
@@ -1,0 +1,458 @@
+// +build linux
+
+package cache
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/continuity/fs"
+	"github.com/containerd/continuity/fs/fstest"
+	"github.com/pkg/errors"
+)
+
+// This test file contains tests that are required in continuity project.
+// (https://github.com/containerd/continuity/blob/v0.1.0/fs/diff_test.go)
+// Most of them are ported from that project and patched to test our
+// overlayfs-optimized differ.
+
+// TestSimpleDiff is a test ported from
+// https://github.com/containerd/continuity/blob/v0.1.0/fs/diff_test.go#L46-L73
+// Copyright The containerd Authors.
+func TestSimpleDiff(t *testing.T) {
+	l1 := fstest.Apply(
+		fstest.CreateDir("/etc", 0755),
+		fstest.CreateFile("/etc/hosts", []byte("mydomain 10.0.0.1"), 0644),
+		fstest.CreateFile("/etc/profile", []byte("PATH=/usr/bin"), 0644),
+		fstest.CreateFile("/etc/unchanged", []byte("PATH=/usr/bin"), 0644),
+		fstest.CreateFile("/etc/unexpected", []byte("#!/bin/sh"), 0644),
+	)
+	l2 := fstest.Apply(
+		fstest.CreateFile("/etc/hosts", []byte("mydomain 10.0.0.120"), 0644),
+		fstest.CreateFile("/etc/profile", []byte("PATH=/usr/bin"), 0666),
+		fstest.CreateDir("/root", 0700),
+		fstest.CreateFile("/root/.bashrc", []byte("PATH=/usr/sbin:/usr/bin"), 0644),
+		fstest.Remove("/etc/unexpected"),
+	)
+	diff := []TestChange{
+		Modify("/etc/hosts"),
+		Modify("/etc/profile"),
+		Delete("/etc/unexpected"),
+		Add("/root"),
+		Add("/root/.bashrc"),
+	}
+
+	if err := testDiffWithBase(l1, l2, diff); err != nil {
+		t.Fatalf("Failed diff with base: %+v", err)
+	}
+}
+
+// TestEmptyFileDiff is a test ported from
+// https://github.com/containerd/continuity/blob/v0.1.0/fs/diff_test.go#L75-L89
+// Copyright The containerd Authors.
+func TestEmptyFileDiff(t *testing.T) {
+	tt := time.Now().Truncate(time.Second)
+	l1 := fstest.Apply(
+		fstest.CreateDir("/etc", 0755),
+		fstest.CreateFile("/etc/empty", []byte(""), 0644),
+		fstest.Chtimes("/etc/empty", tt, tt),
+	)
+	l2 := fstest.Apply()
+	diff := []TestChange{}
+
+	if err := testDiffWithBase(l1, l2, diff); err != nil {
+		t.Fatalf("Failed diff with base: %+v", err)
+	}
+}
+
+// TestNestedDeletion is a test ported from
+// https://github.com/containerd/continuity/blob/v0.1.0/fs/diff_test.go#L91-L111
+// Copyright The containerd Authors.
+func TestNestedDeletion(t *testing.T) {
+	l1 := fstest.Apply(
+		fstest.CreateDir("/d0", 0755),
+		fstest.CreateDir("/d1", 0755),
+		fstest.CreateDir("/d1/d2", 0755),
+		fstest.CreateFile("/d1/d2/f1", []byte("mydomain 10.0.0.1"), 0644),
+	)
+	l2 := fstest.Apply(
+		fstest.RemoveAll("/d0"),
+		fstest.RemoveAll("/d1"),
+	)
+	diff := []TestChange{
+		Delete("/d0"),
+		Delete("/d1"),
+	}
+
+	if err := testDiffWithBase(l1, l2, diff); err != nil {
+		t.Fatalf("Failed diff with base: %+v", err)
+	}
+}
+
+// TestDirectoryReplace is a test ported from
+// https://github.com/containerd/continuity/blob/v0.1.0/fs/diff_test.go#L113-L134
+// Copyright The containerd Authors.
+func TestDirectoryReplace(t *testing.T) {
+	l1 := fstest.Apply(
+		fstest.CreateDir("/dir1", 0755),
+		fstest.CreateFile("/dir1/f1", []byte("#####"), 0644),
+		fstest.CreateDir("/dir1/f2", 0755),
+		fstest.CreateFile("/dir1/f2/f3", []byte("#!/bin/sh"), 0644),
+	)
+	l2 := fstest.Apply(
+		fstest.CreateFile("/dir1/f11", []byte("#New file here"), 0644),
+		fstest.RemoveAll("/dir1/f2"),
+		fstest.CreateFile("/dir1/f2", []byte("Now file"), 0666),
+	)
+	diff := []TestChange{
+		Add("/dir1/f11"),
+		Modify("/dir1/f2"),
+	}
+
+	if err := testDiffWithBase(l1, l2, diff); err != nil {
+		t.Fatalf("Failed diff with base: %+v", err)
+	}
+}
+
+// TestRemoveDirectoryTree is a test ported from
+// https://github.com/containerd/continuity/blob/v0.1.0/fs/diff_test.go#L136-L152
+// Copyright The containerd Authors.
+func TestRemoveDirectoryTree(t *testing.T) {
+	l1 := fstest.Apply(
+		fstest.CreateDir("/dir1/dir2/dir3", 0755),
+		fstest.CreateFile("/dir1/f1", []byte("f1"), 0644),
+		fstest.CreateFile("/dir1/dir2/f2", []byte("f2"), 0644),
+	)
+	l2 := fstest.Apply(
+		fstest.RemoveAll("/dir1"),
+	)
+	diff := []TestChange{
+		Delete("/dir1"),
+	}
+
+	if err := testDiffWithBase(l1, l2, diff); err != nil {
+		t.Fatalf("Failed diff with base: %+v", err)
+	}
+}
+
+// TestRemoveDirectoryTreeWithDash is a test ported from
+// https://github.com/containerd/continuity/blob/v0.1.0/fs/diff_test.go#L154-L172
+// Copyright The containerd Authors.
+func TestRemoveDirectoryTreeWithDash(t *testing.T) {
+	l1 := fstest.Apply(
+		fstest.CreateDir("/dir1/dir2/dir3", 0755),
+		fstest.CreateFile("/dir1/f1", []byte("f1"), 0644),
+		fstest.CreateFile("/dir1/dir2/f2", []byte("f2"), 0644),
+		fstest.CreateDir("/dir1-before", 0755),
+		fstest.CreateFile("/dir1-before/f2", []byte("f2"), 0644),
+	)
+	l2 := fstest.Apply(
+		fstest.RemoveAll("/dir1"),
+	)
+	diff := []TestChange{
+		Delete("/dir1"),
+	}
+
+	if err := testDiffWithBase(l1, l2, diff); err != nil {
+		t.Fatalf("Failed diff with base: %+v", err)
+	}
+}
+
+// TestFileReplace is a test ported from
+// https://github.com/containerd/continuity/blob/v0.1.0/fs/diff_test.go#L174-L192
+// Copyright The containerd Authors.
+func TestFileReplace(t *testing.T) {
+	l1 := fstest.Apply(
+		fstest.CreateFile("/dir1", []byte("a file, not a directory"), 0644),
+	)
+	l2 := fstest.Apply(
+		fstest.Remove("/dir1"),
+		fstest.CreateDir("/dir1/dir2", 0755),
+		fstest.CreateFile("/dir1/dir2/f1", []byte("also a file"), 0644),
+	)
+	diff := []TestChange{
+		Modify("/dir1"),
+		Add("/dir1/dir2"),
+		Add("/dir1/dir2/f1"),
+	}
+
+	if err := testDiffWithBase(l1, l2, diff); err != nil {
+		t.Fatalf("Failed diff with base: %+v", err)
+	}
+}
+
+// TestParentDirectoryPermission is a test ported from
+// https://github.com/containerd/continuity/blob/v0.1.0/fs/diff_test.go#L194-L219
+// Copyright The containerd Authors.
+func TestParentDirectoryPermission(t *testing.T) {
+	l1 := fstest.Apply(
+		fstest.CreateDir("/dir1", 0700),
+		fstest.CreateDir("/dir2", 0751),
+		fstest.CreateDir("/dir3", 0777),
+	)
+	l2 := fstest.Apply(
+		fstest.CreateDir("/dir1/d", 0700),
+		fstest.CreateFile("/dir1/d/f", []byte("irrelevant"), 0644),
+		fstest.CreateFile("/dir1/f", []byte("irrelevant"), 0644),
+		fstest.CreateFile("/dir2/f", []byte("irrelevant"), 0644),
+		fstest.CreateFile("/dir3/f", []byte("irrelevant"), 0644),
+	)
+	diff := []TestChange{
+		Add("/dir1/d"),
+		Add("/dir1/d/f"),
+		Add("/dir1/f"),
+		Add("/dir2/f"),
+		Add("/dir3/f"),
+	}
+
+	if err := testDiffWithBase(l1, l2, diff); err != nil {
+		t.Fatalf("Failed diff with base: %+v", err)
+	}
+}
+
+// TestUpdateWithSameTime is a test ported from
+// https://github.com/containerd/continuity/blob/v0.1.0/fs/diff_test.go#L221-L269
+// Copyright The containerd Authors.
+//
+// NOTE: This test is patched for our differ. See the following NOTE for details.
+func TestUpdateWithSameTime(t *testing.T) {
+	tt := time.Now().Truncate(time.Second)
+	t1 := tt.Add(5 * time.Nanosecond)
+	t2 := tt.Add(6 * time.Nanosecond)
+	l1 := fstest.Apply(
+		fstest.CreateFile("/file-modified-time", []byte("1"), 0644),
+		fstest.Chtimes("/file-modified-time", t1, t1),
+		fstest.CreateFile("/file-no-change", []byte("1"), 0644),
+		fstest.Chtimes("/file-no-change", t1, t1),
+		fstest.CreateFile("/file-same-time", []byte("1"), 0644),
+		fstest.Chtimes("/file-same-time", t1, t1),
+		fstest.CreateFile("/file-truncated-time-1", []byte("1"), 0644),
+		fstest.Chtimes("/file-truncated-time-1", tt, tt),
+		fstest.CreateFile("/file-truncated-time-2", []byte("1"), 0644),
+		fstest.Chtimes("/file-truncated-time-2", tt, tt),
+		fstest.CreateFile("/file-truncated-time-3", []byte("1"), 0644),
+		fstest.Chtimes("/file-truncated-time-3", t1, t1),
+	)
+	l2 := fstest.Apply(
+		fstest.CreateFile("/file-modified-time", []byte("2"), 0644),
+		fstest.Chtimes("/file-modified-time", t2, t2),
+		fstest.CreateFile("/file-no-change", []byte("1"), 0644),
+		fstest.Chtimes("/file-no-change", t1, t1),
+		fstest.CreateFile("/file-same-time", []byte("2"), 0644),
+		fstest.Chtimes("/file-same-time", t1, t1),
+		fstest.CreateFile("/file-truncated-time-1", []byte("1"), 0644),
+		fstest.Chtimes("/file-truncated-time-1", t1, t1),
+		fstest.CreateFile("/file-truncated-time-2", []byte("2"), 0644),
+		fstest.Chtimes("/file-truncated-time-2", tt, tt),
+		fstest.CreateFile("/file-truncated-time-3", []byte("1"), 0644),
+		fstest.Chtimes("/file-truncated-time-3", tt, tt),
+	)
+	diff := []TestChange{
+		Modify("/file-modified-time"),
+
+		// NOTE: Even if the file is identical, overlayfs copies it to
+		//       the upper layer when the modification occurred. continuity's differ avoids counting
+		//       this as "modify" by comparing the time and the file contents between upper and lower
+		//       but here we want to avoid comparing bits which makes the differ slower.
+		// TODO: we need a way to effectively determine two files are identical
+		//       without copmaring bits.
+		Modify("/file-no-change"),
+		Modify("/file-same-time"),
+
+		// Include changes with truncated timestamps. Comparing newly
+		// extracted tars which have truncated timestamps will be
+		// expected to produce changes. The expectation is that diff
+		// archives are generated once and kept, newly generated diffs
+		// will not consider cases where only one side is truncated.
+		Modify("/file-truncated-time-1"),
+		Modify("/file-truncated-time-2"),
+		Modify("/file-truncated-time-3"),
+	}
+
+	if err := testDiffWithBase(l1, l2, diff); err != nil {
+		t.Fatalf("Failed diff with base: %+v", err)
+	}
+}
+
+// TestLchtimes is a test ported from
+// https://github.com/containerd/continuity/blob/v0.1.0/fs/diff_test.go#L271-L291
+// Copyright The containerd Authors.
+// buildkit#172
+func TestLchtimes(t *testing.T) {
+	mtimes := []time.Time{
+		time.Unix(0, 0),  // nsec is 0
+		time.Unix(0, 42), // nsec > 0
+	}
+	for _, mtime := range mtimes {
+		atime := time.Unix(424242, 42)
+		l1 := fstest.Apply(
+			fstest.CreateFile("/foo", []byte("foo"), 0644),
+			fstest.Symlink("/foo", "/lnk0"),
+			fstest.Lchtimes("/lnk0", atime, mtime),
+		)
+		l2 := fstest.Apply() // empty
+		diff := []TestChange{}
+		if err := testDiffWithBase(l1, l2, diff); err != nil {
+			t.Fatalf("Failed diff with base: %+v", err)
+		}
+	}
+}
+
+func testDiffWithBase(base, diff fstest.Applier, expected []TestChange) error {
+	t1, err := ioutil.TempDir("", "diff-with-base-lower-")
+	if err != nil {
+		return errors.Wrap(err, "failed to create temp dir")
+	}
+	defer os.RemoveAll(t1)
+
+	if err := base.Apply(t1); err != nil {
+		return errors.Wrap(err, "failed to apply base filesystem")
+	}
+
+	tupper, err := ioutil.TempDir("", "diff-with-base-upperdir-")
+	if err != nil {
+		return errors.Wrap(err, "failed to create temp dir")
+	}
+	defer os.RemoveAll(tupper)
+
+	workdir, err := ioutil.TempDir("", "diff-with-base-workdir-")
+	if err != nil {
+		return errors.Wrap(err, "failed to create temp dir")
+	}
+	defer os.RemoveAll(workdir)
+
+	return mount.WithTempMount(context.Background(), []mount.Mount{
+		{
+			Type:    "overlay",
+			Source:  "overlay",
+			Options: []string{fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", t1, tupper, workdir)},
+		},
+	}, func(overlayRoot string) error {
+		if err := diff.Apply(overlayRoot); err != nil {
+			return errors.Wrapf(err, "failed to apply diff to overlayRoot")
+		}
+		if err := collectAndCheckChanges(t1, tupper, expected); err != nil {
+			return errors.Wrap(err, "failed to collect changes")
+		}
+		return nil
+	})
+}
+
+func checkChanges(root string, changes, expected []TestChange) error {
+	if len(changes) != len(expected) {
+		return errors.Errorf("Unexpected number of changes:\n%s", diffString(changes, expected))
+	}
+	for i := range changes {
+		if changes[i].Path != expected[i].Path || changes[i].Kind != expected[i].Kind {
+			return errors.Errorf("Unexpected change at %d:\n%s", i, diffString(changes, expected))
+		}
+		if changes[i].Kind != fs.ChangeKindDelete {
+			filename := filepath.Join(root, changes[i].Path)
+			efi, err := os.Stat(filename)
+			if err != nil {
+				return errors.Wrapf(err, "failed to stat %q", filename)
+			}
+			afi := changes[i].FileInfo
+			if afi.Size() != efi.Size() {
+				return errors.Errorf("Unexpected change size %d, %q has size %d", afi.Size(), filename, efi.Size())
+			}
+			if afi.Mode() != efi.Mode() {
+				return errors.Errorf("Unexpected change mode %s, %q has mode %s", afi.Mode(), filename, efi.Mode())
+			}
+			if afi.ModTime() != efi.ModTime() {
+				return errors.Errorf("Unexpected change modtime %s, %q has modtime %s", afi.ModTime(), filename, efi.ModTime())
+			}
+			if expected := filepath.Join(root, changes[i].Path); changes[i].Source != expected {
+				return errors.Errorf("Unexpected source path %s, expected %s", changes[i].Source, expected)
+			}
+		}
+	}
+
+	return nil
+}
+
+type TestChange struct {
+	Kind     fs.ChangeKind
+	Path     string
+	FileInfo os.FileInfo
+	Source   string
+}
+
+func collectAndCheckChanges(base, upperdir string, expected []TestChange) error {
+	ctx := context.Background()
+	changes := []TestChange{}
+
+	emptyLower, err := ioutil.TempDir("", "buildkit-test-emptylower") // empty directory used for the lower of diff view
+	if err != nil {
+		return errors.Wrapf(err, "failed to create temp dir")
+	}
+	defer os.Remove(emptyLower)
+	upperView := []mount.Mount{
+		{
+			Type:    "overlay",
+			Source:  "overlay",
+			Options: []string{fmt.Sprintf("lowerdir=%s", strings.Join([]string{upperdir, emptyLower}, ":"))},
+		},
+	}
+	return mount.WithTempMount(ctx, upperView, func(upperViewRoot string) error {
+		if err := overlayChanges(ctx, func(k fs.ChangeKind, p string, f os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			changes = append(changes, TestChange{
+				Kind:     k,
+				Path:     p,
+				FileInfo: f,
+				Source:   filepath.Join(upperViewRoot, p),
+			})
+			return nil
+		}, upperdir, upperViewRoot, base); err != nil {
+			return err
+		}
+		if err := checkChanges(upperViewRoot, changes, expected); err != nil {
+			return errors.Wrapf(err, "change check falied")
+		}
+		return nil
+	})
+}
+
+func diffString(c1, c2 []TestChange) string {
+	return fmt.Sprintf("got(%d):\n%s\nexpected(%d):\n%s", len(c1), changesString(c1), len(c2), changesString(c2))
+
+}
+
+func changesString(c []TestChange) string {
+	strs := make([]string, len(c))
+	for i := range c {
+		strs[i] = fmt.Sprintf("\t%s\t%s", c[i].Kind, c[i].Path)
+	}
+	return strings.Join(strs, "\n")
+}
+
+func Add(p string) TestChange {
+	return TestChange{
+		Kind: fs.ChangeKindAdd,
+		Path: filepath.FromSlash(p),
+	}
+}
+
+func Delete(p string) TestChange {
+	return TestChange{
+		Kind: fs.ChangeKindDelete,
+		Path: filepath.FromSlash(p),
+	}
+}
+
+func Modify(p string) TestChange {
+	return TestChange{
+		Kind: fs.ChangeKindModify,
+		Path: filepath.FromSlash(p),
+	}
+}

--- a/cache/blobs_nolinux.go
+++ b/cache/blobs_nolinux.go
@@ -1,0 +1,15 @@
+// +build !linux
+
+package cache
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/mount"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+func (sr *immutableRef) tryComputeOverlayBlob(ctx context.Context, lower, upper []mount.Mount, mediaType string, ref string, compressorFunc compressor) (_ ocispecs.Descriptor, ok bool, err error) {
+	return ocispecs.Descriptor{}, true, errors.Errorf("overlayfs-based diff computing is unsupported")
+}

--- a/util/testutil/integration/sandbox.go
+++ b/util/testutil/integration/sandbox.go
@@ -182,6 +182,9 @@ func runBuildkitd(ctx context.Context, conf *BackendConfig, args []string, logs 
 	args = append(args, "--root", tmpdir, "--addr", address, "--debug")
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Env = append(os.Environ(), "BUILDKIT_DEBUG_EXEC_OUTPUT=1", "BUILDKIT_DEBUG_PANIC_ON_ERROR=1", "TMPDIR="+filepath.Join(tmpdir, "tmp"))
+	if runtime.GOOS != "windows" {
+		cmd.Env = append(cmd.Env, "BUILDKIT_DEBUG_FORCE_OVERLAY_DIFF=true")
+	}
 	cmd.Env = append(cmd.Env, extraEnv...)
 	cmd.SysProcAttr = getSysProcAttr()
 


### PR DESCRIPTION
Fixes: https://github.com/moby/buildkit/issues/1704
Fixes: https://github.com/moby/buildkit/issues/1192

Currently, BuildKit creates diff blobs by comparing the whole filesystem object of a snapshot to its parent, using walking differ but it turned out it can long time.

This commit is a PoC for the faster diff approach specifically aiming at overlayfs-based snapshotter.

This PR computes a diff blob of an overlayfs-based snapshot using its "upper" directory instead of using walking differ. That upper directory contains the diff between that snapshot and its parent so we don't need to compare the whole filesystem objects between them.

~Snapshotter must provide the label `containerd.io/snapshot/overlay.upperdir` which contains the path to the upper directory of this snapshot. When this label is provided, `cache.computeBlobChain` tries to compute diff blob using that upper directory. The current version of upstream overlayfs snapshotter doesn't provide this label so I'll open a PR to make it happen if this design looks good to you. This PR uses the patched version of containerd (https://github.com/ktock/containerd/compare/0a3a77bc445379851a5c737955411fc9e630c3ce...50ed319ed86402498e50998fbe0eb8cea91db673).~

**EDIT** now this patch directly parses `mount.Mount` passed from the snapshotter for identifying the directory that contains the changeset.

~Computing diff relies on continuity library. This PR uses `fs.diffDirChanges` of continuity for computing the diff blob from the upper directory. This PR implements `overlayDeleteChange` for detecting files to delete and configures `fs.diffDirChanges` to use this. `fs.diffDirChanges` is a private method in continuity as of now. I hope https://github.com/containerd/continuity/pull/145 by @fuweid is merged or I'll open a PR if needed. This PR uses the patched version of continuity (https://github.com/ktock/continuity/commit/ce76fccd76580e78cc991d49c225287fc5c5a7a3).~

**EDIT** now this patch re-implements the differ that can be used for overlayfs layers.

## Comparison of exporting layers

Dockerfile:

```
FROM $IMG
RUN echo hello > /hello
```

command:

```
buildctl build --progress=plain --frontend=dockerfile.v0 \
         --local context=${CONTEXT} --local dockerfile=${CONTEXT} \
         --output type=docker,name=sample,dest=${RES}/${IMGNAME}.tar
```

|IMG|time of exporting layers(walking differ)|time of exporting layers(overlayfs differ)|
|---|---|---|
|ubuntu:20.04|0.2s|0.1s|
|python:3.9|1.1s|0.1s|
|nvidia/cuda:11.3.1-devel-ubuntu20.04|2.5s|0.1s|

This is an one-shot measurement.
Appreciate any suggestion about benchmarking.

<details>
<summary>full log</summary>

# walking differ

## ubuntu:20.04

```
#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 79B done
#1 DONE 0.1s

#2 [internal] load .dockerignore
#2 transferring context: 2B done
#2 DONE 0.1s

#3 [internal] load metadata for docker.io/library/ubuntu:20.04
#3 DONE 2.7s

#5 [1/2] FROM docker.io/library/ubuntu:20.04@sha256:adf73ca014822ad8237623d388cedf4d5346aa72c270c5acc01431cc93e18e2d
#5 resolve docker.io/library/ubuntu:20.04@sha256:adf73ca014822ad8237623d388cedf4d5346aa72c270c5acc01431cc93e18e2d 0.0s done
#5 sha256:5e9250ddb7d0fa6d13302c7c3e6a0aa40390e42424caed1e5289077ee4054709 187B / 187B 0.2s done
#5 sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 0B / 28.54MB 0.2s
#5 sha256:57671312ef6fdbecf340e5fed0fb0863350cd806c92b1fdd7978adbd02afc5c3 0B / 851B 0.2s
#5 sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 15.73MB / 28.54MB 0.8s
#5 sha256:57671312ef6fdbecf340e5fed0fb0863350cd806c92b1fdd7978adbd02afc5c3 851B / 851B 0.6s done
#5 sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 28.54MB / 28.54MB 1.0s done
#5 extracting sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe
#5 extracting sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 0.8s done
#5 extracting sha256:57671312ef6fdbecf340e5fed0fb0863350cd806c92b1fdd7978adbd02afc5c3 0.0s done
#5 extracting sha256:5e9250ddb7d0fa6d13302c7c3e6a0aa40390e42424caed1e5289077ee4054709 0.0s done
#5 DONE 1.9s
INFO[0005] No non-localhost DNS nameservers are left in resolv.conf. Using default external servers: [nameserver 8.8.8.8 nameserver 8.8.4.4] 
INFO[0005] IPv6 enabled; Adding default IPv6 external servers: [nameserver 2001:4860:4860::8888 nameserver 2001:4860:4860::8844] 

#4 [2/2] RUN echo hello > /hello
#4 DONE 0.1s

#6 exporting to oci image format
#6 exporting layers
#6 exporting layers 0.2s done
#6 exporting manifest sha256:988343cd8dbd8a9014d3c590bac8578fe5164f25d17dac7843135d5187e54bf8 0.0s done
#6 exporting config sha256:a163d59bf83068f96700888408641eb426c78a09c6efd872cfb6e2bea8180f1b 0.0s done
#6 sending tarball
#6 sending tarball 0.1s done
#6 DONE 0.4s
```

## python:3.9

```
#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 77B done
#1 DONE 0.1s

#2 [internal] load .dockerignore
#2 transferring context: 2B done
#2 DONE 0.1s

#3 [internal] load metadata for docker.io/library/python:3.9
#3 DONE 8.7s

#4 [1/2] FROM docker.io/library/python:3.9@sha256:e8e000f3c551f93d7b03d241e38c1206eb8c8a1f1a6179902f74e068fc98ee59
#4 resolve docker.io/library/python:3.9@sha256:e8e000f3c551f93d7b03d241e38c1206eb8c8a1f1a6179902f74e068fc98ee59 0.0s done
#4 sha256:1ec7c3bcb4b287487eab99f3ce2a6932f37957d4c904430c3acd8b2687a72244 0B / 2.35MB 0.2s
#4 sha256:aec2e3a8937195ce2863f352c687f204daf3f261310254bb290ce1e5a82ec005 233B / 233B 0.3s done
#4 sha256:062ada600c9e0239e04bfc21da3719c4d0db3276450b28c455231f416015ba9f 0B / 19.19MB 0.2s
#4 sha256:1334e0fe2851ea7f3d2509a3907312a665d7c6b085e1f0671f6cd2dcf37b82db 0B / 6.15MB 0.2s
#4 sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 0B / 192.35MB 0.2s
#4 sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 0B / 51.84MB 0.2s
#4 sha256:8962bc0fad55b13afedfeb6ad5cb06fd065461cf3e1ae4e7aeae5eeb17b179df 0B / 10.00MB 0.2s
#4 sha256:e8d62473a22dec9ffef056b2017968a9dc484c8f836fb6d79f46980b309e9138 0B / 7.83MB 0.2s
#4 sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 0B / 50.43MB 0.2s
#4 sha256:1ec7c3bcb4b287487eab99f3ce2a6932f37957d4c904430c3acd8b2687a72244 2.35MB / 2.35MB 0.3s done
#4 sha256:1334e0fe2851ea7f3d2509a3907312a665d7c6b085e1f0671f6cd2dcf37b82db 1.05MB / 6.15MB 0.5s
#4 sha256:062ada600c9e0239e04bfc21da3719c4d0db3276450b28c455231f416015ba9f 2.10MB / 19.19MB 0.6s
#4 sha256:1334e0fe2851ea7f3d2509a3907312a665d7c6b085e1f0671f6cd2dcf37b82db 6.15MB / 6.15MB 0.6s done
#4 sha256:062ada600c9e0239e04bfc21da3719c4d0db3276450b28c455231f416015ba9f 6.29MB / 19.19MB 0.8s
#4 sha256:062ada600c9e0239e04bfc21da3719c4d0db3276450b28c455231f416015ba9f 10.49MB / 19.19MB 0.9s
#4 sha256:062ada600c9e0239e04bfc21da3719c4d0db3276450b28c455231f416015ba9f 13.63MB / 19.19MB 1.1s
#4 sha256:062ada600c9e0239e04bfc21da3719c4d0db3276450b28c455231f416015ba9f 15.73MB / 19.19MB 1.2s
#4 sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 3.15MB / 51.84MB 1.2s
#4 sha256:e8d62473a22dec9ffef056b2017968a9dc484c8f836fb6d79f46980b309e9138 1.05MB / 7.83MB 1.2s
#4 sha256:062ada600c9e0239e04bfc21da3719c4d0db3276450b28c455231f416015ba9f 16.78MB / 19.19MB 1.4s
#4 sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 10.49MB / 192.35MB 1.4s
#4 sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 6.29MB / 51.84MB 1.4s
#4 sha256:8962bc0fad55b13afedfeb6ad5cb06fd065461cf3e1ae4e7aeae5eeb17b179df 1.05MB / 10.00MB 1.4s
#4 sha256:e8d62473a22dec9ffef056b2017968a9dc484c8f836fb6d79f46980b309e9138 2.10MB / 7.83MB 1.4s
#4 sha256:062ada600c9e0239e04bfc21da3719c4d0db3276450b28c455231f416015ba9f 17.83MB / 19.19MB 1.5s
#4 sha256:8962bc0fad55b13afedfeb6ad5cb06fd065461cf3e1ae4e7aeae5eeb17b179df 2.10MB / 10.00MB 1.5s
#4 sha256:e8d62473a22dec9ffef056b2017968a9dc484c8f836fb6d79f46980b309e9138 3.15MB / 7.83MB 1.5s
#4 sha256:062ada600c9e0239e04bfc21da3719c4d0db3276450b28c455231f416015ba9f 19.19MB / 19.19MB 1.7s done
#4 sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 11.53MB / 51.84MB 1.7s
#4 sha256:8962bc0fad55b13afedfeb6ad5cb06fd065461cf3e1ae4e7aeae5eeb17b179df 3.15MB / 10.00MB 1.7s
#4 sha256:e8d62473a22dec9ffef056b2017968a9dc484c8f836fb6d79f46980b309e9138 4.19MB / 7.83MB 1.7s
#4 sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 3.15MB / 50.43MB 1.7s
#4 sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 14.68MB / 51.84MB 1.8s
#4 sha256:8962bc0fad55b13afedfeb6ad5cb06fd065461cf3e1ae4e7aeae5eeb17b179df 4.19MB / 10.00MB 1.8s
#4 sha256:e8d62473a22dec9ffef056b2017968a9dc484c8f836fb6d79f46980b309e9138 5.24MB / 7.83MB 1.8s
#4 sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 17.83MB / 51.84MB 2.0s
#4 sha256:8962bc0fad55b13afedfeb6ad5cb06fd065461cf3e1ae4e7aeae5eeb17b179df 5.24MB / 10.00MB 2.0s
#4 sha256:e8d62473a22dec9ffef056b2017968a9dc484c8f836fb6d79f46980b309e9138 6.29MB / 7.83MB 2.0s
#4 sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 22.02MB / 51.84MB 2.1s
#4 sha256:8962bc0fad55b13afedfeb6ad5cb06fd065461cf3e1ae4e7aeae5eeb17b179df 6.29MB / 10.00MB 2.1s
#4 sha256:e8d62473a22dec9ffef056b2017968a9dc484c8f836fb6d79f46980b309e9138 7.83MB / 7.83MB 2.1s done
#4 sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 6.29MB / 50.43MB 2.1s
#4 sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 25.17MB / 51.84MB 2.3s
#4 sha256:8962bc0fad55b13afedfeb6ad5cb06fd065461cf3e1ae4e7aeae5eeb17b179df 7.34MB / 10.00MB 2.3s
#4 sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 29.36MB / 51.84MB 2.4s
#4 sha256:8962bc0fad55b13afedfeb6ad5cb06fd065461cf3e1ae4e7aeae5eeb17b179df 10.00MB / 10.00MB 2.5s done
#4 sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 9.44MB / 50.43MB 2.4s
#4 sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 33.55MB / 51.84MB 2.6s
#4 sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 36.70MB / 51.84MB 2.7s
#4 sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 14.68MB / 50.43MB 2.7s
#4 sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 40.89MB / 51.84MB 2.9s
#4 sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 17.83MB / 50.43MB 2.9s
#4 sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 20.97MB / 192.35MB 3.2s
#4 sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 44.04MB / 51.84MB 3.0s
#4 sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 20.97MB / 50.43MB 3.0s
#4 sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 48.23MB / 51.84MB 3.2s
#4 sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 24.12MB / 50.43MB 3.2s
#4 sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 51.84MB / 51.84MB 3.3s done
#4 sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 27.26MB / 50.43MB 3.3s
#4 sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 32.51MB / 50.43MB 3.5s
#4 sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 38.80MB / 50.43MB 3.6s
#4 sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 44.04MB / 50.43MB 3.8s
#4 sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 31.46MB / 192.35MB 4.1s
#4 sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 50.43MB / 50.43MB 3.9s done
#4 extracting sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87
#4 sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 47.19MB / 192.35MB 4.4s
#4 sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 71.30MB / 192.35MB 4.8s
#4 sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 87.03MB / 192.35MB 5.1s
#4 extracting sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 1.4s done
#4 sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 102.76MB / 192.35MB 5.4s
#4 extracting sha256:e8d62473a22dec9ffef056b2017968a9dc484c8f836fb6d79f46980b309e9138
#4 extracting sha256:e8d62473a22dec9ffef056b2017968a9dc484c8f836fb6d79f46980b309e9138 0.2s done
#4 extracting sha256:8962bc0fad55b13afedfeb6ad5cb06fd065461cf3e1ae4e7aeae5eeb17b179df
#4 sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 118.49MB / 192.35MB 5.7s
#4 extracting sha256:8962bc0fad55b13afedfeb6ad5cb06fd065461cf3e1ae4e7aeae5eeb17b179df 0.2s done
#4 extracting sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9
#4 sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 134.22MB / 192.35MB 6.0s
#4 sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 149.95MB / 192.35MB 6.3s
#4 sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 166.72MB / 192.35MB 6.6s
#4 sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 182.45MB / 192.35MB 6.9s
#4 sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 192.35MB / 192.35MB 7.2s done
#4 extracting sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 1.7s done
#4 extracting sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b
#4 extracting sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 4.9s done
#4 extracting sha256:1334e0fe2851ea7f3d2509a3907312a665d7c6b085e1f0671f6cd2dcf37b82db
#4 extracting sha256:1334e0fe2851ea7f3d2509a3907312a665d7c6b085e1f0671f6cd2dcf37b82db 0.2s done
#4 extracting sha256:062ada600c9e0239e04bfc21da3719c4d0db3276450b28c455231f416015ba9f
#4 extracting sha256:062ada600c9e0239e04bfc21da3719c4d0db3276450b28c455231f416015ba9f 0.6s done
#4 extracting sha256:aec2e3a8937195ce2863f352c687f204daf3f261310254bb290ce1e5a82ec005 0.0s done
#4 extracting sha256:1ec7c3bcb4b287487eab99f3ce2a6932f37957d4c904430c3acd8b2687a72244
INFO[0023] No non-localhost DNS nameservers are left in resolv.conf. Using default external servers: [nameserver 8.8.8.8 nameserver 8.8.4.4] 
INFO[0023] IPv6 enabled; Adding default IPv6 external servers: [nameserver 2001:4860:4860::8888 nameserver 2001:4860:4860::8844] 
#4 extracting sha256:1ec7c3bcb4b287487eab99f3ce2a6932f37957d4c904430c3acd8b2687a72244 0.1s done
#4 DONE 13.4s

#5 [2/2] RUN echo hello > /hello
#5 DONE 0.2s

#6 exporting to oci image format
#6 exporting layers
#6 exporting layers 1.1s done
#6 exporting manifest sha256:4b5a86bcbaec6cee7d8b85f908a82652e39f1f2400dcfe689781effeb5576c85 0.0s done
#6 exporting config sha256:f3abbf3fc12353c2fcfec3b710f1d70a56de2cc5824be7d8a1ed6f97a9bce475 0.0s done
#6 sending tarball
#6 sending tarball 1.7s done
#6 DONE 2.8s
```

## nvidia/cuda:11.3.1-devel-ubuntu20.04

```
#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 103B done
#1 DONE 0.1s

#2 [internal] load .dockerignore
#2 transferring context: 2B done
#2 DONE 0.1s

#3 [internal] load metadata for docker.io/nvidia/cuda:11.3.1-devel-ubuntu20.04
#3 DONE 2.7s

#5 [1/2] FROM docker.io/nvidia/cuda:11.3.1-devel-ubuntu20.04@sha256:1e0aaefc4922000da157cd2e23d975c15b8e29dc87a343b3d91c2393e2fc363c
#5 resolve docker.io/nvidia/cuda:11.3.1-devel-ubuntu20.04@sha256:1e0aaefc4922000da157cd2e23d975c15b8e29dc87a343b3d91c2393e2fc363c done
#5 sha256:56d4c342814717e19bc11910a9ca14fb03a70c1a43157858af4ff952531aba6b 84.83kB / 84.83kB 0.2s done
#5 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 0B / 1.22GB 0.2s
#5 sha256:26aa2a3f926e332d4c3d913ac3e6e830326e0fb586dced9d924060b323be9835 0B / 61.96kB 0.2s
#5 sha256:5489cc61b656f9678b2b4ab7959a61bfe574fc39988136ea24d0fa078b96678b 0B / 6.43kB 0.2s
#5 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 0B / 1.02GB 0.2s
#5 sha256:d07426e4cea449120e1e17c3a5b89268f4d40fa2bade0803b6c70d0e1c67fe30 0B / 11.32MB 0.2s
#5 sha256:2442bbbb3364a992bfb76035b848ddb5319ede6d0afbdc6d8ea750340397f66e 0B / 185B 0.2s
#5 sha256:c76dcc6f3afe0a60183c9148fa635f30351717b39022bea8b5b39b690d391b12 0B / 7.93MB 0.2s
#5 sha256:5e9250ddb7d0fa6d13302c7c3e6a0aa40390e42424caed1e5289077ee4054709 0B / 187B 0.2s
#5 sha256:57671312ef6fdbecf340e5fed0fb0863350cd806c92b1fdd7978adbd02afc5c3 0B / 851B 0.2s
#5 sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 0B / 28.54MB 0.2s
#5 sha256:26aa2a3f926e332d4c3d913ac3e6e830326e0fb586dced9d924060b323be9835 61.96kB / 61.96kB 0.6s done
#5 sha256:5489cc61b656f9678b2b4ab7959a61bfe574fc39988136ea24d0fa078b96678b 6.43kB / 6.43kB 0.7s done
#5 sha256:2442bbbb3364a992bfb76035b848ddb5319ede6d0afbdc6d8ea750340397f66e 185B / 185B 0.8s done
#5 sha256:5e9250ddb7d0fa6d13302c7c3e6a0aa40390e42424caed1e5289077ee4054709 187B / 187B 0.8s done
#5 sha256:d07426e4cea449120e1e17c3a5b89268f4d40fa2bade0803b6c70d0e1c67fe30 2.10MB / 11.32MB 1.1s
#5 sha256:c76dcc6f3afe0a60183c9148fa635f30351717b39022bea8b5b39b690d391b12 2.10MB / 7.93MB 1.1s
#5 sha256:d07426e4cea449120e1e17c3a5b89268f4d40fa2bade0803b6c70d0e1c67fe30 5.24MB / 11.32MB 1.2s
#5 sha256:c76dcc6f3afe0a60183c9148fa635f30351717b39022bea8b5b39b690d391b12 4.19MB / 7.93MB 1.2s
#5 sha256:d07426e4cea449120e1e17c3a5b89268f4d40fa2bade0803b6c70d0e1c67fe30 11.32MB / 11.32MB 1.4s done
#5 sha256:c76dcc6f3afe0a60183c9148fa635f30351717b39022bea8b5b39b690d391b12 5.24MB / 7.93MB 1.4s
#5 sha256:c76dcc6f3afe0a60183c9148fa635f30351717b39022bea8b5b39b690d391b12 7.93MB / 7.93MB 1.5s done
#5 sha256:57671312ef6fdbecf340e5fed0fb0863350cd806c92b1fdd7978adbd02afc5c3 851B / 851B 1.4s done
#5 sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 2.10MB / 28.54MB 1.5s
#5 sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 5.24MB / 28.54MB 1.8s
#5 sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 7.34MB / 28.54MB 2.0s
#5 sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 9.44MB / 28.54MB 2.1s
#5 sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 11.53MB / 28.54MB 2.3s
#5 sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 14.68MB / 28.54MB 2.4s
#5 sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 16.78MB / 28.54MB 2.6s
#5 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 61.87MB / 1.22GB 2.9s
#5 sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 19.92MB / 28.54MB 2.7s
#5 sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 22.02MB / 28.54MB 2.9s
#5 sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 25.17MB / 28.54MB 3.0s
#5 sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 28.54MB / 28.54MB 3.1s done
#5 extracting sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe
#5 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 51.38MB / 1.02GB 4.1s
#5 extracting sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 0.9s done
#5 extracting sha256:57671312ef6fdbecf340e5fed0fb0863350cd806c92b1fdd7978adbd02afc5c3 0.0s done
#5 extracting sha256:5e9250ddb7d0fa6d13302c7c3e6a0aa40390e42424caed1e5289077ee4054709 0.0s done
#5 extracting sha256:c76dcc6f3afe0a60183c9148fa635f30351717b39022bea8b5b39b690d391b12
#5 extracting sha256:c76dcc6f3afe0a60183c9148fa635f30351717b39022bea8b5b39b690d391b12 0.3s done
#5 extracting sha256:d07426e4cea449120e1e17c3a5b89268f4d40fa2bade0803b6c70d0e1c67fe30
#5 extracting sha256:d07426e4cea449120e1e17c3a5b89268f4d40fa2bade0803b6c70d0e1c67fe30 0.3s done
#5 extracting sha256:2442bbbb3364a992bfb76035b848ddb5319ede6d0afbdc6d8ea750340397f66e 0.0s done
#5 extracting sha256:5489cc61b656f9678b2b4ab7959a61bfe574fc39988136ea24d0fa078b96678b 0.0s done
#5 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 125.83MB / 1.22GB 5.7s
#5 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 104.86MB / 1.02GB 6.2s
#5 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 158.33MB / 1.02GB 8.0s
#5 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 187.70MB / 1.22GB 8.6s
#5 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 210.76MB / 1.02GB 9.6s
#5 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 263.19MB / 1.02GB 11.0s
#5 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 250.61MB / 1.22GB 11.9s
#5 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 316.67MB / 1.02GB 13.2s
#5 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 312.48MB / 1.22GB 14.4s
#5 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 371.20MB / 1.02GB 14.9s
#5 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 427.82MB / 1.02GB 16.4s
#5 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 483.39MB / 1.02GB 17.7s
#5 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 376.44MB / 1.22GB 18.9s
#5 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 536.87MB / 1.02GB 19.4s
#5 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 588.25MB / 1.02GB 20.9s
#5 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 441.45MB / 1.22GB 22.7s
#5 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 640.68MB / 1.02GB 22.5s
#5 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 692.06MB / 1.02GB 24.3s
#5 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 503.32MB / 1.22GB 25.1s
#5 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 744.49MB / 1.02GB 26.6s
#5 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 566.23MB / 1.22GB 27.3s
#5 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 796.92MB / 1.02GB 28.8s
#5 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 629.15MB / 1.22GB 29.4s
#5 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 849.35MB / 1.02GB 31.2s
#5 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 692.06MB / 1.22GB 31.5s
#5 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 904.92MB / 1.02GB 33.5s
#5 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 753.93MB / 1.22GB 34.2s
#5 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 956.30MB / 1.02GB 35.1s
#5 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 1.01GB / 1.02GB 36.9s
#5 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 817.89MB / 1.22GB 37.2s
#5 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 1.02GB / 1.02GB 37.3s done
#5 extracting sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928
#5 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 883.95MB / 1.22GB 38.6s
#5 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 946.86MB / 1.22GB 39.8s
#5 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 1.01GB / 1.22GB 41.0s
#5 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 1.08GB / 1.22GB 42.3s
#5 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 1.15GB / 1.22GB 43.5s
#5 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 1.21GB / 1.22GB 44.7s
#5 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 1.22GB / 1.22GB 44.9s done
#5 extracting sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 21.7s done
#5 extracting sha256:26aa2a3f926e332d4c3d913ac3e6e830326e0fb586dced9d924060b323be9835 0.0s done
#5 extracting sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9
INFO[0093] No non-localhost DNS nameservers are left in resolv.conf. Using default external servers: [nameserver 8.8.8.8 nameserver 8.8.4.4] 
INFO[0093] IPv6 enabled; Adding default IPv6 external servers: [nameserver 2001:4860:4860::8888 nameserver 2001:4860:4860::8844] 
#5 extracting sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 30.2s done
#5 extracting sha256:56d4c342814717e19bc11910a9ca14fb03a70c1a43157858af4ff952531aba6b 0.0s done
#5 DONE 89.3s

#4 [2/2] RUN echo hello > /hello
#4 DONE 0.5s

#6 exporting to oci image format
#6 exporting layers
#6 exporting layers 2.5s done
#6 exporting manifest sha256:f8b12cc35ec5cd063e959ee780a01c5aea2cd39e2e58d22d2cd578bc77a13e54
#6 exporting manifest sha256:f8b12cc35ec5cd063e959ee780a01c5aea2cd39e2e58d22d2cd578bc77a13e54 0.0s done
#6 exporting config sha256:ed2d6a735c641636d31d177d3612f606cdd288e070ebf590239b2b9afbc83c04 0.0s done
#6 sending tarball
#6 sending tarball 15.4s done
#6 DONE 17.9s
```

# overlayfs diff

## ubuntu:20.04

```
#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 79B done
#1 DONE 0.1s

#2 [internal] load .dockerignore
#2 transferring context: 2B done
#2 DONE 0.1s

#3 [internal] load metadata for docker.io/library/ubuntu:20.04
#3 DONE 3.1s

#4 [1/2] FROM docker.io/library/ubuntu:20.04@sha256:adf73ca014822ad8237623d388cedf4d5346aa72c270c5acc01431cc93e18e2d
#4 resolve docker.io/library/ubuntu:20.04@sha256:adf73ca014822ad8237623d388cedf4d5346aa72c270c5acc01431cc93e18e2d 0.0s done
#4 sha256:5e9250ddb7d0fa6d13302c7c3e6a0aa40390e42424caed1e5289077ee4054709 0B / 187B 0.2s
#4 sha256:57671312ef6fdbecf340e5fed0fb0863350cd806c92b1fdd7978adbd02afc5c3 0B / 851B 0.2s
#4 sha256:5e9250ddb7d0fa6d13302c7c3e6a0aa40390e42424caed1e5289077ee4054709 187B / 187B 0.3s done
#4 sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 0B / 28.54MB 0.2s
#4 sha256:57671312ef6fdbecf340e5fed0fb0863350cd806c92b1fdd7978adbd02afc5c3 851B / 851B 0.5s done
#4 sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 3.15MB / 28.54MB 0.8s
#4 sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 11.53MB / 28.54MB 0.9s
#4 sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 18.87MB / 28.54MB 1.1s
#4 sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 28.54MB / 28.54MB 1.3s done
#4 extracting sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe
#4 extracting sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 0.8s done
#4 extracting sha256:57671312ef6fdbecf340e5fed0fb0863350cd806c92b1fdd7978adbd02afc5c3 0.0s done
#4 DONE 2.2s
INFO[0006] No non-localhost DNS nameservers are left in resolv.conf. Using default external servers: [nameserver 8.8.8.8 nameserver 8.8.4.4] 
INFO[0006] IPv6 enabled; Adding default IPv6 external servers: [nameserver 2001:4860:4860::8888 nameserver 2001:4860:4860::8844] 

#4 [1/2] FROM docker.io/library/ubuntu:20.04@sha256:adf73ca014822ad8237623d388cedf4d5346aa72c270c5acc01431cc93e18e2d
#4 extracting sha256:5e9250ddb7d0fa6d13302c7c3e6a0aa40390e42424caed1e5289077ee4054709 0.0s done
#4 DONE 2.2s

#5 [2/2] RUN echo hello > /hello
#5 DONE 0.2s

#6 exporting to oci image format
#6 exporting layers
#6 exporting layers 0.1s done
#6 exporting manifest sha256:04ca91c99eba09bc5552a29462d13b163b092e4fb879023663c2cf71cf4ff191 0.0s done
#6 exporting config sha256:c94784bb816a70caecbe6881e562e2b1f0167fb0ee4a93156055dec9d7bc878a 0.0s done
#6 sending tarball
#6 sending tarball 0.2s done
#6 DONE 0.3s
```

## python:3.9

```
#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 77B done
#1 DONE 0.1s

#2 [internal] load .dockerignore
#2 transferring context: 2B done
#2 DONE 0.1s

#3 [internal] load metadata for docker.io/library/python:3.9
#3 DONE 3.4s

#4 [1/2] FROM docker.io/library/python:3.9@sha256:e8e000f3c551f93d7b03d241e38c1206eb8c8a1f1a6179902f74e068fc98ee59
#4 resolve docker.io/library/python:3.9@sha256:e8e000f3c551f93d7b03d241e38c1206eb8c8a1f1a6179902f74e068fc98ee59 0.0s done
#4 DONE 0.5s

#4 [1/2] FROM docker.io/library/python:3.9@sha256:e8e000f3c551f93d7b03d241e38c1206eb8c8a1f1a6179902f74e068fc98ee59
#4 sha256:1ec7c3bcb4b287487eab99f3ce2a6932f37957d4c904430c3acd8b2687a72244 0B / 2.35MB 0.2s
#4 sha256:aec2e3a8937195ce2863f352c687f204daf3f261310254bb290ce1e5a82ec005 0B / 233B 0.2s
#4 sha256:062ada600c9e0239e04bfc21da3719c4d0db3276450b28c455231f416015ba9f 0B / 19.19MB 0.2s
#4 sha256:1334e0fe2851ea7f3d2509a3907312a665d7c6b085e1f0671f6cd2dcf37b82db 0B / 6.15MB 0.2s
#4 sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 0B / 192.35MB 0.2s
#4 sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 0B / 51.84MB 0.2s
#4 sha256:8962bc0fad55b13afedfeb6ad5cb06fd065461cf3e1ae4e7aeae5eeb17b179df 0B / 10.00MB 0.2s
#4 sha256:e8d62473a22dec9ffef056b2017968a9dc484c8f836fb6d79f46980b309e9138 0B / 7.83MB 0.2s
#4 sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 0B / 50.43MB 0.2s
#4 sha256:1ec7c3bcb4b287487eab99f3ce2a6932f37957d4c904430c3acd8b2687a72244 2.35MB / 2.35MB 0.3s done
#4 sha256:aec2e3a8937195ce2863f352c687f204daf3f261310254bb290ce1e5a82ec005 233B / 233B 0.2s done
#4 sha256:062ada600c9e0239e04bfc21da3719c4d0db3276450b28c455231f416015ba9f 4.19MB / 19.19MB 0.5s
#4 sha256:062ada600c9e0239e04bfc21da3719c4d0db3276450b28c455231f416015ba9f 10.49MB / 19.19MB 0.6s
#4 sha256:062ada600c9e0239e04bfc21da3719c4d0db3276450b28c455231f416015ba9f 14.68MB / 19.19MB 0.8s
#4 sha256:1334e0fe2851ea7f3d2509a3907312a665d7c6b085e1f0671f6cd2dcf37b82db 2.10MB / 6.15MB 0.6s
#4 sha256:062ada600c9e0239e04bfc21da3719c4d0db3276450b28c455231f416015ba9f 17.83MB / 19.19MB 0.9s
#4 sha256:1334e0fe2851ea7f3d2509a3907312a665d7c6b085e1f0671f6cd2dcf37b82db 4.19MB / 6.15MB 0.8s
#4 sha256:062ada600c9e0239e04bfc21da3719c4d0db3276450b28c455231f416015ba9f 19.19MB / 19.19MB 1.0s done
#4 sha256:1334e0fe2851ea7f3d2509a3907312a665d7c6b085e1f0671f6cd2dcf37b82db 5.24MB / 6.15MB 0.9s
#4 sha256:1334e0fe2851ea7f3d2509a3907312a665d7c6b085e1f0671f6cd2dcf37b82db 6.15MB / 6.15MB 1.1s done
#4 sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 10.49MB / 192.35MB 1.1s
#4 sha256:8962bc0fad55b13afedfeb6ad5cb06fd065461cf3e1ae4e7aeae5eeb17b179df 1.05MB / 10.00MB 1.2s
#4 sha256:e8d62473a22dec9ffef056b2017968a9dc484c8f836fb6d79f46980b309e9138 1.05MB / 7.83MB 1.2s
#4 sha256:8962bc0fad55b13afedfeb6ad5cb06fd065461cf3e1ae4e7aeae5eeb17b179df 2.10MB / 10.00MB 1.4s
#4 sha256:e8d62473a22dec9ffef056b2017968a9dc484c8f836fb6d79f46980b309e9138 2.10MB / 7.83MB 1.4s
#4 sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 3.15MB / 51.84MB 1.5s
#4 sha256:8962bc0fad55b13afedfeb6ad5cb06fd065461cf3e1ae4e7aeae5eeb17b179df 4.19MB / 10.00MB 1.5s
#4 sha256:e8d62473a22dec9ffef056b2017968a9dc484c8f836fb6d79f46980b309e9138 4.19MB / 7.83MB 1.5s
#4 sha256:8962bc0fad55b13afedfeb6ad5cb06fd065461cf3e1ae4e7aeae5eeb17b179df 6.29MB / 10.00MB 1.7s
#4 sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 3.15MB / 50.43MB 1.7s
#4 sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 22.02MB / 192.35MB 1.8s
#4 sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 6.29MB / 51.84MB 1.8s
#4 sha256:8962bc0fad55b13afedfeb6ad5cb06fd065461cf3e1ae4e7aeae5eeb17b179df 10.00MB / 10.00MB 1.9s done
#4 sha256:e8d62473a22dec9ffef056b2017968a9dc484c8f836fb6d79f46980b309e9138 7.83MB / 7.83MB 1.8s done
#4 sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 6.29MB / 50.43MB 1.8s
#4 sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 10.49MB / 51.84MB 2.1s
#4 sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 11.53MB / 50.43MB 2.1s
#4 sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 15.73MB / 50.43MB 2.3s
#4 sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 15.73MB / 51.84MB 2.4s
#4 sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 18.87MB / 50.43MB 2.4s
#4 sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 32.51MB / 192.35MB 2.6s
#4 sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 22.02MB / 50.43MB 2.6s
#4 sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 20.97MB / 51.84MB 2.7s
#4 sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 25.17MB / 50.43MB 2.7s
#4 sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 28.31MB / 50.43MB 2.9s
#4 sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 25.17MB / 51.84MB 3.0s
#4 sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 31.46MB / 50.43MB 3.0s
#4 sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 28.31MB / 51.84MB 3.2s
#4 sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 35.65MB / 50.43MB 3.2s
#4 sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 42.16MB / 192.35MB 3.3s
#4 sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 38.80MB / 50.43MB 3.3s
#4 sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 32.51MB / 51.84MB 3.5s
#4 sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 41.94MB / 50.43MB 3.5s
#4 sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 35.65MB / 51.84MB 3.6s
#4 sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 47.19MB / 50.43MB 3.8s
#4 sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 40.89MB / 51.84MB 3.9s
#4 sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 50.43MB / 50.43MB 3.9s done
#4 sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 54.53MB / 192.35MB 4.1s
#4 sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 45.09MB / 51.84MB 4.1s
#4 extracting sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87
#4 sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 51.84MB / 51.84MB 4.3s done
#4 sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 68.16MB / 192.35MB 4.5s
#4 sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 82.84MB / 192.35MB 4.8s
#4 sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 98.57MB / 192.35MB 5.1s
#4 extracting sha256:d960726af2bec62a87ceb07182f7b94c47be03909077e23d8226658f80b47f87 1.4s done
#4 sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 115.34MB / 192.35MB 5.4s
#4 extracting sha256:e8d62473a22dec9ffef056b2017968a9dc484c8f836fb6d79f46980b309e9138
#4 extracting sha256:e8d62473a22dec9ffef056b2017968a9dc484c8f836fb6d79f46980b309e9138 0.2s done
#4 extracting sha256:8962bc0fad55b13afedfeb6ad5cb06fd065461cf3e1ae4e7aeae5eeb17b179df
#4 sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 131.07MB / 192.35MB 5.7s
#4 extracting sha256:8962bc0fad55b13afedfeb6ad5cb06fd065461cf3e1ae4e7aeae5eeb17b179df 0.2s done
#4 extracting sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9
#4 sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 146.80MB / 192.35MB 6.0s
#4 sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 161.48MB / 192.35MB 6.3s
#4 sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 176.16MB / 192.35MB 6.6s
#4 sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 192.35MB / 192.35MB 6.9s done
#4 extracting sha256:65d943ee54c1fa196b54ab9a6673174c66eea04cfa1a4ac5b0328b74f066a4d9 1.6s done
#4 extracting sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b
#4 extracting sha256:532f6f7237092ebd79f21ccd3cf050138b31abeed1b29bac39cfdb30786a615b 4.7s done
#4 extracting sha256:1334e0fe2851ea7f3d2509a3907312a665d7c6b085e1f0671f6cd2dcf37b82db
#4 extracting sha256:1334e0fe2851ea7f3d2509a3907312a665d7c6b085e1f0671f6cd2dcf37b82db 0.2s done
#4 DONE 12.3s

#4 [1/2] FROM docker.io/library/python:3.9@sha256:e8e000f3c551f93d7b03d241e38c1206eb8c8a1f1a6179902f74e068fc98ee59
#4 extracting sha256:062ada600c9e0239e04bfc21da3719c4d0db3276450b28c455231f416015ba9f
#4 extracting sha256:062ada600c9e0239e04bfc21da3719c4d0db3276450b28c455231f416015ba9f 0.5s done
#4 extracting sha256:aec2e3a8937195ce2863f352c687f204daf3f261310254bb290ce1e5a82ec005 0.0s done
#4 DONE 12.8s

#4 [1/2] FROM docker.io/library/python:3.9@sha256:e8e000f3c551f93d7b03d241e38c1206eb8c8a1f1a6179902f74e068fc98ee59
#4 extracting sha256:1ec7c3bcb4b287487eab99f3ce2a6932f37957d4c904430c3acd8b2687a72244 0.1s done
#4 DONE 13.0s
INFO[0018] No non-localhost DNS nameservers are left in resolv.conf. Using default external servers: [nameserver 8.8.8.8 nameserver 8.8.4.4] 
INFO[0018] IPv6 enabled; Adding default IPv6 external servers: [nameserver 2001:4860:4860::8888 nameserver 2001:4860:4860::8844] 

#5 [2/2] RUN echo hello > /hello
#5 DONE 0.2s

#6 exporting to oci image format
#6 exporting layers 0.1s done
#6 exporting manifest sha256:921e0ffdbb3f3a3516295405b2d46d6b16bcc5a299b8ce776284584b5d8a5bc7 0.0s done
#6 exporting config sha256:281d75ce26f3aa4333a38c4c34aad798b62a5ee3b475e8f233ee05134bab3d5f 0.0s done
#6 sending tarball
#6 sending tarball 1.5s done
#6 DONE 1.7s
```

## nvidia/cuda:11.3.1-devel-ubuntu20.04

```
#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 103B done
#1 DONE 0.1s

#2 [internal] load .dockerignore
#2 transferring context: 2B done
#2 DONE 0.1s

#3 [internal] load metadata for docker.io/nvidia/cuda:11.3.1-devel-ubuntu20.04
#3 DONE 2.6s

#4 [1/2] FROM docker.io/nvidia/cuda:11.3.1-devel-ubuntu20.04@sha256:1e0aaefc4922000da157cd2e23d975c15b8e29dc87a343b3d91c2393e2fc363c
#4 resolve docker.io/nvidia/cuda:11.3.1-devel-ubuntu20.04@sha256:1e0aaefc4922000da157cd2e23d975c15b8e29dc87a343b3d91c2393e2fc363c 0.0s done
#4 DONE 0.4s

#4 [1/2] FROM docker.io/nvidia/cuda:11.3.1-devel-ubuntu20.04@sha256:1e0aaefc4922000da157cd2e23d975c15b8e29dc87a343b3d91c2393e2fc363c
#4 sha256:56d4c342814717e19bc11910a9ca14fb03a70c1a43157858af4ff952531aba6b 84.83kB / 84.83kB 0.2s done
#4 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 0B / 1.22GB 0.2s
#4 sha256:26aa2a3f926e332d4c3d913ac3e6e830326e0fb586dced9d924060b323be9835 0B / 61.96kB 0.2s
#4 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 0B / 1.02GB 0.2s
#4 sha256:5489cc61b656f9678b2b4ab7959a61bfe574fc39988136ea24d0fa078b96678b 0B / 6.43kB 0.2s
#4 sha256:2442bbbb3364a992bfb76035b848ddb5319ede6d0afbdc6d8ea750340397f66e 0B / 185B 0.2s
#4 sha256:d07426e4cea449120e1e17c3a5b89268f4d40fa2bade0803b6c70d0e1c67fe30 0B / 11.32MB 0.2s
#4 sha256:c76dcc6f3afe0a60183c9148fa635f30351717b39022bea8b5b39b690d391b12 0B / 7.93MB 0.2s
#4 sha256:5e9250ddb7d0fa6d13302c7c3e6a0aa40390e42424caed1e5289077ee4054709 0B / 187B 0.2s
#4 sha256:57671312ef6fdbecf340e5fed0fb0863350cd806c92b1fdd7978adbd02afc5c3 0B / 851B 0.2s
#4 sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 0B / 28.54MB 0.2s
#4 sha256:26aa2a3f926e332d4c3d913ac3e6e830326e0fb586dced9d924060b323be9835 61.96kB / 61.96kB 0.6s done
#4 sha256:2442bbbb3364a992bfb76035b848ddb5319ede6d0afbdc6d8ea750340397f66e 185B / 185B 0.7s done
#4 sha256:5489cc61b656f9678b2b4ab7959a61bfe574fc39988136ea24d0fa078b96678b 6.43kB / 6.43kB 0.8s done
#4 sha256:5e9250ddb7d0fa6d13302c7c3e6a0aa40390e42424caed1e5289077ee4054709 187B / 187B 0.8s done
#4 sha256:57671312ef6fdbecf340e5fed0fb0863350cd806c92b1fdd7978adbd02afc5c3 851B / 851B 0.8s done
#4 sha256:d07426e4cea449120e1e17c3a5b89268f4d40fa2bade0803b6c70d0e1c67fe30 1.05MB / 11.32MB 0.9s
#4 sha256:d07426e4cea449120e1e17c3a5b89268f4d40fa2bade0803b6c70d0e1c67fe30 3.15MB / 11.32MB 1.1s
#4 sha256:d07426e4cea449120e1e17c3a5b89268f4d40fa2bade0803b6c70d0e1c67fe30 5.24MB / 11.32MB 1.2s
#4 sha256:c76dcc6f3afe0a60183c9148fa635f30351717b39022bea8b5b39b690d391b12 1.05MB / 7.93MB 1.2s
#4 sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 3.15MB / 28.54MB 1.2s
#4 sha256:d07426e4cea449120e1e17c3a5b89268f4d40fa2bade0803b6c70d0e1c67fe30 6.29MB / 11.32MB 1.4s
#4 sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 5.24MB / 28.54MB 1.4s
#4 sha256:d07426e4cea449120e1e17c3a5b89268f4d40fa2bade0803b6c70d0e1c67fe30 8.39MB / 11.32MB 1.5s
#4 sha256:c76dcc6f3afe0a60183c9148fa635f30351717b39022bea8b5b39b690d391b12 2.10MB / 7.93MB 1.5s
#4 sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 8.39MB / 28.54MB 1.5s
#4 sha256:d07426e4cea449120e1e17c3a5b89268f4d40fa2bade0803b6c70d0e1c67fe30 9.44MB / 11.32MB 1.7s
#4 sha256:c76dcc6f3afe0a60183c9148fa635f30351717b39022bea8b5b39b690d391b12 3.15MB / 7.93MB 1.7s
#4 sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 10.49MB / 28.54MB 1.7s
#4 sha256:d07426e4cea449120e1e17c3a5b89268f4d40fa2bade0803b6c70d0e1c67fe30 11.32MB / 11.32MB 1.8s done
#4 sha256:c76dcc6f3afe0a60183c9148fa635f30351717b39022bea8b5b39b690d391b12 4.19MB / 7.93MB 1.8s
#4 sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 14.68MB / 28.54MB 1.8s
#4 sha256:c76dcc6f3afe0a60183c9148fa635f30351717b39022bea8b5b39b690d391b12 5.24MB / 7.93MB 2.0s
#4 sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 17.83MB / 28.54MB 2.0s
#4 sha256:c76dcc6f3afe0a60183c9148fa635f30351717b39022bea8b5b39b690d391b12 6.29MB / 7.93MB 2.1s
#4 sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 22.02MB / 28.54MB 2.1s
#4 sha256:c76dcc6f3afe0a60183c9148fa635f30351717b39022bea8b5b39b690d391b12 7.93MB / 7.93MB 2.2s done
#4 sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 28.54MB / 28.54MB 2.3s done
#4 extracting sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe
#4 extracting sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe 0.8s done
#4 extracting sha256:57671312ef6fdbecf340e5fed0fb0863350cd806c92b1fdd7978adbd02afc5c3 0.0s done
#4 extracting sha256:5e9250ddb7d0fa6d13302c7c3e6a0aa40390e42424caed1e5289077ee4054709 0.0s done
#4 extracting sha256:c76dcc6f3afe0a60183c9148fa635f30351717b39022bea8b5b39b690d391b12
#4 extracting sha256:c76dcc6f3afe0a60183c9148fa635f30351717b39022bea8b5b39b690d391b12 0.2s done
#4 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 63.96MB / 1.22GB 3.6s
#4 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 51.38MB / 1.02GB 3.6s
#4 extracting sha256:d07426e4cea449120e1e17c3a5b89268f4d40fa2bade0803b6c70d0e1c67fe30
#4 extracting sha256:d07426e4cea449120e1e17c3a5b89268f4d40fa2bade0803b6c70d0e1c67fe30 0.3s done
#4 extracting sha256:2442bbbb3364a992bfb76035b848ddb5319ede6d0afbdc6d8ea750340397f66e 0.0s done
#4 extracting sha256:5489cc61b656f9678b2b4ab7959a61bfe574fc39988136ea24d0fa078b96678b 0.0s done
#4 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 108.00MB / 1.02GB 5.4s
#4 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 125.83MB / 1.22GB 6.8s
#4 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 161.48MB / 1.02GB 7.5s
#4 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 190.84MB / 1.22GB 8.7s
#4 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 212.86MB / 1.02GB 10.1s
#4 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 252.71MB / 1.22GB 11.4s
#4 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 265.29MB / 1.02GB 12.0s
#4 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 317.72MB / 1.22GB 13.7s
#4 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 317.72MB / 1.02GB 14.9s
#4 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 380.63MB / 1.22GB 15.8s
#4 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 442.50MB / 1.22GB 17.6s
#4 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 372.24MB / 1.02GB 17.7s
#4 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 508.56MB / 1.22GB 20.0s
#4 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 427.82MB / 1.02GB 20.1s
#4 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 481.30MB / 1.02GB 21.8s
#4 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 572.52MB / 1.22GB 23.0s
#4 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 534.79MB / 1.02GB 23.7s
#4 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 586.15MB / 1.02GB 25.2s
#4 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 636.49MB / 1.22GB 26.4s
#4 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 637.53MB / 1.02GB 26.6s
#4 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 691.01MB / 1.02GB 28.2s
#4 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 699.40MB / 1.22GB 29.4s
#4 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 745.54MB / 1.02GB 30.0s
#4 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 800.06MB / 1.02GB 31.7s
#4 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 766.51MB / 1.22GB 32.6s
#4 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 852.49MB / 1.02GB 33.8s
#4 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 834.67MB / 1.22GB 35.0s
#4 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 903.87MB / 1.02GB 35.6s
#4 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 956.30MB / 1.02GB 37.2s
#4 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 896.53MB / 1.22GB 37.8s
#4 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 1.01GB / 1.02GB 39.3s
#4 sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 1.02GB / 1.02GB 39.6s done
#4 extracting sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928
#4 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 959.45MB / 1.22GB 40.2s
#4 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 1.02GB / 1.22GB 41.6s
#4 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 1.09GB / 1.22GB 43.1s
#4 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 1.15GB / 1.22GB 44.9s
#4 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 1.22GB / 1.22GB 46.5s
#4 sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 1.22GB / 1.22GB 46.5s done
#4 extracting sha256:e000561f354f29180ccdceadaca269fa884f5cc764131fd7b69cab3a2c777928 19.5s done
#4 extracting sha256:26aa2a3f926e332d4c3d913ac3e6e830326e0fb586dced9d924060b323be9835 0.0s done
#4 DONE 59.3s

#4 [1/2] FROM docker.io/nvidia/cuda:11.3.1-devel-ubuntu20.04@sha256:1e0aaefc4922000da157cd2e23d975c15b8e29dc87a343b3d91c2393e2fc363c
#4 extracting sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9
INFO[0088] No non-localhost DNS nameservers are left in resolv.conf. Using default external servers: [nameserver 8.8.8.8 nameserver 8.8.4.4] 
INFO[0088] IPv6 enabled; Adding default IPv6 external servers: [nameserver 2001:4860:4860::8888 nameserver 2001:4860:4860::8844] 
#4 extracting sha256:6661fa7c07f196dbbda39c359466ad275984b434fff6f80a8cdd75cfba0e06e9 24.6s done
#4 extracting sha256:56d4c342814717e19bc11910a9ca14fb03a70c1a43157858af4ff952531aba6b 0.0s done
#4 DONE 83.9s

#5 [2/2] RUN echo hello > /hello
#5 DONE 0.3s

#6 exporting to oci image format
#6 exporting layers 0.1s done
#6 exporting manifest sha256:89d4325e58a83b0a79c9369c9906c706960bda7cb67fafa8691e82c334083b6b 0.0s done
#6 exporting config sha256:308c3767b2d2eb9beb88f6e827463cdd6990c03bf59e40bd03ebc24cea7dff53 0.0s done
#6 sending tarball
#6 sending tarball 12.9s done
#6 DONE 13.0s
```

</details>