### PR TITLE
Avoid nil pointer dereference when copying from image with no layers

### DIFF
--- a/solver/llbsolver/result.go
+++ b/solver/llbsolver/result.go
@@ -44,6 +44,9 @@ func NewContentHashFunc(selectors []Selector) solver.ResultBasedCacheFunc {
 		if !ok {
 			return "", errors.Errorf("invalid reference: %T", res)
 		}
+		if ref.ImmutableRef == nil {
+			return "", errors.Errorf("cannot checksum empty reference")
+		}
 
 		if len(selectors) == 0 {
 			selectors = []Selector{{}}


### PR DESCRIPTION
Currently BuildKit panics when copying from an image with no layers:
```sh
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0xdd8c17]

goroutine 326 [running]:
github.com/moby/buildkit/cache/contenthash.(*cacheManager).Checksum(0xc0005ec030, 0x1682c00, 0xc000842140, 0x0, 0x0, 0xc0005d4023, 0x1, 0x0, 0x0, 0x0, ...)
	/src/cache/contenthash/checksum.go:95 +0x37
github.com/moby/buildkit/cache/contenthash.Checksum(0x1682c00, 0xc000842140, 0x0, 0x0, 0xc0005d4023, 0x1, 0x0, 0x0, 0x0, 0x0, ...)
	/src/cache/contenthash/checksum.go:59 +0xd5
github.com/moby/buildkit/solver/llbsolver.NewContentHashFunc.func1.1(0x0, 0x4425d6)
	/src/solver/llbsolver/result.go:59 +0x20a
golang.org/x/sync/errgroup.(*Group).Go.func1(0xc00056a360, 0xc000594510)
	/src/vendor/golang.org/x/sync/errgroup/errgroup.go:57 +0x59
created by golang.org/x/sync/errgroup.(*Group).Go
	/src/vendor/golang.org/x/sync/errgroup/errgroup.go:54 +0x66
```

We can further improve it by allowing it if the selector path is `/` in which case it is effectively a no-op.