### PR TITLE
Dockerfile: remove nsswitch as default in go1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,12 +116,8 @@ FROM scratch AS release
 COPY --from=releaser /out/ /
 
 FROM alpine:${ALPINE_VERSION} AS buildkit-export
-# nsswitch.conf needs to be present to work around
-#   https://github.com/golang/go/issues/35305
-# drop this once we start building with Go 1.16
 RUN apk add --no-cache fuse3 git openssh pigz xz \
-  && ln -s fusermount3 /usr/bin/fusermount \
-  && echo "hosts: files dns" >/etc/nsswitch.conf
+  && ln -s fusermount3 /usr/bin/fusermount
 COPY examples/buildctl-daemonless/buildctl-daemonless.sh /usr/bin/
 VOLUME /var/lib/buildkit
 
@@ -287,15 +283,11 @@ COPY --from=idmap /usr/bin/newuidmap /usr/bin/newuidmap
 COPY --from=idmap /usr/bin/newgidmap /usr/bin/newgidmap
 COPY --from=fuse-overlayfs /out/fuse-overlayfs /usr/bin/
 # we could just set CAP_SETUID filecap rather than `chmod u+s`, but requires kernel >= 4.14
-# nsswitch.conf needs to be present to work around
-#   https://github.com/golang/go/issues/35305
-# drop this once we start building with Go 1.16
 RUN chmod u+s /usr/bin/newuidmap /usr/bin/newgidmap \
   && adduser -D -u 1000 user \
   && mkdir -p /run/user/1000 /home/user/.local/tmp /home/user/.local/share/buildkit \
   && chown -R user /run/user/1000 /home/user \
-  && echo user:100000:65536 | tee /etc/subuid | tee /etc/subgid \
-  && echo "hosts: files dns" >/etc/nsswitch.conf
+  && echo user:100000:65536 | tee /etc/subuid | tee /etc/subgid
 COPY --from=rootlesskit /rootlesskit /usr/bin/
 COPY --from=binaries / /usr/bin/
 COPY examples/buildctl-daemonless/buildctl-daemonless.sh /usr/bin/

--- a/util/resolver/retryhandler/retry.go
+++ b/util/resolver/retryhandler/retry.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"strings"
 	"syscall"
 	"time"
 
@@ -57,7 +56,7 @@ func retryError(err error) bool {
 		return true
 	}
 
-	if errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) {
+	if errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) || errors.Is(err, net.ErrClosed) {
 		return true
 	}
 	// catches TLS timeout or other network-related temporary errors
@@ -66,11 +65,6 @@ func retryError(err error) bool {
 	}
 	// https://github.com/containerd/containerd/pull/4724
 	if errors.Cause(err).Error() == "no response" {
-		return true
-	}
-
-	// net.ErrClosed exposed in go1.16
-	if strings.Contains(err.Error(), "use of closed network connection") {
 		return true
 	}
 


### PR DESCRIPTION
Remove workarounds that were needed before go1.16