### PR TITLE
flightcontrol: reduce contention between goroutines

### DIFF
--- a/util/flightcontrol/flightcontrol.go
+++ b/util/flightcontrol/flightcontrol.go
@@ -39,7 +39,7 @@ func (g *Group) Do(ctx context.Context, key string, fn func(ctx context.Context)
 			return v, err
 		}
 		// backoff logic
-		if backoff >= 3*time.Second {
+		if backoff >= 15*time.Second {
 			err = errors.Wrapf(errRetryTimeout, "flightcontrol")
 			return v, err
 		}
@@ -132,8 +132,16 @@ func (c *call) wait(ctx context.Context) (v interface{}, err error) {
 	select {
 	case <-c.ready:
 		c.mu.Unlock()
-		<-c.cleaned
-		return nil, errRetry
+		if c.err != nil { // on error retry
+			<-c.cleaned
+			return nil, errRetry
+		}
+		pw, ok, _ := progress.FromContext(ctx)
+		if ok {
+			c.progressState.add(pw)
+		}
+		return c.result, nil
+
 	case <-c.ctx.done: // could return if no error
 		c.mu.Unlock()
 		<-c.cleaned


### PR DESCRIPTION
Avoid contention between a lot of calls coming in with the same key. This should reduce/remove to occasional timeout error that still pop up sometimes. It's possible go1.16 update changed the timings to make timeout errors more likely.

I've changed the retry logic for the default path. The timing is changed a bit and you can get a response even if the shared function already just completed but I don't think this is visible for the caller side.

Also increased timeout(now only for error/cancel cases) because there has been no indication of a deadlock.

As follow-ups, I wonder if randomizing the backoff could help a bit. Maybe timeouts sometimes appear because competing goroutines get the same backoff and then compete again. Would really like to completely remove timeout as time-based checks can always have problems if the machine is under massive load but couldn't find a clear solution yet.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>