### PR TITLE
Avoid nil pointer dereference when copying from image with no layers

### DIFF
--- a/cache/contenthash/checksum.go
+++ b/cache/contenthash/checksum.go
@@ -95,7 +95,7 @@ func (cm *cacheManager) Checksum(ctx context.Context, ref cache.ImmutableRef, p 
 		if p == "/" {
 			return digest.FromBytes(nil), nil
 		}
-		return "", errors.Errorf("cannot checksum empty reference")
+		return "", errors.Errorf("%s: no such file or directory", p)
 	}
 	cc, err := cm.GetCacheContext(ctx, ensureOriginMetadata(ref.Metadata()), ref.IdentityMapping())
 	if err != nil {

--- a/cache/contenthash/checksum.go
+++ b/cache/contenthash/checksum.go
@@ -91,6 +91,12 @@ type cacheManager struct {
 }
 
 func (cm *cacheManager) Checksum(ctx context.Context, ref cache.ImmutableRef, p string, opts ChecksumOpts, s session.Group) (digest.Digest, error) {
+	if ref == nil {
+		if p == "/" {
+			return digest.FromBytes(nil), nil
+		}
+		return "", errors.Errorf("cannot checksum empty reference")
+	}
 	cc, err := cm.GetCacheContext(ctx, ensureOriginMetadata(ref.Metadata()), ref.IdentityMapping())
 	if err != nil {
 		return "", nil

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2965,6 +2965,17 @@ func testCopyFromScratch(t *testing.T, sb integration.Sandbox) {
 	_, err = c.Solve(sb.Context(), def, SolveOpt{}, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "/foo: no such file or directory")
+
+	busybox := llb.Image("busybox:latest")
+
+	out := busybox.Run(llb.Shlex(`sh -e -c '[ $(ls /scratch | wc -l) = '0' ]'`))
+	out.AddMount("/scratch", llb.Scratch(), llb.Readonly)
+
+	def, err = out.Marshal(sb.Context())
+	require.NoError(t, err)
+
+	_, err = c.Solve(sb.Context(), def, SolveOpt{}, nil)
+	require.NoError(t, err)
 }
 
 // containerd/containerd#2119

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -66,7 +66,9 @@ type nopWriteCloser struct {
 func (nopWriteCloser) Close() error { return nil }
 
 func TestIntegration(t *testing.T) {
-	mirrors := integration.WithMirroredImages(integration.OfficialImages("busybox:latest", "alpine:latest"))
+	mirroredImages := integration.OfficialImages("busybox:latest", "alpine:latest")
+	mirroredImages["tonistiigi/test:nolayers"] = "docker.io/tonistiigi/test:nolayers"
+	mirrors := integration.WithMirroredImages(mirroredImages)
 
 	integration.Run(t, []integration.Test{
 		testCacheExportCacheKeyLoop,
@@ -93,7 +95,7 @@ func TestIntegration(t *testing.T) {
 		testBasicRegistryCacheImportExport,
 		testBasicLocalCacheImportExport,
 		testCachedMounts,
-		testCopyFromScratch,
+		testCopyFromEmptyImage,
 		testProxyEnv,
 		testLocalSymlinkEscape,
 		testTmpfsMounts,
@@ -2945,37 +2947,39 @@ func testCacheMountNoCache(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 }
 
-func testCopyFromScratch(t *testing.T, sb integration.Sandbox) {
+func testCopyFromEmptyImage(t *testing.T, sb integration.Sandbox) {
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
 
-	st := llb.Scratch().File(llb.Copy(llb.Scratch(), "/", "/"))
-	def, err := st.Marshal(sb.Context())
-	require.NoError(t, err)
+	for _, image := range []llb.State{llb.Scratch(), llb.Image("tonistiigi/test:nolayers")} {
+		st := llb.Scratch().File(llb.Copy(image, "/", "/"))
+		def, err := st.Marshal(sb.Context())
+		require.NoError(t, err)
 
-	_, err = c.Solve(sb.Context(), def, SolveOpt{}, nil)
-	require.NoError(t, err)
+		_, err = c.Solve(sb.Context(), def, SolveOpt{}, nil)
+		require.NoError(t, err)
 
-	st = llb.Scratch().File(llb.Copy(llb.Scratch(), "/foo", "/"))
-	def, err = st.Marshal(sb.Context())
-	require.NoError(t, err)
+		st = llb.Scratch().File(llb.Copy(image, "/foo", "/"))
+		def, err = st.Marshal(sb.Context())
+		require.NoError(t, err)
 
-	_, err = c.Solve(sb.Context(), def, SolveOpt{}, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "/foo: no such file or directory")
+		_, err = c.Solve(sb.Context(), def, SolveOpt{}, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "/foo: no such file or directory")
 
-	busybox := llb.Image("busybox:latest")
+		busybox := llb.Image("busybox:latest")
 
-	out := busybox.Run(llb.Shlex(`sh -e -c '[ $(ls /scratch | wc -l) = '0' ]'`))
-	out.AddMount("/scratch", llb.Scratch(), llb.Readonly)
+		out := busybox.Run(llb.Shlex(`sh -e -c '[ $(ls /scratch | wc -l) = '0' ]'`))
+		out.AddMount("/scratch", image, llb.Readonly)
 
-	def, err = out.Marshal(sb.Context())
-	require.NoError(t, err)
+		def, err = out.Marshal(sb.Context())
+		require.NoError(t, err)
 
-	_, err = c.Solve(sb.Context(), def, SolveOpt{}, nil)
-	require.NoError(t, err)
+		_, err = c.Solve(sb.Context(), def, SolveOpt{}, nil)
+		require.NoError(t, err)
+	}
 }
 
 // containerd/containerd#2119


### PR DESCRIPTION
Fix this panic when copying from an image with no layers:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0xdd8c17]

goroutine 326 [running]:
github.com/moby/buildkit/cache/contenthash.(*cacheManager).Checksum(0xc0005ec030, 0x1682c00, 0xc000842140, 0x0, 0x0, 0xc0005d4023, 0x1, 0x0, 0x0, 0x0, ...)
	/src/cache/contenthash/checksum.go:95 +0x37
github.com/moby/buildkit/cache/contenthash.Checksum(0x1682c00, 0xc000842140, 0x0, 0x0, 0xc0005d4023, 0x1, 0x0, 0x0, 0x0, 0x0, ...)
	/src/cache/contenthash/checksum.go:59 +0xd5
github.com/moby/buildkit/solver/llbsolver.NewContentHashFunc.func1.1(0x0, 0x4425d6)
	/src/solver/llbsolver/result.go:59 +0x20a
golang.org/x/sync/errgroup.(*Group).Go.func1(0xc00056a360, 0xc000594510)
	/src/vendor/golang.org/x/sync/errgroup/errgroup.go:57 +0x59
created by golang.org/x/sync/errgroup.(*Group).Go
	/src/vendor/golang.org/x/sync/errgroup/errgroup.go:54 +0x66
```

When the path is "/", we allow it because it's a noop.

Based on https://github.com/moby/buildkit/pull/2185

Signed-off-by: Aaron Lehmann <alehmann@netflix.com>