### PR TITLE
Explicitly disable shell prefix for shebang heredocs

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -680,6 +680,12 @@ func dispatchRun(d *dispatchState, c *instructions.RunCommand, proxy *llb.ProxyE
 				opt = append(opt, mount)
 
 				args[0] = path.Join(destPath, f)
+
+				// Explicitly disable the shell, since it's not required for
+				// running a shebang-script. Not using shell functionality for
+				// this also allows this to work with non-standard shells (or
+				// even no shell at all).
+				c.PrependShell = false
 			} else {
 				// Just a simple heredoc, so just run the contents in the
 				// shell: this creates the effect of a "fake"-heredoc, so that


### PR DESCRIPTION
Following up to fix #2168, to disable an unnecessary shell invocation with shebang heredocs.

A small patch, but I've added some inline documentation to describe the exact behavior, since it may look a little odd without context.

Essentially:
- Remove the shell (it's not required to achieve the functionality we want)
- Opens the possibility for users to use shebang heredocs with non-standard shells