### PR TITLE
Add support for heredocs in the ONBUILD command

### DIFF
--- a/frontend/dockerfile/instructions/parse.go
+++ b/frontend/dockerfile/instructions/parse.go
@@ -381,11 +381,14 @@ func parseOnBuild(req parseRequest) (*OnbuildCommand, error) {
 	}
 
 	original := regexp.MustCompile(`(?i)^\s*ONBUILD\s*`).ReplaceAllString(req.original, "")
+	for _, heredoc := range req.heredocs {
+		original += "\n" + heredoc.Content + heredoc.Name
+	}
+
 	return &OnbuildCommand{
 		Expression:      original,
 		withNameAndCode: newWithNameAndCode(req),
 	}, nil
-
 }
 
 func parseWorkdir(req parseRequest) (*WorkdirCommand, error) {

--- a/frontend/dockerfile/parser/parser_heredoc.go
+++ b/frontend/dockerfile/parser/parser_heredoc.go
@@ -10,4 +10,8 @@ func init() {
 		command.Copy: true,
 		command.Run:  true,
 	}
+
+	heredocCompoundDirectives = map[string]bool{
+		command.Onbuild: true,
+	}
 }


### PR DESCRIPTION
This start to address some of #2170, extending heredoc support into the `ONBUILD` command. This pretty much just lets heredocs work exactly as expected when combined with `ONBUILD`.

```dockerfile
ONBUILD RUN <<EOF
echo "thing to do as on-build trigger"
EOF
```

With this structure, it should be possible to extend this in the future to `HEALTHCHECK`, however, we'd need some support for heredocs in `CMD` (which I think works nicer in a separate PR, since it's actually unrelated to this).