### PR TITLE
Improve heredoc parsing to allow more generic shell-words

### DIFF
--- a/frontend/dockerfile/parser/parser_heredoc_test.go
+++ b/frontend/dockerfile/parser/parser_heredoc_test.go
@@ -77,6 +77,33 @@ Y
 X
 X
 Y
+
+RUN <<COMPLEX python3
+print('hello world')
+COMPLEX
+
+COPY <<file.txt /dest
+hello world
+file.txt
+
+RUN <<eo'f'
+echo foo
+eof
+
+RUN <<eo\'f
+echo foo
+eo'f
+
+RUN <<'e'o\'f
+echo foo
+eo'f
+
+RUN <<'one two'
+echo bar
+one two
+
+RUN <<$EOF
+$EOF
 	`)
 
 	tests := [][]Heredoc{
@@ -196,6 +223,62 @@ Y
 				Expand:  true,
 			},
 		},
+		{
+			// RUN <<COMPLEX python3
+			{
+				Name:    "COMPLEX",
+				Content: "print('hello world')\n",
+				Expand:  true,
+			},
+		},
+		{
+			// COPY <<file.txt /dest
+			{
+				Name:    "file.txt",
+				Content: "hello world\n",
+				Expand:  true,
+			},
+		},
+		{
+			// RUN <<eo'f'
+			{
+				Name:    "eof",
+				Content: "echo foo\n",
+				Expand:  false,
+			},
+		},
+		{
+			// RUN <<eo\'f
+			{
+				Name:    "eo'f",
+				Content: "echo foo\n",
+				Expand:  true,
+			},
+		},
+		{
+			// RUN <<'e'o\'f
+			{
+				Name:    "eo'f",
+				Content: "echo foo\n",
+				Expand:  false,
+			},
+		},
+		{
+			// RUN <<'one two'
+			{
+				Name:    "one two",
+				Content: "echo bar\n",
+				Expand:  false,
+			},
+		},
+		{
+			// RUN <<$EOF
+			{
+				Name:    "$EOF",
+				Content: "",
+				Expand:  true,
+			},
+		},
 	}
 
 	result, err := Parse(dockerfile)
@@ -238,6 +321,7 @@ func TestParseHeredocHelpers(t *testing.T) {
 		"<<-EOF",
 		"<<-'EOF'",
 		`<<-"EOF"`,
+		`<<EO"F"`,
 	}
 	invalidHeredocs := []string{
 		"<<'EOF",
@@ -252,6 +336,7 @@ func TestParseHeredocHelpers(t *testing.T) {
 		"<<-",
 		"<EOF",
 		"<<<EOF",
+		"<<EOF sh",
 	}
 	for _, src := range notHeredocs {
 		heredoc, err := ParseHeredoc(src)

--- a/frontend/dockerfile/shell/lex.go
+++ b/frontend/dockerfile/shell/lex.go
@@ -20,6 +20,7 @@ import (
 type Lex struct {
 	escapeToken  rune
 	RawQuotes    bool
+	RawEscapes   bool
 	SkipUnsetEnv bool
 }
 
@@ -65,6 +66,7 @@ func (s *Lex) process(word string, env map[string]string) (string, []string, err
 		escapeToken:  s.escapeToken,
 		skipUnsetEnv: s.SkipUnsetEnv,
 		rawQuotes:    s.RawQuotes,
+		rawEscapes:   s.RawEscapes,
 	}
 	sw.scanner.Init(strings.NewReader(word))
 	return sw.process(word)
@@ -75,6 +77,7 @@ type shellWord struct {
 	envs         map[string]string
 	escapeToken  rune
 	rawQuotes    bool
+	rawEscapes   bool
 	skipUnsetEnv bool
 }
 
@@ -168,6 +171,10 @@ func (sw *shellWord) processStopOn(stopChar rune) (string, []string, error) {
 			ch = sw.scanner.Next()
 
 			if ch == sw.escapeToken {
+				if sw.rawEscapes {
+					words.addRawChar(ch)
+				}
+
 				// '\' (default escape token, but ` allowed) escapes, except end of line
 				ch = sw.scanner.Next()
 
@@ -260,6 +267,10 @@ func (sw *shellWord) processDoubleQuote() (string, error) {
 		default:
 			ch := sw.scanner.Next()
 			if ch == sw.escapeToken {
+				if sw.rawEscapes {
+					result.WriteRune(ch)
+				}
+
 				switch sw.scanner.Peek() {
 				case scanner.EOF:
 					// Ignore \ at end of word


### PR DESCRIPTION
Previously, heredoc names have been restricted to simple alphanumeric strings. However, heredocs should support much more complex use-cases, including quoting anywhere, as well as allowing special symbols like `.` for easily expressing file extensions.

This patch adds support for these more complex cases, by using the shell lexer to parse each heredoc name. Additionally, we include improvements to the lexer to optionally preserve escape tokens to avoid problems when lexing words that have already been lexed before.

Not quite sure how I missed this before in the first iteration, since all shells support some really complex word rules for the naming of heredocs, but now there's some tests to catch these weirder cases. The main one of use is doing something like `COPY <<file.txt /` which wasn't possible before (because `.` wouldn't count as part of the heredoc name).