### PR TITLE
progressui: print logs for failed step as summary in plain mode

### DIFF
--- a/util/progress/progressui/display.go
+++ b/util/progress/progressui/display.go
@@ -2,6 +2,7 @@ package progressui
 
 import (
 	"bytes"
+	"container/ring"
 	"context"
 	"fmt"
 	"io"
@@ -130,6 +131,7 @@ type vertex struct {
 	logs          [][]byte
 	logsPartial   bool
 	logsOffset    int
+	logsBuffer    *ring.Ring // stores last logs to print them on error
 	prev          *client.Vertex
 	events        []string
 	lastBlockTime *time.Time
@@ -295,9 +297,19 @@ func (t *trace) printErrorLogs(f io.Writer) {
 		if v.Error != "" && !strings.HasSuffix(v.Error, context.Canceled.Error()) {
 			fmt.Fprintln(f, "------")
 			fmt.Fprintf(f, " > %s:\n", v.Name)
+			// tty keeps original logs
 			for _, l := range v.logs {
 				f.Write(l)
 				fmt.Fprintln(f)
+			}
+			// printer keeps last logs buffer
+			if v.logsBuffer != nil {
+				for i := 0; i < v.logsBuffer.Len(); i++ {
+					if v.logsBuffer.Value != nil {
+						fmt.Fprintln(f, string(v.logsBuffer.Value.([]byte)))
+					}
+					v.logsBuffer = v.logsBuffer.Next()
+				}
 			}
 			fmt.Fprintln(f, "------")
 		}


### PR DESCRIPTION
On "plain" progress mode logs are printed as they appear. That means that when error happens the stderr of the process containing helpful logs might have been already printed before and the user would need to scroll up from the error to find this.  This adds a buffer that keeps last logs for all vertexes, if an error happens that buffer is printed out in the error summary so it always appears in the end of the build.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>