### PR TITLE
Improve build errors and remove useless grpc prefix

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -677,7 +677,7 @@ func testSecurityModeSysfs(t *testing.T, sb integration.Sandbox) {
 
 	if secMode == securitySandbox {
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "executor failed running")
+		require.Contains(t, err.Error(), "did not complete successfully")
 		require.Contains(t, err.Error(), "mkdir /sys/fs/cgroup/cpuset/securitytest")
 	} else {
 		require.NoError(t, err)
@@ -3190,7 +3190,7 @@ func testReadonlyRootFS(t *testing.T, sb integration.Sandbox) {
 	// Would prefer to detect more specifically "Read-only file
 	// system" but that isn't exposed here (it is on the stdio
 	// which we don't see).
-	require.Contains(t, err.Error(), "executor failed running [/bin/touch /foo]:")
+	require.Contains(t, err.Error(), "process \"/bin/touch /foo\" did not complete successfully")
 
 	checkAllReleasable(t, c, sb, true)
 }

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -2149,7 +2149,7 @@ func testDockerfileInvalidCommand(t *testing.T, sb integration.Sandbox) {
 	err = cmd.Run()
 	require.Error(t, err)
 	require.Contains(t, stdout.String(), "/bin/sh -c invalidcmd")
-	require.Contains(t, stdout.String(), "executor failed running")
+	require.Contains(t, stdout.String(), "did not complete successfully")
 }
 
 func testDockerfileADDFromURL(t *testing.T, sb integration.Sandbox) {

--- a/solver/llbsolver/ops/exec.go
+++ b/solver/llbsolver/ops/exec.go
@@ -354,7 +354,7 @@ func (e *execOp) Exec(ctx context.Context, g session.Group, inputs []solver.Resu
 		// Prevent the result from being released.
 		p.OutputRefs[i].Ref = nil
 	}
-	return results, errors.Wrapf(execErr, "executor failed running %v", e.op.Meta.Args)
+	return results, errors.Wrapf(execErr, "process %q did not complete successfully", strings.Join(e.op.Meta.Args, " "))
 }
 
 func proxyEnvList(p *pb.ProxyEnv) []string {

--- a/util/grpcerrors/grpcerrors.go
+++ b/util/grpcerrors/grpcerrors.go
@@ -169,7 +169,7 @@ func FromGRPC(err error) error {
 		}
 	}
 
-	err = status.FromProto(n).Err()
+	err = &grpcStatusErr{st: status.FromProto(n)}
 
 	for _, s := range stacks {
 		if s != nil {
@@ -186,6 +186,21 @@ func FromGRPC(err error) error {
 	}
 
 	return stack.Enable(err)
+}
+
+type grpcStatusErr struct {
+	st *status.Status
+}
+
+func (e *grpcStatusErr) Error() string {
+	if e.st.Code() == codes.OK || e.st.Code() == codes.Unknown {
+		return e.st.Message()
+	}
+	return e.st.Code().String() + ": " + e.st.Message()
+}
+
+func (e *grpcStatusErr) GRPCStatus() *status.Status {
+	return e.st
 }
 
 type withCode struct {


### PR DESCRIPTION
Before:

```
------
 > [st3 2/2] RUN sleep 1 && echo foobar && exit 1:
------
Dockerfile:9
--------------------
   7 |     
   8 |     from alpine as st3
   9 | >>> run sleep 1 && echo foobar && exit 1
  10 |     
  11 |     from scratch
--------------------
error: failed to solve: rpc error: code = Unknown desc = executor failed running [/bin/sh -c sleep 1 && echo foobar && exit 1]: exit code: 1
```

After:

```
------
 > [st3 2/2] RUN sleep 1 && echo foobar && exit 1:
#10 2.308 foobar
------
Dockerfile:9
--------------------
   7 |     
   8 |     from alpine as st3
   9 | >>> run sleep 1 && echo foobar && exit 1
  10 |     
  11 |     from scratch
--------------------
error: failed to solve: process "/bin/sh -c sleep 1 && echo foobar && exit 1" did not complete successfully: exit code: 1
```

Expecting tests that check error strings to fail.