### PR TITLE
Fix ref leak if fileop ref fails to mount.

### DIFF
--- a/solver/llbsolver/file/refmanager.go
+++ b/solver/llbsolver/file/refmanager.go
@@ -8,6 +8,7 @@ import (
 	"github.com/moby/buildkit/snapshot"
 	"github.com/moby/buildkit/solver/llbsolver/ops/fileoptypes"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 func NewRefManager(cm cache.Manager) *RefManager {
@@ -18,7 +19,7 @@ type RefManager struct {
 	cm cache.Manager
 }
 
-func (rm *RefManager) Prepare(ctx context.Context, ref fileoptypes.Ref, readonly bool, g session.Group) (fileoptypes.Mount, error) {
+func (rm *RefManager) Prepare(ctx context.Context, ref fileoptypes.Ref, readonly bool, g session.Group) (_ fileoptypes.Mount, rerr error) {
 	ir, ok := ref.(cache.ImmutableRef)
 	if !ok && ref != nil {
 		return nil, errors.Errorf("invalid ref type: %T", ref)
@@ -36,6 +37,15 @@ func (rm *RefManager) Prepare(ctx context.Context, ref fileoptypes.Ref, readonly
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if rerr != nil {
+			cache.CachePolicyDefault(mr)
+			if err := mr.Metadata().Commit(); err != nil {
+				logrus.Errorf("failed to reset FileOp mutable ref cachepolicy: %v", err)
+			}
+			mr.Release(context.TODO())
+		}
+	}()
 	m, err := mr.Mount(ctx, readonly, g)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Erik Sipsma <erik@sipsma.dev>

Small thing but probably worth fixing. Didn't notice in real world, just while looking at the code.