### PR TITLE
cache: Refactor out cacheRecord equal* fields

### DIFF
--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -228,7 +228,7 @@ func TestManager(t *testing.T) {
 
 	_, err = cm.GetMutable(ctx, active.ID())
 	require.Error(t, err)
-	require.Equal(t, true, errors.Is(err, errNotFound))
+	require.Equal(t, true, errors.Is(err, errInvalid))
 
 	_, err = cm.GetMutable(ctx, snap.ID())
 	require.Error(t, err)
@@ -244,6 +244,8 @@ func TestManager(t *testing.T) {
 
 	err = snap.Release(ctx)
 	require.NoError(t, err)
+
+	checkDiskUsage(ctx, t, cm, 1, 0)
 
 	active2, err := cm.New(ctx, snap2, nil, CachePolicyRetain)
 	require.NoError(t, err)
@@ -822,11 +824,17 @@ func TestPrune(t *testing.T) {
 	err = snap.Release(ctx)
 	require.NoError(t, err)
 
+	checkDiskUsage(ctx, t, cm, 0, 1)
+
 	active, err = cm.New(ctx, snap, nil, CachePolicyRetain)
 	require.NoError(t, err)
 
+	checkDiskUsage(ctx, t, cm, 2, 0)
+
 	snap2, err = active.Commit(ctx)
 	require.NoError(t, err)
+
+	checkDiskUsage(ctx, t, cm, 2, 0)
 
 	err = snap.Release(ctx)
 	require.NoError(t, err)
@@ -882,6 +890,14 @@ func TestLazyCommit(t *testing.T) {
 
 	active, err := cm.New(ctx, nil, nil, CachePolicyRetain)
 	require.NoError(t, err)
+	activeID := active.ID()
+
+	err = active.Release(ctx)
+	require.NoError(t, err)
+
+	active, err = cm.GetMutable(ctx, activeID)
+	require.NoError(t, err)
+	require.Equal(t, active.ID(), activeID)
 
 	// after commit mutable is locked
 	snap, err := active.Commit(ctx)
@@ -918,9 +934,9 @@ func TestLazyCommit(t *testing.T) {
 	// after release mutable becomes available again
 	active2, err := cm.GetMutable(ctx, active.ID())
 	require.NoError(t, err)
-	require.Equal(t, active2.ID(), active.ID())
+	// ID is different now because the previous active was committed
+	require.NotEqual(t, active2.ID(), active.ID())
 
-	// because ref was took mutable old immutable are cleared
 	_, err = cm.Get(ctx, snap.ID())
 	require.Error(t, err)
 	require.Equal(t, true, errors.Is(err, errNotFound))
@@ -935,10 +951,10 @@ func TestLazyCommit(t *testing.T) {
 	err = snap.Release(ctx)
 	require.NoError(t, err)
 
-	// mutable is gone after finalize
+	// mutable is not accessible after finalize
 	_, err = cm.GetMutable(ctx, active2.ID())
 	require.Error(t, err)
-	require.Equal(t, true, errors.Is(err, errNotFound))
+	require.Equal(t, true, errors.Is(err, errInvalid))
 
 	// immutable still works
 	snap2, err = cm.Get(ctx, snap.ID())
@@ -997,21 +1013,64 @@ func TestLazyCommit(t *testing.T) {
 		snapshotterName: "native",
 	})
 	require.NoError(t, err)
-	defer cleanup()
 	cm = co.manager
 
 	snap2, err = cm.Get(ctx, snap.ID())
 	require.NoError(t, err)
+	snap2ID := snap2.ID()
 
 	err = snap2.(*immutableRef).finalizeLocked(ctx)
 	require.NoError(t, err)
+	queueDescription(snap2.Metadata(), "foo")
+	require.NoError(t, snap2.Metadata().Commit())
 
 	err = snap2.Release(ctx)
 	require.NoError(t, err)
 
 	_, err = cm.GetMutable(ctx, active.ID())
 	require.Error(t, err)
-	require.Equal(t, true, errors.Is(err, errNotFound))
+	require.Equal(t, true, errors.Is(err, errInvalid))
+
+	active, err = cm.New(ctx, nil, nil, CachePolicyRetain)
+	require.NoError(t, err)
+	snap3, err := active.Commit(ctx)
+	require.NoError(t, err)
+	snap3ID := snap3.ID()
+
+	// simulate the old equalMutable format to test that the migration logic in cacheManager.init works as expected
+	setEqualMutable(snap3.Metadata(), snap2ID)
+	require.NoError(t, snap3.Metadata().Commit())
+
+	require.NoError(t, snap3.Release(ctx))
+	checkDiskUsage(ctx, t, cm, 0, 3)
+
+	err = cm.Close()
+	require.NoError(t, err)
+	cleanup()
+
+	co, cleanup, err = newCacheManager(ctx, cmOpt{
+		tmpdir:          tmpdir,
+		snapshotter:     snapshotter,
+		snapshotterName: "native",
+	})
+	require.NoError(t, err)
+	defer cleanup()
+	cm = co.manager
+
+	// there's 1 less ref now because cacheManager.init should have gotten rid of the one marked as an equalMutable
+	checkDiskUsage(ctx, t, cm, 0, 2)
+
+	snap3, err = cm.Get(ctx, snap3ID)
+	require.NoError(t, err)
+
+	_, err = cm.Get(ctx, snap2ID)
+	require.True(t, errors.Is(err, errNotFound))
+
+	checkDiskUsage(ctx, t, cm, 1, 1)
+
+	require.Equal(t, "", getEqualMutable(snap3.Metadata()))
+	require.Equal(t, "foo", GetDescription(snap3.Metadata()))
+	require.Equal(t, snap2ID, getSnapshotID(snap3.Metadata()))
 }
 
 func TestGetRemote(t *testing.T) {
@@ -1326,4 +1385,15 @@ func fileToBlob(file *os.File, compress bool) ([]byte, ocispecs.Descriptor, erro
 			"containerd.io/uncompressed": sha.Digest().String(),
 		},
 	}, nil
+}
+
+func setEqualMutable(si *metadata.StorageItem, s string) error {
+	v, err := metadata.NewValue(s)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create %s meta value", deprecatedKeyEqualMutable)
+	}
+	si.Queue(func(b *bolt.Bucket) error {
+		return si.SetValue(b, deprecatedKeyEqualMutable, v)
+	})
+	return nil
 }

--- a/cache/metadata/metadata.go
+++ b/cache/metadata/metadata.go
@@ -398,6 +398,21 @@ func (s *StorageItem) GetAndSetValue(key string, fn func(*Value) (*Value, error)
 	})
 }
 
+func (s *StorageItem) CopyValuesTo(other *StorageItem) error {
+	s.vmu.RLock()
+	defer s.vmu.RUnlock()
+	other.vmu.Lock()
+	defer other.vmu.Unlock()
+	return errors.WithStack(other.Update(func(b *bolt.Bucket) error {
+		for k, v := range s.values {
+			if err := other.setValue(b, k, v); err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
+}
+
 type Value struct {
 	Value json.RawMessage `json:"value,omitempty"`
 	Index string          `json:"index,omitempty"`

--- a/cache/migrate_v2.go
+++ b/cache/migrate_v2.go
@@ -111,14 +111,9 @@ func MigrateV2(ctx context.Context, from, to string, cs content.Store, s snapsho
 			if err != nil {
 				return err
 			}
-			if info.Kind == snapshots.KindCommitted {
-				queueCommitted(item)
-			}
 			if info.Parent != "" {
 				queueParent(item, info.Parent)
 			}
-		} else {
-			queueCommitted(item)
 		}
 		queueSnapshotID(item, id)
 		item.Commit()
@@ -252,8 +247,8 @@ func MigrateV2(ctx context.Context, from, to string, cs content.Store, s snapsho
 	}
 
 	for _, item := range byID {
-		bklog.G(ctx).Infof("migrated %s parent:%q snapshot:%v committed:%v blob:%v diffid:%v chainID:%v blobChainID:%v",
-			item.ID(), getParent(item), getSnapshotID(item), getCommitted(item), getBlob(item), getDiffID(item), getChainID(item), getBlobChainID(item))
+		bklog.G(ctx).Infof("migrated %s parent:%q snapshot:%v blob:%v diffid:%v chainID:%v blobChainID:%v",
+			item.ID(), getParent(item), getSnapshotID(item), getBlob(item), getDiffID(item), getChainID(item), getBlobChainID(item))
 	}
 
 	return nil

--- a/source/git/gitsource.go
+++ b/source/git/gitsource.go
@@ -141,7 +141,7 @@ func (gs *gitSource) mountRemote(ctx context.Context, remote string, auth []stri
 		}
 
 		// same new remote metadata
-		si, _ := gs.md.Get(remoteRef.ID())
+		si := remoteRef.Metadata()
 		v, err := metadata.NewValue(remoteKey)
 		if err != nil {
 			return "", nil, err

--- a/source/local/local.go
+++ b/source/local/local.go
@@ -215,7 +215,7 @@ func (ls *localSourceHandler) snapshot(ctx context.Context, s session.Group, cal
 
 	// skip storing snapshot by the shared key if it already exists
 	skipStoreSharedKey := false
-	si, _ := ls.md.Get(mutable.ID())
+	si := mutable.Metadata()
 	if v := si.Get(keySharedKey); v != nil {
 		var str string
 		if err := v.Unmarshal(&str); err != nil {


### PR DESCRIPTION
The equalMutable and equalImmutable fields were used to implement the
"lazy commit" feature (not to be confused with lazy refs), which allows
refs to put off committing their snapshots to the underlying driver until
absolutely needed.

However, this way of modeling it resulted in there being 2 actual
cacheRecords even when the underlying snapshot was the same. This also
lead to a lot of convoluted logic checking for the existence of the
equal* fields.

This commits switches to a new approach of only maintaining a single
cacheRecord for what used to be separate equal* records. The cacheRecord
internally keeps track of whether it has been finalized or not and
updates which snapshot ID is underlying it.

This results in overall much simpler logic, as can be seen by looking at
the before+after of GetMutable, Commit, prune, and release, among
others. The only meaningfully-sized block of new code added is in
cacheManager.init, which handles migrating records from the old format
and can thus eventually be deleted once the older versions of buildkit
are no longer supported.

This change is backwards compatible because of that migration logic in
cacheManager.init and because MutableRefs have never been saved in the
upper-level solver cache, only ImmutableRefs are there, so removing any
refs that were marked as an equalMutable and merging them into their
equalImmutable will not result in any cache keys unexpectedly missing.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>


- [x] ~Marking this as a Draft until I've added a test for the format migration code in `cacheManager.init`~

@tonistiigi Decided to go with this refactor first because I think it improves my ability to understand the cache code and ref lifecycle management the most. I still want to address some of the other stuff we discussed (like cleaning up the metadata and extracting out snapshotter-specific code+logic from the cache code) as separate subsequent PRs, probably partially mixed in with the merge-op PRs.