### PR TITLE
Add full timestamp to logs

### DIFF
--- a/cmd/buildctl/main.go
+++ b/cmd/buildctl/main.go
@@ -99,6 +99,8 @@ func main() {
 
 	app.Before = func(context *cli.Context) error {
 		debugEnabled = context.GlobalBool("debug")
+
+		logrus.SetFormatter(&logrus.TextFormatter{FullTimestamp: true})
 		if debugEnabled {
 			logrus.SetLevel(logrus.DebugLevel)
 		}

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -211,6 +211,7 @@ func main() {
 			return err
 		}
 
+		logrus.SetFormatter(&logrus.TextFormatter{FullTimestamp: true})
 		if cfg.Debug {
 			logrus.SetLevel(logrus.DebugLevel)
 		}


### PR DESCRIPTION
Close #2026 

Add full timestamp to logs like below.
```
INFO[2021-07-06T23:53:12+09:00] auto snapshotter: using overlayfs
WARN[2021-07-06T23:53:12+09:00] using host network as the default
```

Before
```
INFO[0000] auto snapshotter: using overlayfs
WARN[0000] using host network as the default
```

This is my first PR. I'm sorry if I'm inadequate.