### PR TITLE
log should with traceID and spanID

### DIFF
--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -45,6 +45,7 @@ import (
 	"github.com/moby/buildkit/util/appdefaults"
 	"github.com/moby/buildkit/util/archutil"
 	"github.com/moby/buildkit/util/grpcerrors"
+	_ "github.com/moby/buildkit/util/log"
 	"github.com/moby/buildkit/util/profiler"
 	"github.com/moby/buildkit/util/resolver"
 	"github.com/moby/buildkit/util/stack"

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -1,0 +1,28 @@
+package log
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/log"
+	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func init() {
+	log.G = GetLogger
+}
+
+func GetLogger(ctx context.Context) *logrus.Entry {
+	l := log.GetLogger(ctx)
+
+	spanContext := trace.SpanFromContext(ctx).SpanContext()
+
+	if spanContext.IsValid() {
+		return l.WithFields(logrus.Fields{
+			"traceID": spanContext.TraceID(),
+			"spanID":  spanContext.SpanID(),
+		})
+	}
+
+	return l
+}


### PR DESCRIPTION
Set `log.G` with a `GetLogger` with Fields `traceID` and `spanID` when tracing exists.

example image `docker.io/morlay/buildkit:log-with-tracing`

logs in buidlkit will be 
![image](https://user-images.githubusercontent.com/1667873/125022977-73681900-e0b0-11eb-9d8c-1757aec65543.png)
