### PR TITLE
Fixes Windows symlinks targets

### DIFF
--- a/util/winlayers/differ.go
+++ b/util/winlayers/differ.go
@@ -242,9 +242,6 @@ func makeWindowsLayer(w io.Writer) (io.Writer, func(error), chan error) {
 					return err
 				}
 				h.Name = "Files/" + h.Name
-				if h.Linkname != "" {
-					h.Linkname = "Files/" + h.Linkname
-				}
 				prepareWinHeader(h)
 				addSecurityDescriptor(h)
 				if err := tarWriter.WriteHeader(h); err != nil {


### PR DESCRIPTION
When building with the output ``type=oci`` or ``type=registry``, for Windows symlinks, ``Files/`` is prepended to the symlink Target, which can break the symlink entirely if it's an absolute path (``C:\path\to\file`` becomes ``Files\C:\path\to\file``), and for relative paths workarounds were needed (``path\to\file`` would become ``Files\path\to\file``, and it would have worked if that path was valid).

This problem does not occur when the output type is tar.

Removes the ``Files/`` prefix from the Windows symlinks.

Fixes: https://github.com/docker/buildx/issues/373