### PR TITLE
Skips getting UID/GUID if passwd/group file is not found

### DIFF
--- a/solver/llbsolver/file/user_linux.go
+++ b/solver/llbsolver/file/user_linux.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"os"
+	"syscall"
 
 	"github.com/containerd/continuity/fs"
 	"github.com/moby/buildkit/snapshot"
@@ -45,6 +46,10 @@ func readUser(chopt *pb.ChownOpt, mu, mg fileoptypes.Mount) (*copy.User, error) 
 			}
 
 			ufile, err := os.Open(passwdPath)
+			if errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ENOTDIR) {
+				// Couldn't open the file. Considering this case as not finding the user in the file.
+				break
+			}
 			if err != nil {
 				return nil, err
 			}
@@ -95,6 +100,10 @@ func readUser(chopt *pb.ChownOpt, mu, mg fileoptypes.Mount) (*copy.User, error) 
 			}
 
 			gfile, err := os.Open(groupPath)
+			if errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ENOTDIR) {
+				// Couldn't open the file. Considering this case as not finding the group in the file.
+				break
+			}
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
When running a ``WORKDIR`` instruction, buildkit will create that folder and chown it to the currently set user. For this, it will try to read the ``/etc/passwd`` file to get the proper UID, and if that user is not found in the file, the root user will be considered as the owner.

However, Windows images do not have that file, which will result in an error while building the image. We can consider not finding
the ``/etc/passwd`` file as the same as not finding the user in the file, which would solve this issue.

Fixes: https://github.com/docker/buildx/issues/378