### PR TITLE
Add support for heredocs in CMD dockerfile commands

### DIFF
--- a/frontend/dockerfile/parser/parser.go
+++ b/frontend/dockerfile/parser/parser.go
@@ -132,6 +132,7 @@ var (
 	// Directives allowed to contain heredocs
 	heredocDirectives = map[string]bool{
 		command.Add:  true,
+		command.Cmd:  true,
 		command.Copy: true,
 		command.Run:  true,
 	}


### PR DESCRIPTION
As stated, this patch introduces allowing heredocs in the `CMD` command exactly as in the `RUN` command :tada:

I don't think this is particularly complex - although I do have one bit I'm not quite sure about. For the case of supporting shebangs, we can't have run-mounts for the `CMD`, so I've gone ahead and introduced a new copying layer in these cases (into `/mnt` though, since `/dev` isn't preserved when running). I'm happy to switch to one of the following though if that doesn't work:
- Copy the file over in a separate layer as the `CMD`
- Copy the file over in the same layer as the `CMD`
- Don't support heredoc shebangs at all in `CMD`