### PR TITLE
Fix protoc link

### DIFF
--- a/hack/dockerfiles/generated-files.Dockerfile
+++ b/hack/dockerfiles/generated-files.Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get --no-install-recommends install -y \
 ARG TARGETOS TARGETARCH
 RUN set -e; \
 	arch=$(echo $TARGETARCH | sed -e s/amd64/x86_64/ -e s/arm64/aarch_64/); \
-	wget -q https://github.com/google/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-${TARGETOS}-${arch}.zip && unzip protoc-${PROTOC_VERSION}-${TARGETOS}-${arch}.zip -d /usr/local
+	wget -q https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-${TARGETOS}-${arch}.zip && unzip protoc-${PROTOC_VERSION}-${TARGETOS}-${arch}.zip -d /usr/local
 
 RUN git clone https://github.com/gogo/protobuf.git /go/src/github.com/gogo/protobuf \
 	&& cd /go/src/github.com/gogo/protobuf \


### PR DESCRIPTION
Looks like redirection on `github.com/google/protobuf` is not working anymore and redirects to https://github.com/google/protobuf.dart which fails on CI:

```
#10 [gobuild-base 3/6] RUN set -e; 	arch=$(echo amd64 | sed -e s/amd64/x86_64/ -e s/arm64/aarch_64/); 	wget -q https://github.com/google/protobuf/releases/download/v3.11.4/protoc-3.11.4-linux-${arch}.zip && unzip protoc-3.11.4-linux-${arch}.zip -d /usr/local
#10 ERROR: process "/bin/sh -c set -e; \tarch=$(echo $TARGETARCH | sed -e s/amd64/x86_64/ -e s/arm64/aarch_64/); \twget -q https://github.com/google/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-${TARGETOS}-${arch}.zip && unzip protoc-${PROTOC_VERSION}-${TARGETOS}-${arch}.zip -d /usr/local" did not complete successfully: exit code: 8
```

Moved to https://github.com/protocolbuffers/protobuf instead.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>