### PR TITLE
Additional tests and cleanup for cache/contenthash

### DIFF
--- a/cache/contenthash/checksum.go
+++ b/cache/contenthash/checksum.go
@@ -574,7 +574,7 @@ func (cc *cacheContext) includedPaths(ctx context.Context, m *mount, p string, o
 			continue
 		}
 
-		shouldInclude, err := shouldIncludePath(p, fn, includePatternMatcher, excludePatternMatcher)
+		shouldInclude, err := shouldIncludePath(fn, includePatternMatcher, excludePatternMatcher)
 		if err != nil {
 			return nil, err
 		}
@@ -619,13 +619,12 @@ func (cc *cacheContext) includedPaths(ctx context.Context, m *mount, p string, o
 }
 
 func shouldIncludePath(
-	p string,
 	candidate string,
 	includePatternMatcher *fileutils.PatternMatcher,
 	excludePatternMatcher *fileutils.PatternMatcher,
 ) (bool, error) {
 	if includePatternMatcher != nil {
-		m, err := includePatternMatcher.Matches(filepath.FromSlash(candidate))
+		m, err := includePatternMatcher.Matches(candidate)
 		if err != nil {
 			return false, errors.Wrap(err, "failed to match includepatterns")
 		}
@@ -635,7 +634,7 @@ func shouldIncludePath(
 	}
 
 	if excludePatternMatcher != nil {
-		m, err := excludePatternMatcher.Matches(filepath.FromSlash(candidate))
+		m, err := excludePatternMatcher.Matches(candidate)
 		if err != nil {
 			return false, errors.Wrap(err, "failed to match excludepatterns")
 		}

--- a/cache/contenthash/checksum.go
+++ b/cache/contenthash/checksum.go
@@ -487,11 +487,7 @@ func (cc *cacheContext) includedPaths(ctx context.Context, m *mount, p string, o
 
 	var includePatternMatcher *fileutils.PatternMatcher
 	if len(opts.IncludePatterns) != 0 {
-		rootedIncludePatterns := make([]string, len(opts.IncludePatterns))
-		for i, includePattern := range opts.IncludePatterns {
-			rootedIncludePatterns[i] = keyPath(includePattern)
-		}
-		includePatternMatcher, err = fileutils.NewPatternMatcher(rootedIncludePatterns)
+		includePatternMatcher, err = fileutils.NewPatternMatcher(opts.IncludePatterns)
 		if err != nil {
 			return nil, errors.Wrapf(err, "invalid includepatterns: %s", opts.IncludePatterns)
 		}
@@ -499,11 +495,7 @@ func (cc *cacheContext) includedPaths(ctx context.Context, m *mount, p string, o
 
 	var excludePatternMatcher *fileutils.PatternMatcher
 	if len(opts.ExcludePatterns) != 0 {
-		rootedExcludePatterns := make([]string, len(opts.ExcludePatterns))
-		for i, excludePattern := range opts.ExcludePatterns {
-			rootedExcludePatterns[i] = keyPath(excludePattern)
-		}
-		excludePatternMatcher, err = fileutils.NewPatternMatcher(rootedExcludePatterns)
+		excludePatternMatcher, err = fileutils.NewPatternMatcher(opts.ExcludePatterns)
 		if err != nil {
 			return nil, errors.Wrapf(err, "invalid excludepatterns: %s", opts.ExcludePatterns)
 		}
@@ -557,8 +549,10 @@ func (cc *cacheContext) includedPaths(ctx context.Context, m *mount, p string, o
 				continue
 			}
 		}
+
+		var shouldInclude bool
 		if opts.Wildcard {
-			if lastMatchedDir == "" || !strings.HasPrefix(fn, lastMatchedDir+"/") {
+			if p != "" && (lastMatchedDir == "" || !strings.HasPrefix(fn, lastMatchedDir+"/")) {
 				include, err := path.Match(p, fn)
 				if err != nil {
 					return nil, err
@@ -569,15 +563,23 @@ func (cc *cacheContext) includedPaths(ctx context.Context, m *mount, p string, o
 				}
 				lastMatchedDir = fn
 			}
-		} else if !strings.HasPrefix(fn+"/", p+"/") {
-			k, _, kOk = iter.Next()
-			continue
+
+			shouldInclude, err = shouldIncludePath(strings.TrimSuffix(strings.TrimPrefix(fn+"/", lastMatchedDir+"/"), "/"), includePatternMatcher, excludePatternMatcher)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			if !strings.HasPrefix(fn+"/", p+"/") {
+				k, _, kOk = iter.Next()
+				continue
+			}
+
+			shouldInclude, err = shouldIncludePath(strings.TrimSuffix(strings.TrimPrefix(fn+"/", p+"/"), "/"), includePatternMatcher, excludePatternMatcher)
+			if err != nil {
+				return nil, err
+			}
 		}
 
-		shouldInclude, err := shouldIncludePath(fn, includePatternMatcher, excludePatternMatcher)
-		if err != nil {
-			return nil, err
-		}
 		if !shouldInclude && !dirHeader {
 			k, _, kOk = iter.Next()
 			continue

--- a/cache/contenthash/checksum_test.go
+++ b/cache/contenthash/checksum_test.go
@@ -35,6 +35,7 @@ const (
 	dgstDirD0           = digest.Digest("sha256:d47454417d2c554067fbefe5f5719edc49f3cfe969c36b62e34a187a4da0cc9a")
 	dgstDirD0FileByFile = digest.Digest("sha256:231c3293e329de47fec9e79056686477891fd1f244ed7b1c1fa668489a1f0d50")
 	dgstDirD0Modified   = digest.Digest("sha256:555ffa3028630d97ba37832b749eda85ab676fd64ffb629fbf0f4ec8c1e3bff1")
+	dgstDoubleStar      = digest.Digest("sha256:853b46abef38d02c9e29fdd1557c6002903b262541e60064bc84518d4d3a6f11")
 )
 
 func TestChecksumSymlinkNoParentScan(t *testing.T) {
@@ -538,6 +539,10 @@ func TestChecksumIncludeExclude(t *testing.T) {
 	// new file does not match the include pattern, so the digest should stay the same
 	require.Equal(t, dgstD0AStar, dgstD0AStar2)
 
+	dgstStarStarABC, err := cc.Checksum(context.TODO(), ref, "", ChecksumOpts{IncludePatterns: []string{"**/abc"}}, nil)
+	require.NoError(t, err)
+	require.Equal(t, dgstD0AStar, dgstStarStarABC)
+
 	dgstD1Star2, err := cc.Checksum(context.TODO(), ref, "", ChecksumOpts{IncludePatterns: []string{"d1/*"}}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstD1Star, dgstD1Star2)
@@ -552,6 +557,107 @@ func TestChecksumIncludeExclude(t *testing.T) {
 
 	err = ref.Release(context.TODO())
 	require.NoError(t, err)
+}
+
+func TestChecksumIncludeDoubleStar(t *testing.T) {
+	t.Parallel()
+	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpdir)
+
+	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
+	require.NoError(t, err)
+	cm, _ := setupCacheManager(t, tmpdir, "native", snapshotter)
+	defer cm.Close()
+
+	ch := []string{
+		"ADD prefix dir",
+		"ADD prefix/a dir",
+		"ADD prefix/a/b dir",
+		"ADD prefix/a/b/c dir",
+	}
+
+	ref := createRef(t, cm, ch)
+
+	cc, err := newCacheContext(ref.Metadata(), nil)
+	require.NoError(t, err)
+
+	dgst, err := cc.Checksum(context.TODO(), ref, "prefix/a", ChecksumOpts{IncludePatterns: []string{"**/foo/**"}}, nil)
+	require.NoError(t, err)
+	// Nothing included
+	require.Equal(t, digest.FromBytes([]byte{}), dgst)
+
+	// Same, with Wildcard = true
+	dgst, err = cc.Checksum(context.TODO(), ref, "prefix/a", ChecksumOpts{IncludePatterns: []string{"**/foo/**"}, Wildcard: true}, nil)
+	require.NoError(t, err)
+	require.Equal(t, digest.FromBytes([]byte{}), dgst)
+
+	ch = []string{
+		"ADD prefix dir",
+		"ADD prefix/a dir",
+		"ADD prefix/a/b dir",
+		"ADD prefix/a/b/c dir",
+		"ADD prefix/a/b/c/foo dir",
+		"ADD prefix/a/b/c/foo/bar file abc",
+	}
+
+	ref = createRef(t, cm, ch)
+
+	cc, err = newCacheContext(ref.Metadata(), nil)
+	require.NoError(t, err)
+
+	dgst, err = cc.Checksum(context.TODO(), ref, "prefix/a", ChecksumOpts{IncludePatterns: []string{"**/foo/**", "**/report"}}, nil)
+	require.NoError(t, err)
+	// Now there is a file included
+	require.Equal(t, dgstDoubleStar, dgst)
+
+	// Same, with Wildcard = true
+	dgst, err = cc.Checksum(context.TODO(), ref, "prefix/a", ChecksumOpts{IncludePatterns: []string{"**/foo/**", "**/report"}, Wildcard: true}, nil)
+	require.NoError(t, err)
+	require.Equal(t, dgstDoubleStar, dgst)
+
+}
+
+func TestChecksumIncludeSymlink(t *testing.T) {
+	t.Skip("Test will fail until https://github.com/moby/buildkit/issues/2300 is fixed")
+
+	t.Parallel()
+	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpdir)
+
+	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
+	require.NoError(t, err)
+	cm, _ := setupCacheManager(t, tmpdir, "native", snapshotter)
+	defer cm.Close()
+
+	ch := []string{
+		"ADD data dir",
+		"ADD data/d1 dir",
+		"ADD mnt dir",
+		"ADD mnt/data symlink ../data",
+		"ADD data/d1/foo file abc",
+	}
+
+	ref := createRef(t, cm, ch)
+
+	cc, err := newCacheContext(ref.Metadata(), nil)
+	require.NoError(t, err)
+
+	dgst, err := cc.Checksum(context.TODO(), ref, "data/d1", ChecksumOpts{IncludePatterns: []string{"**/foo"}}, nil)
+	require.NoError(t, err)
+	// File should be included
+	require.NotEqual(t, digest.FromBytes([]byte{}), dgst)
+
+	dgst, err = cc.Checksum(context.TODO(), ref, "mnt/data/d1", ChecksumOpts{IncludePatterns: []string{"**/foo"}}, nil)
+	require.NoError(t, err)
+	// File should be included despite symlink
+	require.NotEqual(t, digest.FromBytes([]byte{}), dgst)
+
+	// Same, with Wildcard = true
+	dgst, err = cc.Checksum(context.TODO(), ref, "mnt/data/d1", ChecksumOpts{IncludePatterns: []string{"**/foo"}, Wildcard: true}, nil)
+	require.NoError(t, err)
+	require.NotEqual(t, digest.FromBytes([]byte{}), dgst)
 }
 
 func TestHandleChange(t *testing.T) {


### PR DESCRIPTION
This adds a little extra testing around ** patterns, and adds a
(currently skipped) test for copying directories under symlinks (#2300).

It removes an extra call to `filepath.FromSlash` in `shouldIncludePath`
and an unused argument to that function.