### PR TITLE
generated files: use "go install" to install binaries

### DIFF
--- a/hack/dockerfiles/generated-files.Dockerfile
+++ b/hack/dockerfiles/generated-files.Dockerfile
@@ -2,28 +2,27 @@
 
 # protoc is dynamically linked to glibc to can't use golang:1.10-alpine
 FROM golang:1.16-buster AS gobuild-base
-# https://github.com/golang/protobuf/blob/v1.3.5/.travis.yml#L15
-ARG PROTOC_VERSION=3.11.4
-ARG GOGO_VERSION=v1.3.2
+
 RUN apt-get update && apt-get --no-install-recommends install -y \
 	unzip \
 	&& true
 
+# https://github.com/golang/protobuf/blob/v1.3.5/.travis.yml#L15
+ARG PROTOC_VERSION=3.11.4
 ARG TARGETOS TARGETARCH
 RUN set -e; \
 	arch=$(echo $TARGETARCH | sed -e s/amd64/x86_64/ -e s/arm64/aarch_64/); \
 	wget -q https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-${TARGETOS}-${arch}.zip && unzip protoc-${PROTOC_VERSION}-${TARGETOS}-${arch}.zip -d /usr/local
 
-RUN git clone https://github.com/gogo/protobuf.git /go/src/github.com/gogo/protobuf \
-	&& cd /go/src/github.com/gogo/protobuf \
-	&& git checkout -q $GOGO_VERSION \
-	&& go install ./protoc-gen-gogo ./protoc-gen-gogofaster ./protoc-gen-gogoslick
+ARG GOGO_VERSION=v1.3.2
+RUN --mount=target=/root/.cache,type=cache GO111MODULE=on go install \
+	github.com/gogo/protobuf/protoc-gen-gogo@${GOGO_VERSION} \
+	github.com/gogo/protobuf/protoc-gen-gogofaster@${GOGO_VERSION} \
+	github.com/gogo/protobuf/protoc-gen-gogoslick@${GOGO_VERSION}
 
 ARG PROTOBUF_VERSION=v1.3.5
-RUN git clone https://github.com/golang/protobuf.git /go/src/github.com/golang/protobuf \
-	&& cd /go/src/github.com/golang/protobuf \
-	&& git checkout -q $PROTOBUF_VERSION \
-	&& go install ./protoc-gen-go
+RUN --mount=target=/root/.cache,type=cache GO111MODULE=on go install \
+	github.com/golang/protobuf/protoc-gen-go@${PROTOBUF_VERSION}
 
 WORKDIR /go/src/github.com/moby/buildkit
 


### PR DESCRIPTION
Now that this repository moved to go1.16, we can use 'go install' to install these binaries, as mentioned in https://github.com/moby/buildkit/pull/2146

Before:

    #11 [gobuild-base 4/6] RUN git clone https://github.com/gogo/protobuf.git /go/src/github.com/gogo/protobuf 	&& cd /go/src/github.com/gogo/protobuf 	&& git checkout -q v1.3.2 	&& go install ./protoc-gen-gogo ./protoc-gen-gogofaster ./protoc-gen-gogoslick
    #11 0.061 Cloning into '/go/src/github.com/gogo/protobuf'...
    #11 DONE 12.7s
    
    #12 [gobuild-base 5/6] RUN git clone https://github.com/golang/protobuf.git /go/src/github.com/golang/protobuf 	&& cd /go/src/github.com/golang/protobuf 	&& git checkout -q v1.3.5 	&& go install ./protoc-gen-go
    #12 0.093 Cloning into '/go/src/github.com/golang/protobuf'...
    #12 DONE 2.7s

After:

    #11 [gobuild-base 4/6] RUN --mount=target=/root/.cache,type=cache GO111MODULE=on go install 	github.com/gogo/protobuf/protoc-gen-gogo@v1.3.2 	github.com/gogo/protobuf/protoc-gen-gogofaster@v1.3.2 	github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.2
    #11 0.200 go: downloading github.com/gogo/protobuf v1.3.2
    #11 DONE 7.4s

    #12 [gobuild-base 5/6] RUN --mount=target=/root/.cache,type=cache GO111MODULE=on go install 	github.com/golang/protobuf/protoc-gen-go@v1.3.5
    #12 0.162 go: downloading github.com/golang/protobuf v1.3.5
    #12 DONE 2.3s


