### PR TITLE
Fix  util/stack to work with newer protoc-gen-go

### DIFF
--- a/util/stack/generate.go
+++ b/util/stack/generate.go
@@ -1,3 +1,3 @@
 package stack
 
-//go:generate protoc -I=. -I=../../vendor/ --go_out=. stack.proto
+//go:generate protoc -I=. -I=../../vendor/ --go_out=. --go_opt=paths=source_relative --go_opt=Mstack.proto=/util/stack stack.proto


### PR DESCRIPTION
follow-up to https://github.com/moby/buildkit/pull/2305


### util/stack: update protoc options to work with newer versions

Generating the util/stack protos failed when updating protoc-gen-go to v1.5.2;
it looks like this is the only proto that's not generated using protoc-gen-gogo):

    util/stack/generate.go
    protoc-gen-go: unable to determine Go import path for "stack.proto"

    Please specify either:
        • a "go_package" option in the .proto source file, or
        • a "M" argument on the command line.

    See https://developers.google.com/protocol-buffers/docs/reference/go-generated#package for more information.

    --go_out: protoc-gen-go: Plugin failed with status code 1.
    util/stack/generate.go:3: running "protoc": exit status 1

Newer protobuf versions expect a go package to be set. Other .proto files in
this repository use the bare package name, but with protoc-gen-go v1.5.2, this
produces an error (package names must at least have a "/"). In addition to
including the option to the .proto file also changes the generated result
(`options go_package "<package name>"`).

Using the `-go_opt=M<package name>` option on the other hand, didn't change the
result (while still on protoc-gen-go v1.3.5), so I used that option instead.

protoc-gen-go v1.5.2 also changed the behavior where the generated file is stored,
seemingly relative to the `../../vendor` path specified. This coud be fixed either
by setting `--go_out=../../`, which was a bit counter-intuitive, or setting the
`--go_opt=paths=source_relative` option. The latter also prevented v1.5.2 from
storing the file in `utils/stack/github.com/moby/buildkit/utils/stack/` (sigh).
