### PR TITLE
Install true wget command for proxy issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -261,7 +261,7 @@ RUN CC=$(xx-clang --print-target-triple)-clang ./autogen.sh --disable-nls --disa
 
 # Rootless mode.
 FROM tonistiigi/alpine:${ALPINE_VERSION} AS rootless
-RUN apk add --no-cache fuse3 fuse-overlayfs git openssh pigz xz
+RUN apk add --no-cache fuse3 fuse-overlayfs git openssh pigz xz wget
 COPY --from=idmap /usr/bin/newuidmap /usr/bin/newuidmap
 COPY --from=idmap /usr/bin/newgidmap /usr/bin/newgidmap
 # we could just set CAP_SETUID filecap rather than `chmod u+s`, but requires kernel >= 4.14


### PR DESCRIPTION
Hello,

## Why ?
I'm trying to download the aws ecr credential helper in my CI or custom image to authenticate my ECR. But I can't download it since the alpine busybox included wget command doesn't support https proxy https://gitlab.alpinelinux.org/alpine/aports/-/issues/10446.

I cannot do without the proxy since it is one of my company prerequesite.

## Alternative

I'm proposing to install the true wget package from apk to fix this issue. Tested on my side and it works fine.

We can instead use curl but it sounds more consistent to keep the same command.