### PR TITLE
allow setting compression level on export

### DIFF
--- a/cache/blobs_linux.go
+++ b/cache/blobs_linux.go
@@ -15,7 +15,6 @@ import (
 	"syscall"
 
 	"github.com/containerd/containerd/archive"
-	ctdcompression "github.com/containerd/containerd/archive/compression"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/mount"
@@ -41,20 +40,6 @@ func (sr *immutableRef) tryComputeOverlayBlob(ctx context.Context, lower, upper 
 		// This is not an overlayfs snapshot. This is not an error so don't return error here
 		// and let the caller fallback to another differ.
 		return emptyDesc, false, nil
-	}
-
-	if compressorFunc == nil {
-		switch mediaType {
-		case ocispecs.MediaTypeImageLayer:
-		case ocispecs.MediaTypeImageLayerGzip:
-			compressorFunc = func(dest io.Writer, requiredMediaType string) (io.WriteCloser, error) {
-				return ctdcompression.CompressStream(dest, ctdcompression.Gzip)
-			}
-		case ocispecs.MediaTypeImageLayer + "+zstd":
-			compressorFunc = zstdWriter
-		default:
-			return emptyDesc, false, errors.Errorf("unsupported diff media type: %v", mediaType)
-		}
 	}
 
 	cw, err := sr.cm.ContentStore.Writer(ctx,

--- a/cache/estargz.go
+++ b/cache/estargz.go
@@ -18,7 +18,7 @@ var eStargzAnnotations = []string{estargz.TOCJSONDigestAnnotation, estargz.Store
 
 // writeEStargz writes the passed blobs stream as an eStargz-compressed blob.
 // getAnnotations function returns all eStargz annotations.
-func writeEStargz() (compressorFunc compressor, finalize func(context.Context, content.Store) (map[string]string, error)) {
+func writeEStargz(level int) (compressorFunc compressor, finalize func(context.Context, content.Store) (map[string]string, error)) {
 	annotations := make(map[string]string)
 	var bInfo blobInfo
 	var mu sync.Mutex
@@ -33,7 +33,7 @@ func writeEStargz() (compressorFunc compressor, finalize func(context.Context, c
 				defer pr.Close()
 				cw, bInfoCh := calculateBlob()
 				defer cw.Close()
-				w := estargz.NewWriter(io.MultiWriter(dest, cw))
+				w := estargz.NewWriterLevel(io.MultiWriter(dest, cw), level)
 				if err := w.AppendTar(pr); err != nil {
 					pr.CloseWithError(err)
 					return

--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -1169,7 +1169,11 @@ func TestGetRemote(t *testing.T) {
 		for _, compressionType := range []compression.Type{compression.Uncompressed, compression.Gzip /*compression.EStargz,*/, compression.Zstd} {
 			compressionType := compressionType
 			eg.Go(func() error {
-				remote, err := ir.GetRemote(egctx, true, compressionType, true, nil)
+				remote, err := ir.GetRemote(egctx, true, CompressionOpt{
+					Type:  compressionType,
+					Force: true,
+					Level: -1,
+				}, nil)
 				require.NoError(t, err)
 				refChain := ir.parentRefChain()
 				for i, desc := range remote.Descriptors {
@@ -1320,7 +1324,7 @@ func checkDiskUsage(ctx context.Context, t *testing.T, cm Manager, inuse, unused
 
 func esgzBlobDigest(uncompressedBlobBytes []byte) (digest.Digest, error) {
 	buf := new(bytes.Buffer)
-	compressorFunc, _ := writeEStargz()
+	compressorFunc, _ := writeEStargz(-1)
 	w, err := compressorFunc(buf, ocispecs.MediaTypeImageLayerGzip)
 	if err != nil {
 		return "", err

--- a/cache/refs.go
+++ b/cache/refs.go
@@ -42,7 +42,7 @@ type ImmutableRef interface {
 	Clone() ImmutableRef
 
 	Extract(ctx context.Context, s session.Group) error // +progress
-	GetRemote(ctx context.Context, createIfNeeded bool, compressionType compression.Type, forceCompression bool, s session.Group) (*solver.Remote, error)
+	GetRemote(ctx context.Context, createIfNeeded bool, compression CompressionOpt, s session.Group) (*solver.Remote, error)
 }
 
 type MutableRef interface {
@@ -52,6 +52,12 @@ type MutableRef interface {
 
 type Mountable interface {
 	Mount(ctx context.Context, readonly bool, s session.Group) (snapshot.Mountable, error)
+}
+
+type CompressionOpt struct {
+	Type  compression.Type
+	Force bool
+	Level int
 }
 
 type ref interface {

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -203,6 +203,16 @@ func (e *imageExporterInstance) Name() string {
 	return "exporting to image"
 }
 
+func (e *imageExporterInstance) Config() exporter.Config {
+	return exporter.Config{
+		Compression: cache.CompressionOpt{
+			Type:  e.layerCompression,
+			Force: e.forceCompression,
+			Level: e.compressionLevel,
+		},
+	}
+}
+
 func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source, sessionID string) (map[string]string, error) {
 	if src.Metadata == nil {
 		src.Metadata = make(map[string][]byte)

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -12,6 +12,7 @@ type Exporter interface {
 
 type ExporterInstance interface {
 	Name() string
+	Config() Config
 	Export(ctx context.Context, src Source, sessionID string) (map[string]string, error)
 }
 
@@ -19,4 +20,8 @@ type Source struct {
 	Ref      cache.ImmutableRef
 	Refs     map[string]cache.ImmutableRef
 	Metadata map[string][]byte
+}
+
+type Config struct {
+	Compression cache.CompressionOpt
 }

--- a/exporter/local/export.go
+++ b/exporter/local/export.go
@@ -38,6 +38,10 @@ func (e *localExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 	return &localExporterInstance{localExporter: e}, nil
 }
 
+func (e *localExporter) Config() exporter.Config {
+	return exporter.Config{}
+}
+
 type localExporterInstance struct {
 	*localExporter
 }

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -140,6 +140,16 @@ func (e *imageExporterInstance) Name() string {
 	return "exporting to oci image format"
 }
 
+func (e *imageExporterInstance) Config() exporter.Config {
+	return exporter.Config{
+		Compression: cache.CompressionOpt{
+			Type:  e.layerCompression,
+			Force: e.forceCompression,
+			Level: e.compressionLevel,
+		},
+	}
+}
+
 func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source, sessionID string) (map[string]string, error) {
 	if e.opt.Variant == VariantDocker && len(src.Refs) > 0 {
 		return nil, errors.Errorf("docker exporter does not currently support exporting manifest lists")

--- a/exporter/tar/export.go
+++ b/exporter/tar/export.go
@@ -45,6 +45,10 @@ func (e *localExporterInstance) Name() string {
 	return "exporting to client"
 }
 
+func (e *localExporterInstance) Config() exporter.Config {
+	return exporter.Config{}
+}
+
 func (e *localExporterInstance) Export(ctx context.Context, inp exporter.Source, sessionID string) (map[string]string, error) {
 	var defers []func()
 

--- a/solver/llbsolver/result.go
+++ b/solver/llbsolver/result.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"path"
 
+	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/cache/contenthash"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver"
@@ -89,6 +90,9 @@ func workerRefConverter(g session.Group) func(ctx context.Context, res solver.Re
 			return nil, errors.Errorf("invalid result: %T", res.Sys())
 		}
 
-		return ref.GetRemote(ctx, true, compression.Default, false, g)
+		return ref.GetRemote(ctx, true, cache.CompressionOpt{
+			Type:  compression.Default,
+			Level: -1,
+		}, g)
 	}
 }

--- a/solver/llbsolver/result.go
+++ b/solver/llbsolver/result.go
@@ -9,7 +9,6 @@ import (
 	"github.com/moby/buildkit/cache/contenthash"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver"
-	"github.com/moby/buildkit/util/compression"
 	"github.com/moby/buildkit/worker"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
@@ -83,16 +82,13 @@ func NewContentHashFunc(selectors []Selector) solver.ResultBasedCacheFunc {
 	}
 }
 
-func workerRefConverter(g session.Group) func(ctx context.Context, res solver.Result) (*solver.Remote, error) {
+func workerRefConverter(g session.Group, compressionopt cache.CompressionOpt) func(ctx context.Context, res solver.Result) (*solver.Remote, error) {
 	return func(ctx context.Context, res solver.Result) (*solver.Remote, error) {
 		ref, ok := res.Sys().(*worker.WorkerRef)
 		if !ok {
 			return nil, errors.Errorf("invalid result: %T", res.Sys())
 		}
 
-		return ref.GetRemote(ctx, true, cache.CompressionOpt{
-			Type:  compression.Default,
-			Level: -1,
-		}, g)
+		return ref.GetRemote(ctx, true, compressionopt, g)
 	}
 }

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -274,7 +274,11 @@ func inlineCache(ctx context.Context, e remotecache.Exporter, res solver.CachedR
 			return nil, errors.Errorf("invalid reference: %T", res.Sys())
 		}
 
-		remote, err := workerRef.GetRemote(ctx, true, compression.Default, false, g)
+		remote, err := workerRef.GetRemote(ctx, true, cache.CompressionOpt{ // todo: compression settings wrong
+			Type:  compression.Default,
+			Force: false,
+			Level: -1,
+		}, g)
 		if err != nil || remote == nil {
 			return nil, nil
 		}

--- a/worker/cacheresult.go
+++ b/worker/cacheresult.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver"
-	"github.com/moby/buildkit/util/compression"
 	"github.com/pkg/errors"
 )
 
@@ -77,7 +77,7 @@ func (s *cacheResultStorage) LoadRemote(ctx context.Context, res solver.CacheRes
 	}
 	defer ref.Release(context.TODO())
 	wref := WorkerRef{ref, w}
-	remote, err := wref.GetRemote(ctx, false, compression.Default, false, g)
+	remote, err := wref.GetRemote(ctx, false, cache.CompressionOpt{}, g)
 	if err != nil {
 		return nil, nil // ignore error. loadRemote is best effort
 	}

--- a/worker/result.go
+++ b/worker/result.go
@@ -6,7 +6,6 @@ import (
 	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver"
-	"github.com/moby/buildkit/util/compression"
 )
 
 func NewWorkerRefResult(ref cache.ImmutableRef, worker Worker) solver.Result {
@@ -29,13 +28,13 @@ func (wr *WorkerRef) ID() string {
 // GetRemote method abstracts ImmutableRef's GetRemote to allow a Worker to override.
 // This is needed for moby integration.
 // Use this method instead of calling ImmutableRef.GetRemote() directly.
-func (wr *WorkerRef) GetRemote(ctx context.Context, createIfNeeded bool, compressionType compression.Type, forceCompression bool, g session.Group) (*solver.Remote, error) {
+func (wr *WorkerRef) GetRemote(ctx context.Context, createIfNeeded bool, compressionopt cache.CompressionOpt, g session.Group) (*solver.Remote, error) {
 	if w, ok := wr.Worker.(interface {
-		GetRemote(context.Context, cache.ImmutableRef, bool, compression.Type, bool, session.Group) (*solver.Remote, error)
+		GetRemote(context.Context, cache.ImmutableRef, bool, cache.CompressionOpt, session.Group) (*solver.Remote, error)
 	}); ok {
-		return w.GetRemote(ctx, wr.ImmutableRef, createIfNeeded, compressionType, forceCompression, g)
+		return w.GetRemote(ctx, wr.ImmutableRef, createIfNeeded, compressionopt, g)
 	}
-	return wr.ImmutableRef.GetRemote(ctx, createIfNeeded, compressionType, forceCompression, g)
+	return wr.ImmutableRef.GetRemote(ctx, createIfNeeded, compressionopt, g)
 }
 
 type workerRefResult struct {


### PR DESCRIPTION
`-o compression-level=n` to configure the compressor.

Second commit tries to fix the multi-blob inline cache that I think was broken already (even before zstd PR). I think it is still broken with this PR as well and to fully fix it I need to change `LoadRemote` signature to `LoadRemotes([]compression) []Remotes`. @ktock  