### PR TITLE
bklog: only log tracing ids when span exporter not nil

### DIFF
--- a/util/bklog/log.go
+++ b/util/bklog/log.go
@@ -12,6 +12,14 @@ var (
 	L = logrus.NewEntry(logrus.StandardLogger())
 )
 
+var (
+	logWithTraceID = false
+)
+
+func EnableLogWithTraceID(b bool) {
+	logWithTraceID = b
+}
+
 type (
 	loggerKey struct{}
 )
@@ -33,13 +41,13 @@ func GetLogger(ctx context.Context) (l *logrus.Entry) {
 		l = L
 	}
 
-	spanContext := trace.SpanFromContext(ctx).SpanContext()
-
-	if spanContext.IsValid() {
-		return l.WithFields(logrus.Fields{
-			"traceID": spanContext.TraceID(),
-			"spanID":  spanContext.SpanID(),
-		})
+	if logWithTraceID {
+		if spanContext := trace.SpanFromContext(ctx).SpanContext(); spanContext.IsValid() {
+			return l.WithFields(logrus.Fields{
+				"traceID": spanContext.TraceID(),
+				"spanID":  spanContext.SpanID(),
+			})
+		}
 	}
 
 	return l

--- a/util/tracing/detect/detect.go
+++ b/util/tracing/detect/detect.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -82,6 +83,10 @@ func detect() error {
 	if exp == nil {
 		return nil
 	}
+
+	// enable log with traceID when valid exporter
+	bklog.EnableLogWithTraceID(true)
+
 	res, err := resource.Detect(context.Background(), serviceNameDetector{})
 	if err != nil {
 		return err


### PR DESCRIPTION
enhance https://github.com/moby/buildkit/pull/2235