### PR TITLE
Enhance ANSI colors for progress ui

### DIFF
--- a/util/progress/progressui/display.go
+++ b/util/progress/progressui/display.go
@@ -519,11 +519,11 @@ func (disp *display) print(d displayInfo, width, height int, all bool) {
 
 		out = align(out, timer, width)
 		if j.completedTime != nil {
-			color := aec.BlueF
+			color := colorRun
 			if j.isCanceled {
-				color = aec.YellowF
+				color = colorCancel
 			} else if j.hasError {
-				color = aec.RedF
+				color = colorError
 			}
 			out = aec.Apply(out, color)
 		}

--- a/util/progress/progressui/term.go
+++ b/util/progress/progressui/term.go
@@ -1,0 +1,12 @@
+//go:build !windows
+// +build !windows
+
+package progressui
+
+import "github.com/morikuni/aec"
+
+var (
+	colorRun    = aec.BlueF
+	colorCancel = aec.YellowF
+	colorError  = aec.RedF
+)

--- a/util/progress/progressui/term_windows.go
+++ b/util/progress/progressui/term_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+// +build windows
+
+package progressui
+
+import "github.com/morikuni/aec"
+
+var (
+	colorRun    = aec.CyanF
+	colorCancel = aec.YellowF
+	colorError  = aec.RedF
+)


### PR DESCRIPTION
relates to
* #1108
* docker/buildx#560
* https://github.com/docker/compose/issues/8629

Attempt to use ANSI colors suitable for most terms:

### xterm

![image](https://user-images.githubusercontent.com/1951866/133858777-b1a0ae4a-ba60-4bd1-af86-b2ea522c9a13.png)

### windows powershell

![image](https://user-images.githubusercontent.com/1951866/133857977-b6ddc7ff-566c-43f7-991a-78540b0805be.png)

### windows cmd

![image](https://user-images.githubusercontent.com/1951866/133858016-e5476655-71d2-4bcc-8ef6-b2098c60185e.png)

### windows terminal

![image](https://user-images.githubusercontent.com/1951866/133858064-40a409fb-8c0b-4b3c-8f0b-69413fa5db49.png)

### tabby

![image](https://user-images.githubusercontent.com/1951866/133858082-0671a733-7793-4d1b-b5d7-8d8620498499.png)

___

We could also use another SGR code for blue like cyan which [seems ok across major terms](https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit):

![image](https://user-images.githubusercontent.com/1951866/133891512-b7f432d0-f43e-4fbb-a242-05b4c4a307ff.png)

There is also the dichromatic palette for color blind. I guess there is a lot of discussion around this topic, so feel free to give your opinion. And another topic around [`NO_COLOR`](https://no-color.org/) that we can discuss in a follow-up.

cc @thaJeztah 

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>