### PR TITLE
resolver timeout fixes

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -238,6 +238,8 @@ func (c *Controller) Solve(ctx context.Context, req *controlapi.SolveRequest) (*
 	atomic.AddInt64(&c.buildCount, 1)
 	defer atomic.AddInt64(&c.buildCount, -1)
 
+	// This method registers job ID in solver.Solve. Make sure there are no blocking calls before that might delay this.
+
 	if err := translateLegacySolveRequest(req); err != nil {
 		return nil, err
 	}

--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -455,7 +455,7 @@ func (jl *Solver) NewJob(id string) (*Job, error) {
 }
 
 func (jl *Solver) Get(id string) (*Job, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
 	defer cancel()
 
 	go func() {

--- a/util/resolver/authorizer.go
+++ b/util/resolver/authorizer.go
@@ -25,11 +25,12 @@ import (
 type authHandlerNS struct {
 	counter int64 // needs to be 64bit aligned for 32bit systems
 
-	mu       sync.Mutex
-	handlers map[string]*authHandler
-	hosts    map[string][]docker.RegistryHost
-	sm       *session.Manager
-	g        flightcontrol.Group
+	handlers   map[string]*authHandler
+	muHandlers sync.Mutex
+	hosts      map[string][]docker.RegistryHost
+	muHosts    sync.Mutex
+	sm         *session.Manager
+	g          flightcontrol.Group
 }
 
 func newAuthHandlerNS(sm *session.Manager) *authHandlerNS {
@@ -118,8 +119,8 @@ func newDockerAuthorizer(client *http.Client, handlers *authHandlerNS, sm *sessi
 
 // Authorize handles auth request.
 func (a *dockerAuthorizer) Authorize(ctx context.Context, req *http.Request) error {
-	a.handlers.mu.Lock()
-	defer a.handlers.mu.Unlock()
+	a.handlers.muHandlers.Lock()
+	defer a.handlers.muHandlers.Unlock()
 
 	// skip if there is no auth handler
 	ah := a.handlers.get(ctx, req.URL.Host, a.sm, a.session)
@@ -141,8 +142,8 @@ func (a *dockerAuthorizer) getCredentials(host string) (sessionID, username, sec
 }
 
 func (a *dockerAuthorizer) AddResponses(ctx context.Context, responses []*http.Response) error {
-	a.handlers.mu.Lock()
-	defer a.handlers.mu.Unlock()
+	a.handlers.muHandlers.Lock()
+	defer a.handlers.muHandlers.Unlock()
 
 	last := responses[len(responses)-1]
 	host := last.Request.URL.Host

--- a/util/resolver/pool.go
+++ b/util/resolver/pool.go
@@ -146,10 +146,13 @@ func (r *Resolver) HostsFunc(host string) ([]docker.RegistryHost, error) {
 		if err != nil || v == nil {
 			return nil, err
 		}
-		res := v.([]docker.RegistryHost)
-		if len(res) == 0 {
+		vv := v.([]docker.RegistryHost)
+		if len(vv) == 0 {
 			return nil, nil
 		}
+		// make a copy so authorizer is set on unique instance
+		res := make([]docker.RegistryHost, len(vv))
+		copy(res, vv)
 		auth := newDockerAuthorizer(res[0].Client, r.handler, r.sm, r.g)
 		for i := range res {
 			res[i].Authorizer = auth


### PR DESCRIPTION
closes #2367
closes #2088

hosts mutex is called on initialization, meaning `GetResolver` might
block if it is in the middle of auth exchange. This is currently bad
in the case where the Job initialization needs to register a name before
timeout is reached.

Authorizer stores the current `session.Group` so if it is
overwritten for another resolver it means that session might
have been dropped and authentication will fail. I haven't been able
to reproduce this issue so not 100% it fixes the case but even if it is
a different race it looks incorrect anyway.

For the Job registration, we might want to do some follow-up change
that avoids running things before job ID is registered.

@maxlaverse


