### PR TITLE
Add BUILDKIT_SANDBOX_HOSTNAME build-arg

### DIFF
--- a/frontend/dockerfile/docs/syntax.md
+++ b/frontend/dockerfile/docs/syntax.md
@@ -318,7 +318,11 @@ eot
 RUN FOO=abc ash /app/script.sh
 ```
 
+## Built-in build args
 
-
-
-
+* `BUILDKIT_CACHE_MOUNT_NS=<string>` set optional cache ID namespace
+* `BUILDKIT_CONTEXT_KEEP_GIT_DIR=<bool>` trigger git context to keep the `.git` directory
+* `BUILDKIT_INLINE_CACHE=<bool>` inline cache metadata to image configuration or not (for Docker-integrated BuildKit (`DOCKER_BUILDKIT=1 docker build`) and `docker buildx`)
+* `BUILDKIT_MULTI_PLATFORM=<bool>` opt into determnistic output regardless of multi-platform output or not
+* `BUILDKIT_SANDBOX_HOSTNAME=<string>` set the hostname (default `buildkitsandbox`)
+* `BUILDKIT_SYNTAX=<image>` set frontend image


### PR DESCRIPTION
Fixes docker/buildx#474
Closes docker/buildx#776

Set the hostname based on the `BUILDKIT_SANDBOX_HOSTNAME` build-arg value. Also add documentation around the current available built-in build args and make build-arg const name more consistent.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>