### PR TITLE
preserve empty comment lines in `Parse`

### DIFF
--- a/frontend/dockerfile/parser/parser.go
+++ b/frontend/dockerfile/parser/parser.go
@@ -300,11 +300,7 @@ func Parse(rwc io.Reader) (*Result, error) {
 		}
 		if isComment(bytesRead) {
 			comment := strings.TrimSpace(string(bytesRead[1:]))
-			if comment == "" {
-				comments = nil
-			} else {
-				comments = append(comments, comment)
-			}
+			comments = append(comments, comment)
 		}
 		bytesRead, err = processLine(d, bytesRead, true)
 		if err != nil {


### PR DESCRIPTION
This is useful for preserving the typesetting of the original comments, e.g. license/copyright statements which require propagation of the statement