### PR TITLE
Move resolver config to a dedicated package

### DIFF
--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"github.com/moby/buildkit/util/resolver"
+	resolverconfig "github.com/moby/buildkit/util/resolver/config"
 )
 
 // Config provides containerd configuration data for the server
@@ -21,7 +21,7 @@ type Config struct {
 		Containerd ContainerdConfig `toml:"containerd"`
 	} `toml:"worker"`
 
-	Registries map[string]resolver.RegistryConfig `toml:"registry"`
+	Registries map[string]resolverconfig.RegistryConfig `toml:"registry"`
 
 	DNS *DNSConfig `toml:"dns"`
 }

--- a/util/push/push.go
+++ b/util/push/push.go
@@ -19,6 +19,7 @@ import (
 	"github.com/moby/buildkit/util/progress"
 	"github.com/moby/buildkit/util/progress/logs"
 	"github.com/moby/buildkit/util/resolver"
+	resolverconfig "github.com/moby/buildkit/util/resolver/config"
 	"github.com/moby/buildkit/util/resolver/limited"
 	"github.com/moby/buildkit/util/resolver/retryhandler"
 	digest "github.com/opencontainers/go-digest"
@@ -54,7 +55,7 @@ func Push(ctx context.Context, sm *session.Manager, sid string, provider content
 	if insecure {
 		insecureTrue := true
 		httpTrue := true
-		hosts = resolver.NewRegistryConfig(map[string]resolver.RegistryConfig{
+		hosts = resolver.NewRegistryConfig(map[string]resolverconfig.RegistryConfig{
 			reference.Domain(parsed): {
 				Insecure:  &insecureTrue,
 				PlainHTTP: &httpTrue,

--- a/util/resolver/config/config.go
+++ b/util/resolver/config/config.go
@@ -1,0 +1,15 @@
+package config
+
+type RegistryConfig struct {
+	Mirrors      []string     `toml:"mirrors"`
+	PlainHTTP    *bool        `toml:"http"`
+	Insecure     *bool        `toml:"insecure"`
+	RootCAs      []string     `toml:"ca"`
+	KeyPairs     []TLSKeyPair `toml:"keypair"`
+	TLSConfigDir []string     `toml:"tlsconfigdir"`
+}
+
+type TLSKeyPair struct {
+	Key         string `toml:"key"`
+	Certificate string `toml:"cert"`
+}

--- a/util/resolver/resolver.go
+++ b/util/resolver/resolver.go
@@ -13,11 +13,12 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/remotes/docker"
+	"github.com/moby/buildkit/util/resolver/config"
 	"github.com/moby/buildkit/util/tracing"
 	"github.com/pkg/errors"
 )
 
-func fillInsecureOpts(host string, c RegistryConfig, h docker.RegistryHost) ([]docker.RegistryHost, error) {
+func fillInsecureOpts(host string, c config.RegistryConfig, h docker.RegistryHost) ([]docker.RegistryHost, error) {
 	var hosts []docker.RegistryHost
 
 	tc, err := loadTLSConfig(c)
@@ -64,7 +65,7 @@ func fillInsecureOpts(host string, c RegistryConfig, h docker.RegistryHost) ([]d
 	return hosts, nil
 }
 
-func loadTLSConfig(c RegistryConfig) (*tls.Config, error) {
+func loadTLSConfig(c config.RegistryConfig) (*tls.Config, error) {
 	for _, d := range c.TLSConfigDir {
 		fs, err := ioutil.ReadDir(d)
 		if err != nil && !errors.Is(err, os.ErrNotExist) && !errors.Is(err, os.ErrPermission) {
@@ -75,7 +76,7 @@ func loadTLSConfig(c RegistryConfig) (*tls.Config, error) {
 				c.RootCAs = append(c.RootCAs, filepath.Join(d, f.Name()))
 			}
 			if strings.HasSuffix(f.Name(), ".cert") {
-				c.KeyPairs = append(c.KeyPairs, TLSKeyPair{
+				c.KeyPairs = append(c.KeyPairs, config.TLSKeyPair{
 					Certificate: filepath.Join(d, f.Name()),
 					Key:         filepath.Join(d, strings.TrimSuffix(f.Name(), ".cert")+".key"),
 				})
@@ -114,22 +115,8 @@ func loadTLSConfig(c RegistryConfig) (*tls.Config, error) {
 	return tc, nil
 }
 
-type RegistryConfig struct {
-	Mirrors      []string     `toml:"mirrors"`
-	PlainHTTP    *bool        `toml:"http"`
-	Insecure     *bool        `toml:"insecure"`
-	RootCAs      []string     `toml:"ca"`
-	KeyPairs     []TLSKeyPair `toml:"keypair"`
-	TLSConfigDir []string     `toml:"tlsconfigdir"`
-}
-
-type TLSKeyPair struct {
-	Key         string `toml:"key"`
-	Certificate string `toml:"cert"`
-}
-
 // NewRegistryConfig converts registry config to docker.RegistryHosts callback
-func NewRegistryConfig(m map[string]RegistryConfig) docker.RegistryHosts {
+func NewRegistryConfig(m map[string]config.RegistryConfig) docker.RegistryHosts {
 	return docker.Registries(
 		func(host string) ([]docker.RegistryHost, error) {
 			c, ok := m[host]


### PR DESCRIPTION
Follow-up #2361 

Move resolver config to a dedicated package to avoid importing resolver dependencies while using `cmd/buildkitd/config` package.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>