### PR TITLE
make sure ci runs on version branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ on:
   pull_request:
     branches:
       - 'master'
+      - 'v*'
 
 env:
   REPO_SLUG_ORIGIN: "moby/buildkit:latest"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches:
       - 'master'
+      - 'v*'
 
 env:
   REPO_SLUG_ORIGIN: "moby/buildkit:latest"


### PR DESCRIPTION
https://github.com/moby/buildkit/pull/1997 was never merged to master.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>