### PR TITLE
don't cast Value when pipe is errored

### DIFF
--- a/solver/edge.go
+++ b/solver/edge.go
@@ -458,7 +458,14 @@ func (e *edge) processUpdate(upt pipe.Receiver) (depChanged bool) {
 			dep.err = err
 		}
 
-		state := upt.Status().Value.(*edgeState)
+		if upt.Status().Value == nil {
+			return
+		}
+		state, isEdgeState := upt.Status().Value.(*edgeState)
+		if !isEdgeState {
+			bklog.G(context.TODO()).Warnf("invalid edgeState value for update: %T", state)
+			return
+		}
 
 		if len(dep.keys) < len(state.keys) {
 			newKeys := state.keys[len(dep.keys):]

--- a/solver/scheduler.go
+++ b/solver/scheduler.go
@@ -352,7 +352,7 @@ func (pf *pipeFactory) NewInputRequest(ee Edge, req *edgeRequest) pipe.Receiver 
 	target := pf.s.ef.getEdge(ee)
 	if target == nil {
 		return pf.NewFuncRequest(func(_ context.Context) (interface{}, error) {
-			return req, errors.Errorf("failed to get edge: inconsistent graph state")
+			return nil, errors.Errorf("failed to get edge: inconsistent graph state")
 		})
 	}
 	p := pf.s.newPipe(target, pf.e, pipe.Request{Payload: req})


### PR DESCRIPTION
Follow up of https://github.com/moby/buildkit/pull/2382

I couldn't find an easy way to get an `&edgeState{}` as Value of the errored pipe. It seems the simplest solution is to not cast the Value in such a situation. Eventually we could also check if the Value can be cast, and return if it's not the case, but I'm not sure if it brings anything. Thoughts @tonistiigi  ?


Having `target==nil` would end up with the following error.

```
# Daemon
ERRO[2021-10-01T21:34:06Z] /moby.buildkit.v1.Control/Solve returned error: rpc error: code = Unknown desc = failed to get edge: inconsistent graph state

# Client
error: failed to solve: failed to get edge: inconsistent graph state
```

/cc @jamesalucas