### PR TITLE
Differ: write diff to the content store over bufio writer

### DIFF
--- a/cache/blobs_linux.go
+++ b/cache/blobs_linux.go
@@ -4,6 +4,7 @@
 package cache
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"fmt"
@@ -71,10 +72,11 @@ func (sr *immutableRef) tryComputeOverlayBlob(ctx context.Context, lower, upper 
 		}
 	}()
 
+	bufW := bufio.NewWriterSize(cw, 128*1024)
 	var labels map[string]string
 	if compressorFunc != nil {
 		dgstr := digest.SHA256.Digester()
-		compressed, err := compressorFunc(cw, mediaType)
+		compressed, err := compressorFunc(bufW, mediaType)
 		if err != nil {
 			return emptyDesc, false, errors.Wrap(err, "failed to get compressed stream")
 		}
@@ -88,11 +90,14 @@ func (sr *immutableRef) tryComputeOverlayBlob(ctx context.Context, lower, upper 
 		}
 		labels[containerdUncompressed] = dgstr.Digest().String()
 	} else {
-		if err = writeOverlayUpperdir(ctx, cw, upperdir, lower); err != nil {
+		if err = writeOverlayUpperdir(ctx, bufW, upperdir, lower); err != nil {
 			return emptyDesc, false, errors.Wrap(err, "failed to write diff")
 		}
 	}
 
+	if err := bufW.Flush(); err != nil {
+		return emptyDesc, false, errors.Wrap(err, "failed to flush diff")
+	}
 	var commitopts []content.Opt
 	if labels != nil {
 		commitopts = append(commitopts, content.WithLabels(labels))


### PR DESCRIPTION
Fixes:  #2365
Alternative of #2366

This commit mitigates the recent performance regression of layer exports with containerd worker + overlayfs differ.

The following measures time to take for `exporting layers` of the following Dockerfile with changing the layer size from 50MB to 1GB ([source](https://github.com/ktock/buildkit/blob/f19220892329be43ac566f03b4aa0a5020eb1c99/hack/overlay/tools/measure.sh)).

```dockerfile
FROM ghcr.io/stargz-containers/ubuntu:20.04-org
RUN head -c ${SIZE} </dev/urandom > /sample
```

Measured on GitHub Actions `ubuntu-20.04` runner.

## containerd worker

The regression is mitigated by this patch.

### master version

https://github.com/ktock/buildkit/actions/runs/1295331304

The overlay differ + containerd worker shows about 2x slower exports.

|`${SIZE}`|overlay differ(sec)|walking differ(sec)|rate(overlay/walking)|
|---|---|---|---|
|1GB|89.7|43.0|2.08|
|500MB|43.5|22.7|1.92|
|100MB|9.1|4.7|1.94|
|50MB|4.6|2.5|1.84|

(avg. of 3 samples)

### This patch

https://github.com/ktock/buildkit/actions/runs/1301685570

Mitigates the performance regression to about 10%.

|`${SIZE}`|overlay differ(sec)|walking differ(sec)|rate(overlay/walking)|
|---|---|---|---|
|1GB|47.7|42.7|1.12|
|500MB|25.5|23.0|1.10|
|100MB|5.2|4.7|1.11|
|50MB|2.6|2.6|1.0|

(avg. of 3 samples)

## OCI worker

No large regression is observed.

### master

https://github.com/ktock/buildkit/actions/runs/1295331304

|`${SIZE}`|overlay differ(sec)|walking differ(sec)|rate(overlay/walking)|
|---|---|---|---|
|1GB|42.8|43.9|0.97|
|500MB|22.6|23.2|0.97|
|100MB|4.6|4.9|0.94|
|50MB|2.3|2.5|0.92|

### This patch

https://github.com/ktock/buildkit/actions/runs/1301685570

|`${SIZE}`|overlay differ(sec)|walking differ(sec)|rate(overlay/walking)|
|---|---|---|---|
|1GB|41.7|41.0|1.02|
|500MB|21.5|22.0|0.97|
|100MB|4.3|4.5|0.95|
|50MB|2.2|2.4|0.91|

