### PR TITLE
Do not enable overlayfs differ for fuse-overlayfs-snapshotter

### DIFF
--- a/cache/blobs.go
+++ b/cache/blobs.go
@@ -126,8 +126,13 @@ func computeBlobChain(ctx context.Context, sr *immutableRef, createIfNeeded bool
 			} else if !isTypeWindows(sr) {
 				enableOverlay, fallback = true, true
 				switch sr.cm.ManagerOpt.Snapshotter.Name() {
-				case "overlayfs", "fuse-overlayfs", "stargz":
-					logWarnOnErr = true // snapshotter should support overlay diff. so print warn log on failure
+				case "overlayfs", "stargz":
+					// overlayfs-based snapshotters should support overlay diff. so print warn log on failure.
+					logWarnOnErr = true
+				case "fuse-overlayfs":
+					// not supported with fuse-overlayfs snapshotter which doesn't provide overlayfs mounts.
+					// TODO: add support for fuse-overlayfs
+					enableOverlay = false
 				}
 			}
 			if enableOverlay {


### PR DESCRIPTION
Following up https://github.com/moby/buildkit/pull/2366#pullrequestreview-764367581 and #2388

Fuse-overlayfs snapshotter doesn't provide overlayfs mounts so overlayfs differ cannot be used. Disable overlayfs differ for that snapshotter.
