### PR TITLE
converter: make sure uncompressed digest annotation is set

### DIFF
--- a/cache/converter.go
+++ b/cache/converter.go
@@ -191,16 +191,13 @@ func (c *conversion) convert(ctx context.Context, cs content.Store, desc ocispec
 	newDesc.MediaType = c.target.DefaultMediaType()
 	newDesc.Digest = info.Digest
 	newDesc.Size = info.Size
-	newDesc.Annotations = nil
+	newDesc.Annotations = map[string]string{labels.LabelUncompressed: diffID.Digest().String()}
 	if c.finalize != nil {
 		a, err := c.finalize(ctx, cs)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed finalize compression")
 		}
 		for k, v := range a {
-			if newDesc.Annotations == nil {
-				newDesc.Annotations = make(map[string]string)
-			}
 			newDesc.Annotations[k] = v
 		}
 	}

--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -1115,6 +1115,8 @@ func TestConversion(t *testing.T) {
 						require.NoError(t, err, testName)
 					}
 					require.Equal(t, recreatedDesc.Digest, orgDesc.Digest, testName)
+					require.NotNil(t, recreatedDesc.Annotations)
+					require.Equal(t, recreatedDesc.Annotations["containerd.io/uncompressed"], orgDesc.Digest.String(), testName)
 					return nil
 				})
 			}


### PR DESCRIPTION
Annotation `"containerd.io/uncompressed"` is required to be set for each blob descriptor and is used e.g. for creating image config.
Make sure this is set to the converted blobs so that they will be handled correctly.
