### PR TITLE
Propagate compression options to the inline cache export

### DIFF
--- a/cache/refs.go
+++ b/cache/refs.go
@@ -42,7 +42,7 @@ type ImmutableRef interface {
 	Clone() ImmutableRef
 
 	Extract(ctx context.Context, s session.Group) error // +progress
-	GetRemote(ctx context.Context, createIfNeeded bool, compressionType compression.Type, forceCompression bool, s session.Group) (*solver.Remote, error)
+	GetRemotes(ctx context.Context, createIfNeeded bool, compressionopt solver.CompressionOpt, all bool, s session.Group) ([]*solver.Remote, error)
 }
 
 type MutableRef interface {
@@ -376,9 +376,29 @@ func compressionVariantDigestLabel(compressionType compression.Type) string {
 	return compressionVariantDigestLabelPrefix + compressionType.String()
 }
 
+func getCompressionVariants(ctx context.Context, cs content.Store, dgst digest.Digest) (res []compression.Type, _ error) {
+	info, err := cs.Info(ctx, dgst)
+	if errors.Is(err, errdefs.ErrNotFound) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+	for k := range info.Labels {
+		if strings.HasPrefix(k, compressionVariantDigestLabelPrefix) {
+			if t := compression.Parse(strings.TrimPrefix(k, compressionVariantDigestLabelPrefix)); t != compression.UnknownCompression {
+				res = append(res, t)
+			}
+		}
+	}
+	return
+}
+
 func (sr *immutableRef) getCompressionBlob(ctx context.Context, compressionType compression.Type) (ocispecs.Descriptor, error) {
-	cs := sr.cm.ContentStore
-	info, err := cs.Info(ctx, sr.getBlob())
+	return getCompressionVariantBlob(ctx, sr.cm.ContentStore, sr.getBlob(), compressionType)
+}
+
+func getCompressionVariantBlob(ctx context.Context, cs content.Store, dgst digest.Digest, compressionType compression.Type) (ocispecs.Descriptor, error) {
+	info, err := cs.Info(ctx, dgst)
 	if err != nil {
 		return ocispecs.Descriptor{}, err
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2231,6 +2231,12 @@ func testBuildExportZstd(t *testing.T, sb integration.Sandbox) {
 				},
 			},
 		},
+		// compression option should work even with inline cache exports
+		CacheExports: []CacheOptionsEntry{
+			{
+				Type: "inline",
+			},
+		},
 	}, nil)
 	require.NoError(t, err)
 
@@ -3028,6 +3034,50 @@ func testBasicInlineCacheImportExport(t *testing.T, sb integration.Sandbox) {
 	require.Equal(t, ok, true)
 
 	require.Equal(t, dgst, dgst2)
+
+	err = c.Prune(sb.Context(), nil, PruneAll)
+	require.NoError(t, err)
+
+	checkAllRemoved(t, c, sb)
+
+	// Export the cache again with compression
+	resp, err = c.Solve(sb.Context(), def, SolveOpt{
+		// specifying inline cache exporter is needed for reproducing containerimage.digest
+		// (not needed for reproducing rootfs/unique)
+		Exports: []ExportEntry{
+			{
+				Type: ExporterImage,
+				Attrs: map[string]string{
+					"name":              target,
+					"push":              "true",
+					"compression":       "uncompressed", // inline cache should work with compression
+					"force-compression": "true",
+				},
+			},
+		},
+		CacheExports: []CacheOptionsEntry{
+			{
+				Type: "inline",
+			},
+		},
+		CacheImports: []CacheOptionsEntry{
+			{
+				Type: "registry",
+				Attrs: map[string]string{
+					"ref": target,
+				},
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	dgst2uncompress, ok := resp.ExporterResponse[exptypes.ExporterImageDigestKey]
+	require.Equal(t, ok, true)
+
+	// dgst2uncompress != dgst, because the compression type is different
+	unique2uncompress, err := readFileInImage(sb.Context(), c, target+"@"+dgst2uncompress, "/unique")
+	require.NoError(t, err)
+	require.EqualValues(t, unique, unique2uncompress)
 
 	err = c.Prune(sb.Context(), nil, PruneAll)
 	require.NoError(t, err)

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -175,6 +175,10 @@ func (ic *ImageWriter) exportLayers(ctx context.Context, compressionType compres
 	layersDone := oneOffProgress(ctx, "exporting layers")
 
 	out := make([]solver.Remote, len(refs))
+	compressionopt := solver.CompressionOpt{
+		Type:  compressionType,
+		Force: forceCompression,
+	}
 
 	for i, ref := range refs {
 		func(i int, ref cache.ImmutableRef) {
@@ -182,10 +186,11 @@ func (ic *ImageWriter) exportLayers(ctx context.Context, compressionType compres
 				return
 			}
 			eg.Go(func() error {
-				remote, err := ref.GetRemote(ctx, true, compressionType, forceCompression, s)
+				remotes, err := ref.GetRemotes(ctx, true, compressionopt, false, s)
 				if err != nil {
 					return err
 				}
+				remote := remotes[0]
 				out[i] = *remote
 				return nil
 			})

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/moby/buildkit/cache"
+	"github.com/moby/buildkit/solver"
 )
 
 type Exporter interface {
@@ -12,6 +13,7 @@ type Exporter interface {
 
 type ExporterInstance interface {
 	Name() string
+	Config() Config
 	Export(ctx context.Context, src Source, sessionID string) (map[string]string, error)
 }
 
@@ -19,4 +21,8 @@ type Source struct {
 	Ref      cache.ImmutableRef
 	Refs     map[string]cache.ImmutableRef
 	Metadata map[string][]byte
+}
+
+type Config struct {
+	Compression solver.CompressionOpt
 }

--- a/exporter/local/export.go
+++ b/exporter/local/export.go
@@ -46,6 +46,10 @@ func (e *localExporterInstance) Name() string {
 	return "exporting to client"
 }
 
+func (e *localExporter) Config() exporter.Config {
+	return exporter.Config{}
+}
+
 func (e *localExporterInstance) Export(ctx context.Context, inp exporter.Source, sessionID string) (map[string]string, error) {
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)

--- a/exporter/tar/export.go
+++ b/exporter/tar/export.go
@@ -45,6 +45,10 @@ func (e *localExporterInstance) Name() string {
 	return "exporting to client"
 }
 
+func (e *localExporterInstance) Config() exporter.Config {
+	return exporter.Config{}
+}
+
 func (e *localExporterInstance) Export(ctx context.Context, inp exporter.Source, sessionID string) (map[string]string, error) {
 	var defers []func()
 

--- a/solver/cachestorage.go
+++ b/solver/cachestorage.go
@@ -47,6 +47,6 @@ type CacheInfoLink struct {
 type CacheResultStorage interface {
 	Save(Result, time.Time) (CacheResult, error)
 	Load(ctx context.Context, res CacheResult) (Result, error)
-	LoadRemote(ctx context.Context, res CacheResult, s session.Group) (*Remote, error)
+	LoadRemotes(ctx context.Context, res CacheResult, compression *CompressionOpt, s session.Group) ([]*Remote, error)
 	Exists(id string) bool
 }

--- a/solver/exporter.go
+++ b/solver/exporter.go
@@ -78,7 +78,8 @@ func (e *exporter) ExportTo(ctx context.Context, t CacheExporterTarget, opt Cach
 		selector digest.Digest
 	}
 
-	rec := t.Add(rootKey(e.k.Digest(), e.k.Output()))
+	recKey := rootKey(e.k.Digest(), e.k.Output())
+	rec := t.Add(recKey)
 	allRec := []CacheExporterRecord{rec}
 
 	addRecord := true
@@ -93,6 +94,8 @@ func (e *exporter) ExportTo(ctx context.Context, t CacheExporterTarget, opt Cach
 
 	var remote *Remote
 	if v := e.record; v != nil && len(e.k.Deps()) > 0 && addRecord {
+		var variants []CacheExporterRecord
+
 		cm := v.cacheManager
 		key := cm.getID(v.key)
 		res, err := cm.backend.Load(key, v.ID)
@@ -100,21 +103,41 @@ func (e *exporter) ExportTo(ctx context.Context, t CacheExporterTarget, opt Cach
 			return nil, err
 		}
 
-		remote, err = cm.results.LoadRemote(ctx, res, opt.Session)
+		remotes, err := cm.results.LoadRemotes(ctx, res, opt.CompressionOpt, opt.Session)
 		if err != nil {
 			return nil, err
 		}
+		if len(remotes) > 0 {
+			remote, remotes = remotes[0], remotes[1:] // pop the first element
+		}
+		if opt.CompressionOpt != nil {
+			for _, r := range remotes { // record all remaining remotes as well
+				rec := t.Add(recKey)
+				rec.AddResult(v.CreatedAt, r)
+				variants = append(variants, rec)
+			}
+		}
 
-		if remote == nil && opt.Mode != CacheExportModeRemoteOnly {
+		if (remote == nil || opt.CompressionOpt != nil) && opt.Mode != CacheExportModeRemoteOnly {
 			res, err := cm.results.Load(ctx, res)
 			if err != nil {
 				return nil, err
 			}
-			remote, err = opt.Convert(ctx, res)
+			remotes, err := opt.ResolveRemotes(ctx, res)
 			if err != nil {
 				return nil, err
 			}
 			res.Release(context.TODO())
+			if remote == nil {
+				remote, remotes = remotes[0], remotes[1:] // pop the first element
+			}
+			if opt.CompressionOpt != nil {
+				for _, r := range remotes { // record all remaining remotes as well
+					rec := t.Add(recKey)
+					rec.AddResult(v.CreatedAt, r)
+					variants = append(variants, rec)
+				}
+			}
 		}
 
 		if remote != nil {
@@ -122,6 +145,7 @@ func (e *exporter) ExportTo(ctx context.Context, t CacheExporterTarget, opt Cach
 				rec.AddResult(v.CreatedAt, remote)
 			}
 		}
+		allRec = append(allRec, variants...)
 	}
 
 	if remote != nil && opt.Mode == CacheExportModeMin {
@@ -154,15 +178,17 @@ func (e *exporter) ExportTo(ctx context.Context, t CacheExporterTarget, opt Cach
 		}
 	}
 
-	for i, srcs := range srcs {
-		for _, src := range srcs {
-			rec.LinkFrom(src.r, i, src.selector.String())
+	for _, rec := range allRec {
+		for i, srcs := range srcs {
+			for _, src := range srcs {
+				rec.LinkFrom(src.r, i, src.selector.String())
+			}
 		}
-	}
 
-	for cm, id := range e.k.ids {
-		if _, err := addBacklinks(t, rec, cm, id, bkm); err != nil {
-			return nil, err
+		for cm, id := range e.k.ids {
+			if _, err := addBacklinks(t, rec, cm, id, bkm); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/solver/llbsolver/result.go
+++ b/solver/llbsolver/result.go
@@ -8,7 +8,6 @@ import (
 	"github.com/moby/buildkit/cache/contenthash"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver"
-	"github.com/moby/buildkit/util/compression"
 	"github.com/moby/buildkit/worker"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
@@ -82,13 +81,13 @@ func NewContentHashFunc(selectors []Selector) solver.ResultBasedCacheFunc {
 	}
 }
 
-func workerRefConverter(g session.Group) func(ctx context.Context, res solver.Result) (*solver.Remote, error) {
-	return func(ctx context.Context, res solver.Result) (*solver.Remote, error) {
+func workerRefResolver(compressionopt solver.CompressionOpt, all bool, g session.Group) func(ctx context.Context, res solver.Result) ([]*solver.Remote, error) {
+	return func(ctx context.Context, res solver.Result) ([]*solver.Remote, error) {
 		ref, ok := res.Sys().(*worker.WorkerRef)
 		if !ok {
 			return nil, errors.Errorf("invalid result: %T", res.Sys())
 		}
 
-		return ref.GetRemote(ctx, true, compression.Default, false, g)
+		return ref.GetRemotes(ctx, true, compressionopt, all, g)
 	}
 }

--- a/solver/memorycachestorage.go
+++ b/solver/memorycachestorage.go
@@ -298,7 +298,7 @@ func (s *inMemoryResultStore) Load(ctx context.Context, res CacheResult) (Result
 	return v.(Result), nil
 }
 
-func (s *inMemoryResultStore) LoadRemote(_ context.Context, _ CacheResult, _ session.Group) (*Remote, error) {
+func (s *inMemoryResultStore) LoadRemotes(_ context.Context, _ CacheResult, _ *CompressionOpt, _ session.Group) ([]*Remote, error) {
 	return nil, nil
 }
 

--- a/solver/scheduler_test.go
+++ b/solver/scheduler_test.go
@@ -3789,11 +3789,11 @@ func testExporterOpts(all bool) CacheExportOpt {
 		mode = CacheExportModeMax
 	}
 	return CacheExportOpt{
-		Convert: func(ctx context.Context, res Result) (*Remote, error) {
+		ResolveRemotes: func(ctx context.Context, res Result) ([]*Remote, error) {
 			if dr, ok := res.Sys().(*dummyResult); ok {
-				return &Remote{Descriptors: []ocispecs.Descriptor{{
+				return []*Remote{{Descriptors: []ocispecs.Descriptor{{
 					Annotations: map[string]string{"value": fmt.Sprintf("%d", dr.intValue)},
-				}}}, nil
+				}}}}, nil
 			}
 			return nil, nil
 		},

--- a/solver/types.go
+++ b/solver/types.go
@@ -7,6 +7,7 @@ import (
 	"github.com/containerd/containerd/content"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/util/compression"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -93,12 +94,21 @@ const (
 
 // CacheExportOpt defines options for exporting build cache
 type CacheExportOpt struct {
-	// Convert can convert a build result to transferable object
-	Convert func(context.Context, Result) (*Remote, error)
+	// ResolveRemotes can convert a build result to transferable objects
+	ResolveRemotes func(context.Context, Result) ([]*Remote, error)
 	// Mode defines a cache export algorithm
 	Mode CacheExportMode
 	// Session is the session group to client (for auth credentials etc)
 	Session session.Group
+	// CompressionOpt is an option to specify the compression of the object to load.
+	// If specified, all objects that meet the option will be cached.
+	CompressionOpt *CompressionOpt
+}
+
+// CompressionOpt is compression information of a blob
+type CompressionOpt struct {
+	Type  compression.Type
+	Force bool
 }
 
 // CacheExporter can export the artifacts of the build chain

--- a/util/compression/compression.go
+++ b/util/compression/compression.go
@@ -41,6 +41,21 @@ const (
 
 var Default = Gzip
 
+func Parse(t string) Type {
+	switch t {
+	case "uncompressed":
+		return Uncompressed
+	case "gzip":
+		return Gzip
+	case "estargz":
+		return EStargz
+	case "zstd":
+		return Zstd
+	default:
+		return UnknownCompression
+	}
+}
+
 func (ct Type) String() string {
 	switch ct {
 	case Uncompressed:
@@ -67,6 +82,14 @@ func (ct Type) DefaultMediaType() string {
 	default:
 		return ocispecs.MediaTypeImageLayer + "+unknown"
 	}
+}
+
+func (ct Type) IsMediaType(mt string) bool {
+	mt, ok := toOCILayerType[mt]
+	if !ok {
+		return false
+	}
+	return mt == ct.DefaultMediaType()
 }
 
 func FromMediaType(mediaType string) Type {

--- a/worker/result.go
+++ b/worker/result.go
@@ -6,7 +6,6 @@ import (
 	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver"
-	"github.com/moby/buildkit/util/compression"
 )
 
 func NewWorkerRefResult(ref cache.ImmutableRef, worker Worker) solver.Result {
@@ -26,16 +25,16 @@ func (wr *WorkerRef) ID() string {
 	return wr.Worker.ID() + "::" + refID
 }
 
-// GetRemote method abstracts ImmutableRef's GetRemote to allow a Worker to override.
+// GetRemotes method abstracts ImmutableRef's GetRemotes to allow a Worker to override.
 // This is needed for moby integration.
-// Use this method instead of calling ImmutableRef.GetRemote() directly.
-func (wr *WorkerRef) GetRemote(ctx context.Context, createIfNeeded bool, compressionType compression.Type, forceCompression bool, g session.Group) (*solver.Remote, error) {
+// Use this method instead of calling ImmutableRef.GetRemotes() directly.
+func (wr *WorkerRef) GetRemotes(ctx context.Context, createIfNeeded bool, compressionopt solver.CompressionOpt, all bool, g session.Group) ([]*solver.Remote, error) {
 	if w, ok := wr.Worker.(interface {
-		GetRemote(context.Context, cache.ImmutableRef, bool, compression.Type, bool, session.Group) (*solver.Remote, error)
+		GetRemotes(context.Context, cache.ImmutableRef, bool, solver.CompressionOpt, bool, session.Group) ([]*solver.Remote, error)
 	}); ok {
-		return w.GetRemote(ctx, wr.ImmutableRef, createIfNeeded, compressionType, forceCompression, g)
+		return w.GetRemotes(ctx, wr.ImmutableRef, createIfNeeded, compressionopt, all, g)
 	}
-	return wr.ImmutableRef.GetRemote(ctx, createIfNeeded, compressionType, forceCompression, g)
+	return wr.ImmutableRef.GetRemotes(ctx, createIfNeeded, compressionopt, all, g)
 }
 
 type workerRefResult struct {


### PR DESCRIPTION
This is a following-up patch for #2350 to move that forward.

Currently, compression options aren't propagated to the inline cache export and it always uses gzip compressor. This leads to an issue that the `compression` option is ignored when `--export-cache type=inline` is specified. 

For example, a build something like the following ignores `compression=uncompressed` option and creates gzip images.

```
buildctl build --progress=plain --frontend=dockerfile.v0 --local context=/tmp/tmp.XAIR6qwH5h --local dockerfile=/tmp/tmp.XAIR6qwH5h \
               --output type=image,name=registry:5000/image:1,push=true,compression=uncompressed \
               --export-cache type=inline
```

This patch solves this issue by propagating compression options to the inline cache export as well. This also adds an option to `solver.(*exporter).ExportTo()` to avoid unexpected contents are recorded when inline export.

This adds @tonistiigi as a co-author because this patch is based on a commit of #2350.
