### PR TITLE
Re-add Finalize method to ImmutableRef.

### DIFF
--- a/cache/blobs.go
+++ b/cache/blobs.go
@@ -39,7 +39,7 @@ func (sr *immutableRef) computeBlobChain(ctx context.Context, createIfNeeded boo
 		return errors.Errorf("missing lease requirement for computeBlobChain")
 	}
 
-	if err := sr.finalizeLocked(ctx); err != nil {
+	if err := sr.Finalize(ctx); err != nil {
 		return err
 	}
 

--- a/cache/manager.go
+++ b/cache/manager.go
@@ -129,7 +129,7 @@ func (cm *cacheManager) GetByBlob(ctx context.Context, desc ocispecs.Descriptor,
 		chainID = imagespecidentity.ChainID([]digest.Digest{p.getChainID(), chainID})
 		blobChainID = imagespecidentity.ChainID([]digest.Digest{p.getBlobChainID(), blobChainID})
 
-		if err := p.finalizeLocked(ctx); err != nil {
+		if err := p.Finalize(ctx); err != nil {
 			p.Release(context.TODO())
 			return nil, err
 		}
@@ -467,7 +467,7 @@ func (cm *cacheManager) New(ctx context.Context, s ImmutableRef, sess session.Gr
 			}
 			parent = p.(*immutableRef)
 		}
-		if err := parent.finalizeLocked(ctx); err != nil {
+		if err := parent.Finalize(ctx); err != nil {
 			return nil, err
 		}
 		if err := parent.Extract(ctx, sess); err != nil {

--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -226,7 +226,7 @@ func TestManager(t *testing.T) {
 
 	checkDiskUsage(ctx, t, cm, 1, 0)
 
-	err = snap.(*immutableRef).finalizeLocked(ctx)
+	err = snap.Finalize(ctx)
 	require.NoError(t, err)
 
 	err = snap.Release(ctx)
@@ -948,7 +948,7 @@ func TestLazyCommit(t *testing.T) {
 	require.NoError(t, err)
 
 	// this time finalize commit
-	err = snap.(*immutableRef).finalizeLocked(ctx)
+	err = snap.Finalize(ctx)
 	require.NoError(t, err)
 
 	err = snap.Release(ctx)
@@ -1022,7 +1022,7 @@ func TestLazyCommit(t *testing.T) {
 	snap2, err = cm.Get(ctx, snap.ID())
 	require.NoError(t, err)
 
-	err = snap2.(*immutableRef).finalizeLocked(ctx)
+	err = snap2.Finalize(ctx)
 	require.NoError(t, err)
 
 	err = snap2.Release(ctx)

--- a/cache/refs.go
+++ b/cache/refs.go
@@ -40,6 +40,9 @@ type ImmutableRef interface {
 	Ref
 	Parent() ImmutableRef
 	Clone() ImmutableRef
+	// Finalize commits the snapshot to the driver if it's not already.
+	// This means the snapshot can no longer be mounted as mutable.
+	Finalize(context.Context) error
 
 	Extract(ctx context.Context, s session.Group) error // +progress
 	GetRemote(ctx context.Context, createIfNeeded bool, compressionType compression.Type, forceCompression bool, s session.Group) (*solver.Remote, error)
@@ -818,7 +821,7 @@ func (sr *immutableRef) release(ctx context.Context) error {
 	return nil
 }
 
-func (sr *immutableRef) finalizeLocked(ctx context.Context) error {
+func (sr *immutableRef) Finalize(ctx context.Context) error {
 	sr.mu.Lock()
 	defer sr.mu.Unlock()
 	return sr.finalize(ctx)


### PR DESCRIPTION
It turns out that while Buildkit code did not need this method to
be public, moby code does still use it, so we have to re-add it
after its removal in #2216 (commit b85ef15).

This commit is not a revert because some of the changes are
still desirable, namely the removal of the "commit" parameter
which didn't serve any purpose.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>