### PR TITLE
executor: make sure supplementary groups are set for unset user

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1730,19 +1730,19 @@ func testUser(t *testing.T, sb integration.Sandbox) {
 
 	dt, err := ioutil.ReadFile(filepath.Join(destDir, "user"))
 	require.NoError(t, err)
-	require.Contains(t, string(dt), "daemon")
+	require.Equal(t, "daemon", strings.TrimSpace(string(dt)))
 
 	dt, err = ioutil.ReadFile(filepath.Join(destDir, "group"))
 	require.NoError(t, err)
-	require.Contains(t, string(dt), "daemon")
+	require.Equal(t, "daemon", strings.TrimSpace(string(dt)))
 
 	dt, err = ioutil.ReadFile(filepath.Join(destDir, "nobody"))
 	require.NoError(t, err)
-	require.Contains(t, string(dt), "nobody")
+	require.Equal(t, "nobody", strings.TrimSpace(string(dt)))
 
 	dt, err = ioutil.ReadFile(filepath.Join(destDir, "userone"))
 	require.NoError(t, err)
-	require.Contains(t, string(dt), "1")
+	require.Equal(t, "1", strings.TrimSpace(string(dt)))
 
 	dt, err = ioutil.ReadFile(filepath.Join(destDir, "root_supplementary"))
 	require.NoError(t, err)

--- a/executor/oci/user.go
+++ b/executor/oci/user.go
@@ -15,6 +15,12 @@ import (
 )
 
 func GetUser(root, username string) (uint32, uint32, []uint32, error) {
+	var isDefault bool
+	if username == "" {
+		username = "0"
+		isDefault = true
+	}
+
 	// fast path from uid/gid
 	if uid, gid, err := ParseUIDGID(username); err == nil {
 		return uid, gid, nil, nil
@@ -31,6 +37,9 @@ func GetUser(root, username string) (uint32, uint32, []uint32, error) {
 
 	execUser, err := user.GetExecUser(username, nil, passwdFile, groupFile)
 	if err != nil {
+		if isDefault {
+			return 0, 0, nil, nil
+		}
 		return 0, 0, nil, err
 	}
 	var sgids []uint32


### PR DESCRIPTION
fixes #2341

Ensure that unset user has same supplementary groups as root.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>