### PR TITLE
go fmt: add //go:build

### DIFF
--- a/cache/blobs_linux_test.go
+++ b/cache/blobs_linux_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package cache

--- a/cache/blobs_nolinux.go
+++ b/cache/blobs_nolinux.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package cache

--- a/cache/contenthash/filehash_unix.go
+++ b/cache/contenthash/filehash_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package contenthash

--- a/cache/contenthash/filehash_windows.go
+++ b/cache/contenthash/filehash_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package contenthash

--- a/client/client_unix.go
+++ b/client/client_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package client

--- a/cmd/buildctl/main_unix.go
+++ b/cmd/buildctl/main_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package main

--- a/cmd/buildkitd/config/gcpolicy_unix.go
+++ b/cmd/buildkitd/config/gcpolicy_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package config

--- a/cmd/buildkitd/config/gcpolicy_windows.go
+++ b/cmd/buildkitd/config/gcpolicy_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package config

--- a/cmd/buildkitd/main_containerd_worker.go
+++ b/cmd/buildkitd/main_containerd_worker.go
@@ -1,3 +1,4 @@
+//go:build (linux && !no_containerd_worker) || (windows && !no_containerd_worker)
 // +build linux,!no_containerd_worker windows,!no_containerd_worker
 
 package main

--- a/cmd/buildkitd/main_oci_worker.go
+++ b/cmd/buildkitd/main_oci_worker.go
@@ -1,3 +1,4 @@
+//go:build linux && !no_oci_worker
 // +build linux,!no_oci_worker
 
 package main

--- a/cmd/buildkitd/main_unix.go
+++ b/cmd/buildkitd/main_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package main

--- a/cmd/buildkitd/main_windows.go
+++ b/cmd/buildkitd/main_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package main

--- a/cmd/buildkitd/util_unsupported.go
+++ b/cmd/buildkitd/util_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package main

--- a/examples/gobuild/main.go
+++ b/examples/gobuild/main.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package main

--- a/executor/oci/spec_unix.go
+++ b/executor/oci/spec_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package oci

--- a/executor/oci/spec_windows.go
+++ b/executor/oci/spec_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package oci

--- a/executor/runcexecutor/executor_common.go
+++ b/executor/runcexecutor/executor_common.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package runcexecutor

--- a/frontend/dockerfile/dockerfile2llb/convert_norunsecurity.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_norunsecurity.go
@@ -1,3 +1,4 @@
+//go:build !dfrunsecurity
 // +build !dfrunsecurity
 
 package dockerfile2llb

--- a/frontend/dockerfile/dockerfile2llb/convert_runsecurity.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_runsecurity.go
@@ -1,3 +1,4 @@
+//go:build dfrunsecurity
 // +build dfrunsecurity
 
 package dockerfile2llb

--- a/frontend/dockerfile/dockerfile_heredoc_test.go
+++ b/frontend/dockerfile/dockerfile_heredoc_test.go
@@ -1,3 +1,4 @@
+//go:build dfheredoc
 // +build dfheredoc
 
 package dockerfile

--- a/frontend/dockerfile/instructions/commands_runsecurity.go
+++ b/frontend/dockerfile/instructions/commands_runsecurity.go
@@ -1,3 +1,4 @@
+//go:build dfrunsecurity
 // +build dfrunsecurity
 
 package instructions

--- a/frontend/dockerfile/instructions/errors_unix.go
+++ b/frontend/dockerfile/instructions/errors_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package instructions

--- a/frontend/dockerfile/instructions/parse_heredoc_test.go
+++ b/frontend/dockerfile/instructions/parse_heredoc_test.go
@@ -1,3 +1,4 @@
+//go:build dfheredoc
 // +build dfheredoc
 
 package instructions

--- a/frontend/dockerfile/parser/parser_heredoc.go
+++ b/frontend/dockerfile/parser/parser_heredoc.go
@@ -1,3 +1,4 @@
+//go:build dfheredoc
 // +build dfheredoc
 
 package parser

--- a/frontend/dockerfile/parser/parser_heredoc_test.go
+++ b/frontend/dockerfile/parser/parser_heredoc_test.go
@@ -1,3 +1,4 @@
+//go:build dfheredoc
 // +build dfheredoc
 
 package parser

--- a/frontend/dockerfile/shell/equal_env_unix.go
+++ b/frontend/dockerfile/shell/equal_env_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package shell

--- a/session/sshforward/sshprovider/agentprovider_unix.go
+++ b/session/sshforward/sshprovider/agentprovider_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package sshprovider

--- a/session/sshforward/sshprovider/agentprovider_windows.go
+++ b/session/sshforward/sshprovider/agentprovider_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package sshprovider

--- a/snapshot/localmounter_unix.go
+++ b/snapshot/localmounter_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package snapshot

--- a/solver/llbsolver/file/user_nolinux.go
+++ b/solver/llbsolver/file/user_nolinux.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package file

--- a/source/git/gitsource_unix.go
+++ b/source/git/gitsource_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package git

--- a/source/git/gitsource_windows.go
+++ b/source/git/gitsource_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package git

--- a/util/appcontext/appcontext_unix.go
+++ b/util/appcontext/appcontext_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package appcontext

--- a/util/appdefaults/appdefaults_unix.go
+++ b/util/appdefaults/appdefaults_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package appdefaults

--- a/util/archutil/386_binary.go
+++ b/util/archutil/386_binary.go
@@ -1,3 +1,4 @@
+//go:build !386
 // +build !386
 
 package archutil

--- a/util/archutil/386_check.go
+++ b/util/archutil/386_check.go
@@ -1,3 +1,4 @@
+//go:build !386
 // +build !386
 
 package archutil

--- a/util/archutil/386_check_386.go
+++ b/util/archutil/386_check_386.go
@@ -1,3 +1,4 @@
+//go:build 386
 // +build 386
 
 package archutil

--- a/util/archutil/amd64_binary.go
+++ b/util/archutil/amd64_binary.go
@@ -1,3 +1,4 @@
+//go:build !amd64
 // +build !amd64
 
 package archutil

--- a/util/archutil/amd64_check.go
+++ b/util/archutil/amd64_check.go
@@ -1,3 +1,4 @@
+//go:build !amd64
 // +build !amd64
 
 package archutil

--- a/util/archutil/amd64_check_amd64.go
+++ b/util/archutil/amd64_check_amd64.go
@@ -1,3 +1,4 @@
+//go:build amd64
 // +build amd64
 
 package archutil

--- a/util/archutil/arm64_binary.go
+++ b/util/archutil/arm64_binary.go
@@ -1,3 +1,4 @@
+//go:build !arm64
 // +build !arm64
 
 package archutil

--- a/util/archutil/arm64_check.go
+++ b/util/archutil/arm64_check.go
@@ -1,3 +1,4 @@
+//go:build !arm64
 // +build !arm64
 
 package archutil

--- a/util/archutil/arm64_check_arm64.go
+++ b/util/archutil/arm64_check_arm64.go
@@ -1,3 +1,4 @@
+//go:build arm64
 // +build arm64
 
 package archutil

--- a/util/archutil/arm_binary.go
+++ b/util/archutil/arm_binary.go
@@ -1,3 +1,4 @@
+//go:build !arm
 // +build !arm
 
 package archutil

--- a/util/archutil/arm_check.go
+++ b/util/archutil/arm_check.go
@@ -1,3 +1,4 @@
+//go:build !arm
 // +build !arm
 
 package archutil

--- a/util/archutil/arm_check_arm.go
+++ b/util/archutil/arm_check_arm.go
@@ -1,3 +1,4 @@
+//go:build arm
 // +build arm
 
 package archutil

--- a/util/archutil/check_unix.go
+++ b/util/archutil/check_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package archutil

--- a/util/archutil/check_windows.go
+++ b/util/archutil/check_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package archutil

--- a/util/archutil/generate.go
+++ b/util/archutil/generate.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package main

--- a/util/archutil/mips64_binary.go
+++ b/util/archutil/mips64_binary.go
@@ -1,3 +1,4 @@
+//go:build !mips64
 // +build !mips64
 
 package archutil

--- a/util/archutil/mips64_check.go
+++ b/util/archutil/mips64_check.go
@@ -1,3 +1,4 @@
+//go:build !mips64
 // +build !mips64
 
 package archutil

--- a/util/archutil/mips64_check_mips64.go
+++ b/util/archutil/mips64_check_mips64.go
@@ -1,3 +1,4 @@
+//go:build mips64
 // +build mips64
 
 package archutil

--- a/util/archutil/mips64le_binary.go
+++ b/util/archutil/mips64le_binary.go
@@ -1,3 +1,4 @@
+//go:build !mips64le
 // +build !mips64le
 
 package archutil

--- a/util/archutil/mips64le_check.go
+++ b/util/archutil/mips64le_check.go
@@ -1,3 +1,4 @@
+//go:build !mips64le
 // +build !mips64le
 
 package archutil

--- a/util/archutil/mips64le_check_mips64le.go
+++ b/util/archutil/mips64le_check_mips64le.go
@@ -1,3 +1,4 @@
+//go:build mips64le
 // +build mips64le
 
 package archutil

--- a/util/archutil/ppc64le_binary.go
+++ b/util/archutil/ppc64le_binary.go
@@ -1,3 +1,4 @@
+//go:build !ppc64le
 // +build !ppc64le
 
 package archutil

--- a/util/archutil/ppc64le_check.go
+++ b/util/archutil/ppc64le_check.go
@@ -1,3 +1,4 @@
+//go:build !ppc64le
 // +build !ppc64le
 
 package archutil

--- a/util/archutil/ppc64le_check_ppc64le.go
+++ b/util/archutil/ppc64le_check_ppc64le.go
@@ -1,3 +1,4 @@
+//go:build ppc64le
 // +build ppc64le
 
 package archutil

--- a/util/archutil/riscv64_binary.go
+++ b/util/archutil/riscv64_binary.go
@@ -1,3 +1,4 @@
+//go:build !riscv64
 // +build !riscv64
 
 package archutil

--- a/util/archutil/riscv64_check.go
+++ b/util/archutil/riscv64_check.go
@@ -1,3 +1,4 @@
+//go:build !riscv64
 // +build !riscv64
 
 package archutil

--- a/util/archutil/riscv64_check_riscv64.go
+++ b/util/archutil/riscv64_check_riscv64.go
@@ -1,3 +1,4 @@
+//go:build riscv64
 // +build riscv64
 
 package archutil

--- a/util/archutil/s390x_binary.go
+++ b/util/archutil/s390x_binary.go
@@ -1,3 +1,4 @@
+//go:build !s390x
 // +build !s390x
 
 package archutil

--- a/util/archutil/s390x_check.go
+++ b/util/archutil/s390x_check.go
@@ -1,3 +1,4 @@
+//go:build !s390x
 // +build !s390x
 
 package archutil

--- a/util/archutil/s390x_check_s390x.go
+++ b/util/archutil/s390x_check_s390x.go
@@ -1,3 +1,4 @@
+//go:build s390x
 // +build s390x
 
 package archutil

--- a/util/network/cniprovider/cni_unsafe.go
+++ b/util/network/cniprovider/cni_unsafe.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package cniprovider

--- a/util/network/cniprovider/createns_linux.go
+++ b/util/network/cniprovider/createns_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package cniprovider

--- a/util/network/cniprovider/createns_unix.go
+++ b/util/network/cniprovider/createns_unix.go
@@ -1,3 +1,4 @@
+//go:build !linux && !windows
 // +build !linux,!windows
 
 package cniprovider

--- a/util/network/cniprovider/createns_windows.go
+++ b/util/network/cniprovider/createns_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package cniprovider

--- a/util/network/host.go
+++ b/util/network/host.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package network

--- a/util/network/netproviders/network_unix.go
+++ b/util/network/netproviders/network_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package netproviders

--- a/util/network/netproviders/network_windows.go
+++ b/util/network/netproviders/network_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package netproviders

--- a/util/rootless/specconv/specconv_nonlinux.go
+++ b/util/rootless/specconv/specconv_nonlinux.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package specconv

--- a/util/system/path_unix.go
+++ b/util/system/path_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package system

--- a/util/system/path_windows.go
+++ b/util/system/path_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package system

--- a/util/system/path_windows_test.go
+++ b/util/system/path_windows_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package system

--- a/util/testutil/integration/sandbox_unix.go
+++ b/util/testutil/integration/sandbox_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package integration

--- a/util/testutil/integration/sandbox_windows.go
+++ b/util/testutil/integration/sandbox_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package integration

--- a/worker/containerd/containerd_test.go
+++ b/worker/containerd/containerd_test.go
@@ -1,3 +1,4 @@
+//go:build linux && !no_containerd_worker
 // +build linux,!no_containerd_worker
 
 package containerd

--- a/worker/runc/runc_test.go
+++ b/worker/runc/runc_test.go
@@ -1,3 +1,4 @@
+//go:build linux && !no_runc_worker
 // +build linux,!no_runc_worker
 
 package runc


### PR DESCRIPTION
`//go:build` lines are preferred over `// +build` since Go 1.17: https://golang.org/doc/go1.17#tools

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>