### PR TITLE
gha: fix handling removed blobs on reexport

### DIFF
--- a/cache/remotecache/export.go
+++ b/cache/remotecache/export.go
@@ -68,7 +68,7 @@ func NewExporter(ingester content.Ingester, ref string, oci bool) Exporter {
 
 func (ce *contentCacheExporter) Finalize(ctx context.Context) (map[string]string, error) {
 	res := make(map[string]string)
-	config, descs, err := ce.chains.Marshal()
+	config, descs, err := ce.chains.Marshal(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cache/remotecache/gha/gha.go
+++ b/cache/remotecache/gha/gha.go
@@ -106,7 +106,7 @@ func (ce *exporter) indexKey() string {
 
 func (ce *exporter) Finalize(ctx context.Context) (map[string]string, error) {
 	// res := make(map[string]string)
-	config, descs, err := ce.chains.Marshal()
+	config, descs, err := ce.chains.Marshal(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cache/remotecache/inline/inline.go
+++ b/cache/remotecache/inline/inline.go
@@ -38,8 +38,8 @@ func (ce *exporter) reset() {
 	ce.chains = cc
 }
 
-func (ce *exporter) ExportForLayers(layers []digest.Digest) ([]byte, error) {
-	config, descs, err := ce.chains.Marshal()
+func (ce *exporter) ExportForLayers(ctx context.Context, layers []digest.Digest) ([]byte, error) {
+	config, descs, err := ce.chains.Marshal(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func (ce *exporter) ExportForLayers(layers []digest.Digest) ([]byte, error) {
 		return nil, err
 	}
 
-	cfg, _, err := cc.Marshal()
+	cfg, _, err := cc.Marshal(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cache/remotecache/v1/chains.go
+++ b/cache/remotecache/v1/chains.go
@@ -1,6 +1,7 @@
 package cacheimport
 
 import (
+	"context"
 	"strings"
 	"sync"
 	"time"
@@ -75,7 +76,7 @@ func (c *CacheChains) normalize() error {
 	return nil
 }
 
-func (c *CacheChains) Marshal() (*CacheConfig, DescriptorProvider, error) {
+func (c *CacheChains) Marshal(ctx context.Context) (*CacheConfig, DescriptorProvider, error) {
 	if err := c.normalize(); err != nil {
 		return nil, nil, err
 	}
@@ -87,7 +88,7 @@ func (c *CacheChains) Marshal() (*CacheConfig, DescriptorProvider, error) {
 	}
 
 	for _, it := range c.items {
-		if err := marshalItem(it, st); err != nil {
+		if err := marshalItem(ctx, it, st); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/cache/remotecache/v1/chains_test.go
+++ b/cache/remotecache/v1/chains_test.go
@@ -1,6 +1,7 @@
 package cacheimport
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -33,7 +34,7 @@ func TestSimpleMarshal(t *testing.T) {
 
 	addRecords()
 
-	cfg, _, err := cc.Marshal()
+	cfg, _, err := cc.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	require.Equal(t, len(cfg.Layers), 2)
@@ -65,7 +66,7 @@ func TestSimpleMarshal(t *testing.T) {
 	// adding same info again doesn't produce anything extra
 	addRecords()
 
-	cfg2, descPairs, err := cc.Marshal()
+	cfg2, descPairs, err := cc.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	require.EqualValues(t, cfg, cfg2)
@@ -78,13 +79,13 @@ func TestSimpleMarshal(t *testing.T) {
 	err = Parse(dt, descPairs, newChains)
 	require.NoError(t, err)
 
-	cfg3, _, err := cc.Marshal()
+	cfg3, _, err := cc.Marshal(context.TODO())
 	require.NoError(t, err)
 	require.EqualValues(t, cfg, cfg3)
 
 	// add extra item
 	cc.Add(outputKey(dgst("bay"), 0))
-	cfg, _, err = cc.Marshal()
+	cfg, _, err = cc.Marshal(context.TODO())
 	require.NoError(t, err)
 
 	require.Equal(t, len(cfg.Layers), 2)

--- a/cache/remotecache/v1/utils.go
+++ b/cache/remotecache/v1/utils.go
@@ -1,12 +1,14 @@
 package cacheimport
 
 import (
+	"context"
 	"fmt"
 	"sort"
 
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/solver"
 	digest "github.com/opencontainers/go-digest"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -277,9 +279,19 @@ type marshalState struct {
 	recordsByItem map[*item]int
 }
 
-func marshalRemote(r *solver.Remote, state *marshalState) string {
+func marshalRemote(ctx context.Context, r *solver.Remote, state *marshalState) string {
 	if len(r.Descriptors) == 0 {
 		return ""
+	}
+
+	if cd, ok := r.Provider.(interface {
+		CheckDescriptor(context.Context, ocispecs.Descriptor) error
+	}); ok && len(r.Descriptors) > 0 {
+		for _, d := range r.Descriptors {
+			if cd.CheckDescriptor(ctx, d) != nil {
+				return ""
+			}
+		}
 	}
 	var parentID string
 	if len(r.Descriptors) > 1 {
@@ -287,7 +299,7 @@ func marshalRemote(r *solver.Remote, state *marshalState) string {
 			Descriptors: r.Descriptors[:len(r.Descriptors)-1],
 			Provider:    r.Provider,
 		}
-		parentID = marshalRemote(r2, state)
+		parentID = marshalRemote(ctx, r2, state)
 	}
 	desc := r.Descriptors[len(r.Descriptors)-1]
 
@@ -318,7 +330,7 @@ func marshalRemote(r *solver.Remote, state *marshalState) string {
 	return id
 }
 
-func marshalItem(it *item, state *marshalState) error {
+func marshalItem(ctx context.Context, it *item, state *marshalState) error {
 	if _, ok := state.recordsByItem[it]; ok {
 		return nil
 	}
@@ -330,7 +342,7 @@ func marshalItem(it *item, state *marshalState) error {
 
 	for i, m := range it.links {
 		for l := range m {
-			if err := marshalItem(l.src, state); err != nil {
+			if err := marshalItem(ctx, l.src, state); err != nil {
 				return err
 			}
 			idx, ok := state.recordsByItem[l.src]
@@ -345,7 +357,7 @@ func marshalItem(it *item, state *marshalState) error {
 	}
 
 	if it.result != nil {
-		id := marshalRemote(it.result, state)
+		id := marshalRemote(ctx, it.result, state)
 		if id != "" {
 			idx, ok := state.chainsByID[id]
 			if !ok {

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -290,7 +290,7 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 
 func inlineCache(ctx context.Context, e remotecache.Exporter, res solver.CachedResult, compressionopt solver.CompressionOpt, g session.Group) ([]byte, error) {
 	if efl, ok := e.(interface {
-		ExportForLayers([]digest.Digest) ([]byte, error)
+		ExportForLayers(context.Context, []digest.Digest) ([]byte, error)
 	}); ok {
 		workerRef, ok := res.Sys().(*worker.WorkerRef)
 		if !ok {
@@ -317,7 +317,7 @@ func inlineCache(ctx context.Context, e remotecache.Exporter, res solver.CachedR
 			return nil, err
 		}
 
-		return efl.ExportForLayers(digests)
+		return efl.ExportForLayers(ctx, digests)
 	}
 	return nil, nil
 }


### PR DESCRIPTION
fix #2426

When reexporting blobs that matched cache check that the blob is still available. Otherwise exporting would ask to provide the blob and would fail on requesting it.

The downside of this is that we need to check more blobs and do more requests against github API, meaning it would be easier to hit rate limits.

Another approach would be to try to export a broken chain that would continue to fail on the next builds. An additional problem with that is that one could do `--cache-from type=gha --cache-to type=registry` and then pushing a broken export would be quite a bad failure as blobs are not allowed to just disappear randomly in the registry like they are in github cache.

In the future maybe it makes sense to create an LRU cache for the github API URL requests that would keep cache between builds. Small requests that are immutable could be reused without doing new requests. It could of course still break if blob gets deleted while it is cached but I think it is unlikely github would delete a blob that was just requested. Currently, there are cases where even for the same blob we may need to check it twice, one from the import and another on the export side.
 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>