### PR TITLE
Fix #2439 (`COPY` with Heredocs eats quotes)

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -594,6 +594,21 @@ func dispatch(d *dispatchState, cmd command, opt dispatchOpt) error {
 			return err
 		}
 	}
+	if ex, ok := cmd.Command.(instructions.SupportsSingleWordExpansionRaw); ok {
+		err := ex.ExpandRaw(func(word string) (string, error) {
+			env, err := d.state.Env(context.TODO())
+			if err != nil {
+				return "", err
+			}
+
+			lex := shell.NewLex('\\')
+			lex.RawQuotes = true
+			return lex.ProcessWord(word, env)
+		})
+		if err != nil {
+			return err
+		}
+	}
 
 	var err error
 	switch c := cmd.Command.(type) {

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -602,7 +602,7 @@ func dispatch(d *dispatchState, cmd command, opt dispatchOpt) error {
 			}
 
 			lex := shell.NewLex('\\')
-			lex.RawQuotes = true
+			lex.SkipProcessQuotes = true
 			return lex.ProcessWord(word, env)
 		})
 		if err != nil {

--- a/frontend/dockerfile/instructions/commands.go
+++ b/frontend/dockerfile/instructions/commands.go
@@ -71,9 +71,16 @@ func newWithNameAndCode(req parseRequest) withNameAndCode {
 // SingleWordExpander is a provider for variable expansion where 1 word => 1 output
 type SingleWordExpander func(word string) (string, error)
 
-// SupportsSingleWordExpansion interface marks a command as supporting variable expansion
+// SupportsSingleWordExpansion interface marks a command as supporting variable
+// expansion
 type SupportsSingleWordExpansion interface {
 	Expand(expander SingleWordExpander) error
+}
+
+// SupportsSingleWordExpansionRaw interface marks a command as supporting
+// variable expansion, while ensuring that quotes are preserved
+type SupportsSingleWordExpansionRaw interface {
+	ExpandRaw(expander SingleWordExpander) error
 }
 
 // PlatformSpecific adds platform checks to a command
@@ -180,18 +187,6 @@ type SourcesAndDest struct {
 }
 
 func (s *SourcesAndDest) Expand(expander SingleWordExpander) error {
-	for i, content := range s.SourceContents {
-		if !content.Expand {
-			continue
-		}
-
-		expandedData, err := expander(content.Data)
-		if err != nil {
-			return err
-		}
-		s.SourceContents[i].Data = expandedData
-	}
-
 	err := expandSliceInPlace(s.SourcePaths, expander)
 	if err != nil {
 		return err
@@ -203,6 +198,21 @@ func (s *SourcesAndDest) Expand(expander SingleWordExpander) error {
 	}
 	s.DestPath = expandedDestPath
 
+	return nil
+}
+
+func (s *SourcesAndDest) ExpandRaw(expander SingleWordExpander) error {
+	for i, content := range s.SourceContents {
+		if !content.Expand {
+			continue
+		}
+
+		expandedData, err := expander(content.Data)
+		if err != nil {
+			return err
+		}
+		s.SourceContents[i].Data = expandedData
+	}
 	return nil
 }
 

--- a/frontend/dockerfile/instructions/parse_heredoc_test.go
+++ b/frontend/dockerfile/instructions/parse_heredoc_test.go
@@ -147,6 +147,21 @@ EOF`,
 				},
 			},
 		},
+		{
+			dockerfile: `COPY <<EOF /quotes
+"quotes"
+EOF`,
+			sourcesAndDest: SourcesAndDest{
+				DestPath: "/quotes",
+				SourceContents: []SourceContent{
+					{
+						Path:   "EOF",
+						Data:   "\"quotes\"\n",
+						Expand: true,
+					},
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/frontend/dockerfile/parser/parser_heredoc_test.go
+++ b/frontend/dockerfile/parser/parser_heredoc_test.go
@@ -73,6 +73,11 @@ FILE1
 content 2
 FILE2
 
+COPY <<EOF /quotes
+"foo"
+'bar'
+EOF
+
 COPY <<X <<Y /dest
 Y
 X
@@ -208,6 +213,14 @@ $EOF
 			{
 				Name:    "FILE2",
 				Content: "content 2\n",
+				Expand:  true,
+			},
+		},
+		{
+			// COPY <<EOF /quotes
+			{
+				Name:    "EOF",
+				Content: "\"foo\"\n'bar'\n",
 				Expand:  true,
 			},
 		},

--- a/frontend/dockerfile/shell/lex.go
+++ b/frontend/dockerfile/shell/lex.go
@@ -173,6 +173,7 @@ func (sw *shellWord) processStopOn(stopChar rune) (string, []string, error) {
 			if ch == sw.escapeToken {
 				if sw.rawEscapes {
 					words.addRawChar(ch)
+					result.WriteRune(ch)
 				}
 
 				// '\' (default escape token, but ` allowed) escapes, except end of line

--- a/frontend/dockerfile/shell/lex.go
+++ b/frontend/dockerfile/shell/lex.go
@@ -18,10 +18,11 @@ import (
 // It doesn't support all flavors of ${xx:...} formats but new ones can
 // be added by adding code to the "special ${} format processing" section
 type Lex struct {
-	escapeToken  rune
-	RawQuotes    bool
-	RawEscapes   bool
-	SkipUnsetEnv bool
+	escapeToken       rune
+	RawQuotes         bool
+	RawEscapes        bool
+	SkipProcessQuotes bool
+	SkipUnsetEnv      bool
 }
 
 // NewLex creates a new Lex which uses escapeToken to escape quotes.
@@ -62,23 +63,25 @@ func (s *Lex) ProcessWordsWithMap(word string, env map[string]string) ([]string,
 
 func (s *Lex) process(word string, env map[string]string) (string, []string, error) {
 	sw := &shellWord{
-		envs:         env,
-		escapeToken:  s.escapeToken,
-		skipUnsetEnv: s.SkipUnsetEnv,
-		rawQuotes:    s.RawQuotes,
-		rawEscapes:   s.RawEscapes,
+		envs:              env,
+		escapeToken:       s.escapeToken,
+		skipUnsetEnv:      s.SkipUnsetEnv,
+		skipProcessQuotes: s.SkipProcessQuotes,
+		rawQuotes:         s.RawQuotes,
+		rawEscapes:        s.RawEscapes,
 	}
 	sw.scanner.Init(strings.NewReader(word))
 	return sw.process(word)
 }
 
 type shellWord struct {
-	scanner      scanner.Scanner
-	envs         map[string]string
-	escapeToken  rune
-	rawQuotes    bool
-	rawEscapes   bool
-	skipUnsetEnv bool
+	scanner           scanner.Scanner
+	envs              map[string]string
+	escapeToken       rune
+	rawQuotes         bool
+	rawEscapes        bool
+	skipUnsetEnv      bool
+	skipProcessQuotes bool
 }
 
 func (sw *shellWord) process(source string) (string, []string, error) {
@@ -141,9 +144,11 @@ func (sw *shellWord) processStopOn(stopChar rune) (string, []string, error) {
 	var words wordsStruct
 
 	var charFuncMapping = map[rune]func() (string, error){
-		'\'': sw.processSingleQuote,
-		'"':  sw.processDoubleQuote,
-		'$':  sw.processDollar,
+		'$': sw.processDollar,
+	}
+	if !sw.skipProcessQuotes {
+		charFuncMapping['\''] = sw.processSingleQuote
+		charFuncMapping['"'] = sw.processDoubleQuote
 	}
 
 	for sw.scanner.Peek() != scanner.EOF {


### PR DESCRIPTION
Woops :smile:

From the commit message:

> In the contents of COPY/ADD, we perform expansion on variables using a lexer. However, this lexer, by default, removes quotes as well expanding variables - this isn't really the kind of behavior we're after, as it feels quite unintuitive.
>     
> To fix this, we introduce a new ExpandRaw function, which commands can implement that implement an alternative expansion that preserves quotes (and possibly other characters/features in the future).
>     
> Additionally, we introduce new tests to more clearly define the behavior. One major note is that backslashes are not passed and are processed, following normal escape rules (so that we can use `$` symbols directly).

This fixes #2439 but does also leave backslashes in COPY not working quite as one might expect - I think this can probably be fixed with some documentation, happy to patch that if needed. Additionally, users can get "raw" content by quoting the heredoc to prevent expansion, i.e. `<<"EOF"`.