### PR TITLE
ci: fix git protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ buildctl build \
 buildctl build \
     --frontend gateway.v0 \
     --opt source=docker/dockerfile \
-    --opt context=git://github.com/moby/moby \
+    --opt context=https://github.com/moby/moby.git \
     --opt build-arg:APT_MIRROR=cdn-fastly.deb.debian.org
 ```
 

--- a/hack/util
+++ b/hack/util
@@ -46,7 +46,7 @@ currentcontext="."
 cacheFromFlags=""
 cacheToFlags=""
 if [ "$GITHUB_ACTIONS" = "true" ]; then
-  currentref="git://github.com/$GITHUB_REPOSITORY#$GITHUB_REF"
+  currentref="https://github.com/$GITHUB_REPOSITORY.git#$GITHUB_REF"
   if [ -n "$CACHE_FROM" ]; then
     for cfrom in $CACHE_FROM; do
       cacheFromFlags="${cacheFromFlags}--cache-from=$cfrom "


### PR DESCRIPTION
https://github.blog/2021-09-01-improving-git-protocol-security-github/

```
#1 0.234 fatal: remote error: 
#1 0.234   The unauthenticated git protocol on port 9418 is no longer supported.
#1 0.234 Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>