### PR TITLE
limit vertex size with 50000 to avoid huge grpc message making client…

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -333,8 +333,8 @@ func (c *Controller) Status(req *controlapi.StatusRequest, stream controlapi.Con
 				return nil
 			}
 			logSize := 0
-			retry := false
 			for {
+				retry := false
 				sr := controlapi.StatusResponse{}
 				for _, v := range ss.Vertexes {
 					sr.Vertexes = append(sr.Vertexes, &controlapi.Vertex{
@@ -366,7 +366,7 @@ func (c *Controller) Status(req *controlapi.StatusRequest, stream controlapi.Con
 						Msg:       v.Data,
 						Timestamp: v.Timestamp,
 					})
-					logSize += len(v.Data)
+					logSize += len(v.Data) + emptyLogVertexSize
 					// avoid logs growing big and split apart if they do
 					if logSize > 1024*1024 {
 						ss.Vertexes = nil

--- a/control/init.go
+++ b/control/init.go
@@ -1,0 +1,10 @@
+package control
+
+import controlapi "github.com/moby/buildkit/api/services/control"
+
+var emptyLogVertexSize int
+
+func init() {
+	emptyLogVertex := controlapi.VertexLog{}
+	emptyLogVertexSize = emptyLogVertex.Size()
+}


### PR DESCRIPTION
fix issue in https://github.com/moby/buildkit/issues/1539

when run maven compile in Dockerfile there are a lot of log vertex in status grpc response(>200000) . The grpc header and other fields in vertex message create grpc message exceeded 20M, which cause receiving buffer in buildctl overflow 