### PR TITLE
push: workaround deadlock in containerd pusher

### DIFF
--- a/cache/remotecache/registry/registry.go
+++ b/cache/remotecache/registry/registry.go
@@ -10,6 +10,7 @@ import (
 	"github.com/moby/buildkit/cache/remotecache"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/util/contentutil"
+	"github.com/moby/buildkit/util/push"
 	"github.com/moby/buildkit/util/resolver"
 	"github.com/moby/buildkit/util/resolver/limited"
 	digest "github.com/opencontainers/go-digest"
@@ -48,7 +49,7 @@ func ResolveCacheExporterFunc(sm *session.Manager, hosts docker.RegistryHosts) r
 			ociMediatypes = b
 		}
 		remote := resolver.DefaultPool.GetResolver(hosts, ref, "push", sm, g)
-		pusher, err := remote.Pusher(ctx, ref)
+		pusher, err := push.Pusher(ctx, remote, ref)
 		if err != nil {
 			return nil, err
 		}

--- a/util/contentutil/refs.go
+++ b/util/contentutil/refs.go
@@ -37,15 +37,19 @@ func IngesterFromRef(ref string) (content.Ingester, error) {
 		Client: http.DefaultClient,
 	})
 
-	pusher, err := remote.Pusher(context.TODO(), ref)
+	p, err := remote.Pusher(context.TODO(), ref)
 	if err != nil {
 		return nil, err
 	}
 
 	return &ingester{
 		locker: locker.New(),
-		pusher: pusher,
+		pusher: &pusher{p},
 	}, nil
+}
+
+type pusher struct {
+	remotes.Pusher
 }
 
 type ingester struct {


### PR DESCRIPTION
fixes docker/buildx#834

Since 1.5 containerd pusher has an issue https://github.com/containerd/containerd/issues/6242 and deadlocks after first error appears(eg. connection dropped or registry error). Purely by coincidence, this error was not affecting buildkit until v0.9.1 because the incorrect logic is behind an interface detection check https://github.com/containerd/containerd/blob/5b09dc5eb0c671d87dc3482d5f63326a4416b74d/remotes/handlers.go#L172-L173 and Buildkit used a wrapper around pusher object.

In v0.9.2 while fixing another issue that wrap was removed and exposed this issue. https://github.com/moby/buildkit/pull/2403/files#diff-9f53bfee1c63146562c6d43b0bc3e476d9e966c93a1b8904031d37ea2f0896bfL82

I have reported this to containerd. Meanwhile, this adds arbitrary wrap around all our usage of `Pusher` to work around this.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>