### PR TITLE
Fix ticker leak in DisplaySolveStatus

### DIFF
--- a/util/progress/progressui/display.go
+++ b/util/progress/progressui/display.go
@@ -22,7 +22,6 @@ import (
 )
 
 func DisplaySolveStatus(ctx context.Context, phase string, c console.Console, w io.Writer, ch chan *client.SolveStatus) error {
-
 	modeConsole := c != nil
 
 	disp := &display{c: c, phase: phase}
@@ -46,7 +45,10 @@ func DisplaySolveStatus(ctx context.Context, phase string, c console.Console, w 
 
 	var done bool
 	ticker := time.NewTicker(tickerTimeout)
-	defer ticker.Stop()
+	// implemented as closure because "ticker" can change
+	defer func() {
+		ticker.Stop()
+	}()
 
 	displayLimiter := rate.NewLimiter(rate.Every(displayTimeout), 1)
 


### PR DESCRIPTION
The "defer" is bound to the original value of the ticker, and won't stop
a ticker that's created later in the function. Example:
https://play.golang.org/p/puat5JEf5Jw

Ran into this in a health checker that periodically created buildkit
clients.

cc @coryb