### PR TITLE
buildinfo: add build attributes and frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,8 +435,43 @@ The directory of the specified file must already exist and be writable.
 buildctl build ... --metadata-file metadata.json
 ```
 
+```shell
+jq '.' metadata.json
 ```
-{"containerimage.digest": "sha256:ea0cfb27fd41ea0405d3095880c1efa45710f5bcdddb7d7d5a7317ad4825ae14",...}
+```json
+{
+  "containerimage.buildinfo": {
+    "frontend": "dockerfile.v0",
+    "attrs": {
+      "context": "https://github.com/crazy-max/buildkit-buildsources-test.git#master",
+      "filename": "Dockerfile",
+      "source": "docker/dockerfile:master"
+    },
+    "sources": [
+      {
+        "type": "docker-image",
+        "ref": "docker.io/docker/buildx-bin:0.6.1@sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
+        "pin": "sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0"
+      },
+      {
+        "type": "docker-image",
+        "ref": "docker.io/library/alpine:3.13",
+        "pin": "sha256:026f721af4cf2843e07bba648e158fb35ecc876d822130633cc49f707f0fc88c"
+      }
+    ]
+  },
+  "containerimage.config.digest": "sha256:2937f66a9722f7f4a2df583de2f8cb97fc9196059a410e7f00072fc918930e66",
+  "containerimage.descriptor": {
+    "annotations": {
+      "config.digest": "sha256:2937f66a9722f7f4a2df583de2f8cb97fc9196059a410e7f00072fc918930e66",
+      "org.opencontainers.image.created": "2022-02-08T21:28:03Z"
+    },
+    "digest": "sha256:19ffeab6f8bc9293ac2c3fdf94ebe28396254c993aea0b5a542cfb02e0883fa3",
+    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+    "size": 506
+  },
+  "containerimage.digest": "sha256:19ffeab6f8bc9293ac2c3fdf94ebe28396254c993aea0b5a542cfb02e0883fa3"
+}
 ```
 
 ## Systemd socket activation

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Keys supported by image output:
 * `compression-level=[value]`: compression level for gzip, estargz (0-9) and zstd (0-22)
 * `force-compression=true`: forcefully apply `compression` option to all layers (including already existing layers).
 * `buildinfo=[all,imageconfig,metadata,none]`: choose [build dependency](docs/build-repro.md#build-dependencies) version to export (default `all`).
+* `buildinfo-attrs=true`: inline build info attributes in [image config](docs/build-repro.md#image-config) (default `false`).
 
 If credentials are required, `buildctl` will attempt to read Docker configuration file `$DOCKER_CONFIG/config.json`.
 `$DOCKER_CONFIG` defaults to `~/.docker`.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -5174,10 +5174,10 @@ func testBuildInfoInline(t *testing.T, sb integration.Sandbox) {
 			require.NoError(t, err)
 
 			if tt.buildAttrs {
-				require.Equal(t, len(bi.Attrs), 1)
-				require.Equal(t, bi.Attrs, map[string]string{"build-arg:foo": "bar"})
+				require.Contains(t, bi.Attrs, "build-arg:foo")
+				require.Equal(t, bi.Attrs["build-arg:foo"], "bar")
 			} else {
-				require.Equal(t, len(bi.Attrs), 0)
+				require.NotContains(t, bi.Attrs, "build-arg:foo")
 			}
 			require.Equal(t, len(bi.Sources), 1)
 			require.Equal(t, bi.Sources[0].Type, binfotypes.SourceTypeDockerImage)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -5090,7 +5090,8 @@ func testBuildInfoExporter(t *testing.T, sb integration.Sandbox) {
 	err = json.Unmarshal(decbi, &exbi)
 	require.NoError(t, err)
 
-	require.Equal(t, exbi.Attrs, map[string]string{"build-arg:foo": "bar"})
+	attrval := "bar"
+	require.Equal(t, exbi.Attrs, map[string]*string{"build-arg:foo": &attrval})
 	require.Equal(t, len(exbi.Sources), 1)
 	require.Equal(t, exbi.Sources[0].Type, binfotypes.SourceTypeDockerImage)
 	require.Equal(t, exbi.Sources[0].Ref, "docker.io/library/busybox:latest")
@@ -5174,8 +5175,9 @@ func testBuildInfoInline(t *testing.T, sb integration.Sandbox) {
 			require.NoError(t, err)
 
 			if tt.buildAttrs {
+				attrval := "bar"
 				require.Contains(t, bi.Attrs, "build-arg:foo")
-				require.Equal(t, bi.Attrs["build-arg:foo"], "bar")
+				require.Equal(t, bi.Attrs["build-arg:foo"], &attrval)
 			} else {
 				require.NotContains(t, bi.Attrs, "build-arg:foo")
 			}

--- a/docs/build-repro.md
+++ b/docs/build-repro.md
@@ -26,7 +26,6 @@ The structure is base64 encoded and has the following format when decoded:
   "frontend": "dockerfile.v0",
   "attrs": {
     "build-arg:foo": "bar",
-    "cmdline": "crazymax/dockerfile:master",
     "context": "https://github.com/crazy-max/buildkit-buildsources-test.git#master",
     "filename": "Dockerfile",
     "platform": "linux/amd64,linux/arm64",
@@ -74,8 +73,7 @@ base64:
 {
   "ExporterResponse": {
     "containerimage.buildinfo": "<base64>",
-    "containerimage.digest": "sha256:...",
-    "image.name": "..."
+    "containerimage.digest": "sha256:..."
   }
 }
 ```
@@ -88,8 +86,42 @@ platform:
   "ExporterResponse": {
     "containerimage.buildinfo/linux/amd64": "<base64>",
     "containerimage.buildinfo/linux/arm64": "<base64>",
-    "containerimage.digest": "sha256:...",
-    "image.name": "..."
+    "containerimage.digest": "sha256:..."
   }
+}
+```
+
+### Metadata JSON output
+
+If you're using the `--metadata-file` flag with [`buildctl`](../README.md#metadata),
+[`buildx build`](https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md)
+or [`buildx bake`](https://github.com/docker/buildx/blob/master/docs/reference/buildx_bake.md):
+
+```shell
+jq '.' metadata.json
+```
+```json
+{
+  "containerimage.buildinfo": {
+    "frontend": "dockerfile.v0",
+    "attrs": {
+      "context": "https://github.com/crazy-max/buildkit-buildsources-test.git#master",
+      "filename": "Dockerfile",
+      "source": "docker/dockerfile:master"
+    },
+    "sources": [
+      {
+        "type": "docker-image",
+        "ref": "docker.io/docker/buildx-bin:0.6.1@sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
+        "pin": "sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0"
+      },
+      {
+        "type": "docker-image",
+        "ref": "docker.io/library/alpine:3.13",
+        "pin": "sha256:026f721af4cf2843e07bba648e158fb35ecc876d822130633cc49f707f0fc88c"
+      }
+    ]
+  },
+  "containerimage.digest": "sha256:..."
 }
 ```

--- a/docs/build-repro.md
+++ b/docs/build-repro.md
@@ -4,7 +4,7 @@
 
 Build dependencies are generated when your image has been built. These
 dependencies include versions of used images, git repositories and HTTP URLs
-used by LLB `Source` operation.
+used by LLB `Source` operation as well as build request attributes.
 
 By default, the build dependencies are embedded in the image configuration and
 also available in the solver response. The export mode can be refined with
@@ -23,6 +23,15 @@ The structure is base64 encoded and has the following format when decoded:
 
 ```json
 {
+  "frontend": "dockerfile.v0",
+  "attrs": {
+    "build-arg:foo": "bar",
+    "cmdline": "crazymax/dockerfile:master",
+    "context": "https://github.com/crazy-max/buildkit-buildsources-test.git#master",
+    "filename": "Dockerfile",
+    "platform": "linux/amd64,linux/arm64",
+    "source": "crazymax/dockerfile:master"
+  },
   "sources": [
     {
       "type": "docker-image",
@@ -48,9 +57,12 @@ The structure is base64 encoded and has the following format when decoded:
 }
 ```
 
-* `type` defines the source type (`docker-image`, `git` or `http`).
-* `ref` is the reference of the source.
-* `pin` is the source digest.
+* `frontend` defines the frontend used to build.
+* `attrs` defines build request attributes.
+* `sources` defines build dependencies.
+  * `type` defines the source type (`docker-image`, `git` or `http`).
+  * `ref` is the reference of the source.
+  * `pin` is the source digest.
 
 ### Exporter response (metadata)
 

--- a/examples/dockerfile2llb/main.go
+++ b/examples/dockerfile2llb/main.go
@@ -30,7 +30,7 @@ func main() {
 
 	caps := pb.Caps.CapSet(pb.Caps.All())
 
-	state, img, err := dockerfile2llb.Dockerfile2LLB(appcontext.Context(), df, dockerfile2llb.ConvertOpt{
+	state, img, bi, err := dockerfile2llb.Dockerfile2LLB(appcontext.Context(), df, dockerfile2llb.ConvertOpt{
 		MetaResolver: imagemetaresolver.Default(),
 		Target:       opt.target,
 		LLBCaps:      &caps,
@@ -41,6 +41,7 @@ func main() {
 	}
 
 	_ = img
+	_ = bi
 
 	dt, err := state.Marshal(context.TODO())
 	if err != nil {

--- a/exporter/containerimage/exptypes/types.go
+++ b/exporter/containerimage/exptypes/types.go
@@ -13,7 +13,6 @@ const (
 	ExporterImageDescriptorKey   = "containerimage.descriptor"
 	ExporterInlineCache          = "containerimage.inlinecache"
 	ExporterBuildInfo            = "containerimage.buildinfo"
-	ExporterBuildInfoAttrs       = "buildinfo.attrs"
 	ExporterPlatformsKey         = "refs.platforms"
 )
 

--- a/exporter/containerimage/exptypes/types.go
+++ b/exporter/containerimage/exptypes/types.go
@@ -1,7 +1,6 @@
 package exptypes
 
 import (
-	srctypes "github.com/moby/buildkit/source/types"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -27,29 +26,3 @@ type Platform struct {
 	ID       string
 	Platform ocispecs.Platform
 }
-
-// BuildInfo defines build dependencies that will be added to image config as
-// moby.buildkit.buildinfo.v1 key and returned in solver ExporterResponse as
-// ExporterBuildInfo key.
-type BuildInfo struct {
-	// Type defines the BuildInfoType source type (docker-image, git, http).
-	Type BuildInfoType `json:"type,omitempty"`
-	// Ref is the reference of the source.
-	Ref string `json:"ref,omitempty"`
-	// Alias is a special field used to match with the actual source ref
-	// because frontend might have already transformed a string user typed
-	// before generating LLB.
-	Alias string `json:"alias,omitempty"`
-	// Pin is the source digest.
-	Pin string `json:"pin,omitempty"`
-}
-
-// BuildInfoType contains source type.
-type BuildInfoType string
-
-// List of source types.
-const (
-	BuildInfoTypeDockerImage BuildInfoType = srctypes.DockerImageScheme
-	BuildInfoTypeGit         BuildInfoType = srctypes.GitScheme
-	BuildInfoTypeHTTP        BuildInfoType = srctypes.HTTPScheme
-)

--- a/exporter/containerimage/exptypes/types.go
+++ b/exporter/containerimage/exptypes/types.go
@@ -13,6 +13,7 @@ const (
 	ExporterImageDescriptorKey   = "containerimage.descriptor"
 	ExporterInlineCache          = "containerimage.inlinecache"
 	ExporterBuildInfo            = "containerimage.buildinfo"
+	ExporterBuildInfoAttrs       = "buildinfo.attrs"
 	ExporterPlatformsKey         = "refs.platforms"
 )
 

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/moby/buildkit/solver"
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/buildinfo"
+	binfotypes "github.com/moby/buildkit/util/buildinfo/types"
 	"github.com/moby/buildkit/util/compression"
 	"github.com/moby/buildkit/util/progress"
 	"github.com/moby/buildkit/util/system"
@@ -416,9 +417,9 @@ func patchImageConfig(dt []byte, descs []ocispecs.Descriptor, history []ocispecs
 		if err != nil {
 			return nil, err
 		}
-		m[buildinfo.ImageConfigField] = dt
-	} else if _, ok := m[buildinfo.ImageConfigField]; ok {
-		delete(m, buildinfo.ImageConfigField)
+		m[binfotypes.ImageConfigField] = dt
+	} else if _, ok := m[binfotypes.ImageConfigField]; ok {
+		delete(m, binfotypes.ImageConfigField)
 	}
 
 	dt, err = json.Marshal(m)

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -347,7 +347,7 @@ func Dockerfile2LLB(ctx context.Context, dt []byte, opt ConvertOpt) (*llb.State,
 						}
 						if !isScratch {
 							// if image not scratch set original image name as ref
-							// and actual reference as alias in BuildSource
+							// and actual reference as alias in binfotypes.Source
 							d.buildSource = &binfotypes.Source{
 								Type:  binfotypes.SourceTypeDockerImage,
 								Ref:   origName,

--- a/frontend/dockerfile/dockerfile2llb/convert_test.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_test.go
@@ -1,7 +1,6 @@
 package dockerfile2llb
 
 import (
-	"encoding/json"
 	"strings"
 	"testing"
 
@@ -36,7 +35,7 @@ ENV FOO bar
 COPY f1 f2 /sub/
 RUN ls -l
 `
-	_, _, err := Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
+	_, _, _, err := Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
 	assert.NoError(t, err)
 
 	df = `FROM scratch AS foo
@@ -45,7 +44,7 @@ FROM foo
 COPY --from=foo f1 /
 COPY --from=0 f2 /
 	`
-	_, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
+	_, _, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
 	assert.NoError(t, err)
 
 	df = `FROM scratch AS foo
@@ -54,12 +53,12 @@ FROM foo
 COPY --from=foo f1 /
 COPY --from=0 f2 /
 	`
-	_, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{
+	_, _, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{
 		Target: "Foo",
 	})
 	assert.NoError(t, err)
 
-	_, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{
+	_, _, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{
 		Target: "nosuch",
 	})
 	assert.Error(t, err)
@@ -67,21 +66,21 @@ COPY --from=0 f2 /
 	df = `FROM scratch
 	ADD http://github.com/moby/buildkit/blob/master/README.md /
 		`
-	_, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
+	_, _, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
 	assert.NoError(t, err)
 
 	df = `FROM scratch
 	COPY http://github.com/moby/buildkit/blob/master/README.md /
 		`
-	_, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
+	_, _, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
 	assert.EqualError(t, err, "source can't be a URL for COPY")
 
 	df = `FROM "" AS foo`
-	_, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
+	_, _, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
 	assert.Error(t, err)
 
 	df = `FROM ${BLANK} AS foo`
-	_, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
+	_, _, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
 	assert.Error(t, err)
 }
 
@@ -179,7 +178,7 @@ func TestDockerfileCircularDependencies(t *testing.T) {
 	df := `FROM busybox AS stage0
 COPY --from=stage0 f1 /sub/
 `
-	_, _, err := Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
+	_, _, _, err := Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
 	assert.EqualError(t, err, "circular dependency detected on stage: stage0")
 
 	// multiple stages with circular dependency
@@ -190,7 +189,7 @@ COPY --from=stage0 f2 /sub/
 FROM busybox AS stage2
 COPY --from=stage1 f2 /sub/
 `
-	_, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
+	_, _, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
 	assert.EqualError(t, err, "circular dependency detected on stage: stage0")
 }
 
@@ -200,7 +199,7 @@ func TestTargetBuildInfo(t *testing.T) {
 FROM busybox
 ADD https://raw.githubusercontent.com/moby/buildkit/master/README.md /
 `
-	_, image, err := Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{
+	_, _, bi, err := Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{
 		TargetPlatform: &ocispecs.Platform{
 			Architecture: "amd64",
 			OS:           "linux",
@@ -212,19 +211,11 @@ ADD https://raw.githubusercontent.com/moby/buildkit/master/README.md /
 			},
 		},
 	})
-
-	require.NoError(t, err)
-	require.NotNil(t, image.BuildInfo)
-
-	var bi binfotypes.BuildInfo
-	err = json.Unmarshal(image.BuildInfo, &bi)
 	require.NoError(t, err)
 
-	sources := bi.Sources
-	require.Equal(t, 1, len(sources))
-
-	assert.Equal(t, binfotypes.SourceTypeDockerImage, sources[0].Type)
-	assert.Equal(t, "busybox", sources[0].Ref)
-	assert.True(t, strings.HasPrefix(sources[0].Alias, "docker.io/library/busybox@"))
-	assert.NotEmpty(t, sources[0].Pin)
+	require.Equal(t, 1, len(bi.Sources))
+	assert.Equal(t, binfotypes.SourceTypeDockerImage, bi.Sources[0].Type)
+	assert.Equal(t, "busybox", bi.Sources[0].Ref)
+	assert.True(t, strings.HasPrefix(bi.Sources[0].Alias, "docker.io/library/busybox@"))
+	assert.NotEmpty(t, bi.Sources[0].Pin)
 }

--- a/frontend/dockerfile/dockerfile2llb/image.go
+++ b/frontend/dockerfile/dockerfile2llb/image.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/strslice"
+	binfotypes "github.com/moby/buildkit/util/buildinfo/types"
 	"github.com/moby/buildkit/util/system"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -54,8 +55,8 @@ type Image struct {
 	// Variant defines platform variant. To be added to OCI.
 	Variant string `json:"variant,omitempty"`
 
-	// BuildInfo defines build dependencies.
-	BuildInfo []byte `json:"moby.buildkit.buildinfo.v1,omitempty"`
+	// binfotypes.ImageConfig defines build dependencies.
+	binfotypes.ImageConfig
 }
 
 func clone(src Image) Image {

--- a/frontend/dockerfile/dockerfile2llb/image.go
+++ b/frontend/dockerfile/dockerfile2llb/image.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/strslice"
-	binfotypes "github.com/moby/buildkit/util/buildinfo/types"
 	"github.com/moby/buildkit/util/system"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -54,9 +53,6 @@ type Image struct {
 
 	// Variant defines platform variant. To be added to OCI.
 	Variant string `json:"variant,omitempty"`
-
-	// binfotypes.ImageConfig defines build dependencies.
-	binfotypes.ImageConfig
 }
 
 func clone(src Image) Image {
@@ -65,7 +61,6 @@ func clone(src Image) Image {
 	img.Config.Env = append([]string{}, src.Config.Env...)
 	img.Config.Cmd = append([]string{}, src.Config.Cmd...)
 	img.Config.Entrypoint = append([]string{}, src.Config.Entrypoint...)
-	img.BuildInfo = src.BuildInfo
 	return img
 }
 

--- a/frontend/dockerfile/dockerfile_buildinfo_test.go
+++ b/frontend/dockerfile/dockerfile_buildinfo_test.go
@@ -168,7 +168,7 @@ RUN echo $foo
 	require.NoError(t, err)
 
 	require.Contains(t, bi.Attrs, "build-arg:foo")
-	require.Equal(t, "bar", bi.Attrs["build-arg:foo"])
+	require.Equal(t, "bar", *bi.Attrs["build-arg:foo"])
 }
 
 // moby/buildkit#2476
@@ -231,7 +231,7 @@ ADD https://raw.githubusercontent.com/moby/moby/master/README.md /
 		require.NoError(t, err)
 
 		require.Contains(t, bi.Attrs, "build-arg:foo")
-		require.Equal(t, "bar", bi.Attrs["build-arg:foo"])
+		require.Equal(t, "bar", *bi.Attrs["build-arg:foo"])
 
 		sources := bi.Sources
 		require.Equal(t, 2, len(sources))

--- a/frontend/dockerfile/dockerfile_buildinfo_test.go
+++ b/frontend/dockerfile/dockerfile_buildinfo_test.go
@@ -1,0 +1,249 @@
+package dockerfile
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/containerd/continuity/fs/fstest"
+	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/exporter/containerimage/exptypes"
+	"github.com/moby/buildkit/frontend/dockerfile/builder"
+	binfotypes "github.com/moby/buildkit/util/buildinfo/types"
+	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var buildinfoTests = integration.TestFuncs(
+	testBuildSources,
+	testBuildAttrs,
+	testBuildInfoMultiPlatform,
+)
+
+func init() {
+	allTests = append(allTests, buildinfoTests...)
+}
+
+// moby/buildkit#2311
+func testBuildSources(t *testing.T, sb integration.Sandbox) {
+	f := getFrontend(t, sb)
+
+	gitDir, err := ioutil.TempDir("", "buildkit")
+	require.NoError(t, err)
+	defer os.RemoveAll(gitDir)
+
+	dockerfile := `
+FROM alpine:latest@sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300 AS alpine
+FROM busybox:latest
+ADD https://raw.githubusercontent.com/moby/moby/master/README.md /
+COPY --from=alpine /bin/busybox /alpine-busybox
+`
+
+	err = ioutil.WriteFile(filepath.Join(gitDir, "Dockerfile"), []byte(dockerfile), 0600)
+	require.NoError(t, err)
+
+	err = runShell(gitDir,
+		"git init",
+		"git config --local user.email test",
+		"git config --local user.name test",
+		"git add Dockerfile",
+		"git commit -m initial",
+		"git branch buildinfo",
+		"git update-server-info",
+	)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.FileServer(http.Dir(filepath.Join(gitDir))))
+	defer server.Close()
+
+	destDir, err := ioutil.TempDir("", "buildkit")
+	require.NoError(t, err)
+	defer os.RemoveAll(destDir)
+
+	out := filepath.Join(destDir, "out.tar")
+	outW, err := os.Create(out)
+	require.NoError(t, err)
+
+	c, err := client.New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	res, err := f.Solve(sb.Context(), c, client.SolveOpt{
+		Exports: []client.ExportEntry{
+			{
+				Type:   client.ExporterOCI,
+				Output: fixedWriteCloser(outW),
+			},
+		},
+		FrontendAttrs: map[string]string{
+			builder.DefaultLocalNameContext: server.URL + "/.git#buildinfo",
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	require.Contains(t, res.ExporterResponse, exptypes.ExporterBuildInfo)
+	dtbi, err := base64.StdEncoding.DecodeString(res.ExporterResponse[exptypes.ExporterBuildInfo])
+	require.NoError(t, err)
+
+	var bi binfotypes.BuildInfo
+	err = json.Unmarshal(dtbi, &bi)
+	require.NoError(t, err)
+
+	sources := bi.Sources
+	require.Equal(t, 3, len(sources))
+
+	assert.Equal(t, binfotypes.SourceTypeDockerImage, sources[0].Type)
+	assert.Equal(t, "docker.io/library/alpine:latest@sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300", sources[0].Ref)
+	assert.Equal(t, "sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300", sources[0].Pin)
+
+	assert.Equal(t, binfotypes.SourceTypeDockerImage, sources[1].Type)
+	assert.Equal(t, "docker.io/library/busybox:latest", sources[1].Ref)
+	assert.NotEmpty(t, sources[1].Pin)
+
+	assert.Equal(t, binfotypes.SourceTypeHTTP, sources[2].Type)
+	assert.Equal(t, "https://raw.githubusercontent.com/moby/moby/master/README.md", sources[2].Ref)
+	assert.Equal(t, "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c", sources[2].Pin)
+}
+
+// moby/buildkit#2476
+func testBuildAttrs(t *testing.T, sb integration.Sandbox) {
+	f := getFrontend(t, sb)
+	f.RequiresBuildctl(t)
+
+	dockerfile := `
+FROM busybox:latest
+ARG foo
+RUN echo $foo
+`
+
+	dir, err := tmpdir(
+		fstest.CreateFile("Dockerfile", []byte(dockerfile), 0600),
+	)
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	c, err := client.New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	destDir, err := ioutil.TempDir("", "buildkit")
+	require.NoError(t, err)
+	defer os.RemoveAll(destDir)
+
+	out := filepath.Join(destDir, "out.tar")
+	outW, err := os.Create(out)
+	require.NoError(t, err)
+
+	res, err := f.Solve(sb.Context(), c, client.SolveOpt{
+		FrontendAttrs: map[string]string{
+			"build-arg:foo": "bar",
+		},
+		Exports: []client.ExportEntry{
+			{
+				Type:   client.ExporterOCI,
+				Output: fixedWriteCloser(outW),
+			},
+		},
+		LocalDirs: map[string]string{
+			builder.DefaultLocalNameDockerfile: dir,
+			builder.DefaultLocalNameContext:    dir,
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	require.Contains(t, res.ExporterResponse, exptypes.ExporterBuildInfo)
+	dtbi, err := base64.StdEncoding.DecodeString(res.ExporterResponse[exptypes.ExporterBuildInfo])
+	require.NoError(t, err)
+
+	var bi binfotypes.BuildInfo
+	err = json.Unmarshal(dtbi, &bi)
+	require.NoError(t, err)
+
+	require.Contains(t, bi.Attrs, "build-arg:foo")
+	require.Equal(t, "bar", bi.Attrs["build-arg:foo"])
+}
+
+// moby/buildkit#2476
+func testBuildInfoMultiPlatform(t *testing.T, sb integration.Sandbox) {
+	f := getFrontend(t, sb)
+	f.RequiresBuildctl(t)
+
+	dockerfile := `
+FROM busybox:latest
+ARG foo
+RUN echo $foo
+ADD https://raw.githubusercontent.com/moby/moby/master/README.md /
+`
+
+	dir, err := tmpdir(
+		fstest.CreateFile("Dockerfile", []byte(dockerfile), 0600),
+	)
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	c, err := client.New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	destDir, err := ioutil.TempDir("", "buildkit")
+	require.NoError(t, err)
+	defer os.RemoveAll(destDir)
+
+	out := filepath.Join(destDir, "out.tar")
+	outW, err := os.Create(out)
+	require.NoError(t, err)
+
+	platforms := []string{"linux/amd64", "linux/arm64"}
+
+	res, err := f.Solve(sb.Context(), c, client.SolveOpt{
+		FrontendAttrs: map[string]string{
+			"build-arg:foo": "bar",
+			"platform":      strings.Join(platforms, ","),
+		},
+		Exports: []client.ExportEntry{
+			{
+				Type:   client.ExporterOCI,
+				Output: fixedWriteCloser(outW),
+			},
+		},
+		LocalDirs: map[string]string{
+			builder.DefaultLocalNameDockerfile: dir,
+			builder.DefaultLocalNameContext:    dir,
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	for _, platform := range platforms {
+		require.Contains(t, res.ExporterResponse, fmt.Sprintf("%s/%s", exptypes.ExporterBuildInfo, platform))
+		dtbi, err := base64.StdEncoding.DecodeString(res.ExporterResponse[fmt.Sprintf("%s/%s", exptypes.ExporterBuildInfo, platform)])
+		require.NoError(t, err)
+
+		var bi binfotypes.BuildInfo
+		err = json.Unmarshal(dtbi, &bi)
+		require.NoError(t, err)
+
+		require.Contains(t, bi.Attrs, "build-arg:foo")
+		require.Equal(t, "bar", bi.Attrs["build-arg:foo"])
+		require.Contains(t, bi.Attrs, "platform")
+		require.Equal(t, strings.Join(platforms, ","), bi.Attrs["platform"])
+
+		sources := bi.Sources
+		require.Equal(t, 2, len(sources))
+
+		assert.Equal(t, binfotypes.SourceTypeDockerImage, sources[0].Type)
+		assert.Equal(t, "docker.io/library/busybox:latest", sources[0].Ref)
+		assert.NotEmpty(t, sources[0].Pin)
+
+		assert.Equal(t, binfotypes.SourceTypeHTTP, sources[1].Type)
+		assert.Equal(t, "https://raw.githubusercontent.com/moby/moby/master/README.md", sources[1].Ref)
+		assert.Equal(t, "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c", sources[1].Pin)
+	}
+}

--- a/frontend/dockerfile/dockerfile_buildinfo_test.go
+++ b/frontend/dockerfile/dockerfile_buildinfo_test.go
@@ -232,8 +232,6 @@ ADD https://raw.githubusercontent.com/moby/moby/master/README.md /
 
 		require.Contains(t, bi.Attrs, "build-arg:foo")
 		require.Equal(t, "bar", bi.Attrs["build-arg:foo"])
-		require.Contains(t, bi.Attrs, "platform")
-		require.Equal(t, strings.Join(platforms, ","), bi.Attrs["platform"])
 
 		sources := bi.Sources
 		require.Equal(t, 2, len(sources))

--- a/frontend/dockerfile/docs/syntax.md
+++ b/frontend/dockerfile/docs/syntax.md
@@ -321,7 +321,10 @@ RUN --security=insecure cat /proc/self/status | grep CapEff
 
 * `BUILDKIT_CACHE_MOUNT_NS=<string>` set optional cache ID namespace
 * `BUILDKIT_CONTEXT_KEEP_GIT_DIR=<bool>` trigger git context to keep the `.git` directory
-* `BUILDKIT_INLINE_CACHE=<bool>` inline cache metadata to image configuration or not (for Docker-integrated BuildKit (`DOCKER_BUILDKIT=1 docker build`) and `docker buildx`)
+* `BUILDKIT_INLINE_BUILDINFO_ATTRS=<bool>`¹ inline build info attributes in image config or not
+* `BUILDKIT_INLINE_CACHE=<bool>`¹ inline cache metadata to image config or not
 * `BUILDKIT_MULTI_PLATFORM=<bool>` opt into determnistic output regardless of multi-platform output or not
 * `BUILDKIT_SANDBOX_HOSTNAME=<string>` set the hostname (default `buildkitsandbox`)
 * `BUILDKIT_SYNTAX=<image>` set frontend image
+
+> **¹** For Docker-integrated BuildKit (`DOCKER_BUILDKIT=1 docker build`) and `docker buildx`

--- a/solver/llbsolver/bridge.go
+++ b/solver/llbsolver/bridge.go
@@ -62,7 +62,7 @@ func (b *llbBridge) Warn(ctx context.Context, dgst digest.Digest, msg string, op
 	})
 }
 
-func (b *llbBridge) loadResult(ctx context.Context, def *pb.Definition, cacheImports []gw.CacheOptionsEntry) (solver.CachedResult, solver.BuildInfo, error) {
+func (b *llbBridge) loadResult(ctx context.Context, def *pb.Definition, cacheImports []gw.CacheOptionsEntry) (solver.CachedResult, solver.BuildSources, error) {
 	w, err := b.resolveWorker()
 	if err != nil {
 		return nil, nil, err
@@ -162,13 +162,13 @@ func (b *llbBridge) Solve(ctx context.Context, req frontend.SolveRequest, sid st
 }
 
 type resultProxy struct {
-	cb         func(context.Context) (solver.CachedResult, solver.BuildInfo, error)
+	cb         func(context.Context) (solver.CachedResult, solver.BuildSources, error)
 	def        *pb.Definition
 	g          flightcontrol.Group
 	mu         sync.Mutex
 	released   bool
 	v          solver.CachedResult
-	bi         solver.BuildInfo
+	bsrc       solver.BuildSources
 	err        error
 	errResults []solver.Result
 }
@@ -177,8 +177,8 @@ func newResultProxy(b *llbBridge, req frontend.SolveRequest) *resultProxy {
 	rp := &resultProxy{
 		def: req.Definition,
 	}
-	rp.cb = func(ctx context.Context) (solver.CachedResult, solver.BuildInfo, error) {
-		res, bi, err := b.loadResult(ctx, req.Definition, req.CacheImports)
+	rp.cb = func(ctx context.Context) (solver.CachedResult, solver.BuildSources, error) {
+		res, bsrc, err := b.loadResult(ctx, req.Definition, req.CacheImports)
 		var ee *llberrdefs.ExecError
 		if errors.As(err, &ee) {
 			ee.EachRef(func(res solver.Result) error {
@@ -188,7 +188,7 @@ func newResultProxy(b *llbBridge, req frontend.SolveRequest) *resultProxy {
 			// acquire ownership so ExecError finalizer doesn't attempt to release as well
 			ee.OwnerBorrowed = true
 		}
-		return res, bi, err
+		return res, bsrc, err
 	}
 	return rp
 }
@@ -197,8 +197,8 @@ func (rp *resultProxy) Definition() *pb.Definition {
 	return rp.def
 }
 
-func (rp *resultProxy) BuildInfo() solver.BuildInfo {
-	return rp.bi
+func (rp *resultProxy) BuildSources() solver.BuildSources {
+	return rp.bsrc
 }
 
 func (rp *resultProxy) Release(ctx context.Context) (err error) {
@@ -259,7 +259,7 @@ func (rp *resultProxy) Result(ctx context.Context) (res solver.CachedResult, err
 			return rp.v, rp.err
 		}
 		rp.mu.Unlock()
-		v, bi, err := rp.cb(ctx)
+		v, bsrc, err := rp.cb(ctx)
 		if err != nil {
 			select {
 			case <-ctx.Done():
@@ -278,7 +278,7 @@ func (rp *resultProxy) Result(ctx context.Context) (res solver.CachedResult, err
 			return nil, errors.Errorf("evaluating released result")
 		}
 		rp.v = v
-		rp.bi = bi
+		rp.bsrc = bsrc
 		rp.err = err
 		rp.mu.Unlock()
 		return v, err

--- a/solver/llbsolver/bridge.go
+++ b/solver/llbsolver/bridge.go
@@ -23,7 +23,6 @@ import (
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/buildinfo"
-	binfotypes "github.com/moby/buildkit/util/buildinfo/types"
 	"github.com/moby/buildkit/util/flightcontrol"
 	"github.com/moby/buildkit/util/progress"
 	"github.com/moby/buildkit/worker"
@@ -166,20 +165,14 @@ func (b *llbBridge) Solve(ctx context.Context, req frontend.SolveRequest, sid st
 
 	if len(res.Refs) > 0 {
 		for p := range res.Refs {
-			dtbi, errm := buildinfo.GetMetadata(res.Metadata, fmt.Sprintf("%s/%s", exptypes.ExporterBuildInfo, p), binfotypes.BuildInfo{
-				Frontend: req.Frontend,
-				Attrs:    req.FrontendOpt,
-			})
+			dtbi, errm := buildinfo.GetMetadata(res.Metadata, fmt.Sprintf("%s/%s", exptypes.ExporterBuildInfo, p), req.Frontend, req.FrontendOpt)
 			if errm != nil {
 				return nil, err
 			}
 			res.Metadata[fmt.Sprintf("%s/%s", exptypes.ExporterBuildInfo, p)] = dtbi
 		}
 	} else {
-		dtbi, errm := buildinfo.GetMetadata(res.Metadata, exptypes.ExporterBuildInfo, binfotypes.BuildInfo{
-			Frontend: req.Frontend,
-			Attrs:    req.FrontendOpt,
-		})
+		dtbi, errm := buildinfo.GetMetadata(res.Metadata, exptypes.ExporterBuildInfo, req.Frontend, req.FrontendOpt)
 		if errm != nil {
 			return nil, err
 		}

--- a/solver/llbsolver/ops/source.go
+++ b/solver/llbsolver/ops/source.go
@@ -78,16 +78,16 @@ func (s *sourceOp) CacheMap(ctx context.Context, g session.Group, index int) (*s
 		dgst = digest.Digest("random:" + strings.TrimPrefix(dgst.String(), dgst.Algorithm().String()+":"))
 	}
 
-	var buildInfo map[string]string
+	var buildSources map[string]string
 	if !strings.HasPrefix(s.op.Source.GetIdentifier(), "local://") {
-		buildInfo = map[string]string{s.op.Source.GetIdentifier(): pin}
+		buildSources = map[string]string{s.op.Source.GetIdentifier(): pin}
 	}
 
 	return &solver.CacheMap{
 		// TODO: add os/arch
-		Digest:    dgst,
-		Opts:      cacheOpts,
-		BuildInfo: buildInfo,
+		Digest:       dgst,
+		Opts:         cacheOpts,
+		BuildSources: buildSources,
 	}, done, nil
 }
 

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -176,7 +176,7 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 			}
 			inp.Ref = workerRef.ImmutableRef
 
-			dtbi, err := buildinfo.Merge(ctx, res.BuildSources(), inp.Metadata[exptypes.ExporterImageConfigKey])
+			dtbi, err := buildinfo.Encode(ctx, req, res.BuildSources(), inp.Metadata[exptypes.ExporterImageConfigKey])
 			if err != nil {
 				return nil, err
 			}
@@ -208,7 +208,7 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 					}
 					m[k] = workerRef.ImmutableRef
 
-					dtbi, err := buildinfo.Merge(ctx, res.BuildSources(), inp.Metadata[fmt.Sprintf("%s/%s", exptypes.ExporterImageConfigKey, k)])
+					dtbi, err := buildinfo.Encode(ctx, req, res.BuildSources(), inp.Metadata[fmt.Sprintf("%s/%s", exptypes.ExporterImageConfigKey, k)])
 					if err != nil {
 						return nil, err
 					}

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -175,8 +175,7 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 				return nil, errors.Errorf("invalid reference: %T", r.Sys())
 			}
 			inp.Ref = workerRef.ImmutableRef
-
-			dtbi, err := buildinfo.Encode(ctx, req, res.BuildSources(), inp.Metadata[exptypes.ExporterImageConfigKey])
+			dtbi, err := buildinfo.Encode(ctx, req.Frontend, inp.Metadata[exptypes.ExporterBuildInfoAttrs], res.BuildSources(), inp.Metadata[exptypes.ExporterImageConfigKey])
 			if err != nil {
 				return nil, err
 			}
@@ -207,8 +206,7 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 						return nil, errors.Errorf("invalid reference: %T", r.Sys())
 					}
 					m[k] = workerRef.ImmutableRef
-
-					dtbi, err := buildinfo.Encode(ctx, req, res.BuildSources(), inp.Metadata[fmt.Sprintf("%s/%s", exptypes.ExporterImageConfigKey, k)])
+					dtbi, err := buildinfo.Encode(ctx, req.Frontend, inp.Metadata[exptypes.ExporterBuildInfoAttrs], res.BuildSources(), inp.Metadata[fmt.Sprintf("%s/%s", exptypes.ExporterImageConfigKey, k)])
 					if err != nil {
 						return nil, err
 					}

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -176,7 +176,7 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 			}
 			inp.Ref = workerRef.ImmutableRef
 
-			dtbi, err := buildinfo.Merge(ctx, res.BuildInfo(), inp.Metadata[exptypes.ExporterImageConfigKey])
+			dtbi, err := buildinfo.Merge(ctx, res.BuildSources(), inp.Metadata[exptypes.ExporterImageConfigKey])
 			if err != nil {
 				return nil, err
 			}
@@ -208,7 +208,7 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 					}
 					m[k] = workerRef.ImmutableRef
 
-					dtbi, err := buildinfo.Merge(ctx, res.BuildInfo(), inp.Metadata[fmt.Sprintf("%s/%s", exptypes.ExporterImageConfigKey, k)])
+					dtbi, err := buildinfo.Merge(ctx, res.BuildSources(), inp.Metadata[fmt.Sprintf("%s/%s", exptypes.ExporterImageConfigKey, k)])
 					if err != nil {
 						return nil, err
 					}

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -175,7 +175,7 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 				return nil, errors.Errorf("invalid reference: %T", r.Sys())
 			}
 			inp.Ref = workerRef.ImmutableRef
-			dtbi, err := buildinfo.Encode(ctx, req.Frontend, inp.Metadata[exptypes.ExporterBuildInfoAttrs], res.BuildSources(), inp.Metadata[exptypes.ExporterImageConfigKey])
+			dtbi, err := buildinfo.Encode(ctx, inp.Metadata[exptypes.ExporterBuildInfo], res.BuildSources())
 			if err != nil {
 				return nil, err
 			}
@@ -206,7 +206,7 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 						return nil, errors.Errorf("invalid reference: %T", r.Sys())
 					}
 					m[k] = workerRef.ImmutableRef
-					dtbi, err := buildinfo.Encode(ctx, req.Frontend, inp.Metadata[exptypes.ExporterBuildInfoAttrs], res.BuildSources(), inp.Metadata[fmt.Sprintf("%s/%s", exptypes.ExporterImageConfigKey, k)])
+					dtbi, err := buildinfo.Encode(ctx, inp.Metadata[fmt.Sprintf("%s/%s", exptypes.ExporterBuildInfo, k)], res.BuildSources())
 					if err != nil {
 						return nil, err
 					}

--- a/solver/types.go
+++ b/solver/types.go
@@ -76,7 +76,7 @@ type ResultProxy interface {
 	Result(context.Context) (CachedResult, error)
 	Release(context.Context) error
 	Definition() *pb.Definition
-	BuildInfo() BuildInfo
+	BuildSources() BuildSources
 }
 
 // CacheExportMode is the type for setting cache exporting modes
@@ -197,13 +197,13 @@ type CacheMap struct {
 	// the cache. Opts should not have any impact on the computed cache key.
 	Opts CacheOpts
 
-	// BuildInfo contains build dependencies that will be set from source
+	// BuildSources contains build dependencies that will be set from source
 	// operation.
-	BuildInfo map[string]string
+	BuildSources BuildSources
 }
 
-// BuildInfo contains solved build dependencies.
-type BuildInfo map[string]string
+// BuildSources contains solved build dependencies.
+type BuildSources map[string]string
 
 // ExportableCacheKey is a cache key connected with an exporter that can export
 // a chain of cacherecords pointing to that key

--- a/util/buildinfo/buildinfo.go
+++ b/util/buildinfo/buildinfo.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/docker/distribution/reference"
-	"github.com/moby/buildkit/frontend"
 	"github.com/moby/buildkit/source"
 	binfotypes "github.com/moby/buildkit/util/buildinfo/types"
 	"github.com/moby/buildkit/util/urlutil"
@@ -26,7 +25,7 @@ func Decode(enc string) (bi binfotypes.BuildInfo, _ error) {
 }
 
 // Encode encodes build info.
-func Encode(ctx context.Context, req frontend.SolveRequest, buildSources map[string]string, imageConfig []byte) ([]byte, error) {
+func Encode(ctx context.Context, frontend string, frontendAttrs []byte, buildSources map[string]string, imageConfig []byte) ([]byte, error) {
 	icbi, err := FromImageConfig(imageConfig)
 	if err != nil {
 		return nil, err
@@ -35,9 +34,15 @@ func Encode(ctx context.Context, req frontend.SolveRequest, buildSources map[str
 	if err != nil {
 		return nil, err
 	}
+	attrs := make(map[string]string)
+	if frontendAttrs != nil {
+		if err := json.Unmarshal(frontendAttrs, &attrs); err != nil {
+			return nil, err
+		}
+	}
 	return json.Marshal(binfotypes.BuildInfo{
-		Frontend: req.Frontend,
-		Attrs:    filterAttrs(req.FrontendOpt),
+		Frontend: frontend,
+		Attrs:    filterAttrs(attrs),
 		Sources:  srcs,
 	})
 }

--- a/util/buildinfo/buildinfo.go
+++ b/util/buildinfo/buildinfo.go
@@ -26,7 +26,7 @@ func Decode(enc string) (bi binfotypes.BuildInfo, _ error) {
 }
 
 // Encode encodes build info.
-func Encode(ctx context.Context, solveReq frontend.SolveRequest, buildSources map[string]string, imageConfig []byte) ([]byte, error) {
+func Encode(ctx context.Context, req frontend.SolveRequest, buildSources map[string]string, imageConfig []byte) ([]byte, error) {
 	icbi, err := FromImageConfig(imageConfig)
 	if err != nil {
 		return nil, err
@@ -36,8 +36,8 @@ func Encode(ctx context.Context, solveReq frontend.SolveRequest, buildSources ma
 		return nil, err
 	}
 	return json.Marshal(binfotypes.BuildInfo{
-		Frontend: solveReq.Frontend,
-		Attrs:    filterAttrs(solveReq.FrontendOpt),
+		Frontend: req.Frontend,
+		Attrs:    filterAttrs(req.FrontendOpt),
 		Sources:  srcs,
 	})
 }
@@ -152,6 +152,29 @@ func FromImageConfig(imageConfig []byte) (bi binfotypes.BuildInfo, _ error) {
 		return bi, errors.Wrap(err, "failed to unmarshal buildinfo")
 	}
 	return bi, nil
+}
+
+// FormatOpts holds build info format options.
+type FormatOpts struct {
+	RemoveAttrs bool
+}
+
+// Format formats build info.
+func Format(dt []byte, format FormatOpts) (_ []byte, err error) {
+	if len(dt) == 0 {
+		return dt, nil
+	}
+	var bi binfotypes.BuildInfo
+	if err := json.Unmarshal(dt, &bi); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal buildinfo for formatting")
+	}
+	if format.RemoveAttrs {
+		bi.Attrs = nil
+	}
+	if dt, err = json.Marshal(bi); err != nil {
+		return nil, err
+	}
+	return dt, nil
 }
 
 var knownAttrs = []string{

--- a/util/buildinfo/buildinfo.go
+++ b/util/buildinfo/buildinfo.go
@@ -199,10 +199,16 @@ var knownAttrs = []string{
 func filterAttrs(attrs map[string]string) map[string]string {
 	filtered := make(map[string]string)
 	for k, v := range attrs {
+		// Control args are filtered out
+		if isControlArg(k) {
+			continue
+		}
+		// Always include args and labels
 		if strings.HasPrefix(k, "build-arg:") || strings.HasPrefix(k, "label:") {
 			filtered[k] = v
 			continue
 		}
+		// Filter only for known attributes
 		for _, knownAttr := range knownAttrs {
 			if knownAttr == k {
 				filtered[k] = v
@@ -211,4 +217,24 @@ func filterAttrs(attrs map[string]string) map[string]string {
 		}
 	}
 	return filtered
+}
+
+var knownControlArgs = []string{
+	"BUILDKIT_CACHE_MOUNT_NS",
+	"BUILDKIT_CONTEXT_KEEP_GIT_DIR",
+	"BUILDKIT_INLINE_BUILDINFO_ATTRS",
+	"BUILDKIT_INLINE_CACHE",
+	"BUILDKIT_MULTI_PLATFORM",
+	"BUILDKIT_SANDBOX_HOSTNAME",
+	"BUILDKIT_SYNTAX",
+}
+
+// isControlArg checks if a build attributes is a control arg
+func isControlArg(attrKey string) bool {
+	for _, k := range knownControlArgs {
+		if strings.HasPrefix(attrKey, "build-arg:"+k) {
+			return true
+		}
+	}
+	return false
 }

--- a/util/buildinfo/buildinfo_test.go
+++ b/util/buildinfo/buildinfo_test.go
@@ -96,10 +96,8 @@ func TestFormat(t *testing.T) {
 		Frontend: "dockerfile.v0",
 		Attrs: map[string]string{
 			"build-arg:foo": "bar",
-			"cmdline":       "crazymax/dockerfile:master",
 			"context":       "https://github.com/crazy-max/buildkit-buildsources-test.git#master",
 			"filename":      "Dockerfile",
-			"platform":      "linux/amd64,linux/arm64",
 			"source":        "crazymax/dockerfile:master",
 		},
 		Sources: []binfotypes.Source{

--- a/util/buildinfo/buildinfo_test.go
+++ b/util/buildinfo/buildinfo_test.go
@@ -2,6 +2,7 @@ package buildinfo
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	binfotypes "github.com/moby/buildkit/util/buildinfo/types"
@@ -9,9 +10,55 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var bifixture = binfotypes.BuildInfo{
+	Frontend: "dockerfile.v0",
+	Attrs: map[string]string{
+		"build-arg:BUILDKIT_INLINE_BUILDINFO_ATTRS": "1",
+		"build-arg:foo": "bar",
+		"cmdline":       "crazymax/dockerfile:master",
+		"context":       "https://github.com/crazy-max/buildkit-buildsources-test.git#master",
+		"filename":      "Dockerfile",
+		"platform":      "linux/amd64,linux/arm64",
+		"source":        "crazymax/dockerfile:master",
+	},
+	Sources: []binfotypes.Source{
+		{
+			Type: binfotypes.SourceTypeDockerImage,
+			Ref:  "docker.io/docker/buildx-bin:0.6.1@sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
+			Pin:  "sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
+		},
+		{
+			Type: binfotypes.SourceTypeDockerImage,
+			Ref:  "docker.io/library/alpine:3.13",
+			Pin:  "sha256:1d30d1ba3cb90962067e9b29491fbd56997979d54376f23f01448b5c5cd8b462",
+		},
+		{
+			Type: binfotypes.SourceTypeDockerImage,
+			Ref:  "docker.io/moby/buildkit:v0.9.0",
+			Pin:  "sha256:8dc668e7f66db1c044aadbed306020743516a94848793e0f81f94a087ee78cab",
+		},
+		{
+			Type: binfotypes.SourceTypeDockerImage,
+			Ref:  "docker.io/tonistiigi/xx@sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04",
+			Pin:  "sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04",
+		},
+		{
+			Type: binfotypes.SourceTypeGit,
+			Ref:  "https://github.com/crazy-max/buildkit-buildsources-test.git#master",
+			Pin:  "259a5aa5aa5bb3562d12cc631fe399f4788642c1",
+		},
+		{
+			Type: binfotypes.SourceTypeHTTP,
+			Ref:  "https://raw.githubusercontent.com/moby/moby/master/README.md",
+			Pin:  "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c",
+		},
+	},
+}
+
 func TestDecode(t *testing.T) {
-	bi, err := Decode("eyJzb3VyY2VzIjpbeyJ0eXBlIjoiaW1hZ2UiLCJyZWYiOiJkb2NrZXIuaW8vZG9ja2VyL2J1aWxkeC1iaW46MC42LjFAc2hhMjU2OmE2NTJjZWQ0YTQxNDE5NzdjN2RhYWVkMGEwNzRkY2Q5ODQ0YTc4ZDdkMjYxNTQ2NWIxMmY0MzNhZTZkZDI5ZjAiLCJwaW4iOiJzaGEyNTY6YTY1MmNlZDRhNDE0MTk3N2M3ZGFhZWQwYTA3NGRjZDk4NDRhNzhkN2QyNjE1NDY1YjEyZjQzM2FlNmRkMjlmMCJ9LHsidHlwZSI6ImltYWdlIiwicmVmIjoiZG9ja2VyLmlvL2xpYnJhcnkvYWxwaW5lOjMuMTMiLCJwaW4iOiJzaGEyNTY6MWQzMGQxYmEzY2I5MDk2MjA2N2U5YjI5NDkxZmJkNTY5OTc5NzlkNTQzNzZmMjNmMDE0NDhiNWM1Y2Q4YjQ2MiJ9LHsidHlwZSI6ImltYWdlIiwicmVmIjoiZG9ja2VyLmlvL21vYnkvYnVpbGRraXQ6djAuOS4wIiwicGluIjoic2hhMjU2OjhkYzY2OGU3ZjY2ZGIxYzA0NGFhZGJlZDMwNjAyMDc0MzUxNmE5NDg0ODc5M2UwZjgxZjk0YTA4N2VlNzhjYWIifSx7InR5cGUiOiJpbWFnZSIsInJlZiI6ImRvY2tlci5pby90b25pc3RpaWdpL3h4QHNoYTI1NjoyMWE2MWJlNDc0NGY2NTMxY2I1ZjMzYjBlNmY0MGVkZTQxZmEzYTFiOGM4MmQ1OTQ2MTc4ZjgwY2M4NGJmYzA0IiwicGluIjoic2hhMjU2OjIxYTYxYmU0NzQ0ZjY1MzFjYjVmMzNiMGU2ZjQwZWRlNDFmYTNhMWI4YzgyZDU5NDYxNzhmODBjYzg0YmZjMDQifSx7InR5cGUiOiJnaXQiLCJyZWYiOiJodHRwczovL2dpdGh1Yi5jb20vY3JhenktbWF4L2J1aWxka2l0LWJ1aWxkc291cmNlcy10ZXN0LmdpdCNtYXN0ZXIiLCJwaW4iOiIyNTlhNWFhNWFhNWJiMzU2MmQxMmNjNjMxZmUzOTlmNDc4ODY0MmMxIn0seyJ0eXBlIjoiaHR0cCIsInJlZiI6Imh0dHBzOi8vcmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbS9tb2J5L21vYnkvbWFzdGVyL1JFQURNRS5tZCIsInBpbiI6InNoYTI1Njo0MTk0NTUyMDJiMGVmOTdlNDgwZDdmODE5OWIyNmE3MjFhNDE3ODE4YmMwZTJkMTA2OTc1Zjc0MzIzZjI1ZTZjIn1dfQ==")
+	bi, err := Decode("eyJmcm9udGVuZCI6ImRvY2tlcmZpbGUudjAiLCJhdHRycyI6eyJidWlsZC1hcmc6QlVJTERLSVRfSU5MSU5FX0JVSUxESU5GT19BVFRSUyI6IjEiLCJjbWRsaW5lIjoiY3JhenltYXgvZG9ja2VyZmlsZTpidWlsZGF0dHJzIiwiY29udGV4dCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9jcmF6eS1tYXgvYnVpbGRraXQtYnVpbGRzb3VyY2VzLXRlc3QuZ2l0I21hc3RlciIsImZpbGVuYW1lIjoiRG9ja2VyZmlsZSIsInNvdXJjZSI6ImNyYXp5bWF4L2RvY2tlcmZpbGU6YnVpbGRhdHRycyJ9LCJzb3VyY2VzIjpbeyJ0eXBlIjoiZG9ja2VyLWltYWdlIiwicmVmIjoiZG9ja2VyLmlvL2RvY2tlci9idWlsZHgtYmluOjAuNi4xQHNoYTI1NjphNjUyY2VkNGE0MTQxOTc3YzdkYWFlZDBhMDc0ZGNkOTg0NGE3OGQ3ZDI2MTU0NjViMTJmNDMzYWU2ZGQyOWYwIiwicGluIjoic2hhMjU2OmE2NTJjZWQ0YTQxNDE5NzdjN2RhYWVkMGEwNzRkY2Q5ODQ0YTc4ZDdkMjYxNTQ2NWIxMmY0MzNhZTZkZDI5ZjAifSx7InR5cGUiOiJkb2NrZXItaW1hZ2UiLCJyZWYiOiJkb2NrZXIuaW8vbGlicmFyeS9hbHBpbmU6My4xMyIsInBpbiI6InNoYTI1NjowMjZmNzIxYWY0Y2YyODQzZTA3YmJhNjQ4ZTE1OGZiMzVlY2M4NzZkODIyMTMwNjMzY2M0OWY3MDdmMGZjODhjIn0seyJ0eXBlIjoiZG9ja2VyLWltYWdlIiwicmVmIjoiZG9ja2VyLmlvL21vYnkvYnVpbGRraXQ6djAuOS4wIiwicGluIjoic2hhMjU2OjhkYzY2OGU3ZjY2ZGIxYzA0NGFhZGJlZDMwNjAyMDc0MzUxNmE5NDg0ODc5M2UwZjgxZjk0YTA4N2VlNzhjYWIifSx7InR5cGUiOiJkb2NrZXItaW1hZ2UiLCJyZWYiOiJkb2NrZXIuaW8vdG9uaXN0aWlnaS94eEBzaGEyNTY6MjFhNjFiZTQ3NDRmNjUzMWNiNWYzM2IwZTZmNDBlZGU0MWZhM2ExYjhjODJkNTk0NjE3OGY4MGNjODRiZmMwNCIsInBpbiI6InNoYTI1NjoyMWE2MWJlNDc0NGY2NTMxY2I1ZjMzYjBlNmY0MGVkZTQxZmEzYTFiOGM4MmQ1OTQ2MTc4ZjgwY2M4NGJmYzA0In0seyJ0eXBlIjoiZ2l0IiwicmVmIjoiaHR0cHM6Ly9naXRodWIuY29tL2NyYXp5LW1heC9idWlsZGtpdC1idWlsZHNvdXJjZXMtdGVzdC5naXQjbWFzdGVyIiwicGluIjoiNDNhOGJmOWMzNTFhYmY2NGIwODY1YTZhMDU0OGExZGUxZGVkNDBhOCJ9LHsidHlwZSI6Imh0dHAiLCJyZWYiOiJodHRwczovL3Jhdy5naXRodWJ1c2VyY29udGVudC5jb20vbW9ieS9tb2J5L21hc3Rlci9SRUFETUUubWQiLCJwaW4iOiJzaGEyNTY6NDE5NDU1MjAyYjBlZjk3ZTQ4MGQ3ZjgxOTliMjZhNzIxYTQxNzgxOGJjMGUyZDEwNjk3NWY3NDMyM2YyNWU2YyJ9XX0=")
 	require.NoError(t, err)
+	assert.Equal(t, 5, len(bi.Attrs))
 	assert.Equal(t, 6, len(bi.Sources))
 }
 
@@ -89,4 +136,81 @@ func TestMergeSources(t *testing.T) {
 			Pin:  "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c",
 		},
 	}, srcs)
+}
+
+func TestFromImageConfig(t *testing.T) {
+	dtbi, err := json.Marshal(bifixture)
+	require.NoError(t, err)
+	dtic, err := json.Marshal(struct {
+		BuildInfo []byte `json:"moby.buildkit.buildinfo.v1"`
+	}{
+		BuildInfo: dtbi,
+	})
+	require.NoError(t, err)
+	bi, err := FromImageConfig(dtic)
+	require.NoError(t, err)
+	assert.Equal(t, 7, len(bi.Attrs))
+	assert.Equal(t, 6, len(bi.Sources))
+}
+
+func TestFormat(t *testing.T) {
+	bi := binfotypes.BuildInfo{
+		Frontend: "dockerfile.v0",
+		Attrs: map[string]string{
+			"build-arg:foo": "bar",
+			"cmdline":       "crazymax/dockerfile:master",
+			"context":       "https://github.com/crazy-max/buildkit-buildsources-test.git#master",
+			"filename":      "Dockerfile",
+			"platform":      "linux/amd64,linux/arm64",
+			"source":        "crazymax/dockerfile:master",
+		},
+		Sources: []binfotypes.Source{
+			{
+				Type:  binfotypes.SourceTypeDockerImage,
+				Ref:   "docker.io/docker/buildx-bin:0.6.1@sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
+				Alias: "docker.io/docker/buildx-bin:0.6.1@sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
+				Pin:   "sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
+			},
+		},
+	}
+
+	cases := []struct {
+		name       string
+		formatopts FormatOpts
+		want       binfotypes.BuildInfo
+	}{
+		{
+			name:       "unchanged",
+			formatopts: FormatOpts{RemoveAttrs: false},
+			want:       bi,
+		},
+		{
+			name:       "remove attrs",
+			formatopts: FormatOpts{RemoveAttrs: true},
+			want: binfotypes.BuildInfo{
+				Frontend: "dockerfile.v0",
+				Sources: []binfotypes.Source{
+					{
+						Type:  binfotypes.SourceTypeDockerImage,
+						Ref:   "docker.io/docker/buildx-bin:0.6.1@sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
+						Alias: "docker.io/docker/buildx-bin:0.6.1@sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
+						Pin:   "sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			dt, err := json.Marshal(bi)
+			require.NoError(t, err)
+			dt, err = Format(dt, tt.formatopts)
+			require.NoError(t, err)
+			var res binfotypes.BuildInfo
+			err = json.Unmarshal(dt, &res)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, res)
+		})
+	}
 }

--- a/util/buildinfo/buildinfo_test.go
+++ b/util/buildinfo/buildinfo_test.go
@@ -94,11 +94,11 @@ func TestMergeSources(t *testing.T) {
 func TestFormat(t *testing.T) {
 	bi := binfotypes.BuildInfo{
 		Frontend: "dockerfile.v0",
-		Attrs: map[string]string{
-			"build-arg:foo": "bar",
-			"context":       "https://github.com/crazy-max/buildkit-buildsources-test.git#master",
-			"filename":      "Dockerfile",
-			"source":        "crazymax/dockerfile:master",
+		Attrs: map[string]*string{
+			"build-arg:foo": stringPtr("bar"),
+			"context":       stringPtr("https://github.com/crazy-max/buildkit-buildsources-test.git#master"),
+			"filename":      stringPtr("Dockerfile"),
+			"source":        stringPtr("crazymax/dockerfile:master"),
 		},
 		Sources: []binfotypes.Source{
 			{
@@ -155,21 +155,27 @@ func TestFormat(t *testing.T) {
 func TestReduceMap(t *testing.T) {
 	cases := []struct {
 		name     string
-		m1       map[string]string
+		m1       map[string]*string
 		m2       map[string]string
 		expected map[string]string
 	}{
 		{
 			name:     "first",
-			m1:       map[string]string{"foo": "bar", "abc": "def"},
+			m1:       map[string]*string{"foo": stringPtr("bar"), "abc": stringPtr("def")},
 			m2:       map[string]string{"bar": "foo", "abc": "ghi"},
 			expected: map[string]string{"foo": "bar", "abc": "def", "bar": "foo"},
 		},
 		{
 			name:     "last",
-			m1:       map[string]string{"bar": "foo", "abc": "ghi"},
+			m1:       map[string]*string{"bar": stringPtr("foo"), "abc": stringPtr("ghi")},
 			m2:       map[string]string{"foo": "bar", "abc": "def"},
 			expected: map[string]string{"bar": "foo", "abc": "ghi", "foo": "bar"},
+		},
+		{
+			name:     "nilattr",
+			m1:       map[string]*string{"foo": stringPtr("bar"), "abc": stringPtr("fgh"), "baz": nil},
+			m2:       map[string]string{"foo": "bar", "baz": "fuu"},
+			expected: map[string]string{"foo": "bar", "abc": "fgh", "baz": "fuu"},
 		},
 		{
 			name:     "null1",
@@ -179,7 +185,7 @@ func TestReduceMap(t *testing.T) {
 		},
 		{
 			name:     "null2",
-			m1:       map[string]string{"foo": "bar", "abc": "def"},
+			m1:       map[string]*string{"foo": stringPtr("bar"), "abc": stringPtr("def")},
 			m2:       nil,
 			expected: map[string]string{"foo": "bar", "abc": "def"},
 		},
@@ -190,4 +196,9 @@ func TestReduceMap(t *testing.T) {
 			require.Equal(t, tt.expected, reduceMap(tt.m2, tt.m1))
 		})
 	}
+}
+
+// stringPtr returns a pointer to the string value passed in.
+func stringPtr(v string) *string {
+	return &v
 }

--- a/util/buildinfo/buildinfo_test.go
+++ b/util/buildinfo/buildinfo_test.go
@@ -1,0 +1,105 @@
+package buildinfo
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	binfotypes "github.com/moby/buildkit/util/buildinfo/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecode(t *testing.T) {
+	bi, err := Decode("eyJzb3VyY2VzIjpbeyJ0eXBlIjoiaW1hZ2UiLCJyZWYiOiJkb2NrZXIuaW8vZG9ja2VyL2J1aWxkeC1iaW46MC42LjFAc2hhMjU2OmE2NTJjZWQ0YTQxNDE5NzdjN2RhYWVkMGEwNzRkY2Q5ODQ0YTc4ZDdkMjYxNTQ2NWIxMmY0MzNhZTZkZDI5ZjAiLCJwaW4iOiJzaGEyNTY6YTY1MmNlZDRhNDE0MTk3N2M3ZGFhZWQwYTA3NGRjZDk4NDRhNzhkN2QyNjE1NDY1YjEyZjQzM2FlNmRkMjlmMCJ9LHsidHlwZSI6ImltYWdlIiwicmVmIjoiZG9ja2VyLmlvL2xpYnJhcnkvYWxwaW5lOjMuMTMiLCJwaW4iOiJzaGEyNTY6MWQzMGQxYmEzY2I5MDk2MjA2N2U5YjI5NDkxZmJkNTY5OTc5NzlkNTQzNzZmMjNmMDE0NDhiNWM1Y2Q4YjQ2MiJ9LHsidHlwZSI6ImltYWdlIiwicmVmIjoiZG9ja2VyLmlvL21vYnkvYnVpbGRraXQ6djAuOS4wIiwicGluIjoic2hhMjU2OjhkYzY2OGU3ZjY2ZGIxYzA0NGFhZGJlZDMwNjAyMDc0MzUxNmE5NDg0ODc5M2UwZjgxZjk0YTA4N2VlNzhjYWIifSx7InR5cGUiOiJpbWFnZSIsInJlZiI6ImRvY2tlci5pby90b25pc3RpaWdpL3h4QHNoYTI1NjoyMWE2MWJlNDc0NGY2NTMxY2I1ZjMzYjBlNmY0MGVkZTQxZmEzYTFiOGM4MmQ1OTQ2MTc4ZjgwY2M4NGJmYzA0IiwicGluIjoic2hhMjU2OjIxYTYxYmU0NzQ0ZjY1MzFjYjVmMzNiMGU2ZjQwZWRlNDFmYTNhMWI4YzgyZDU5NDYxNzhmODBjYzg0YmZjMDQifSx7InR5cGUiOiJnaXQiLCJyZWYiOiJodHRwczovL2dpdGh1Yi5jb20vY3JhenktbWF4L2J1aWxka2l0LWJ1aWxkc291cmNlcy10ZXN0LmdpdCNtYXN0ZXIiLCJwaW4iOiIyNTlhNWFhNWFhNWJiMzU2MmQxMmNjNjMxZmUzOTlmNDc4ODY0MmMxIn0seyJ0eXBlIjoiaHR0cCIsInJlZiI6Imh0dHBzOi8vcmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbS9tb2J5L21vYnkvbWFzdGVyL1JFQURNRS5tZCIsInBpbiI6InNoYTI1Njo0MTk0NTUyMDJiMGVmOTdlNDgwZDdmODE5OWIyNmE3MjFhNDE3ODE4YmMwZTJkMTA2OTc1Zjc0MzIzZjI1ZTZjIn1dfQ==")
+	require.NoError(t, err)
+	assert.Equal(t, 6, len(bi.Sources))
+}
+
+func TestMerge(t *testing.T) {
+	buildSourcesLLB := map[string]string{
+		"docker-image://docker.io/docker/buildx-bin:0.6.1@sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0": "sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
+		"docker-image://docker.io/library/alpine:3.13@sha256:1d30d1ba3cb90962067e9b29491fbd56997979d54376f23f01448b5c5cd8b462":     "sha256:1d30d1ba3cb90962067e9b29491fbd56997979d54376f23f01448b5c5cd8b462",
+		"docker-image://docker.io/moby/buildkit:v0.9.0@sha256:8dc668e7f66db1c044aadbed306020743516a94848793e0f81f94a087ee78cab":    "sha256:8dc668e7f66db1c044aadbed306020743516a94848793e0f81f94a087ee78cab",
+		"docker-image://docker.io/tonistiigi/xx@sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04":           "sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04",
+		"git://https://github.com/crazy-max/buildkit-buildsources-test.git#master":                                                 "259a5aa5aa5bb3562d12cc631fe399f4788642c1",
+		"https://raw.githubusercontent.com/moby/moby/master/README.md":                                                             "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c",
+	}
+
+	buildInfoImageConfig, err := json.Marshal(binfotypes.BuildInfo{
+		Sources: []binfotypes.Source{
+			{
+				Type:  binfotypes.SourceTypeDockerImage,
+				Ref:   "docker.io/docker/buildx-bin:0.6.1@sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
+				Alias: "docker.io/docker/buildx-bin:0.6.1@sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
+				Pin:   "sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
+			},
+			{
+				Type:  binfotypes.SourceTypeDockerImage,
+				Ref:   "docker.io/library/alpine:3.13",
+				Alias: "docker.io/library/alpine:3.13@sha256:1d30d1ba3cb90962067e9b29491fbd56997979d54376f23f01448b5c5cd8b462",
+				Pin:   "sha256:1d30d1ba3cb90962067e9b29491fbd56997979d54376f23f01448b5c5cd8b462",
+			},
+			{
+				Type:  binfotypes.SourceTypeDockerImage,
+				Ref:   "docker.io/moby/buildkit:v0.9.0",
+				Alias: "docker.io/moby/buildkit:v0.9.0@sha256:8dc668e7f66db1c044aadbed306020743516a94848793e0f81f94a087ee78cab",
+				Pin:   "sha256:8dc668e7f66db1c044aadbed306020743516a94848793e0f81f94a087ee78cab",
+			},
+			{
+				Type:  binfotypes.SourceTypeDockerImage,
+				Ref:   "docker.io/tonistiigi/xx@sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04",
+				Alias: "docker.io/tonistiigi/xx@sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04",
+				Pin:   "sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	bic, err := json.Marshal(binfotypes.ImageConfig{
+		BuildInfo: buildInfoImageConfig,
+	})
+	require.NoError(t, err)
+
+	ret, err := Merge(context.Background(), buildSourcesLLB, bic)
+	require.NoError(t, err)
+
+	dec, err := Decode(base64.StdEncoding.EncodeToString(ret))
+	require.NoError(t, err)
+
+	assert.Equal(t, binfotypes.BuildInfo{
+		Sources: []binfotypes.Source{
+			{
+				Type: binfotypes.SourceTypeDockerImage,
+				Ref:  "docker.io/docker/buildx-bin:0.6.1@sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
+				Pin:  "sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
+			},
+			{
+				Type: binfotypes.SourceTypeDockerImage,
+				Ref:  "docker.io/library/alpine:3.13",
+				Pin:  "sha256:1d30d1ba3cb90962067e9b29491fbd56997979d54376f23f01448b5c5cd8b462",
+			},
+			{
+				Type: binfotypes.SourceTypeDockerImage,
+				Ref:  "docker.io/moby/buildkit:v0.9.0",
+				Pin:  "sha256:8dc668e7f66db1c044aadbed306020743516a94848793e0f81f94a087ee78cab",
+			},
+			{
+				Type: binfotypes.SourceTypeDockerImage,
+				Ref:  "docker.io/tonistiigi/xx@sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04",
+				Pin:  "sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04",
+			},
+			{
+				Type: binfotypes.SourceTypeGit,
+				Ref:  "https://github.com/crazy-max/buildkit-buildsources-test.git#master",
+				Pin:  "259a5aa5aa5bb3562d12cc631fe399f4788642c1",
+			},
+			{
+				Type: binfotypes.SourceTypeHTTP,
+				Ref:  "https://raw.githubusercontent.com/moby/moby/master/README.md",
+				Pin:  "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c",
+			},
+		},
+	}, dec)
+}

--- a/util/buildinfo/buildinfo_test.go
+++ b/util/buildinfo/buildinfo_test.go
@@ -10,51 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var bifixture = binfotypes.BuildInfo{
-	Frontend: "dockerfile.v0",
-	Attrs: map[string]string{
-		"build-arg:BUILDKIT_INLINE_BUILDINFO_ATTRS": "1",
-		"build-arg:foo": "bar",
-		"cmdline":       "crazymax/dockerfile:master",
-		"context":       "https://github.com/crazy-max/buildkit-buildsources-test.git#master",
-		"filename":      "Dockerfile",
-		"platform":      "linux/amd64,linux/arm64",
-		"source":        "crazymax/dockerfile:master",
-	},
-	Sources: []binfotypes.Source{
-		{
-			Type: binfotypes.SourceTypeDockerImage,
-			Ref:  "docker.io/docker/buildx-bin:0.6.1@sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
-			Pin:  "sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
-		},
-		{
-			Type: binfotypes.SourceTypeDockerImage,
-			Ref:  "docker.io/library/alpine:3.13",
-			Pin:  "sha256:1d30d1ba3cb90962067e9b29491fbd56997979d54376f23f01448b5c5cd8b462",
-		},
-		{
-			Type: binfotypes.SourceTypeDockerImage,
-			Ref:  "docker.io/moby/buildkit:v0.9.0",
-			Pin:  "sha256:8dc668e7f66db1c044aadbed306020743516a94848793e0f81f94a087ee78cab",
-		},
-		{
-			Type: binfotypes.SourceTypeDockerImage,
-			Ref:  "docker.io/tonistiigi/xx@sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04",
-			Pin:  "sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04",
-		},
-		{
-			Type: binfotypes.SourceTypeGit,
-			Ref:  "https://github.com/crazy-max/buildkit-buildsources-test.git#master",
-			Pin:  "259a5aa5aa5bb3562d12cc631fe399f4788642c1",
-		},
-		{
-			Type: binfotypes.SourceTypeHTTP,
-			Ref:  "https://raw.githubusercontent.com/moby/moby/master/README.md",
-			Pin:  "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c",
-		},
-	},
-}
-
 func TestDecode(t *testing.T) {
 	bi, err := Decode("eyJmcm9udGVuZCI6ImRvY2tlcmZpbGUudjAiLCJhdHRycyI6eyJidWlsZC1hcmc6QlVJTERLSVRfSU5MSU5FX0JVSUxESU5GT19BVFRSUyI6IjEiLCJjbWRsaW5lIjoiY3JhenltYXgvZG9ja2VyZmlsZTpidWlsZGF0dHJzIiwiY29udGV4dCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9jcmF6eS1tYXgvYnVpbGRraXQtYnVpbGRzb3VyY2VzLXRlc3QuZ2l0I21hc3RlciIsImZpbGVuYW1lIjoiRG9ja2VyZmlsZSIsInNvdXJjZSI6ImNyYXp5bWF4L2RvY2tlcmZpbGU6YnVpbGRhdHRycyJ9LCJzb3VyY2VzIjpbeyJ0eXBlIjoiZG9ja2VyLWltYWdlIiwicmVmIjoiZG9ja2VyLmlvL2RvY2tlci9idWlsZHgtYmluOjAuNi4xQHNoYTI1NjphNjUyY2VkNGE0MTQxOTc3YzdkYWFlZDBhMDc0ZGNkOTg0NGE3OGQ3ZDI2MTU0NjViMTJmNDMzYWU2ZGQyOWYwIiwicGluIjoic2hhMjU2OmE2NTJjZWQ0YTQxNDE5NzdjN2RhYWVkMGEwNzRkY2Q5ODQ0YTc4ZDdkMjYxNTQ2NWIxMmY0MzNhZTZkZDI5ZjAifSx7InR5cGUiOiJkb2NrZXItaW1hZ2UiLCJyZWYiOiJkb2NrZXIuaW8vbGlicmFyeS9hbHBpbmU6My4xMyIsInBpbiI6InNoYTI1NjowMjZmNzIxYWY0Y2YyODQzZTA3YmJhNjQ4ZTE1OGZiMzVlY2M4NzZkODIyMTMwNjMzY2M0OWY3MDdmMGZjODhjIn0seyJ0eXBlIjoiZG9ja2VyLWltYWdlIiwicmVmIjoiZG9ja2VyLmlvL21vYnkvYnVpbGRraXQ6djAuOS4wIiwicGluIjoic2hhMjU2OjhkYzY2OGU3ZjY2ZGIxYzA0NGFhZGJlZDMwNjAyMDc0MzUxNmE5NDg0ODc5M2UwZjgxZjk0YTA4N2VlNzhjYWIifSx7InR5cGUiOiJkb2NrZXItaW1hZ2UiLCJyZWYiOiJkb2NrZXIuaW8vdG9uaXN0aWlnaS94eEBzaGEyNTY6MjFhNjFiZTQ3NDRmNjUzMWNiNWYzM2IwZTZmNDBlZGU0MWZhM2ExYjhjODJkNTk0NjE3OGY4MGNjODRiZmMwNCIsInBpbiI6InNoYTI1NjoyMWE2MWJlNDc0NGY2NTMxY2I1ZjMzYjBlNmY0MGVkZTQxZmEzYTFiOGM4MmQ1OTQ2MTc4ZjgwY2M4NGJmYzA0In0seyJ0eXBlIjoiZ2l0IiwicmVmIjoiaHR0cHM6Ly9naXRodWIuY29tL2NyYXp5LW1heC9idWlsZGtpdC1idWlsZHNvdXJjZXMtdGVzdC5naXQjbWFzdGVyIiwicGluIjoiNDNhOGJmOWMzNTFhYmY2NGIwODY1YTZhMDU0OGExZGUxZGVkNDBhOCJ9LHsidHlwZSI6Imh0dHAiLCJyZWYiOiJodHRwczovL3Jhdy5naXRodWJ1c2VyY29udGVudC5jb20vbW9ieS9tb2J5L21hc3Rlci9SRUFETUUubWQiLCJwaW4iOiJzaGEyNTY6NDE5NDU1MjAyYjBlZjk3ZTQ4MGQ3ZjgxOTliMjZhNzIxYTQxNzgxOGJjMGUyZDEwNjk3NWY3NDMyM2YyNWU2YyJ9XX0=")
 	require.NoError(t, err)
@@ -72,36 +27,34 @@ func TestMergeSources(t *testing.T) {
 		"https://raw.githubusercontent.com/moby/moby/master/README.md":                                                             "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c",
 	}
 
-	buildInfo := binfotypes.BuildInfo{
-		Sources: []binfotypes.Source{
-			{
-				Type:  binfotypes.SourceTypeDockerImage,
-				Ref:   "docker.io/docker/buildx-bin:0.6.1@sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
-				Alias: "docker.io/docker/buildx-bin:0.6.1@sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
-				Pin:   "sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
-			},
-			{
-				Type:  binfotypes.SourceTypeDockerImage,
-				Ref:   "docker.io/library/alpine:3.13",
-				Alias: "docker.io/library/alpine:3.13@sha256:1d30d1ba3cb90962067e9b29491fbd56997979d54376f23f01448b5c5cd8b462",
-				Pin:   "sha256:1d30d1ba3cb90962067e9b29491fbd56997979d54376f23f01448b5c5cd8b462",
-			},
-			{
-				Type:  binfotypes.SourceTypeDockerImage,
-				Ref:   "docker.io/moby/buildkit:v0.9.0",
-				Alias: "docker.io/moby/buildkit:v0.9.0@sha256:8dc668e7f66db1c044aadbed306020743516a94848793e0f81f94a087ee78cab",
-				Pin:   "sha256:8dc668e7f66db1c044aadbed306020743516a94848793e0f81f94a087ee78cab",
-			},
-			{
-				Type:  binfotypes.SourceTypeDockerImage,
-				Ref:   "docker.io/tonistiigi/xx@sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04",
-				Alias: "docker.io/tonistiigi/xx@sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04",
-				Pin:   "sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04",
-			},
+	frontendSources := []binfotypes.Source{
+		{
+			Type:  binfotypes.SourceTypeDockerImage,
+			Ref:   "docker.io/docker/buildx-bin:0.6.1@sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
+			Alias: "docker.io/docker/buildx-bin:0.6.1@sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
+			Pin:   "sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
+		},
+		{
+			Type:  binfotypes.SourceTypeDockerImage,
+			Ref:   "docker.io/library/alpine:3.13",
+			Alias: "docker.io/library/alpine:3.13@sha256:1d30d1ba3cb90962067e9b29491fbd56997979d54376f23f01448b5c5cd8b462",
+			Pin:   "sha256:1d30d1ba3cb90962067e9b29491fbd56997979d54376f23f01448b5c5cd8b462",
+		},
+		{
+			Type:  binfotypes.SourceTypeDockerImage,
+			Ref:   "docker.io/moby/buildkit:v0.9.0",
+			Alias: "docker.io/moby/buildkit:v0.9.0@sha256:8dc668e7f66db1c044aadbed306020743516a94848793e0f81f94a087ee78cab",
+			Pin:   "sha256:8dc668e7f66db1c044aadbed306020743516a94848793e0f81f94a087ee78cab",
+		},
+		{
+			Type:  binfotypes.SourceTypeDockerImage,
+			Ref:   "docker.io/tonistiigi/xx@sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04",
+			Alias: "docker.io/tonistiigi/xx@sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04",
+			Pin:   "sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04",
 		},
 	}
 
-	srcs, err := mergeSources(context.Background(), buildSourcesLLB, buildInfo)
+	srcs, err := mergeSources(context.Background(), buildSourcesLLB, frontendSources)
 	require.NoError(t, err)
 
 	assert.Equal(t, []binfotypes.Source{
@@ -136,21 +89,6 @@ func TestMergeSources(t *testing.T) {
 			Pin:  "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c",
 		},
 	}, srcs)
-}
-
-func TestFromImageConfig(t *testing.T) {
-	dtbi, err := json.Marshal(bifixture)
-	require.NoError(t, err)
-	dtic, err := json.Marshal(struct {
-		BuildInfo []byte `json:"moby.buildkit.buildinfo.v1"`
-	}{
-		BuildInfo: dtbi,
-	})
-	require.NoError(t, err)
-	bi, err := FromImageConfig(dtic)
-	require.NoError(t, err)
-	assert.Equal(t, 7, len(bi.Attrs))
-	assert.Equal(t, 6, len(bi.Sources))
 }
 
 func TestFormat(t *testing.T) {
@@ -200,6 +138,7 @@ func TestFormat(t *testing.T) {
 			},
 		},
 	}
+
 	for _, tt := range cases {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
@@ -211,6 +150,46 @@ func TestFormat(t *testing.T) {
 			err = json.Unmarshal(dt, &res)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, res)
+		})
+	}
+}
+
+func TestReduceMap(t *testing.T) {
+	cases := []struct {
+		name     string
+		m1       map[string]string
+		m2       map[string]string
+		expected map[string]string
+	}{
+		{
+			name:     "first",
+			m1:       map[string]string{"foo": "bar", "abc": "def"},
+			m2:       map[string]string{"bar": "foo", "abc": "ghi"},
+			expected: map[string]string{"foo": "bar", "abc": "def", "bar": "foo"},
+		},
+		{
+			name:     "last",
+			m1:       map[string]string{"bar": "foo", "abc": "ghi"},
+			m2:       map[string]string{"foo": "bar", "abc": "def"},
+			expected: map[string]string{"bar": "foo", "abc": "ghi", "foo": "bar"},
+		},
+		{
+			name:     "null1",
+			m1:       nil,
+			m2:       map[string]string{"foo": "bar", "abc": "def"},
+			expected: map[string]string{"foo": "bar", "abc": "def"},
+		},
+		{
+			name:     "null2",
+			m1:       map[string]string{"foo": "bar", "abc": "def"},
+			m2:       nil,
+			expected: map[string]string{"foo": "bar", "abc": "def"},
+		},
+	}
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, reduceMap(tt.m2, tt.m1))
 		})
 	}
 }

--- a/util/buildinfo/buildinfo_test.go
+++ b/util/buildinfo/buildinfo_test.go
@@ -2,8 +2,6 @@ package buildinfo
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"testing"
 
 	binfotypes "github.com/moby/buildkit/util/buildinfo/types"
@@ -17,7 +15,7 @@ func TestDecode(t *testing.T) {
 	assert.Equal(t, 6, len(bi.Sources))
 }
 
-func TestMerge(t *testing.T) {
+func TestMergeSources(t *testing.T) {
 	buildSourcesLLB := map[string]string{
 		"docker-image://docker.io/docker/buildx-bin:0.6.1@sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0": "sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
 		"docker-image://docker.io/library/alpine:3.13@sha256:1d30d1ba3cb90962067e9b29491fbd56997979d54376f23f01448b5c5cd8b462":     "sha256:1d30d1ba3cb90962067e9b29491fbd56997979d54376f23f01448b5c5cd8b462",
@@ -27,7 +25,7 @@ func TestMerge(t *testing.T) {
 		"https://raw.githubusercontent.com/moby/moby/master/README.md":                                                             "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c",
 	}
 
-	buildInfoImageConfig, err := json.Marshal(binfotypes.BuildInfo{
+	buildInfo := binfotypes.BuildInfo{
 		Sources: []binfotypes.Source{
 			{
 				Type:  binfotypes.SourceTypeDockerImage,
@@ -54,52 +52,41 @@ func TestMerge(t *testing.T) {
 				Pin:   "sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04",
 			},
 		},
-	})
+	}
+
+	srcs, err := mergeSources(context.Background(), buildSourcesLLB, buildInfo)
 	require.NoError(t, err)
 
-	bic, err := json.Marshal(binfotypes.ImageConfig{
-		BuildInfo: buildInfoImageConfig,
-	})
-	require.NoError(t, err)
-
-	ret, err := Merge(context.Background(), buildSourcesLLB, bic)
-	require.NoError(t, err)
-
-	dec, err := Decode(base64.StdEncoding.EncodeToString(ret))
-	require.NoError(t, err)
-
-	assert.Equal(t, binfotypes.BuildInfo{
-		Sources: []binfotypes.Source{
-			{
-				Type: binfotypes.SourceTypeDockerImage,
-				Ref:  "docker.io/docker/buildx-bin:0.6.1@sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
-				Pin:  "sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
-			},
-			{
-				Type: binfotypes.SourceTypeDockerImage,
-				Ref:  "docker.io/library/alpine:3.13",
-				Pin:  "sha256:1d30d1ba3cb90962067e9b29491fbd56997979d54376f23f01448b5c5cd8b462",
-			},
-			{
-				Type: binfotypes.SourceTypeDockerImage,
-				Ref:  "docker.io/moby/buildkit:v0.9.0",
-				Pin:  "sha256:8dc668e7f66db1c044aadbed306020743516a94848793e0f81f94a087ee78cab",
-			},
-			{
-				Type: binfotypes.SourceTypeDockerImage,
-				Ref:  "docker.io/tonistiigi/xx@sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04",
-				Pin:  "sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04",
-			},
-			{
-				Type: binfotypes.SourceTypeGit,
-				Ref:  "https://github.com/crazy-max/buildkit-buildsources-test.git#master",
-				Pin:  "259a5aa5aa5bb3562d12cc631fe399f4788642c1",
-			},
-			{
-				Type: binfotypes.SourceTypeHTTP,
-				Ref:  "https://raw.githubusercontent.com/moby/moby/master/README.md",
-				Pin:  "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c",
-			},
+	assert.Equal(t, []binfotypes.Source{
+		{
+			Type: binfotypes.SourceTypeDockerImage,
+			Ref:  "docker.io/docker/buildx-bin:0.6.1@sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
+			Pin:  "sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
 		},
-	}, dec)
+		{
+			Type: binfotypes.SourceTypeDockerImage,
+			Ref:  "docker.io/library/alpine:3.13",
+			Pin:  "sha256:1d30d1ba3cb90962067e9b29491fbd56997979d54376f23f01448b5c5cd8b462",
+		},
+		{
+			Type: binfotypes.SourceTypeDockerImage,
+			Ref:  "docker.io/moby/buildkit:v0.9.0",
+			Pin:  "sha256:8dc668e7f66db1c044aadbed306020743516a94848793e0f81f94a087ee78cab",
+		},
+		{
+			Type: binfotypes.SourceTypeDockerImage,
+			Ref:  "docker.io/tonistiigi/xx@sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04",
+			Pin:  "sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04",
+		},
+		{
+			Type: binfotypes.SourceTypeGit,
+			Ref:  "https://github.com/crazy-max/buildkit-buildsources-test.git#master",
+			Pin:  "259a5aa5aa5bb3562d12cc631fe399f4788642c1",
+		},
+		{
+			Type: binfotypes.SourceTypeHTTP,
+			Ref:  "https://raw.githubusercontent.com/moby/moby/master/README.md",
+			Pin:  "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c",
+		},
+	}, srcs)
 }

--- a/util/buildinfo/types/types.go
+++ b/util/buildinfo/types/types.go
@@ -1,0 +1,46 @@
+package binfotypes
+
+import (
+	srctypes "github.com/moby/buildkit/source/types"
+)
+
+// ImageConfigField defines the key of build dependencies.
+const ImageConfigField = "moby.buildkit.buildinfo.v1"
+
+// ImageConfig defines the structure of build dependencies
+// inside image config.
+type ImageConfig struct {
+	BuildInfo []byte `json:"moby.buildkit.buildinfo.v1,omitempty"`
+}
+
+// BuildInfo defines the main structure added to image config as
+// ImageConfigField key and returned in solver ExporterResponse as
+// exptypes.ExporterBuildInfo key.
+type BuildInfo struct {
+	// Sources defines build dependencies.
+	Sources []Source `json:"sources,omitempty"`
+}
+
+// Source defines a build dependency.
+type Source struct {
+	// Type defines the SourceType source type (docker-image, git, http).
+	Type SourceType `json:"type,omitempty"`
+	// Ref is the reference of the source.
+	Ref string `json:"ref,omitempty"`
+	// Alias is a special field used to match with the actual source ref
+	// because frontend might have already transformed a string user typed
+	// before generating LLB.
+	Alias string `json:"alias,omitempty"`
+	// Pin is the source digest.
+	Pin string `json:"pin,omitempty"`
+}
+
+// SourceType contains source type.
+type SourceType string
+
+// List of source types.
+const (
+	SourceTypeDockerImage SourceType = srctypes.DockerImageScheme
+	SourceTypeGit         SourceType = srctypes.GitScheme
+	SourceTypeHTTP        SourceType = srctypes.HTTPScheme
+)

--- a/util/buildinfo/types/types.go
+++ b/util/buildinfo/types/types.go
@@ -17,6 +17,10 @@ type ImageConfig struct {
 // ImageConfigField key and returned in solver ExporterResponse as
 // exptypes.ExporterBuildInfo key.
 type BuildInfo struct {
+	// Frontend defines the frontend used to build.
+	Frontend string `json:"frontend,omitempty"`
+	// Attrs defines build request attributes.
+	Attrs map[string]string `json:"attrs,omitempty"`
 	// Sources defines build dependencies.
 	Sources []Source `json:"sources,omitempty"`
 }

--- a/util/buildinfo/types/types.go
+++ b/util/buildinfo/types/types.go
@@ -20,7 +20,7 @@ type BuildInfo struct {
 	// Frontend defines the frontend used to build.
 	Frontend string `json:"frontend,omitempty"`
 	// Attrs defines build request attributes.
-	Attrs map[string]string `json:"attrs,omitempty"`
+	Attrs map[string]*string `json:"attrs,omitempty"`
 	// Sources defines build dependencies.
 	Sources []Source `json:"sources,omitempty"`
 }


### PR DESCRIPTION
follow-up #2311

store additional build dependencies such as `frontend` and `attrs`.

```shell
# buildkit
$ docker buildx build --push --platform linux/amd64,linux/arm64 \
  --build-arg "BUILDKIT_CONTEXT_KEEP_GIT_DIR=1" \
  --tag "crazymax/buildkit:buildattrs" \
  https://github.com/crazy-max/buildkit.git#buildinfo-attrs

# frontend
$ docker buildx build --push --platform linux/amd64,linux/arm64 \
  --build-arg "CHANNEL=mainline" \
  --build-arg "BUILDKIT_CONTEXT_KEEP_GIT_DIR=1" \
  --tag "crazymax/dockerfile:buildattrs" \
  --file "./frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile" \
  https://github.com/crazy-max/buildkit.git#buildinfo-attrs

# buildx to inline build attrs (opt-in atm)
$ docker buildx bake https://github.com/crazy-max/buildx.git#inline-buildattrs binaries
$ cp ./bin/buildx ~/.docker/cli-plugins/docker-buildx
```

Pre-built frontend `# syntax=crazymax/dockerfile:buildattrs` and BuildKit image `crazymax/buildkit:buildattrs` can be used to test this feature:

```shell
$ docker buildx create --name buildattrs --driver-opt image=crazymax/buildkit:buildattrs --use
```

```shell
# buildattrs enabled
$ docker buildx build --metadata-file metadata.json \
  --load --tag buildattrs:latest \
  --build-arg BUILDKIT_INLINE_BUILDINFO_ATTRS=1 \
  https://github.com/crazy-max/buildkit-buildsources-test.git#master

$ cat metadata.json | jq -r '."containerimage.buildinfo"' | base64 --decode | jq
{
  "frontend": "dockerfile.v0",
  "attrs": {
    "cmdline": "crazymax/dockerfile:buildattrs",
    "context": "https://github.com/crazy-max/buildkit-buildsources-test.git#master",
    "filename": "Dockerfile",
    "source": "crazymax/dockerfile:buildattrs"
  },
  "sources": [
    {
      "type": "docker-image",
      "ref": "docker.io/docker/buildx-bin:0.6.1@sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
      "pin": "sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0"
    },
    {
      "type": "docker-image",
      "ref": "docker.io/library/alpine:3.13",
      "pin": "sha256:026f721af4cf2843e07bba648e158fb35ecc876d822130633cc49f707f0fc88c"
    },
    {
      "type": "docker-image",
      "ref": "docker.io/moby/buildkit:v0.9.0",
      "pin": "sha256:8dc668e7f66db1c044aadbed306020743516a94848793e0f81f94a087ee78cab"
    },
    {
      "type": "docker-image",
      "ref": "docker.io/tonistiigi/xx@sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04",
      "pin": "sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04"
    },
    {
      "type": "git",
      "ref": "https://github.com/crazy-max/buildkit-buildsources-test.git#master",
      "pin": "43a8bf9c351abf64b0865a6a0548a1de1ded40a8"
    },
    {
      "type": "http",
      "ref": "https://raw.githubusercontent.com/moby/moby/master/README.md",
      "pin": "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c"
    }
  ]
}

$ docker image save buildattrs:latest | tar -ax --exclude 'manifest.json' --wildcards '*.json' -O | jq -r '."moby.buildkit.buildinfo.v1"' | base64 --decode | jq
{
  "frontend": "dockerfile.v0",
  "attrs": {
    "cmdline": "crazymax/dockerfile:buildattrs",
    "context": "https://github.com/crazy-max/buildkit-buildsources-test.git#master",
    "filename": "Dockerfile",
    "source": "crazymax/dockerfile:buildattrs"
  },
  "sources": [
    {
      "type": "docker-image",
      "ref": "docker.io/docker/buildx-bin:0.6.1@sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
      "pin": "sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0"
    },
    {
      "type": "docker-image",
      "ref": "docker.io/library/alpine:3.13",
      "pin": "sha256:026f721af4cf2843e07bba648e158fb35ecc876d822130633cc49f707f0fc88c"
    },
    {
      "type": "docker-image",
      "ref": "docker.io/moby/buildkit:v0.9.0",
      "pin": "sha256:8dc668e7f66db1c044aadbed306020743516a94848793e0f81f94a087ee78cab"
    },
    {
      "type": "docker-image",
      "ref": "docker.io/tonistiigi/xx@sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04",
      "pin": "sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04"
    },
    {
      "type": "git",
      "ref": "https://github.com/crazy-max/buildkit-buildsources-test.git#master",
      "pin": "43a8bf9c351abf64b0865a6a0548a1de1ded40a8"
    },
    {
      "type": "http",
      "ref": "https://raw.githubusercontent.com/moby/moby/master/README.md",
      "pin": "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c"
    }
  ]
}
```

```shell
# buildattrs disabled (default)
$ docker buildx build --metadata-file metadata.json \
  --load --tag buildattrs:latest \
  https://github.com/crazy-max/buildkit-buildsources-test.git#master

$ cat metadata.json | jq -r '."containerimage.buildinfo"' | base64 --decode | jq
{
  "frontend": "dockerfile.v0",
  "attrs": {
    "cmdline": "crazymax/dockerfile:buildattrs",
    "context": "https://github.com/crazy-max/buildkit-buildsources-test.git#master",
    "filename": "Dockerfile",
    "source": "crazymax/dockerfile:buildattrs"
  },
  "sources": [
    {
      "type": "docker-image",
      "ref": "docker.io/docker/buildx-bin:0.6.1@sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
      "pin": "sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0"
    },
    {
      "type": "docker-image",
      "ref": "docker.io/library/alpine:3.13",
      "pin": "sha256:026f721af4cf2843e07bba648e158fb35ecc876d822130633cc49f707f0fc88c"
    },
    {
      "type": "docker-image",
      "ref": "docker.io/moby/buildkit:v0.9.0",
      "pin": "sha256:8dc668e7f66db1c044aadbed306020743516a94848793e0f81f94a087ee78cab"
    },
    {
      "type": "docker-image",
      "ref": "docker.io/tonistiigi/xx@sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04",
      "pin": "sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04"
    },
    {
      "type": "git",
      "ref": "https://github.com/crazy-max/buildkit-buildsources-test.git#master",
      "pin": "43a8bf9c351abf64b0865a6a0548a1de1ded40a8"
    },
    {
      "type": "http",
      "ref": "https://raw.githubusercontent.com/moby/moby/master/README.md",
      "pin": "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c"
    }
  ]
}

$ docker image save buildattrs:latest | tar -ax --exclude 'manifest.json' --wildcards '*.json' -O | jq -r '."moby.buildkit.buildinfo.v1"' | base64 --decode | jq
{
  "frontend": "dockerfile.v0",
  "sources": [
    {
      "type": "docker-image",
      "ref": "docker.io/docker/buildx-bin:0.6.1@sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0",
      "pin": "sha256:a652ced4a4141977c7daaed0a074dcd9844a78d7d2615465b12f433ae6dd29f0"
    },
    {
      "type": "docker-image",
      "ref": "docker.io/library/alpine:3.13",
      "pin": "sha256:026f721af4cf2843e07bba648e158fb35ecc876d822130633cc49f707f0fc88c"
    },
    {
      "type": "docker-image",
      "ref": "docker.io/moby/buildkit:v0.9.0",
      "pin": "sha256:8dc668e7f66db1c044aadbed306020743516a94848793e0f81f94a087ee78cab"
    },
    {
      "type": "docker-image",
      "ref": "docker.io/tonistiigi/xx@sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04",
      "pin": "sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04"
    },
    {
      "type": "git",
      "ref": "https://github.com/crazy-max/buildkit-buildsources-test.git#master",
      "pin": "43a8bf9c351abf64b0865a6a0548a1de1ded40a8"
    },
    {
      "type": "http",
      "ref": "https://raw.githubusercontent.com/moby/moby/master/README.md",
      "pin": "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c"
    }
  ]
}
```
