### PR TITLE
Clarify Export cache docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,8 @@ In most case you want to use the `inline` cache exporter.
 However, note that the `inline` cache exporter only supports `min` cache mode. 
 To enable `max` cache mode, push the image and the cache separately by using `registry` cache exporter.
 
+`inline` and `registry` exporters both store the cache in the registry. For importing the cache, `type=registry` is sufficient for both, as specifying the cache format is not necessary.
+
 #### Inline (push image and cache together)
 
 ```bash
@@ -331,6 +333,8 @@ buildctl build ... \
 ```
 
 Note that the inline cache is not imported unless [`--import-cache type=registry,ref=...`](#registry-push-image-and-cache-separately) is provided.
+
+Inline cache embeds cache metadata into the image config. The layers in the image will be left untouched compared to the image with no cache information.
 
 :information_source: Docker-integrated BuildKit (`DOCKER_BUILDKIT=1 docker build`) and `docker buildx`requires 
 `--build-arg BUILDKIT_INLINE_CACHE=1` to be specified to enable the `inline` cache exporter.
@@ -386,6 +390,10 @@ buildctl build ... \
   --export-cache type=gha \
   --import-cache type=gha
 ```
+
+Github Actions cache saves both cache metadata and layers to GitHub's Cache service. This cache currently has a [size limit of 10GB](https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy) that is shared accross different caches in the repo. If you exceed this limit, GitHub will save your cache but will begin evicting caches until the total size is less than 10 GB. Recycling caches too often can result in slower runtimes overall.
+
+Similarly to using [actions/cache](https://github.com/actions/cache), caches are [scoped by branch](https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache), with the default and target branches being available to every branch.
 
 Following attributes are required to authenticate against the [Github Actions Cache service API](https://github.com/tonistiigi/go-actions-cache/blob/master/api.md#authentication):
 * `url`: Cache server URL (default `$ACTIONS_CACHE_URL`)


### PR DESCRIPTION
Incorporating some additional information about export caches as explained in https://github.com/moby/buildkit/issues/2477

- implications to image and cache size
- cache keys
- to and from type mismatch

cc @tonistiigi 
