### PR TITLE
Disable redirect_dir for avoiding incorrect diff

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -140,6 +140,7 @@ func TestIntegration(t *testing.T) {
 		testMergeOp,
 		testMergeOpCache,
 		testRmSymlink,
+		testMoveParentDir,
 	), mirrors)
 
 	integration.Run(t, integration.TestFuncs(
@@ -3628,6 +3629,74 @@ func testWhiteoutParentDir(t *testing.T, sb integration.Sandbox) {
 	require.True(t, ok)
 
 	_, ok = m["foo/"]
+	require.True(t, ok)
+}
+
+// #2490
+func testMoveParentDir(t *testing.T, sb integration.Sandbox) {
+	c, err := New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	busybox := llb.Image("busybox:latest")
+	st := llb.Scratch()
+
+	run := func(cmd string) {
+		st = busybox.Run(llb.Shlex(cmd), llb.Dir("/wd")).AddMount("/wd", st)
+	}
+
+	run(`sh -c "mkdir -p foo; echo -n first > foo/bar;"`)
+	run(`mv foo foo2`)
+
+	def, err := st.Marshal(sb.Context())
+	require.NoError(t, err)
+
+	destDir, err := ioutil.TempDir("", "buildkit")
+	require.NoError(t, err)
+	defer os.RemoveAll(destDir)
+
+	out := filepath.Join(destDir, "out.tar")
+	outW, err := os.Create(out)
+	require.NoError(t, err)
+	_, err = c.Solve(sb.Context(), def, SolveOpt{
+		Exports: []ExportEntry{
+			{
+				Type:   ExporterOCI,
+				Output: fixedWriteCloser(outW),
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	dt, err := ioutil.ReadFile(out)
+	require.NoError(t, err)
+
+	m, err := testutil.ReadTarToMap(dt, false)
+	require.NoError(t, err)
+
+	var index ocispecs.Index
+	err = json.Unmarshal(m["index.json"].Data, &index)
+	require.NoError(t, err)
+
+	var mfst ocispecs.Manifest
+	err = json.Unmarshal(m["blobs/sha256/"+index.Manifests[0].Digest.Hex()].Data, &mfst)
+	require.NoError(t, err)
+
+	lastLayer := mfst.Layers[len(mfst.Layers)-1]
+
+	layer, ok := m["blobs/sha256/"+lastLayer.Digest.Hex()]
+	require.True(t, ok)
+
+	m, err = testutil.ReadTarToMap(layer.Data, true)
+	require.NoError(t, err)
+
+	_, ok = m[".wh.foo"]
+	require.True(t, ok)
+
+	_, ok = m["foo2/"]
+	require.True(t, ok)
+
+	_, ok = m["foo2/bar"]
 	require.True(t, ok)
 }
 

--- a/snapshot/staticmountable.go
+++ b/snapshot/staticmountable.go
@@ -20,8 +20,13 @@ func (cm *staticMountable) Mount() ([]mount.Mount, func() error, error) {
 	mounts := make([]mount.Mount, len(cm.mounts))
 	copy(mounts, cm.mounts)
 
+	redirectDirOption := getRedirectDirOption()
+	if redirectDirOption != "" {
+		mounts = setRedirectDir(mounts, redirectDirOption)
+	}
+
 	atomic.AddInt32(&cm.count, 1)
-	return cm.mounts, func() error {
+	return mounts, func() error {
 		if atomic.AddInt32(&cm.count, -1) < 0 {
 			if v := os.Getenv("BUILDKIT_DEBUG_PANIC_ON_ERROR"); v == "1" {
 				panic("release of released mount " + cm.id)


### PR DESCRIPTION
#2490

Overlayfs differ cannot calculate diff correctly if redirect_dir is enabled.
~~This commit fixes this issue by falling back to walking differ if redirect_dir is enabled as done in moby (https://github.com/moby/moby/pull/34342).~~ This commit fixes this issue by disabling redirect_dir if it's supported by kernel. 

This'll cause performance drawback on such kernels so we should fix overlayfs differ to handle redirect_dir correctly on these kernels.

cc @sipsma 