### PR TITLE
hack: update install-buildx

### DIFF
--- a/hack/install-buildx
+++ b/hack/install-buildx
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-set -eu -o pipefail
+set -euo pipefail
 
-if [ -z "${BINDIR}" ] && [ -z "${PREFIX}" ]; then
-  PREFIX="$(realpath "$(dirname "$0")"/..)"
+if [ -z "${BINDIR:-}" ] && [ -z "${PREFIX:-}" ]; then
+  PREFIX="$(realpath "$(dirname "$0")/..")"
 fi
 
 : "${VERSION:=v0.5.1}"

--- a/hack/install-buildx
+++ b/hack/install-buildx
@@ -5,7 +5,7 @@ if [ -z "${BINDIR:-}" ] && [ -z "${PREFIX:-}" ]; then
   PREFIX="$(realpath "$(dirname "$0")/..")"
 fi
 
-: "${VERSION:=v0.5.1}"
+: "${VERSION:=v0.7.1}"
 : "${BINDIR:="${PREFIX}/bin"}"
 : "${DEST:="${BINDIR}/buildx"}"
 


### PR DESCRIPTION
- Fix unbound var error for BINDIR, PREFIX
- Update buildx version 0.5.1 => 0.7.1
