### PR TITLE
remote cache: support arbitrary layers as results

### DIFF
--- a/cache/remotecache/inline/inline.go
+++ b/cache/remotecache/inline/inline.go
@@ -9,6 +9,7 @@ import (
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver"
 	digest "github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -73,14 +74,55 @@ func (ce *exporter) ExportForLayers(ctx context.Context, layers []digest.Digest)
 		return nil, nil
 	}
 
-	cache := map[int]int{}
-
 	// reorder layers based on the order in the image
+	blobIndexes := make(map[digest.Digest]int, len(layers))
+	for i, blob := range layers {
+		blobIndexes[blob] = i
+	}
+
 	for i, r := range cfg.Records {
 		for j, rr := range r.Results {
-			n := getSortedLayerIndex(rr.LayerIndex, cfg.Layers, cache)
-			rr.LayerIndex = n
-			r.Results[j] = rr
+			resultBlobs := layerToBlobs(rr.LayerIndex, cfg.Layers)
+			// match being true means the result is in the same order as the image
+			var match bool
+			if len(resultBlobs) <= len(layers) {
+				match = true
+				for k, resultBlob := range resultBlobs {
+					layerBlob := layers[k]
+					if resultBlob != layerBlob {
+						match = false
+						break
+					}
+				}
+			}
+			if match {
+				// The layers of the result are in the same order as the image, so we can
+				// specify it just using the CacheResult struct and specifying LayerIndex
+				// as the top-most layer of the result.
+				rr.LayerIndex = len(resultBlobs) - 1
+				r.Results[j] = rr
+			} else {
+				// The layers of the result are not in the same order as the image, so we
+				// have to use ChainedResult to specify each layer of the result individually.
+				chainedResult := v1.ChainedResult{}
+				for _, resultBlob := range resultBlobs {
+					idx, ok := blobIndexes[resultBlob]
+					if !ok {
+						return nil, errors.Errorf("failed to find blob %s in layers", resultBlob)
+					}
+					chainedResult.LayerIndexes = append(chainedResult.LayerIndexes, idx)
+				}
+				r.Results[j] = v1.CacheResult{}
+				r.ChainedResults = append(r.ChainedResults, chainedResult)
+			}
+			// remove any CacheResults that had to be converted to the ChainedResult format.
+			var filteredResults []v1.CacheResult
+			for _, rr := range r.Results {
+				if rr != (v1.CacheResult{}) {
+					filteredResults = append(filteredResults, rr)
+				}
+			}
+			r.Results = filteredResults
 			cfg.Records[i] = r
 		}
 	}
@@ -94,14 +136,16 @@ func (ce *exporter) ExportForLayers(ctx context.Context, layers []digest.Digest)
 	return dt, nil
 }
 
-func getSortedLayerIndex(idx int, layers []v1.CacheLayer, cache map[int]int) int {
-	if idx == -1 {
-		return -1
+func layerToBlobs(idx int, layers []v1.CacheLayer) []digest.Digest {
+	var ds []digest.Digest
+	for idx != -1 {
+		layer := layers[idx]
+		ds = append(ds, layer.Blob)
+		idx = layer.ParentIndex
 	}
-	l := layers[idx]
-	if i, ok := cache[idx]; ok {
-		return i
+	// reverse so they go lowest to highest
+	for i, j := 0, len(ds)-1; i < j; i, j = i+1, j-1 {
+		ds[i], ds[j] = ds[j], ds[i]
 	}
-	cache[idx] = getSortedLayerIndex(l.ParentIndex, layers, cache) + 1
-	return cache[idx]
+	return ds
 }

--- a/cache/remotecache/v1/spec.go
+++ b/cache/remotecache/v1/spec.go
@@ -27,14 +27,20 @@ type LayerAnnotations struct {
 }
 
 type CacheRecord struct {
-	Results []CacheResult  `json:"layers,omitempty"`
-	Digest  digest.Digest  `json:"digest,omitempty"`
-	Inputs  [][]CacheInput `json:"inputs,omitempty"`
+	Results        []CacheResult   `json:"layers,omitempty"`
+	ChainedResults []ChainedResult `json:"chains,omitempty"`
+	Digest         digest.Digest   `json:"digest,omitempty"`
+	Inputs         [][]CacheInput  `json:"inputs,omitempty"`
 }
 
 type CacheResult struct {
 	LayerIndex int       `json:"layer"`
 	CreatedAt  time.Time `json:"createdAt,omitempty"`
+}
+
+type ChainedResult struct {
+	LayerIndexes []int     `json:"layers"`
+	CreatedAt    time.Time `json:"createdAt,omitempty"`
 }
 
 type CacheInput struct {


### PR DESCRIPTION
This change enables inline cache to work as expected with MergeOp by
supporting a new type of result, DiffResult, which enables results to be
specified as a specific ordered set of layers inside an image.
Previously, results could only be specified with a singe layer index,
which meant that they had to start at the image's base layer and end at
that index. That meant that merge inputs couldn't be specified as they
are often a subset of the image layers that don't begin at the base.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>