### PR TITLE
Add terminal color choosing support

### DIFF
--- a/util/progress/progressui/colors.go
+++ b/util/progress/progressui/colors.go
@@ -1,0 +1,40 @@
+package progressui
+
+import (
+	"os"
+	"strings"
+
+	"github.com/morikuni/aec"
+)
+
+var termColorMap = map[string]aec.ANSI{
+	"":        colorRun,
+	"default": aec.DefaultF,
+
+	"black":   aec.BlackF,
+	"red":     aec.RedF,
+	"green":   aec.GreenF,
+	"yellow":  aec.YellowF,
+	"blue":    aec.BlueF,
+	"magenta": aec.MagentaF,
+	"cyan":    aec.CyanF,
+	"white":   aec.WhiteF,
+
+	"light-black":   aec.LightBlackF,
+	"light-red":     aec.LightRedF,
+	"light-green":   aec.LightGreenF,
+	"light-yellow":  aec.LightYellowF,
+	"light-blue":    aec.LightBlueF,
+	"light-magenta": aec.LightMagentaF,
+	"light-cyan":    aec.LightCyanF,
+	"light-white":   aec.LightWhiteF,
+}
+
+func getTermColor() aec.ANSI {
+	envColorString := os.Getenv("BUILDKIT_TERM_COLOR")
+	c, ok := termColorMap[strings.ToLower(envColorString)]
+	if !ok {
+		return colorRun
+	}
+	return c
+}

--- a/util/progress/progressui/display.go
+++ b/util/progress/progressui/display.go
@@ -521,7 +521,7 @@ func (disp *display) print(d displayInfo, width, height int, all bool) {
 
 		out = align(out, timer, width)
 		if j.completedTime != nil {
-			color := colorRun
+			color := getTermColor()
 			if j.isCanceled {
 				color = colorCancel
 			} else if j.hasError {


### PR DESCRIPTION
This adds the capability of choosing the color to print in the terminal by just setting an envvar called `BUILDKIT_TERM_COLOR`.

Note that this is a "follow-up" of https://github.com/moby/buildkit/pull/2368 making it more flexible so that the users can choose it's preferred color depending on their terminal themes and preferences.

It supports the following values:
```
"default"

"black"
"red"
"green"
"yellow"
"blue"
"magenta"
"cyan"
"white"

"light-black"
"light-red"
"light-green"
"light-yellow"
"light-blue"
"light-magenta"
"light-cyan"
"light-white"
```