### PR TITLE
Setting just servername to :authority pseudo header in client when using TLS.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -43,6 +43,7 @@ func New(ctx context.Context, address string, opts ...ClientOpt) (*Client, error
 	}
 	needDialer := true
 	needWithInsecure := true
+	tlsServerName := ""
 
 	var unary []grpc.UnaryClientInterceptor
 	var stream []grpc.StreamClientInterceptor
@@ -63,6 +64,7 @@ func New(ctx context.Context, address string, opts ...ClientOpt) (*Client, error
 			}
 			gopts = append(gopts, opt)
 			needWithInsecure = false
+			tlsServerName = credInfo.ServerName
 		}
 		if wt, ok := o.(*withTracer); ok {
 			customTracer = true
@@ -106,14 +108,23 @@ func New(ctx context.Context, address string, opts ...ClientOpt) (*Client, error
 		address = appdefaults.Address
 	}
 
-	// grpc-go uses a slightly different naming scheme: https://github.com/grpc/grpc/blob/master/doc/naming.md
-	// This will end up setting rfc non-complient :authority header to address string (e.g. tcp://127.0.0.1:1234).
-	// So, here sets right authority header via WithAuthority DialOption.
-	addressURL, err := url.Parse(address)
-	if err != nil {
-		return nil, err
+	// Setting :authority pseudo header
+	// - HTTP/2 (RFC7540) defines :authority pseudo header includes
+	//   the authority portion of target URI but it must not include
+	//   userinfo part (i.e. url.Host).
+	//   ref: https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.3
+	// - However, when TLS specified, grpc-go requires it must match
+	//   with its servername specified for certificate validation.
+	authority := tlsServerName
+	if authority == "" {
+		// authority as hostname from target address
+		uri, err := url.Parse(address)
+		if err != nil {
+			return nil, err
+		}
+		authority = uri.Host
 	}
-	gopts = append(gopts, grpc.WithAuthority(addressURL.Host))
+	gopts = append(gopts, grpc.WithAuthority(authority))
 
 	unary = append(unary, grpcerrors.UnaryClientInterceptor)
 	stream = append(stream, grpcerrors.StreamClientInterceptor)


### PR DESCRIPTION
fixes https://github.com/moby/buildkit/issues/2510

`google.golang.org/grpc@v1.42.0` (updated recently in https://github.com/moby/buildkit/pull/2481) introduced better handling for `:authority` pseudo-header implemented in https://github.com/grpc/grpc-go/pull/4817. This requires `WithAuthority` dial option value must match with the server name of its transport creds.  

The current implementation always uses `url.Host ("host:port")` of `--addr` as an authority pseudo-header value because [HTTP/2(RFC7540)](https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.3) defines so, i.e the authority portion of target URI without userinfo part.  This causes grpc-go's authority validation to fail.

This PR fixes the issue so that it uses `ServerName` in the tls config as `:authority` header when tls specified, uses normal `host:port` part otherwise.