### PR TITLE
README.md: Add Gitpod as consuming project

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ BuildKit is used by the following projects:
 -   [Docker buildx](https://github.com/docker/buildx)
 -   [Okteto Cloud](https://okteto.com/)
 -   [Earthly earthfiles](https://github.com/vladaionescu/earthly)
+-   [Gitpod](https://github.com/gitpod-io/gitpod)
 
 ## Quick start
 


### PR DESCRIPTION
Recently [Gitpod started using buildkit](https://github.com/gitpod-io/gitpod/tree/main/components/image-builder-bob) to build [all of its workspaces images](https://twitter.com/csweichel/status/1470312552399790090). We'd be excited to be listed as project which uses buildkit.