### PR TITLE
README.md: add buildkit-nix frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Currently, the following high-level languages has been implemented for LLB:
 -   [HLB](https://github.com/openllb/hlb)
 -   [Earthfile (Earthly)](https://github.com/earthly/earthly)
 -   [Cargo Wharf (Rust)](https://github.com/denzp/cargo-wharf)
+-   [Nix](https://github.com/AkihiroSuda/buildkit-nix)
 -   (open a PR to add your own language)
 
 ### Exploring Dockerfiles


### PR DESCRIPTION
BuildKit-Nix ( https://github.com/AkihiroSuda/buildkit-nix ) is a frontend to use Nix derivations as Dockerfiles (`docker build -f default.nix .`)

