### PR TITLE
fix panic from umask-git on invalid ref

### DIFF
--- a/source/git/gitsource_unix.go
+++ b/source/git/gitsource_unix.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/docker/docker/pkg/reexec"
@@ -63,8 +64,12 @@ func gitMain() {
 	close(done)
 	if err != nil {
 		if exiterr, ok := err.(*exec.ExitError); ok {
-			status := exiterr.Sys().(unix.WaitStatus)
-			os.Exit(status.ExitStatus())
+			switch status := exiterr.Sys().(type) {
+			case unix.WaitStatus:
+				os.Exit(status.ExitStatus())
+			case syscall.WaitStatus:
+				os.Exit(status.ExitStatus())
+			}
 		}
 		os.Exit(1)
 	}


### PR DESCRIPTION
If the ref is invalid we are seeing a panic from `umask-git` because
the error type is not always a unix.WaitStatus:
```
    #1 0.227 fatal: Not a valid object name 000111222333444555666777888999aaabbbcccd^{commit}
    #1 0.229 panic: interface conversion: interface {} is syscall.WaitStatus, not unix.WaitStatus
    #1 0.229
    #1 0.229 goroutine 1 [running]:
    #1 0.229 github.com/moby/buildkit/source/git.gitMain()
    #1 0.229 	/src/source/git/gitsource_unix.go:66 +0x27d
    #1 0.229 github.com/docker/docker/pkg/reexec.Init(...)
    #1 0.229 	/src/vendor/github.com/docker/docker/pkg/reexec/reexec.go:26
    #1 0.229 main.init.0()
    #1 0.229 	/src/cmd/buildkitd/main.go:76 +0xf6
    #1 0.633 fatal: reference is not a tree: 000111222333444555666777888999aaabbbcccd
    #1 0.635 panic: interface conversion: interface {} is syscall.WaitStatus, not unix.WaitStatus
    #1 0.635
    #1 0.635 goroutine 1 [running]:
    #1 0.635 github.com/moby/buildkit/source/git.gitMain()
    #1 0.635 	/src/source/git/gitsource_unix.go:66 +0x27d
    #1 0.635 github.com/docker/docker/pkg/reexec.Init(...)
    #1 0.635 	/src/vendor/github.com/docker/docker/pkg/reexec/reexec.go:26
    #1 0.635 main.init.0()
    #1 0.635 	/src/cmd/buildkitd/main.go:76 +0xf6
```

This is from trying to solve:
```
    llb.Git("https://github.com/moby/buildkit.git", "000111222333444555666777888999aaabbbcccd")
```