### PR TITLE
dockerfile: fix image name when loaded named context

### DIFF
--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -839,14 +839,15 @@ func contextByName(ctx context.Context, c client.Client, name string, platform *
 	}
 	switch vv[0] {
 	case "docker-image":
+		ref := strings.TrimPrefix(vv[1], "//")
 		imgOpt := []llb.ImageOption{
-			llb.WithCustomName("[context " + name + "] " + vv[1]),
+			llb.WithCustomName("[context " + name + "] " + ref),
 			llb.WithMetaResolver(c),
 		}
 		if platform != nil {
 			imgOpt = append(imgOpt, llb.Platform(*platform))
 		}
-		st := llb.Image(strings.TrimPrefix(vv[1], "//"), imgOpt...)
+		st := llb.Image(ref, imgOpt...)
 		return &st, nil, nil
 	case "git":
 		st, ok := detectGitContext(v, "1")


### PR DESCRIPTION
Currently in progressbar image name has `//` prefix.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>