### PR TITLE
dockerfile: apply dockerignore on loading local contexts

### DIFF
--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -863,7 +863,44 @@ func contextByName(ctx context.Context, c client.Client, name string, platform *
 		}
 		return st, nil, nil
 	case "local":
-		st := llb.Local(vv[1], llb.WithCustomName("[context "+name+"] load from client"), llb.SessionID(c.BuildOpts().SessionID), llb.SharedKeyHint("context:"+name))
+		st := llb.Local(vv[1],
+			llb.SessionID(c.BuildOpts().SessionID),
+			llb.FollowPaths([]string{dockerignoreFilename}),
+			llb.SharedKeyHint("context:"+name+"-"+dockerignoreFilename),
+			llb.WithCustomName("[context "+name+"] load "+dockerignoreFilename),
+			llb.Differ(llb.DiffNone, false),
+		)
+		def, err := st.Marshal(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+		res, err := c.Solve(ctx, client.SolveRequest{
+			Evaluate:   true,
+			Definition: def.ToPB(),
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		ref, err := res.SingleRef()
+		if err != nil {
+			return nil, nil, err
+		}
+		dt, _ := ref.ReadFile(ctx, client.ReadRequest{
+			Filename: dockerignoreFilename,
+		}) // error ignored
+		var excludes []string
+		if len(dt) != 0 {
+			excludes, err = dockerignore.ReadAll(bytes.NewBuffer(dt))
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+		st = llb.Local(vv[1],
+			llb.WithCustomName("[context "+name+"] load from client"),
+			llb.SessionID(c.BuildOpts().SessionID),
+			llb.SharedKeyHint("context:"+name),
+			llb.ExcludePatterns(excludes),
+		)
 		return &st, nil, nil
 	case "input":
 		inputs, err := c.Inputs(ctx)


### PR DESCRIPTION
When loading named context from a local directory first see if it contains a `.dockerignore` file and apply it as a filter if it does.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>