### PR TITLE
Remove goto statements causing failed edges to never unpark

### DIFF
--- a/solver/edge.go
+++ b/solver/edge.go
@@ -68,6 +68,8 @@ type edge struct {
 	index         *edgeIndex
 
 	secondaryExporters []expDep
+
+	failedOnce sync.Once
 }
 
 // dep holds state for a dependant edge
@@ -375,7 +377,9 @@ func (e *edge) makeExportable(k *CacheKey, records []*CacheRecord) ExportableCac
 
 func (e *edge) markFailed(f *pipeFactory, err error) {
 	e.err = err
-	e.postpone(f)
+	e.failedOnce.Do(func() {
+		e.postpone(f)
+	})
 }
 
 // processUpdate is called by unpark for every updated pipe request

--- a/solver/scheduler.go
+++ b/solver/scheduler.go
@@ -138,7 +138,6 @@ func (s *scheduler) dispatch(e *edge) {
 		debugSchedulerPostUnpark(e, inc)
 	}
 
-postUnpark:
 	// set up new requests that didn't complete/were added by this run
 	openIncoming := make([]*edgePipe, 0, len(inc))
 	for _, r := range s.incoming[e] {
@@ -189,11 +188,9 @@ postUnpark:
 	// unpark(), not for any external input.
 	if len(openIncoming) > 0 && len(openOutgoing) == 0 {
 		e.markFailed(pf, errors.New("buildkit scheduler error: return leaving incoming open. Please report this with BUILDKIT_SCHEDULER_DEBUG=1"))
-		goto postUnpark
 	}
 	if len(openIncoming) == 0 && len(openOutgoing) > 0 {
 		e.markFailed(pf, errors.New("buildkit scheduler error: return leaving outgoing open. Please report this with BUILDKIT_SCHEDULER_DEBUG=1"))
-		goto postUnpark
 	}
 }
 


### PR DESCRIPTION
Fixes #2526

Though we still need to figure out how #2526 triggered `markFailed` in the first place.