### PR TITLE
cache: do not ignore readonly option

### DIFF
--- a/cache/refs.go
+++ b/cache/refs.go
@@ -775,6 +775,9 @@ func (sr *immutableRef) Mount(ctx context.Context, readonly bool, s session.Grou
 	defer sr.mu.Unlock()
 
 	if sr.mountCache != nil {
+		if readonly {
+			return setReadonly(sr.mountCache), nil
+		}
 		return sr.mountCache, nil
 	}
 
@@ -1258,6 +1261,9 @@ func (sr *mutableRef) Mount(ctx context.Context, readonly bool, s session.Group)
 	defer sr.mu.Unlock()
 
 	if sr.mountCache != nil {
+		if readonly {
+			return setReadonly(sr.mountCache), nil
+		}
 		return sr.mountCache, nil
 	}
 


### PR DESCRIPTION
Fixes https://github.com/moby/buildkit/pull/2491#issuecomment-1010123172

Currently, read-only option for a mount is sometimes ignored and this seems to lead to conflicts between (unexpectedly-)writable overlay mounts (related: https://github.com/moby/buildkit/issues/2334).

cc @tonistiigi @crazy-max 