### PR TITLE
tracing: move to newer env names

### DIFF
--- a/util/tracing/env/traceenv.go
+++ b/util/tracing/env/traceenv.go
@@ -18,9 +18,19 @@ func init() {
 }
 
 func initContext(ctx context.Context) context.Context {
+	// open-telemetry/opentelemetry-specification#740
+	parent := os.Getenv("TRACEPARENT")
+	state := os.Getenv("TRACESTATE")
+
+	if parent != "" {
+		tc := propagation.TraceContext{}
+		return tc.Extract(ctx, &textMap{parent: parent, state: state})
+	}
+
+	// deprecated: removed in v0.11.0
 	// previously defined in https://github.com/open-telemetry/opentelemetry-swift/blob/4ea467ed4b881d7329bf2254ca7ed7f2d9d6e1eb/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift#L14-L15
-	parent := os.Getenv("OTEL_TRACE_PARENT")
-	state := os.Getenv("OTEL_TRACE_STATE")
+	parent = os.Getenv("OTEL_TRACE_PARENT")
+	state = os.Getenv("OTEL_TRACE_STATE")
 
 	if parent == "" {
 		return ctx

--- a/util/tracing/exec/traceexec.go
+++ b/util/tracing/exec/traceexec.go
@@ -20,12 +20,21 @@ func Environ(ctx context.Context) []string {
 
 	var env []string
 
+	// deprecated: removed in v0.11.0
 	// previously defined in https://github.com/open-telemetry/opentelemetry-swift/blob/4ea467ed4b881d7329bf2254ca7ed7f2d9d6e1eb/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift#L14-L15
 	if tm.parent != "" {
 		env = append(env, "OTEL_TRACE_PARENT="+tm.parent)
 	}
 	if tm.state != "" {
 		env = append(env, "OTEL_TRACE_STATE="+tm.state)
+	}
+
+	// open-telemetry/opentelemetry-specification#740
+	if tm.parent != "" {
+		env = append(env, "TRACEPARENT="+tm.parent)
+	}
+	if tm.state != "" {
+		env = append(env, "TRACESTATE="+tm.state)
 	}
 
 	return env


### PR DESCRIPTION
open-telemetry/opentelemetry-specification#740 has decided to
promote different set of env for CLI propagation.

Switch to use them so we are more consistent with other
tools. Old ones should be removed in a future release.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>