### PR TITLE
Dockerfile: update Alpine to 3.15 (install shadow-uidmap from APK)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,9 @@ ARG BUILDKIT_TARGET=buildkitd
 ARG REGISTRY_VERSION=2.7.1
 ARG ROOTLESSKIT_VERSION=v0.14.2
 ARG CNI_VERSION=v0.9.1
-ARG SHADOW_VERSION=4.8.1
 ARG STARGZ_SNAPSHOTTER_VERSION=v0.10.1
 
-ARG ALPINE_VERSION=3.14
+ARG ALPINE_VERSION=3.15
 
 # git stage is used for checking out remote repository sources
 FROM --platform=$BUILDPLATFORM alpine:${ALPINE_VERSION} AS git
@@ -256,31 +255,10 @@ ENV BUILDKIT_RUN_NETWORK_INTEGRATION_TESTS=1 BUILDKIT_CNI_INIT_LOCK_PATH=/run/bu
 FROM integration-tests AS dev-env
 VOLUME /var/lib/buildkit
 
-# newuidmap & newgidmap binaries (shadow-uidmap 4.8.1-r0) shipped with alpine cannot be executed without CAP_SYS_ADMIN,
-# because the binaries are built without libcap-dev.
-# So we need to build the binaries with libcap enabled.
-# TODO: ask the Alpine upstream to enable libcap: https://github.com/moby/buildkit/issues/2038
-FROM --platform=$BUILDPLATFORM alpine:${ALPINE_VERSION} AS idmap
-RUN apk add --no-cache git autoconf automake clang lld gettext-dev libtool make byacc binutils
-COPY --from=xx / /
-ARG SHADOW_VERSION
-RUN git clone https://github.com/shadow-maint/shadow.git /shadow && cd /shadow && git checkout $SHADOW_VERSION
-WORKDIR /shadow
-ARG TARGETPLATFORM
-RUN xx-apk add --no-cache musl-dev gcc libcap-dev
-RUN CC=$(xx-clang --print-target-triple)-clang ./autogen.sh --disable-nls --disable-man --without-audit --without-selinux --without-acl --without-attr --without-tcb --without-nscd --host $(xx-clang --print-target-triple) \
-  && make -j $(nproc) \
-  && xx-verify src/newuidmap src/newuidmap \
-  && cp src/newuidmap src/newgidmap /usr/bin
-
 # Rootless mode.
 FROM tonistiigi/alpine:${ALPINE_VERSION} AS rootless
-RUN apk add --no-cache fuse3 fuse-overlayfs git openssh pigz xz
-COPY --from=idmap /usr/bin/newuidmap /usr/bin/newuidmap
-COPY --from=idmap /usr/bin/newgidmap /usr/bin/newgidmap
-# we could just set CAP_SETUID filecap rather than `chmod u+s`, but requires kernel >= 4.14
-RUN chmod u+s /usr/bin/newuidmap /usr/bin/newgidmap \
-  && adduser -D -u 1000 user \
+RUN apk add --no-cache fuse3 fuse-overlayfs git openssh pigz shadow-uidmap xz
+RUN adduser -D -u 1000 user \
   && mkdir -p /run/user/1000 /home/user/.local/tmp /home/user/.local/share/buildkit \
   && chown -R user /run/user/1000 /home/user \
   && echo user:100000:65536 | tee /etc/subuid | tee /etc/subgid


### PR DESCRIPTION
Alpine 3.15 contains https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/25365 , so we can now install shadow-uidmap frok APK.

Close #2038
Close #2580
