### PR TITLE
exporter: support for compression-level

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Keys supported by image output:
 * `dangling-name-prefix=[value]`: name image with `prefix@<digest>` , used for anonymous images
 * `name-canonical=true`: add additional canonical name `name@<digest>`
 * `compression=[uncompressed,gzip,estargz,zstd]`: choose compression type for layers newly created and cached, gzip is default value. estargz should be used with `oci-mediatypes=true`.
+* `compression-level=[value]`: compression level for gzip, estargz (0-9) and zstd (0-22)
 * `force-compression=true`: forcefully apply `compression` option to all layers (including already existing layers).
 * `buildinfo=[all,imageconfig,metadata,none]`: choose [build dependency](docs/build-repro.md#build-dependencies) version to export (default `all`).
 

--- a/cache/blobs_linux.go
+++ b/cache/blobs_linux.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"io"
 
-	ctdcompression "github.com/containerd/containerd/archive/compression"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/mount"
@@ -31,20 +30,6 @@ func (sr *immutableRef) tryComputeOverlayBlob(ctx context.Context, lower, upper 
 		// This is not an overlayfs snapshot. This is not an error so don't return error here
 		// and let the caller fallback to another differ.
 		return emptyDesc, false, nil
-	}
-
-	if compressorFunc == nil {
-		switch mediaType {
-		case ocispecs.MediaTypeImageLayer:
-		case ocispecs.MediaTypeImageLayerGzip:
-			compressorFunc = func(dest io.Writer, requiredMediaType string) (io.WriteCloser, error) {
-				return ctdcompression.CompressStream(dest, ctdcompression.Gzip)
-			}
-		case ocispecs.MediaTypeImageLayer + "+zstd":
-			compressorFunc = zstdWriter
-		default:
-			return emptyDesc, false, errors.Errorf("unsupported diff media type: %v", mediaType)
-		}
 	}
 
 	cw, err := sr.cm.ContentStore.Writer(ctx,

--- a/cache/estargz.go
+++ b/cache/estargz.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"archive/tar"
+	"compress/gzip"
 	"context"
 	"fmt"
 	"io"
@@ -21,7 +22,7 @@ var eStargzAnnotations = []string{estargz.TOCJSONDigestAnnotation, estargz.Store
 
 // compressEStargz writes the passed blobs stream as an eStargz-compressed blob.
 // finalize function finalizes the written blob metadata and returns all eStargz annotations.
-func compressEStargz() (compressorFunc compressor, finalize func(context.Context, content.Store) (map[string]string, error)) {
+func compressEStargz(comp compression.Config) (compressorFunc compressor, finalize func(context.Context, content.Store) (map[string]string, error)) {
 	var cInfo *compressionInfo
 	var writeErr error
 	var mu sync.Mutex
@@ -43,7 +44,11 @@ func compressEStargz() (compressorFunc compressor, finalize func(context.Context
 
 				blobInfoW, bInfoCh := calculateBlobInfo()
 				defer blobInfoW.Close()
-				w := estargz.NewWriter(io.MultiWriter(dest, blobInfoW))
+				level := gzip.BestCompression
+				if comp.Level != nil {
+					level = *comp.Level
+				}
+				w := estargz.NewWriterLevel(io.MultiWriter(dest, blobInfoW), level)
 
 				// Using lossless API here to make sure that decompressEStargz provides the exact
 				// same tar as the original.

--- a/cache/refs.go
+++ b/cache/refs.go
@@ -46,7 +46,7 @@ type ImmutableRef interface {
 	Finalize(context.Context) error
 
 	Extract(ctx context.Context, s session.Group) error // +progress
-	GetRemotes(ctx context.Context, createIfNeeded bool, compressionopt solver.CompressionOpt, all bool, s session.Group) ([]*solver.Remote, error)
+	GetRemotes(ctx context.Context, createIfNeeded bool, compressionopt compression.Config, all bool, s session.Group) ([]*solver.Remote, error)
 	LayerChain() RefList
 }
 

--- a/cache/remotecache/v1/cachestorage.go
+++ b/cache/remotecache/v1/cachestorage.go
@@ -7,6 +7,7 @@ import (
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/util/compression"
 	"github.com/moby/buildkit/worker"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
@@ -267,7 +268,7 @@ func (cs *cacheResultStorage) Load(ctx context.Context, res solver.CacheResult) 
 	return worker.NewWorkerRefResult(ref, cs.w), nil
 }
 
-func (cs *cacheResultStorage) LoadRemotes(ctx context.Context, res solver.CacheResult, compressionopts *solver.CompressionOpt, _ session.Group) ([]*solver.Remote, error) {
+func (cs *cacheResultStorage) LoadRemotes(ctx context.Context, res solver.CacheResult, compressionopts *compression.Config, _ session.Group) ([]*solver.Remote, error) {
 	if r := cs.byResultID(res.ID); r != nil && r.result != nil {
 		if compressionopts == nil {
 			return []*solver.Remote{r.result}, nil

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/moby/buildkit/cache"
-	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/util/compression"
 )
 
 type Exporter interface {
@@ -24,5 +24,5 @@ type Source struct {
 }
 
 type Config struct {
-	Compression solver.CompressionOpt
+	Compression compression.Config
 }

--- a/solver/cachestorage.go
+++ b/solver/cachestorage.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/util/compression"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
@@ -47,6 +48,6 @@ type CacheInfoLink struct {
 type CacheResultStorage interface {
 	Save(Result, time.Time) (CacheResult, error)
 	Load(ctx context.Context, res CacheResult) (Result, error)
-	LoadRemotes(ctx context.Context, res CacheResult, compression *CompressionOpt, s session.Group) ([]*Remote, error)
+	LoadRemotes(ctx context.Context, res CacheResult, compression *compression.Config, s session.Group) ([]*Remote, error)
 	Exists(id string) bool
 }

--- a/solver/llbsolver/result.go
+++ b/solver/llbsolver/result.go
@@ -8,6 +8,7 @@ import (
 	"github.com/moby/buildkit/cache/contenthash"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/util/compression"
 	"github.com/moby/buildkit/worker"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
@@ -81,7 +82,7 @@ func NewContentHashFunc(selectors []Selector) solver.ResultBasedCacheFunc {
 	}
 }
 
-func workerRefResolver(compressionopt solver.CompressionOpt, all bool, g session.Group) func(ctx context.Context, res solver.Result) ([]*solver.Remote, error) {
+func workerRefResolver(compressionopt compression.Config, all bool, g session.Group) func(ctx context.Context, res solver.Result) ([]*solver.Remote, error) {
 	return func(ctx context.Context, res solver.Result) ([]*solver.Remote, error) {
 		ref, ok := res.Sys().(*worker.WorkerRef)
 		if !ok {

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -254,11 +254,9 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 
 				// all keys have same export chain so exporting others is not needed
 				_, err = r.CacheKeys()[0].Exporter.ExportTo(ctx, e, solver.CacheExportOpt{
-					ResolveRemotes: workerRefResolver(solver.CompressionOpt{
-						Type: compression.Default, // TODO: make configurable
-					}, false, g),
-					Mode:    exp.CacheExportMode,
-					Session: g,
+					ResolveRemotes: workerRefResolver(compression.New(compression.Default), false, g), // TODO: make configurable
+					Mode:           exp.CacheExportMode,
+					Session:        g,
 				})
 				return err
 			}); err != nil {
@@ -295,7 +293,7 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 	}, nil
 }
 
-func inlineCache(ctx context.Context, e remotecache.Exporter, res solver.CachedResult, compressionopt solver.CompressionOpt, g session.Group) ([]byte, error) {
+func inlineCache(ctx context.Context, e remotecache.Exporter, res solver.CachedResult, compressionopt compression.Config, g session.Group) ([]byte, error) {
 	if efl, ok := e.(interface {
 		ExportForLayers(context.Context, []digest.Digest) ([]byte, error)
 	}); ok {

--- a/solver/memorycachestorage.go
+++ b/solver/memorycachestorage.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/util/compression"
 	"github.com/pkg/errors"
 )
 
@@ -298,7 +299,7 @@ func (s *inMemoryResultStore) Load(ctx context.Context, res CacheResult) (Result
 	return v.(Result), nil
 }
 
-func (s *inMemoryResultStore) LoadRemotes(_ context.Context, _ CacheResult, _ *CompressionOpt, _ session.Group) ([]*Remote, error) {
+func (s *inMemoryResultStore) LoadRemotes(_ context.Context, _ CacheResult, _ *compression.Config, _ session.Group) ([]*Remote, error) {
 	return nil, nil
 }
 

--- a/solver/types.go
+++ b/solver/types.go
@@ -102,13 +102,7 @@ type CacheExportOpt struct {
 	Session session.Group
 	// CompressionOpt is an option to specify the compression of the object to load.
 	// If specified, all objects that meet the option will be cached.
-	CompressionOpt *CompressionOpt
-}
-
-// CompressionOpt is compression information of a blob
-type CompressionOpt struct {
-	Type  compression.Type
-	Force bool
+	CompressionOpt *compression.Config
 }
 
 // CacheExporter can export the artifacts of the build chain

--- a/util/compression/compression.go
+++ b/util/compression/compression.go
@@ -34,6 +34,28 @@ const (
 	UnknownCompression Type = -1
 )
 
+type Config struct {
+	Type  Type
+	Force bool
+	Level *int
+}
+
+func New(t Type) Config {
+	return Config{
+		Type: t,
+	}
+}
+
+func (c Config) SetForce(v bool) Config {
+	c.Force = v
+	return c
+}
+
+func (c Config) SetLevel(l int) Config {
+	c.Level = &l
+	return c
+}
+
 const (
 	mediaTypeDockerSchema2LayerZstd = images.MediaTypeDockerSchema2Layer + ".zstd"
 	mediaTypeImageLayerZstd         = ocispecs.MediaTypeImageLayer + "+zstd" // unreleased image-spec#790

--- a/worker/cacheresult.go
+++ b/worker/cacheresult.go
@@ -66,7 +66,7 @@ func (s *cacheResultStorage) load(ctx context.Context, id string, hidden bool) (
 	return NewWorkerRefResult(ref, w), nil
 }
 
-func (s *cacheResultStorage) LoadRemotes(ctx context.Context, res solver.CacheResult, compressionopt *solver.CompressionOpt, g session.Group) ([]*solver.Remote, error) {
+func (s *cacheResultStorage) LoadRemotes(ctx context.Context, res solver.CacheResult, compressionopt *compression.Config, g session.Group) ([]*solver.Remote, error) {
 	w, refID, err := s.getWorkerRef(res.ID)
 	if err != nil {
 		return nil, err
@@ -81,7 +81,8 @@ func (s *cacheResultStorage) LoadRemotes(ctx context.Context, res solver.CacheRe
 	wref := WorkerRef{ref, w}
 	all := true // load as many compression blobs as possible
 	if compressionopt == nil {
-		compressionopt = &solver.CompressionOpt{Type: compression.Default}
+		comp := compression.New(compression.Default)
+		compressionopt = &comp
 		all = false
 	}
 	remotes, err := wref.GetRemotes(ctx, false, *compressionopt, all, g)

--- a/worker/result.go
+++ b/worker/result.go
@@ -6,6 +6,7 @@ import (
 	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/util/compression"
 )
 
 func NewWorkerRefResult(ref cache.ImmutableRef, worker Worker) solver.Result {
@@ -28,9 +29,9 @@ func (wr *WorkerRef) ID() string {
 // GetRemotes method abstracts ImmutableRef's GetRemotes to allow a Worker to override.
 // This is needed for moby integration.
 // Use this method instead of calling ImmutableRef.GetRemotes() directly.
-func (wr *WorkerRef) GetRemotes(ctx context.Context, createIfNeeded bool, compressionopt solver.CompressionOpt, all bool, g session.Group) ([]*solver.Remote, error) {
+func (wr *WorkerRef) GetRemotes(ctx context.Context, createIfNeeded bool, compressionopt compression.Config, all bool, g session.Group) ([]*solver.Remote, error) {
 	if w, ok := wr.Worker.(interface {
-		GetRemotes(context.Context, cache.ImmutableRef, bool, solver.CompressionOpt, bool, session.Group) ([]*solver.Remote, error)
+		GetRemotes(context.Context, cache.ImmutableRef, bool, compression.Config, bool, session.Group) ([]*solver.Remote, error)
 	}); ok {
 		return w.GetRemotes(ctx, wr.ImmutableRef, createIfNeeded, compressionopt, all, g)
 	}


### PR DESCRIPTION
replaces #2350

`compression-level` option can be set on export to
define the preferred speed vs compression ratio. The
value is a number dependent on the compression algorithm.

@ktock 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>