### PR TITLE
resolver: set buildkit own user-agent

### DIFF
--- a/client/llb/imagemetaresolver/resolver.go
+++ b/client/llb/imagemetaresolver/resolver.go
@@ -11,6 +11,7 @@ import (
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/util/contentutil"
 	"github.com/moby/buildkit/util/imageutil"
+	"github.com/moby/buildkit/version"
 	"github.com/moby/locker"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -40,9 +41,12 @@ func New(with ...ImageMetaResolverOpt) llb.ImageMetaResolver {
 	for _, f := range with {
 		f(&opts)
 	}
+	headers := http.Header{}
+	headers.Set("User-Agent", version.UserAgent())
 	return &imageMetaResolver{
 		resolver: docker.NewResolver(docker.ResolverOptions{
-			Client: http.DefaultClient,
+			Client:  http.DefaultClient,
+			Headers: headers,
 		}),
 		platform: opts.platform,
 		buffer:   contentutil.NewBuffer(),

--- a/util/contentutil/refs.go
+++ b/util/contentutil/refs.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
+	"github.com/moby/buildkit/version"
 	"github.com/moby/locker"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -16,8 +17,11 @@ import (
 )
 
 func ProviderFromRef(ref string) (ocispecs.Descriptor, content.Provider, error) {
+	headers := http.Header{}
+	headers.Set("User-Agent", version.UserAgent())
 	remote := docker.NewResolver(docker.ResolverOptions{
-		Client: http.DefaultClient,
+		Client:  http.DefaultClient,
+		Headers: headers,
 	})
 
 	name, desc, err := remote.Resolve(context.TODO(), ref)
@@ -33,8 +37,11 @@ func ProviderFromRef(ref string) (ocispecs.Descriptor, content.Provider, error) 
 }
 
 func IngesterFromRef(ref string) (content.Ingester, error) {
+	headers := http.Header{}
+	headers.Set("User-Agent", version.UserAgent())
 	remote := docker.NewResolver(docker.ResolverOptions{
-		Client: http.DefaultClient,
+		Client:  http.DefaultClient,
+		Headers: headers,
 	})
 
 	p, err := remote.Pusher(context.TODO(), ref)

--- a/util/resolver/pool.go
+++ b/util/resolver/pool.go
@@ -3,6 +3,7 @@ package resolver
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -14,6 +15,7 @@ import (
 	distreference "github.com/docker/distribution/reference"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/source"
+	"github.com/moby/buildkit/version"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -104,8 +106,11 @@ func newResolver(hosts docker.RegistryHosts, handler *authHandlerNS, sm *session
 		g:       g,
 		handler: handler,
 	}
+	headers := http.Header{}
+	headers.Set("User-Agent", version.UserAgent())
 	r.Resolver = docker.NewResolver(docker.ResolverOptions{
-		Hosts: r.HostsFunc,
+		Hosts:   r.HostsFunc,
+		Headers: headers,
 	})
 	return r
 }


### PR DESCRIPTION
Instead of using containerd defaults set our own user-agent on registry requests.

For dev versions I added some pattern matching to avoid putting sha in the requests as it would be useless for any kind of statistics.

![image](https://user-images.githubusercontent.com/585223/152107427-b01b74fc-bd01-4907-8f5b-afc66b20fe05.png)

(The double value comes from some tracing artifact, there is no actual double header).

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>