### PR TITLE
Resolver: ensure `WithSession` to pass the session to the resolver

### DIFF
--- a/util/resolver/pool.go
+++ b/util/resolver/pool.go
@@ -166,6 +166,9 @@ func (r *Resolver) WithSession(s session.Group) *Resolver {
 	r2 := *r
 	r2.auth = nil
 	r2.g = s
+	r2.Resolver = docker.NewResolver(docker.ResolverOptions{
+		Hosts: r2.HostsFunc, // this refers to the newly-configured session so we need to recreate the resolver.
+	})
 	return &r2
 }
 


### PR DESCRIPTION
Currently, unlazying blobs created by the previous build seems to fail because `resolver.Resolver.WithSession()` doesn't propagate session to authorizer during unlazying.
This commit fixes this issue.

### reproducing issue

- buildkit version: master (a640b47cb19c4f0ff47f2444f3215ee851598a8e)

```console
# cat <<EOF > /tmp/ctx/Dockerfile
FROM ghcr.io/stargz-containers/ubuntu:20.04-org
EOF
# buildctl build --progress=plain --frontend=dockerfile.v0 --local context=/tmp/ctx --local dockerfile=/tmp/ctx
# buildctl build --progress=plain --frontend=dockerfile.v0 --local context=/tmp/ctx --local dockerfile=/tmp/ctx \
                 --output type=oci,dest=/tmp/out.tar,oci-mediatypes=true,compression=zstd,force-compression=true
```

The second build in the above fails with the following error:

```
ERRO[2022-02-07T06:11:09Z] /moby.buildkit.v1.Control/Solve returned error: rpc error: code = Unknown desc = failed to ensure compression type of "zstd": failed to copy: httpReadSeeker: failed open: no active sessions
```

<details>
<summary>full log</summary>

```console
# buildctl build --progress=plain --frontend=dockerfile.v0 --local context=/tmp/ctx --local dockerfile=/tmp/ctx
#1 [internal] load build definition from Dockerfile
#1 DONE 0.0s

#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 85B done
#1 DONE 0.0s

#2 [internal] load .dockerignore
#2 transferring context: 2B done
#2 DONE 0.1s

#3 [internal] load metadata for ghcr.io/stargz-containers/ubuntu:20.04-org
#3 DONE 0.4s

#4 [1/1] FROM ghcr.io/stargz-containers/ubuntu:20.04-org@sha256:adf73ca014822ad8237623d388cedf4d5346aa72c270c5acc01431cc93e18e2d
#4 resolve ghcr.io/stargz-containers/ubuntu:20.04-org@sha256:adf73ca014822ad8237623d388cedf4d5346aa72c270c5acc01431cc93e18e2d 0.0s done
#4 DONE 0.0s

#4 [1/1] FROM ghcr.io/stargz-containers/ubuntu:20.04-org@sha256:adf73ca014822ad8237623d388cedf4d5346aa72c270c5acc01431cc93e18e2d
#4 DONE 0.1s


# buildctl build --progress=plain --frontend=dockerfile.v0 --local context=/tmp/ctx --local dockerfile=/tmp/ctx \
                 --output type=oci,dest=/tmp/out.tar,oci-mediatypes=true,compression=zstd,force-compression=true
#1 [internal] load build definition from Dockerfile
#1 DONE 0.0s

#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 85B done
#1 DONE 0.0s

#2 [internal] load .dockerignore
#2 transferring context: 2B done
#2 DONE 0.0s

#3 [internal] load metadata for ghcr.io/stargz-containers/ubuntu:20.04-org
#3 DONE 0.7s

#4 [1/1] FROM ghcr.io/stargz-containers/ubuntu:20.04-org@sha256:adf73ca014822ad8237623d388cedf4d5346aa72c270c5acc01431cc93e18e2d
#4 resolve ghcr.io/stargz-containers/ubuntu:20.04-org@sha256:adf73ca014822ad8237623d388cedf4d5346aa72c270c5acc01431cc93e18e2d 0.0s done
#4 sha256:5e9250ddb7d0fa6d13302c7c3e6a0aa40390e42424caed1e5289077ee4054709 0B / 187B 0.2s
ERRO[2022-02-07T06:11:09Z] /moby.buildkit.v1.Control/Solve returned error: rpc error: code = Unknown desc = failed to ensure compression type of "zstd": failed to copy: httpReadSeeker: failed open: no active sessions 
#4 DONE 0.2s

#5 exporting to oci image format
#5 exporting layers 0.2s done
#5 ERROR: failed to ensure compression type of "zstd": failed to copy: httpReadSeeker: failed open: no active sessions
------
 > exporting to oci image format:
------
error: failed to solve: failed to ensure compression type of "zstd": failed to copy: httpReadSeeker: failed open: no active sessions
```

</details>
