### PR TITLE
cache: Allow sharing compression variants among refs

### DIFF
--- a/cache/converter.go
+++ b/cache/converter.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containerd/containerd/images/converter"
 	"github.com/containerd/containerd/labels"
 	"github.com/moby/buildkit/identity"
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/compression"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -129,6 +130,7 @@ var bufioPool = sync.Pool{
 }
 
 func (c *conversion) convert(ctx context.Context, cs content.Store, desc ocispecs.Descriptor) (*ocispecs.Descriptor, error) {
+	bklog.G(ctx).WithField("blob", desc).WithField("target", c.target).Debugf("converting blob to the target compression")
 	// prepare the source and destination
 	labelz := make(map[string]string)
 	ref := fmt.Sprintf("convert-from-%s-to-%s-%s", desc.Digest, c.target.Type.String(), identity.NewID())

--- a/cache/remote.go
+++ b/cache/remote.go
@@ -12,6 +12,7 @@ import (
 	"github.com/moby/buildkit/cache/config"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/compression"
 	"github.com/moby/buildkit/util/contentutil"
 	"github.com/moby/buildkit/util/leaseutil"
@@ -53,7 +54,7 @@ func (sr *immutableRef) GetRemotes(ctx context.Context, createIfNeeded bool, ref
 	// compression with all combination of copmressions
 	res := []*solver.Remote{remote}
 	topmost, parentChain := remote.Descriptors[len(remote.Descriptors)-1], remote.Descriptors[:len(remote.Descriptors)-1]
-	vDesc, err := getCompressionVariantBlob(ctx, sr.cm.ContentStore, topmost.Digest, refCfg.Compression.Type)
+	vDesc, err := getBlobWithCompression(ctx, sr.cm.ContentStore, topmost, refCfg.Compression.Type)
 	if err != nil {
 		return res, nil // compression variant doesn't exist. return the main blob only.
 	}
@@ -108,16 +109,16 @@ func getAvailableBlobs(ctx context.Context, cs content.Store, chain *solver.Remo
 	if err != nil {
 		return nil, err
 	}
-	compressions, err := getCompressionVariants(ctx, cs, target.Digest)
-	if err != nil {
-		return nil, err
+	var descs []ocispecs.Descriptor
+	if err := walkBlob(ctx, cs, target, func(desc ocispecs.Descriptor) bool {
+		descs = append(descs, desc)
+		return true
+	}); err != nil {
+		bklog.G(ctx).WithError(err).Warn("failed to walk variant blob") // is not a critical error at this moment.
 	}
 	var res []*solver.Remote
-	for _, c := range compressions {
-		desc, err := getCompressionVariantBlob(ctx, cs, target.Digest, c)
-		if err != nil {
-			return nil, err
-		}
+	for _, desc := range descs {
+		desc := desc
 		if len(parents) == 0 { // bottommost ref
 			res = append(res, &solver.Remote{
 				Descriptors: []ocispecs.Descriptor{desc},
@@ -217,9 +218,9 @@ func (sr *immutableRef) getRemote(ctx context.Context, createIfNeeded bool, refC
 			} else if needs {
 				// ensure the compression type.
 				// compressed blob must be created and stored in the content store.
-				blobDesc, err := ref.getCompressionBlob(ctx, refCfg.Compression.Type)
+				blobDesc, err := getBlobWithCompressionWithRetry(ctx, ref, refCfg.Compression, s)
 				if err != nil {
-					return nil, errors.Wrapf(err, "compression blob for %q not found", refCfg.Compression.Type)
+					return nil, errors.Wrapf(err, "failed to get compression blob %q", refCfg.Compression.Type)
 				}
 				newDesc := desc
 				newDesc.MediaType = blobDesc.MediaType
@@ -249,6 +250,16 @@ func (sr *immutableRef) getRemote(ctx context.Context, createIfNeeded bool, refC
 		})
 	}
 	return remote, nil
+}
+
+func getBlobWithCompressionWithRetry(ctx context.Context, ref *immutableRef, comp compression.Config, s session.Group) (ocispecs.Descriptor, error) {
+	if blobDesc, err := ref.getBlobWithCompression(ctx, comp.Type); err == nil {
+		return blobDesc, nil
+	}
+	if err := ensureCompression(ctx, ref, comp, s); err != nil {
+		return ocispecs.Descriptor{}, errors.Wrapf(err, "failed to get and ensure compression type of %q", comp.Type)
+	}
+	return ref.getBlobWithCompression(ctx, comp.Type)
 }
 
 type lazyMultiProvider struct {
@@ -300,6 +311,11 @@ func (p lazyRefProvider) Unlazy(ctx context.Context) error {
 		} else if !isLazy {
 			return nil, nil
 		}
+		defer func() {
+			if rerr == nil {
+				rerr = p.ref.linkBlob(ctx, p.desc)
+			}
+		}()
 
 		if p.dh == nil {
 			// shouldn't happen, if you have a lazy immutable ref it already should be validated
@@ -334,14 +350,6 @@ func (p lazyRefProvider) Unlazy(ctx context.Context) error {
 			}
 		}
 
-		compressionType := compression.FromMediaType(p.desc.MediaType)
-		if compressionType == compression.UnknownCompression {
-			return nil, errors.Errorf("unhandled layer media type: %q", p.desc.MediaType)
-		}
-
-		if err := p.ref.addCompressionBlob(ctx, p.desc, compressionType); err != nil {
-			return nil, err
-		}
 		return nil, nil
 	})
 	return err


### PR DESCRIPTION
Fixes: #2346

Currently, a compression variant of a ref is not visible from another. This leads to duplicated conversion as mentioned in #2346.
This commit allows refs sharing compression variants with each other.

When a ref converts a blob (compression blob A) to another compression (compression blob B), Blob A and B are linked together using GC label to make sure that all linked variants are released together (i.e. they aren't released even when refs lease only some of them). (Maybe in the future we can switch to the lease-based approach as discussed in  #2347. But how can we manage the ref counter of the lease itself among refs in a simple way?)

When a ref exports a compression variant, it first walks all linked compression variant blobs and checks if there is a blob that can be reused without conversion. Conversion happens only when no blob can be reused.

## latency of exporing layers

This runs two builds with two compression types (gzip and zstd). Both of the builds share the same lower layers.

A:

```dockerfile
FROM ${REGISTRY}/${IMG}
RUN echo hello > /hello
```

B: 

```dockerfile
FROM ${REGISTRY}/${IMG}
RUN echo hi > /hi
```

Before the measurement, zstd-compressed B is stored to the registry.

- Steps: https://github.com/ktock/buildkit/blob/5b9997d2b45ce57ed8ad07969840069e1292a388/hack/blob/measure.sh#L51-L71
  - First, we build A as gzip then convert it to zstd.
    - Here, gzip and zstd variants of `${REGISTRY}/${IMG}` are stored to the content store.
  - Next, we pull zstd-compressed B (contains zstd-version of `${REGISTRY}/${IMG}` in the lower layers) from the registry then convert it to gzip.
    - Here, gzip-version of `${REGISTRY}/${IMG}` has already been cached during building A, so this build should reuse these blobs without duplicated conversions.
    - This PR-version of BuildKit successfully reuses it but master version of BuildKit doesn't.

The following shows the time to export layers during building gzip-version of B at the final step in the above.
This PR exports layers without conversion so it's faster than the master version.

- measured on Github Actions ubuntu runner:
  - PR: https://github.com/ktock/buildkit/actions/runs/1805493851
  - master: https://github.com/ktock/buildkit/actions/runs/1805496498

### OCI worker

|`${IMG}`|master|PR|
|---|---|---|
|ubuntu:20.04|4.1s|0s|
|tomcat:10.0.0-jdk15-openjdk-buster|23.3s|0s|

### containerd worker

|`${IMG}`|master|PR|
|---|---|---|
|ubuntu:20.04|25.5s|0s|
|tomcat:10.0.0-jdk15-openjdk-buster|190.2s|0.1s|

master version of containerd worker's performance is too worse than OCI worker.
This is because of the lack of bufio writers for the content store.
This will be fixed by #2601.
