### PR TITLE
image exporter: return image descriptor in response

### DIFF
--- a/cmd/buildctl/buildctl_test.go
+++ b/cmd/buildctl/buildctl_test.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path"
 	"testing"
 
 	"github.com/moby/buildkit/util/testutil/integration"
@@ -30,4 +34,97 @@ func testUsage(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, sb.Cmd().Run())
 
 	require.NoError(t, sb.Cmd("--help").Run())
+}
+
+func TestWriteMetadataFile(t *testing.T) {
+	tmpdir, err := os.MkdirTemp("", "buildkit")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpdir)
+
+	cases := []struct {
+		name             string
+		exporterResponse map[string]string
+		excpected        map[string]interface{}
+	}{
+		{
+			name: "common",
+			exporterResponse: map[string]string{
+				"containerimage.config.digest": "sha256:2937f66a9722f7f4a2df583de2f8cb97fc9196059a410e7f00072fc918930e66",
+				"containerimage.descriptor":    "eyJtZWRpYVR5cGUiOiJhcHBsaWNhdGlvbi92bmQub2NpLmltYWdlLm1hbmlmZXN0LnYxK2pzb24iLCJkaWdlc3QiOiJzaGEyNTY6MTlmZmVhYjZmOGJjOTI5M2FjMmMzZmRmOTRlYmUyODM5NjI1NGM5OTNhZWEwYjVhNTQyY2ZiMDJlMDg4M2ZhMyIsInNpemUiOjUwNiwiYW5ub3RhdGlvbnMiOnsib3JnLm9wZW5jb250YWluZXJzLmltYWdlLmNyZWF0ZWQiOiIyMDIyLTAyLTA4VDE5OjIxOjAzWiJ9fQ==", // {"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:19ffeab6f8bc9293ac2c3fdf94ebe28396254c993aea0b5a542cfb02e0883fa3","size":506,"annotations":{"org.opencontainers.image.created":"2022-02-08T19:21:03Z"}}
+				"containerimage.digest":        "sha256:19ffeab6f8bc9293ac2c3fdf94ebe28396254c993aea0b5a542cfb02e0883fa3",
+			},
+			excpected: map[string]interface{}{
+				"containerimage.config.digest": "sha256:2937f66a9722f7f4a2df583de2f8cb97fc9196059a410e7f00072fc918930e66",
+				"containerimage.descriptor": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						"org.opencontainers.image.created": "2022-02-08T19:21:03Z",
+					},
+					"digest":    "sha256:19ffeab6f8bc9293ac2c3fdf94ebe28396254c993aea0b5a542cfb02e0883fa3",
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"size":      float64(506),
+				},
+				"containerimage.digest": "sha256:19ffeab6f8bc9293ac2c3fdf94ebe28396254c993aea0b5a542cfb02e0883fa3",
+			},
+		},
+		{
+			name: "b64json",
+			exporterResponse: map[string]string{
+				"key":                   "MTI=", // 12
+				"containerimage.digest": "sha256:19ffeab6f8bc9293ac2c3fdf94ebe28396254c993aea0b5a542cfb02e0883fa3",
+			},
+			excpected: map[string]interface{}{
+				"key":                   "MTI=",
+				"containerimage.digest": "sha256:19ffeab6f8bc9293ac2c3fdf94ebe28396254c993aea0b5a542cfb02e0883fa3",
+			},
+		},
+		{
+			name: "emptyjson",
+			exporterResponse: map[string]string{
+				"key":                   "e30=", // {}
+				"containerimage.digest": "sha256:19ffeab6f8bc9293ac2c3fdf94ebe28396254c993aea0b5a542cfb02e0883fa3",
+			},
+			excpected: map[string]interface{}{
+				"key":                   "e30=",
+				"containerimage.digest": "sha256:19ffeab6f8bc9293ac2c3fdf94ebe28396254c993aea0b5a542cfb02e0883fa3",
+			},
+		},
+		{
+			name: "invalidjson",
+			exporterResponse: map[string]string{
+				"key":                   "W10=", // []
+				"containerimage.digest": "sha256:19ffeab6f8bc9293ac2c3fdf94ebe28396254c993aea0b5a542cfb02e0883fa3",
+			},
+			excpected: map[string]interface{}{
+				"key":                   "W10=",
+				"containerimage.digest": "sha256:19ffeab6f8bc9293ac2c3fdf94ebe28396254c993aea0b5a542cfb02e0883fa3",
+			},
+		},
+		{
+			name: "nullobject",
+			exporterResponse: map[string]string{
+				"key":                   "eyJmb28iOm51bGwsImJhciI6ImJheiJ9", // {"foo":null,"bar":"baz"}
+				"containerimage.digest": "sha256:19ffeab6f8bc9293ac2c3fdf94ebe28396254c993aea0b5a542cfb02e0883fa3",
+			},
+			excpected: map[string]interface{}{
+				"key": map[string]interface{}{
+					"foo": nil,
+					"bar": "baz",
+				},
+				"containerimage.digest": "sha256:19ffeab6f8bc9293ac2c3fdf94ebe28396254c993aea0b5a542cfb02e0883fa3",
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			fname := path.Join(tmpdir, "metadata_"+tt.name)
+			require.NoError(t, writeMetadataFile(fname, tt.exporterResponse))
+			current, err := ioutil.ReadFile(fname)
+			require.NoError(t, err)
+			var raw map[string]interface{}
+			require.NoError(t, json.Unmarshal(current, &raw))
+			require.Equal(t, tt.excpected, raw)
+		})
+	}
 }

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -2,6 +2,8 @@ package containerimage
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -346,7 +348,15 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source,
 	resp[exptypes.ExporterImageDigestKey] = desc.Digest.String()
 	if v, ok := desc.Annotations[exptypes.ExporterConfigDigestKey]; ok {
 		resp[exptypes.ExporterImageConfigDigestKey] = v
+		delete(desc.Annotations, exptypes.ExporterConfigDigestKey)
 	}
+
+	dtdesc, err := json.Marshal(desc)
+	if err != nil {
+		return nil, err
+	}
+	resp[exptypes.ExporterImageDescriptorKey] = base64.StdEncoding.EncodeToString(dtdesc)
+
 	return resp, nil
 }
 

--- a/exporter/containerimage/exptypes/types.go
+++ b/exporter/containerimage/exptypes/types.go
@@ -11,6 +11,7 @@ const (
 	ExporterImageDigestKey       = "containerimage.digest"
 	ExporterImageConfigKey       = "containerimage.config"
 	ExporterImageConfigDigestKey = "containerimage.config.digest"
+	ExporterImageDescriptorKey   = "containerimage.descriptor"
 	ExporterInlineCache          = "containerimage.inlinecache"
 	ExporterBuildInfo            = "containerimage.buildinfo"
 	ExporterPlatformsKey         = "refs.platforms"

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -2,6 +2,8 @@ package oci
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"strconv"
 	"strings"
 	"time"
@@ -208,11 +210,18 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source,
 	desc.Annotations[ocispecs.AnnotationCreated] = time.Now().UTC().Format(time.RFC3339)
 
 	resp := make(map[string]string)
+
 	resp[exptypes.ExporterImageDigestKey] = desc.Digest.String()
 	if v, ok := desc.Annotations[exptypes.ExporterConfigDigestKey]; ok {
 		resp[exptypes.ExporterImageConfigDigestKey] = v
 		delete(desc.Annotations, exptypes.ExporterConfigDigestKey)
 	}
+
+	dtdesc, err := json.Marshal(desc)
+	if err != nil {
+		return nil, err
+	}
+	resp[exptypes.ExporterImageDescriptorKey] = base64.StdEncoding.EncodeToString(dtdesc)
 
 	if n, ok := src.Metadata["image.name"]; e.name == "*" && ok {
 		e.name = string(n)


### PR DESCRIPTION
fixes #2558 

```shell
$ ./hack/binaries
$ sudo ./bin/buildkitd &
$ sudo ./bin/buildctl build --progress plain --frontend gateway.v0 --opt source=docker/dockerfile --metadata-file metadata.json --local context=. --local dockerfile=. --output type=oci,dest=test.tar
$ cat metadata.json  | jq
```
```json
{
  "containerimage.buildinfo": {
    "sources": [
      {
        "pin": "sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300",
        "ref": "docker.io/library/alpine@sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300",
        "type": "docker-image"
      }
    ]
  },
  "containerimage.config.digest": "sha256:2937f66a9722f7f4a2df583de2f8cb97fc9196059a410e7f00072fc918930e66",
  "containerimage.descriptor": {
    "annotations": {
      "config.digest": "sha256:2937f66a9722f7f4a2df583de2f8cb97fc9196059a410e7f00072fc918930e66",
      "org.opencontainers.image.created": "2022-02-08T21:28:03Z"
    },
    "digest": "sha256:19ffeab6f8bc9293ac2c3fdf94ebe28396254c993aea0b5a542cfb02e0883fa3",
    "mediaType": "application/vnd.oci.image.manifest.v1+json",
    "size": 506
  },
  "containerimage.digest": "sha256:19ffeab6f8bc9293ac2c3fdf94ebe28396254c993aea0b5a542cfb02e0883fa3"
}
```

@tonistiigi About `config.digest` as annotation should this be removed like?: https://github.com/moby/buildkit/blob/a640b47cb19c4f0ff47f2444f3215ee851598a8e/exporter/oci/export.go#L214

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>