### PR TITLE
Add Qovery to the list of buildkit users

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ BuildKit is used by the following projects:
 -   [Earthly earthfiles](https://github.com/vladaionescu/earthly)
 -   [Gitpod](https://github.com/gitpod-io/gitpod)
 -   [Dagger](https://dagger.io)
+-   [Qovery](https://www.qovery.com)
 
 ## Quick start
 


### PR DESCRIPTION
Hi, more than 20k developers using Qovery which heavily relies on Buildkit. Thank you