### PR TITLE
Close readclosers returned by DecompressStream

### DIFF
--- a/solver/llbsolver/file/unpack.go
+++ b/solver/llbsolver/file/unpack.go
@@ -55,6 +55,7 @@ func isArchivePath(path string) bool {
 	if err != nil {
 		return false
 	}
+	defer rdr.Close()
 	r := tar.NewReader(rdr)
 	_, err = r.Next()
 	return err == nil


### PR DESCRIPTION
use unpigz to decompress, found that  many  ` /usr/bin/unpigz -d -c  ` processes left;
> $  ps aux | grep unpigz 
root        490  0.0  0.0  40672  1104 ?        Sl   05:22   0:00 /usr/bin/unpigz -d -c
root       2491  0.0  0.0  40672  1104 ?        Sl   05:44   0:00 /usr/bin/unpigz -d -c
root       3861  0.0  0.0  40672  1188 ?        Sl   06:04   0:00 /usr/bin/unpigz -d -c
root       5080  0.0  0.0  40672  1312 ?        Sl   06:19   0:00 /usr/bin/unpigz -d -c
root       6754  0.0  0.0  40672  1088 ?        Sl   06:52   0:00 /usr/bin/unpigz -d -c
root       8515  0.0  0.0  40672  1128 ?        Sl   07:14   0:00 /usr/bin/unpigz -d -c
root       9879  0.0  0.0  40672  1312 ?        Sl   07:34   0:00 /usr/bin/unpigz -d -c
root      11095  0.0  0.0  40672  1168 ?        Sl   07:49   0:00 /usr/bin/unpigz -d -c
root      12759  0.0  0.0  40672  1160 ?        Sl   08:22   0:00 /usr/bin/unpigz -d -c
root      14519  0.0  0.0  40672  1304 ?        Sl   08:44   0:00 /usr/bin/unpigz -d -c
root      15885  0.0  0.0  40672  1136 ?        Sl   09:04   0:00 /usr/bin/unpigz -d -c
root      17827  0.0  0.0  40672  1192 ?        Sl   09:19   0:00 /usr/bin/unpigz -d -c
root      20001  0.0  0.0  40672  1160 ?        Sl   09:47   0:00 /usr/bin/unpigz -d -c
root      20221  0.0  0.0  40672  1140 ?        Sl   09:47   0:00 /usr/bin/unpigz -d -c
root      20316  0.0  0.0  40672  1192 ?        Sl   09:47   0:00 /usr/bin/unpigz -d -c
root      21890  0.0  0.0  40672  1108 ?        Sl   09:52   0:00 /usr/bin/unpigz -d -c
root      22729  0.0  0.0  40672  1084 ?        Sl   09:53   0:00 /usr/bin/unpigz -d -c

#https://github.com/moby/moby/pull/34218 
Signed-off-by: genglu.gl <luzigeng32@163.com> 