### PR TITLE
Fix cross-repo push fallback when access to the source repo is not granted

### DIFF
--- a/session/auth/authprovider/authprovider.go
+++ b/session/auth/authprovider/authprovider.go
@@ -28,6 +28,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+const defaultExpiration = 60
+
 func NewDockerAuthProvider(stderr io.Writer) session.Attachable {
 	return &authProvider{
 		config:      config.LoadDefaultConfigFile(stderr),
@@ -196,6 +198,9 @@ func (ap *authProvider) getAuthorityKey(host string, salt []byte) (ed25519.Priva
 }
 
 func toTokenResponse(token string, issuedAt time.Time, expires int) *auth.FetchTokenResponse {
+	if expires == 0 {
+		expires = defaultExpiration
+	}
 	resp := &auth.FetchTokenResponse{
 		Token:     token,
 		ExpiresIn: int64(expires),

--- a/util/resolver/authorizer.go
+++ b/util/resolver/authorizer.go
@@ -405,11 +405,6 @@ func (ah *authHandler) fetchToken(ctx context.Context, sm *session.Manager, g se
 }
 
 func invalidAuthorization(c auth.Challenge, responses []*http.Response) error {
-	lastResponse := responses[len(responses)-1]
-	if lastResponse.StatusCode == http.StatusUnauthorized {
-		return errors.Wrapf(docker.ErrInvalidAuthorization, "authorization status: %v", lastResponse.StatusCode)
-	}
-
 	errStr := c.Parameters["error"]
 	if errStr == "" {
 		return nil

--- a/util/resolver/authorizer.go
+++ b/util/resolver/authorizer.go
@@ -23,6 +23,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const defaultExpiration = 60
+
 type authHandlerNS struct {
 	counter int64 // needs to be 64bit aligned for 32bit systems
 
@@ -351,6 +353,9 @@ func (ah *authHandler) fetchToken(ctx context.Context, sm *session.Manager, g se
 		if err != nil {
 			return nil, err
 		}
+		if resp.ExpiresIn == 0 {
+			resp.ExpiresIn = defaultExpiration
+		}
 		issuedAt, expires = time.Unix(resp.IssuedAt, 0), int(resp.ExpiresIn)
 		token = resp.Token
 		return nil, nil
@@ -378,6 +383,9 @@ func (ah *authHandler) fetchToken(ctx context.Context, sm *session.Manager, g se
 					if err != nil {
 						return nil, err
 					}
+					if resp.ExpiresIn == 0 {
+						resp.ExpiresIn = defaultExpiration
+					}
 					issuedAt, expires = resp.IssuedAt, resp.ExpiresIn
 					token = resp.AccessToken
 					return nil, nil
@@ -389,6 +397,9 @@ func (ah *authHandler) fetchToken(ctx context.Context, sm *session.Manager, g se
 			}
 			return nil, err
 		}
+		if resp.ExpiresIn == 0 {
+			resp.ExpiresIn = defaultExpiration
+		}
 		issuedAt, expires = resp.IssuedAt, resp.ExpiresIn
 		token = resp.Token
 		return nil, nil
@@ -397,6 +408,9 @@ func (ah *authHandler) fetchToken(ctx context.Context, sm *session.Manager, g se
 	resp, err := auth.FetchToken(ctx, ah.client, hdr, to)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to fetch anonymous token")
+	}
+	if resp.ExpiresIn == 0 {
+		resp.ExpiresIn = defaultExpiration
 	}
 	issuedAt, expires = resp.IssuedAt, resp.ExpiresIn
 


### PR DESCRIPTION
fixes #2454

Reverts #2062 and replace with a default expiration time for the case where expiration time is not sent by the server.

@jmacelroy @dchw