### PR TITLE
Enable estargz-based lazy pulling on registry cache importer

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -138,6 +138,7 @@ func TestIntegration(t *testing.T) {
 		testSourceMapFromRef,
 		testLazyImagePush,
 		testStargzLazyPull,
+		testStargzLazyInlineCacheImportExport,
 		testFileOpInputSwap,
 		testRelativeMountpoint,
 		testLocalSourceDiffer,
@@ -2878,6 +2879,161 @@ func testBuildPushAndValidate(t *testing.T, sb integration.Sandbox) {
 
 	_, ok = m["foo/sub/bar"]
 	require.False(t, ok)
+}
+
+func testStargzLazyInlineCacheImportExport(t *testing.T, sb integration.Sandbox) {
+	skipDockerd(t, sb)
+	requiresLinux(t)
+
+	cdAddress := sb.ContainerdAddress()
+	if cdAddress == "" || sb.Snapshotter() != "stargz" {
+		t.Skip("test requires containerd worker with stargz snapshotter")
+	}
+
+	client, err := newContainerd(cdAddress)
+	require.NoError(t, err)
+	defer client.Close()
+	registry, err := sb.NewRegistry()
+	if errors.Is(err, integration.ErrRequirements) {
+		t.Skip(err.Error())
+	}
+	require.NoError(t, err)
+
+	var (
+		imageService = client.ImageService()
+		contentStore = client.ContentStore()
+		ctx          = namespaces.WithNamespace(sb.Context(), "buildkit")
+	)
+
+	c, err := New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	// Prepare stargz inline cache
+	orgImage := "docker.io/library/alpine:latest"
+	sgzImage := registry + "/stargz/alpine:" + identity.NewID()
+	baseDef := llb.Image(orgImage).Run(llb.Args([]string{"/bin/touch", "/foo"}))
+	def, err := baseDef.Marshal(sb.Context())
+	require.NoError(t, err)
+	_, err = c.Solve(sb.Context(), def, SolveOpt{
+		Exports: []ExportEntry{
+			{
+				Type: ExporterImage,
+				Attrs: map[string]string{
+					"name":              sgzImage,
+					"push":              "true",
+					"compression":       "estargz",
+					"oci-mediatypes":    "true",
+					"force-compression": "true",
+				},
+			},
+		},
+		CacheExports: []CacheOptionsEntry{
+			{
+				Type: "inline",
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	// clear all local state out
+	err = imageService.Delete(ctx, sgzImage, images.SynchronousDelete())
+	require.NoError(t, err)
+	checkAllReleasable(t, c, sb, true)
+
+	// stargz layers should be lazy even for executing something on them
+	def, err = baseDef.
+		Run(llb.Args([]string{"/bin/touch", "/bar"})).
+		Marshal(sb.Context())
+	require.NoError(t, err)
+	target := registry + "/buildkit/testlazyimage:" + identity.NewID()
+	_, err = c.Solve(sb.Context(), def, SolveOpt{
+		Exports: []ExportEntry{
+			{
+				Type: ExporterImage,
+				Attrs: map[string]string{
+					"name":           target,
+					"push":           "true",
+					"oci-mediatypes": "true",
+					"compression":    "estargz",
+				},
+			},
+		},
+		CacheExports: []CacheOptionsEntry{
+			{
+				Type: "inline",
+			},
+		},
+		CacheImports: []CacheOptionsEntry{
+			{
+				Type: "registry",
+				Attrs: map[string]string{
+					"ref": sgzImage,
+				},
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	img, err := imageService.Get(ctx, target)
+	require.NoError(t, err)
+
+	manifest, err := images.Manifest(ctx, contentStore, img.Target, nil)
+	require.NoError(t, err)
+
+	// Check if image layers are lazy.
+	// The topmost(last) layer created by `Run` isn't lazy so we skip the check for the layer.
+	var sgzLayers []ocispecs.Descriptor
+	for i, layer := range manifest.Layers[:len(manifest.Layers)-1] {
+		_, err = contentStore.Info(ctx, layer.Digest)
+		require.ErrorIs(t, err, ctderrdefs.ErrNotFound, "unexpected error %v on layer %+v (%d)", err, layer, i)
+		sgzLayers = append(sgzLayers, layer)
+	}
+	require.NotEqual(t, 0, len(sgzLayers), "no layer can be used for checking lazypull")
+
+	// The topmost(last) layer created by `Run` shouldn't be lazy
+	_, err = contentStore.Info(ctx, manifest.Layers[len(manifest.Layers)-1].Digest)
+	require.NoError(t, err)
+
+	// clear all local state out
+	err = imageService.Delete(ctx, img.Name, images.SynchronousDelete())
+	require.NoError(t, err)
+	checkAllReleasable(t, c, sb, true)
+
+	// stargz layers should be exportable
+	destDir, err := ioutil.TempDir("", "buildkit")
+	require.NoError(t, err)
+	defer os.RemoveAll(destDir)
+	out := filepath.Join(destDir, "out.tar")
+	outW, err := os.Create(out)
+	require.NoError(t, err)
+	_, err = c.Solve(sb.Context(), def, SolveOpt{
+		Exports: []ExportEntry{
+			{
+				Type:   ExporterOCI,
+				Output: fixedWriteCloser(outW),
+			},
+		},
+		CacheImports: []CacheOptionsEntry{
+			{
+				Type: "registry",
+				Attrs: map[string]string{
+					"ref": sgzImage,
+				},
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	// Check if image layers are un-lazied
+	for _, layer := range sgzLayers {
+		_, err = contentStore.Info(ctx, layer.Digest)
+		require.NoError(t, err)
+	}
+
+	err = c.Prune(sb.Context(), nil, PruneAll)
+	require.NoError(t, err)
+	checkAllRemoved(t, c, sb)
 }
 
 func testStargzLazyPull(t *testing.T, sb integration.Sandbox) {

--- a/util/contentutil/multiprovider.go
+++ b/util/contentutil/multiprovider.go
@@ -26,6 +26,30 @@ type MultiProvider struct {
 	sub  map[digest.Digest]content.Provider
 }
 
+func (mp *MultiProvider) SnapshotLabels(descs []ocispecs.Descriptor, index int) map[string]string {
+	if len(descs) < index {
+		return nil
+	}
+	desc := descs[index]
+	type snapshotLabels interface {
+		SnapshotLabels([]ocispecs.Descriptor, int) map[string]string
+	}
+
+	mp.mu.RLock()
+	if p, ok := mp.sub[desc.Digest]; ok {
+		mp.mu.RUnlock()
+		if cd, ok := p.(snapshotLabels); ok {
+			return cd.SnapshotLabels(descs, index)
+		}
+	} else {
+		mp.mu.RUnlock()
+	}
+	if cd, ok := mp.base.(snapshotLabels); ok {
+		return cd.SnapshotLabels(descs, index)
+	}
+	return nil
+}
+
 func (mp *MultiProvider) CheckDescriptor(ctx context.Context, desc ocispecs.Descriptor) error {
 	type checkDescriptor interface {
 		CheckDescriptor(context.Context, ocispecs.Descriptor) error

--- a/util/estargz/labels.go
+++ b/util/estargz/labels.go
@@ -1,0 +1,38 @@
+package estargz
+
+import (
+	"fmt"
+	"strings"
+
+	ctdlabels "github.com/containerd/containerd/labels"
+	"github.com/containerd/stargz-snapshotter/estargz"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func SnapshotLabels(ref string, descs []ocispecs.Descriptor, targetIndex int) map[string]string {
+	if len(descs) < targetIndex {
+		return nil
+	}
+	desc := descs[targetIndex]
+	labels := make(map[string]string)
+	for _, k := range []string{estargz.TOCJSONDigestAnnotation, estargz.StoreUncompressedSizeAnnotation} {
+		labels[k] = desc.Annotations[k]
+	}
+	labels["containerd.io/snapshot/remote/stargz.reference"] = ref
+	labels["containerd.io/snapshot/remote/stargz.digest"] = desc.Digest.String()
+	var (
+		layersKey = "containerd.io/snapshot/remote/stargz.layers"
+		layers    string
+	)
+	for _, l := range descs[targetIndex:] {
+		ls := fmt.Sprintf("%s,", l.Digest.String())
+		// This avoids the label hits the size limitation.
+		// Skipping layers is allowed here and only affects performance.
+		if err := ctdlabels.Validate(layersKey, layers+ls); err != nil {
+			break
+		}
+		layers += ls
+	}
+	labels[layersKey] = strings.TrimSuffix(layers, ",")
+	return labels
+}


### PR DESCRIPTION
Currently, stargz-snapshotter performs lazy pulling for estargz-fromatted base images but doesn't for estargz-formatted remote (inline) caches. This is because registry cache importer doesn't pass snapshot labels to stargz-snapshotter. This commit fixes this issue.

Since this commit, if remote cache is exported as estargz (currenly this only happens for inline caches) and stargz-snapshotter is enabled, remote caches aren't unlazied even when running commands on it.
Example of exporting estargz-formatted inline cache:

```
buildctl build --progress=plain --frontend=dockerfile.v0 --local context=/tmp/ctx --local dockerfile=/tmp/ctx \
               --output type=image,name=registry2-buildkit:5000/sample1/img:1,push=true,compression=estargz,force-compression=true,oci-mediatype=true \
               --export-cache type=inline
```
