### PR TITLE
buildkitd: fix handling multiple addr flags

### DIFF
--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -441,15 +441,7 @@ func applyMainFlags(c *cli.Context, cfg *config.Config) error {
 	}
 
 	if c.IsSet("addr") || len(cfg.GRPC.Address) == 0 {
-		addrs := c.StringSlice("addr")
-		if len(addrs) > 1 {
-			addrs = addrs[1:] // https://github.com/urfave/cli/issues/160
-		}
-
-		cfg.GRPC.Address = make([]string, 0, len(addrs))
-		for _, v := range addrs {
-			cfg.GRPC.Address = append(cfg.GRPC.Address, v)
-		}
+		cfg.GRPC.Address = c.StringSlice("addr")
 	}
 
 	if c.IsSet("allow-insecure-entitlement") {


### PR DESCRIPTION
fix #2536

The issue in the cli package that added extra
field has been fixed now.

Looks like the issue was fixed with https://github.com/urfave/cli/pull/981

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>