### PR TITLE
buildkitd: handle config loading errors correctly

### DIFF
--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -375,7 +375,7 @@ func defaultConf() (config.Config, error) {
 		if !errors.As(err, &pe) {
 			return config.Config{}, err
 		}
-		return cfg, nil
+		logrus.Warnf("failed to load default config: %v", err)
 	}
 	setDefaultConfig(&cfg)
 


### PR DESCRIPTION
fix #2542

Looks like the panic comes because this function returns an empty object instead of setting the default options. New behavior is that if the default config does not exist there is no error, if toml parsing fails it is a real error and if there is a file error(eg. EPERM) then warning is printed.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>