### PR TITLE
cache: Clean up temporary mount pool on restart

### DIFF
--- a/cache/contenthash/checksum_test.go
+++ b/cache/contenthash/checksum_test.go
@@ -1223,6 +1223,7 @@ func setupCacheManager(t *testing.T, tmpdir string, snapshotterName string, snap
 		Applier:        applier,
 		Differ:         differ,
 		GarbageCollect: mdb.GarbageCollect,
+		MountPoolRoot:  filepath.Join(tmpdir, "cachemounts"),
 	})
 	require.NoError(t, err)
 

--- a/cache/manager.go
+++ b/cache/manager.go
@@ -46,6 +46,7 @@ type ManagerOpt struct {
 	Applier         diff.Applier
 	Differ          diff.Comparer
 	MetadataStore   *metadata.Store
+	MountPoolRoot   string
 }
 
 type Accessor interface {
@@ -90,6 +91,8 @@ type cacheManager struct {
 	Differ          diff.Comparer
 	MetadataStore   *metadata.Store
 
+	mountPool sharableMountPool
+
 	muPrune sync.Mutex // make sure parallel prune is not allowed so there will not be inconsistent results
 	unlazyG flightcontrol.Group
 }
@@ -110,6 +113,12 @@ func NewManager(opt ManagerOpt) (Manager, error) {
 	if err := cm.init(context.TODO()); err != nil {
 		return nil, err
 	}
+
+	p, err := newSharableMountPool(opt.MountPoolRoot)
+	if err != nil {
+		return nil, err
+	}
+	cm.mountPool = p
 
 	// cm.scheduleGC(5 * time.Minute)
 

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/klauspost/compress v1.14.3
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/moby/locker v1.0.1
+	github.com/moby/sys/mountinfo v0.6.0
 	github.com/moby/sys/signal v0.6.0
 	github.com/morikuni/aec v1.0.0
 	github.com/opencontainers/go-digest v1.0.0
@@ -104,7 +105,6 @@ require (
 	github.com/ishidawataru/sctp v0.0.0-20210226210310-f2269e66cdee // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/moby/sys/mount v0.3.0 // indirect
-	github.com/moby/sys/mountinfo v0.6.0 // indirect
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.1 // indirect

--- a/solver/llbsolver/mounts/mount_test.go
+++ b/solver/llbsolver/mounts/mount_test.go
@@ -128,6 +128,7 @@ func newCacheManager(ctx context.Context, opt cmOpt) (co *cmOut, cleanup func() 
 		Differ:         differ,
 		LeaseManager:   lm,
 		GarbageCollect: mdb.GarbageCollect,
+		MountPoolRoot:  filepath.Join(tmpdir, "cachemounts"),
 	})
 	if err != nil {
 		return nil, nil, err

--- a/source/git/gitsource_test.go
+++ b/source/git/gitsource_test.go
@@ -571,6 +571,7 @@ func setupGitSource(t *testing.T, tmpdir string) source.Source {
 		Applier:        applier,
 		Differ:         differ,
 		GarbageCollect: mdb.GarbageCollect,
+		MountPoolRoot:  filepath.Join(tmpdir, "cachemounts"),
 	})
 	require.NoError(t, err)
 

--- a/source/http/httpsource_test.go
+++ b/source/http/httpsource_test.go
@@ -373,6 +373,7 @@ func newHTTPSource(tmpdir string) (source.Source, error) {
 		Applier:        applier,
 		Differ:         differ,
 		GarbageCollect: mdb.GarbageCollect,
+		MountPoolRoot:  filepath.Join(tmpdir, "cachemounts"),
 	})
 	if err != nil {
 		return nil, err

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -75,6 +75,7 @@ type WorkerOpt struct {
 	GarbageCollect  func(context.Context) (gc.Stats, error)
 	ParallelismSem  *semaphore.Weighted
 	MetadataStore   *metadata.Store
+	MountPoolRoot   string
 }
 
 // Worker is a local worker instance with dedicated snapshotter, cache, and so on.
@@ -103,6 +104,7 @@ func NewWorker(ctx context.Context, opt WorkerOpt) (*Worker, error) {
 		ContentStore:    opt.ContentStore,
 		Differ:          opt.Differ,
 		MetadataStore:   opt.MetadataStore,
+		MountPoolRoot:   opt.MountPoolRoot,
 	})
 	if err != nil {
 		return nil, err

--- a/worker/containerd/containerd.go
+++ b/worker/containerd/containerd.go
@@ -132,6 +132,7 @@ func newContainerd(root string, client *containerd.Client, snapshotterName, ns s
 		LeaseManager:   lm,
 		GarbageCollect: gc,
 		ParallelismSem: parallelismSem,
+		MountPoolRoot:  filepath.Join(root, "cachemounts"),
 	}
 	return opt, nil
 }

--- a/worker/runc/runc.go
+++ b/worker/runc/runc.go
@@ -135,6 +135,7 @@ func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, proc
 		LeaseManager:    lm,
 		GarbageCollect:  mdb.GarbageCollect,
 		ParallelismSem:  parallelismSem,
+		MountPoolRoot:   filepath.Join(root, "cachemounts"),
 	}
 	return opt, nil
 }


### PR DESCRIPTION
Following-up https://github.com/moby/buildkit/pull/2637#discussion_r807235198

Currently, if buildkitd crashes before unmounting temporary (writable) overlayfs mounts, it could leak these mounts.
Then if buildkitd started up again, same issue of duplicating overlay mounts can happen because the old mounts remain on the host.

This commit fixes this issue by introducing a directory `cachemounts` under `/var/lib/buildkit/` for storing all temporary overlay mounts.
When buildkitd starts, it cleans up all existing (old) mounts under that directory so we can avoid the issue of duplicating overlay mounts.
