### PR TITLE
fix nil pointer dereference in bridge result

### DIFF
--- a/solver/llbsolver/bridge.go
+++ b/solver/llbsolver/bridge.go
@@ -165,15 +165,15 @@ func (b *llbBridge) Solve(ctx context.Context, req frontend.SolveRequest, sid st
 
 	if len(res.Refs) > 0 {
 		for p := range res.Refs {
-			dtbi, errm := buildinfo.GetMetadata(res.Metadata, fmt.Sprintf("%s/%s", exptypes.ExporterBuildInfo, p), req.Frontend, req.FrontendOpt)
-			if errm != nil {
+			dtbi, err := buildinfo.GetMetadata(res.Metadata, fmt.Sprintf("%s/%s", exptypes.ExporterBuildInfo, p), req.Frontend, req.FrontendOpt)
+			if err != nil {
 				return nil, err
 			}
 			res.Metadata[fmt.Sprintf("%s/%s", exptypes.ExporterBuildInfo, p)] = dtbi
 		}
 	} else {
-		dtbi, errm := buildinfo.GetMetadata(res.Metadata, exptypes.ExporterBuildInfo, req.Frontend, req.FrontendOpt)
-		if errm != nil {
+		dtbi, err := buildinfo.GetMetadata(res.Metadata, exptypes.ExporterBuildInfo, req.Frontend, req.FrontendOpt)
+		if err != nil {
 			return nil, err
 		}
 		res.Metadata[exptypes.ExporterBuildInfo] = dtbi


### PR DESCRIPTION
encounter that issue while working on #2654:

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0xd33ab9]

goroutine 533 [running]:
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End·dwrap·12()
        /src/vendor/go.opentelemetry.io/otel/sdk/trace/span.go:307 +0x2a
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc000d7ec00, {0x0, 0x0, 0x0})
        /src/vendor/go.opentelemetry.io/otel/sdk/trace/span.go:346 +0x9a2
panic({0x11b68a0, 0x1e58990})
        /usr/local/go/src/runtime/panic.go:1038 +0x215
github.com/moby/buildkit/frontend/gateway.(*llbBridgeForwarder).Solve(0xc0006be000, {0x1538c28, 0xc000b5d4d0}, 0xc000da8640)
        /src/frontend/gateway/gateway.go:647 +0x2f9
github.com/moby/buildkit/control/gateway.(*GatewayForwarder).Solve(0x0, {0x1538c28, 0xc000b5d4d0}, 0x0)
        /src/control/gateway/gateway.go:103 +0x6f
github.com/moby/buildkit/frontend/gateway/pb._LLBBridge_Solve_Handler.func1({0x1538c28, 0xc000b5d4d0}, {0x1339ac0, 0xc000da8640})
        /src/frontend/gateway/pb/gateway.pb.go:2665 +0x78
github.com/moby/buildkit/util/grpcerrors.UnaryServerInterceptor({0x1538c28, 0xc000b5d4d0}, {0x1339ac0, 0xc000da8640}, 0x0, 0x0)
        /src/util/grpcerrors/intercept.go:14 +0x3d
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1({0x1538c28, 0xc000b5d4d0}, {0x1339ac0, 0xc000da8640})
        /src/vendor/github.com/grpc-ecosystem/go-grpc-middleware/chain.go:25 +0x3a
go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc.UnaryServerInterceptor.func1({0x1538b80, 0xc001016a80}, {0x1339ac0, 0xc000da8640}, 0xc001326540, 0xc001326560)
        /src/vendor/go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go:325 +0x61c
main.unaryInterceptor.func1({0x1538c28, 0xc000b5ced0}, {0x1339ac0, 0xc000da8640}, 0xc001326540, 0xc001326560)
        /src/cmd/buildkitd/main.go:570 +0x1b8
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1({0x1538c28, 0xc000b5ced0}, {0x1339ac0, 0xc000da8640})
        /src/vendor/github.com/grpc-ecosystem/go-grpc-middleware/chain.go:25 +0x3a
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1({0x1538c28, 0xc000b5ced0}, {0x1339ac0, 0xc000da8640}, 0xc000d82bb8, 0x11b5760)
        /src/vendor/github.com/grpc-ecosystem/go-grpc-middleware/chain.go:34 +0xbf
github.com/moby/buildkit/frontend/gateway/pb._LLBBridge_Solve_Handler({0x130e080, 0xc000d44ed0}, {0x1538c28, 0xc000b5ced0}, 0xc000b44de0, 0xc000c131a0)
        /src/frontend/gateway/pb/gateway.pb.go:2667 +0x138
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000936000, {0x1551190, 0xc0006836c0}, 0xc000cf2360, 0xc000d451a0, 0x1e69878, 0x0)
        /src/vendor/google.golang.org/grpc/server.go:1282 +0xccf
google.golang.org/grpc.(*Server).handleStream(0xc000936000, {0x1551190, 0xc0006836c0}, 0xc000cf2360, 0x0)
        /src/vendor/google.golang.org/grpc/server.go:1616 +0xa2a
google.golang.org/grpc.(*Server).serveStreams.func1.2()
        /src/vendor/google.golang.org/grpc/server.go:921 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
        /src/vendor/google.golang.org/grpc/server.go:919 +0x294
```

not sure why staticcheck don't see that with golangci-lint and https://staticcheck.io/docs/checks#SA5011.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>