### PR TITLE
client: make sure local cache import is propagated via gateway API

### DIFF
--- a/client/build.go
+++ b/client/build.go
@@ -44,7 +44,13 @@ func (c *Client) Build(ctx context.Context, opt SolveOpt, product string, buildF
 		})
 	}
 
-	cb := func(ref string, s *session.Session) error {
+	cb := func(ref string, s *session.Session, opts map[string]string) error {
+		for k, v := range opts {
+			if feOpts == nil {
+				feOpts = map[string]string{}
+			}
+			feOpts[k] = v
+		}
 		gwClient := c.gatewayClientForBuild(ref)
 		g, err := grpcclient.New(ctx, feOpts, s.ID(), product, gwClient, gworkers)
 		if err != nil {

--- a/frontend/gateway/grpcclient/client.go
+++ b/frontend/gateway/grpcclient/client.go
@@ -341,6 +341,24 @@ func (c *grpcClient) Solve(ctx context.Context, creq client.SolveRequest) (res *
 		}
 	}
 
+	// these options are added by go client in solve()
+	if _, ok := creq.FrontendOpt["cache-imports"]; !ok {
+		if v, ok := c.opts["cache-imports"]; ok {
+			if creq.FrontendOpt == nil {
+				creq.FrontendOpt = map[string]string{}
+			}
+			creq.FrontendOpt["cache-imports"] = v
+		}
+	}
+	if _, ok := creq.FrontendOpt["cache-from"]; !ok {
+		if v, ok := c.opts["cache-from"]; ok {
+			if creq.FrontendOpt == nil {
+				creq.FrontendOpt = map[string]string{}
+			}
+			creq.FrontendOpt["cache-from"] = v
+		}
+	}
+
 	req := &pb.SolveRequest{
 		Definition:          creq.Definition,
 		Frontend:            creq.Frontend,


### PR DESCRIPTION
fixes #2599

Currently the local cache import only worked with client.Solve
function.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>