### PR TITLE
Support rootless containerd worker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,7 @@ jobs:
           - ./frontend/dockerfile
         worker:
           - containerd
+          - containerd-rootless
           - containerd-1.5
           - containerd-1.4
           - containerd-snapshotter-stargz

--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -99,6 +99,8 @@ type ContainerdConfig struct {
 	ApparmorProfile string `toml:"apparmor-profile"`
 
 	MaxParallelism int `toml:"max-parallelism"`
+
+	Rootless bool `toml:"rootless"`
 }
 
 type GCPolicy struct {

--- a/docs/rootless.md
+++ b/docs/rootless.md
@@ -24,10 +24,8 @@ You may have to disable SELinux, or run BuildKit with `--oci-worker-snapshotter=
   On kernel >= 4.18, the `fuse-overlayfs` snapshotter is used instead of `overlayfs`.
   On kernel < 4.18, the `native` snapshotter is used.
 * Network mode is always set to `network.host`.
-* No support for `containerd` worker.
-  ("worker" here is a BuildKit term, not a Kubernetes term. Running rootless BuildKit in containerd is fully supported.)
 
-## Running BuildKit in Rootless mode
+## Running BuildKit in Rootless mode (OCI worker)
 
 [RootlessKit](https://github.com/rootless-containers/rootlesskit/) needs to be installed.
 
@@ -42,6 +40,22 @@ $ buildctl --addr unix:///run/user/$UID/buildkit/buildkitd.sock build ...
 To isolate BuildKit daemon's network namespace from the host (recommended):
 ```console
 $ rootlesskit --net=slirp4netns --copy-up=/etc --disable-host-loopback buildkitd
+```
+
+## Running BuildKit in Rootless mode (containerd worker)
+
+[RootlessKit](https://github.com/rootless-containers/rootlesskit/) needs to be installed.
+
+Run containerd in rootless mode using rootlesskit following [containerd's document](https://github.com/containerd/containerd/blob/main/docs/rootless.md).
+
+```
+$ containerd-rootless.sh
+```
+
+Then let buildkitd join the same namespace as containerd.
+
+```
+$ containerd-rootless-setuptool.sh nsenter -- buildkitd --oci-worker=false --containerd-worker=true --containerd-worker-snapshotter=native
 ```
 
 ## Troubleshooting

--- a/worker/containerd/containerd.go
+++ b/worker/containerd/containerd.go
@@ -26,16 +26,16 @@ import (
 )
 
 // NewWorkerOpt creates a WorkerOpt.
-func NewWorkerOpt(root string, address, snapshotterName, ns string, labels map[string]string, dns *oci.DNSConfig, nopt netproviders.Opt, apparmorProfile string, parallelismSem *semaphore.Weighted, traceSocket string, opts ...containerd.ClientOpt) (base.WorkerOpt, error) {
+func NewWorkerOpt(root string, address, snapshotterName, ns string, rootless bool, labels map[string]string, dns *oci.DNSConfig, nopt netproviders.Opt, apparmorProfile string, parallelismSem *semaphore.Weighted, traceSocket string, opts ...containerd.ClientOpt) (base.WorkerOpt, error) {
 	opts = append(opts, containerd.WithDefaultNamespace(ns))
 	client, err := containerd.New(address, opts...)
 	if err != nil {
 		return base.WorkerOpt{}, errors.Wrapf(err, "failed to connect client to %q . make sure containerd is running", address)
 	}
-	return newContainerd(root, client, snapshotterName, ns, labels, dns, nopt, apparmorProfile, parallelismSem, traceSocket)
+	return newContainerd(root, client, snapshotterName, ns, rootless, labels, dns, nopt, apparmorProfile, parallelismSem, traceSocket)
 }
 
-func newContainerd(root string, client *containerd.Client, snapshotterName, ns string, labels map[string]string, dns *oci.DNSConfig, nopt netproviders.Opt, apparmorProfile string, parallelismSem *semaphore.Weighted, traceSocket string) (base.WorkerOpt, error) {
+func newContainerd(root string, client *containerd.Client, snapshotterName, ns string, rootless bool, labels map[string]string, dns *oci.DNSConfig, nopt netproviders.Opt, apparmorProfile string, parallelismSem *semaphore.Weighted, traceSocket string) (base.WorkerOpt, error) {
 	if strings.Contains(snapshotterName, "/") {
 		return base.WorkerOpt{}, errors.Errorf("bad snapshotter name: %q", snapshotterName)
 	}
@@ -122,7 +122,7 @@ func newContainerd(root string, client *containerd.Client, snapshotterName, ns s
 		ID:             id,
 		Labels:         xlabels,
 		MetadataStore:  md,
-		Executor:       containerdexecutor.New(client, root, "", np, dns, apparmorProfile, traceSocket),
+		Executor:       containerdexecutor.New(client, root, "", np, dns, apparmorProfile, traceSocket, rootless),
 		Snapshotter:    snap,
 		ContentStore:   cs,
 		Applier:        winlayers.NewFileSystemApplierWithWindows(cs, df),

--- a/worker/containerd/containerd_test.go
+++ b/worker/containerd/containerd_test.go
@@ -32,7 +32,8 @@ func newWorkerOpt(t *testing.T, addr string) (base.WorkerOpt, func()) {
 	tmpdir, err := ioutil.TempDir("", "workertest")
 	require.NoError(t, err)
 	cleanup := func() { os.RemoveAll(tmpdir) }
-	workerOpt, err := NewWorkerOpt(tmpdir, addr, "overlayfs", "buildkit-test", nil, nil, netproviders.Opt{Mode: "host"}, "", nil, "")
+	rootless := false
+	workerOpt, err := NewWorkerOpt(tmpdir, addr, "overlayfs", "buildkit-test", rootless, nil, nil, netproviders.Opt{Mode: "host"}, "", nil, "")
 	require.NoError(t, err)
 	return workerOpt, cleanup
 }
@@ -44,6 +45,9 @@ func checkRequirement(t *testing.T) {
 }
 
 func testContainerdWorkerExec(t *testing.T, sb integration.Sandbox) {
+	if sb.Rootless() {
+		t.Skip("requires root")
+	}
 	workerOpt, cleanupWorkerOpt := newWorkerOpt(t, sb.ContainerdAddress())
 	defer cleanupWorkerOpt()
 	w, err := base.NewWorker(context.TODO(), workerOpt)
@@ -53,6 +57,9 @@ func testContainerdWorkerExec(t *testing.T, sb integration.Sandbox) {
 }
 
 func testContainerdWorkerExecFailures(t *testing.T, sb integration.Sandbox) {
+	if sb.Rootless() {
+		t.Skip("requires root")
+	}
 	workerOpt, cleanupWorkerOpt := newWorkerOpt(t, sb.ContainerdAddress())
 	defer cleanupWorkerOpt()
 	w, err := base.NewWorker(context.TODO(), workerOpt)


### PR DESCRIPTION
Fixes #1325

This commit adds support for rootless containerd worker.
This also enables integration tests for rootless containerd worker configuration.

## Example configuration

Rootless containerd can run using rootlesskit following [containerd's document](https://github.com/containerd/containerd/blob/main/docs/rootless.md).

```
$ rootlesskit --copy-up=/run --state-dir=/path/to/rootlesskit-state-dir containerd -c config.toml
```

Example `config.toml`:

```toml
version = 2
root = "/home/penguin/.local/share/containerd"
state = "/run/user/1001/containerd"

[grpc]
  address = "/run/user/1001/containerd/containerd.sock"
```

Then buildkitd can join the same namespace as containerd.

```
$ nsenter -U --preserve-credentials -m -t $(cat /path/to/rootlesskit-state-dir/child_pid) \
          buildkitd --oci-worker=false --containerd-worker=true --containerd-worker-snapshotter=native \
          --containerd-worker-addr=/run/user/1001/containerd/containerd.sock
```
