### PR TITLE
Do not drop logger set by containerd

### DIFF
--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/pkg/seed"
 	"github.com/containerd/containerd/pkg/userns"
 	"github.com/containerd/containerd/platforms"
@@ -76,9 +75,6 @@ func init() {
 	if reexec.Init() {
 		os.Exit(0)
 	}
-
-	// overwrites containerd/log.G
-	log.G = bklog.GetLogger
 }
 
 var propagators = propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{})

--- a/util/bklog/log.go
+++ b/util/bklog/log.go
@@ -3,9 +3,16 @@ package bklog
 import (
 	"context"
 
+	"github.com/containerd/containerd/log"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel/trace"
 )
+
+func init() {
+	// overwrites containerd/log
+	log.G = GetLogger
+	log.L = L
+}
 
 var (
 	G = GetLogger
@@ -37,6 +44,8 @@ func GetLogger(ctx context.Context) (l *logrus.Entry) {
 
 	if logger != nil {
 		l = logger.(*logrus.Entry)
+	} else if logger := log.GetLogger(ctx); logger != nil {
+		l = logger
 	} else {
 		l = L
 	}


### PR DESCRIPTION
Related to  #2656

Currently, bklog overwrites `(github.com/containerd/containerd/log).G` and doesn't preserve the logger set by `(github.com/containerd/containerd/log).WithLogger`.

This causes log fields set by `(github.com/containerd/containerd/log).WithLogger` are dropped.

This commit fixes this issue by allowing `bklog.GetLogger` to get logger set by `(github.com/containerd/containerd/log).WithLogger`.
