### PR TITLE
stargz: fix panic on restart

### DIFF
--- a/cmd/buildkitd/main_oci_worker.go
+++ b/cmd/buildkitd/main_oci_worker.go
@@ -402,7 +402,7 @@ func snapshotterFactory(commonRoot string, cfg config.OCIConfig, sm *session.Man
 			}
 			return remotesn.NewSnapshotter(context.Background(),
 				filepath.Join(root, "snapshotter"),
-				fs, remotesn.AsynchronousRemove)
+				fs, remotesn.AsynchronousRemove, remotesn.NoRestore)
 		}
 	default:
 		return snFactory, errors.Errorf("unknown snapshotter name: %q", name)

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	github.com/containerd/fuse-overlayfs-snapshotter v1.0.2
 	github.com/containerd/go-cni v1.1.3
 	github.com/containerd/go-runc v1.0.0
-	github.com/containerd/stargz-snapshotter v0.11.1
-	github.com/containerd/stargz-snapshotter/estargz v0.11.1
+	github.com/containerd/stargz-snapshotter v0.11.2-0.20220223051521-b1ce4c8d8294
+	github.com/containerd/stargz-snapshotter/estargz v0.11.2-0.20220223051521-b1ce4c8d8294
 	github.com/containerd/typeurl v1.0.2
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/docker/cli v20.10.12+incompatible

--- a/go.sum
+++ b/go.sum
@@ -345,11 +345,12 @@ github.com/containerd/nri v0.0.0-20201007170849-eb1350a75164/go.mod h1:+2wGSDGFY
 github.com/containerd/nri v0.0.0-20210316161719-dbaa18c31c14/go.mod h1:lmxnXF6oMkbqs39FiCt1s0R2HSMhcLel9vNL3m4AaeY=
 github.com/containerd/nri v0.1.0/go.mod h1:lmxnXF6oMkbqs39FiCt1s0R2HSMhcLel9vNL3m4AaeY=
 github.com/containerd/stargz-snapshotter v0.0.0-20201027054423-3a04e4c2c116/go.mod h1:o59b3PCKVAf9jjiKtCc/9hLAd+5p/rfhBfm6aBcTEr4=
-github.com/containerd/stargz-snapshotter v0.11.1 h1:U0kHsxJlSBosOH7Ib/EgsWyTK0iA8sCeAG4mHtJoBL8=
-github.com/containerd/stargz-snapshotter v0.11.1/go.mod h1:3PJpOcsh0wqu+p/U/HBbUnG6wzIuw5hP6oRn1hXzQhc=
+github.com/containerd/stargz-snapshotter v0.11.2-0.20220223051521-b1ce4c8d8294 h1:ra5BUvrReW8pvtKnMq2u95WXaKeWnNaDyV7Btxqq/ag=
+github.com/containerd/stargz-snapshotter v0.11.2-0.20220223051521-b1ce4c8d8294/go.mod h1:3PJpOcsh0wqu+p/U/HBbUnG6wzIuw5hP6oRn1hXzQhc=
 github.com/containerd/stargz-snapshotter/estargz v0.4.1/go.mod h1:x7Q9dg9QYb4+ELgxmo4gBUeJB0tl5dqH1Sdz0nJU1QM=
-github.com/containerd/stargz-snapshotter/estargz v0.11.1 h1:mNQqxcAWmDrV6d6yUvzFhfY8puNzoQz9v4diW+Pmei4=
 github.com/containerd/stargz-snapshotter/estargz v0.11.1/go.mod h1:6VoPcf4M1wvnogWxqc4TqBWWErCS+R+ucnPZId2VbpQ=
+github.com/containerd/stargz-snapshotter/estargz v0.11.2-0.20220223051521-b1ce4c8d8294 h1:wcJH/EdebQmIqwrbApmEG2tOOw9nHL+kewKbgN8FUfU=
+github.com/containerd/stargz-snapshotter/estargz v0.11.2-0.20220223051521-b1ce4c8d8294/go.mod h1:6VoPcf4M1wvnogWxqc4TqBWWErCS+R+ucnPZId2VbpQ=
 github.com/containerd/ttrpc v0.0.0-20190828154514-0e0f228740de/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
 github.com/containerd/ttrpc v0.0.0-20190828172938-92c8520ef9f8/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
 github.com/containerd/ttrpc v0.0.0-20191028202541-4f1b8fe65a5c/go.mod h1:LPm1u0xBw8r8NOKoOdNMeVHSawSsltak+Ihv+etqsE8=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -152,7 +152,7 @@ github.com/containerd/go-cni
 # github.com/containerd/go-runc v1.0.0
 ## explicit; go 1.13
 github.com/containerd/go-runc
-# github.com/containerd/stargz-snapshotter v0.11.1
+# github.com/containerd/stargz-snapshotter v0.11.2-0.20220223051521-b1ce4c8d8294
 ## explicit; go 1.16
 github.com/containerd/stargz-snapshotter/cache
 github.com/containerd/stargz-snapshotter/fs
@@ -171,7 +171,7 @@ github.com/containerd/stargz-snapshotter/task
 github.com/containerd/stargz-snapshotter/util/cacheutil
 github.com/containerd/stargz-snapshotter/util/namedmutex
 github.com/containerd/stargz-snapshotter/util/testutil
-# github.com/containerd/stargz-snapshotter/estargz v0.11.1
+# github.com/containerd/stargz-snapshotter/estargz v0.11.2-0.20220223051521-b1ce4c8d8294
 ## explicit; go 1.16
 github.com/containerd/stargz-snapshotter/estargz
 github.com/containerd/stargz-snapshotter/estargz/errorutil


### PR DESCRIPTION
Fixes  #2667

This patch updates stargz-snapshotter to fix the issue of the panic on restart. (containerd/stargz-snapshotter#659)
This was because a code path that shouldn't be executed by BuildKit happens if there are some existing snapshots on restart.

We can reproduce the panic using the following example

1. Buliding an image with lazy pulling

```console
# cat <<EOF > /tmp/ctx1/Dockerfile
FROM ghcr.io/stargz-containers/ubuntu:20.04-esgz
RUN echo hello > /hello
EOF
# buildctl build --progress=plain --frontend=dockerfile.v0 --local context=/tmp/ctx1 --local dockerfile=/tmp/ctx1 \
               --output type=oci,dest=/tmp/out.tar
```

2. Restarting buildkitd. Here, we encounter panic with message `buildkitd: failed to restore remote snapshot` as described in #2667.
