### PR TITLE
merge: disable stargz hardlinking

### DIFF
--- a/snapshot/merge.go
+++ b/snapshot/merge.go
@@ -19,7 +19,6 @@ import (
 var hardlinkMergeSnapshotters = map[string]struct{}{
 	"native":    {},
 	"overlayfs": {},
-	"stargz":    {},
 }
 
 // overlayBasedSnapshotters are the names of snapshotter that use overlay mounts, which
@@ -84,7 +83,7 @@ func NewMergeSnapshotter(ctx context.Context, sn Snapshotter, lm leases.Manager)
 			tryCrossSnapshotLink = false
 			skipBaseLayers = false
 		} else {
-			tryCrossSnapshotLink = userxattr
+			tryCrossSnapshotLink = tryCrossSnapshotLink && userxattr
 			// Disable skipping base layers when in pre-5.11 rootless mode. Skipping the base layers
 			// necessitates the ability to set opaque xattrs sometimes, which only works in 5.11+
 			// kernels that support userxattr.


### PR DESCRIPTION
The stargz snapshotter creates separate FUSE mounts for each lazy
snapshot and non-FUSE mounts for newly created local snapshots. This
means that hardlinking during diffApply fails. The code then falls back
to doing a copy, which works fine, but it also results in a ton of debug
logs about the failing hardlinks to be printed. This change just results
in those noisy log lines no longer appearing.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

Related to #2671