### PR TITLE
Fix refs ignoring gc labels of contents

### DIFF
--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -1266,10 +1266,6 @@ func TestSharingCompressionVariant(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup()
 
-	ctx, done, err := leaseutil.WithLease(ctx, co.lm, leaseutil.MakeTemporary)
-	require.NoError(t, err)
-	defer done(context.TODO())
-
 	allCompressions := []compression.Type{compression.Uncompressed, compression.Gzip, compression.Zstd, compression.EStargz}
 
 	do := func(test func(testCaseSharingCompressionVariant)) {
@@ -1382,7 +1378,7 @@ func testSharingCompressionVariant(ctx context.Context, t *testing.T, co *cmOut,
 		require.NoError(t, err)
 		defer aRef.Release(ctx)
 		var bDesc ocispecs.Descriptor
-		for _, compressionType := range testCase.aVariants {
+		for _, compressionType := range append([]compression.Type{testCase.a}, testCase.aVariants...) {
 			remotes, err := aRef.GetRemotes(ctx, true, config.RefConfig{Compression: compression.New(compressionType).SetForce(true)}, false, nil)
 			require.NoError(t, err)
 			require.Equal(t, 1, len(remotes))
@@ -1395,7 +1391,7 @@ func testSharingCompressionVariant(ctx context.Context, t *testing.T, co *cmOut,
 		bRef, err := cm.GetByBlob(ctx, bDesc, nil, descHandlers)
 		require.NoError(t, err)
 		defer bRef.Release(ctx)
-		for _, compressionType := range testCase.bVariants {
+		for _, compressionType := range append([]compression.Type{testCase.b}, testCase.bVariants...) {
 			remotes, err := bRef.GetRemotes(ctx, true, config.RefConfig{Compression: compression.New(compressionType).SetForce(true)}, false, nil)
 			require.NoError(t, err)
 			require.Equal(t, 1, len(remotes))


### PR DESCRIPTION
Following-up  #2603

Though compression variants are linked using gc labels, they can be ignored and garbage collected because the lease of each ref has a lable [`containerd.io/gc.flat` which ignores the label references of the leased blob](https://github.com/containerd/containerd/blob/v1.6.0/docs/garbage-collection.md#garbage-collection-labels).

This commit fixes this issue by introducing a new lease for compression variants. This lease doesn't have `containerd.io/gc.flat` label to allow label references.

Reproducing issue:

1. Doing the following builds on containerd worker

```console
# mkdir -p /tmp/ctx1
# cat <<EOF > /tmp/ctx1/Dockerfile
FROM ghcr.io/stargz-containers/alpine:3.10.2-org
RUN /bin/touch /foo
EOF
# buildctl build --progress=plain --frontend=dockerfile.v0 --local context=/tmp/ctx1 --local dockerfile=/tmp/ctx1 \
               --output type=oci,dest=/tmp/out.tar,compression=uncompressed,force-compression=true
```

2. Here, uncompressed blob variant `sha256:03901b4a2ea88eeaad62dbe59b072b28b6efa00491962b8741081c5df50c65e0` can be garbage collected.

```console
# ctr -n buildkit content ls
DIGEST									SIZE	AGE		LABELS
sha256:35a69f8b545d5ec63bc720f4333ba9607340e59c3911af0c803d1ed00e727c5d	1.536kB	2 seconds	buildkit.io/blob/mediatype=application/vnd.oci.image.layer.v1.tar,buildkit.io/blob/annotation.containerd.io/uncompressed=sha256:35a69f8b545d5ec63bc720f4333ba9607340e59c3911af0c803d1ed00e727c5d,containerd.io/gc.ref.content.blob-sha256:35a69f8b545d5ec63bc720f4333ba9607340e59c3911af0c803d1ed00e727c5d=sha256:35a69f8b545d5ec63bc720f4333ba9607340e59c3911af0c803d1ed00e727c5d
sha256:499416c8a5bcb311d75e12fb4667886e32b43aaf11003be2a334cbe265e81ce4	528B	5 seconds	-
sha256:72c42ed48c3a2db31b7dafe17d275b634664a708d901ec9fd57b1529280f01fb	1.638kB	6 seconds	containerd.io/distribution.source.ghcr.io=stargz-containers/alpine
sha256:961769676411f082461f9ef46626dd7a2d1e2b2a38e6a44364bcbecf51e66dd4	1.512kB	5 seconds	containerd.io/distribution.source.ghcr.io=stargz-containers/alpine
sha256:9d48c3bd43c520dc2784e868a780e976b207cbf493eaff8c6596eb871cbd9609	2.79MB	3 seconds	buildkit.io/compression/estargz=false,buildkit.io/blob/mediatype=application/vnd.docker.image.rootfs.diff.tar.gzip,buildkit.io/blob/annotation.containerd.io/uncompressed=sha256:03901b4a2ea88eeaad62dbe59b072b28b6efa00491962b8741081c5df50c65e0,containerd.io/gc.ref.content.blob-sha256:9d48c3bd43c520dc2784e868a780e976b207cbf493eaff8c6596eb871cbd9609=sha256:9d48c3bd43c520dc2784e868a780e976b207cbf493eaff8c6596eb871cbd9609,containerd.io/gc.ref.content.blob-sha256:03901b4a2ea88eeaad62dbe59b072b28b6efa00491962b8741081c5df50c65e0=sha256:03901b4a2ea88eeaad62dbe59b072b28b6efa00491962b8741081c5df50c65e0
sha256:acd3ca9941a85e8ed16515bfc5328e4e2f8c128caa72959a58a127b7801ee01f	528B	5 seconds	containerd.io/distribution.source.ghcr.io=stargz-containers/alpine
sha256:e575001ba2b301714514c05cda5f5ed1cdd6914072370eaba846118ea759f280	1.51kB	4 seconds	-
```
