### PR TITLE
test: Ensure testPullZstdImage pulls zstd image

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2654,11 +2654,23 @@ func testPullZstdImage(t *testing.T, sb integration.Sandbox) {
 					"name":        target,
 					"push":        "true",
 					"compression": "zstd",
+
+					// containerd applier supports only zstd with oci-mediatype.
+					"oci-mediatypes": "true",
 				},
 			},
 		},
 	}, nil)
 	require.NoError(t, err)
+
+	if sb.Name() == "containerd-1.4" {
+		// containerd 1.4 doesn't support zstd compression
+		return
+	}
+	err = c.Prune(sb.Context(), nil, PruneAll)
+	require.NoError(t, err)
+
+	checkAllRemoved(t, c, sb)
 
 	st = llb.Scratch().File(llb.Copy(llb.Image(target), "/data", "/zdata"))
 

--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -51,6 +51,7 @@ type Sandbox interface {
 	PrintLogs(*testing.T)
 	NewRegistry() (string, error)
 	Value(string) interface{} // chosen matrix value
+	Name() string
 }
 
 // BackendConfig is used to configure backends created by a worker.

--- a/util/testutil/integration/sandbox.go
+++ b/util/testutil/integration/sandbox.go
@@ -51,6 +51,11 @@ type sandbox struct {
 	cleanup *multiCloser
 	mv      matrixValue
 	ctx     context.Context
+	name    string
+}
+
+func (sb *sandbox) Name() string {
+	return sb.name
 }
 
 func (sb *sandbox) Context() context.Context {
@@ -135,6 +140,7 @@ func newSandbox(ctx context.Context, w Worker, mirror string, mv matrixValue) (s
 		cleanup: deferF,
 		mv:      mv,
 		ctx:     ctx,
+		name:    w.Name(),
 	}, cl, nil
 }
 


### PR DESCRIPTION
Currently, `testPullZstdImage` in `client_test.go` doesn't seem to test pulling of zstd image but use locally cached one. This commit ensures that test checks if pulling zstd image work.

According to the fixed test, 2 limitations for zstd images are found.

1. applier service of containerd supports only zstd mediatype with oci-mediatpye but doesn't support zstd with docker-medatype ([related containerd code](https://github.com/containerd/containerd/blob/4595cdef8921c4a87e409b2b004e823afa600df3/images/mediatypes.go#L57-L106))
2. applier service of containerd 1.4 doesn't support zstd ([related commit](https://github.com/containerd/containerd/commit/30802fac7303648863b7f18b7d6ab4f5336390ec))

This commit fixes that test to make it aware of these limitations.
