### PR TITLE
buildinfo: merge build sources for deps

### DIFF
--- a/solver/llbsolver/bridge.go
+++ b/solver/llbsolver/bridge.go
@@ -159,24 +159,30 @@ func (b *llbBridge) Solve(ctx context.Context, req frontend.SolveRequest, sid st
 		return &frontend.Result{}, nil
 	}
 
-	if res.Metadata == nil {
-		res.Metadata = make(map[string][]byte)
-	}
-
 	if len(res.Refs) > 0 {
 		for p := range res.Refs {
 			dtbi, err := buildinfo.GetMetadata(res.Metadata, fmt.Sprintf("%s/%s", exptypes.ExporterBuildInfo, p), req.Frontend, req.FrontendOpt)
 			if err != nil {
 				return nil, err
 			}
-			res.Metadata[fmt.Sprintf("%s/%s", exptypes.ExporterBuildInfo, p)] = dtbi
+			if dtbi != nil && len(dtbi) > 0 {
+				if res.Metadata == nil {
+					res.Metadata = make(map[string][]byte)
+				}
+				res.Metadata[fmt.Sprintf("%s/%s", exptypes.ExporterBuildInfo, p)] = dtbi
+			}
 		}
 	} else {
 		dtbi, err := buildinfo.GetMetadata(res.Metadata, exptypes.ExporterBuildInfo, req.Frontend, req.FrontendOpt)
 		if err != nil {
 			return nil, err
 		}
-		res.Metadata[exptypes.ExporterBuildInfo] = dtbi
+		if dtbi != nil && len(dtbi) > 0 {
+			if res.Metadata == nil {
+				res.Metadata = make(map[string][]byte)
+			}
+			res.Metadata[exptypes.ExporterBuildInfo] = dtbi
+		}
 	}
 
 	return

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -158,15 +158,15 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 		return nil, err
 	}
 
-	if res.Metadata == nil {
-		res.Metadata = make(map[string][]byte)
-	}
 	if r := res.Ref; r != nil {
 		dtbi, err := buildinfo.Encode(ctx, res.Metadata, exptypes.ExporterBuildInfo, r.BuildSources())
 		if err != nil {
 			return nil, err
 		}
 		if dtbi != nil && len(dtbi) > 0 {
+			if res.Metadata == nil {
+				res.Metadata = make(map[string][]byte)
+			}
 			res.Metadata[exptypes.ExporterBuildInfo] = dtbi
 		}
 	}
@@ -180,6 +180,9 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 				return nil, err
 			}
 			if dtbi != nil && len(dtbi) > 0 {
+				if res.Metadata == nil {
+					res.Metadata = make(map[string][]byte)
+				}
 				res.Metadata[fmt.Sprintf("%s/%s", exptypes.ExporterBuildInfo, k)] = dtbi
 			}
 		}

--- a/util/buildinfo/buildinfo.go
+++ b/util/buildinfo/buildinfo.go
@@ -349,25 +349,6 @@ func GetMetadata(metadata map[string][]byte, key string, reqFrontend string, req
 	return dtbi, nil
 }
 
-// FromImageConfig returns build info from image config.
-func FromImageConfig(dt []byte) (*binfotypes.BuildInfo, error) {
-	if len(dt) == 0 {
-		return nil, nil
-	}
-	var config binfotypes.ImageConfig
-	if err := json.Unmarshal(dt, &config); err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal image config")
-	}
-	if len(config.BuildInfo) == 0 {
-		return nil, nil
-	}
-	bi, err := Decode(config.BuildInfo)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to decode build info from image config")
-	}
-	return &bi, nil
-}
-
 func reduceMapString(m1 map[string]string, m2 map[string]*string) map[string]string {
 	if m1 == nil && m2 == nil {
 		return nil

--- a/util/buildinfo/buildinfo.go
+++ b/util/buildinfo/buildinfo.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	ctnref "github.com/containerd/containerd/reference"
 	"github.com/docker/distribution/reference"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/source"
@@ -26,7 +27,7 @@ func Decode(enc string) (bi binfotypes.BuildInfo, _ error) {
 }
 
 // Encode encodes build info.
-func Encode(ctx context.Context, metadata map[string][]byte, key string, buildSources map[string]string) ([]byte, error) {
+func Encode(ctx context.Context, metadata map[string][]byte, key string, llbSources map[string]string) ([]byte, error) {
 	var bi binfotypes.BuildInfo
 	if metadata == nil {
 		metadata = make(map[string][]byte)
@@ -36,46 +37,48 @@ func Encode(ctx context.Context, metadata map[string][]byte, key string, buildSo
 			return nil, err
 		}
 	}
-	if deps, err := decodeDeps(key, bi.Attrs); err == nil {
-		bi.Deps = reduceMapBuildInfo(deps, bi.Deps)
-	} else {
-		return nil, err
-	}
-	if sources, err := mergeSources(ctx, buildSources, bi.Sources); err == nil {
+	if sources, err := mergeSources(llbSources, bi.Sources); err == nil {
 		bi.Sources = sources
 	} else {
 		return nil, err
 	}
-	bi.Attrs = filterAttrs(key, bi.Attrs)
+	bi.Sources = dedupSources(bi, allDepsSources(bi, nil))
 	return json.Marshal(bi)
 }
 
 // mergeSources combines and fixes build sources from frontend sources.
-func mergeSources(ctx context.Context, buildSources map[string]string, frontendSources []binfotypes.Source) ([]binfotypes.Source, error) {
-	// Iterate and combine build sources
+func mergeSources(llbSources map[string]string, frontendSources []binfotypes.Source) ([]binfotypes.Source, error) {
+	if llbSources == nil {
+		llbSources = make(map[string]string)
+	}
+	// iterate and combine build sources
 	mbs := map[string]binfotypes.Source{}
-	for buildSource, pin := range buildSources {
-		src, err := source.FromString(buildSource)
+	for llbSource, pin := range llbSources {
+		src, err := source.FromString(llbSource)
 		if err != nil {
 			return nil, err
 		}
 		switch sourceID := src.(type) {
 		case *source.ImageIdentifier:
 			for i, fsrc := range frontendSources {
+				if fsrc.Type != binfotypes.SourceTypeDockerImage {
+					continue
+				}
 				// use original user input from frontend sources
-				if fsrc.Type == binfotypes.SourceTypeDockerImage && fsrc.Alias == sourceID.Reference.String() {
-					if _, ok := mbs[fsrc.Alias]; !ok {
-						parsed, err := reference.ParseNormalizedNamed(fsrc.Ref)
-						if err != nil {
-							return nil, errors.Wrapf(err, "failed to parse %s", fsrc.Ref)
-						}
-						mbs[fsrc.Alias] = binfotypes.Source{
-							Type: binfotypes.SourceTypeDockerImage,
-							Ref:  reference.TagNameOnly(parsed).String(),
-							Pin:  pin,
-						}
-						frontendSources = append(frontendSources[:i], frontendSources[i+1:]...)
+				if fsrc.Alias == sourceID.Reference.String() || fsrc.Pin == pin {
+					if fsrc.Alias == "" {
+						fsrc.Alias = sourceID.Reference.String()
 					}
+					parsed, err := reference.ParseNormalizedNamed(fsrc.Ref)
+					if err != nil {
+						return nil, errors.Wrapf(err, "failed to parse %s", fsrc.Ref)
+					}
+					mbs[fsrc.Alias] = binfotypes.Source{
+						Type: binfotypes.SourceTypeDockerImage,
+						Ref:  reference.TagNameOnly(parsed).String(),
+						Pin:  pin,
+					}
+					frontendSources = append(frontendSources[:i], frontendSources[i+1:]...)
 					break
 				}
 			}
@@ -147,8 +150,7 @@ func mergeSources(ctx context.Context, buildSources map[string]string, frontendS
 func decodeDeps(key string, attrs map[string]*string) (map[string]binfotypes.BuildInfo, error) {
 	var platform string
 	// extract platform from metadata key
-	skey := strings.SplitN(key, "/", 2)
-	if len(skey) == 2 {
+	if skey := strings.SplitN(key, "/", 2); len(skey) == 2 {
 		platform = skey[1]
 	}
 
@@ -159,8 +161,10 @@ func decodeDeps(key string, attrs map[string]*string) (map[string]binfotypes.Bui
 			continue
 		}
 
-		// if platform is defined, only decode dependencies for that platform
-		if platform != "" && !strings.HasSuffix(k, "::"+platform) {
+		// if platform is defined in the key, only decode dependencies
+		// for that platform and vice versa
+		hasPlatform := len(strings.SplitN(k, "::", 2)) == 2
+		if (platform != "" && !hasPlatform) || (platform == "" && hasPlatform) {
 			continue
 		}
 
@@ -184,7 +188,10 @@ func decodeDeps(key string, attrs map[string]*string) (map[string]binfotypes.Bui
 		// set dep key
 		var depkey string
 		kl := strings.SplitN(k, ":", 2)
-		depkey = kl[1]
+		if len(kl) != 2 {
+			continue
+		}
+		depkey = strings.SplitN(kl[1], "::", 2)[0]
 		if platform != "" {
 			depkey = strings.TrimSuffix(depkey, "::"+platform)
 		}
@@ -195,6 +202,58 @@ func decodeDeps(key string, attrs map[string]*string) (map[string]binfotypes.Bui
 		return nil, nil
 	}
 	return res, nil
+}
+
+// dedupSources deduplicates regular sources from dependencies ones.
+func dedupSources(bi binfotypes.BuildInfo, depsSources []binfotypes.Source) (srcs []binfotypes.Source) {
+	// dedup sources from deps
+	for i, src := range bi.Sources {
+		for _, dsrc := range depsSources {
+			if src == dsrc {
+				bi.Sources = append(bi.Sources[:i], bi.Sources[i+1:]...)
+			} else if src.Type == binfotypes.SourceTypeDockerImage {
+				_, dgst := ctnref.SplitObject(src.Ref)
+				if dgst != "" && src.Pin == dsrc.Pin {
+					bi.Sources = append(bi.Sources[:i], bi.Sources[i+1:]...)
+				}
+			}
+		}
+	}
+	// dedup regular sources
+	msrc := make(map[binfotypes.Source]struct{})
+	for _, src := range bi.Sources {
+		msrc[src] = struct{}{}
+	}
+	for src := range msrc {
+		srcs = append(srcs, src)
+	}
+	sort.Slice(srcs, func(i, j int) bool {
+		return srcs[i].Ref < srcs[j].Ref
+	})
+	return srcs
+}
+
+// allDepsSources gathers dependencies sources.
+func allDepsSources(bi binfotypes.BuildInfo, visited map[binfotypes.Source]struct{}) (res []binfotypes.Source) {
+	if visited == nil {
+		visited = make(map[binfotypes.Source]struct{})
+	}
+	if len(bi.Deps) == 0 {
+		return res
+	}
+	for _, dbi := range bi.Deps {
+		for _, dsrc := range dbi.Sources {
+			if _, ok := visited[dsrc]; ok {
+				continue
+			}
+			visited[dsrc] = struct{}{}
+		}
+		res = allDepsSources(dbi, visited)
+	}
+	for src := range visited {
+		res = append(res, src)
+	}
+	return res
 }
 
 // FormatOpts holds build info format options.
@@ -263,16 +322,20 @@ func filterAttrs(key string, attrs map[string]*string) map[string]*string {
 		// input context key and value has to be cleaned up
 		// before being included
 		if strings.HasPrefix(k, "context:") {
-			if platform != "" {
-				// if platform is defined, only include the relevant platform
-				if !strings.HasSuffix(k, "::"+platform) {
-					continue
-				}
-				ctxival := strings.TrimSuffix(*v, "::"+platform)
-				filtered[strings.TrimSuffix(k, "::"+platform)] = &ctxival
+			ctxkey := strings.SplitN(k, "::", 2)
+			hasCtxPlatform := len(ctxkey) == 2
+			// if platform is set and also defined in key, set context
+			// for the right one.
+			if hasCtxPlatform && platform != "" && platform != ctxkey[1] {
 				continue
 			}
-			filtered[k] = v
+			if platform == "" && hasCtxPlatform {
+				ctxval := strings.TrimSuffix(*v, "::"+ctxkey[1])
+				filtered[strings.TrimSuffix(k, "::"+ctxkey[1])] = &ctxval
+				continue
+			}
+			ctxival := strings.TrimSuffix(*v, "::"+platform)
+			filtered[strings.TrimSuffix(k, "::"+platform)] = &ctxival
 			continue
 		}
 		// filter only for known attributes

--- a/util/buildinfo/buildinfo_test.go
+++ b/util/buildinfo/buildinfo_test.go
@@ -1,7 +1,6 @@
 package buildinfo
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 
@@ -55,7 +54,7 @@ func TestMergeSources(t *testing.T) {
 		},
 	}
 
-	srcs, err := mergeSources(context.Background(), buildSourcesLLB, frontendSources)
+	srcs, err := mergeSources(buildSourcesLLB, frontendSources)
 	require.NoError(t, err)
 
 	assert.Equal(t, []binfotypes.Source{
@@ -107,7 +106,7 @@ func TestDecodeDeps(t *testing.T) {
 				"build-arg:foo":         stringPtr("bar"),
 				"context:baseapp":       stringPtr("input:0-base"),
 				"filename":              stringPtr("Dockerfile"),
-				"input-metadata:0-base": stringPtr("{\"containerimage.buildinfo\":\"eyJmcm9udGVuZCI6ImRvY2tlcmZpbGUudjAiLCJhdHRycyI6eyJidWlsZC1hcmc6YmFyIjoiZm9vIiwiYnVpbGQtYXJnOmZvbyI6ImJhciIsImZpbGVuYW1lIjoiYmFzZWFwcC5Eb2NrZXJmaWxlIn0sInNvdXJjZXMiOlt7InR5cGUiOiJkb2NrZXItaW1hZ2UiLCJyZWYiOiJidXN5Ym94IiwiYWxpYXMiOiJkb2NrZXIuaW8vbGlicmFyeS9idXN5Ym94QHNoYTI1NjphZmNjN2YxYWMxYjQ5ZGIzMTdhNzE5NmM5MDJlNjFjNmMzYzQ2MDdkNjM1OTllZTFhODJkNzAyZDI0OWEwY2NiIiwicGluIjoic2hhMjU2OmFmY2M3ZjFhYzFiNDlkYjMxN2E3MTk2YzkwMmU2MWM2YzNjNDYwN2Q2MzU5OWVlMWE4MmQ3MDJkMjQ5YTBjY2IifV19\",\"containerimage.config\":\"eyJhcmNoaXRlY3R1cmUiOiJhbWQ2NCIsIm9zIjoibGludXgiLCJyb290ZnMiOnsidHlwZSI6ImxheWVycyIsImRpZmZfaWRzIjpbInNoYTI1NjpkMzE1MDVmZDUwNTBmNmI5NmNhMzI2OGQxZGI1OGZjOTFhZTU2MWRkZjE0ZWFhYmM0MWQ2M2VhMmVmOGMxYzZkIl19LCJoaXN0b3J5IjpbeyJjcmVhdGVkIjoiMjAyMi0wMi0wNFQyMToyMDoxMi4zMTg5MTc4MjJaIiwiY3JlYXRlZF9ieSI6Ii9iaW4vc2ggLWMgIyhub3ApIEFERCBmaWxlOjFjODUwN2UzZTliMjJiOTc3OGYyZWRiYjk1MDA2MWUwNmJkZTZhMWY1M2I2OWUxYzYxMDI1MDAyOWMzNzNiNzIgaW4gLyAifSx7ImNyZWF0ZWQiOiIyMDIyLTAyLTA0VDIxOjIwOjEyLjQ5Nzc5NDgwOVoiLCJjcmVhdGVkX2J5IjoiL2Jpbi9zaCAtYyAjKG5vcCkgIENNRCBbXCJzaFwiXSIsImVtcHR5X2xheWVyIjp0cnVlfSx7ImNyZWF0ZWRfYnkiOiJXT1JLRElSIC9zcmMiLCJjb21tZW50IjoiYnVpbGRraXQuZG9ja2VyZmlsZS52MCJ9XSwiY29uZmlnIjp7IkVudiI6WyJQQVRIPS91c3IvbG9jYWwvc2JpbjovdXNyL2xvY2FsL2JpbjovdXNyL3NiaW46L3Vzci9iaW46L3NiaW46L2JpbiJdLCJDbWQiOlsic2giXSwiV29ya2luZ0RpciI6Ii9zcmMiLCJPbkJ1aWxkIjpudWxsfX0=\"}"),
+				"input-metadata:0-base": stringPtr("{\"containerimage.buildinfo\":\"eyJmcm9udGVuZCI6ImRvY2tlcmZpbGUudjAiLCJhdHRycyI6eyJidWlsZC1hcmc6YmFyIjoiZm9vIiwiYnVpbGQtYXJnOmZvbyI6ImJhciIsImZpbGVuYW1lIjoiYmFzZWFwcC5Eb2NrZXJmaWxlIn0sInNvdXJjZXMiOlt7InR5cGUiOiJkb2NrZXItaW1hZ2UiLCJyZWYiOiJkb2NrZXIuaW8vbGlicmFyeS9idXN5Ym94OmxhdGVzdCIsInBpbiI6InNoYTI1NjphZmNjN2YxYWMxYjQ5ZGIzMTdhNzE5NmM5MDJlNjFjNmMzYzQ2MDdkNjM1OTllZTFhODJkNzAyZDI0OWEwY2NiIn1dfQ==\",\"containerimage.config\":\"eyJhcmNoaXRlY3R1cmUiOiJhbWQ2NCIsIm9zIjoibGludXgiLCJyb290ZnMiOnsidHlwZSI6ImxheWVycyIsImRpZmZfaWRzIjpbInNoYTI1NjpkMzE1MDVmZDUwNTBmNmI5NmNhMzI2OGQxZGI1OGZjOTFhZTU2MWRkZjE0ZWFhYmM0MWQ2M2VhMmVmOGMxYzZkIl19LCJoaXN0b3J5IjpbeyJjcmVhdGVkIjoiMjAyMi0wMi0wNFQyMToyMDoxMi4zMTg5MTc4MjJaIiwiY3JlYXRlZF9ieSI6Ii9iaW4vc2ggLWMgIyhub3ApIEFERCBmaWxlOjFjODUwN2UzZTliMjJiOTc3OGYyZWRiYjk1MDA2MWUwNmJkZTZhMWY1M2I2OWUxYzYxMDI1MDAyOWMzNzNiNzIgaW4gLyAifSx7ImNyZWF0ZWQiOiIyMDIyLTAyLTA0VDIxOjIwOjEyLjQ5Nzc5NDgwOVoiLCJjcmVhdGVkX2J5IjoiL2Jpbi9zaCAtYyAjKG5vcCkgIENNRCBbXCJzaFwiXSIsImVtcHR5X2xheWVyIjp0cnVlfSx7ImNyZWF0ZWRfYnkiOiJXT1JLRElSIC9zcmMiLCJjb21tZW50IjoiYnVpbGRraXQuZG9ja2VyZmlsZS52MCJ9XSwiY29uZmlnIjp7IkVudiI6WyJQQVRIPS91c3IvbG9jYWwvc2JpbjovdXNyL2xvY2FsL2JpbjovdXNyL3NiaW46L3Vzci9iaW46L3NiaW46L2JpbiJdLCJDbWQiOlsic2giXSwiV29ya2luZ0RpciI6Ii9zcmMiLCJPbkJ1aWxkIjpudWxsfX0=\"}"),
 			},
 			want: map[string]binfotypes.BuildInfo{
 				"0-base": {
@@ -119,10 +118,9 @@ func TestDecodeDeps(t *testing.T) {
 					},
 					Sources: []binfotypes.Source{
 						{
-							Type:  binfotypes.SourceTypeDockerImage,
-							Ref:   "busybox",
-							Alias: "docker.io/library/busybox@sha256:afcc7f1ac1b49db317a7196c902e61c6c3c4607d63599ee1a82d702d249a0ccb",
-							Pin:   "sha256:afcc7f1ac1b49db317a7196c902e61c6c3c4607d63599ee1a82d702d249a0ccb",
+							Type: binfotypes.SourceTypeDockerImage,
+							Ref:  "docker.io/library/busybox:latest",
+							Pin:  "sha256:afcc7f1ac1b49db317a7196c902e61c6c3c4607d63599ee1a82d702d249a0ccb",
 						},
 					},
 				},
@@ -135,8 +133,8 @@ func TestDecodeDeps(t *testing.T) {
 				"context:base::linux/amd64":        stringPtr("input:base::linux/amd64"),
 				"context:base::linux/arm64":        stringPtr("input:base::linux/arm64"),
 				"dockerfilekey":                    stringPtr("dockerfile2"),
-				"input-metadata:base::linux/amd64": stringPtr("{\"containerimage.buildinfo\":\"eyJmcm9udGVuZCI6ImRvY2tlcmZpbGUudjAiLCJzb3VyY2VzIjpbeyJ0eXBlIjoiZG9ja2VyLWltYWdlIiwicmVmIjoiYWxwaW5lIiwiYWxpYXMiOiJkb2NrZXIuaW8vbGlicmFyeS9hbHBpbmVAc2hhMjU2OmU3ZDg4ZGU3M2RiM2QzZmQ5YjJkNjNhYTdmNDQ3YTEwZmQwMjIwYjdjYmYzOTgwM2M4MDNmMmFmOWJhMjU2YjMiLCJwaW4iOiJzaGEyNTY6ZTdkODhkZTczZGIzZDNmZDliMmQ2M2FhN2Y0NDdhMTBmZDAyMjBiN2NiZjM5ODAzYzgwM2YyYWY5YmEyNTZiMyJ9XX0=\",\"containerimage.config\":\"eyJhcmNoaXRlY3R1cmUiOiJhbWQ2NCIsIm9zIjoibGludXgiLCJyb290ZnMiOnsidHlwZSI6ImxheWVycyIsImRpZmZfaWRzIjpbInNoYTI1Njo4ZDNhYzM0ODk5OTY0MjNmNTNkNjA4N2M4MTE4MDAwNjI2M2I3OWYyMDZkM2ZkZWM5ZTY2ZjBlMjdjZWI4NzU5Il19LCJoaXN0b3J5IjpbeyJjcmVhdGVkIjoiMjAyMS0xMS0yNFQyMDoxOTo0MC4xOTk3MDA5NDZaIiwiY3JlYXRlZF9ieSI6Ii9iaW4vc2ggLWMgIyhub3ApIEFERCBmaWxlOjkyMzNmNmYyMjM3ZDc5NjU5YTk1MjFmN2UzOTBkZjIxN2NlYzQ5ZjFhOGFhM2ExMjE0N2JiY2ExOTU2YWNkYjkgaW4gLyAifSx7ImNyZWF0ZWQiOiIyMDIxLTExLTI0VDIwOjE5OjQwLjQ4MzM2NzU0NloiLCJjcmVhdGVkX2J5IjoiL2Jpbi9zaCAtYyAjKG5vcCkgIENNRCBbXCIvYmluL3NoXCJdIiwiZW1wdHlfbGF5ZXIiOnRydWV9LHsiY3JlYXRlZF9ieSI6IkFSRyBUQVJHRVRBUkNIIiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAiLCJlbXB0eV9sYXllciI6dHJ1ZX0seyJjcmVhdGVkX2J5IjoiRU5WIEZPTz1iYXItYW1kNjQiLCJjb21tZW50IjoiYnVpbGRraXQuZG9ja2VyZmlsZS52MCIsImVtcHR5X2xheWVyIjp0cnVlfSx7ImNyZWF0ZWRfYnkiOiJSVU4gfDEgVEFSR0VUQVJDSD1hbWQ2NCAvYmluL3NoIC1jIGVjaG8gXCJmb28gJFRBUkdFVEFSQ0hcIiBcdTAwM2UgL291dCAjIGJ1aWxka2l0IiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAifV0sImNvbmZpZyI6eyJFbnYiOlsiUEFUSD0vdXNyL2xvY2FsL3NiaW46L3Vzci9sb2NhbC9iaW46L3Vzci9zYmluOi91c3IvYmluOi9zYmluOi9iaW4iLCJGT089YmFyLWFtZDY0Il0sIkNtZCI6WyIvYmluL3NoIl0sIk9uQnVpbGQiOm51bGx9fQ==\"}"),
-				"input-metadata:base::linux/arm64": stringPtr("{\"containerimage.buildinfo\":\"eyJmcm9udGVuZCI6ImRvY2tlcmZpbGUudjAiLCJzb3VyY2VzIjpbeyJ0eXBlIjoiZG9ja2VyLWltYWdlIiwicmVmIjoiYWxwaW5lIiwiYWxpYXMiOiJkb2NrZXIuaW8vbGlicmFyeS9hbHBpbmVAc2hhMjU2OmU3ZDg4ZGU3M2RiM2QzZmQ5YjJkNjNhYTdmNDQ3YTEwZmQwMjIwYjdjYmYzOTgwM2M4MDNmMmFmOWJhMjU2YjMiLCJwaW4iOiJzaGEyNTY6ZTdkODhkZTczZGIzZDNmZDliMmQ2M2FhN2Y0NDdhMTBmZDAyMjBiN2NiZjM5ODAzYzgwM2YyYWY5YmEyNTZiMyJ9XX0=\",\"containerimage.config\":\"eyJhcmNoaXRlY3R1cmUiOiJhcm02NCIsIm9zIjoibGludXgiLCJyb290ZnMiOnsidHlwZSI6ImxheWVycyIsImRpZmZfaWRzIjpbInNoYTI1Njo4ZDNhYzM0ODk5OTY0MjNmNTNkNjA4N2M4MTE4MDAwNjI2M2I3OWYyMDZkM2ZkZWM5ZTY2ZjBlMjdjZWI4NzU5Il19LCJoaXN0b3J5IjpbeyJjcmVhdGVkIjoiMjAyMS0xMS0yNFQyMDoxOTo0MC4xOTk3MDA5NDZaIiwiY3JlYXRlZF9ieSI6Ii9iaW4vc2ggLWMgIyhub3ApIEFERCBmaWxlOjkyMzNmNmYyMjM3ZDc5NjU5YTk1MjFmN2UzOTBkZjIxN2NlYzQ5ZjFhOGFhM2ExMjE0N2JiY2ExOTU2YWNkYjkgaW4gLyAifSx7ImNyZWF0ZWQiOiIyMDIxLTExLTI0VDIwOjE5OjQwLjQ4MzM2NzU0NloiLCJjcmVhdGVkX2J5IjoiL2Jpbi9zaCAtYyAjKG5vcCkgIENNRCBbXCIvYmluL3NoXCJdIiwiZW1wdHlfbGF5ZXIiOnRydWV9LHsiY3JlYXRlZF9ieSI6IkFSRyBUQVJHRVRBUkNIIiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAiLCJlbXB0eV9sYXllciI6dHJ1ZX0seyJjcmVhdGVkX2J5IjoiRU5WIEZPTz1iYXItYXJtNjQiLCJjb21tZW50IjoiYnVpbGRraXQuZG9ja2VyZmlsZS52MCIsImVtcHR5X2xheWVyIjp0cnVlfSx7ImNyZWF0ZWRfYnkiOiJSVU4gfDEgVEFSR0VUQVJDSD1hcm02NCAvYmluL3NoIC1jIGVjaG8gXCJmb28gJFRBUkdFVEFSQ0hcIiBcdTAwM2UgL291dCAjIGJ1aWxka2l0IiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAifV0sImNvbmZpZyI6eyJFbnYiOlsiUEFUSD0vdXNyL2xvY2FsL3NiaW46L3Vzci9sb2NhbC9iaW46L3Vzci9zYmluOi91c3IvYmluOi9zYmluOi9iaW4iLCJGT089YmFyLWFybTY0Il0sIkNtZCI6WyIvYmluL3NoIl0sIk9uQnVpbGQiOm51bGx9fQ==\"}"),
+				"input-metadata:base::linux/amd64": stringPtr("{\"containerimage.buildinfo\":\"eyJmcm9udGVuZCI6ImRvY2tlcmZpbGUudjAiLCJzb3VyY2VzIjpbeyJ0eXBlIjoiZG9ja2VyLWltYWdlIiwicmVmIjoiZG9ja2VyLmlvL2xpYnJhcnkvYWxwaW5lOmxhdGVzdCIsInBpbiI6InNoYTI1NjplN2Q4OGRlNzNkYjNkM2ZkOWIyZDYzYWE3ZjQ0N2ExMGZkMDIyMGI3Y2JmMzk4MDNjODAzZjJhZjliYTI1NmIzIn1dfQ==\",\"containerimage.config\":\"eyJhcmNoaXRlY3R1cmUiOiJhbWQ2NCIsIm9zIjoibGludXgiLCJyb290ZnMiOnsidHlwZSI6ImxheWVycyIsImRpZmZfaWRzIjpbInNoYTI1Njo4ZDNhYzM0ODk5OTY0MjNmNTNkNjA4N2M4MTE4MDAwNjI2M2I3OWYyMDZkM2ZkZWM5ZTY2ZjBlMjdjZWI4NzU5Il19LCJoaXN0b3J5IjpbeyJjcmVhdGVkIjoiMjAyMS0xMS0yNFQyMDoxOTo0MC4xOTk3MDA5NDZaIiwiY3JlYXRlZF9ieSI6Ii9iaW4vc2ggLWMgIyhub3ApIEFERCBmaWxlOjkyMzNmNmYyMjM3ZDc5NjU5YTk1MjFmN2UzOTBkZjIxN2NlYzQ5ZjFhOGFhM2ExMjE0N2JiY2ExOTU2YWNkYjkgaW4gLyAifSx7ImNyZWF0ZWQiOiIyMDIxLTExLTI0VDIwOjE5OjQwLjQ4MzM2NzU0NloiLCJjcmVhdGVkX2J5IjoiL2Jpbi9zaCAtYyAjKG5vcCkgIENNRCBbXCIvYmluL3NoXCJdIiwiZW1wdHlfbGF5ZXIiOnRydWV9LHsiY3JlYXRlZF9ieSI6IkFSRyBUQVJHRVRBUkNIIiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAiLCJlbXB0eV9sYXllciI6dHJ1ZX0seyJjcmVhdGVkX2J5IjoiRU5WIEZPTz1iYXItYW1kNjQiLCJjb21tZW50IjoiYnVpbGRraXQuZG9ja2VyZmlsZS52MCIsImVtcHR5X2xheWVyIjp0cnVlfSx7ImNyZWF0ZWRfYnkiOiJSVU4gfDEgVEFSR0VUQVJDSD1hbWQ2NCAvYmluL3NoIC1jIGVjaG8gXCJmb28gJFRBUkdFVEFSQ0hcIiBcdTAwM2UgL291dCAjIGJ1aWxka2l0IiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAifV0sImNvbmZpZyI6eyJFbnYiOlsiUEFUSD0vdXNyL2xvY2FsL3NiaW46L3Vzci9sb2NhbC9iaW46L3Vzci9zYmluOi91c3IvYmluOi9zYmluOi9iaW4iLCJGT089YmFyLWFtZDY0Il0sIkNtZCI6WyIvYmluL3NoIl0sIk9uQnVpbGQiOm51bGx9fQ==\"}"),
+				"input-metadata:base::linux/arm64": stringPtr("{\"containerimage.buildinfo\":\"eyJmcm9udGVuZCI6ImRvY2tlcmZpbGUudjAiLCJzb3VyY2VzIjpbeyJ0eXBlIjoiZG9ja2VyLWltYWdlIiwicmVmIjoiZG9ja2VyLmlvL2xpYnJhcnkvYWxwaW5lOmxhdGVzdCIsInBpbiI6InNoYTI1NjplN2Q4OGRlNzNkYjNkM2ZkOWIyZDYzYWE3ZjQ0N2ExMGZkMDIyMGI3Y2JmMzk4MDNjODAzZjJhZjliYTI1NmIzIn1dfQ==\",\"containerimage.config\":\"eyJhcmNoaXRlY3R1cmUiOiJhcm02NCIsIm9zIjoibGludXgiLCJyb290ZnMiOnsidHlwZSI6ImxheWVycyIsImRpZmZfaWRzIjpbInNoYTI1Njo4ZDNhYzM0ODk5OTY0MjNmNTNkNjA4N2M4MTE4MDAwNjI2M2I3OWYyMDZkM2ZkZWM5ZTY2ZjBlMjdjZWI4NzU5Il19LCJoaXN0b3J5IjpbeyJjcmVhdGVkIjoiMjAyMS0xMS0yNFQyMDoxOTo0MC4xOTk3MDA5NDZaIiwiY3JlYXRlZF9ieSI6Ii9iaW4vc2ggLWMgIyhub3ApIEFERCBmaWxlOjkyMzNmNmYyMjM3ZDc5NjU5YTk1MjFmN2UzOTBkZjIxN2NlYzQ5ZjFhOGFhM2ExMjE0N2JiY2ExOTU2YWNkYjkgaW4gLyAifSx7ImNyZWF0ZWQiOiIyMDIxLTExLTI0VDIwOjE5OjQwLjQ4MzM2NzU0NloiLCJjcmVhdGVkX2J5IjoiL2Jpbi9zaCAtYyAjKG5vcCkgIENNRCBbXCIvYmluL3NoXCJdIiwiZW1wdHlfbGF5ZXIiOnRydWV9LHsiY3JlYXRlZF9ieSI6IkFSRyBUQVJHRVRBUkNIIiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAiLCJlbXB0eV9sYXllciI6dHJ1ZX0seyJjcmVhdGVkX2J5IjoiRU5WIEZPTz1iYXItYXJtNjQiLCJjb21tZW50IjoiYnVpbGRraXQuZG9ja2VyZmlsZS52MCIsImVtcHR5X2xheWVyIjp0cnVlfSx7ImNyZWF0ZWRfYnkiOiJSVU4gfDEgVEFSR0VUQVJDSD1hcm02NCAvYmluL3NoIC1jIGVjaG8gXCJmb28gJFRBUkdFVEFSQ0hcIiBcdTAwM2UgL291dCAjIGJ1aWxka2l0IiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAifV0sImNvbmZpZyI6eyJFbnYiOlsiUEFUSD0vdXNyL2xvY2FsL3NiaW46L3Vzci9sb2NhbC9iaW46L3Vzci9zYmluOi91c3IvYmluOi9zYmluOi9iaW4iLCJGT089YmFyLWFybTY0Il0sIkNtZCI6WyIvYmluL3NoIl0sIk9uQnVpbGQiOm51bGx9fQ==\"}"),
 				"platform":                         stringPtr("linux/amd64,linux/arm64"),
 			},
 			want: map[string]binfotypes.BuildInfo{
@@ -145,10 +143,9 @@ func TestDecodeDeps(t *testing.T) {
 					Attrs:    nil,
 					Sources: []binfotypes.Source{
 						{
-							Type:  binfotypes.SourceTypeDockerImage,
-							Ref:   "alpine",
-							Alias: "docker.io/library/alpine@sha256:e7d88de73db3d3fd9b2d63aa7f447a10fd0220b7cbf39803c803f2af9ba256b3",
-							Pin:   "sha256:e7d88de73db3d3fd9b2d63aa7f447a10fd0220b7cbf39803c803f2af9ba256b3",
+							Type: binfotypes.SourceTypeDockerImage,
+							Ref:  "docker.io/library/alpine:latest",
+							Pin:  "sha256:e7d88de73db3d3fd9b2d63aa7f447a10fd0220b7cbf39803c803f2af9ba256b3",
 						},
 					},
 				},
@@ -161,6 +158,116 @@ func TestDecodeDeps(t *testing.T) {
 			deps, err := decodeDeps(tt.key, tt.attrs)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, deps)
+		})
+	}
+}
+
+func TestDedupSources(t *testing.T) {
+	cases := []struct {
+		name string
+		bi   binfotypes.BuildInfo
+		want []binfotypes.Source
+	}{
+		{
+			name: "deps",
+			bi: binfotypes.BuildInfo{
+				Frontend: "dockerfile.v0",
+				Attrs: map[string]*string{
+					"context:base": stringPtr("input:base"),
+				},
+				Sources: []binfotypes.Source{
+					{
+						Type: "docker-image",
+						Ref:  "docker.io/library/alpine@sha256:e7d88de73db3d3fd9b2d63aa7f447a10fd0220b7cbf39803c803f2af9ba256b3",
+						Pin:  "sha256:e7d88de73db3d3fd9b2d63aa7f447a10fd0220b7cbf39803c803f2af9ba256b3",
+					},
+					{
+						Type: "docker-image",
+						Ref:  "docker.io/library/busybox:latest",
+						Pin:  "sha256:b69959407d21e8a062e0416bf13405bb2b71ed7a84dde4158ebafacfa06f5578",
+					},
+					{
+						Type: "http",
+						Ref:  "https://raw.githubusercontent.com/moby/moby/master/README.md",
+						Pin:  "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c",
+					},
+				},
+				Deps: map[string]binfotypes.BuildInfo{
+					"base": {
+						Frontend: "dockerfile.v0",
+						Sources: []binfotypes.Source{
+							{
+								Type: "docker-image",
+								Ref:  "docker.io/library/alpine:latest",
+								Pin:  "sha256:e7d88de73db3d3fd9b2d63aa7f447a10fd0220b7cbf39803c803f2af9ba256b3",
+							},
+						},
+					},
+				},
+			},
+			want: []binfotypes.Source{
+				{
+					Type: "docker-image",
+					Ref:  "docker.io/library/busybox:latest",
+					Pin:  "sha256:b69959407d21e8a062e0416bf13405bb2b71ed7a84dde4158ebafacfa06f5578",
+				},
+				{
+					Type: "http",
+					Ref:  "https://raw.githubusercontent.com/moby/moby/master/README.md",
+					Pin:  "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c",
+				},
+			},
+		},
+		{
+			name: "regular",
+			bi: binfotypes.BuildInfo{
+				Frontend: "dockerfile.v0",
+				Attrs: map[string]*string{
+					"context:base": stringPtr("input:base"),
+				},
+				Sources: []binfotypes.Source{
+					{
+						Type: "docker-image",
+						Ref:  "docker.io/library/alpine@sha256:e7d88de73db3d3fd9b2d63aa7f447a10fd0220b7cbf39803c803f2af9ba256b3",
+						Pin:  "sha256:e7d88de73db3d3fd9b2d63aa7f447a10fd0220b7cbf39803c803f2af9ba256b3",
+					},
+					{
+						Type: "docker-image",
+						Ref:  "docker.io/library/busybox:latest",
+						Pin:  "sha256:b69959407d21e8a062e0416bf13405bb2b71ed7a84dde4158ebafacfa06f5578",
+					},
+					{
+						Type: "docker-image",
+						Ref:  "docker.io/library/busybox:latest",
+						Pin:  "sha256:b69959407d21e8a062e0416bf13405bb2b71ed7a84dde4158ebafacfa06f5578",
+					},
+				},
+				Deps: map[string]binfotypes.BuildInfo{
+					"base": {
+						Frontend: "dockerfile.v0",
+						Sources: []binfotypes.Source{
+							{
+								Type: "docker-image",
+								Ref:  "docker.io/library/alpine:latest",
+								Pin:  "sha256:e7d88de73db3d3fd9b2d63aa7f447a10fd0220b7cbf39803c803f2af9ba256b3",
+							},
+						},
+					},
+				},
+			},
+			want: []binfotypes.Source{
+				{
+					Type: "docker-image",
+					Ref:  "docker.io/library/busybox:latest",
+					Pin:  "sha256:b69959407d21e8a062e0416bf13405bb2b71ed7a84dde4158ebafacfa06f5578",
+				},
+			},
+		},
+	}
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, dedupSources(tt.bi, allDepsSources(tt.bi, nil)))
 		})
 	}
 }
@@ -198,8 +305,8 @@ func TestFilterAttrs(t *testing.T) {
 				"context:base::linux/amd64":        stringPtr("input:base::linux/amd64"),
 				"context:base::linux/arm64":        stringPtr("input:base::linux/arm64"),
 				"dockerfilekey":                    stringPtr("dockerfile2"),
-				"input-metadata:base::linux/amd64": stringPtr("{\"containerimage.buildinfo\":\"eyJmcm9udGVuZCI6ImRvY2tlcmZpbGUudjAiLCJzb3VyY2VzIjpbeyJ0eXBlIjoiZG9ja2VyLWltYWdlIiwicmVmIjoiYWxwaW5lIiwiYWxpYXMiOiJkb2NrZXIuaW8vbGlicmFyeS9hbHBpbmVAc2hhMjU2OmU3ZDg4ZGU3M2RiM2QzZmQ5YjJkNjNhYTdmNDQ3YTEwZmQwMjIwYjdjYmYzOTgwM2M4MDNmMmFmOWJhMjU2YjMiLCJwaW4iOiJzaGEyNTY6ZTdkODhkZTczZGIzZDNmZDliMmQ2M2FhN2Y0NDdhMTBmZDAyMjBiN2NiZjM5ODAzYzgwM2YyYWY5YmEyNTZiMyJ9XX0=\",\"containerimage.config\":\"eyJhcmNoaXRlY3R1cmUiOiJhbWQ2NCIsIm9zIjoibGludXgiLCJyb290ZnMiOnsidHlwZSI6ImxheWVycyIsImRpZmZfaWRzIjpbInNoYTI1Njo4ZDNhYzM0ODk5OTY0MjNmNTNkNjA4N2M4MTE4MDAwNjI2M2I3OWYyMDZkM2ZkZWM5ZTY2ZjBlMjdjZWI4NzU5Il19LCJoaXN0b3J5IjpbeyJjcmVhdGVkIjoiMjAyMS0xMS0yNFQyMDoxOTo0MC4xOTk3MDA5NDZaIiwiY3JlYXRlZF9ieSI6Ii9iaW4vc2ggLWMgIyhub3ApIEFERCBmaWxlOjkyMzNmNmYyMjM3ZDc5NjU5YTk1MjFmN2UzOTBkZjIxN2NlYzQ5ZjFhOGFhM2ExMjE0N2JiY2ExOTU2YWNkYjkgaW4gLyAifSx7ImNyZWF0ZWQiOiIyMDIxLTExLTI0VDIwOjE5OjQwLjQ4MzM2NzU0NloiLCJjcmVhdGVkX2J5IjoiL2Jpbi9zaCAtYyAjKG5vcCkgIENNRCBbXCIvYmluL3NoXCJdIiwiZW1wdHlfbGF5ZXIiOnRydWV9LHsiY3JlYXRlZF9ieSI6IkFSRyBUQVJHRVRBUkNIIiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAiLCJlbXB0eV9sYXllciI6dHJ1ZX0seyJjcmVhdGVkX2J5IjoiRU5WIEZPTz1iYXItYW1kNjQiLCJjb21tZW50IjoiYnVpbGRraXQuZG9ja2VyZmlsZS52MCIsImVtcHR5X2xheWVyIjp0cnVlfSx7ImNyZWF0ZWRfYnkiOiJSVU4gfDEgVEFSR0VUQVJDSD1hbWQ2NCAvYmluL3NoIC1jIGVjaG8gXCJmb28gJFRBUkdFVEFSQ0hcIiBcdTAwM2UgL291dCAjIGJ1aWxka2l0IiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAifV0sImNvbmZpZyI6eyJFbnYiOlsiUEFUSD0vdXNyL2xvY2FsL3NiaW46L3Vzci9sb2NhbC9iaW46L3Vzci9zYmluOi91c3IvYmluOi9zYmluOi9iaW4iLCJGT089YmFyLWFtZDY0Il0sIkNtZCI6WyIvYmluL3NoIl0sIk9uQnVpbGQiOm51bGx9fQ==\"}"),
-				"input-metadata:base::linux/arm64": stringPtr("{\"containerimage.buildinfo\":\"eyJmcm9udGVuZCI6ImRvY2tlcmZpbGUudjAiLCJzb3VyY2VzIjpbeyJ0eXBlIjoiZG9ja2VyLWltYWdlIiwicmVmIjoiYWxwaW5lIiwiYWxpYXMiOiJkb2NrZXIuaW8vbGlicmFyeS9hbHBpbmVAc2hhMjU2OmU3ZDg4ZGU3M2RiM2QzZmQ5YjJkNjNhYTdmNDQ3YTEwZmQwMjIwYjdjYmYzOTgwM2M4MDNmMmFmOWJhMjU2YjMiLCJwaW4iOiJzaGEyNTY6ZTdkODhkZTczZGIzZDNmZDliMmQ2M2FhN2Y0NDdhMTBmZDAyMjBiN2NiZjM5ODAzYzgwM2YyYWY5YmEyNTZiMyJ9XX0=\",\"containerimage.config\":\"eyJhcmNoaXRlY3R1cmUiOiJhcm02NCIsIm9zIjoibGludXgiLCJyb290ZnMiOnsidHlwZSI6ImxheWVycyIsImRpZmZfaWRzIjpbInNoYTI1Njo4ZDNhYzM0ODk5OTY0MjNmNTNkNjA4N2M4MTE4MDAwNjI2M2I3OWYyMDZkM2ZkZWM5ZTY2ZjBlMjdjZWI4NzU5Il19LCJoaXN0b3J5IjpbeyJjcmVhdGVkIjoiMjAyMS0xMS0yNFQyMDoxOTo0MC4xOTk3MDA5NDZaIiwiY3JlYXRlZF9ieSI6Ii9iaW4vc2ggLWMgIyhub3ApIEFERCBmaWxlOjkyMzNmNmYyMjM3ZDc5NjU5YTk1MjFmN2UzOTBkZjIxN2NlYzQ5ZjFhOGFhM2ExMjE0N2JiY2ExOTU2YWNkYjkgaW4gLyAifSx7ImNyZWF0ZWQiOiIyMDIxLTExLTI0VDIwOjE5OjQwLjQ4MzM2NzU0NloiLCJjcmVhdGVkX2J5IjoiL2Jpbi9zaCAtYyAjKG5vcCkgIENNRCBbXCIvYmluL3NoXCJdIiwiZW1wdHlfbGF5ZXIiOnRydWV9LHsiY3JlYXRlZF9ieSI6IkFSRyBUQVJHRVRBUkNIIiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAiLCJlbXB0eV9sYXllciI6dHJ1ZX0seyJjcmVhdGVkX2J5IjoiRU5WIEZPTz1iYXItYXJtNjQiLCJjb21tZW50IjoiYnVpbGRraXQuZG9ja2VyZmlsZS52MCIsImVtcHR5X2xheWVyIjp0cnVlfSx7ImNyZWF0ZWRfYnkiOiJSVU4gfDEgVEFSR0VUQVJDSD1hcm02NCAvYmluL3NoIC1jIGVjaG8gXCJmb28gJFRBUkdFVEFSQ0hcIiBcdTAwM2UgL291dCAjIGJ1aWxka2l0IiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAifV0sImNvbmZpZyI6eyJFbnYiOlsiUEFUSD0vdXNyL2xvY2FsL3NiaW46L3Vzci9sb2NhbC9iaW46L3Vzci9zYmluOi91c3IvYmluOi9zYmluOi9iaW4iLCJGT089YmFyLWFybTY0Il0sIkNtZCI6WyIvYmluL3NoIl0sIk9uQnVpbGQiOm51bGx9fQ==\"}"),
+				"input-metadata:base::linux/amd64": stringPtr("{\"containerimage.buildinfo\":\"eyJmcm9udGVuZCI6ImRvY2tlcmZpbGUudjAiLCJzb3VyY2VzIjpbeyJ0eXBlIjoiZG9ja2VyLWltYWdlIiwicmVmIjoiZG9ja2VyLmlvL2xpYnJhcnkvYWxwaW5lOmxhdGVzdCIsInBpbiI6InNoYTI1NjplN2Q4OGRlNzNkYjNkM2ZkOWIyZDYzYWE3ZjQ0N2ExMGZkMDIyMGI3Y2JmMzk4MDNjODAzZjJhZjliYTI1NmIzIn1dfQ==\",\"containerimage.config\":\"eyJhcmNoaXRlY3R1cmUiOiJhbWQ2NCIsIm9zIjoibGludXgiLCJyb290ZnMiOnsidHlwZSI6ImxheWVycyIsImRpZmZfaWRzIjpbInNoYTI1Njo4ZDNhYzM0ODk5OTY0MjNmNTNkNjA4N2M4MTE4MDAwNjI2M2I3OWYyMDZkM2ZkZWM5ZTY2ZjBlMjdjZWI4NzU5Il19LCJoaXN0b3J5IjpbeyJjcmVhdGVkIjoiMjAyMS0xMS0yNFQyMDoxOTo0MC4xOTk3MDA5NDZaIiwiY3JlYXRlZF9ieSI6Ii9iaW4vc2ggLWMgIyhub3ApIEFERCBmaWxlOjkyMzNmNmYyMjM3ZDc5NjU5YTk1MjFmN2UzOTBkZjIxN2NlYzQ5ZjFhOGFhM2ExMjE0N2JiY2ExOTU2YWNkYjkgaW4gLyAifSx7ImNyZWF0ZWQiOiIyMDIxLTExLTI0VDIwOjE5OjQwLjQ4MzM2NzU0NloiLCJjcmVhdGVkX2J5IjoiL2Jpbi9zaCAtYyAjKG5vcCkgIENNRCBbXCIvYmluL3NoXCJdIiwiZW1wdHlfbGF5ZXIiOnRydWV9LHsiY3JlYXRlZF9ieSI6IkFSRyBUQVJHRVRBUkNIIiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAiLCJlbXB0eV9sYXllciI6dHJ1ZX0seyJjcmVhdGVkX2J5IjoiRU5WIEZPTz1iYXItYW1kNjQiLCJjb21tZW50IjoiYnVpbGRraXQuZG9ja2VyZmlsZS52MCIsImVtcHR5X2xheWVyIjp0cnVlfSx7ImNyZWF0ZWRfYnkiOiJSVU4gfDEgVEFSR0VUQVJDSD1hbWQ2NCAvYmluL3NoIC1jIGVjaG8gXCJmb28gJFRBUkdFVEFSQ0hcIiBcdTAwM2UgL291dCAjIGJ1aWxka2l0IiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAifV0sImNvbmZpZyI6eyJFbnYiOlsiUEFUSD0vdXNyL2xvY2FsL3NiaW46L3Vzci9sb2NhbC9iaW46L3Vzci9zYmluOi91c3IvYmluOi9zYmluOi9iaW4iLCJGT089YmFyLWFtZDY0Il0sIkNtZCI6WyIvYmluL3NoIl0sIk9uQnVpbGQiOm51bGx9fQ==\"}"),
+				"input-metadata:base::linux/arm64": stringPtr("{\"containerimage.buildinfo\":\"eyJmcm9udGVuZCI6ImRvY2tlcmZpbGUudjAiLCJzb3VyY2VzIjpbeyJ0eXBlIjoiZG9ja2VyLWltYWdlIiwicmVmIjoiZG9ja2VyLmlvL2xpYnJhcnkvYWxwaW5lOmxhdGVzdCIsInBpbiI6InNoYTI1NjplN2Q4OGRlNzNkYjNkM2ZkOWIyZDYzYWE3ZjQ0N2ExMGZkMDIyMGI3Y2JmMzk4MDNjODAzZjJhZjliYTI1NmIzIn1dfQ==\",\"containerimage.config\":\"eyJhcmNoaXRlY3R1cmUiOiJhcm02NCIsIm9zIjoibGludXgiLCJyb290ZnMiOnsidHlwZSI6ImxheWVycyIsImRpZmZfaWRzIjpbInNoYTI1Njo4ZDNhYzM0ODk5OTY0MjNmNTNkNjA4N2M4MTE4MDAwNjI2M2I3OWYyMDZkM2ZkZWM5ZTY2ZjBlMjdjZWI4NzU5Il19LCJoaXN0b3J5IjpbeyJjcmVhdGVkIjoiMjAyMS0xMS0yNFQyMDoxOTo0MC4xOTk3MDA5NDZaIiwiY3JlYXRlZF9ieSI6Ii9iaW4vc2ggLWMgIyhub3ApIEFERCBmaWxlOjkyMzNmNmYyMjM3ZDc5NjU5YTk1MjFmN2UzOTBkZjIxN2NlYzQ5ZjFhOGFhM2ExMjE0N2JiY2ExOTU2YWNkYjkgaW4gLyAifSx7ImNyZWF0ZWQiOiIyMDIxLTExLTI0VDIwOjE5OjQwLjQ4MzM2NzU0NloiLCJjcmVhdGVkX2J5IjoiL2Jpbi9zaCAtYyAjKG5vcCkgIENNRCBbXCIvYmluL3NoXCJdIiwiZW1wdHlfbGF5ZXIiOnRydWV9LHsiY3JlYXRlZF9ieSI6IkFSRyBUQVJHRVRBUkNIIiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAiLCJlbXB0eV9sYXllciI6dHJ1ZX0seyJjcmVhdGVkX2J5IjoiRU5WIEZPTz1iYXItYXJtNjQiLCJjb21tZW50IjoiYnVpbGRraXQuZG9ja2VyZmlsZS52MCIsImVtcHR5X2xheWVyIjp0cnVlfSx7ImNyZWF0ZWRfYnkiOiJSVU4gfDEgVEFSR0VUQVJDSD1hcm02NCAvYmluL3NoIC1jIGVjaG8gXCJmb28gJFRBUkdFVEFSQ0hcIiBcdTAwM2UgL291dCAjIGJ1aWxka2l0IiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAifV0sImNvbmZpZyI6eyJFbnYiOlsiUEFUSD0vdXNyL2xvY2FsL3NiaW46L3Vzci9sb2NhbC9iaW46L3Vzci9zYmluOi91c3IvYmluOi9zYmluOi9iaW4iLCJGT089YmFyLWFybTY0Il0sIkNtZCI6WyIvYmluL3NoIl0sIk9uQnVpbGQiOm51bGx9fQ==\"}"),
 				"platform":                         stringPtr("linux/amd64,linux/arm64"),
 			},
 			want: map[string]*string{

--- a/util/imageutil/buildinfo.go
+++ b/util/imageutil/buildinfo.go
@@ -1,0 +1,32 @@
+package imageutil
+
+import (
+	"encoding/base64"
+	"encoding/json"
+
+	binfotypes "github.com/moby/buildkit/util/buildinfo/types"
+	"github.com/pkg/errors"
+)
+
+// BuildInfo returns build info from image config.
+func BuildInfo(dt []byte) (*binfotypes.BuildInfo, error) {
+	if len(dt) == 0 {
+		return nil, nil
+	}
+	var config binfotypes.ImageConfig
+	if err := json.Unmarshal(dt, &config); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal image config")
+	}
+	if len(config.BuildInfo) == 0 {
+		return nil, nil
+	}
+	dtbi, err := base64.StdEncoding.DecodeString(config.BuildInfo)
+	if err != nil {
+		return nil, err
+	}
+	var bi binfotypes.BuildInfo
+	if err = json.Unmarshal(dtbi, &bi); err != nil {
+		return nil, errors.Wrap(err, "failed to decode buildinfo from image config")
+	}
+	return &bi, nil
+}


### PR DESCRIPTION
follow-up #2654

fixes an issue where sources for buildinfo dependencies were not merged. this also deduplicates sources from main buildinfo that only belong to dependencies.