### PR TITLE
Fix nil error on `buildctl debug`

### DIFF
--- a/cmd/buildctl/common/trace.go
+++ b/cmd/buildctl/common/trace.go
@@ -44,7 +44,7 @@ func AttachAppContext(app *cli.App) error {
 	}
 
 	app.ExitErrHandler = func(clicontext *cli.Context, err error) {
-		if span != nil {
+		if span != nil && err != nil {
 			span.SetStatus(codes.Error, err.Error())
 		}
 		cli.HandleExitCoder(err)


### PR DESCRIPTION
This commit fixes the error on `buildctl debug`.

```console
# buildctl debug
NAME:
   buildctl debug - debug utilities

USAGE:
   buildctl debug command [command options] [arguments...]

COMMANDS:
   dump-llb       dump LLB in human-readable format. LLB can be also passed via stdin. This command does not require the daemon to be running.
   dump-metadata  dump the meta in human-readable format.  This command requires the daemon NOT to be running.
   workers        list workers

OPTIONS:
   --help, -h  show help
   
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xb53517]

goroutine 1 [running]:
github.com/moby/buildkit/cmd/buildctl/common.AttachAppContext.func2(0xc0006bee78, {0x0, 0x0})
	/go/src/github.com/moby/buildkit/cmd/buildctl/common/trace.go:48 +0x37
github.com/urfave/cli.(*App).handleExitCoder(0xc6a220, 0xdf3748, {0x0, 0x0})
	/go/src/github.com/moby/buildkit/vendor/github.com/urfave/cli/app.go:496 +0x38
github.com/urfave/cli.(*App).RunAsSubcommand(0xc00018a540, 0xc000512000)
	/go/src/github.com/moby/buildkit/vendor/github.com/urfave/cli/app.go:414 +0x93f
github.com/urfave/cli.Command.startApp({{0xdad64a, 0x5}, {0x0, 0x0}, {0x0, 0x0, 0x0}, {0xdb707a, 0xf}, {0x0, ...}, ...}, ...)
	/go/src/github.com/moby/buildkit/vendor/github.com/urfave/cli/command.go:373 +0x6e9
github.com/urfave/cli.Command.Run({{0xdad64a, 0x5}, {0x0, 0x0}, {0x0, 0x0, 0x0}, {0xdb707a, 0xf}, {0x0, ...}, ...}, ...)
	/go/src/github.com/moby/buildkit/vendor/github.com/urfave/cli/command.go:102 +0x828
github.com/urfave/cli.(*App).Run(0xc000515340, {0xc000032040, 0x2, 0x2})
	/go/src/github.com/moby/buildkit/vendor/github.com/urfave/cli/app.go:279 +0x80c
main.main()
	/go/src/github.com/moby/buildkit/cmd/buildctl/main.go:116 +0x8b9
```
