### PR TITLE
progressui: fix possible out of order indexing on plain mode

### DIFF
--- a/util/progress/progressui/display.go
+++ b/util/progress/progressui/display.go
@@ -119,7 +119,6 @@ type trace struct {
 	localTimeDiff time.Duration
 	vertexes      []*vertex
 	byDigest      map[digest.Digest]*vertex
-	nextIndex     int
 	updates       map[digest.Digest]struct{}
 	modeConsole   bool
 	groups        map[string]*vertexGroup // group id -> group
@@ -410,7 +409,6 @@ func (t *trace) update(s *client.SolveStatus, termWidth int) {
 		if v.ProgressGroup != nil {
 			group, ok := t.groups[v.ProgressGroup.Id]
 			if !ok {
-				t.nextIndex++
 				group = &vertexGroup{
 					vertex: &vertex{
 						Vertex: &client.Vertex{
@@ -419,7 +417,6 @@ func (t *trace) update(s *client.SolveStatus, termWidth int) {
 						},
 						byID:          make(map[string]*status),
 						statusUpdates: make(map[string]struct{}),
-						index:         t.nextIndex,
 						intervals:     make(map[int64]interval),
 						hidden:        true,
 					},
@@ -441,11 +438,9 @@ func (t *trace) update(s *client.SolveStatus, termWidth int) {
 		}
 		prev, ok := t.byDigest[v.Digest]
 		if !ok {
-			t.nextIndex++
 			t.byDigest[v.Digest] = &vertex{
 				byID:          make(map[string]*status),
 				statusUpdates: make(map[string]struct{}),
-				index:         t.nextIndex,
 				intervals:     make(map[int64]interval),
 			}
 			if t.modeConsole {

--- a/util/progress/progressui/printer.go
+++ b/util/progress/progressui/printer.go
@@ -27,10 +27,11 @@ type lastStatus struct {
 }
 
 type textMux struct {
-	w        io.Writer
-	current  digest.Digest
-	last     map[string]lastStatus
-	notFirst bool
+	w         io.Writer
+	current   digest.Digest
+	last      map[string]lastStatus
+	notFirst  bool
+	nextIndex int
 }
 
 func (p *textMux) printVtx(t *trace, dgst digest.Digest) {
@@ -41,6 +42,11 @@ func (p *textMux) printVtx(t *trace, dgst digest.Digest) {
 	v, ok := t.byDigest[dgst]
 	if !ok {
 		return
+	}
+
+	if v.index == 0 {
+		p.nextIndex++
+		v.index = p.nextIndex
 	}
 
 	if dgst != p.current {


### PR DESCRIPTION
fixes #2681

Generate index when vertex is printing, not when it is received.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>