### PR TITLE
progressui: handle case where active statuses appear completed vertex

### DIFF
--- a/util/progress/progressui/printer.go
+++ b/util/progress/progressui/printer.go
@@ -75,6 +75,7 @@ func (p *textMux) printVtx(t *trace, dgst digest.Digest) {
 	}
 	v.events = v.events[:0]
 
+	isOpenStatus := false // remote cache loading can currently produce status updates without active vertex
 	for _, s := range v.statuses {
 		if _, ok := v.statusUpdates[s.ID]; ok {
 			doPrint := true
@@ -118,6 +119,8 @@ func (p *textMux) printVtx(t *trace, dgst digest.Digest) {
 			}
 			if s.Completed != nil {
 				tm += " done"
+			} else {
+				isOpenStatus = true
 			}
 			fmt.Fprintf(p.w, "#%d %s%s%s\n", v.index, s.ID, bytes, tm)
 		}
@@ -157,7 +160,7 @@ func (p *textMux) printVtx(t *trace, dgst digest.Digest) {
 	}
 
 	p.current = dgst
-	if v.Completed != nil {
+	if v.Completed != nil && !isOpenStatus {
 		p.current = ""
 		v.count = 0
 


### PR DESCRIPTION
There seems to be a bug currently on daemon side on writing progress while importing remote cache. It looks like the status messages appear while the vertex messages show the current vertex as complete.

@sipsma I think the issue is that the vertex messages only come when `cache.Load` is called but that function doesn't actually pull the data. Later when blobs are lazily loaded only the status events come. I can repro it by:

```
FROM alpine
RUN apk add curl
run dd if=/dev/urandom of=/foo bs=1M count=50
#run sleep 1
``` 

First build `docker buildx build --cache-to type=local,dest=/tmp/cache .` then prune cache, comment out the sleep line, and run `docker buildx build --cache-from type=local,src=/tmp/cache --progress=plain .`.

I think we should fix it in the daemon side as well but not very familiar with that code. The current fix is to handle it on client-side and not write the suffix for the vertex when there are active status rows.



Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>