### PR TITLE
ci: opt-in buildinfo attrs with output opt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax = docker/dockerfile-upstream:master
+# syntax=docker/dockerfile-upstream:master
 
 ARG RUNC_VERSION=v1.0.2
 ARG CONTAINERD_VERSION=v1.6.0

--- a/frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile
+++ b/frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile
@@ -1,4 +1,4 @@
-# syntax = docker/dockerfile:1.3
+# syntax=docker/dockerfile-upstream:master
 
 # xx is a helper for cross-compilation
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:golang@sha256:810dc54d5144f133a218e88e319184bf8b9ce01d37d46ddb37573e90decd9eef AS xx

--- a/frontend/dockerfile/cmd/dockerfile-frontend/hack/release
+++ b/frontend/dockerfile/cmd/dockerfile-frontend/hack/release
@@ -87,7 +87,7 @@ case $TYP in
   buildxCmd build $platformFlag $cacheFromFlags $cacheToFlags \
     --build-arg "CHANNEL=$TAG" \
     --build-arg "BUILDTAGS=$buildTags" \
-    --output "type=image,name=$REPO:$pushTag,$pushFlag" \
+    --output "type=image,name=$REPO:$pushTag,buildinfo-attrs=true,$pushFlag" \
     --file "./frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile" \
     $currentcontext
   ;;
@@ -104,7 +104,7 @@ case $TYP in
   buildxCmd build $platformFlag $cacheFromFlags $cacheToFlags \
     --build-arg "CHANNEL=$TAG" \
     --build-arg "BUILDTAGS=$buildTags" \
-    --output "type=image,\"name=$publishedNames\",$pushFlag" \
+    --output "type=image,\"name=$publishedNames\",buildinfo-attrs=true,$pushFlag" \
     --file "./frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile" \
     $currentcontext
   ;;
@@ -144,7 +144,7 @@ case $TYP in
       buildxCmd build $platformFlag $cacheFromFlags $cacheToFlags \
         --build-arg "CHANNEL=$TAG" \
         --build-arg "BUILDTAGS=$buildTags" \
-        --output "type=image,name=$REPO:$dt-$TAG,$pushFlag" \
+        --output "type=image,name=$REPO:$dt-$TAG,buildinfo-attrs=true,$pushFlag" \
         --file "./frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile" \
         $currentcontext
       rm $tmp/buildid

--- a/hack/dockerfiles/generated-files.Dockerfile
+++ b/hack/dockerfiles/generated-files.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.3
+# syntax=docker/dockerfile-upstream:master
 
 # protoc is dynamically linked to glibc to can't use golang:1.10-alpine
 FROM golang:1.17-buster AS gobuild-base

--- a/hack/dockerfiles/lint.Dockerfile
+++ b/hack/dockerfiles/lint.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.3
+# syntax=docker/dockerfile-upstream:master
 
 FROM golang:1.17-alpine
 RUN apk add --no-cache gcc musl-dev yamllint

--- a/hack/dockerfiles/shfmt.Dockerfile
+++ b/hack/dockerfiles/shfmt.Dockerfile
@@ -1,4 +1,4 @@
-# syntax = docker/dockerfile:1.3
+# syntax=docker/dockerfile-upstream:master
 FROM mvdan/shfmt:v3.1.2-alpine AS shfmt
 WORKDIR /src
 ARG SHFMT_FLAGS="-i 2 -ci"

--- a/hack/dockerfiles/vendor.Dockerfile
+++ b/hack/dockerfiles/vendor.Dockerfile
@@ -1,4 +1,4 @@
-# syntax = docker/dockerfile:1.3
+# syntax=docker/dockerfile-upstream:master
 
 FROM golang:1.17-alpine AS vendored
 RUN  apk add --no-cache git

--- a/hack/images
+++ b/hack/images
@@ -41,10 +41,10 @@ fi
 
 outputFlag="--output=type=image,push=false"
 if [ "$PUSH" = "push" ]; then
-  outputFlag="--output=type=image,push=true"
+  outputFlag="--output=type=image,buildinfo-attrs=true,push=true"
 fi
 if [ -n "$localmode" ]; then
-  outputFlag="--output=type=docker"
+  outputFlag="--output=type=docker,buildinfo-attrs=true"
 fi
 
 targetFlag=""

--- a/hack/util
+++ b/hack/util
@@ -59,5 +59,5 @@ if [ "$GITHUB_ACTIONS" = "true" ]; then
   fi
 fi
 if [ -n "$currentref" ]; then
-  currentcontext="--build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 --build-arg BUILDKIT_INLINE_BUILDINFO_ATTRS=1 $currentref"
+  currentcontext="--build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 $currentref"
 fi


### PR DESCRIPTION
follow-up #2679

buildinfo attributes were not included because the built-in build-arg `BUILDKIT_INLINE_BUILDINFO_ATTRS` requires buildx >= 0.8 which is not currently available on GitHub runners so use `buildinfo-attrs` output opt instead.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>