### PR TITLE
dockerfile: check named context for default platform if none set

### DIFF
--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -819,6 +819,10 @@ func contextByNameFunc(c client.Client, p *ocispecs.Platform) func(context.Conte
 		}
 		name = strings.TrimSuffix(reference.FamiliarString(named), ":latest")
 
+		if p == nil {
+			pp := platforms.Normalize(platforms.DefaultSpec())
+			p = &pp
+		}
 		if p != nil {
 			name := name + "::" + platforms.Format(platforms.Normalize(*p))
 			st, img, err := contextByName(ctx, c, name, p)


### PR DESCRIPTION
In case it is not a multi-platform build still check if a named context is passed for the default platform.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>