### PR TITLE
buildctl debug workers: add --format option

### DIFF
--- a/client/prune.go
+++ b/client/prune.go
@@ -59,10 +59,10 @@ type PruneOption interface {
 }
 
 type PruneInfo struct {
-	Filter       []string
-	All          bool
-	KeepDuration time.Duration
-	KeepBytes    int64
+	Filter       []string      `json:"filter"`
+	All          bool          `json:"all"`
+	KeepDuration time.Duration `json:"keepDuration"`
+	KeepBytes    int64         `json:"keepBytes"`
 }
 
 type pruneOptionFunc func(*PruneInfo)

--- a/client/workers.go
+++ b/client/workers.go
@@ -13,10 +13,10 @@ import (
 
 // WorkerInfo contains information about a worker
 type WorkerInfo struct {
-	ID        string
-	Labels    map[string]string
-	Platforms []ocispecs.Platform
-	GCPolicy  []PruneInfo
+	ID        string              `json:"id"`
+	Labels    map[string]string   `json:"labels"`
+	Platforms []ocispecs.Platform `json:"platforms"`
+	GCPolicy  []PruneInfo         `json:"gcPolicy"`
 }
 
 // ListWorkers lists all active workers

--- a/cmd/buildctl/debug/workers.go
+++ b/cmd/buildctl/debug/workers.go
@@ -1,17 +1,21 @@
 package debug
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"sort"
 	"strings"
 	"text/tabwriter"
+	"text/template"
 
 	"github.com/containerd/containerd/platforms"
 	"github.com/moby/buildkit/client"
 	bccommon "github.com/moby/buildkit/cmd/buildctl/common"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
 	"github.com/tonistiigi/units"
 	"github.com/urfave/cli"
 )
@@ -29,6 +33,10 @@ var WorkersCommand = cli.Command{
 			Name:  "verbose, v",
 			Usage: "Verbose output",
 		},
+		cli.StringFlag{
+			Name:  "format",
+			Usage: "Format the output using the given Go template, e.g, '{{json .}}'",
+		},
 	},
 }
 
@@ -42,6 +50,21 @@ func listWorkers(clicontext *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	if format := clicontext.String("format"); format != "" {
+		if clicontext.Bool("verbose") {
+			logrus.Debug("Ignoring --verbose")
+		}
+		tmpl, err := parseTemplate(format)
+		if err != nil {
+			return err
+		}
+		if err := tmpl.Execute(clicontext.App.Writer, workers); err != nil {
+			return err
+		}
+		_, err = fmt.Fprintf(clicontext.App.Writer, "\n")
+		return err
+	}
+
 	tw := tabwriter.NewWriter(os.Stdout, 1, 8, 1, '\t', 0)
 
 	if clicontext.Bool("verbose") {
@@ -112,4 +135,26 @@ func joinPlatforms(p []ocispecs.Platform) string {
 		str = append(str, platforms.Format(platforms.Normalize(pp)))
 	}
 	return strings.Join(str, ",")
+}
+
+func parseTemplate(format string) (*template.Template, error) {
+	// aliases is from https://github.com/containerd/nerdctl/blob/v0.17.1/cmd/nerdctl/fmtutil.go#L116-L126 (Apache License 2.0)
+	aliases := map[string]string{
+		"json": "{{json .}}",
+	}
+	if alias, ok := aliases[format]; ok {
+		format = alias
+	}
+	// funcs is from https://github.com/docker/cli/blob/v20.10.12/templates/templates.go#L12-L20 (Apache License 2.0)
+	funcs := template.FuncMap{
+		"json": func(v interface{}) string {
+			buf := &bytes.Buffer{}
+			enc := json.NewEncoder(buf)
+			enc.SetEscapeHTML(false)
+			enc.Encode(v)
+			// Remove the trailing new line added by the encoder
+			return strings.TrimSpace(buf.String())
+		},
+	}
+	return template.New("").Funcs(funcs).Parse(format)
 }


### PR DESCRIPTION
For https://github.com/containerd/nerdctl/pull/858#discussion_r819255971

<details>

<summary><code>buildctl debug workers --format '{{json .}}' | jq .</code></summary>

<p>

```json
[
    {
        "id": "arw1g9hrf1gyogbj9q07r7bz3",
        "labels": {
            "org.mobyproject.buildkit.worker.executor": "oci",
            "org.mobyproject.buildkit.worker.hostname": "suda-ws01",
            "org.mobyproject.buildkit.worker.snapshotter": "overlayfs"
        },
        "platforms": [
            {
                "architecture": "amd64",
                "os": "linux"
            },
            {
                "architecture": "amd64",
                "os": "linux",
                "variant": "v2"
            },
            {
                "architecture": "amd64",
                "os": "linux",
                "variant": "v3"
            },
            {
                "architecture": "amd64",
                "os": "linux",
                "variant": "v4"
            },
            {
                "architecture": "386",
                "os": "linux"
            }
        ],
        "gcPolicy": [
            {
                "filter": [
                    "type==source.local,type==exec.cachemount,type==source.git.checkout"
                ],
                "all": false,
                "keepDuration": 172800000000000,
                "keepBytes": 512000000
            },
            {
                "filter": null,
                "all": false,
                "keepDuration": 5184000000000000,
                "keepBytes": 10000000000
            },
            {
                "filter": null,
                "all": false,
                "keepDuration": 0,
                "keepBytes": 10000000000
            },
            {
                "filter": null,
                "all": true,
                "keepDuration": 0,
                "keepBytes": 10000000000
            }
        ]
    },
    {
        "id": "p8j7aehcyngcuardp5q7qjoop",
        "labels": {
            "org.mobyproject.buildkit.worker.containerd.namespace": "buildkit",
            "org.mobyproject.buildkit.worker.containerd.uuid": "49042c58-0800-45ce-9de8-fd150bb173c6",
            "org.mobyproject.buildkit.worker.executor": "containerd",
            "org.mobyproject.buildkit.worker.hostname": "suda-ws01",
            "org.mobyproject.buildkit.worker.snapshotter": "overlayfs"
        },
        "platforms": [
            {
                "architecture": "amd64",
                "os": "linux"
            },
            {
                "architecture": "amd64",
                "os": "linux",
                "variant": "v2"
            },
            {
                "architecture": "amd64",
                "os": "linux",
                "variant": "v3"
            },
            {
                "architecture": "amd64",
                "os": "linux",
                "variant": "v4"
            },
            {
                "architecture": "386",
                "os": "linux"
            }
        ],
        "gcPolicy": [
            {
                "filter": [
                    "type==source.local,type==exec.cachemount,type==source.git.checkout"
                ],
                "all": false,
                "keepDuration": 172800000000000,
                "keepBytes": 512000000
            },
            {
                "filter": null,
                "all": false,
                "keepDuration": 5184000000000000,
                "keepBytes": 10000000000
            },
            {
                "filter": null,
                "all": false,
                "keepDuration": 0,
                "keepBytes": 10000000000
            },
            {
                "filter": null,
                "all": true,
                "keepDuration": 0,
                "keepBytes": 10000000000
            }
        ]
    }
]
```

</p>

</details>