### PR TITLE
cache: set default compression for estargz

### DIFF
--- a/cache/estargz.go
+++ b/cache/estargz.go
@@ -44,7 +44,7 @@ func compressEStargz(comp compression.Config) (compressorFunc compressor, finali
 
 				blobInfoW, bInfoCh := calculateBlobInfo()
 				defer blobInfoW.Close()
-				level := gzip.BestCompression
+				level := gzip.DefaultCompression
 				if comp.Level != nil {
 					level = *comp.Level
 				}

--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -2412,7 +2412,7 @@ func checkDiskUsage(ctx context.Context, t *testing.T, cm Manager, inuse, unused
 
 func esgzBlobDigest(uncompressedBlobBytes []byte) (blobDigest digest.Digest, err error) {
 	esgzDigester := digest.Canonical.Digester()
-	w := estargz.NewWriter(esgzDigester.Hash())
+	w := estargz.NewWriterLevel(esgzDigester.Hash(), gzip.DefaultCompression)
 	if err := w.AppendTarLossLess(bytes.NewReader(uncompressedBlobBytes)); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Default `estargz` compression level to `gzip.DefaultCompression`. This is consistent with other compression methods and possibly a better tradeoff as `BestCompression` is quite slow. If users want to use a different level they can set it manually.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>