### PR TITLE
Promote `buildctl debug workers` to `buildctl workers`

### DIFF
--- a/cmd/buildctl/main.go
+++ b/cmd/buildctl/main.go
@@ -91,6 +91,7 @@ func main() {
 		diskUsageCommand,
 		pruneCommand,
 		buildCommand,
+		workersCommand,
 		debugCommand,
 		dialStdioCommand,
 	}

--- a/cmd/buildctl/workers.go
+++ b/cmd/buildctl/workers.go
@@ -1,0 +1,7 @@
+package main
+
+import (
+	"github.com/moby/buildkit/cmd/buildctl/debug"
+)
+
+var workersCommand = debug.WorkersCommand


### PR DESCRIPTION
This command has been widely used for inspecting functionality of the daemon, and is going to have JSON output in PR #2698.
