### PR TITLE
Load GitHub runtime environment when using buildctl

### DIFF
--- a/cmd/buildctl/build/exportcache.go
+++ b/cmd/buildctl/build/exportcache.go
@@ -39,6 +39,9 @@ func parseExportCacheCSV(s string) (client.CacheOptionsEntry, error) {
 	if _, ok := ex.Attrs["mode"]; !ok {
 		ex.Attrs["mode"] = "min"
 	}
+	if ex.Type == "gha" {
+		return loadGithubEnv(ex)
+	}
 	return ex, nil
 }
 

--- a/cmd/buildctl/build/importcache.go
+++ b/cmd/buildctl/build/importcache.go
@@ -36,6 +36,9 @@ func parseImportCacheCSV(s string) (client.CacheOptionsEntry, error) {
 	if im.Type == "" {
 		return im, errors.New("--import-cache requires type=<type>")
 	}
+	if im.Type == "gha" {
+		return loadGithubEnv(im)
+	}
 	return im, nil
 }
 

--- a/cmd/buildctl/build/importcache_test.go
+++ b/cmd/buildctl/build/importcache_test.go
@@ -48,7 +48,36 @@ func TestParseImportCache(t *testing.T) {
 				},
 			},
 		},
+		{
+			importCaches: []string{"type=gha,url=https://foo.bar,token=foo"},
+			expected: []client.CacheOptionsEntry{
+				{
+					Type: "gha",
+					Attrs: map[string]string{
+						"url":   "https://foo.bar",
+						"token": "foo",
+					},
+				},
+			},
+		},
+		{
+			importCaches: []string{"type=gha"},
+			expected: []client.CacheOptionsEntry{
+				{
+					Type: "gha",
+					Attrs: map[string]string{
+						"url":   "https://github.com/test", // Set from env below
+						"token": "bar",                     // Set from env below
+					},
+				},
+			},
+		},
 	}
+
+	// Set values for GitHub parse cache
+	t.Setenv("ACTIONS_CACHE_URL", "https://github.com/test")
+	t.Setenv("ACTIONS_RUNTIME_TOKEN", "bar")
+
 	for _, tc := range testCases {
 		im, err := ParseImportCache(tc.importCaches)
 		if tc.expectedErr == "" {

--- a/cmd/buildctl/build/util.go
+++ b/cmd/buildctl/build/util.go
@@ -1,0 +1,33 @@
+package build
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+
+	"github.com/moby/buildkit/client"
+)
+
+// loadGithubEnv verify that url and token attributes exists in the
+// cache.
+// If not, it will search for $ACTIONS_RUNTIME_TOKEN and $ACTIONS_CACHE_URL
+// environments variables and add it to cache Options
+// Since it works for both import and export
+func loadGithubEnv(cache client.CacheOptionsEntry) (client.CacheOptionsEntry, error) {
+	if _, ok := cache.Attrs["url"]; !ok {
+		url, ok := os.LookupEnv("ACTIONS_CACHE_URL")
+		if !ok {
+			return cache, errors.New("cache with type gha requires url parameter or $ACTIONS_CACHE_URL")
+		}
+		cache.Attrs["url"] = url
+	}
+
+	if _, ok := cache.Attrs["token"]; !ok {
+		token, ok := os.LookupEnv("ACTIONS_RUNTIME_TOKEN")
+		if !ok {
+			return cache, errors.New("cache with type gha requires token parameter or $ACTIONS_RUNTIME_TOKEN")
+		}
+		cache.Attrs["token"] = token
+	}
+	return cache, nil
+}


### PR DESCRIPTION
When using `buildctl`, it's not explained in the documentation that GitHub attributes `url` and `token` must be manually set to make this works.
That miscomprehension is visible with #2706.

To do not meet that error again, this commit add a precision on how use GitHub cache with buildctl.

Signed-off-by: Vasek - Tom C <tom.chauveau@epitech.eu>