### PR TITLE
Set ProgressKey in solver instead of ops.

### DIFF
--- a/cache/opts.go
+++ b/cache/opts.go
@@ -35,5 +35,3 @@ type NeedsRemoteProviderError []digest.Digest //nolint:errname
 func (m NeedsRemoteProviderError) Error() string {
 	return fmt.Sprintf("missing descriptor handlers for lazy blobs %+v", []digest.Digest(m))
 }
-
-type ProgressKey struct{}

--- a/solver/cacheopts.go
+++ b/solver/cacheopts.go
@@ -4,11 +4,14 @@ import (
 	"context"
 
 	"github.com/moby/buildkit/util/bklog"
+	"github.com/moby/buildkit/util/progress"
 
 	digest "github.com/opencontainers/go-digest"
 )
 
 type CacheOpts map[interface{}]interface{}
+
+type progressKey struct{}
 
 type cacheOptGetterKey struct{}
 
@@ -90,4 +93,16 @@ func walkAncestors(ctx context.Context, start *state, f func(*state) bool) {
 			stack[len(stack)-1] = append(stack[len(stack)-1], parent)
 		}
 	}
+}
+
+func ProgressControllerFromContext(ctx context.Context) progress.Controller {
+	var pg progress.Controller
+	if optGetter := CacheOptGetterOf(ctx); optGetter != nil {
+		if kv := optGetter(false, progressKey{}); kv != nil {
+			if v, ok := kv[progressKey{}].(progress.Controller); ok {
+				pg = v
+			}
+		}
+	}
+	return pg
 }

--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -13,6 +13,7 @@ import (
 	"github.com/moby/buildkit/solver/errdefs"
 	"github.com/moby/buildkit/util/flightcontrol"
 	"github.com/moby/buildkit/util/progress"
+	"github.com/moby/buildkit/util/progress/controller"
 	"github.com/moby/buildkit/util/tracing"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
@@ -781,6 +782,15 @@ func (s *sharedOp) CacheMap(ctx context.Context, index int) (resp *cacheMapResp,
 		}
 		if complete {
 			if err == nil {
+				if res.Opts == nil {
+					res.Opts = CacheOpts(make(map[interface{}]interface{}))
+				}
+				res.Opts[progressKey{}] = &controller.Controller{
+					WriterFactory: progress.FromContext(ctx),
+					Digest:        s.st.vtx.Digest(),
+					Name:          s.st.vtx.Name(),
+					ProgressGroup: s.st.vtx.Options().ProgressGroup,
+				}
 				s.cacheRes = append(s.cacheRes, res)
 				s.cacheDone = done
 			}

--- a/solver/llbsolver/ops/diff.go
+++ b/solver/llbsolver/ops/diff.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/moby/buildkit/util/progress"
-	"github.com/moby/buildkit/util/progress/controller"
 	"github.com/moby/buildkit/worker"
 	"github.com/pkg/errors"
 
@@ -23,7 +21,6 @@ type diffOp struct {
 	op     *pb.DiffOp
 	worker worker.Worker
 	vtx    solver.Vertex
-	pg     progress.Controller
 }
 
 func NewDiffOp(v solver.Vertex, op *pb.Op_Diff, w worker.Worker) (solver.Op, error) {
@@ -64,16 +61,7 @@ func (d *diffOp) CacheMap(ctx context.Context, group session.Group, index int) (
 			ComputeDigestFunc solver.ResultBasedCacheFunc
 			PreprocessFunc    solver.PreprocessFunc
 		}, depCount),
-		Opts: solver.CacheOpts(make(map[interface{}]interface{})),
 	}
-
-	d.pg = &controller.Controller{
-		WriterFactory: progress.FromContext(ctx),
-		Digest:        d.vtx.Digest(),
-		Name:          d.vtx.Name(),
-		ProgressGroup: d.vtx.Options().ProgressGroup,
-	}
-	cm.Opts[cache.ProgressKey{}] = d.pg
 
 	return cm, true, nil
 }
@@ -121,7 +109,7 @@ func (d *diffOp) Exec(ctx context.Context, g session.Group, inputs []solver.Resu
 		return []solver.Result{worker.NewWorkerRefResult(nil, d.worker)}, nil
 	}
 
-	diffRef, err := d.worker.CacheManager().Diff(ctx, lowerRef, upperRef, d.pg,
+	diffRef, err := d.worker.CacheManager().Diff(ctx, lowerRef, upperRef, solver.ProgressControllerFromContext(ctx),
 		cache.WithDescription(d.vtx.Name()))
 	if err != nil {
 		return nil, err

--- a/solver/llbsolver/ops/exec.go
+++ b/solver/llbsolver/ops/exec.go
@@ -21,8 +21,6 @@ import (
 	"github.com/moby/buildkit/solver/llbsolver/errdefs"
 	"github.com/moby/buildkit/solver/llbsolver/mounts"
 	"github.com/moby/buildkit/solver/pb"
-	"github.com/moby/buildkit/util/progress"
-	"github.com/moby/buildkit/util/progress/controller"
 	"github.com/moby/buildkit/util/progress/logs"
 	utilsystem "github.com/moby/buildkit/util/system"
 	"github.com/moby/buildkit/worker"
@@ -45,7 +43,6 @@ type execOp struct {
 	platform    *pb.Platform
 	numInputs   int
 	parallelism *semaphore.Weighted
-	vtx         solver.Vertex
 }
 
 func NewExecOp(v solver.Vertex, op *pb.Op_Exec, platform *pb.Platform, cm cache.Manager, parallelism *semaphore.Weighted, sm *session.Manager, exec executor.Executor, w worker.Worker) (solver.Op, error) {
@@ -63,7 +60,6 @@ func NewExecOp(v solver.Vertex, op *pb.Op_Exec, platform *pb.Platform, cm cache.
 		w:           w,
 		platform:    platform,
 		parallelism: parallelism,
-		vtx:         v,
 	}, nil
 }
 
@@ -145,14 +141,6 @@ func (e *execOp) CacheMap(ctx context.Context, g session.Group, index int) (*sol
 			ComputeDigestFunc solver.ResultBasedCacheFunc
 			PreprocessFunc    solver.PreprocessFunc
 		}, e.numInputs),
-		Opts: solver.CacheOpts(map[interface{}]interface{}{
-			cache.ProgressKey{}: &controller.Controller{
-				WriterFactory: progress.FromContext(ctx),
-				Digest:        e.vtx.Digest(),
-				Name:          e.vtx.Name(),
-				ProgressGroup: e.vtx.Options().ProgressGroup,
-			},
-		}),
 	}
 
 	deps, err := e.getMountDeps()

--- a/solver/llbsolver/ops/file.go
+++ b/solver/llbsolver/ops/file.go
@@ -19,8 +19,6 @@ import (
 	"github.com/moby/buildkit/solver/llbsolver/ops/fileoptypes"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/flightcontrol"
-	"github.com/moby/buildkit/util/progress"
-	"github.com/moby/buildkit/util/progress/controller"
 	"github.com/moby/buildkit/worker"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
@@ -37,7 +35,6 @@ type fileOp struct {
 	solver      *FileOpSolver
 	numInputs   int
 	parallelism *semaphore.Weighted
-	vtx         solver.Vertex
 }
 
 func NewFileOp(v solver.Vertex, op *pb.Op_File, cm cache.Manager, parallelism *semaphore.Weighted, w worker.Worker) (solver.Op, error) {
@@ -51,7 +48,6 @@ func NewFileOp(v solver.Vertex, op *pb.Op_File, cm cache.Manager, parallelism *s
 		w:           w,
 		solver:      NewFileOpSolver(w, &file.Backend{}, file.NewRefManager(cm)),
 		parallelism: parallelism,
-		vtx:         v,
 	}, nil
 }
 
@@ -138,14 +134,6 @@ func (f *fileOp) CacheMap(ctx context.Context, g session.Group, index int) (*sol
 			ComputeDigestFunc solver.ResultBasedCacheFunc
 			PreprocessFunc    solver.PreprocessFunc
 		}, f.numInputs),
-		Opts: solver.CacheOpts(map[interface{}]interface{}{
-			cache.ProgressKey{}: &controller.Controller{
-				WriterFactory: progress.FromContext(ctx),
-				Digest:        f.vtx.Digest(),
-				Name:          f.vtx.Name(),
-				ProgressGroup: f.vtx.Options().ProgressGroup,
-			},
-		}),
 	}
 
 	for idx, m := range selectors {


### PR DESCRIPTION
This centralizes the location where ProgressKey gets set, which works
because it only needs information about the vertex, nothing op-specific.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

Addresses this comment: https://github.com/moby/buildkit/pull/2708#discussion_r821126775