### PR TITLE
test: deflake `CacheImportExport` tests

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2673,10 +2673,8 @@ func testPullZstdImage(t *testing.T, sb integration.Sandbox) {
 		// containerd 1.4 doesn't support zstd compression
 		return
 	}
-	err = c.Prune(sb.Context(), nil, PruneAll)
-	require.NoError(t, err)
 
-	checkAllRemoved(t, c, sb)
+	ensurePruneAll(t, c, sb)
 
 	st = llb.Scratch().File(llb.Copy(llb.Image(target), "/data", "/zdata"))
 
@@ -2964,9 +2962,7 @@ func testStargzLazyRegistryCacheImportExport(t *testing.T, sb integration.Sandbo
 	require.NoError(t, err)
 
 	// clear all local state out
-	err = c.Prune(sb.Context(), nil, PruneAll)
-	require.NoError(t, err)
-	checkAllRemoved(t, c, sb)
+	ensurePruneAll(t, c, sb)
 
 	// stargz layers should be lazy even for executing something on them
 	def, err = baseDef.
@@ -3048,9 +3044,7 @@ func testStargzLazyRegistryCacheImportExport(t *testing.T, sb integration.Sandbo
 		require.NoError(t, err)
 	}
 
-	err = c.Prune(sb.Context(), nil, PruneAll)
-	require.NoError(t, err)
-	checkAllRemoved(t, c, sb)
+	ensurePruneAll(t, c, sb)
 }
 
 func testStargzLazyInlineCacheImportExport(t *testing.T, sb integration.Sandbox) {
@@ -3203,9 +3197,7 @@ func testStargzLazyInlineCacheImportExport(t *testing.T, sb integration.Sandbox)
 		require.NoError(t, err)
 	}
 
-	err = c.Prune(sb.Context(), nil, PruneAll)
-	require.NoError(t, err)
-	checkAllRemoved(t, c, sb)
+	ensurePruneAll(t, c, sb)
 }
 
 func testStargzLazyPull(t *testing.T, sb integration.Sandbox) {
@@ -3330,9 +3322,7 @@ func testStargzLazyPull(t *testing.T, sb integration.Sandbox) {
 		require.NoError(t, err)
 	}
 
-	err = c.Prune(sb.Context(), nil, PruneAll)
-	require.NoError(t, err)
-	checkAllRemoved(t, c, sb)
+	ensurePruneAll(t, c, sb)
 }
 
 func testLazyImagePush(t *testing.T, sb integration.Sandbox) {
@@ -3814,10 +3804,7 @@ func testBasicInlineCacheImportExport(t *testing.T, sb integration.Sandbox) {
 	unique, err := readFileInImage(sb.Context(), c, target+"@"+dgst, "/unique")
 	require.NoError(t, err)
 
-	err = c.Prune(sb.Context(), nil, PruneAll)
-	require.NoError(t, err)
-
-	checkAllRemoved(t, c, sb)
+	ensurePruneAll(t, c, sb)
 
 	resp, err = c.Solve(sb.Context(), def, SolveOpt{
 		// specifying inline cache exporter is needed for reproducing containerimage.digest
@@ -3852,10 +3839,7 @@ func testBasicInlineCacheImportExport(t *testing.T, sb integration.Sandbox) {
 
 	require.Equal(t, dgst, dgst2)
 
-	err = c.Prune(sb.Context(), nil, PruneAll)
-	require.NoError(t, err)
-
-	checkAllRemoved(t, c, sb)
+	ensurePruneAll(t, c, sb)
 
 	// Export the cache again with compression
 	resp, err = c.Solve(sb.Context(), def, SolveOpt{
@@ -3896,10 +3880,7 @@ func testBasicInlineCacheImportExport(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 	require.EqualValues(t, unique, unique2uncompress)
 
-	err = c.Prune(sb.Context(), nil, PruneAll)
-	require.NoError(t, err)
-
-	checkAllRemoved(t, c, sb)
+	ensurePruneAll(t, c, sb)
 
 	resp, err = c.Solve(sb.Context(), def, SolveOpt{
 		Exports: []ExportEntry{
@@ -5301,6 +5282,11 @@ func requiresLinux(t *testing.T) {
 	}
 }
 
+// ensurePruneAll tries to ensure Prune completes with retries.
+// Current cache implementation defers release-related logic using goroutine so
+// there can be situation where a build has finished but the following prune doesn't
+// cleanup cache because some records still haven't been released.
+// This function tries to ensure prune by retrying it.
 func ensurePruneAll(t *testing.T, c *Client, sb integration.Sandbox) {
 	for i := 0; i < 2; i++ {
 		require.NoError(t, c.Prune(sb.Context(), nil, PruneAll))
@@ -5315,21 +5301,6 @@ func ensurePruneAll(t *testing.T, c *Client, sb integration.Sandbox) {
 		t.Logf("retrying prune(%d)", i)
 	}
 	t.Fatalf("failed to ensure prune")
-}
-
-func checkAllRemoved(t *testing.T, c *Client, sb integration.Sandbox) {
-	retries := 0
-	for {
-		require.True(t, 20 > retries)
-		retries++
-		du, err := c.DiskUsage(sb.Context())
-		require.NoError(t, err)
-		if len(du) > 0 {
-			time.Sleep(500 * time.Millisecond)
-			continue
-		}
-		break
-	}
 }
 
 func checkAllReleasable(t *testing.T, c *Client, sb integration.Sandbox, checkContent bool) {


### PR DESCRIPTION
Fixes https://github.com/moby/buildkit/pull/2685#pullrequestreview-900491854

On the master branch, `CacheImportExport` tests are flaky. This patch deflakes these tests.

- https://github.com/moby/buildkit/runs/5445980508?check_suite_focus=true#step:6:1759
- https://github.com/moby/buildkit/runs/5425504420?check_suite_focus=true#step:6:1254
- https://github.com/moby/buildkit/runs/5425504420?check_suite_focus=true#step:6:1254

 (On my machine, `testBasicLocalCacheImportExport` failed about 3 tiems in 100 attemptions).

Current cache implementation defers release-related logic using goroutine.

https://github.com/moby/buildkit/blob/bbf149ba70a54740fdf9c251dda6451b84cd452f/cache/refs.go#L1361-L1367

This seems to cause the situation where a build has finished but the following `*cacheManager.Prune()` doesn't cleanup cache because some records still haven't been released.
For example, the following diff can increase the test flakiness.

```diff
diff --git a/cache/refs.go b/cache/refs.go
index c937dd1b..3edb7979 100644
--- a/cache/refs.go
+++ b/cache/refs.go
@@ -1359,6 +1359,7 @@ func (cr *cacheRecord) finalize(ctx context.Context) error {
 
        mutable.dead = true
        go func() {
+               time.Sleep(time.Second)
                cr.cm.mu.Lock()
                defer cr.cm.mu.Unlock()
                if err := mutable.remove(context.TODO(), true); err != nil {
```

This commit deflakes these tests by allowing the test to retry prune some times.
