### PR TITLE
Remove uses of deprecated io/ioutil

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ run:
 linters:
   enable:
     - deadcode
+    - depguard
     - gofmt
     - goimports
     - revive
@@ -30,6 +31,13 @@ linters:
   disable-all: true
 
 linters-settings:
+  depguard:
+    list-type: blacklist
+    include-go-root: true
+    packages:
+      # The io/ioutil package has been deprecated.
+      # https://go.dev/doc/go1.16#ioutil
+      - io/ioutil
   importas:
     alias:
       - pkg: "github.com/opencontainers/image-spec/specs-go/v1"

--- a/cache/contenthash/checksum_test.go
+++ b/cache/contenthash/checksum_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -43,7 +42,7 @@ const (
 
 func TestChecksumSymlinkNoParentScan(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	tmpdir, err := os.MkdirTemp("", "buildkit-state")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -72,7 +71,7 @@ func TestChecksumSymlinkNoParentScan(t *testing.T) {
 
 func TestChecksumHardlinks(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	tmpdir, err := os.MkdirTemp("", "buildkit-state")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -155,7 +154,7 @@ func TestChecksumHardlinks(t *testing.T) {
 
 func TestChecksumWildcardOrFilter(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	tmpdir, err := os.MkdirTemp("", "buildkit-state")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -212,7 +211,7 @@ func TestChecksumWildcardOrFilter(t *testing.T) {
 
 func TestChecksumWildcardWithBadMountable(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	tmpdir, err := os.MkdirTemp("", "buildkit-state")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -232,7 +231,7 @@ func TestChecksumWildcardWithBadMountable(t *testing.T) {
 
 func TestSymlinksNoFollow(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	tmpdir, err := os.MkdirTemp("", "buildkit-state")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -291,7 +290,7 @@ func TestSymlinksNoFollow(t *testing.T) {
 
 func TestChecksumBasicFile(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	tmpdir, err := os.MkdirTemp("", "buildkit-state")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -449,7 +448,7 @@ func TestChecksumIncludeExclude(t *testing.T) {
 func testChecksumIncludeExclude(t *testing.T, wildcard bool) {
 	t.Parallel()
 
-	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	tmpdir, err := os.MkdirTemp("", "buildkit-state")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -584,7 +583,7 @@ func testChecksumIncludeExclude(t *testing.T, wildcard bool) {
 
 func TestChecksumIncludeDoubleStar(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	tmpdir, err := os.MkdirTemp("", "buildkit-state")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -652,7 +651,7 @@ func TestChecksumIncludeDoubleStar(t *testing.T) {
 
 func TestChecksumIncludeSymlink(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	tmpdir, err := os.MkdirTemp("", "buildkit-state")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -725,7 +724,7 @@ func TestChecksumIncludeSymlink(t *testing.T) {
 
 func TestHandleChange(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	tmpdir, err := os.MkdirTemp("", "buildkit-state")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -803,7 +802,7 @@ func TestHandleChange(t *testing.T) {
 
 func TestHandleRecursiveDir(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	tmpdir, err := os.MkdirTemp("", "buildkit-state")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -852,7 +851,7 @@ func TestHandleRecursiveDir(t *testing.T) {
 
 func TestChecksumUnorderedFiles(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	tmpdir, err := os.MkdirTemp("", "buildkit-state")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -905,7 +904,7 @@ func TestChecksumUnorderedFiles(t *testing.T) {
 
 func TestSymlinkInPathScan(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	tmpdir, err := os.MkdirTemp("", "buildkit-state")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -936,7 +935,7 @@ func TestSymlinkInPathScan(t *testing.T) {
 
 func TestSymlinkNeedsScan(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	tmpdir, err := os.MkdirTemp("", "buildkit-state")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -969,7 +968,7 @@ func TestSymlinkNeedsScan(t *testing.T) {
 
 func TestSymlinkAbsDirSuffix(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	tmpdir, err := os.MkdirTemp("", "buildkit-state")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -996,7 +995,7 @@ func TestSymlinkAbsDirSuffix(t *testing.T) {
 
 func TestSymlinkThroughParent(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	tmpdir, err := os.MkdirTemp("", "buildkit-state")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -1051,7 +1050,7 @@ func TestSymlinkThroughParent(t *testing.T) {
 
 func TestSymlinkInPathHandleChange(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	tmpdir, err := os.MkdirTemp("", "buildkit-state")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -1114,7 +1113,7 @@ func TestSymlinkInPathHandleChange(t *testing.T) {
 
 func TestPersistence(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	tmpdir, err := os.MkdirTemp("", "buildkit-state")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 

--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -75,7 +74,7 @@ func newCacheManager(ctx context.Context, opt cmOpt) (co *cmOut, cleanup func() 
 		opt.snapshotterName = "native"
 	}
 
-	tmpdir, err := ioutil.TempDir("", "cachemanager")
+	tmpdir, err := os.MkdirTemp("", "cachemanager")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -167,14 +166,14 @@ func TestSharableMountPoolCleanup(t *testing.T) {
 	t.Parallel()
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := ioutil.TempDir("", "cachemanager")
+	tmpdir, err := os.MkdirTemp("", "cachemanager")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
 	// Emulate the situation where the pool dir is dirty
 	mountPoolDir := filepath.Join(tmpdir, "cachemounts")
 	require.NoError(t, os.MkdirAll(mountPoolDir, 0700))
-	_, err = ioutil.TempDir(mountPoolDir, "buildkit")
+	_, err = os.MkdirTemp(mountPoolDir, "buildkit")
 	require.NoError(t, err)
 
 	// Initialize cache manager and check if pool is cleaned up
@@ -194,7 +193,7 @@ func TestManager(t *testing.T) {
 
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := ioutil.TempDir("", "cachemanager")
+	tmpdir, err := os.MkdirTemp("", "cachemanager")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -317,7 +316,7 @@ func TestManager(t *testing.T) {
 	err = cm.Close()
 	require.NoError(t, err)
 
-	dirs, err := ioutil.ReadDir(filepath.Join(tmpdir, "snapshots/snapshots"))
+	dirs, err := os.ReadDir(filepath.Join(tmpdir, "snapshots/snapshots"))
 	require.NoError(t, err)
 	require.Equal(t, 0, len(dirs))
 }
@@ -326,7 +325,7 @@ func TestLazyGetByBlob(t *testing.T) {
 	t.Parallel()
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := ioutil.TempDir("", "cachemanager")
+	tmpdir, err := os.MkdirTemp("", "cachemanager")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -371,7 +370,7 @@ func TestMergeBlobchainID(t *testing.T) {
 	t.Parallel()
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := ioutil.TempDir("", "cachemanager")
+	tmpdir, err := os.MkdirTemp("", "cachemanager")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -444,7 +443,7 @@ func TestSnapshotExtract(t *testing.T) {
 	t.Parallel()
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := ioutil.TempDir("", "cachemanager")
+	tmpdir, err := os.MkdirTemp("", "cachemanager")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -487,7 +486,7 @@ func TestSnapshotExtract(t *testing.T) {
 
 	require.Equal(t, false, !snap2.(*immutableRef).getBlobOnly())
 
-	dirs, err := ioutil.ReadDir(filepath.Join(tmpdir, "snapshots/snapshots"))
+	dirs, err := os.ReadDir(filepath.Join(tmpdir, "snapshots/snapshots"))
 	require.NoError(t, err)
 	require.Equal(t, 0, len(dirs))
 
@@ -499,7 +498,7 @@ func TestSnapshotExtract(t *testing.T) {
 	require.Equal(t, true, !snap.(*immutableRef).getBlobOnly())
 	require.Equal(t, true, !snap2.(*immutableRef).getBlobOnly())
 
-	dirs, err = ioutil.ReadDir(filepath.Join(tmpdir, "snapshots/snapshots"))
+	dirs, err = os.ReadDir(filepath.Join(tmpdir, "snapshots/snapshots"))
 	require.NoError(t, err)
 	require.Equal(t, 2, len(dirs))
 
@@ -512,7 +511,7 @@ func TestSnapshotExtract(t *testing.T) {
 
 	require.Equal(t, len(buf.all), 0)
 
-	dirs, err = ioutil.ReadDir(filepath.Join(tmpdir, "snapshots/snapshots"))
+	dirs, err = os.ReadDir(filepath.Join(tmpdir, "snapshots/snapshots"))
 	require.NoError(t, err)
 	require.Equal(t, 2, len(dirs))
 
@@ -530,7 +529,7 @@ func TestSnapshotExtract(t *testing.T) {
 
 	checkDiskUsage(ctx, t, cm, 2, 0)
 
-	dirs, err = ioutil.ReadDir(filepath.Join(tmpdir, "snapshots/snapshots"))
+	dirs, err = os.ReadDir(filepath.Join(tmpdir, "snapshots/snapshots"))
 	require.NoError(t, err)
 	require.Equal(t, 2, len(dirs))
 
@@ -553,7 +552,7 @@ func TestSnapshotExtract(t *testing.T) {
 
 	require.Equal(t, len(buf.all), 1)
 
-	dirs, err = ioutil.ReadDir(filepath.Join(tmpdir, "snapshots/snapshots"))
+	dirs, err = os.ReadDir(filepath.Join(tmpdir, "snapshots/snapshots"))
 	require.NoError(t, err)
 	require.Equal(t, 1, len(dirs))
 
@@ -569,7 +568,7 @@ func TestSnapshotExtract(t *testing.T) {
 
 	checkDiskUsage(ctx, t, cm, 0, 0)
 
-	dirs, err = ioutil.ReadDir(filepath.Join(tmpdir, "snapshots/snapshots"))
+	dirs, err = os.ReadDir(filepath.Join(tmpdir, "snapshots/snapshots"))
 	require.NoError(t, err)
 	require.Equal(t, 0, len(dirs))
 
@@ -584,7 +583,7 @@ func TestExtractOnMutable(t *testing.T) {
 	t.Parallel()
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := ioutil.TempDir("", "cachemanager")
+	tmpdir, err := os.MkdirTemp("", "cachemanager")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -643,7 +642,7 @@ func TestExtractOnMutable(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(len(b2)), size)
 
-	dirs, err := ioutil.ReadDir(filepath.Join(tmpdir, "snapshots/snapshots"))
+	dirs, err := os.ReadDir(filepath.Join(tmpdir, "snapshots/snapshots"))
 	require.NoError(t, err)
 	require.Equal(t, 1, len(dirs))
 
@@ -664,7 +663,7 @@ func TestExtractOnMutable(t *testing.T) {
 
 	require.Equal(t, len(buf.all), 0)
 
-	dirs, err = ioutil.ReadDir(filepath.Join(tmpdir, "snapshots/snapshots"))
+	dirs, err = os.ReadDir(filepath.Join(tmpdir, "snapshots/snapshots"))
 	require.NoError(t, err)
 	require.Equal(t, 2, len(dirs))
 
@@ -682,7 +681,7 @@ func TestExtractOnMutable(t *testing.T) {
 
 	require.Equal(t, len(buf.all), 2)
 
-	dirs, err = ioutil.ReadDir(filepath.Join(tmpdir, "snapshots/snapshots"))
+	dirs, err = os.ReadDir(filepath.Join(tmpdir, "snapshots/snapshots"))
 	require.NoError(t, err)
 	require.Equal(t, 0, len(dirs))
 
@@ -693,7 +692,7 @@ func TestSetBlob(t *testing.T) {
 	t.Parallel()
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := ioutil.TempDir("", "cachemanager")
+	tmpdir, err := os.MkdirTemp("", "cachemanager")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -866,7 +865,7 @@ func TestPrune(t *testing.T) {
 	t.Parallel()
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := ioutil.TempDir("", "cachemanager")
+	tmpdir, err := os.MkdirTemp("", "cachemanager")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -896,7 +895,7 @@ func TestPrune(t *testing.T) {
 
 	checkDiskUsage(ctx, t, cm, 2, 0)
 
-	dirs, err := ioutil.ReadDir(filepath.Join(tmpdir, "snapshots/snapshots"))
+	dirs, err := os.ReadDir(filepath.Join(tmpdir, "snapshots/snapshots"))
 	require.NoError(t, err)
 	require.Equal(t, 2, len(dirs))
 
@@ -909,7 +908,7 @@ func TestPrune(t *testing.T) {
 	checkDiskUsage(ctx, t, cm, 2, 0)
 	require.Equal(t, len(buf.all), 0)
 
-	dirs, err = ioutil.ReadDir(filepath.Join(tmpdir, "snapshots/snapshots"))
+	dirs, err = os.ReadDir(filepath.Join(tmpdir, "snapshots/snapshots"))
 	require.NoError(t, err)
 	require.Equal(t, 2, len(dirs))
 
@@ -927,7 +926,7 @@ func TestPrune(t *testing.T) {
 	checkDiskUsage(ctx, t, cm, 1, 0)
 	require.Equal(t, len(buf.all), 1)
 
-	dirs, err = ioutil.ReadDir(filepath.Join(tmpdir, "snapshots/snapshots"))
+	dirs, err = os.ReadDir(filepath.Join(tmpdir, "snapshots/snapshots"))
 	require.NoError(t, err)
 	require.Equal(t, 1, len(dirs))
 
@@ -967,7 +966,7 @@ func TestPrune(t *testing.T) {
 	checkDiskUsage(ctx, t, cm, 0, 0)
 	require.Equal(t, len(buf.all), 2)
 
-	dirs, err = ioutil.ReadDir(filepath.Join(tmpdir, "snapshots/snapshots"))
+	dirs, err = os.ReadDir(filepath.Join(tmpdir, "snapshots/snapshots"))
 	require.NoError(t, err)
 	require.Equal(t, 0, len(dirs))
 }
@@ -977,7 +976,7 @@ func TestLazyCommit(t *testing.T) {
 
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := ioutil.TempDir("", "cachemanager")
+	tmpdir, err := os.MkdirTemp("", "cachemanager")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -1135,7 +1134,7 @@ func TestLoopLeaseContent(t *testing.T) {
 
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := ioutil.TempDir("", "cachemanager")
+	tmpdir, err := os.MkdirTemp("", "cachemanager")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -1252,7 +1251,7 @@ func TestSharingCompressionVariant(t *testing.T) {
 
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := ioutil.TempDir("", "cachemanager")
+	tmpdir, err := os.MkdirTemp("", "cachemanager")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -1520,7 +1519,7 @@ func TestConversion(t *testing.T) {
 
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := ioutil.TempDir("", "cachemanager")
+	tmpdir, err := os.MkdirTemp("", "cachemanager")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -1617,7 +1616,7 @@ func TestGetRemotes(t *testing.T) {
 
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := ioutil.TempDir("", "cachemanager")
+	tmpdir, err := os.MkdirTemp("", "cachemanager")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -1917,7 +1916,7 @@ func TestNondistributableBlobs(t *testing.T) {
 
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := ioutil.TempDir("", "cachemanager")
+	tmpdir, err := os.MkdirTemp("", "cachemanager")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -2048,7 +2047,7 @@ func TestMergeOp(t *testing.T) {
 
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := ioutil.TempDir("", "cachemanager")
+	tmpdir, err := os.MkdirTemp("", "cachemanager")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -2164,7 +2163,7 @@ func TestDiffOp(t *testing.T) {
 
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := ioutil.TempDir("", "cachemanager")
+	tmpdir, err := os.MkdirTemp("", "cachemanager")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -2254,7 +2253,7 @@ func TestLoadHalfFinalizedRef(t *testing.T) {
 
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := ioutil.TempDir("", "cachemanager")
+	tmpdir, err := os.MkdirTemp("", "cachemanager")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -2334,7 +2333,7 @@ func TestMountReadOnly(t *testing.T) {
 
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := ioutil.TempDir("", "cachemanager")
+	tmpdir, err := os.MkdirTemp("", "cachemanager")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -2582,7 +2581,7 @@ func fileToBlob(file *os.File, compress bool) ([]byte, ocispecs.Descriptor, erro
 }
 
 func mapToSystemTarBlob(m map[string]string) ([]byte, ocispecs.Descriptor, error) {
-	tmpdir, err := ioutil.TempDir("", "tarcreation")
+	tmpdir, err := os.MkdirTemp("", "tarcreation")
 	if err != nil {
 		return nil, ocispecs.Descriptor{}, err
 	}
@@ -2591,7 +2590,7 @@ func mapToSystemTarBlob(m map[string]string) ([]byte, ocispecs.Descriptor, error
 	expected := map[string]string{}
 	for k, v := range m {
 		expected[k] = v
-		if err := ioutil.WriteFile(filepath.Join(tmpdir, k), []byte(v), 0600); err != nil {
+		if err := os.WriteFile(filepath.Join(tmpdir, k), []byte(v), 0600); err != nil {
 			return nil, ocispecs.Descriptor{}, err
 		}
 	}
@@ -2620,7 +2619,7 @@ func mapToSystemTarBlob(m map[string]string) ([]byte, ocispecs.Descriptor, error
 			return nil, ocispecs.Descriptor{}, errors.Errorf("unexpected file %s", h.Name)
 		}
 		delete(expected, k)
-		gotV, err := ioutil.ReadAll(tr)
+		gotV, err := io.ReadAll(tr)
 		if err != nil {
 			return nil, ocispecs.Descriptor{}, err
 		}

--- a/cache/metadata/metadata_test.go
+++ b/cache/metadata/metadata_test.go
@@ -1,7 +1,6 @@
 package metadata
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,7 +12,7 @@ import (
 func TestGetSetSearch(t *testing.T) {
 	t.Parallel()
 
-	tmpdir, err := ioutil.TempDir("", "buildkit-storage")
+	tmpdir, err := os.MkdirTemp("", "buildkit-storage")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -112,7 +111,7 @@ func TestGetSetSearch(t *testing.T) {
 func TestIndexes(t *testing.T) {
 	t.Parallel()
 
-	tmpdir, err := ioutil.TempDir("", "buildkit-storage")
+	tmpdir, err := os.MkdirTemp("", "buildkit-storage")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -172,7 +171,7 @@ func TestIndexes(t *testing.T) {
 func TestExternalData(t *testing.T) {
 	t.Parallel()
 
-	tmpdir, err := ioutil.TempDir("", "buildkit-storage")
+	tmpdir, err := os.MkdirTemp("", "buildkit-storage")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 

--- a/cache/refs.go
+++ b/cache/refs.go
@@ -3,7 +3,6 @@ package cache
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1631,7 +1630,7 @@ func (sm *sharableMountable) Mount() (_ []mount.Mount, _ func() error, retErr er
 			// Don't need temporary mount wrapper for non-overlayfs mounts
 			return mounts, release, nil
 		}
-		dir, err := ioutil.TempDir(sm.mountPoolRoot, "buildkit")
+		dir, err := os.MkdirTemp(sm.mountPoolRoot, "buildkit")
 		if err != nil {
 			return nil, nil, err
 		}

--- a/cache/util/fsutil.go
+++ b/cache/util/fsutil.go
@@ -3,7 +3,6 @@ package util
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -59,7 +58,7 @@ func ReadFile(ctx context.Context, mount snapshot.Mountable, req ReadRequest) ([
 		}
 
 		if req.Range == nil {
-			dt, err = ioutil.ReadFile(fp)
+			dt, err = os.ReadFile(fp)
 			if err != nil {
 				return errors.WithStack(err)
 			}
@@ -68,7 +67,7 @@ func ReadFile(ctx context.Context, mount snapshot.Mountable, req ReadRequest) ([
 			if err != nil {
 				return errors.WithStack(err)
 			}
-			dt, err = ioutil.ReadAll(io.NewSectionReader(f, int64(req.Range.Offset), int64(req.Range.Length)))
+			dt, err = io.ReadAll(io.NewSectionReader(f, int64(req.Range.Offset), int64(req.Range.Length)))
 			f.Close()
 			if err != nil {
 				return errors.WithStack(err)

--- a/client/build_test.go
+++ b/client/build_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -134,7 +133,7 @@ func testClientGatewaySolve(t *testing.T, sb integration.Sandbox) {
 		return r, nil
 	}
 
-	tmpdir, err := ioutil.TempDir("", "buildkit")
+	tmpdir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -153,7 +152,7 @@ func testClientGatewaySolve(t *testing.T, sb integration.Sandbox) {
 	}, product, b, nil)
 	require.NoError(t, err)
 
-	read, err := ioutil.ReadFile(filepath.Join(tmpdir, "foo"))
+	read, err := os.ReadFile(filepath.Join(tmpdir, "foo"))
 	require.NoError(t, err)
 	require.Equal(t, testStr, string(read))
 
@@ -476,7 +475,7 @@ func testClientGatewayContainerExecPipe(t *testing.T, sb integration.Sandbox) {
 			Args:   []string{"cat"},
 			Cwd:    "/",
 			Tty:    false,
-			Stdin:  ioutil.NopCloser(stdin2),
+			Stdin:  io.NopCloser(stdin2),
 			Stdout: stdout2,
 		})
 
@@ -688,11 +687,11 @@ func testClientGatewayContainerMounts(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 	defer c.Close()
 
-	tmpdir, err := ioutil.TempDir("", "buildkit-buildctl")
+	tmpdir, err := os.MkdirTemp("", "buildkit-buildctl")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
-	err = ioutil.WriteFile(filepath.Join(tmpdir, "local-file"), []byte("local"), 0644)
+	err = os.WriteFile(filepath.Join(tmpdir, "local-file"), []byte("local"), 0644)
 	require.NoError(t, err)
 
 	a := agent.NewKeyring()

--- a/client/client.go
+++ b/client/client.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"net"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/containerd/containerd/defaults"
@@ -212,7 +212,7 @@ func WithCredentials(serverName, ca, cert, key string) ClientOpt {
 }
 
 func loadCredentials(opts *withCredentials) (grpc.DialOption, error) {
-	ca, err := ioutil.ReadFile(opts.CACert)
+	ca, err := os.ReadFile(opts.CACert)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not read ca certificate")
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -12,7 +12,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -198,11 +197,11 @@ func testCacheExportCacheKeyLoop(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 	defer c.Close()
 
-	tmpdir, err := ioutil.TempDir("", "buildkit-buildctl")
+	tmpdir, err := os.MkdirTemp("", "buildkit-buildctl")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
-	err = ioutil.WriteFile(filepath.Join(tmpdir, "foo"), []byte("foodata"), 0600)
+	err = os.WriteFile(filepath.Join(tmpdir, "foo"), []byte("foodata"), 0600)
 	require.NoError(t, err)
 
 	for _, mode := range []bool{false, true} {
@@ -297,7 +296,7 @@ func testExportBusyboxLocal(t *testing.T, sb integration.Sandbox) {
 	def, err := llb.Image("busybox").Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -439,7 +438,7 @@ func testSSHMount(t *testing.T, sb integration.Sandbox) {
 	def, err = out.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -454,11 +453,11 @@ func testSSHMount(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "sock"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "sock"))
 	require.NoError(t, err)
 	require.Equal(t, "/run/buildkit/ssh_agent.0", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "out"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "out"))
 	require.NoError(t, err)
 	require.Contains(t, string(dt), "2048")
 	require.Contains(t, string(dt), "(RSA)")
@@ -486,7 +485,7 @@ func testSSHMount(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "out"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "out"))
 	require.NoError(t, err)
 	require.Contains(t, string(dt), "agent refused operation")
 
@@ -510,11 +509,11 @@ func testSSHMount(t *testing.T, sb integration.Sandbox) {
 		},
 	)
 
-	tmpDir, err := ioutil.TempDir("", "buildkit")
+	tmpDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 
-	err = ioutil.WriteFile(filepath.Join(tmpDir, "key"), dt, 0600)
+	err = os.WriteFile(filepath.Join(tmpDir, "key"), dt, 0600)
 	require.NoError(t, err)
 
 	ssh, err = sshprovider.NewSSHAgentProvider([]sshprovider.AgentConfig{{
@@ -522,7 +521,7 @@ func testSSHMount(t *testing.T, sb integration.Sandbox) {
 	}})
 	require.NoError(t, err)
 
-	destDir, err = ioutil.TempDir("", "buildkit")
+	destDir, err = os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -537,7 +536,7 @@ func testSSHMount(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "out"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "out"))
 	require.NoError(t, err)
 	require.Contains(t, string(dt), "1024")
 	require.Contains(t, string(dt), "(RSA)")
@@ -572,7 +571,7 @@ func testShmSize(t *testing.T, sb integration.Sandbox) {
 	def, err := out.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -586,7 +585,7 @@ func testShmSize(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "out"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "out"))
 	require.NoError(t, err)
 	require.Contains(t, string(dt), `size=131072k`)
 }
@@ -609,7 +608,7 @@ func testUlimit(t *testing.T, sb integration.Sandbox) {
 	def, err := st.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -623,11 +622,11 @@ func testUlimit(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "first"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "first"))
 	require.NoError(t, err)
 	require.Equal(t, `1062`, strings.TrimSpace(string(dt)))
 
-	dt2, err := ioutil.ReadFile(filepath.Join(destDir, "second"))
+	dt2, err := os.ReadFile(filepath.Join(destDir, "second"))
 	require.NoError(t, err)
 	require.NotEqual(t, `1062`, strings.TrimSpace(string(dt2)))
 }
@@ -654,7 +653,7 @@ func testCgroupParent(t *testing.T, sb integration.Sandbox) {
 	def, err := st.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -668,11 +667,11 @@ func testCgroupParent(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "first"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "first"))
 	require.NoError(t, err)
 	require.Contains(t, strings.TrimSpace(string(dt)), `/foocgroup/buildkit/`)
 
-	dt2, err := ioutil.ReadFile(filepath.Join(destDir, "second"))
+	dt2, err := os.ReadFile(filepath.Join(destDir, "second"))
 	require.NoError(t, err)
 	require.NotContains(t, strings.TrimSpace(string(dt2)), `/foocgroup/buildkit/`)
 }
@@ -796,7 +795,7 @@ func testSecurityMode(t *testing.T, sb integration.Sandbox) {
 	def, err := st.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -812,7 +811,7 @@ func testSecurityMode(t *testing.T, sb integration.Sandbox) {
 
 	require.NoError(t, err)
 
-	contents, err := ioutil.ReadFile(filepath.Join(destDir, "out"))
+	contents, err := os.ReadFile(filepath.Join(destDir, "out"))
 	require.NoError(t, err)
 
 	caps, err := strconv.ParseUint(strings.TrimSpace(string(contents)), 16, 64)
@@ -917,7 +916,7 @@ func testFrontendImageNaming(t *testing.T, sb integration.Sandbox) {
 			require.Contains(t, exporterResponse, "image.name")
 			require.Equal(t, exporterResponse["image.name"], "docker.io/library/"+imageName)
 
-			dt, err := ioutil.ReadFile(out)
+			dt, err := os.ReadFile(out)
 			require.NoError(t, err)
 
 			m, err := testutil.ReadTarToMap(dt, false)
@@ -989,7 +988,7 @@ func testFrontendImageNaming(t *testing.T, sb integration.Sandbox) {
 			for _, exp := range []string{ExporterOCI, ExporterDocker, ExporterImage} {
 				exp := exp // capture loop variable.
 				t.Run(exp, func(t *testing.T) {
-					destDir, err := ioutil.TempDir("", "buildkit")
+					destDir, err := os.MkdirTemp("", "buildkit")
 					require.NoError(t, err)
 					defer os.RemoveAll(destDir)
 
@@ -1255,7 +1254,7 @@ func testRelativeWorkDir(t *testing.T, sb integration.Sandbox) {
 	def, err := pwd.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -1269,7 +1268,7 @@ func testRelativeWorkDir(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "pwd"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "pwd"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("/test1/test2\n"), dt)
 }
@@ -1286,7 +1285,7 @@ func testFileOpMkdirMkfile(t *testing.T, sb integration.Sandbox) {
 	def, err := st.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -1304,7 +1303,7 @@ func testFileOpMkdirMkfile(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 	require.Equal(t, true, fi.IsDir())
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "bar"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "bar"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("contents"), dt)
 }
@@ -1340,7 +1339,7 @@ func testFileOpCopyRm(t *testing.T, sb integration.Sandbox) {
 	def, err := st.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -1358,7 +1357,7 @@ func testFileOpCopyRm(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "myfile2"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "myfile2"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("data0"), dt)
 
@@ -1366,14 +1365,14 @@ func testFileOpCopyRm(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 	require.Equal(t, true, fi.IsDir())
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "out/bar"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "out/bar"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("bar0"), dt)
 
 	_, err = os.Stat(filepath.Join(destDir, "out/foo"))
 	require.ErrorIs(t, err, os.ErrNotExist)
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "file2"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "file2"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("file2"), dt)
 }
@@ -1411,7 +1410,7 @@ func testFileOpCopyIncludeExclude(t *testing.T, sb integration.Sandbox) {
 	def, err := st.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -1428,7 +1427,7 @@ func testFileOpCopyIncludeExclude(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "sub", "foo"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "sub", "foo"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("foo0"), dt)
 
@@ -1437,7 +1436,7 @@ func testFileOpCopyIncludeExclude(t *testing.T, sb integration.Sandbox) {
 		require.ErrorIs(t, err, os.ErrNotExist)
 	}
 
-	randBytes, err := ioutil.ReadFile(filepath.Join(destDir, "unique"))
+	randBytes, err := os.ReadFile(filepath.Join(destDir, "unique"))
 	require.NoError(t, err)
 
 	// Create additional file which doesn't match the include pattern, and make
@@ -1460,7 +1459,7 @@ func testFileOpCopyIncludeExclude(t *testing.T, sb integration.Sandbox) {
 	def, err = st.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err = ioutil.TempDir("", "buildkit")
+	destDir, err = os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -1477,7 +1476,7 @@ func testFileOpCopyIncludeExclude(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	randBytes2, err := ioutil.ReadFile(filepath.Join(destDir, "unique"))
+	randBytes2, err := os.ReadFile(filepath.Join(destDir, "unique"))
 	require.NoError(t, err)
 
 	require.Equal(t, randBytes, randBytes2)
@@ -1543,7 +1542,7 @@ func testLocalSourceWithDiffer(t *testing.T, sb integration.Sandbox, d llb.DiffT
 	def, err := st.Marshal(context.TODO())
 	require.NoError(t, err)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -1560,11 +1559,11 @@ func testLocalSourceWithDiffer(t *testing.T, sb integration.Sandbox, d llb.DiffT
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "foo"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "foo"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("foo"), dt)
 
-	err = ioutil.WriteFile(filepath.Join(dir, "foo"), []byte("bar"), 0600)
+	err = os.WriteFile(filepath.Join(dir, "foo"), []byte("bar"), 0600)
 	require.NoError(t, err)
 
 	err = syscall.UtimesNano(filepath.Join(dir, "foo"), []syscall.Timespec{tv, tv})
@@ -1583,7 +1582,7 @@ func testLocalSourceWithDiffer(t *testing.T, sb integration.Sandbox, d llb.DiffT
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "foo"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "foo"))
 	require.NoError(t, err)
 	if d == llb.DiffMetadata {
 		require.Equal(t, []byte("foo"), dt)
@@ -1618,7 +1617,7 @@ func testFileOpRmWildcard(t *testing.T, sb integration.Sandbox) {
 	def, err := st.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -1635,7 +1634,7 @@ func testFileOpRmWildcard(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "bar/remaining"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "bar/remaining"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("bar1"), dt)
 
@@ -1719,7 +1718,7 @@ func testBuildHTTPSource(t *testing.T, sb integration.Sandbox) {
 	require.Equal(t, server.Stats("/foo").AllRequests, 1)
 	require.Equal(t, server.Stats("/foo").CachedRequests, 0)
 
-	tmpdir, err := ioutil.TempDir("", "buildkit")
+	tmpdir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -1736,7 +1735,7 @@ func testBuildHTTPSource(t *testing.T, sb integration.Sandbox) {
 	require.Equal(t, server.Stats("/foo").AllRequests, 2)
 	require.Equal(t, server.Stats("/foo").CachedRequests, 1)
 
-	dt, err := ioutil.ReadFile(filepath.Join(tmpdir, "foo"))
+	dt, err := os.ReadFile(filepath.Join(tmpdir, "foo"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("content1"), dt)
 
@@ -1759,7 +1758,7 @@ func testBuildHTTPSource(t *testing.T, sb integration.Sandbox) {
 	require.Equal(t, server.Stats("/foo").AllRequests, 3)
 	require.Equal(t, server.Stats("/foo").CachedRequests, 1)
 
-	dt, err = ioutil.ReadFile(filepath.Join(tmpdir, "bar"))
+	dt, err = os.ReadFile(filepath.Join(tmpdir, "bar"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("content1"), dt)
 
@@ -1792,7 +1791,7 @@ func testResolveAndHosts(t *testing.T, sb integration.Sandbox) {
 	def, err := st.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -1806,11 +1805,11 @@ func testResolveAndHosts(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "resolv.conf"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "resolv.conf"))
 	require.NoError(t, err)
 	require.Contains(t, string(dt), "nameserver")
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "hosts"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "hosts"))
 	require.NoError(t, err)
 	require.Contains(t, string(dt), "127.0.0.1	localhost")
 }
@@ -1846,7 +1845,7 @@ func testUser(t *testing.T, sb integration.Sandbox) {
 	def, err := out.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -1860,32 +1859,32 @@ func testUser(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "user"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "user"))
 	require.NoError(t, err)
 	require.Equal(t, "daemon", strings.TrimSpace(string(dt)))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "group"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "group"))
 	require.NoError(t, err)
 	require.Equal(t, "daemon", strings.TrimSpace(string(dt)))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "nobody"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "nobody"))
 	require.NoError(t, err)
 	require.Equal(t, "nobody", strings.TrimSpace(string(dt)))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "userone"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "userone"))
 	require.NoError(t, err)
 	require.Equal(t, "1", strings.TrimSpace(string(dt)))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "root_supplementary"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "root_supplementary"))
 	require.NoError(t, err)
 	require.True(t, strings.HasPrefix(string(dt), "root "))
 	require.True(t, strings.Contains(string(dt), "wheel"))
 
-	dt2, err := ioutil.ReadFile(filepath.Join(destDir, "default_supplementary"))
+	dt2, err := os.ReadFile(filepath.Join(destDir, "default_supplementary"))
 	require.NoError(t, err)
 	require.Equal(t, string(dt), string(dt2))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "default_uid"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "default_uid"))
 	require.NoError(t, err)
 	require.Equal(t, "0", strings.TrimSpace(string(dt)))
 
@@ -1913,7 +1912,7 @@ func testOCIExporter(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 
 	for _, exp := range []string{ExporterOCI, ExporterDocker} {
-		destDir, err := ioutil.TempDir("", "buildkit")
+		destDir, err := os.MkdirTemp("", "buildkit")
 		require.NoError(t, err)
 		defer os.RemoveAll(destDir)
 
@@ -1936,7 +1935,7 @@ func testOCIExporter(t *testing.T, sb integration.Sandbox) {
 		}, nil)
 		require.NoError(t, err)
 
-		dt, err := ioutil.ReadFile(out)
+		dt, err := os.ReadFile(out)
 		require.NoError(t, err)
 
 		m, err := testutil.ReadTarToMap(dt, false)
@@ -2015,7 +2014,7 @@ func testFrontendMetadataReturn(t *testing.T, sb integration.Sandbox) {
 			{
 				Type:   ExporterOCI,
 				Attrs:  map[string]string{},
-				Output: fixedWriteCloser(nopWriteCloser{ioutil.Discard}),
+				Output: fixedWriteCloser(nopWriteCloser{io.Discard}),
 			},
 		},
 	}, "", frontend, nil)
@@ -2074,7 +2073,7 @@ func testFrontendUseSolveResults(t *testing.T, sb integration.Sandbox) {
 		})
 	}
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -2088,7 +2087,7 @@ func testFrontendUseSolveResults(t *testing.T, sb integration.Sandbox) {
 	}, "", frontend, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "foo2"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "foo2"))
 	require.NoError(t, err)
 	require.Equal(t, dt, []byte("data"))
 }
@@ -2154,7 +2153,7 @@ func testTarExporterWithSocket(t *testing.T, sb integration.Sandbox) {
 				Type:  ExporterTar,
 				Attrs: map[string]string{},
 				Output: func(m map[string]string) (io.WriteCloser, error) {
-					return nopWriteCloser{ioutil.Discard}, nil
+					return nopWriteCloser{io.Discard}, nil
 				},
 			},
 		},
@@ -2547,7 +2546,7 @@ func testBuildExportZstd(t *testing.T, sb integration.Sandbox) {
 	def, err := st.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -2574,7 +2573,7 @@ func testBuildExportZstd(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(out)
+	dt, err := os.ReadFile(out)
 	require.NoError(t, err)
 
 	m, err := testutil.ReadTarToMap(dt, false)
@@ -2612,7 +2611,7 @@ func testBuildExportZstd(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err = ioutil.ReadFile(out)
+	dt, err = os.ReadFile(out)
 	require.NoError(t, err)
 
 	m, err = testutil.ReadTarToMap(dt, false)
@@ -2681,7 +2680,7 @@ func testPullZstdImage(t *testing.T, sb integration.Sandbox) {
 	def, err = st.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -2695,7 +2694,7 @@ func testPullZstdImage(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "zdata"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "zdata"))
 	require.NoError(t, err)
 	require.Equal(t, dt, []byte("zstd"))
 }
@@ -2747,7 +2746,7 @@ func testBuildPushAndValidate(t *testing.T, sb integration.Sandbox) {
 	def, err = firstBuild.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -2761,11 +2760,11 @@ func testBuildPushAndValidate(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "foo/sub/bar"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "foo/sub/bar"))
 	require.NoError(t, err)
 	require.Equal(t, dt, []byte("first"))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "foo/sub/baz"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "foo/sub/baz"))
 	require.NoError(t, err)
 	require.Equal(t, dt, []byte("second"))
 
@@ -2927,7 +2926,7 @@ func testStargzLazyRegistryCacheImportExport(t *testing.T, sb integration.Sandbo
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -3167,7 +3166,7 @@ func testStargzLazyInlineCacheImportExport(t *testing.T, sb integration.Sandbox)
 	checkAllReleasable(t, c, sb, true)
 
 	// stargz layers should be exportable
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 	out := filepath.Join(destDir, "out.tar")
@@ -3300,7 +3299,7 @@ func testStargzLazyPull(t *testing.T, sb integration.Sandbox) {
 	checkAllReleasable(t, c, sb, true)
 
 	// stargz layers should be exportable
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 	out := filepath.Join(destDir, "out.tar")
@@ -3473,11 +3472,11 @@ func testZstdLocalCacheExport(t *testing.T, sb integration.Sandbox) {
 	def, err := st.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
-	destOutDir, err := ioutil.TempDir("", "buildkit")
+	destOutDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destOutDir)
 
@@ -3502,13 +3501,13 @@ func testZstdLocalCacheExport(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 
 	var index ocispecs.Index
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "index.json"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "index.json"))
 	require.NoError(t, err)
 	err = json.Unmarshal(dt, &index)
 	require.NoError(t, err)
 
 	var layerIndex ocispecs.Index
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "blobs/sha256/"+index.Manifests[0].Digest.Hex()))
+	dt, err = os.ReadFile(filepath.Join(destDir, "blobs/sha256/"+index.Manifests[0].Digest.Hex()))
 	require.NoError(t, err)
 	err = json.Unmarshal(dt, &layerIndex)
 	require.NoError(t, err)
@@ -3517,14 +3516,14 @@ func testZstdLocalCacheExport(t *testing.T, sb integration.Sandbox) {
 	require.Equal(t, ocispecs.MediaTypeImageLayer+"+zstd", lastLayer.MediaType)
 
 	zstdLayerDigest := lastLayer.Digest.Hex()
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "blobs/sha256/"+zstdLayerDigest))
+	dt, err = os.ReadFile(filepath.Join(destDir, "blobs/sha256/"+zstdLayerDigest))
 	require.NoError(t, err)
 	require.Equal(t, dt[:4], []byte{0x28, 0xb5, 0x2f, 0xfd})
 }
 
 func testUncompressedLocalCacheImportExport(t *testing.T, sb integration.Sandbox) {
 	skipDockerd(t, sb)
-	dir, err := ioutil.TempDir("", "buildkit")
+	dir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 	im := CacheOptionsEntry{
@@ -3575,7 +3574,7 @@ func testZstdLocalCacheImportExport(t *testing.T, sb integration.Sandbox) {
 		// containerd 1.4 doesn't support zstd compression
 		return
 	}
-	dir, err := ioutil.TempDir("", "buildkit")
+	dir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 	im := CacheOptionsEntry{
@@ -3645,7 +3644,7 @@ func testBasicCacheImportExport(t *testing.T, sb integration.Sandbox, cacheOptio
 	def, err := st.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -3660,16 +3659,16 @@ func testBasicCacheImportExport(t *testing.T, sb integration.Sandbox, cacheOptio
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "const"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "const"))
 	require.NoError(t, err)
 	require.Equal(t, string(dt), "foobar")
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "unique"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "unique"))
 	require.NoError(t, err)
 
 	ensurePruneAll(t, c, sb)
 
-	destDir, err = ioutil.TempDir("", "buildkit")
+	destDir, err = os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -3683,11 +3682,11 @@ func testBasicCacheImportExport(t *testing.T, sb integration.Sandbox, cacheOptio
 	}, nil)
 	require.NoError(t, err)
 
-	dt2, err := ioutil.ReadFile(filepath.Join(destDir, "const"))
+	dt2, err := os.ReadFile(filepath.Join(destDir, "const"))
 	require.NoError(t, err)
 	require.Equal(t, string(dt2), "foobar")
 
-	dt2, err = ioutil.ReadFile(filepath.Join(destDir, "unique"))
+	dt2, err = os.ReadFile(filepath.Join(destDir, "unique"))
 	require.NoError(t, err)
 	require.Equal(t, string(dt), string(dt2))
 }
@@ -3734,7 +3733,7 @@ func testMultipleRegistryCacheImportExport(t *testing.T, sb integration.Sandbox)
 
 func testBasicLocalCacheImportExport(t *testing.T, sb integration.Sandbox) {
 	skipDockerd(t, sb)
-	dir, err := ioutil.TempDir("", "buildkit")
+	dir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 	im := CacheOptionsEntry{
@@ -3917,7 +3916,7 @@ func readFileInImage(ctx context.Context, c *Client, ref, path string) ([]byte, 
 	if err != nil {
 		return nil, err
 	}
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	if err != nil {
 		return nil, err
 	}
@@ -3934,7 +3933,7 @@ func readFileInImage(ctx context.Context, c *Client, ref, path string) ([]byte, 
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.ReadFile(filepath.Join(destDir, filepath.Clean(path)))
+	return os.ReadFile(filepath.Join(destDir, filepath.Clean(path)))
 }
 
 func testCachedMounts(t *testing.T, sb integration.Sandbox) {
@@ -3970,7 +3969,7 @@ func testCachedMounts(t *testing.T, sb integration.Sandbox) {
 	st.AddMount("/src0", llb.Scratch(), llb.AsPersistentCacheDir("mycache1", llb.CacheMountShared))
 	st.AddMount("/src1", base, llb.AsPersistentCacheDir("mycache2", llb.CacheMountShared))
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -3987,15 +3986,15 @@ func testCachedMounts(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "foo"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "foo"))
 	require.NoError(t, err)
 	require.Equal(t, string(dt), "first")
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "bar"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "bar"))
 	require.NoError(t, err)
 	require.Equal(t, string(dt), "second")
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "baz"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "baz"))
 	require.NoError(t, err)
 	require.Equal(t, string(dt), "base")
 
@@ -4215,7 +4214,7 @@ func testDuplicateWhiteouts(t *testing.T, sb integration.Sandbox) {
 	def, err := st.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -4233,7 +4232,7 @@ func testDuplicateWhiteouts(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(out)
+	dt, err := os.ReadFile(out)
 	require.NoError(t, err)
 
 	m, err := testutil.ReadTarToMap(dt, false)
@@ -4287,7 +4286,7 @@ func testWhiteoutParentDir(t *testing.T, sb integration.Sandbox) {
 	def, err := st.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -4304,7 +4303,7 @@ func testWhiteoutParentDir(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(out)
+	dt, err := os.ReadFile(out)
 	require.NoError(t, err)
 
 	m, err := testutil.ReadTarToMap(dt, false)
@@ -4352,7 +4351,7 @@ func testMoveParentDir(t *testing.T, sb integration.Sandbox) {
 	def, err := st.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -4369,7 +4368,7 @@ func testMoveParentDir(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(out)
+	dt, err := os.ReadFile(out)
 	require.NoError(t, err)
 
 	m, err := testutil.ReadTarToMap(dt, false)
@@ -4612,7 +4611,7 @@ func testRmSymlink(t *testing.T, sb integration.Sandbox) {
 	def, err := mnt.File(llb.Rm("link")).Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -4648,7 +4647,7 @@ func testProxyEnv(t *testing.T, sb integration.Sandbox) {
 	def, err := out.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -4662,7 +4661,7 @@ func testProxyEnv(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "env"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "env"))
 	require.NoError(t, err)
 	require.Equal(t, string(dt), "httpvalue-httpsvalue-noproxyvalue-noproxyvalue-allproxyvalue-allproxyvalue")
 
@@ -4676,7 +4675,7 @@ func testProxyEnv(t *testing.T, sb integration.Sandbox) {
 	def, err = out.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err = ioutil.TempDir("", "buildkit")
+	destDir, err = os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -4690,7 +4689,7 @@ func testProxyEnv(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "env"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "env"))
 	require.NoError(t, err)
 	require.Equal(t, string(dt), "httpvalue-httpsvalue-noproxyvalue-noproxyvalue-allproxyvalue-allproxyvalue")
 }
@@ -4961,7 +4960,7 @@ func testMergeOpCache(t *testing.T, sb integration.Sandbox, mode string) {
 	}
 
 	// get the random value at /bar/2
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -4975,7 +4974,7 @@ func testMergeOpCache(t *testing.T, sb integration.Sandbox, mode string) {
 	}, nil)
 	require.NoError(t, err)
 
-	bar2Contents, err := ioutil.ReadFile(filepath.Join(destDir, "bar", "2"))
+	bar2Contents, err := os.ReadFile(filepath.Join(destDir, "bar", "2"))
 	require.NoError(t, err)
 
 	// clear all local state out
@@ -5067,7 +5066,7 @@ func testMergeOpCache(t *testing.T, sb integration.Sandbox, mode string) {
 	}
 
 	// check the random value at /bar/2 didn't change
-	destDir, err = ioutil.TempDir("", "buildkit")
+	destDir, err = os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -5082,7 +5081,7 @@ func testMergeOpCache(t *testing.T, sb integration.Sandbox, mode string) {
 	}, nil)
 	require.NoError(t, err)
 
-	newBar2Contents, err := ioutil.ReadFile(filepath.Join(destDir, "bar", "2"))
+	newBar2Contents, err := os.ReadFile(filepath.Join(destDir, "bar", "2"))
 	require.NoError(t, err)
 
 	require.Equalf(t, bar2Contents, newBar2Contents, "bar/2 contents changed")
@@ -5116,7 +5115,7 @@ func testMergeOpCache(t *testing.T, sb integration.Sandbox, mode string) {
 	require.NoError(t, err)
 
 	// check the random value at /bar/2 didn't change
-	destDir, err = ioutil.TempDir("", "buildkit")
+	destDir, err = os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -5131,7 +5130,7 @@ func testMergeOpCache(t *testing.T, sb integration.Sandbox, mode string) {
 	}, nil)
 	require.NoError(t, err)
 
-	newBar2Contents, err = ioutil.ReadFile(filepath.Join(destDir, "bar", "2"))
+	newBar2Contents, err = os.ReadFile(filepath.Join(destDir, "bar", "2"))
 	require.NoError(t, err)
 
 	require.Equalf(t, bar2Contents, newBar2Contents, "bar/2 contents changed")
@@ -5177,7 +5176,7 @@ func requireContents(ctx context.Context, t *testing.T, c *Client, sb integratio
 	def, err := state.Marshal(ctx)
 	require.NoError(t, err)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -5227,7 +5226,7 @@ func requireEqualContents(ctx context.Context, t *testing.T, c *Client, stateA, 
 	defA, err := stateA.Marshal(ctx)
 	require.NoError(t, err)
 
-	destDirA, err := ioutil.TempDir("", "buildkit")
+	destDirA, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDirA)
 
@@ -5244,7 +5243,7 @@ func requireEqualContents(ctx context.Context, t *testing.T, c *Client, stateA, 
 	defB, err := stateB.Marshal(ctx)
 	require.NoError(t, err)
 
-	destDirB, err := ioutil.TempDir("", "buildkit")
+	destDirB, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDirB)
 
@@ -5393,7 +5392,7 @@ func testInvalidExporter(t *testing.T, sb integration.Sandbox) {
 	def, err := llb.Image("busybox:latest").Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -5478,7 +5477,7 @@ func testParallelLocalBuilds(t *testing.T, sb integration.Sandbox) {
 				def, err := llb.Local("source").Marshal(sb.Context())
 				require.NoError(t, err)
 
-				destDir, err := ioutil.TempDir("", "buildkit")
+				destDir, err := os.MkdirTemp("", "buildkit")
 				require.NoError(t, err)
 				defer os.RemoveAll(destDir)
 
@@ -5495,7 +5494,7 @@ func testParallelLocalBuilds(t *testing.T, sb integration.Sandbox) {
 				}, nil)
 				require.NoError(t, err)
 
-				act, err := ioutil.ReadFile(filepath.Join(destDir, fn))
+				act, err := os.ReadFile(filepath.Join(destDir, fn))
 				require.NoError(t, err)
 
 				require.Equal(t, "contents", string(act))
@@ -5527,7 +5526,7 @@ func testRelativeMountpoint(t *testing.T, sb integration.Sandbox) {
 	def, err := st.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -5541,7 +5540,7 @@ func testRelativeMountpoint(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "data"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "data"))
 	require.NoError(t, err)
 	require.Equal(t, dt, []byte(id))
 }
@@ -5732,7 +5731,7 @@ func testBuildInfoNoExport(t *testing.T, sb integration.Sandbox) {
 }
 
 func tmpdir(appliers ...fstest.Applier) (string, error) {
-	tmpdir, err := ioutil.TempDir("", "buildkit-client")
+	tmpdir, err := os.MkdirTemp("", "buildkit-client")
 	if err != nil {
 		return "", err
 	}
@@ -5743,7 +5742,7 @@ func tmpdir(appliers ...fstest.Applier) (string, error) {
 }
 
 func makeSSHAgentSock(agent agent.Agent) (p string, cleanup func() error, err error) {
-	tmpDir, err := ioutil.TempDir("", "buildkit")
+	tmpDir, err := os.MkdirTemp("", "buildkit")
 	if err != nil {
 		return "", nil, err
 	}

--- a/client/llb/marshal.go
+++ b/client/llb/marshal.go
@@ -2,7 +2,6 @@ package llb
 
 import (
 	"io"
-	"io/ioutil"
 
 	"github.com/containerd/containerd/platforms"
 	"github.com/moby/buildkit/solver/pb"
@@ -67,7 +66,7 @@ func WriteTo(def *Definition, w io.Writer) error {
 }
 
 func ReadFrom(r io.Reader) (*Definition, error) {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/client/ociindex/ociindex.go
+++ b/client/ociindex/ociindex.go
@@ -2,7 +2,7 @@ package ociindex
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/gofrs/flock"
@@ -62,7 +62,7 @@ func PutDescToIndexJSONFileLocked(indexJSONPath string, desc ocispecs.Descriptor
 	}
 	defer f.Close()
 	var idx ocispecs.Index
-	b, err := ioutil.ReadAll(f)
+	b, err := io.ReadAll(f)
 	if err != nil {
 		return errors.Wrapf(err, "could not read %s", indexJSONPath)
 	}
@@ -101,7 +101,7 @@ func ReadIndexJSONFileLocked(indexJSONPath string) (*ocispecs.Index, error) {
 		lock.Unlock()
 		os.RemoveAll(lockPath)
 	}()
-	b, err := ioutil.ReadFile(indexJSONPath)
+	b, err := os.ReadFile(indexJSONPath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not read %s", indexJSONPath)
 	}

--- a/cmd/buildctl/build_test.go
+++ b/cmd/buildctl/build_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -55,7 +54,7 @@ func testBuildLocalExporter(t *testing.T, sb integration.Sandbox) {
 	rdr, err := marshal(sb.Context(), out)
 	require.NoError(t, err)
 
-	tmpdir, err := ioutil.TempDir("", "buildkit-buildctl")
+	tmpdir, err := os.MkdirTemp("", "buildkit-buildctl")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -65,7 +64,7 @@ func testBuildLocalExporter(t *testing.T, sb integration.Sandbox) {
 
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(tmpdir, "foo"))
+	dt, err := os.ReadFile(filepath.Join(tmpdir, "foo"))
 	require.NoError(t, err)
 	require.Equal(t, string(dt), "bar")
 }
@@ -121,7 +120,7 @@ func testBuildMetadataFile(t *testing.T, sb integration.Sandbox) {
 	rdr, err := marshal(sb.Context(), st.Root())
 	require.NoError(t, err)
 
-	tmpDir, err := ioutil.TempDir("", "buildkit-buildctl")
+	tmpDir, err := os.MkdirTemp("", "buildkit-buildctl")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 
@@ -140,7 +139,7 @@ func testBuildMetadataFile(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 
 	require.FileExists(t, metadataFile)
-	metadataBytes, err := ioutil.ReadFile(metadataFile)
+	metadataBytes, err := os.ReadFile(metadataFile)
 	require.NoError(t, err)
 
 	var metadata map[string]interface{}
@@ -193,7 +192,7 @@ func marshal(ctx context.Context, st llb.State) (io.Reader, error) {
 }
 
 func tmpdir(appliers ...fstest.Applier) (string, error) {
-	tmpdir, err := ioutil.TempDir("", "buildkit-buildctl")
+	tmpdir, err := os.MkdirTemp("", "buildkit-buildctl")
 	if err != nil {
 		return "", err
 	}

--- a/cmd/buildctl/buildctl_test.go
+++ b/cmd/buildctl/buildctl_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -120,7 +119,7 @@ func TestWriteMetadataFile(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fname := path.Join(tmpdir, "metadata_"+tt.name)
 			require.NoError(t, writeMetadataFile(fname, tt.exporterResponse))
-			current, err := ioutil.ReadFile(fname)
+			current, err := os.ReadFile(fname)
 			require.NoError(t, err)
 			var raw map[string]interface{}
 			require.NoError(t, json.Unmarshal(current, &raw))

--- a/cmd/buildctl/debug/dumpmetadata.go
+++ b/cmd/buildctl/debug/dumpmetadata.go
@@ -2,7 +2,6 @@ package debug
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -41,7 +40,7 @@ var DumpMetadataCommand = cli.Command{
 }
 
 func findMetadataDBFiles(root string) ([]string, error) {
-	dirs, err := ioutil.ReadDir(root)
+	dirs, err := os.ReadDir(root)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/user"
@@ -594,7 +593,7 @@ func serverCredentials(cfg config.TLSConfig) (*tls.Config, error) {
 	}
 	if caFile != "" {
 		certPool := x509.NewCertPool()
-		ca, err := ioutil.ReadFile(caFile)
+		ca, err := os.ReadFile(caFile)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not read ca certificate")
 		}

--- a/examples/dockerfile2llb/main.go
+++ b/examples/dockerfile2llb/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"flag"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 
@@ -23,7 +23,7 @@ func main() {
 	flag.StringVar(&opt.target, "target", "", "target stage")
 	flag.Parse()
 
-	df, err := ioutil.ReadAll(os.Stdin)
+	df, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/kubernetes/consistenthash/main.go
+++ b/examples/kubernetes/consistenthash/main.go
@@ -16,7 +16,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -38,7 +38,7 @@ func xmain() error {
 		return errors.New("should not reach here")
 	}
 	key := os.Args[1]
-	stdin, err := ioutil.ReadAll(os.Stdin)
+	stdin, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		return err
 	}

--- a/executor/containerdexecutor/executor.go
+++ b/executor/containerdexecutor/executor.go
@@ -3,7 +3,6 @@ package containerdexecutor
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -315,10 +314,10 @@ func fixProcessOutput(process *executor.ProcessInfo) {
 	// failed to start io pipe copy: unable to copy pipes: containerd-shim: opening file "" failed: open : no such file or directory: unknown
 	// So just stub out any missing output
 	if process.Stdout == nil {
-		process.Stdout = &nopCloser{ioutil.Discard}
+		process.Stdout = &nopCloser{io.Discard}
 	}
 	if process.Stderr == nil {
-		process.Stderr = &nopCloser{ioutil.Discard}
+		process.Stderr = &nopCloser{io.Discard}
 	}
 }
 

--- a/executor/oci/hosts.go
+++ b/executor/oci/hosts.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -56,7 +55,7 @@ func makeHostsFile(stateDir string, extraHosts []executor.HostIP, idmap *idtools
 	}
 
 	tmpPath := p + ".tmp"
-	if err := ioutil.WriteFile(tmpPath, b.Bytes(), 0644); err != nil {
+	if err := os.WriteFile(tmpPath, b.Bytes(), 0644); err != nil {
 		return "", nil, err
 	}
 

--- a/executor/oci/resolvconf.go
+++ b/executor/oci/resolvconf.go
@@ -2,7 +2,6 @@ package oci
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -101,7 +100,7 @@ func GetResolvConf(ctx context.Context, stateDir string, idmap *idtools.Identity
 		}
 
 		tmpPath := p + ".tmp"
-		if err := ioutil.WriteFile(tmpPath, f.Content, 0644); err != nil {
+		if err := os.WriteFile(tmpPath, f.Content, 0644); err != nil {
 			return "", err
 		}
 

--- a/executor/oci/resolvconf_test.go
+++ b/executor/oci/resolvconf_test.go
@@ -2,7 +2,6 @@ package oci
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -27,13 +26,13 @@ nameserver 8.8.4.4
 nameserver 2001:4860:4860::8888
 nameserver 2001:4860:4860::8844`
 
-	dir, err := ioutil.TempDir("", "buildkit-test")
+	dir, err := os.MkdirTemp("", "buildkit-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 	ctx := context.Background()
 	p, err := GetResolvConf(ctx, dir, nil, nil)
 	require.NoError(t, err)
-	b, err := ioutil.ReadFile(p)
+	b, err := os.ReadFile(p)
 	require.NoError(t, err)
 	require.Equal(t, string(b), defaultResolvConf)
 }

--- a/exporter/local/export.go
+++ b/exporter/local/export.go
@@ -2,7 +2,6 @@ package local
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -67,7 +66,7 @@ func (e *localExporterInstance) Export(ctx context.Context, inp exporter.Source,
 			var err error
 			var idmap *idtools.IdentityMapping
 			if ref == nil {
-				src, err = ioutil.TempDir("", "buildkit")
+				src, err = os.MkdirTemp("", "buildkit")
 				if err != nil {
 					return err
 				}

--- a/exporter/tar/export.go
+++ b/exporter/tar/export.go
@@ -2,7 +2,6 @@ package local
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -83,7 +82,7 @@ func (e *localExporterInstance) Export(ctx context.Context, inp exporter.Source,
 		var err error
 		var idmap *idtools.IdentityMapping
 		if ref == nil {
-			src, err = ioutil.TempDir("", "buildkit")
+			src, err = os.MkdirTemp("", "buildkit")
 			if err != nil {
 				return nil, err
 			}

--- a/frontend/dockerfile/dockerfile_buildinfo_test.go
+++ b/frontend/dockerfile/dockerfile_buildinfo_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -47,7 +46,7 @@ func testBuildInfoSources(t *testing.T, sb integration.Sandbox) {
 	f := getFrontend(t, sb)
 	f.RequiresBuildctl(t)
 
-	gitDir, err := ioutil.TempDir("", "buildkit")
+	gitDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(gitDir)
 
@@ -58,7 +57,7 @@ ADD https://raw.githubusercontent.com/moby/moby/master/README.md /
 COPY --from=alpine /bin/busybox /alpine-busybox
 `
 
-	err = ioutil.WriteFile(filepath.Join(gitDir, "Dockerfile"), []byte(dockerfile), 0600)
+	err = os.WriteFile(filepath.Join(gitDir, "Dockerfile"), []byte(dockerfile), 0600)
 	require.NoError(t, err)
 
 	err = runShell(gitDir,
@@ -75,7 +74,7 @@ COPY --from=alpine /bin/busybox /alpine-busybox
 	server := httptest.NewServer(http.FileServer(http.Dir(filepath.Join(gitDir))))
 	defer server.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -145,7 +144,7 @@ FROM busybox:latest
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -204,7 +203,7 @@ RUN echo $foo
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -263,7 +262,7 @@ ADD https://raw.githubusercontent.com/moby/moby/master/README.md /
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -337,7 +336,7 @@ COPY --from=base /out /
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -404,7 +403,7 @@ COPY --from=base /o* /
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -545,7 +544,7 @@ COPY --from=build /foo /out /
 		return res, nil
 	}
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -691,7 +690,7 @@ COPY --from=build /foo /out /
 		return res, nil
 	}
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -822,7 +821,7 @@ RUN echo "foo is $FOO" > /foo
 		return res, nil
 	}
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 

--- a/frontend/dockerfile/dockerfile_heredoc_test.go
+++ b/frontend/dockerfile/dockerfile_heredoc_test.go
@@ -2,7 +2,6 @@ package dockerfile
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -78,7 +77,7 @@ COPY --from=build /dest /
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -104,7 +103,7 @@ COPY --from=build /dest /
 	}
 
 	for name, content := range contents {
-		dt, err := ioutil.ReadFile(filepath.Join(destDir, name))
+		dt, err := os.ReadFile(filepath.Join(destDir, name))
 		require.NoError(t, err)
 		require.Equal(t, content, string(dt))
 	}
@@ -151,7 +150,7 @@ EOF
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -169,31 +168,31 @@ EOF
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "quotefile"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "quotefile"))
 	require.NoError(t, err)
 	require.Equal(t, "\"quotes in file\"\n", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "slashfile1"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "slashfile1"))
 	require.NoError(t, err)
 	require.Equal(t, "\n", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "slashfile2"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "slashfile2"))
 	require.NoError(t, err)
 	require.Equal(t, "\\\n", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "slashfile3"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "slashfile3"))
 	require.NoError(t, err)
 	require.Equal(t, "$\n", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "rawslashfile1"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "rawslashfile1"))
 	require.NoError(t, err)
 	require.Equal(t, "\\\n", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "rawslashfile2"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "rawslashfile2"))
 	require.NoError(t, err)
 	require.Equal(t, "\\\\\n", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "rawslashfile3"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "rawslashfile3"))
 	require.NoError(t, err)
 	require.Equal(t, "\\$\n", string(dt))
 }
@@ -223,7 +222,7 @@ COPY --from=build /dest /dest
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -241,7 +240,7 @@ COPY --from=build /dest /dest
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "dest"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "dest"))
 	require.NoError(t, err)
 	require.Equal(t, "i am\nroot\n", string(dt))
 }
@@ -273,7 +272,7 @@ COPY --from=build /dest /dest
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -291,7 +290,7 @@ COPY --from=build /dest /dest
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "dest"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "dest"))
 	require.NoError(t, err)
 	require.Equal(t, "foo\n", string(dt))
 }
@@ -324,7 +323,7 @@ COPY --from=build /dest /dest
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -342,7 +341,7 @@ COPY --from=build /dest /dest
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "dest"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "dest"))
 	require.NoError(t, err)
 	require.Equal(t, "hello\nworld\n", string(dt))
 }
@@ -389,7 +388,7 @@ COPY --from=build /dest /
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -415,7 +414,7 @@ COPY --from=build /dest /
 	}
 
 	for name, content := range contents {
-		dt, err := ioutil.ReadFile(filepath.Join(destDir, name))
+		dt, err := os.ReadFile(filepath.Join(destDir, name))
 		require.NoError(t, err)
 		require.Equal(t, content, string(dt))
 	}
@@ -481,7 +480,7 @@ COPY --from=build /dest /
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -511,7 +510,7 @@ COPY --from=build /dest /
 	}
 
 	for name, content := range contents {
-		dt, err := ioutil.ReadFile(filepath.Join(destDir, name))
+		dt, err := os.ReadFile(filepath.Join(destDir, name))
 		require.NoError(t, err)
 		require.Equal(t, content, string(dt))
 	}
@@ -577,7 +576,7 @@ COPY --from=build /dest /
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -610,7 +609,7 @@ COPY --from=build /dest /
 	}
 
 	for name, content := range contents {
-		dt, err := ioutil.ReadFile(filepath.Join(destDir, name))
+		dt, err := os.ReadFile(filepath.Join(destDir, name))
 		require.NoError(t, err)
 		require.Equal(t, content, string(dt))
 	}
@@ -682,7 +681,7 @@ EOF
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -700,7 +699,7 @@ EOF
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "dest"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "dest"))
 	require.NoError(t, err)
 	require.Equal(t, "hello world\n", string(dt))
 }

--- a/frontend/dockerfile/dockerfile_mount_test.go
+++ b/frontend/dockerfile/dockerfile_mount_test.go
@@ -1,7 +1,6 @@
 package dockerfile
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -187,7 +186,7 @@ COPY --from=second /unique /unique
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -205,7 +204,7 @@ COPY --from=second /unique /unique
 	}, nil)
 	require.NoError(t, err)
 
-	dt1, err := ioutil.ReadFile(filepath.Join(destDir, "unique"))
+	dt1, err := os.ReadFile(filepath.Join(destDir, "unique"))
 	require.NoError(t, err)
 
 	// repeat with changed file that should be still cached by content
@@ -216,7 +215,7 @@ COPY --from=second /unique /unique
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	destDir, err = ioutil.TempDir("", "buildkit")
+	destDir, err = os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -234,7 +233,7 @@ COPY --from=second /unique /unique
 	}, nil)
 	require.NoError(t, err)
 
-	dt2, err := ioutil.ReadFile(filepath.Join(destDir, "unique"))
+	dt2, err := os.ReadFile(filepath.Join(destDir, "unique"))
 	require.NoError(t, err)
 	require.Equal(t, dt1, dt2)
 }
@@ -474,7 +473,7 @@ COPY --from=base /tmpfssize /
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -492,7 +491,7 @@ COPY --from=base /tmpfssize /
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "tmpfssize"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "tmpfssize"))
 	require.NoError(t, err)
 	require.Contains(t, string(dt), `size=131072k`)
 }

--- a/frontend/dockerfile/dockerfile_ssh_test.go
+++ b/frontend/dockerfile/dockerfile_ssh_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -55,11 +54,11 @@ RUN --mount=type=ssh,mode=741,uid=100,gid=102 [ "$(stat -c "%u %g %f" $SSH_AUTH_
 		},
 	)
 
-	tmpDir, err := ioutil.TempDir("", "buildkit")
+	tmpDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 
-	err = ioutil.WriteFile(filepath.Join(tmpDir, "key"), dt, 0600)
+	err = os.WriteFile(filepath.Join(tmpDir, "key"), dt, 0600)
 	require.NoError(t, err)
 
 	ssh, err := sshprovider.NewSSHAgentProvider([]sshprovider.AgentConfig{{

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -240,7 +239,7 @@ echo -n $my_arg $1 > /out
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -269,7 +268,7 @@ echo -n $my_arg $1 > /out
 			}, nil)
 			require.NoError(t, err)
 
-			dt, err := ioutil.ReadFile(filepath.Join(destDir, "out"))
+			dt, err := os.ReadFile(filepath.Join(destDir, "out"))
 			require.NoError(t, err)
 			require.Equal(t, x.expected, string(dt))
 		})
@@ -295,7 +294,7 @@ RUN [ "$myenv" = 'foo%sbar' ]
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -431,7 +430,7 @@ COPY --from=base2 /foo /f
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	cacheDir, err := ioutil.TempDir("", "buildkit")
+	cacheDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(cacheDir)
 
@@ -581,7 +580,7 @@ WORKDIR /
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -787,7 +786,7 @@ COPY --from=base unique /
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -805,13 +804,13 @@ COPY --from=base unique /
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "unique"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "unique"))
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(filepath.Join(dir, "bar"), []byte("bar-data-mod"), 0600)
+	err = os.WriteFile(filepath.Join(dir, "bar"), []byte("bar-data-mod"), 0600)
 	require.NoError(t, err)
 
-	destDir, err = ioutil.TempDir("", "buildkit")
+	destDir, err = os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -829,14 +828,14 @@ COPY --from=base unique /
 	}, nil)
 	require.NoError(t, err)
 
-	dt2, err := ioutil.ReadFile(filepath.Join(destDir, "unique"))
+	dt2, err := os.ReadFile(filepath.Join(destDir, "unique"))
 	require.NoError(t, err)
 	require.Equal(t, string(dt), string(dt2))
 
-	err = ioutil.WriteFile(filepath.Join(dir, "foo2"), []byte("foo2-data-mod"), 0600)
+	err = os.WriteFile(filepath.Join(dir, "foo2"), []byte("foo2-data-mod"), 0600)
 	require.NoError(t, err)
 
-	destDir, err = ioutil.TempDir("", "buildkit")
+	destDir, err = os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -854,7 +853,7 @@ COPY --from=base unique /
 	}, nil)
 	require.NoError(t, err)
 
-	dt2, err = ioutil.ReadFile(filepath.Join(destDir, "unique"))
+	dt2, err = os.ReadFile(filepath.Join(destDir, "unique"))
 	require.NoError(t, err)
 	require.NotEqual(t, string(dt), string(dt2))
 }
@@ -878,7 +877,7 @@ COPY foo nomatch* /
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -896,7 +895,7 @@ COPY foo nomatch* /
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "foo"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "foo"))
 	require.NoError(t, err)
 	require.Equal(t, "contents0", string(dt))
 }
@@ -1065,7 +1064,7 @@ COPY link/foo .
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -1086,7 +1085,7 @@ COPY link/foo .
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "foo"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "foo"))
 	require.NoError(t, err)
 	require.Equal(t, "contents", string(dt))
 }
@@ -1113,7 +1112,7 @@ COPY --from=build /sub2/foo bar
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -1134,7 +1133,7 @@ COPY --from=build /sub2/foo bar
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "foo"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "foo"))
 	require.NoError(t, err)
 	require.Equal(t, "data", string(dt))
 }
@@ -1159,7 +1158,7 @@ COPY . /
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -1238,7 +1237,7 @@ COPY --from=build /out .
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -1256,7 +1255,7 @@ COPY --from=build /out .
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "out"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "out"))
 	require.NoError(t, err)
 	require.Equal(t, "bar-box-foo", string(dt))
 }
@@ -1284,7 +1283,7 @@ COPY --from=build /out .
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -1302,7 +1301,7 @@ COPY --from=build /out .
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "out"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "out"))
 	require.NoError(t, err)
 	require.Equal(t, "foo bar:box-foo:123 456", string(dt))
 }
@@ -1327,7 +1326,7 @@ COPY Dockerfile .
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -1352,7 +1351,7 @@ COPY Dockerfile .
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "out.tar"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "out.tar"))
 	require.NoError(t, err)
 
 	m, err := testutil.ReadTarToMap(dt, false)
@@ -1423,7 +1422,7 @@ COPY arch-$TARGETARCH whoami
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -1444,21 +1443,21 @@ COPY arch-$TARGETARCH whoami
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "windows_amd64/whoami"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "windows_amd64/whoami"))
 	require.NoError(t, err)
 	require.Equal(t, "i am amd64", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "linux_arm_v7/whoami"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "linux_arm_v7/whoami"))
 	require.NoError(t, err)
 	require.Equal(t, "i am arm", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "linux_s390x/whoami"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "linux_s390x/whoami"))
 	require.NoError(t, err)
 	require.Equal(t, "i am s390x", string(dt))
 
 	// repeat with oci exporter
 
-	destDir, err = ioutil.TempDir("", "buildkit")
+	destDir, err = os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -1483,7 +1482,7 @@ COPY arch-$TARGETARCH whoami
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "out.tar"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "out.tar"))
 	require.NoError(t, err)
 
 	m, err := testutil.ReadTarToMap(dt, false)
@@ -1577,7 +1576,7 @@ COPY foo /
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -1598,7 +1597,7 @@ COPY foo /
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "foo"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "foo"))
 	require.NoError(t, err)
 	require.Equal(t, "contents2", string(dt))
 }
@@ -1678,7 +1677,7 @@ COPY foo/sub bar
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -1723,7 +1722,7 @@ COPY sub/l* alllinks/
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -1744,19 +1743,19 @@ COPY sub/l* alllinks/
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "foo"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "foo"))
 	require.NoError(t, err)
 	require.Equal(t, "bar-contents", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "alllinks/l0"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "alllinks/l0"))
 	require.NoError(t, err)
 	require.Equal(t, "subfile-contents", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "alllinks/lfile"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "alllinks/lfile"))
 	require.NoError(t, err)
 	require.Equal(t, "lfile-contents", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "alllinks/l1"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "alllinks/l1"))
 	require.NoError(t, err)
 	require.Equal(t, "baz-contents", string(dt))
 }
@@ -1771,11 +1770,11 @@ FROM scratch
 COPY --from=0 /foo /foo
 `)
 
-	srcDir, err := ioutil.TempDir("", "buildkit")
+	srcDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(srcDir)
 
-	err = ioutil.WriteFile(filepath.Join(srcDir, "Dockerfile"), dockerfile, 0600)
+	err = os.WriteFile(filepath.Join(srcDir, "Dockerfile"), dockerfile, 0600)
 	require.NoError(t, err)
 
 	resp := httpserver.Response{
@@ -1788,7 +1787,7 @@ COPY --from=0 /foo /foo
 	})
 	defer server.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -1810,7 +1809,7 @@ COPY --from=0 /foo /foo
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "foo"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "foo"))
 	require.NoError(t, err)
 	require.Equal(t, "foo-contents", string(dt))
 }
@@ -2012,7 +2011,7 @@ COPY foo .
 	def, err := echo.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -2030,7 +2029,7 @@ COPY foo .
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "foo"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "foo"))
 	require.NoError(t, err)
 	require.Equal(t, "foo0", string(dt))
 }
@@ -2238,7 +2237,7 @@ ADD %s /dest/
 	err = cmd.Run()
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "dest/foo"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "dest/foo"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("content1"), dt)
 
@@ -2266,7 +2265,7 @@ ADD %s /dest/
 	require.NoError(t, err)
 
 	destFile := filepath.Join(destDir, "dest/__unnamed__")
-	dt, err = ioutil.ReadFile(destFile)
+	dt, err = os.ReadFile(destFile)
 	require.NoError(t, err)
 	require.Equal(t, []byte("content2"), dt)
 
@@ -2317,7 +2316,7 @@ ADD t.tar /
 	cmd := sb.Cmd(args + fmt.Sprintf(" --exporter=local --exporter-opt output=%s", destDir))
 	require.NoError(t, cmd.Run())
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "foo"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "foo"))
 	require.NoError(t, err)
 	require.Equal(t, expectedContent, dt)
 
@@ -2351,7 +2350,7 @@ ADD t.tar.gz /
 	cmd = sb.Cmd(args + fmt.Sprintf(" --exporter=local --exporter-opt output=%s", destDir))
 	require.NoError(t, cmd.Run())
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "foo"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "foo"))
 	require.NoError(t, err)
 	require.Equal(t, expectedContent, dt)
 
@@ -2378,7 +2377,7 @@ COPY t.tar.gz /
 	cmd = sb.Cmd(args + fmt.Sprintf(" --exporter=local --exporter-opt output=%s", destDir))
 	require.NoError(t, cmd.Run())
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "t.tar.gz"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "t.tar.gz"))
 	require.NoError(t, err)
 	require.Equal(t, buf2.Bytes(), dt)
 
@@ -2414,7 +2413,7 @@ ADD %s /
 	cmd = sb.Cmd(args + fmt.Sprintf(" --exporter=local --exporter-opt output=%s", destDir))
 	require.NoError(t, cmd.Run())
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "t.tar.gz"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "t.tar.gz"))
 	require.NoError(t, err)
 	require.Equal(t, buf2.Bytes(), dt)
 
@@ -2440,7 +2439,7 @@ ADD %s /newname.tar.gz
 	cmd = sb.Cmd(args + fmt.Sprintf(" --exporter=local --exporter-opt output=%s", destDir))
 	require.NoError(t, cmd.Run())
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "newname.tar.gz"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "newname.tar.gz"))
 	require.NoError(t, err)
 	require.Equal(t, buf2.Bytes(), dt)
 }
@@ -2491,7 +2490,7 @@ ADD *.tar /dest
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -2513,11 +2512,11 @@ ADD *.tar /dest
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "dest/foo"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "dest/foo"))
 	require.NoError(t, err)
 	require.Equal(t, "content0", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "dest/bar"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "dest/bar"))
 	require.NoError(t, err)
 	require.Equal(t, "content1", string(dt))
 }
@@ -2600,7 +2599,7 @@ COPY foo /symlink/
 	cmd := sb.Cmd(args + fmt.Sprintf(" --exporter=local --exporter-opt output=%s", destDir))
 	require.NoError(t, cmd.Run())
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "tmp/symlink-target/foo"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "tmp/symlink-target/foo"))
 	require.NoError(t, err)
 	require.Equal(t, expectedContent, dt)
 }
@@ -2779,7 +2778,7 @@ Dockerfile
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -2797,7 +2796,7 @@ Dockerfile
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "foo"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "foo"))
 	require.NoError(t, err)
 	require.Equal(t, "foo-contents", string(dt))
 
@@ -2817,7 +2816,7 @@ Dockerfile
 	require.Error(t, err)
 	require.True(t, errors.Is(err, os.ErrNotExist))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "bay"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "bay"))
 	require.NoError(t, err)
 	require.Equal(t, "bay-contents", string(dt))
 }
@@ -3049,7 +3048,7 @@ USER nobody
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -3067,11 +3066,11 @@ USER nobody
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "rootuser"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "rootuser"))
 	require.NoError(t, err)
 	require.Equal(t, "root\n", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "daemonuser"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "daemonuser"))
 	require.NoError(t, err)
 	require.Equal(t, "daemon\n", string(dt))
 
@@ -3152,7 +3151,7 @@ COPY --from=base /out /
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -3174,15 +3173,15 @@ COPY --from=base /out /
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "fooowner"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "fooowner"))
 	require.NoError(t, err)
 	require.Equal(t, "daemon daemon\n", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "subowner"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "subowner"))
 	require.NoError(t, err)
 	require.Equal(t, "1000 nobody\n", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "foobisowner"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "foobisowner"))
 	require.NoError(t, err)
 	require.Equal(t, "1000 nobody\n", string(dt))
 }
@@ -3219,7 +3218,7 @@ COPY --from=base /out /
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -3245,15 +3244,15 @@ COPY --from=base /out /
 	}
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "fooperm"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "fooperm"))
 	require.NoError(t, err)
 	require.Equal(t, "0644\n", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "barperm"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "barperm"))
 	require.NoError(t, err)
 	require.Equal(t, "0777\n", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "foobisperm"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "foobisperm"))
 	require.NoError(t, err)
 	require.Equal(t, "0000\n", string(dt))
 }
@@ -3287,7 +3286,7 @@ COPY files dest
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -3308,11 +3307,11 @@ COPY files dest
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "sub/dir1/dir2/foo"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "sub/dir1/dir2/foo"))
 	require.NoError(t, err)
 	require.Equal(t, "foo-contents", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "dest/foo.go"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "dest/foo.go"))
 	require.NoError(t, err)
 	require.Equal(t, "foo.go-contents", string(dt))
 }
@@ -3339,7 +3338,7 @@ COPY $FOO baz
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -3360,7 +3359,7 @@ COPY $FOO baz
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "baz"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "baz"))
 	require.NoError(t, err)
 	require.Equal(t, "bar-contents", string(dt))
 }
@@ -3398,7 +3397,7 @@ COPY sub/dir1 subdest6
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -3419,45 +3418,45 @@ COPY sub/dir1 subdest6
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "gofiles/foo.go"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "gofiles/foo.go"))
 	require.NoError(t, err)
 	require.Equal(t, "foo-contents", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "gofiles/bar.go"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "gofiles/bar.go"))
 	require.NoError(t, err)
 	require.Equal(t, "bar-contents", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "foo2.go"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "foo2.go"))
 	require.NoError(t, err)
 	require.Equal(t, "foo-contents", string(dt))
 
 	if isFileOp { // non-fileop implementation is historically buggy
-		dt, err = ioutil.ReadFile(filepath.Join(destDir, "subdest/dir2/foo"))
+		dt, err = os.ReadFile(filepath.Join(destDir, "subdest/dir2/foo"))
 		require.NoError(t, err)
 		require.Equal(t, "foo-contents", string(dt))
 	}
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "subdest2/foo"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "subdest2/foo"))
 	require.NoError(t, err)
 	require.Equal(t, "foo-contents", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "subdest3/bar"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "subdest3/bar"))
 	require.NoError(t, err)
 	require.Equal(t, "foo-contents", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "all/foo.go"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "all/foo.go"))
 	require.NoError(t, err)
 	require.Equal(t, "foo-contents", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "subdest4/dir2/foo"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "subdest4/dir2/foo"))
 	require.NoError(t, err)
 	require.Equal(t, "foo-contents", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "subdest5/dir2/foo"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "subdest5/dir2/foo"))
 	require.NoError(t, err)
 	require.Equal(t, "foo-contents", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "subdest6/dir2/foo"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "subdest6/dir2/foo"))
 	require.NoError(t, err)
 	require.Equal(t, "foo-contents", string(dt))
 }
@@ -3568,7 +3567,7 @@ COPY --from=build /dest /dest
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "dest"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "dest"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("0644\n0755\n0413\n"), dt)
 }
@@ -3576,7 +3575,7 @@ COPY --from=build /dest /dest
 func testDockerfileFromGit(t *testing.T, sb integration.Sandbox) {
 	f := getFrontend(t, sb)
 
-	gitDir, err := ioutil.TempDir("", "buildkit")
+	gitDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(gitDir)
 
@@ -3587,7 +3586,7 @@ FROM scratch
 COPY --from=build foo bar
 `
 
-	err = ioutil.WriteFile(filepath.Join(gitDir, "Dockerfile"), []byte(dockerfile), 0600)
+	err = os.WriteFile(filepath.Join(gitDir, "Dockerfile"), []byte(dockerfile), 0600)
 	require.NoError(t, err)
 
 	err = runShell(gitDir,
@@ -3604,7 +3603,7 @@ COPY --from=build foo bar
 COPY --from=build foo bar2
 `
 
-	err = ioutil.WriteFile(filepath.Join(gitDir, "Dockerfile"), []byte(dockerfile), 0600)
+	err = os.WriteFile(filepath.Join(gitDir, "Dockerfile"), []byte(dockerfile), 0600)
 	require.NoError(t, err)
 
 	err = runShell(gitDir,
@@ -3617,7 +3616,7 @@ COPY --from=build foo bar2
 	server := httptest.NewServer(http.FileServer(http.Dir(filepath.Join(gitDir))))
 	defer server.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -3638,7 +3637,7 @@ COPY --from=build foo bar2
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "bar"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "bar"))
 	require.NoError(t, err)
 	require.Equal(t, "fromgit", string(dt))
 
@@ -3647,7 +3646,7 @@ COPY --from=build foo bar2
 	require.True(t, errors.Is(err, os.ErrNotExist))
 
 	// second request from master branch contains both files
-	destDir, err = ioutil.TempDir("", "buildkit")
+	destDir, err = os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -3664,11 +3663,11 @@ COPY --from=build foo bar2
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "bar"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "bar"))
 	require.NoError(t, err)
 	require.Equal(t, "fromgit", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "bar2"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "bar2"))
 	require.NoError(t, err)
 	require.Equal(t, "fromgit", string(dt))
 }
@@ -3709,7 +3708,7 @@ COPY foo bar
 	})
 	defer server.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -3731,7 +3730,7 @@ COPY foo bar
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "bar"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "bar"))
 	require.NoError(t, err)
 	require.Equal(t, "foo-contents", string(dt))
 }
@@ -3754,7 +3753,7 @@ COPY --from=busybox /etc/passwd test
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -3772,7 +3771,7 @@ COPY --from=busybox /etc/passwd test
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "test"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "test"))
 	require.NoError(t, err)
 	require.Contains(t, string(dt), "root")
 
@@ -3792,7 +3791,7 @@ COPY --from=golang /usr/bin/go go
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	destDir, err = ioutil.TempDir("", "buildkit")
+	destDir, err = os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -3810,7 +3809,7 @@ COPY --from=golang /usr/bin/go go
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "go"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "go"))
 	require.NoError(t, err)
 	require.Contains(t, string(dt), "foo")
 }
@@ -3837,7 +3836,7 @@ COPY --from=stage1 baz bax
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -3858,7 +3857,7 @@ COPY --from=stage1 baz bax
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "baz"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "baz"))
 	require.NoError(t, err)
 	require.Contains(t, string(dt), "foo-contents")
 }
@@ -3881,7 +3880,7 @@ LABEL foo=bar
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -3959,7 +3958,7 @@ RUN ls /files/file1
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -4068,7 +4067,7 @@ ONBUILD RUN mkdir -p /out && echo -n 11 >> /out/foo
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -4086,7 +4085,7 @@ ONBUILD RUN mkdir -p /out && echo -n 11 >> /out/foo
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "foo"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "foo"))
 	require.NoError(t, err)
 	require.Equal(t, "11", string(dt))
 }
@@ -4245,7 +4244,7 @@ COPY --from=base unique /
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -4271,16 +4270,16 @@ COPY --from=base unique /
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "const"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "const"))
 	require.NoError(t, err)
 	require.Equal(t, "foobar", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "unique"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "unique"))
 	require.NoError(t, err)
 
 	ensurePruneAll(t, c, sb)
 
-	destDir, err = ioutil.TempDir("", "buildkit")
+	destDir, err = os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -4301,15 +4300,15 @@ COPY --from=base unique /
 	}, nil)
 	require.NoError(t, err)
 
-	dt2, err := ioutil.ReadFile(filepath.Join(destDir, "const"))
+	dt2, err := os.ReadFile(filepath.Join(destDir, "const"))
 	require.NoError(t, err)
 	require.Equal(t, "foobar", string(dt2))
 
-	dt2, err = ioutil.ReadFile(filepath.Join(destDir, "unique"))
+	dt2, err = os.ReadFile(filepath.Join(destDir, "unique"))
 	require.NoError(t, err)
 	require.Equal(t, string(dt), string(dt2))
 
-	destDir, err = ioutil.TempDir("", "buildkit")
+	destDir, err = os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 }
@@ -4335,7 +4334,7 @@ RUN echo bar > bar
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -4416,7 +4415,7 @@ RUN echo bar > bar
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -4497,7 +4496,7 @@ COPY --from=s1 unique2 /
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -4518,7 +4517,7 @@ COPY --from=s1 unique2 /
 	_, err = f.Solve(sb.Context(), c, opt, nil)
 	require.NoError(t, err)
 
-	destDir2, err := ioutil.TempDir("", "buildkit")
+	destDir2, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -4528,22 +4527,22 @@ COPY --from=s1 unique2 /
 	_, err = f.Solve(sb.Context(), c, opt, nil)
 	require.NoError(t, err)
 
-	unique1Dir1, err := ioutil.ReadFile(filepath.Join(destDir, "unique"))
+	unique1Dir1, err := os.ReadFile(filepath.Join(destDir, "unique"))
 	require.NoError(t, err)
 
-	unique1Dir2, err := ioutil.ReadFile(filepath.Join(destDir2, "unique"))
+	unique1Dir2, err := os.ReadFile(filepath.Join(destDir2, "unique"))
 	require.NoError(t, err)
 
-	unique2Dir1, err := ioutil.ReadFile(filepath.Join(destDir, "unique2"))
+	unique2Dir1, err := os.ReadFile(filepath.Join(destDir, "unique2"))
 	require.NoError(t, err)
 
-	unique2Dir2, err := ioutil.ReadFile(filepath.Join(destDir2, "unique2"))
+	unique2Dir2, err := os.ReadFile(filepath.Join(destDir2, "unique2"))
 	require.NoError(t, err)
 
 	require.NotEqual(t, string(unique1Dir1), string(unique1Dir2))
 	require.NotEqual(t, string(unique2Dir1), string(unique2Dir2))
 
-	destDir3, err := ioutil.TempDir("", "buildkit")
+	destDir3, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -4553,10 +4552,10 @@ COPY --from=s1 unique2 /
 	_, err = f.Solve(sb.Context(), c, opt, nil)
 	require.NoError(t, err)
 
-	unique1Dir3, err := ioutil.ReadFile(filepath.Join(destDir3, "unique"))
+	unique1Dir3, err := os.ReadFile(filepath.Join(destDir3, "unique"))
 	require.NoError(t, err)
 
-	unique2Dir3, err := ioutil.ReadFile(filepath.Join(destDir3, "unique2"))
+	unique2Dir3, err := os.ReadFile(filepath.Join(destDir3, "unique2"))
 	require.NoError(t, err)
 
 	require.Equal(t, string(unique1Dir2), string(unique1Dir3))
@@ -4585,7 +4584,7 @@ COPY foo2 bar2
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -4605,11 +4604,11 @@ COPY foo2 bar2
 	_, err = f.Solve(sb.Context(), c, opt, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "bar"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "bar"))
 	require.NoError(t, err)
 	require.Equal(t, "d0", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "bar2"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "bar2"))
 	require.NoError(t, err)
 	require.Equal(t, "d1", string(dt))
 }
@@ -4636,7 +4635,7 @@ COPY --from=build out .
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -4660,11 +4659,11 @@ COPY --from=build out .
 	_, err = f.Solve(sb.Context(), c, opt, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "platform"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "platform"))
 	require.NoError(t, err)
 	require.Equal(t, "darwin/ppc64le", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "os"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "os"))
 	require.NoError(t, err)
 	require.Equal(t, "freebsd", string(dt))
 }
@@ -4692,7 +4691,7 @@ COPY --from=build /out /
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -4717,12 +4716,12 @@ COPY --from=build /out /
 	_, err = f.Solve(sb.Context(), c, opt, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "out"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "out"))
 	require.NoError(t, err)
 	require.Equal(t, "hpvalue::npvalue::foocontents::::bazcontent", string(dt))
 
 	// repeat with changed default args should match the old cache
-	destDir, err = ioutil.TempDir("", "buildkit")
+	destDir, err = os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -4746,12 +4745,12 @@ COPY --from=build /out /
 	_, err = f.Solve(sb.Context(), c, opt, nil)
 	require.NoError(t, err)
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "out"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "out"))
 	require.NoError(t, err)
 	require.Equal(t, "hpvalue::npvalue::foocontents::::bazcontent", string(dt))
 
 	// changing actual value invalidates cache
-	destDir, err = ioutil.TempDir("", "buildkit")
+	destDir, err = os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -4775,7 +4774,7 @@ COPY --from=build /out /
 	_, err = f.Solve(sb.Context(), c, opt, nil)
 	require.NoError(t, err)
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "out"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "out"))
 	require.NoError(t, err)
 	require.Equal(t, "hpvalue2::::foocontents2::::bazcontent", string(dt))
 }
@@ -4869,7 +4868,7 @@ COPY foo bar
 	url := up.Add(buf)
 
 	// repeat with changed default args should match the old cache
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -4893,7 +4892,7 @@ COPY foo bar
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "bar"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "bar"))
 	require.NoError(t, err)
 	require.Equal(t, string(dt), "contents")
 }
@@ -4946,7 +4945,7 @@ COPY foo foo2
 		})
 	}
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -4964,7 +4963,7 @@ COPY foo foo2
 	}, "", frontend, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "foo3"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "foo3"))
 	require.NoError(t, err)
 	require.Equal(t, dt, []byte("data"))
 }
@@ -4976,7 +4975,7 @@ func testFrontendInputs(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -4997,7 +4996,7 @@ func testFrontendInputs(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	expected, err := ioutil.ReadFile(filepath.Join(destDir, "foo"))
+	expected, err := os.ReadFile(filepath.Join(destDir, "foo"))
 	require.NoError(t, err)
 
 	dockerfile := []byte(`
@@ -5027,7 +5026,7 @@ COPY foo foo2
 	}, nil)
 	require.NoError(t, err)
 
-	actual, err := ioutil.ReadFile(filepath.Join(destDir, "foo2"))
+	actual, err := os.ReadFile(filepath.Join(destDir, "foo2"))
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
 }
@@ -5189,7 +5188,7 @@ COPY --from=base /shmsize /
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -5210,7 +5209,7 @@ COPY --from=base /shmsize /
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "shmsize"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "shmsize"))
 	require.NoError(t, err)
 	require.Contains(t, string(dt), `size=131072k`)
 }
@@ -5234,7 +5233,7 @@ COPY --from=base /ulimit /
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -5255,7 +5254,7 @@ COPY --from=base /ulimit /
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "ulimit"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "ulimit"))
 	require.NoError(t, err)
 	require.Equal(t, `1062`, strings.TrimSpace(string(dt)))
 }
@@ -5283,7 +5282,7 @@ COPY --from=base /out /
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -5304,7 +5303,7 @@ COPY --from=base /out /
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "out"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "out"))
 	require.NoError(t, err)
 	require.Contains(t, strings.TrimSpace(string(dt)), `/foocgroup/buildkit/`)
 }
@@ -5331,7 +5330,7 @@ COPY --from=base /out /
 
 	f := getFrontend(t, sb)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -5352,7 +5351,7 @@ COPY --from=base /out /
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "out"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "out"))
 	require.NoError(t, err)
 	require.True(t, len(dt) > 0)
 }
@@ -5389,7 +5388,7 @@ COPY --from=base /o* /
 
 	f := getFrontend(t, sb)
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -5411,11 +5410,11 @@ COPY --from=base /o* /
 	}, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "out"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "out"))
 	require.NoError(t, err)
 	require.True(t, len(dt) > 0)
 
-	_, err = ioutil.ReadFile(filepath.Join(destDir, "out2"))
+	_, err = os.ReadFile(filepath.Join(destDir, "out2"))
 	require.Error(t, err)
 	require.True(t, errors.Is(err, os.ErrNotExist))
 }
@@ -5503,7 +5502,7 @@ COPY --from=build /foo /out /
 
 	product := "buildkit_test"
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -5522,11 +5521,11 @@ COPY --from=build /foo /out /
 	}, product, b, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "out"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "out"))
 	require.NoError(t, err)
 	require.Equal(t, "first\n", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "foo"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "foo"))
 	require.NoError(t, err)
 	require.Equal(t, "foo is bar\n", string(dt))
 }
@@ -5644,7 +5643,7 @@ COPY --from=build /foo /out /
 
 	product := "buildkit_test"
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -5663,25 +5662,25 @@ COPY --from=build /foo /out /
 	}, product, b, nil)
 	require.NoError(t, err)
 
-	dt, err := ioutil.ReadFile(filepath.Join(destDir, "linux_amd64/out"))
+	dt, err := os.ReadFile(filepath.Join(destDir, "linux_amd64/out"))
 	require.NoError(t, err)
 	require.Equal(t, "foo amd64\n", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "linux_amd64/foo"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "linux_amd64/foo"))
 	require.NoError(t, err)
 	require.Equal(t, "foo is bar-amd64\n", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "linux_arm64/out"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "linux_arm64/out"))
 	require.NoError(t, err)
 	require.Equal(t, "foo arm64\n", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(destDir, "linux_arm64/foo"))
+	dt, err = os.ReadFile(filepath.Join(destDir, "linux_arm64/foo"))
 	require.NoError(t, err)
 	require.Equal(t, "foo is bar-arm64\n", string(dt))
 }
 
 func tmpdir(appliers ...fstest.Applier) (string, error) {
-	tmpdir, err := ioutil.TempDir("", "buildkit-dockerfile")
+	tmpdir, err := os.MkdirTemp("", "buildkit-dockerfile")
 	if err != nil {
 		return "", err
 	}

--- a/frontend/dockerfile/dockerignore/dockerignore_test.go
+++ b/frontend/dockerfile/dockerignore/dockerignore_test.go
@@ -2,14 +2,13 @@ package dockerignore
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
 func TestReadAll(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "dockerignore-test")
+	tmpDir, err := os.MkdirTemp("", "dockerignore-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -26,7 +25,7 @@ func TestReadAll(t *testing.T) {
 
 	diName := filepath.Join(tmpDir, ".dockerignore")
 	content := fmt.Sprintf("test1\n/test2\n/a/file/here\n\nlastfile\n# this is a comment\n! /inverted/abs/path\n!\n! \n")
-	err = ioutil.WriteFile(diName, []byte(content), 0777)
+	err = os.WriteFile(diName, []byte(content), 0777)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/frontend/dockerfile/parser/parser_test.go
+++ b/frontend/dockerfile/parser/parser_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -56,7 +55,7 @@ func TestParseCases(t *testing.T) {
 			result, err := Parse(df)
 			require.NoError(t, err, dockerfile)
 
-			content, err := ioutil.ReadFile(resultfile)
+			content, err := os.ReadFile(resultfile)
 			require.NoError(t, err, resultfile)
 
 			if runtime.GOOS == "windows" {

--- a/frontend/frontend_test.go
+++ b/frontend/frontend_test.go
@@ -2,7 +2,6 @@ package frontend
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -43,7 +42,7 @@ func testReturnNil(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := ioutil.TempDir("", "buildkit")
+	destDir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
@@ -297,7 +296,7 @@ func testRefStatFile(t *testing.T, sb integration.Sandbox) {
 }
 
 func tmpdir(appliers ...fstest.Applier) (string, error) {
-	tmpdir, err := ioutil.TempDir("", "buildkit-frontend")
+	tmpdir, err := os.MkdirTemp("", "buildkit-frontend")
 	if err != nil {
 		return "", err
 	}

--- a/session/auth/authprovider/tokenseed.go
+++ b/session/auth/authprovider/tokenseed.go
@@ -3,7 +3,6 @@ package authprovider
 import (
 	"crypto/rand"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -47,7 +46,7 @@ func (ts *tokenSeeds) getSeed(host string) ([]byte, error) {
 	fp := filepath.Join(ts.dir, ".token_seed")
 
 	// we include client side randomness to avoid chosen plaintext attack from the daemon side
-	dt, err := ioutil.ReadFile(fp)
+	dt, err := os.ReadFile(fp)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) && !errors.Is(err, syscall.ENOTDIR) && !errors.Is(err, os.ErrPermission) {
 			return nil, err
@@ -68,7 +67,7 @@ func (ts *tokenSeeds) getSeed(host string) ([]byte, error) {
 		return nil, err
 	}
 
-	if err := ioutil.WriteFile(fp, dt, 0600); err != nil {
+	if err := os.WriteFile(fp, dt, 0600); err != nil {
 		if !errors.Is(err, syscall.EROFS) && !errors.Is(err, os.ErrPermission) {
 			return nil, err
 		}

--- a/session/content/content_test.go
+++ b/session/content/content_test.go
@@ -2,7 +2,6 @@ package content
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -24,7 +23,7 @@ func TestContentAttachable(t *testing.T) {
 	attachableStores := make(map[string]content.Store)
 	testBlobs := make(map[string]map[digest.Digest][]byte)
 	for _, id := range ids {
-		tmpDir, err := ioutil.TempDir("", "contenttest")
+		tmpDir, err := os.MkdirTemp("", "contenttest")
 		require.NoError(t, err)
 		defer os.RemoveAll(tmpDir)
 		store, err := local.NewStore(tmpDir)

--- a/session/filesync/filesync_test.go
+++ b/session/filesync/filesync_test.go
@@ -2,7 +2,7 @@ package filesync
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -16,16 +16,16 @@ import (
 func TestFileSyncIncludePatterns(t *testing.T) {
 	ctx := context.TODO()
 	t.Parallel()
-	tmpDir, err := ioutil.TempDir("", "fsynctest")
+	tmpDir, err := os.MkdirTemp("", "fsynctest")
 	require.NoError(t, err)
 
-	destDir, err := ioutil.TempDir("", "fsynctest")
+	destDir, err := os.MkdirTemp("", "fsynctest")
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(filepath.Join(tmpDir, "foo"), []byte("content1"), 0600)
+	err = os.WriteFile(filepath.Join(tmpDir, "foo"), []byte("content1"), 0600)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(filepath.Join(tmpDir, "bar"), []byte("content2"), 0600)
+	err = os.WriteFile(filepath.Join(tmpDir, "bar"), []byte("content2"), 0600)
 	require.NoError(t, err)
 
 	s, err := session.NewSession(ctx, "foo", "bar")
@@ -58,10 +58,10 @@ func TestFileSyncIncludePatterns(t *testing.T) {
 			return err
 		}
 
-		_, err = ioutil.ReadFile(filepath.Join(destDir, "foo"))
+		_, err = os.ReadFile(filepath.Join(destDir, "foo"))
 		assert.Error(t, err)
 
-		dt, err := ioutil.ReadFile(filepath.Join(destDir, "bar"))
+		dt, err := os.ReadFile(filepath.Join(destDir, "bar"))
 		if err != nil {
 			return err
 		}

--- a/session/secrets/secretsprovider/store.go
+++ b/session/secrets/secretsprovider/store.go
@@ -2,7 +2,6 @@ package secretsprovider
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 
 	"github.com/moby/buildkit/session/secrets"
@@ -57,7 +56,7 @@ func (fs *fileStore) GetSecret(ctx context.Context, id string) ([]byte, error) {
 	if v.Env != "" {
 		return []byte(os.Getenv(v.Env)), nil
 	}
-	dt, err := ioutil.ReadFile(v.FilePath)
+	dt, err := os.ReadFile(v.FilePath)
 	if err != nil {
 		return nil, err
 	}

--- a/session/sshforward/ssh.go
+++ b/session/sshforward/ssh.go
@@ -1,7 +1,6 @@
 package sshforward
 
 import (
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -64,7 +63,7 @@ type SocketOpt struct {
 }
 
 func MountSSHSocket(ctx context.Context, c session.Caller, opt SocketOpt) (sockPath string, closer func() error, err error) {
-	dir, err := ioutil.TempDir("", ".buildkit-ssh-sock")
+	dir, err := os.MkdirTemp("", ".buildkit-ssh-sock")
 	if err != nil {
 		return "", nil, errors.WithStack(err)
 	}

--- a/session/sshforward/sshprovider/agentprovider.go
+++ b/session/sshforward/sshprovider/agentprovider.go
@@ -3,7 +3,6 @@ package sshprovider
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"runtime"
@@ -166,7 +165,7 @@ func toAgentSource(paths []string) (source, error) {
 		if err != nil {
 			return source{}, errors.Wrapf(err, "failed to open %s", p)
 		}
-		dt, err := ioutil.ReadAll(&io.LimitedReader{R: f, N: 100 * 1024})
+		dt, err := io.ReadAll(&io.LimitedReader{R: f, N: 100 * 1024})
 		if err != nil {
 			return source{}, errors.Wrapf(err, "failed to read %s", p)
 		}

--- a/snapshot/localmounter_unix.go
+++ b/snapshot/localmounter_unix.go
@@ -4,7 +4,6 @@
 package snapshot
 
 import (
-	"io/ioutil"
 	"os"
 	"syscall"
 
@@ -38,7 +37,7 @@ func (lm *localMounter) Mount() (string, error) {
 		}
 	}
 
-	dir, err := ioutil.TempDir("", "buildkit-mount")
+	dir, err := os.MkdirTemp("", "buildkit-mount")
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create temp dir")
 	}

--- a/snapshot/snapshotter_test.go
+++ b/snapshot/snapshotter_test.go
@@ -6,7 +6,6 @@ package snapshot
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,7 +47,7 @@ func newSnapshotter(ctx context.Context, snapshotterName string) (_ context.Cont
 		}
 	}()
 
-	tmpdir, err := ioutil.TempDir("", "buildkit-test")
+	tmpdir, err := os.MkdirTemp("", "buildkit-test")
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/solver/bboltcachestorage/storage_test.go
+++ b/solver/bboltcachestorage/storage_test.go
@@ -1,7 +1,6 @@
 package bboltcachestorage
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,7 +12,7 @@ import (
 
 func TestBoltCacheStorage(t *testing.T) {
 	testutil.RunCacheStorageTests(t, func() (solver.CacheKeyStorage, func()) {
-		tmpDir, err := ioutil.TempDir("", "storage")
+		tmpDir, err := os.MkdirTemp("", "storage")
 		require.NoError(t, err)
 
 		cleanup := func() {

--- a/solver/jobs_test.go
+++ b/solver/jobs_test.go
@@ -1,7 +1,6 @@
 package solver
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -62,7 +61,7 @@ func testParallelism(t *testing.T, sb integration.Sandbox) {
 
 	timeStart := time.Now()
 	eg, egCtx := errgroup.WithContext(ctx)
-	tmpDir, err := ioutil.TempDir("", "solver-jobs-test-")
+	tmpDir, err := os.MkdirTemp("", "solver-jobs-test-")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 	solveOpt := client.SolveOpt{

--- a/solver/llbsolver/file/backend.go
+++ b/solver/llbsolver/file/backend.go
@@ -2,7 +2,6 @@ package file
 
 import (
 	"context"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -110,7 +109,7 @@ func mkfile(ctx context.Context, d string, action pb.FileActionMkFile, user *cop
 		return err
 	}
 
-	if err := ioutil.WriteFile(p, action.Data, os.FileMode(action.Mode)&0777); err != nil {
+	if err := os.WriteFile(p, action.Data, os.FileMode(action.Mode)&0777); err != nil {
 		return err
 	}
 

--- a/solver/llbsolver/mounts/mount.go
+++ b/solver/llbsolver/mounts/mount.go
@@ -3,7 +3,6 @@ package mounts
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -282,7 +281,7 @@ type secretMountInstance struct {
 }
 
 func (sm *secretMountInstance) Mount() ([]mount.Mount, func() error, error) {
-	dir, err := ioutil.TempDir("", "buildkit-secrets")
+	dir, err := os.MkdirTemp("", "buildkit-secrets")
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to create temp dir")
 	}
@@ -320,7 +319,7 @@ func (sm *secretMountInstance) Mount() ([]mount.Mount, func() error, error) {
 
 	randID := identity.NewID()
 	fp := filepath.Join(dir, randID)
-	if err := ioutil.WriteFile(fp, sm.sm.data, 0600); err != nil {
+	if err := os.WriteFile(fp, sm.sm.data, 0600); err != nil {
 		cleanup()
 		return nil, nil, err
 	}

--- a/solver/llbsolver/mounts/mount_test.go
+++ b/solver/llbsolver/mounts/mount_test.go
@@ -2,7 +2,6 @@ package mounts
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -53,7 +52,7 @@ func newCacheManager(ctx context.Context, opt cmOpt) (co *cmOut, cleanup func() 
 		opt.snapshotterName = "native"
 	}
 
-	tmpdir, err := ioutil.TempDir("", "cachemanager")
+	tmpdir, err := os.MkdirTemp("", "cachemanager")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -153,7 +152,7 @@ func TestCacheMountPrivateRefs(t *testing.T) {
 	t.Parallel()
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := ioutil.TempDir("", "cachemanager")
+	tmpdir, err := os.MkdirTemp("", "cachemanager")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -220,7 +219,7 @@ func TestCacheMountSharedRefs(t *testing.T) {
 	t.Parallel()
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := ioutil.TempDir("", "cachemanager")
+	tmpdir, err := os.MkdirTemp("", "cachemanager")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -270,7 +269,7 @@ func TestCacheMountLockedRefs(t *testing.T) {
 	t.Parallel()
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := ioutil.TempDir("", "cachemanager")
+	tmpdir, err := os.MkdirTemp("", "cachemanager")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -333,7 +332,7 @@ func TestCacheMountSharedRefsDeadlock(t *testing.T) {
 	// not parallel
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := ioutil.TempDir("", "cachemanager")
+	tmpdir, err := os.MkdirTemp("", "cachemanager")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 

--- a/solver/llbsolver/ops/exec_binfmt.go
+++ b/solver/llbsolver/ops/exec_binfmt.go
@@ -2,7 +2,6 @@ package ops
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -47,7 +46,7 @@ type staticEmulatorMount struct {
 }
 
 func (m *staticEmulatorMount) Mount() ([]mount.Mount, func() error, error) {
-	tmpdir, err := ioutil.TempDir("", "buildkit-qemu-emulator")
+	tmpdir, err := os.MkdirTemp("", "buildkit-qemu-emulator")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/source/git/gitsource.go
+++ b/source/git/gitsource.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"os/exec"
@@ -273,7 +272,7 @@ func (gs *gitSourceHandler) mountKnownHosts(ctx context.Context) (string, func()
 	if gs.src.KnownSSHHosts == "" {
 		return "", nil, errors.Errorf("no configured known hosts forwarded from the client")
 	}
-	knownHosts, err := ioutil.TempFile("", "")
+	knownHosts, err := os.CreateTemp("", "")
 	if err != nil {
 		return "", nil, err
 	}
@@ -543,7 +542,7 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context, g session.Group) (out 
 	} else {
 		cd := checkoutDir
 		if subdir != "." {
-			cd, err = ioutil.TempDir(cd, "checkout")
+			cd, err = os.MkdirTemp(cd, "checkout")
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to create temporary checkout dir")
 			}

--- a/source/git/gitsource_test.go
+++ b/source/git/gitsource_test.go
@@ -2,7 +2,6 @@ package git
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -52,13 +51,13 @@ func testRepeatedFetch(t *testing.T, keepGitDir bool) {
 	t.Parallel()
 	ctx := context.TODO()
 
-	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	tmpdir, err := os.MkdirTemp("", "buildkit-state")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
 	gs := setupGitSource(t, tmpdir)
 
-	repodir, err := ioutil.TempDir("", "buildkit-gitsource")
+	repodir, err := os.MkdirTemp("", "buildkit-gitsource")
 	require.NoError(t, err)
 	defer os.RemoveAll(repodir)
 
@@ -94,7 +93,7 @@ func testRepeatedFetch(t *testing.T, keepGitDir bool) {
 	require.NoError(t, err)
 	defer lm.Unmount()
 
-	dt, err := ioutil.ReadFile(filepath.Join(dir, "def"))
+	dt, err := os.ReadFile(filepath.Join(dir, "def"))
 	require.NoError(t, err)
 
 	require.Equal(t, "bar\n", string(dt))
@@ -145,12 +144,12 @@ func testRepeatedFetch(t *testing.T, keepGitDir bool) {
 	require.NoError(t, err)
 	defer lm.Unmount()
 
-	dt, err = ioutil.ReadFile(filepath.Join(dir, "ghi"))
+	dt, err = os.ReadFile(filepath.Join(dir, "ghi"))
 	require.NoError(t, err)
 
 	require.Equal(t, "baz\n", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(dir, "sub/subfile"))
+	dt, err = os.ReadFile(filepath.Join(dir, "sub/subfile"))
 	require.NoError(t, err)
 
 	require.Equal(t, "subcontents\n", string(dt))
@@ -171,13 +170,13 @@ func testFetchBySHA(t *testing.T, keepGitDir bool) {
 	t.Parallel()
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	tmpdir, err := os.MkdirTemp("", "buildkit-state")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
 	gs := setupGitSource(t, tmpdir)
 
-	repodir, err := ioutil.TempDir("", "buildkit-gitsource")
+	repodir, err := os.MkdirTemp("", "buildkit-gitsource")
 	require.NoError(t, err)
 	defer os.RemoveAll(repodir)
 
@@ -222,12 +221,12 @@ func testFetchBySHA(t *testing.T, keepGitDir bool) {
 	require.NoError(t, err)
 	defer lm.Unmount()
 
-	dt, err := ioutil.ReadFile(filepath.Join(dir, "ghi"))
+	dt, err := os.ReadFile(filepath.Join(dir, "ghi"))
 	require.NoError(t, err)
 
 	require.Equal(t, "baz\n", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(dir, "sub/subfile"))
+	dt, err = os.ReadFile(filepath.Join(dir, "sub/subfile"))
 	require.NoError(t, err)
 
 	require.Equal(t, "subcontents\n", string(dt))
@@ -257,13 +256,13 @@ func testFetchByTag(t *testing.T, tag, expectedCommitSubject string, isAnnotated
 	t.Parallel()
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	tmpdir, err := os.MkdirTemp("", "buildkit-state")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
 	gs := setupGitSource(t, tmpdir)
 
-	repodir, err := ioutil.TempDir("", "buildkit-gitsource")
+	repodir, err := os.MkdirTemp("", "buildkit-gitsource")
 	require.NoError(t, err)
 	defer os.RemoveAll(repodir)
 
@@ -299,11 +298,11 @@ func testFetchByTag(t *testing.T, tag, expectedCommitSubject string, isAnnotated
 	require.NoError(t, err)
 	defer lm.Unmount()
 
-	dt, err := ioutil.ReadFile(filepath.Join(dir, "def"))
+	dt, err := os.ReadFile(filepath.Join(dir, "def"))
 	require.NoError(t, err)
 	require.Equal(t, "bar\n", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(dir, "foo13"))
+	dt, err = os.ReadFile(filepath.Join(dir, "foo13"))
 	if hasFoo13File {
 		require.Nil(t, err)
 		require.Equal(t, "sbb\n", string(dt))
@@ -351,20 +350,20 @@ func testMultipleRepos(t *testing.T, keepGitDir bool) {
 	t.Parallel()
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	tmpdir, err := os.MkdirTemp("", "buildkit-state")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
 	gs := setupGitSource(t, tmpdir)
 
-	repodir, err := ioutil.TempDir("", "buildkit-gitsource")
+	repodir, err := os.MkdirTemp("", "buildkit-gitsource")
 	require.NoError(t, err)
 	defer os.RemoveAll(repodir)
 
 	repodir, err = setupGitRepo(repodir)
 	require.NoError(t, err)
 
-	repodir2, err := ioutil.TempDir("", "buildkit-gitsource")
+	repodir2, err := os.MkdirTemp("", "buildkit-gitsource")
 	require.NoError(t, err)
 	defer os.RemoveAll(repodir2)
 
@@ -429,12 +428,12 @@ func testMultipleRepos(t *testing.T, keepGitDir bool) {
 	require.NoError(t, err)
 	defer lm.Unmount()
 
-	dt, err := ioutil.ReadFile(filepath.Join(dir, "def"))
+	dt, err := os.ReadFile(filepath.Join(dir, "def"))
 	require.NoError(t, err)
 
 	require.Equal(t, "bar\n", string(dt))
 
-	dt, err = ioutil.ReadFile(filepath.Join(dir2, "xyz"))
+	dt, err = os.ReadFile(filepath.Join(dir2, "xyz"))
 	require.NoError(t, err)
 
 	require.Equal(t, "xyz\n", string(dt))
@@ -448,7 +447,7 @@ func TestCredentialRedaction(t *testing.T) {
 	t.Parallel()
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	tmpdir, err := os.MkdirTemp("", "buildkit-state")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -480,13 +479,13 @@ func testSubdir(t *testing.T, keepGitDir bool) {
 	t.Parallel()
 	ctx := context.TODO()
 
-	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	tmpdir, err := os.MkdirTemp("", "buildkit-state")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
 	gs := setupGitSource(t, tmpdir)
 
-	repodir, err := ioutil.TempDir("", "buildkit-gitsource")
+	repodir, err := os.MkdirTemp("", "buildkit-gitsource")
 	require.NoError(t, err)
 	defer os.RemoveAll(repodir)
 
@@ -531,12 +530,12 @@ func testSubdir(t *testing.T, keepGitDir bool) {
 	require.NoError(t, err)
 	defer lm.Unmount()
 
-	fis, err := ioutil.ReadDir(dir)
+	fis, err := os.ReadDir(dir)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(fis))
 
-	dt, err := ioutil.ReadFile(filepath.Join(dir, "bar"))
+	dt, err := os.ReadFile(filepath.Join(dir, "bar"))
 	require.NoError(t, err)
 
 	require.Equal(t, "abc\n", string(dt))

--- a/source/http/httpsource_test.go
+++ b/source/http/httpsource_test.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -36,7 +35,7 @@ func TestHTTPSource(t *testing.T) {
 	t.Parallel()
 	ctx := context.TODO()
 
-	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	tmpdir, err := os.MkdirTemp("", "buildkit-state")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -159,7 +158,7 @@ func TestHTTPDefaultName(t *testing.T) {
 	t.Parallel()
 	ctx := context.TODO()
 
-	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	tmpdir, err := os.MkdirTemp("", "buildkit-state")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -209,7 +208,7 @@ func TestHTTPInvalidURL(t *testing.T) {
 	t.Parallel()
 	ctx := context.TODO()
 
-	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	tmpdir, err := os.MkdirTemp("", "buildkit-state")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -237,7 +236,7 @@ func TestHTTPChecksum(t *testing.T) {
 	t.Parallel()
 	ctx := context.TODO()
 
-	tmpdir, err := ioutil.TempDir("", "buildkit-state")
+	tmpdir, err := os.MkdirTemp("", "buildkit-state")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -328,7 +327,7 @@ func readFile(ctx context.Context, ref cache.ImmutableRef, fp string) ([]byte, e
 
 	defer lm.Unmount()
 
-	dt, err := ioutil.ReadFile(filepath.Join(dir, fp))
+	dt, err := os.ReadFile(filepath.Join(dir, fp))
 	if err != nil {
 		return nil, err
 	}

--- a/util/archutil/check_unix.go
+++ b/util/archutil/check_unix.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -23,7 +22,7 @@ func withChroot(cmd *exec.Cmd, dir string) {
 }
 
 func check(arch, bin string) (string, error) {
-	tmpdir, err := ioutil.TempDir("", "qemu-check")
+	tmpdir, err := os.MkdirTemp("", "qemu-check")
 	if err != nil {
 		return "", err
 	}

--- a/util/contentutil/buffer.go
+++ b/util/contentutil/buffer.go
@@ -3,7 +3,7 @@ package contentutil
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"sync"
 	"time"
 
@@ -64,7 +64,7 @@ func (b *buffer) ReaderAt(ctx context.Context, desc ocispecs.Descriptor) (conten
 	if err != nil {
 		return nil, err
 	}
-	return &readerAt{Reader: r, Closer: ioutil.NopCloser(r), size: int64(r.Len())}, nil
+	return &readerAt{Reader: r, Closer: io.NopCloser(r), size: int64(r.Len())}, nil
 }
 
 func (b *buffer) getBytesReader(ctx context.Context, dgst digest.Digest) (*bytes.Reader, error) {

--- a/util/imageutil/schema1.go
+++ b/util/imageutil/schema1.go
@@ -3,7 +3,7 @@ package imageutil
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"strings"
 	"time"
 
@@ -19,7 +19,7 @@ func readSchema1Config(ctx context.Context, ref string, desc ocispecs.Descriptor
 		return "", nil, err
 	}
 	defer rc.Close()
-	dt, err := ioutil.ReadAll(rc)
+	dt, err := io.ReadAll(rc)
 	if err != nil {
 		return "", nil, errors.Wrap(err, "failed to fetch schema1 manifest")
 	}

--- a/util/overlay/overlay_linux.go
+++ b/util/overlay/overlay_linux.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -114,7 +113,7 @@ func GetOverlayLayers(m mount.Mount) ([]string, error) {
 // WriteUpperdir writes a layer tar archive into the specified writer, based on
 // the diff information stored in the upperdir.
 func WriteUpperdir(ctx context.Context, w io.Writer, upperdir string, lower []mount.Mount) error {
-	emptyLower, err := ioutil.TempDir("", "buildkit") // empty directory used for the lower of diff view
+	emptyLower, err := os.MkdirTemp("", "buildkit") // empty directory used for the lower of diff view
 	if err != nil {
 		return errors.Wrapf(err, "failed to create temp dir")
 	}

--- a/util/overlay/overlay_linux_test.go
+++ b/util/overlay/overlay_linux_test.go
@@ -6,7 +6,6 @@ package overlay
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -337,7 +336,7 @@ func TestLchtimes(t *testing.T) {
 }
 
 func testDiffWithBase(base, diff fstest.Applier, expected []TestChange, opts ...string) error {
-	t1, err := ioutil.TempDir("", "diff-with-base-lower-")
+	t1, err := os.MkdirTemp("", "diff-with-base-lower-")
 	if err != nil {
 		return errors.Wrap(err, "failed to create temp dir")
 	}
@@ -347,13 +346,13 @@ func testDiffWithBase(base, diff fstest.Applier, expected []TestChange, opts ...
 		return errors.Wrap(err, "failed to apply base filesystem")
 	}
 
-	tupper, err := ioutil.TempDir("", "diff-with-base-upperdir-")
+	tupper, err := os.MkdirTemp("", "diff-with-base-upperdir-")
 	if err != nil {
 		return errors.Wrap(err, "failed to create temp dir")
 	}
 	defer os.RemoveAll(tupper)
 
-	workdir, err := ioutil.TempDir("", "diff-with-base-workdir-")
+	workdir, err := os.MkdirTemp("", "diff-with-base-workdir-")
 	if err != nil {
 		return errors.Wrap(err, "failed to create temp dir")
 	}
@@ -420,7 +419,7 @@ func collectAndCheckChanges(base, upperdir string, expected []TestChange) error 
 	ctx := context.Background()
 	changes := []TestChange{}
 
-	emptyLower, err := ioutil.TempDir("", "buildkit-test-emptylower") // empty directory used for the lower of diff view
+	emptyLower, err := os.MkdirTemp("", "buildkit-test-emptylower") // empty directory used for the lower of diff view
 	if err != nil {
 		return errors.Wrapf(err, "failed to create temp dir")
 	}

--- a/util/resolver/resolver.go
+++ b/util/resolver/resolver.go
@@ -3,7 +3,6 @@ package resolver
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -67,7 +66,7 @@ func fillInsecureOpts(host string, c config.RegistryConfig, h docker.RegistryHos
 
 func loadTLSConfig(c config.RegistryConfig) (*tls.Config, error) {
 	for _, d := range c.TLSConfigDir {
-		fs, err := ioutil.ReadDir(d)
+		fs, err := os.ReadDir(d)
 		if err != nil && !errors.Is(err, os.ErrNotExist) && !errors.Is(err, os.ErrPermission) {
 			return nil, errors.WithStack(err)
 		}
@@ -98,7 +97,7 @@ func loadTLSConfig(c config.RegistryConfig) (*tls.Config, error) {
 	}
 
 	for _, p := range c.RootCAs {
-		dt, err := ioutil.ReadFile(p)
+		dt, err := os.ReadFile(p)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to read %s", p)
 		}

--- a/util/testutil/integration/containerd.go
+++ b/util/testutil/integration/containerd.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -110,7 +109,7 @@ func (c *containerd) New(ctx context.Context, cfg *BackendConfig) (b Backend, cl
 		rootless = true
 	}
 
-	tmpdir, err := ioutil.TempDir("", "bktest_containerd")
+	tmpdir, err := os.MkdirTemp("", "bktest_containerd")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -158,7 +157,7 @@ disabled_plugins = ["cri"]
 	}
 
 	configFile := filepath.Join(tmpdir, "config.toml")
-	if err := ioutil.WriteFile(configFile, []byte(config), 0644); err != nil {
+	if err := os.WriteFile(configFile, []byte(config), 0644); err != nil {
 		return nil, nil, err
 	}
 

--- a/util/testutil/integration/dockerd.go
+++ b/util/testutil/integration/dockerd.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"time"
@@ -58,7 +57,7 @@ func (c dockerd) New(ctx context.Context, cfg *BackendConfig) (b Backend, cl fun
 	var proxyGroup errgroup.Group
 	deferF.append(proxyGroup.Wait)
 
-	workDir, err := ioutil.TempDir("", "integration")
+	workDir, err := os.MkdirTemp("", "integration")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -98,7 +97,7 @@ func (c dockerd) New(ctx context.Context, cfg *BackendConfig) (b Backend, cl fun
 	// Create a file descriptor to be used as a Unix domain socket.
 	// Remove it immediately (the name will still be valid for the socket) so that
 	// we don't leave files all over the users tmp tree.
-	f, err := ioutil.TempFile("", "buildkit-integration")
+	f, err := os.CreateTemp("", "buildkit-integration")
 	if err != nil {
 		return
 	}

--- a/util/testutil/integration/frombinary.go
+++ b/util/testutil/integration/frombinary.go
@@ -3,7 +3,6 @@ package integration
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 
 	"github.com/containerd/containerd/content"
@@ -15,7 +14,7 @@ import (
 func providerFromBinary(fn string) (_ ocispecs.Descriptor, _ content.Provider, _ func(), err error) {
 	ctx := context.TODO()
 
-	tmpDir, err := ioutil.TempDir("", "buildkit-state")
+	tmpDir, err := os.MkdirTemp("", "buildkit-state")
 	if err != nil {
 		return ocispecs.Descriptor{}, nil, nil, err
 	}

--- a/util/testutil/integration/registry.go
+++ b/util/testutil/integration/registry.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -31,7 +30,7 @@ func NewRegistry(dir string) (url string, cl func() error, err error) {
 	}()
 
 	if dir == "" {
-		tmpdir, err := ioutil.TempDir("", "test-registry")
+		tmpdir, err := os.MkdirTemp("", "test-registry")
 		if err != nil {
 			return "", nil, err
 		}
@@ -52,7 +51,7 @@ http:
     addr: 127.0.0.1:0
 `, filepath.Join(dir, "data"))
 
-		if err := ioutil.WriteFile(filepath.Join(dir, "config.yaml"), []byte(template), 0600); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(template), 0600); err != nil {
 			return "", nil, err
 		}
 	}
@@ -84,7 +83,7 @@ func detectPort(ctx context.Context, rc io.ReadCloser) (string, error) {
 	found := make(chan struct{})
 	defer func() {
 		close(found)
-		go io.Copy(ioutil.Discard, rc)
+		go io.Copy(io.Discard, rc)
 	}()
 
 	go func() {

--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -295,7 +294,7 @@ mirrors=["%s"]
 }
 
 func writeConfig(updaters []ConfigUpdater) (string, error) {
-	tmpdir, err := ioutil.TempDir("", "bktest_config")
+	tmpdir, err := os.MkdirTemp("", "bktest_config")
 	if err != nil {
 		return "", err
 	}
@@ -308,7 +307,7 @@ func writeConfig(updaters []ConfigUpdater) (string, error) {
 		s = upt.UpdateConfigFile(s)
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(tmpdir, buildkitdConfigFile), []byte(s), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpdir, buildkitdConfigFile), []byte(s), 0644); err != nil {
 		return "", err
 	}
 	return tmpdir, nil
@@ -428,7 +427,7 @@ func runStargzSnapshotter(cfg *BackendConfig) (address string, cl func() error, 
 		}
 	}()
 
-	tmpStargzDir, err := ioutil.TempDir("", "bktest_containerd_stargz_grpc")
+	tmpStargzDir, err := os.MkdirTemp("", "bktest_containerd_stargz_grpc")
 	if err != nil {
 		return "", nil, err
 	}

--- a/util/testutil/integration/sandbox.go
+++ b/util/testutil/integration/sandbox.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -167,7 +166,7 @@ func runBuildkitd(ctx context.Context, conf *BackendConfig, args []string, logs 
 		args = append(args, "--config="+conf.ConfigFile)
 	}
 
-	tmpdir, err := ioutil.TempDir("", "bktest_buildkitd")
+	tmpdir, err := os.MkdirTemp("", "bktest_buildkitd")
 	if err != nil {
 		return "", nil, err
 	}

--- a/util/testutil/tar.go
+++ b/util/testutil/tar.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"io"
-	"io/ioutil"
 
 	"github.com/pkg/errors"
 )
@@ -41,7 +40,7 @@ func ReadTarToMap(dt []byte, compressed bool) (map[string]*TarItem, error) {
 
 		var dt []byte
 		if h.Typeflag == tar.TypeReg {
-			dt, err = ioutil.ReadAll(tr)
+			dt, err = io.ReadAll(tr)
 			if err != nil {
 				return nil, errors.Wrapf(err, "error reading file")
 			}

--- a/util/winlayers/applier.go
+++ b/util/winlayers/applier.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"context"
 	"io"
-	"io/ioutil"
 	"runtime"
 	"strings"
 	"sync"
@@ -87,7 +86,7 @@ func (s *winApplier) Apply(ctx context.Context, desc ocispecs.Descriptor, mounts
 		}
 
 		// Read any trailing data
-		if _, err := io.Copy(ioutil.Discard, rc); err != nil {
+		if _, err := io.Copy(io.Discard, rc); err != nil {
 			discard(err)
 			return err
 		}
@@ -144,7 +143,7 @@ func filter(in io.Reader, f func(*tar.Header) bool) (io.Reader, func(error)) {
 					}
 				} else {
 					if h.Size > 0 {
-						if _, err := io.Copy(ioutil.Discard, tarReader); err != nil {
+						if _, err := io.Copy(io.Discard, tarReader); err != nil {
 							return err
 						}
 					}

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -3,7 +3,6 @@ package base
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -468,11 +467,11 @@ func (w *Worker) FromRemote(ctx context.Context, remote *solver.Remote) (ref cac
 // If not exist, it creates a random one,
 func ID(root string) (string, error) {
 	f := filepath.Join(root, "workerid")
-	b, err := ioutil.ReadFile(f)
+	b, err := os.ReadFile(f)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			id := identity.NewID()
-			err := ioutil.WriteFile(f, []byte(id), 0400)
+			err := os.WriteFile(f, []byte(id), 0400)
 			return id, err
 		}
 		return "", err

--- a/worker/base/worker_test.go
+++ b/worker/base/worker_test.go
@@ -1,7 +1,6 @@
 package base
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -10,7 +9,7 @@ import (
 
 func TestID(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := ioutil.TempDir("", "worker-base-test-id")
+	tmpdir, err := os.MkdirTemp("", "worker-base-test-id")
 	require.NoError(t, err)
 
 	id0, err := ID(tmpdir)

--- a/worker/containerd/containerd_test.go
+++ b/worker/containerd/containerd_test.go
@@ -5,7 +5,6 @@ package containerd
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -29,7 +28,7 @@ func TestContainerdWorkerIntegration(t *testing.T) {
 }
 
 func newWorkerOpt(t *testing.T, addr string) (base.WorkerOpt, func()) {
-	tmpdir, err := ioutil.TempDir("", "workertest")
+	tmpdir, err := os.MkdirTemp("", "workertest")
 	require.NoError(t, err)
 	cleanup := func() { os.RemoveAll(tmpdir) }
 	rootless := false

--- a/worker/runc/runc_test.go
+++ b/worker/runc/runc_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -30,7 +29,7 @@ import (
 )
 
 func newWorkerOpt(t *testing.T, processMode oci.ProcessMode) (base.WorkerOpt, func()) {
-	tmpdir, err := ioutil.TempDir("", "workertest")
+	tmpdir, err := os.MkdirTemp("", "workertest")
 	require.NoError(t, err)
 	cleanup := func() { os.RemoveAll(tmpdir) }
 
@@ -143,7 +142,7 @@ func TestRuncWorker(t *testing.T) {
 	require.NoError(t, err)
 
 	//Verifies fix for issue https://github.com/moby/buildkit/issues/429
-	dt, err := ioutil.ReadFile(filepath.Join(target, "run", "bar"))
+	dt, err := os.ReadFile(filepath.Join(target, "run", "bar"))
 
 	require.NoError(t, err)
 	require.Equal(t, string(dt), "foo\n")
@@ -199,7 +198,7 @@ func TestRuncWorkerNoProcessSandbox(t *testing.T) {
 
 	// ensure the procfs is shared
 	selfPID := os.Getpid()
-	selfCmdline, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/cmdline", selfPID))
+	selfCmdline, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", selfPID))
 	require.NoError(t, err)
 	meta := executor.Meta{
 		Args: []string{"/bin/cat", fmt.Sprintf("/proc/%d/cmdline", selfPID)},

--- a/worker/tests/common.go
+++ b/worker/tests/common.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"testing"
 	"time"
 
@@ -126,7 +125,7 @@ func TestWorkerExec(t *testing.T, w *base.Worker) {
 		Meta: executor.Meta{
 			Args: []string{"sh", "-c", "cat > /tmp/msg"},
 		},
-		Stdin:  ioutil.NopCloser(stdin),
+		Stdin:  io.NopCloser(stdin),
 		Stdout: &nopCloser{stdout},
 		Stderr: &nopCloser{stderr},
 	})


### PR DESCRIPTION
The package has been deprecated since Go 1.16: https://go.dev/doc/go1.16#ioutil