### PR TITLE
Bump Golang version from 1.16 to 1.17 in windows build CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
       -
         name: Cache Go modules
         uses: actions/cache@v2


### PR DESCRIPTION
Since go1.17 is set on all other containers, using go1.16 in only one pipeline can lead to unexpected behaviour
and difference during test.

This PR just update Golang version to 1.17 in `build.yaml` to have the same Go version everywhere in the CI

Signed-off-by: Vasek - Tom C <tom.chauveau@epitech.eu>