### PR TITLE
snapshot: use temporary lease during diffapply

### DIFF
--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -2243,6 +2243,20 @@ func TestDiffOp(t *testing.T) {
 	checkDiskUsage(ctx, t, cm, 0, 8)
 	require.NoError(t, cm.Prune(ctx, nil, client.PruneInfo{All: true}))
 	checkDiskUsage(ctx, t, cm, 0, 0)
+
+	// Test using nil as upper
+	newLower, err = cm.New(ctx, nil, nil)
+	require.NoError(t, err)
+	lowerB, err := newLower.Commit(ctx)
+	require.NoError(t, err)
+	diff, err = cm.Diff(ctx, lowerB, nil, nil)
+	require.NoError(t, err)
+	checkDiskUsage(ctx, t, cm, 2, 0)
+	require.NoError(t, lowerB.Release(ctx))
+	require.NoError(t, diff.Release(ctx))
+	checkDiskUsage(ctx, t, cm, 0, 2)
+	require.NoError(t, cm.Prune(ctx, nil, client.PruneInfo{All: true}))
+	checkDiskUsage(ctx, t, cm, 0, 0)
 }
 
 func TestLoadHalfFinalizedRef(t *testing.T) {

--- a/cache/refs.go
+++ b/cache/refs.go
@@ -533,7 +533,7 @@ func (cr *cacheRecord) layerDigestChain() []digest.Digest {
 	}
 	switch cr.kind() {
 	case Diff:
-		if cr.getBlob() == "" {
+		if cr.getBlob() == "" && cr.diffParents.upper != nil {
 			// this diff just reuses the upper blob
 			cr.layerDigestChainCache = cr.diffParents.upper.layerDigestChain()
 		} else {

--- a/snapshot/merge.go
+++ b/snapshot/merge.go
@@ -130,7 +130,7 @@ func (sn *mergeSnapshotter) Merge(ctx context.Context, key string, diffs []Diff,
 		diffs = diffs[baseIndex:]
 	}
 
-	tempLeaseCtx, done, err := leaseutil.WithLease(ctx, sn.lm, leaseutil.MakeTemporary)
+	ctx, done, err := leaseutil.WithLease(ctx, sn.lm, leaseutil.MakeTemporary)
 	if err != nil {
 		return errors.Wrap(err, "failed to create temporary lease for view mounts during merge")
 	}
@@ -138,7 +138,7 @@ func (sn *mergeSnapshotter) Merge(ctx context.Context, key string, diffs []Diff,
 
 	// Make the snapshot that will be merged into
 	prepareKey := identity.NewID()
-	if err := sn.Prepare(tempLeaseCtx, prepareKey, baseKey); err != nil {
+	if err := sn.Prepare(ctx, prepareKey, baseKey); err != nil {
 		return errors.Wrapf(err, "failed to prepare %q", key)
 	}
 	applyMounts, err := sn.Mounts(ctx, prepareKey)


### PR DESCRIPTION
A temporary lease ctx was previously made during the snapshotter Merge
method but it was not passed to diffApply, which may have meant that
temporary View snapshots created there could be garbage collected by
containerd at any time.

It's possible this was encountered in CI, but I was unable to reproduce
the failure after 1000 attempts locally, so this commit is just a best
guess at the problem.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

I can't be sure because I couldn't reproduce it but this is my best guess at the CI error @crazy-max pointed out [here](https://github.com/moby/buildkit/pull/2725#issuecomment-1066521712).

I also included a commit for a separate issue I noticed while fixing the main one: 

`cache: check that diff upper isn't nil`
Before this, if you called DiskUsage when there was a Diff ref that had
a nil upper and that ref had not yet had a blob set, the
layerDigestChain method would get a nil pointer exception.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>