### PR TITLE
integration: add helper for skipping tests with dockerd

### DIFF
--- a/client/build_test.go
+++ b/client/build_test.go
@@ -1649,7 +1649,7 @@ func testClientGatewayContainerSecurityMode(t *testing.T, sb integration.Sandbox
 		}
 		allowedEntitlements = []entitlements.Entitlement{}
 	} else {
-		skipDockerd(t, sb)
+		integration.SkipIfDockerd(t, sb)
 		assertCaps = func(caps uint64) {
 			/*
 				$ capsh --decode=0000003fffffffff

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -705,7 +705,7 @@ func testNetworkMode(t *testing.T, sb integration.Sandbox) {
 }
 
 func testPushByDigest(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -766,7 +766,7 @@ func testSecurityMode(t *testing.T, sb integration.Sandbox) {
 		}
 		allowedEntitlements = []entitlements.Entitlement{}
 	} else {
-		skipDockerd(t, sb)
+		integration.SkipIfDockerd(t, sb)
 		assertCaps = func(caps uint64) {
 			/*
 				$ capsh --decode=0000003fffffffff
@@ -833,7 +833,7 @@ func testSecurityModeSysfs(t *testing.T, sb integration.Sandbox) {
 	if secMode == securitySandbox {
 		allowedEntitlements = []entitlements.Entitlement{}
 	} else {
-		skipDockerd(t, sb)
+		integration.SkipIfDockerd(t, sb)
 		mode = llb.SecurityModeInsecure
 		allowedEntitlements = []entitlements.Entitlement{entitlements.EntitlementSecurityInsecure}
 	}
@@ -895,7 +895,7 @@ func testSecurityModeErrors(t *testing.T, sb integration.Sandbox) {
 }
 
 func testFrontendImageNaming(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -1892,7 +1892,7 @@ func testUser(t *testing.T, sb integration.Sandbox) {
 }
 
 func testOCIExporter(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -1995,7 +1995,7 @@ func testOCIExporter(t *testing.T, sb integration.Sandbox) {
 }
 
 func testFrontendMetadataReturn(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -2092,16 +2092,8 @@ func testFrontendUseSolveResults(t *testing.T, sb integration.Sandbox) {
 	require.Equal(t, dt, []byte("data"))
 }
 
-func skipDockerd(t *testing.T, sb integration.Sandbox) {
-	// TODO: remove me once dockerd supports the image and exporter.
-	t.Helper()
-	if os.Getenv("TEST_DOCKERD") == "1" {
-		t.Skip("dockerd missing a required exporter, cache exporter, or entitlement")
-	}
-}
-
 func testExporterTargetExists(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -2699,7 +2691,7 @@ func testPullZstdImage(t *testing.T, sb integration.Sandbox) {
 	require.Equal(t, dt, []byte("zstd"))
 }
 func testBuildPushAndValidate(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -2899,7 +2891,7 @@ func testBuildPushAndValidate(t *testing.T, sb integration.Sandbox) {
 }
 
 func testStargzLazyRegistryCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	requiresLinux(t)
 
 	cdAddress := sb.ContainerdAddress()
@@ -3047,7 +3039,7 @@ func testStargzLazyRegistryCacheImportExport(t *testing.T, sb integration.Sandbo
 }
 
 func testStargzLazyInlineCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	requiresLinux(t)
 
 	cdAddress := sb.ContainerdAddress()
@@ -3200,7 +3192,7 @@ func testStargzLazyInlineCacheImportExport(t *testing.T, sb integration.Sandbox)
 }
 
 func testStargzLazyPull(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	requiresLinux(t)
 
 	cdAddress := sb.ContainerdAddress()
@@ -3325,7 +3317,7 @@ func testStargzLazyPull(t *testing.T, sb integration.Sandbox) {
 }
 
 func testLazyImagePush(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	requiresLinux(t)
 
 	cdAddress := sb.ContainerdAddress()
@@ -3522,7 +3514,7 @@ func testZstdLocalCacheExport(t *testing.T, sb integration.Sandbox) {
 }
 
 func testUncompressedLocalCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	dir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
@@ -3544,7 +3536,7 @@ func testUncompressedLocalCacheImportExport(t *testing.T, sb integration.Sandbox
 }
 
 func testUncompressedRegistryCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	registry, err := sb.NewRegistry()
 	if errors.Is(err, integration.ErrRequirements) {
 		t.Skip(err.Error())
@@ -3569,7 +3561,7 @@ func testUncompressedRegistryCacheImportExport(t *testing.T, sb integration.Sand
 }
 
 func testZstdLocalCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	if sb.Name() == "containerd-1.4" {
 		// containerd 1.4 doesn't support zstd compression
 		return
@@ -3596,7 +3588,7 @@ func testZstdLocalCacheImportExport(t *testing.T, sb integration.Sandbox) {
 }
 
 func testZstdRegistryCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	if sb.Name() == "containerd-1.4" {
 		// containerd 1.4 doesn't support zstd compression
 		return
@@ -3692,7 +3684,7 @@ func testBasicCacheImportExport(t *testing.T, sb integration.Sandbox, cacheOptio
 }
 
 func testBasicRegistryCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	registry, err := sb.NewRegistry()
 	if errors.Is(err, integration.ErrRequirements) {
 		t.Skip(err.Error())
@@ -3709,7 +3701,7 @@ func testBasicRegistryCacheImportExport(t *testing.T, sb integration.Sandbox) {
 }
 
 func testMultipleRegistryCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	registry, err := sb.NewRegistry()
 	if errors.Is(err, integration.ErrRequirements) {
 		t.Skip(err.Error())
@@ -3732,7 +3724,7 @@ func testMultipleRegistryCacheImportExport(t *testing.T, sb integration.Sandbox)
 }
 
 func testBasicLocalCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	dir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
@@ -3752,7 +3744,7 @@ func testBasicLocalCacheImportExport(t *testing.T, sb integration.Sandbox) {
 }
 
 func testBasicInlineCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	requiresLinux(t)
 	registry, err := sb.NewRegistry()
 	if errors.Is(err, integration.ErrRequirements) {
@@ -4195,7 +4187,7 @@ func testCopyFromEmptyImage(t *testing.T, sb integration.Sandbox) {
 
 // containerd/containerd#2119
 func testDuplicateWhiteouts(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -4267,7 +4259,7 @@ func testDuplicateWhiteouts(t *testing.T, sb integration.Sandbox) {
 
 // #276
 func testWhiteoutParentDir(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -4807,7 +4799,7 @@ func testMergeOpCacheMax(t *testing.T, sb integration.Sandbox) {
 
 func testMergeOpCache(t *testing.T, sb integration.Sandbox, mode string) {
 	t.Helper()
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	requiresLinux(t)
 
 	cdAddress := sb.ContainerdAddress()

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -705,7 +705,7 @@ func testNetworkMode(t *testing.T, sb integration.Sandbox) {
 }
 
 func testPushByDigest(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb, "direct push")
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -895,7 +895,7 @@ func testSecurityModeErrors(t *testing.T, sb integration.Sandbox) {
 }
 
 func testFrontendImageNaming(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb, "oci exporter", "direct push")
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -1892,7 +1892,7 @@ func testUser(t *testing.T, sb integration.Sandbox) {
 }
 
 func testOCIExporter(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb, "oci exporter")
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -1995,7 +1995,7 @@ func testOCIExporter(t *testing.T, sb integration.Sandbox) {
 }
 
 func testFrontendMetadataReturn(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb, "oci exporter")
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -2093,7 +2093,7 @@ func testFrontendUseSolveResults(t *testing.T, sb integration.Sandbox) {
 }
 
 func testExporterTargetExists(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb, "oci exporter")
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -2691,7 +2691,7 @@ func testPullZstdImage(t *testing.T, sb integration.Sandbox) {
 	require.Equal(t, dt, []byte("zstd"))
 }
 func testBuildPushAndValidate(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb, "direct push")
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -2891,7 +2891,7 @@ func testBuildPushAndValidate(t *testing.T, sb integration.Sandbox) {
 }
 
 func testStargzLazyRegistryCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb, "remote cache export")
 	requiresLinux(t)
 
 	cdAddress := sb.ContainerdAddress()
@@ -3039,7 +3039,7 @@ func testStargzLazyRegistryCacheImportExport(t *testing.T, sb integration.Sandbo
 }
 
 func testStargzLazyInlineCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb, "remote cache export")
 	requiresLinux(t)
 
 	cdAddress := sb.ContainerdAddress()
@@ -3192,7 +3192,6 @@ func testStargzLazyInlineCacheImportExport(t *testing.T, sb integration.Sandbox)
 }
 
 func testStargzLazyPull(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
 	requiresLinux(t)
 
 	cdAddress := sb.ContainerdAddress()
@@ -3317,7 +3316,7 @@ func testStargzLazyPull(t *testing.T, sb integration.Sandbox) {
 }
 
 func testLazyImagePush(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb, "direct push")
 	requiresLinux(t)
 
 	cdAddress := sb.ContainerdAddress()
@@ -3514,7 +3513,7 @@ func testZstdLocalCacheExport(t *testing.T, sb integration.Sandbox) {
 }
 
 func testUncompressedLocalCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb, "remote cache export")
 	dir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
@@ -3536,7 +3535,7 @@ func testUncompressedLocalCacheImportExport(t *testing.T, sb integration.Sandbox
 }
 
 func testUncompressedRegistryCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb, "remote cache export")
 	registry, err := sb.NewRegistry()
 	if errors.Is(err, integration.ErrRequirements) {
 		t.Skip(err.Error())
@@ -3561,7 +3560,7 @@ func testUncompressedRegistryCacheImportExport(t *testing.T, sb integration.Sand
 }
 
 func testZstdLocalCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb, "remote cache export")
 	if sb.Name() == "containerd-1.4" {
 		// containerd 1.4 doesn't support zstd compression
 		return
@@ -3588,7 +3587,7 @@ func testZstdLocalCacheImportExport(t *testing.T, sb integration.Sandbox) {
 }
 
 func testZstdRegistryCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb, "remote cache export")
 	if sb.Name() == "containerd-1.4" {
 		// containerd 1.4 doesn't support zstd compression
 		return
@@ -3684,7 +3683,7 @@ func testBasicCacheImportExport(t *testing.T, sb integration.Sandbox, cacheOptio
 }
 
 func testBasicRegistryCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb, "remote cache export")
 	registry, err := sb.NewRegistry()
 	if errors.Is(err, integration.ErrRequirements) {
 		t.Skip(err.Error())
@@ -3701,7 +3700,7 @@ func testBasicRegistryCacheImportExport(t *testing.T, sb integration.Sandbox) {
 }
 
 func testMultipleRegistryCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb, "remote cache export")
 	registry, err := sb.NewRegistry()
 	if errors.Is(err, integration.ErrRequirements) {
 		t.Skip(err.Error())
@@ -3724,7 +3723,7 @@ func testMultipleRegistryCacheImportExport(t *testing.T, sb integration.Sandbox)
 }
 
 func testBasicLocalCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb, "remote cache export")
 	dir, err := os.MkdirTemp("", "buildkit")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
@@ -3744,7 +3743,7 @@ func testBasicLocalCacheImportExport(t *testing.T, sb integration.Sandbox) {
 }
 
 func testBasicInlineCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb, "direct push")
 	requiresLinux(t)
 	registry, err := sb.NewRegistry()
 	if errors.Is(err, integration.ErrRequirements) {
@@ -4187,7 +4186,7 @@ func testCopyFromEmptyImage(t *testing.T, sb integration.Sandbox) {
 
 // containerd/containerd#2119
 func testDuplicateWhiteouts(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb, "oci exporter")
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -4259,7 +4258,7 @@ func testDuplicateWhiteouts(t *testing.T, sb integration.Sandbox) {
 
 // #276
 func testWhiteoutParentDir(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb, "oci exporter")
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -4799,7 +4798,7 @@ func testMergeOpCacheMax(t *testing.T, sb integration.Sandbox) {
 
 func testMergeOpCache(t *testing.T, sb integration.Sandbox, mode string) {
 	t.Helper()
-	integration.SkipIfDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb, "direct push")
 	requiresLinux(t)
 
 	cdAddress := sb.ContainerdAddress()

--- a/client/mergediff_test.go
+++ b/client/mergediff_test.go
@@ -1310,7 +1310,6 @@ func (tc verifyBlobReuse) Name() string {
 }
 
 func (tc verifyBlobReuse) Run(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
 	requiresLinux(t)
 
 	cdAddress := sb.ContainerdAddress()

--- a/client/mergediff_test.go
+++ b/client/mergediff_test.go
@@ -1310,7 +1310,7 @@ func (tc verifyBlobReuse) Name() string {
 }
 
 func (tc verifyBlobReuse) Run(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	requiresLinux(t)
 
 	cdAddress := sb.ContainerdAddress()

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -1307,7 +1307,7 @@ COPY --from=build /out .
 }
 
 func testDefaultShellAndPath(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -1397,7 +1397,7 @@ COPY Dockerfile .
 }
 
 func testExportMultiPlatform(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -2065,7 +2065,7 @@ FROM busybox:${tag}
 }
 
 func testDockerfileDirs(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	f := getFrontend(t, sb)
 	f.RequiresBuildctl(t)
 
@@ -2134,7 +2134,7 @@ func testDockerfileDirs(t *testing.T, sb integration.Sandbox) {
 }
 
 func testDockerfileInvalidCommand(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	f := getFrontend(t, sb)
 	f.RequiresBuildctl(t)
 	dockerfile := []byte(`
@@ -2161,7 +2161,7 @@ func testDockerfileInvalidCommand(t *testing.T, sb integration.Sandbox) {
 }
 
 func testDockerfileInvalidInstruction(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	f := getFrontend(t, sb)
 	f.RequiresBuildctl(t)
 	dockerfile := []byte(`
@@ -2192,7 +2192,7 @@ func testDockerfileInvalidInstruction(t *testing.T, sb integration.Sandbox) {
 }
 
 func testDockerfileADDFromURL(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	f := getFrontend(t, sb)
 	f.RequiresBuildctl(t)
 
@@ -2275,7 +2275,7 @@ ADD %s /dest/
 }
 
 func testDockerfileAddArchive(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	f := getFrontend(t, sb)
 	f.RequiresBuildctl(t)
 
@@ -2558,7 +2558,7 @@ RUN [ "$(stat -c "%u %G" /foo)" == "1000 nobody" ]
 }
 
 func testSymlinkDestination(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	f := getFrontend(t, sb)
 	f.RequiresBuildctl(t)
 
@@ -2672,7 +2672,7 @@ ENV foo=bar
 }
 
 func testExposeExpansion(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 
 	f := getFrontend(t, sb)
 
@@ -2887,7 +2887,7 @@ func testDockerfileLowercase(t *testing.T, sb integration.Sandbox) {
 }
 
 func testExportedHistory(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	f := getFrontend(t, sb)
 	f.RequiresBuildctl(t)
 
@@ -2965,16 +2965,8 @@ RUN ["ls"]
 	require.NotNil(t, ociimg.History[6].Created)
 }
 
-func skipDockerd(t *testing.T, sb integration.Sandbox) {
-	// TODO: remove me once dockerd supports the image and exporter.
-	t.Helper()
-	if os.Getenv("TEST_DOCKERD") == "1" {
-		t.Skip("dockerd missing a required exporter, cache exporter, or entitlement")
-	}
-}
-
 func testUser(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 
 	f := getFrontend(t, sb)
 
@@ -3513,7 +3505,7 @@ RUN sh -c "[ $(cat /test5/foo) = 'hello' ]"
 }
 
 func testAddURLChmod(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	f := getFrontend(t, sb)
 	f.RequiresBuildctl(t)
 
@@ -3863,7 +3855,7 @@ COPY --from=stage1 baz bax
 }
 
 func testLabels(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -3939,7 +3931,7 @@ LABEL foo=bar
 
 // #2008
 func testWildcardRenameCache(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -4091,7 +4083,7 @@ ONBUILD RUN mkdir -p /out && echo -n 11 >> /out/foo
 }
 
 func testCacheMultiPlatformImportExport(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	f := getFrontend(t, sb)
 
 	registry, err := sb.NewRegistry()
@@ -4214,7 +4206,7 @@ COPY --from=base arch /
 }
 
 func testCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	f := getFrontend(t, sb)
 
 	registry, err := sb.NewRegistry()
@@ -4314,7 +4306,7 @@ COPY --from=base unique /
 }
 
 func testReproducibleIDs(t *testing.T, sb integration.Sandbox) {
-	skipDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb)
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -1307,7 +1307,7 @@ COPY --from=build /out .
 }
 
 func testDefaultShellAndPath(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb, "oci exporter")
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -1397,7 +1397,7 @@ COPY Dockerfile .
 }
 
 func testExportMultiPlatform(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb, "oci exporter", "multi-platform")
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -2065,7 +2065,6 @@ FROM busybox:${tag}
 }
 
 func testDockerfileDirs(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
 	f := getFrontend(t, sb)
 	f.RequiresBuildctl(t)
 
@@ -2134,7 +2133,6 @@ func testDockerfileDirs(t *testing.T, sb integration.Sandbox) {
 }
 
 func testDockerfileInvalidCommand(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
 	f := getFrontend(t, sb)
 	f.RequiresBuildctl(t)
 	dockerfile := []byte(`
@@ -2161,7 +2159,6 @@ func testDockerfileInvalidCommand(t *testing.T, sb integration.Sandbox) {
 }
 
 func testDockerfileInvalidInstruction(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
 	f := getFrontend(t, sb)
 	f.RequiresBuildctl(t)
 	dockerfile := []byte(`
@@ -2192,7 +2189,6 @@ func testDockerfileInvalidInstruction(t *testing.T, sb integration.Sandbox) {
 }
 
 func testDockerfileADDFromURL(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
 	f := getFrontend(t, sb)
 	f.RequiresBuildctl(t)
 
@@ -2275,7 +2271,6 @@ ADD %s /dest/
 }
 
 func testDockerfileAddArchive(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
 	f := getFrontend(t, sb)
 	f.RequiresBuildctl(t)
 
@@ -2558,7 +2553,6 @@ RUN [ "$(stat -c "%u %G" /foo)" == "1000 nobody" ]
 }
 
 func testSymlinkDestination(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
 	f := getFrontend(t, sb)
 	f.RequiresBuildctl(t)
 
@@ -2672,8 +2666,6 @@ ENV foo=bar
 }
 
 func testExposeExpansion(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
-
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -2887,7 +2879,6 @@ func testDockerfileLowercase(t *testing.T, sb integration.Sandbox) {
 }
 
 func testExportedHistory(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
 	f := getFrontend(t, sb)
 	f.RequiresBuildctl(t)
 
@@ -2966,8 +2957,6 @@ RUN ["ls"]
 }
 
 func testUser(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
-
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -3505,7 +3494,6 @@ RUN sh -c "[ $(cat /test5/foo) = 'hello' ]"
 }
 
 func testAddURLChmod(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
 	f := getFrontend(t, sb)
 	f.RequiresBuildctl(t)
 
@@ -3855,7 +3843,6 @@ COPY --from=stage1 baz bax
 }
 
 func testLabels(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -3931,7 +3918,6 @@ LABEL foo=bar
 
 // #2008
 func testWildcardRenameCache(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -4083,7 +4069,7 @@ ONBUILD RUN mkdir -p /out && echo -n 11 >> /out/foo
 }
 
 func testCacheMultiPlatformImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb, "direct push")
 	f := getFrontend(t, sb)
 
 	registry, err := sb.NewRegistry()
@@ -4206,7 +4192,7 @@ COPY --from=base arch /
 }
 
 func testCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
+	integration.SkipIfDockerd(t, sb, "remote cache export")
 	f := getFrontend(t, sb)
 
 	registry, err := sb.NewRegistry()
@@ -4306,7 +4292,6 @@ COPY --from=base unique /
 }
 
 func testReproducibleIDs(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb)
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`

--- a/util/testutil/integration/dockerd.go
+++ b/util/testutil/integration/dockerd.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net"
 	"os"
+	"strings"
+	"testing"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -141,7 +143,23 @@ func (c dockerd) New(ctx context.Context, cfg *BackendConfig) (b Backend, cl fun
 	})
 
 	return backend{
-		address:  "unix://" + listener.Addr().String(),
-		rootless: false,
+		address:   "unix://" + listener.Addr().String(),
+		rootless:  false,
+		isDockerd: true,
 	}, cl, nil
+}
+
+func SkipIfDockerd(t *testing.T, sb Sandbox, reason ...string) {
+	t.Helper()
+	sbx, ok := sb.(*sandbox)
+	if !ok {
+		t.Fatalf("invalid sandbox type %T", sb)
+	}
+	b, ok := sbx.Backend.(backend)
+	if !ok {
+		t.Fatalf("invalid backend type %T", b)
+	}
+	if b.isDockerd {
+		t.Skipf("dockerd worker can not currently run this test due to missing features (%s)", strings.Join(reason, ", "))
+	}
 }

--- a/util/testutil/integration/sandbox.go
+++ b/util/testutil/integration/sandbox.go
@@ -25,6 +25,7 @@ type backend struct {
 	containerdAddress string
 	rootless          bool
 	snapshotter       string
+	isDockerd         bool
 }
 
 func (b backend) Address() string {


### PR DESCRIPTION
- Replace the current private method with a reusable helper.
- Add reason messages for skipping. Places where I removed the call are skipped anyway for a different requirement(buildctl,containerd) or in some cases I did not understand why such test should be skipped and requires new evaluation. For the entitlements tests, I was not sure what the actual reason is so left empty.