### PR TITLE
dockerfile: fix named context input platform resolution

### DIFF
--- a/client/llb/state.go
+++ b/client/llb/state.go
@@ -236,6 +236,9 @@ func (s State) WithImageConfig(c []byte) (State, error) {
 			WorkingDir string   `json:"WorkingDir,omitempty"`
 			User       string   `json:"User,omitempty"`
 		} `json:"config,omitempty"`
+		Architecture string `json:"architecture"`
+		Variant      string `json:"variant,omitempty"`
+		OS           string `json:"os"`
 	}
 	if err := json.Unmarshal(c, &img); err != nil {
 		return State{}, err
@@ -251,6 +254,13 @@ func (s State) WithImageConfig(c []byte) (State, error) {
 		}
 	}
 	s = s.Dir(img.Config.WorkingDir)
+	if img.Architecture != "" && img.OS != "" {
+		s = s.Platform(ocispecs.Platform{
+			OS:           img.OS,
+			Architecture: img.Architecture,
+			Variant:      img.Variant,
+		})
+	}
 	return s, nil
 }
 

--- a/client/llb/state.go
+++ b/client/llb/state.go
@@ -230,16 +230,7 @@ func (s State) WithOutput(o Output) State {
 }
 
 func (s State) WithImageConfig(c []byte) (State, error) {
-	var img struct {
-		Config struct {
-			Env        []string `json:"Env,omitempty"`
-			WorkingDir string   `json:"WorkingDir,omitempty"`
-			User       string   `json:"User,omitempty"`
-		} `json:"config,omitempty"`
-		Architecture string `json:"architecture"`
-		Variant      string `json:"variant,omitempty"`
-		OS           string `json:"os"`
-	}
+	var img ocispecs.Image
 	if err := json.Unmarshal(c, &img); err != nil {
 		return State{}, err
 	}


### PR DESCRIPTION
This fixes the case where the named context source is input with a different platform than the target platform. For example when including a cross-compilation stage.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>