### PR TITLE
integration: don't error if connection already closed with dockerd worker

### DIFF
--- a/util/testutil/integration/dockerd.go
+++ b/util/testutil/integration/dockerd.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -143,7 +144,11 @@ func (c dockerd) New(ctx context.Context, cfg *BackendConfig) (b Backend, cl fun
 			}
 			conn, err := dockerAPI.DialHijack(ctx, "/grpc", "h2c", nil)
 			if err != nil {
-				return errors.Wrapf(err, "dockerd grpc conn error: %s", formatLogs(cfg.Logs))
+				if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, net.ErrClosed) {
+					logrus.Warn("dockerd conn already closed: ", err)
+					return nil
+				}
+				return errors.Wrap(err, "dockerd grpc conn error")
 			}
 
 			proxyGroup.Go(func() error {


### PR DESCRIPTION
follow-up https://github.com/moby/moby/pull/43431#issuecomment-1079895253

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>