### PR TITLE
exporter: normalize default platform string

### DIFF
--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -403,10 +403,10 @@ func (e *imageExporterInstance) unpackImage(ctx context.Context, img images.Imag
 
 	topLayerRef := src.Ref
 	if len(src.Refs) > 0 {
-		if r, ok := src.Refs[platforms.DefaultString()]; ok {
+		if r, ok := src.Refs[defaultPlatform()]; ok {
 			topLayerRef = r
 		} else {
-			return errors.Errorf("no reference for default platform %s", platforms.DefaultString())
+			return errors.Errorf("no reference for default platform %s", defaultPlatform())
 		}
 	}
 
@@ -481,4 +481,10 @@ func addAnnotations(m map[digest.Digest]map[string]string, desc ocispecs.Descrip
 	for k, v := range desc.Annotations {
 		a[k] = v
 	}
+}
+
+func defaultPlatform() string {
+	// Use normalized platform string to avoid the mismatch with platform options which
+	// are normalized using platforms.Normalize()
+	return platforms.Format(platforms.Normalize(platforms.DefaultSpec()))
 }


### PR DESCRIPTION
#2754
Related https://github.com/containerd/containerd/issues/3225

Platforms options are normalized but exporter doesn't normalize the default platform (i.e. uses `platfroms.DefaultString()`).
This mismatch seems to cause the unpack failure on arm.

https://github.com/moby/buildkit/blob/d7744bcb3532b8efb0ee59cc5a805a3f06e6aa9a/frontend/dockerfile/builder/build.go#L672
