### PR TITLE
progressui: fix printing of hidden vertexes.

### DIFF
--- a/util/progress/progressui/printer.go
+++ b/util/progress/progressui/printer.go
@@ -256,7 +256,7 @@ func (p *textMux) print(t *trace) {
 		}
 		// make any open vertex active
 		for dgst, v := range t.byDigest {
-			if v.isStarted() && !v.isCompleted() {
+			if v.isStarted() && !v.isCompleted() && v.ProgressGroup == nil && !v.hidden {
 				p.printVtx(t, dgst)
 				return
 			}
@@ -279,6 +279,10 @@ func (p *textMux) print(t *trace) {
 	for dgst := range rest {
 		v, ok := t.byDigest[dgst]
 		if !ok {
+			continue
+		}
+		if v.lastBlockTime == nil {
+			// shouldn't happen, but not worth crashing over
 			continue
 		}
 		tm := now.Sub(*v.lastBlockTime)


### PR DESCRIPTION
The plain progress has a loop that iterates over each vertex the trace
knows about (rather than just the updated ones). Before this, that loop
was not checking to see if a vertex was supposed to be skipped due to
being in a group or due to being hidden.

This resulted in vertexes being printed unnecessarily. It also led to a
rare case where a vertex with nil lastBlockTime could be set to the
'current' field, which could then result in a nil pointer exception.

The update here just adds the appropriate checks to the loop.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>