### PR TITLE
ci: set buildx 0.8.2 version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ env:
   CACHE_GHA_SCOPE_IT: "integration-tests"
   CACHE_GHA_SCOPE_BINARIES: "binaries"
   CACHE_GHA_SCOPE_CROSS: "cross"
+  BUILDX_VERSION: "v0.8.2"  # leave empty to use the one available on GitHub virtual environment
 
 jobs:
   base:
@@ -41,6 +42,7 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         with:
+          version: ${{ env.BUILDX_VERSION }}
           driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
           buildkitd-flags: --debug
       -
@@ -100,6 +102,7 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         with:
+          version: ${{ env.BUILDX_VERSION }}
           driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
           buildkitd-flags: --debug
       -
@@ -215,6 +218,7 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         with:
+          version: ${{ env.BUILDX_VERSION }}
           driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
           buildkitd-flags: --debug
       -
@@ -274,6 +278,7 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         with:
+          version: ${{ env.BUILDX_VERSION }}
           driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
           buildkitd-flags: --debug
       -
@@ -309,6 +314,7 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         with:
+          version: ${{ env.BUILDX_VERSION }}
           driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
           buildkitd-flags: --debug
       -
@@ -384,6 +390,7 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         with:
+          version: ${{ env.BUILDX_VERSION }}
           driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
           buildkitd-flags: --debug
       -

--- a/.github/workflows/buildx-image.yml
+++ b/.github/workflows/buildx-image.yml
@@ -27,6 +27,7 @@ on:
 
 env:
   REPO_SLUG_TARGET: "moby/buildkit"
+  BUILDX_VERSION: "v0.8.2"  # leave empty to use the one available on GitHub virtual environment
 
 jobs:
   create:
@@ -41,6 +42,8 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+        with:
+          version: ${{ env.BUILDX_VERSION }}
       -
         name: Login to DockerHub
         if: github.event.inputs.dry-run != 'true'

--- a/.github/workflows/dockerd.yml
+++ b/.github/workflows/dockerd.yml
@@ -13,6 +13,7 @@ env:
   REPO_SLUG_ORIGIN: "moby/buildkit:latest"
   CACHE_GHA_SCOPE_IT: "integration-tests"
   CACHE_GHA_SCOPE_BINARIES: "binaries"
+  BUILDX_VERSION: "v0.8.2"  # leave empty to use the one available on GitHub virtual environment
 
 jobs:
   prepare:
@@ -43,6 +44,7 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         with:
+          version: ${{ env.BUILDX_VERSION }}
           driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
           buildkitd-flags: --debug
       -
@@ -107,6 +109,7 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         with:
+          version: ${{ env.BUILDX_VERSION }}
           driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
           buildkitd-flags: --debug
       -

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,6 +15,7 @@ on:
 
 env:
   REPO_SLUG_ORIGIN: "moby/buildkit:latest"
+  BUILDX_VERSION: "v0.8.2"  # leave empty to use the one available on GitHub virtual environment
 
 jobs:
   validate:
@@ -35,6 +36,7 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         with:
+          version: ${{ env.BUILDX_VERSION }}
           driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
       -
         name: Run


### PR DESCRIPTION
atm GitHub runner still has buildx 0.8.1 which causes errors in our workflows: https://github.com/moby/buildkit/runs/5845916468?check_suite_focus=true#step:7:728

```
#122 [linux/s390x buildkit-export 2/3] RUN apk add --no-cache fuse3 git openssh pigz xz   && ln -s fusermount3 /usr/bin/fusermount
#122 CACHED
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xfca460]

goroutine 31 [running]:
github.com/moby/buildkit/util/progress/progressui.(*textMux).print(0xc0008e3e08, 0xc0008e3e80)
	/build/moby-buildx/.gopath/src/github.com/docker/buildx/vendor/github.com/moby/buildkit/util/progress/progressui/printer.go:284 +0x7c0
github.com/moby/buildkit/util/progress/progressui.DisplaySolveStatus(0x255d660, 0xc0002543c0, 0x0, 0x0, 0x0, 0x0, 0x25180c0, 0xc000128010, 0xc00005b380, 0x0, ...)
	/build/moby-buildx/.gopath/src/github.com/docker/buildx/vendor/github.com/moby/buildkit/util/progress/progressui/display.go:83 +0x405
github.com/docker/buildx/util/progress.NewPrinter.func1(0x7fffa321773c, 0x5, 0xc00059dba0, 0x2567118, 0xc000128010, 0x255d660, 0xc0002543c0, 0xc00005b380, 0xc0002cb810, 0xc00005b3e0)
	/build/moby-buildx/.gopath/src/github.com/docker/buildx/util/progress/printer.go:99 +0x132
created by github.com/docker/buildx/util/progress.NewPrinter
	/build/moby-buildx/.gopath/src/github.com/docker/buildx/util/progress/printer.go:87 +0x1e5
```

set buildx version to 0.8.2 to fix it.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>