### PR TITLE
version: fix parsing user-agent version

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -45,18 +45,18 @@ var (
 )
 
 func UserAgent() string {
-	version := defaultVersion
+	uaVersion := defaultVersion
 
 	reOnce.Do(func() {
 		reRelease = regexp.MustCompile(`^(v[0-9]+\.[0-9]+)\.[0-9]+$`)
 		reDev = regexp.MustCompile(`^(v[0-9]+\.[0-9]+)\.[0-9]+`)
 	})
 
-	if matches := reRelease.FindAllStringSubmatch(version, 1); len(matches) > 0 {
-		version = matches[0][1]
-	} else if matches := reDev.FindAllStringSubmatch(version, 1); len(matches) > 0 {
-		version = matches[0][1] + "-dev"
+	if matches := reRelease.FindAllStringSubmatch(Version, 1); len(matches) > 0 {
+		uaVersion = matches[0][1]
+	} else if matches := reDev.FindAllStringSubmatch(Version, 1); len(matches) > 0 {
+		uaVersion = matches[0][1] + "-dev"
 	}
 
-	return "buildkit/" + version
+	return "buildkit/" + uaVersion
 }


### PR DESCRIPTION
Pretty awful typo that made the User-Agent version to always be v0.0.0. I renamed the variable to it is less likely to use it in an incorrect place.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>