### PR TITLE
examples/kubernetes: replace deprecated seccomp annotations with securityContext

### DIFF
--- a/examples/kubernetes/deployment+service.rootless.yaml
+++ b/examples/kubernetes/deployment+service.rootless.yaml
@@ -15,7 +15,6 @@ spec:
         app: buildkitd
       annotations:
         container.apparmor.security.beta.kubernetes.io/buildkitd: unconfined
-        container.seccomp.security.alpha.kubernetes.io/buildkitd: unconfined
     # see buildkit/docs/rootless.md for caveats of rootless mode
     spec:
       containers:
@@ -52,6 +51,9 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 30
           securityContext:
+            # Needs Kubernetes >= 1.19
+            seccompProfile:
+              type: Unconfined
             # To change UID/GID, you need to rebuild the image
             runAsUser: 1000
             runAsGroup: 1000

--- a/examples/kubernetes/job.rootless.yaml
+++ b/examples/kubernetes/job.rootless.yaml
@@ -7,7 +7,6 @@ spec:
     metadata:
       annotations:
         container.apparmor.security.beta.kubernetes.io/buildkit: unconfined
-        container.seccomp.security.alpha.kubernetes.io/buildkit: unconfined
     # see buildkit/docs/rootless.md for caveats of rootless mode
     spec:
       restartPolicy: Never
@@ -43,6 +42,9 @@ spec:
           # To push the image to a registry, add
           # `--output type=image,name=docker.io/username/image,push=true`
           securityContext:
+            # Needs Kubernetes >= 1.19
+            seccompProfile:
+              type: Unconfined
             # To change UID/GID, you need to rebuild the image
             runAsUser: 1000
             runAsGroup: 1000

--- a/examples/kubernetes/pod.rootless.yaml
+++ b/examples/kubernetes/pod.rootless.yaml
@@ -4,7 +4,6 @@ metadata:
   name: buildkitd
   annotations:
     container.apparmor.security.beta.kubernetes.io/buildkitd: unconfined
-    container.seccomp.security.alpha.kubernetes.io/buildkitd: unconfined
 # see buildkit/docs/rootless.md for caveats of rootless mode
 spec:
   containers:
@@ -29,6 +28,9 @@ spec:
         initialDelaySeconds: 5
         periodSeconds: 30
       securityContext:
+        # Needs Kubernetes >= 1.19
+        seccompProfile:
+          type: Unconfined
         # To change UID/GID, you need to rebuild the image
         runAsUser: 1000
         runAsGroup: 1000

--- a/examples/kubernetes/statefulset.rootless.yaml
+++ b/examples/kubernetes/statefulset.rootless.yaml
@@ -17,7 +17,6 @@ spec:
         app: buildkitd
       annotations:
         container.apparmor.security.beta.kubernetes.io/buildkitd: unconfined
-        container.seccomp.security.alpha.kubernetes.io/buildkitd: unconfined
     # see buildkit/docs/rootless.md for caveats of rootless mode
     spec:
       containers:
@@ -42,6 +41,9 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 30
           securityContext:
+            # Needs Kubernetes >= 1.19
+            seccompProfile:
+              type: Unconfined
             # To change UID/GID, you need to rebuild the image
             runAsUser: 1000
             runAsGroup: 1000


### PR DESCRIPTION
Kubernetes added the official `securityContext.seccompProfile` support in Kubernetes 1.19.
Seccomp is still disabled by default.

The legacy `container.seccomp.security.alpha.kubernetes.io/<PODNAME>` annotation has been deprecated and will be unsupported in Kubernetes 1.25.
https://kubernetes.io/docs/tutorials/security/seccomp/

A test cluster can be created with the following minikube command:
```
minikube start --feature-gates SeccompDefault=true --extra-config kubelet.seccomp-default=true
```

Fix  #2515
