### PR TITLE
buildctl: remove deprecated flags (`--exporter`, `--exporter-opt`, `--frontend-opt`, ...)

### DIFF
--- a/cmd/buildctl/build/exportcache.go
+++ b/cmd/buildctl/build/exportcache.go
@@ -45,34 +45,22 @@ func parseExportCacheCSV(s string) (client.CacheOptionsEntry, error) {
 	return ex, nil
 }
 
-// ParseExportCache parses --export-cache (and legacy --export-cache-opt)
-func ParseExportCache(exportCaches, legacyExportCacheOpts []string) ([]client.CacheOptionsEntry, error) {
+// ParseExportCache parses --export-cache
+func ParseExportCache(exportCaches []string) ([]client.CacheOptionsEntry, error) {
 	var exports []client.CacheOptionsEntry
-	if len(legacyExportCacheOpts) > 0 {
-		if len(exportCaches) != 1 {
-			return nil, errors.New("--export-cache-opt requires exactly single --export-cache")
-		}
-	}
 	for _, exportCache := range exportCaches {
 		legacy := !strings.Contains(exportCache, "type=")
 		if legacy {
-			logrus.Warnf("--export-cache <ref> --export-cache-opt <opt>=<optval> is deprecated. Please use --export-cache type=registry,ref=<ref>,<opt>=<optval>[,<opt>=<optval>] instead")
-			attrs, err := attrMap(legacyExportCacheOpts)
-			if err != nil {
-				return nil, err
-			}
-			if _, ok := attrs["mode"]; !ok {
-				attrs["mode"] = "min"
-			}
-			attrs["ref"] = exportCache
+			// Deprecated since BuildKit v0.4.0, but no plan to remove: https://github.com/moby/buildkit/pull/2783#issuecomment-1093449772
+			logrus.Warnf("--export-cache <ref> is deprecated. Please use --export-cache type=registry,ref=<ref>,<opt>=<optval>[,<opt>=<optval>] instead")
 			exports = append(exports, client.CacheOptionsEntry{
-				Type:  "registry",
-				Attrs: attrs,
+				Type: "registry",
+				Attrs: map[string]string{
+					"mode": "min",
+					"ref":  exportCache,
+				},
 			})
 		} else {
-			if len(legacyExportCacheOpts) > 0 {
-				return nil, errors.New("--export-cache-opt is not supported for the specified --export-cache. Please use --export-cache type=<type>,<opt>=<optval>[,<opt>=<optval>] instead")
-			}
 			ex, err := parseExportCacheCSV(exportCache)
 			if err != nil {
 				return nil, err

--- a/cmd/buildctl/build/exportcache_test.go
+++ b/cmd/buildctl/build/exportcache_test.go
@@ -9,10 +9,9 @@ import (
 
 func TestParseExportCache(t *testing.T) {
 	type testCase struct {
-		exportCaches          []string // --export-cache
-		legacyExportCacheOpts []string // --export-cache-opt (legacy)
-		expected              []client.CacheOptionsEntry
-		expectedErr           string
+		exportCaches []string // --export-cache
+		expected     []client.CacheOptionsEntry
+		expectedErr  string
 	}
 	testCases := []testCase{
 		{
@@ -28,28 +27,22 @@ func TestParseExportCache(t *testing.T) {
 			},
 		},
 		{
-			exportCaches:          []string{"example.com/foo/bar"},
-			legacyExportCacheOpts: []string{"mode=max"},
+			exportCaches: []string{"example.com/foo/bar"},
 			expected: []client.CacheOptionsEntry{
 				{
 					Type: "registry",
 					Attrs: map[string]string{
 						"ref":  "example.com/foo/bar",
-						"mode": "max",
+						"mode": "min",
 					},
 				},
 			},
-		},
-		{
-			exportCaches:          []string{"type=registry,ref=example.com/foo/bar"},
-			legacyExportCacheOpts: []string{"mode=max"},
-			expectedErr:           "--export-cache-opt is not supported for the specified --export-cache",
 		},
 		// TODO: test multiple exportCaches (valid for CLI but not supported by solver)
 
 	}
 	for _, tc := range testCases {
-		ex, err := ParseExportCache(tc.exportCaches, tc.legacyExportCacheOpts)
+		ex, err := ParseExportCache(tc.exportCaches)
 		if tc.expectedErr == "" {
 			require.EqualValues(t, tc.expected, ex)
 		} else {

--- a/cmd/buildctl/build/importcache.go
+++ b/cmd/buildctl/build/importcache.go
@@ -48,6 +48,7 @@ func ParseImportCache(importCaches []string) ([]client.CacheOptionsEntry, error)
 	for _, importCache := range importCaches {
 		legacy := !strings.Contains(importCache, "type=")
 		if legacy {
+			// Deprecated since BuildKit v0.4.0, but no plan to remove: https://github.com/moby/buildkit/pull/2783#issuecomment-1093449772
 			logrus.Warn("--import-cache <ref> is deprecated. Please use --import-cache type=registry,ref=<ref>,<opt>=<optval>[,<opt>=<optval>] instead.")
 			imports = append(imports, client.CacheOptionsEntry{
 				Type:  "registry",

--- a/cmd/buildctl/build/opt.go
+++ b/cmd/buildctl/build/opt.go
@@ -1,27 +1,5 @@
 package build
 
-import (
-	"github.com/sirupsen/logrus"
-)
-
-func ParseOpt(opts, legacyFrontendOpts []string) (map[string]string, error) {
-	m := make(map[string]string)
-	if len(legacyFrontendOpts) > 0 {
-		logrus.Warn("--frontend-opt <opt>=<optval> is deprecated. Please use --opt <opt>=<optval> instead.")
-		legacy, err := attrMap(legacyFrontendOpts)
-		if err != nil {
-			return nil, err
-		}
-		for k, v := range legacy {
-			m[k] = v
-		}
-	}
-	modern, err := attrMap(opts)
-	if err != nil {
-		return nil, err
-	}
-	for k, v := range modern {
-		m[k] = v
-	}
-	return m, nil
+func ParseOpt(opts []string) (map[string]string, error) {
+	return attrMap(opts)
 }

--- a/cmd/buildctl/build/output.go
+++ b/cmd/buildctl/build/output.go
@@ -65,28 +65,6 @@ func ParseOutput(exports []string) ([]client.ExportEntry, error) {
 	return entries, nil
 }
 
-// ParseLegacyExporter parses legacy --exporter <type> --exporter-opt <opt>=<optval>
-func ParseLegacyExporter(legacyExporter string, legacyExporterOpts []string) ([]client.ExportEntry, error) {
-	var ex client.ExportEntry
-	ex.Type = legacyExporter
-	var err error
-	ex.Attrs, err = attrMap(legacyExporterOpts)
-	if err != nil {
-		return nil, errors.Wrap(err, "invalid exporter-opt")
-	}
-	if v, ok := ex.Attrs["dest"]; ok {
-		return nil, errors.Errorf("dest=%s not supported for --exporter-opt, you meant output=%s?", v, v)
-	}
-	ex.Output, ex.OutputDir, err = resolveExporterDest(ex.Type, ex.Attrs["output"])
-	if err != nil {
-		return nil, errors.Wrap(err, "invalid exporter option: output")
-	}
-	if ex.Output != nil || ex.OutputDir != "" {
-		delete(ex.Attrs, "output")
-	}
-	return []client.ExportEntry{ex}, nil
-}
-
 // resolveExporterDest returns at most either one of io.WriteCloser (single file) or a string (directory path).
 func resolveExporterDest(exporter, dest string) (func(map[string]string) (io.WriteCloser, error), string, error) {
 	wrapWriter := func(wc io.WriteCloser) func(map[string]string) (io.WriteCloser, error) {

--- a/cmd/buildctl/build_test.go
+++ b/cmd/buildctl/build_test.go
@@ -58,7 +58,7 @@ func testBuildLocalExporter(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
-	cmd := sb.Cmd(fmt.Sprintf("build --progress=plain --exporter=local --exporter-opt output=%s", tmpdir))
+	cmd := sb.Cmd(fmt.Sprintf("build --progress=plain --output type=local,dest=%s", tmpdir))
 	cmd.Stdin = rdr
 	err = cmd.Run()
 
@@ -85,8 +85,7 @@ func testBuildContainerdExporter(t *testing.T, sb integration.Sandbox) {
 
 	buildCmd := []string{
 		"build", "--progress=plain",
-		"--exporter=image", "--exporter-opt", "unpack=true",
-		"--exporter-opt", "name=" + imageName,
+		"--output", "type=image,unpack=true,name=" + imageName,
 	}
 
 	cmd := sb.Cmd(strings.Join(buildCmd, " "))

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -2166,7 +2166,7 @@ ADD %s /dest/
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
-	cmd := sb.Cmd(args + fmt.Sprintf(" --exporter=local --exporter-opt output=%s", destDir))
+	cmd := sb.Cmd(args + fmt.Sprintf(" --output type=local,dest=%s", destDir))
 	err = cmd.Run()
 	require.NoError(t, err)
 
@@ -2193,7 +2193,7 @@ ADD %s /dest/
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
-	cmd = sb.Cmd(args + fmt.Sprintf(" --exporter=local --exporter-opt output=%s", destDir))
+	cmd = sb.Cmd(args + fmt.Sprintf(" --output type=local,dest=%s", destDir))
 	err = cmd.Run()
 	require.NoError(t, err)
 
@@ -2245,7 +2245,7 @@ ADD t.tar /
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
-	cmd := sb.Cmd(args + fmt.Sprintf(" --exporter=local --exporter-opt output=%s", destDir))
+	cmd := sb.Cmd(args + fmt.Sprintf(" --output type=local,dest=%s", destDir))
 	require.NoError(t, cmd.Run())
 
 	dt, err := os.ReadFile(filepath.Join(destDir, "foo"))
@@ -2279,7 +2279,7 @@ ADD t.tar.gz /
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
-	cmd = sb.Cmd(args + fmt.Sprintf(" --exporter=local --exporter-opt output=%s", destDir))
+	cmd = sb.Cmd(args + fmt.Sprintf(" --output type=local,dest=%s", destDir))
 	require.NoError(t, cmd.Run())
 
 	dt, err = os.ReadFile(filepath.Join(destDir, "foo"))
@@ -2306,7 +2306,7 @@ COPY t.tar.gz /
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
-	cmd = sb.Cmd(args + fmt.Sprintf(" --exporter=local --exporter-opt output=%s", destDir))
+	cmd = sb.Cmd(args + fmt.Sprintf(" --output type=local,dest=%s", destDir))
 	require.NoError(t, cmd.Run())
 
 	dt, err = os.ReadFile(filepath.Join(destDir, "t.tar.gz"))
@@ -2342,7 +2342,7 @@ ADD %s /
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
-	cmd = sb.Cmd(args + fmt.Sprintf(" --exporter=local --exporter-opt output=%s", destDir))
+	cmd = sb.Cmd(args + fmt.Sprintf(" --output type=local,dest=%s", destDir))
 	require.NoError(t, cmd.Run())
 
 	dt, err = os.ReadFile(filepath.Join(destDir, "t.tar.gz"))
@@ -2368,7 +2368,7 @@ ADD %s /newname.tar.gz
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
-	cmd = sb.Cmd(args + fmt.Sprintf(" --exporter=local --exporter-opt output=%s", destDir))
+	cmd = sb.Cmd(args + fmt.Sprintf(" --output type=local,dest=%s", destDir))
 	require.NoError(t, cmd.Run())
 
 	dt, err = os.ReadFile(filepath.Join(destDir, "newname.tar.gz"))
@@ -2525,7 +2525,7 @@ COPY foo /symlink/
 	require.NoError(t, err)
 	defer os.RemoveAll(destDir)
 
-	cmd := sb.Cmd(args + fmt.Sprintf(" --exporter=local --exporter-opt output=%s", destDir))
+	cmd := sb.Cmd(args + fmt.Sprintf(" --output type=local,dest=%s", destDir))
 	require.NoError(t, cmd.Run())
 
 	dt, err := os.ReadFile(filepath.Join(destDir, "tmp/symlink-target/foo"))
@@ -2556,7 +2556,7 @@ ENV foo=bar
 	defer os.RemoveAll(trace)
 
 	target := "example.com/moby/dockerfilescratch:test"
-	cmd := sb.Cmd(args + " --exporter=image --exporter-opt=name=" + target)
+	cmd := sb.Cmd(args + " --output type=image,name=" + target)
 	err = cmd.Run()
 	require.NoError(t, err)
 
@@ -2844,7 +2844,7 @@ RUN ["ls"]
 	integration.SkipIfDockerd(t, sb, "image export")
 
 	target := "example.com/moby/dockerfilescratch:test"
-	cmd := sb.Cmd(args + " --exporter=image --exporter-opt=name=" + target)
+	cmd := sb.Cmd(args + " --output type=image,name=" + target)
 	require.NoError(t, cmd.Run())
 
 	// TODO: expose this test to OCI worker


### PR DESCRIPTION
| Removed flags                            | Replacement                                                           |
|--------------------------------|------------------------------------------------|
| `--exporter`, `--exporter-opt` | `--output type=<type>[,<opt>=<optval>]`         |
| `--frontend-opt`                        | `--opt <opt>=<optval>`                                         |
| `--export-cache-opt`               | `--export-cache type=<type>,<opt>=<optval>` |

| Deprecated but retained forms  | Replacement                                                     |
|--------------------------------|---------------------------------------------|
| `--export-cache <ref>`             | `--export-cache type=registry,ref=<ref>`     |
| `--import-cache <ref>`             | `--import-cache type=registry,ref=<ref>`     |

These flags and forms have been deprecated since BuildKit 0.4.0 (Mar 2019): https://github.com/moby/buildkit/commit/5c9f7b8ff
