### PR TITLE
control: remove unused error return from Controller.Register()

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -81,11 +81,10 @@ func NewController(opt Opt) (*Controller, error) {
 	return c, nil
 }
 
-func (c *Controller) Register(server *grpc.Server) error {
+func (c *Controller) Register(server *grpc.Server) {
 	controlapi.RegisterControlServer(server, c)
 	c.gatewayForwarder.Register(server)
 	tracev1.RegisterTraceServiceServer(server, c)
-	return nil
 }
 
 func (c *Controller) DiskUsage(ctx context.Context, r *controlapi.DiskUsageRequest) (*controlapi.DiskUsageResponse, error) {


### PR DESCRIPTION
I noticed we were not handling errors in the integration in Moby, and looking at the code in BuildKit, it appears this never returned an error, and no error handling was present in BuildKit itself.

This function was added in 45bcca5c80e2ebbdf6a2128ad366966484010bdd, and never returned an error at the time, so possibly this was anticipating "for future use", but 5 years have passed, so perhaps that will never happen :)

Coincidentally, this also makes implement the `session.Attachable` interface in https://github.com/moby/buildkit/blob/1c037fd52f3481aded331ee74bff7cb1b4d99be6/session/session.go#L32-L35

    // Attachable defines a feature that can be exposed on a session
    type Attachable interface {
        Register(*grpc.Server)
    }

(Not sure if that's a "good" thing or a "bad" thing)
