### PR TITLE
[v0.10] examples/kubernetes: replace deprecated seccomp annotations with securityContext

### DIFF
--- a/examples/kubernetes/deployment+service.rootless.yaml
+++ b/examples/kubernetes/deployment+service.rootless.yaml
@@ -15,7 +15,6 @@ spec:
         app: buildkitd
       annotations:
         container.apparmor.security.beta.kubernetes.io/buildkitd: unconfined
-        container.seccomp.security.alpha.kubernetes.io/buildkitd: unconfined
     # see buildkit/docs/rootless.md for caveats of rootless mode
     spec:
       containers:
@@ -52,6 +51,9 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 30
           securityContext:
+            # Needs Kubernetes >= 1.19
+            seccompProfile:
+              type: Unconfined
             # To change UID/GID, you need to rebuild the image
             runAsUser: 1000
             runAsGroup: 1000

--- a/examples/kubernetes/job.rootless.yaml
+++ b/examples/kubernetes/job.rootless.yaml
@@ -7,7 +7,6 @@ spec:
     metadata:
       annotations:
         container.apparmor.security.beta.kubernetes.io/buildkit: unconfined
-        container.seccomp.security.alpha.kubernetes.io/buildkit: unconfined
     # see buildkit/docs/rootless.md for caveats of rootless mode
     spec:
       restartPolicy: Never
@@ -43,6 +42,9 @@ spec:
           # To push the image to a registry, add
           # `--output type=image,name=docker.io/username/image,push=true`
           securityContext:
+            # Needs Kubernetes >= 1.19
+            seccompProfile:
+              type: Unconfined
             # To change UID/GID, you need to rebuild the image
             runAsUser: 1000
             runAsGroup: 1000

--- a/examples/kubernetes/pod.rootless.yaml
+++ b/examples/kubernetes/pod.rootless.yaml
@@ -4,7 +4,6 @@ metadata:
   name: buildkitd
   annotations:
     container.apparmor.security.beta.kubernetes.io/buildkitd: unconfined
-    container.seccomp.security.alpha.kubernetes.io/buildkitd: unconfined
 # see buildkit/docs/rootless.md for caveats of rootless mode
 spec:
   containers:
@@ -29,6 +28,9 @@ spec:
         initialDelaySeconds: 5
         periodSeconds: 30
       securityContext:
+        # Needs Kubernetes >= 1.19
+        seccompProfile:
+          type: Unconfined
         # To change UID/GID, you need to rebuild the image
         runAsUser: 1000
         runAsGroup: 1000

--- a/examples/kubernetes/statefulset.rootless.yaml
+++ b/examples/kubernetes/statefulset.rootless.yaml
@@ -17,7 +17,6 @@ spec:
         app: buildkitd
       annotations:
         container.apparmor.security.beta.kubernetes.io/buildkitd: unconfined
-        container.seccomp.security.alpha.kubernetes.io/buildkitd: unconfined
     # see buildkit/docs/rootless.md for caveats of rootless mode
     spec:
       containers:
@@ -42,6 +41,9 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 30
           securityContext:
+            # Needs Kubernetes >= 1.19
+            seccompProfile:
+              type: Unconfined
             # To change UID/GID, you need to rebuild the image
             runAsUser: 1000
             runAsGroup: 1000


### PR DESCRIPTION
cherry-pick #2782

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
(cherry picked from commit 5e2cfb89f85f5e938ec193faa041da817e0bcaaf)
Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>