### PR TITLE
examples/dockerfile2llb: add `--partial-image-config-file`, `--partial-metadata-file`

### DIFF
--- a/examples/dockerfile2llb/main.go
+++ b/examples/dockerfile2llb/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"io"
-	"log"
 	"os"
 
 	"github.com/moby/buildkit/client/llb"
@@ -12,6 +11,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/appcontext"
+	"github.com/sirupsen/logrus"
 )
 
 type buildOpt struct {
@@ -19,13 +19,19 @@ type buildOpt struct {
 }
 
 func main() {
+	if err := xmain(); err != nil {
+		logrus.Fatal(err)
+	}
+}
+
+func xmain() error {
 	var opt buildOpt
 	flag.StringVar(&opt.target, "target", "", "target stage")
 	flag.Parse()
 
 	df, err := io.ReadAll(os.Stdin)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	caps := pb.Caps.CapSet(pb.Caps.All())
@@ -36,8 +42,7 @@ func main() {
 		LLBCaps:      &caps,
 	})
 	if err != nil {
-		log.Printf("err: %+v", err)
-		panic(err)
+		return err
 	}
 
 	_ = img
@@ -45,7 +50,7 @@ func main() {
 
 	dt, err := state.Marshal(context.TODO())
 	if err != nil {
-		panic(err)
+		return err
 	}
-	llb.WriteTo(dt, os.Stdout)
+	return llb.WriteTo(dt, os.Stdout)
 }


### PR DESCRIPTION
https://github.com/moby/buildkit/blob/86c33b66e176a6fc74b88d6f46798d3ec18e2e73/frontend/dockerfile/dockerfile2llb/convert.go#L73

The stdout is for `*llb.State`, `--partial-image-config-file` is for `*Image`, `--partial-metadata-file` is for `*binfotypes.BuildInfo`.


The `*binfotypes.BuildInfo` contains source information for `docker-image` but does not contain other source information such as `http`.