### PR TITLE
Allow pulling partial layer chains from an image

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -161,6 +161,7 @@ func TestIntegration(t *testing.T) {
 		testUncompressedRegistryCacheImportExport,
 		testStargzLazyRegistryCacheImportExport,
 		testCallInfo,
+		testPullWithLayerLimit,
 	)
 	tests = append(tests, diffOpTestCases()...)
 	integration.Run(t, tests, mirrors)
@@ -5750,6 +5751,125 @@ func testBuildInfoNoExport(t *testing.T, sb integration.Sandbox) {
 	require.Equal(t, len(exbi.Sources), 1)
 	require.Equal(t, exbi.Sources[0].Type, binfotypes.SourceTypeDockerImage)
 	require.Equal(t, exbi.Sources[0].Ref, "docker.io/library/busybox:latest")
+}
+
+func testPullWithLayerLimit(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerd(t, sb, "direct push")
+	requiresLinux(t)
+	c, err := New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	st := llb.Scratch().
+		File(llb.Mkfile("/first", 0644, []byte("first"))).
+		File(llb.Mkfile("/second", 0644, []byte("second"))).
+		File(llb.Mkfile("/third", 0644, []byte("third")))
+
+	def, err := st.Marshal(sb.Context())
+	require.NoError(t, err)
+
+	registry, err := sb.NewRegistry()
+	if errors.Is(err, integration.ErrRequirements) {
+		t.Skip(err.Error())
+	}
+	require.NoError(t, err)
+
+	target := registry + "/buildkit/testlayers:latest"
+
+	_, err = c.Solve(sb.Context(), def, SolveOpt{
+		Exports: []ExportEntry{
+			{
+				Type: ExporterImage,
+				Attrs: map[string]string{
+					"name": target,
+					"push": "true",
+				},
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	// pull 2 first layers
+	st = llb.Image(target, llb.WithLayerLimit(2)).
+		File(llb.Mkfile("/forth", 0644, []byte("forth")))
+
+	def, err = st.Marshal(sb.Context())
+	require.NoError(t, err)
+
+	destDir, err := os.MkdirTemp("", "buildkit")
+	require.NoError(t, err)
+	defer os.RemoveAll(destDir)
+
+	_, err = c.Solve(sb.Context(), def, SolveOpt{
+		Exports: []ExportEntry{{
+			Type:      ExporterLocal,
+			OutputDir: destDir,
+		}},
+	}, nil)
+	require.NoError(t, err)
+
+	dt, err := os.ReadFile(filepath.Join(destDir, "first"))
+	require.NoError(t, err)
+	require.Equal(t, string(dt), "first")
+
+	dt, err = os.ReadFile(filepath.Join(destDir, "second"))
+	require.NoError(t, err)
+	require.Equal(t, string(dt), "second")
+
+	_, err = os.ReadFile(filepath.Join(destDir, "third"))
+	require.Error(t, err)
+	require.True(t, errors.Is(err, os.ErrNotExist))
+
+	dt, err = os.ReadFile(filepath.Join(destDir, "forth"))
+	require.NoError(t, err)
+	require.Equal(t, string(dt), "forth")
+
+	// pull 3rd layer only
+	st = llb.Diff(
+		llb.Image(target, llb.WithLayerLimit(2)),
+		llb.Image(target)).
+		File(llb.Mkfile("/forth", 0644, []byte("forth")))
+
+	def, err = st.Marshal(sb.Context())
+	require.NoError(t, err)
+
+	destDir, err = os.MkdirTemp("", "buildkit")
+	require.NoError(t, err)
+	defer os.RemoveAll(destDir)
+
+	_, err = c.Solve(sb.Context(), def, SolveOpt{
+		Exports: []ExportEntry{{
+			Type:      ExporterLocal,
+			OutputDir: destDir,
+		}},
+	}, nil)
+	require.NoError(t, err)
+
+	_, err = os.ReadFile(filepath.Join(destDir, "first"))
+	require.Error(t, err)
+	require.True(t, errors.Is(err, os.ErrNotExist))
+
+	_, err = os.ReadFile(filepath.Join(destDir, "second"))
+	require.Error(t, err)
+	require.True(t, errors.Is(err, os.ErrNotExist))
+
+	dt, err = os.ReadFile(filepath.Join(destDir, "third"))
+	require.NoError(t, err)
+	require.Equal(t, string(dt), "third")
+
+	dt, err = os.ReadFile(filepath.Join(destDir, "forth"))
+	require.NoError(t, err)
+	require.Equal(t, string(dt), "forth")
+
+	// zero limit errors cleanly
+	st = llb.Image(target, llb.WithLayerLimit(0))
+
+	def, err = st.Marshal(sb.Context())
+	require.NoError(t, err)
+
+	_, err = c.Solve(sb.Context(), def, SolveOpt{}, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid layer limit")
 }
 
 func testCallInfo(t *testing.T, sb integration.Sandbox) {

--- a/client/llb/resolver.go
+++ b/client/llb/resolver.go
@@ -23,6 +23,12 @@ func ResolveDigest(v bool) ImageOption {
 	})
 }
 
+func WithLayerLimit(l int) ImageOption {
+	return imageOptionFunc(func(ii *ImageInfo) {
+		ii.layerLimit = &l
+	})
+}
+
 // ImageMetaResolver can resolve image config metadata from a reference
 type ImageMetaResolver interface {
 	ResolveImageConfig(ctx context.Context, ref string, opt ResolveImageConfigOpt) (digest.Digest, []byte, error)

--- a/client/llb/source.go
+++ b/client/llb/source.go
@@ -116,6 +116,11 @@ func Image(ref string, opts ...ImageOption) State {
 		attrs[pb.AttrImageRecordType] = info.RecordType
 	}
 
+	if ll := info.layerLimit; ll != nil {
+		attrs[pb.AttrImageLayerLimit] = strconv.FormatInt(int64(*ll), 10)
+		addCap(&info.Constraints, pb.CapSourceImageLayerLimit)
+	}
+
 	src := NewSource("docker-image://"+ref, attrs, info.Constraints) // controversial
 	if err != nil {
 		src.err = err
@@ -204,6 +209,7 @@ type ImageInfo struct {
 	metaResolver  ImageMetaResolver
 	resolveDigest bool
 	resolveMode   ResolveMode
+	layerLimit    *int
 	RecordType    string
 }
 

--- a/solver/pb/attr.go
+++ b/solver/pb/attr.go
@@ -26,6 +26,7 @@ const AttrImageResolveModeDefault = "default"
 const AttrImageResolveModeForcePull = "pull"
 const AttrImageResolveModePreferLocal = "local"
 const AttrImageRecordType = "image.recordtype"
+const AttrImageLayerLimit = "image.layerlimit"
 
 const AttrLocalDiffer = "local.differ"
 const AttrLocalDifferNone = "none"

--- a/solver/pb/caps.go
+++ b/solver/pb/caps.go
@@ -9,8 +9,10 @@ var Caps apicaps.CapList
 // considered immutable. After a capability is marked stable it should not be disabled.
 
 const (
-	CapSourceImage                apicaps.CapID = "source.image"
-	CapSourceImageResolveMode     apicaps.CapID = "source.image.resolvemode"
+	CapSourceImage            apicaps.CapID = "source.image"
+	CapSourceImageResolveMode apicaps.CapID = "source.image.resolvemode"
+	CapSourceImageLayerLimit  apicaps.CapID = "source.image.layerlimit"
+
 	CapSourceLocal                apicaps.CapID = "source.local"
 	CapSourceLocalUnique          apicaps.CapID = "source.local.unique"
 	CapSourceLocalSessionID       apicaps.CapID = "source.local.sessionid"
@@ -82,6 +84,12 @@ func init() {
 
 	Caps.Init(apicaps.Cap{
 		ID:      CapSourceImageResolveMode,
+		Enabled: true,
+		Status:  apicaps.CapStatusExperimental,
+	})
+
+	Caps.Init(apicaps.Cap{
+		ID:      CapSourceImageLayerLimit,
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})

--- a/source/identifier.go
+++ b/source/identifier.go
@@ -85,6 +85,15 @@ func FromLLB(op *pb.Op_Source, platform *pb.Platform) (Identifier, error) {
 					return nil, err
 				}
 				id.RecordType = rt
+			case pb.AttrImageLayerLimit:
+				l, err := strconv.Atoi(v)
+				if err != nil {
+					return nil, errors.Wrapf(err, "invalid layer limit %s", v)
+				}
+				if l <= 0 {
+					return nil, errors.Errorf("invalid layer limit %s", v)
+				}
+				id.LayerLimit = &l
 			}
 		}
 	}
@@ -190,6 +199,7 @@ type ImageIdentifier struct {
 	Platform    *ocispecs.Platform
 	ResolveMode ResolveMode
 	RecordType  client.UsageRecordType
+	LayerLimit  *int
 }
 
 func NewImageIdentifier(str string) (*ImageIdentifier, error) {


### PR DESCRIPTION
Adds a new `WithLayerLimit` option to `llb.Image`
only pulls specified number of layers instead of
full image.

This can be used in combination with DiffOp/MergeOp
to pull any subset of layers from an image in any order.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>