### PR TITLE
cache: set committed to true for merge+diff refs.

### DIFF
--- a/cache/manager.go
+++ b/cache/manager.go
@@ -794,7 +794,7 @@ func (cm *cacheManager) createMergeRef(ctx context.Context, parents parentRefs, 
 	}
 
 	rec.queueSnapshotID(snapshotID)
-
+	rec.queueCommitted(true)
 	if err := rec.commitMetadata(); err != nil {
 		return nil, err
 	}
@@ -969,6 +969,7 @@ func (cm *cacheManager) createDiffRef(ctx context.Context, parents parentRefs, d
 	}
 
 	rec.queueSnapshotID(snapshotID)
+	rec.queueCommitted(true)
 	if err := rec.commitMetadata(); err != nil {
 		return nil, err
 	}

--- a/cache/manager.go
+++ b/cache/manager.go
@@ -458,6 +458,13 @@ func (cm *cacheManager) getRecord(ctx context.Context, id string, opts ...RefOpt
 		cacheMetadata: md,
 	}
 
+	// TODO:(sipsma) this is kludge to deal with a bug in v0.10.{0,1} where
+	// merge and diff refs didn't have committed set to true:
+	// https://github.com/moby/buildkit/issues/2740
+	if kind := rec.kind(); kind == Merge || kind == Diff {
+		rec.mutable = false
+	}
+
 	// the record was deleted but we crashed before data on disk was removed
 	if md.getDeleted() {
 		if err := rec.remove(ctx, true); err != nil {

--- a/cache/manager.go
+++ b/cache/manager.go
@@ -503,6 +503,11 @@ func (cm *cacheManager) getRecord(ctx context.Context, id string, opts ...RefOpt
 }
 
 func (cm *cacheManager) parentsOf(ctx context.Context, md *cacheMetadata, opts ...RefOption) (ps parentRefs, rerr error) {
+	defer func() {
+		if rerr != nil {
+			ps.release(context.TODO())
+		}
+	}()
 	if parentID := md.getParent(); parentID != "" {
 		p, err := cm.get(ctx, parentID, nil, append(opts, NoUpdateLastUsed))
 		if err != nil {

--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -2091,6 +2091,7 @@ func TestMergeOp(t *testing.T) {
 
 	singleMerge, err := cm.Merge(ctx, baseRefs[:1], nil)
 	require.NoError(t, err)
+	require.True(t, singleMerge.(*immutableRef).getCommitted())
 	m, err := singleMerge.Mount(ctx, true, nil)
 	require.NoError(t, err)
 	ms, unmount, err := m.Mount()
@@ -2111,6 +2112,7 @@ func TestMergeOp(t *testing.T) {
 
 	merge1, err := cm.Merge(ctx, baseRefs[:3], nil)
 	require.NoError(t, err)
+	require.True(t, merge1.(*immutableRef).getCommitted())
 	_, err = merge1.Mount(ctx, true, nil)
 	require.NoError(t, err)
 	size1, err := merge1.(*immutableRef).size(ctx)
@@ -2120,6 +2122,7 @@ func TestMergeOp(t *testing.T) {
 
 	merge2, err := cm.Merge(ctx, baseRefs[3:], nil)
 	require.NoError(t, err)
+	require.True(t, merge2.(*immutableRef).getCommitted())
 	_, err = merge2.Mount(ctx, true, nil)
 	require.NoError(t, err)
 	size2, err := merge2.(*immutableRef).size(ctx)
@@ -2135,6 +2138,7 @@ func TestMergeOp(t *testing.T) {
 
 	merge3, err := cm.Merge(ctx, []ImmutableRef{merge1, merge2}, nil)
 	require.NoError(t, err)
+	require.True(t, merge3.(*immutableRef).getCommitted())
 	require.NoError(t, merge1.Release(ctx))
 	require.NoError(t, merge2.Release(ctx))
 	_, err = merge3.Mount(ctx, true, nil)


### PR DESCRIPTION
Before this, merge and diff refs were incorrectly not being marked as
committed, which meant that when cache was reloaded they would be marked
as mutable, which in turn lead to them being removed by the cache
manager's init method. If the ref was a parent, this could cause an
inconsistent state to arise.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

I can no longer reproduce the problem in #2740 after this fix, but that problem was not totally consistent for me to reproduce locally, so appreciate if you can give it a try too @tonistiigi 

~I also haven't 100% connected every dot between the problem being fixed here and the exact error message that was arising in that issue, so I will continue investigating to make sure there's not more problems besides the one patched in this PR.~
EDIT: I figured it out and added comments explaining what's going on in #2740 