### PR TITLE
dockerfile (labs): implement `ADD <git ref>` 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ run:
 
   build-tags:
     - dfrunsecurity
+    - dfaddgit
 
 linters:
   enable:

--- a/frontend/dockerfile/dockerfile2llb/convert_addgit.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_addgit.go
@@ -1,0 +1,6 @@
+//go:build dfaddgit
+// +build dfaddgit
+
+package dockerfile2llb
+
+const addGitEnabled = true

--- a/frontend/dockerfile/dockerfile2llb/convert_noaddgit.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_noaddgit.go
@@ -1,0 +1,6 @@
+//go:build !dfaddgit
+// +build !dfaddgit
+
+package dockerfile2llb
+
+const addGitEnabled = false

--- a/frontend/dockerfile/dockerfile_addgit_test.go
+++ b/frontend/dockerfile/dockerfile_addgit_test.go
@@ -1,0 +1,115 @@
+//go:build dfaddgit
+// +build dfaddgit
+
+package dockerfile
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"text/template"
+
+	"github.com/containerd/continuity/fs/fstest"
+	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/frontend/dockerfile/builder"
+	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/stretchr/testify/require"
+)
+
+var addGitTests = integration.TestFuncs(
+	testAddGit,
+)
+
+func init() {
+	allTests = append(allTests, addGitTests...)
+}
+
+func testAddGit(t *testing.T, sb integration.Sandbox) {
+	f := getFrontend(t, sb)
+
+	gitDir, err := os.MkdirTemp("", "buildkit")
+	require.NoError(t, err)
+	defer os.RemoveAll(gitDir)
+	gitCommands := []string{
+		"git init",
+		"git config --local user.email test",
+		"git config --local user.name test",
+	}
+	makeCommit := func(tag string) []string {
+		return []string{
+			"echo foo of " + tag + " >foo",
+			"git add foo",
+			"git commit -m " + tag,
+			"git tag " + tag,
+		}
+	}
+	gitCommands = append(gitCommands, makeCommit("v0.0.1")...)
+	gitCommands = append(gitCommands, makeCommit("v0.0.2")...)
+	gitCommands = append(gitCommands, makeCommit("v0.0.3")...)
+	gitCommands = append(gitCommands, "git update-server-info")
+	err = runShell(gitDir, gitCommands...)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.FileServer(http.Dir(filepath.Join(gitDir))))
+	defer server.Close()
+	serverURL := server.URL
+	t.Logf("serverURL=%q", serverURL)
+
+	dockerfile, err := applyTemplate(`
+FROM alpine
+
+# Basic case
+ADD {{.ServerURL}}/.git#v0.0.1 /x
+RUN cd /x && \
+  [ "$(cat foo)" = "foo of v0.0.1" ]
+
+# Complicated case
+ARG REPO="{{.ServerURL}}/.git"
+ARG TAG="v0.0.2"
+ADD --keep-git-dir=true --chown=4242:8484 ${REPO}#${TAG} /buildkit-chowned
+RUN apk add git
+USER 4242
+RUN cd /buildkit-chowned && \
+  [ "$(cat foo)" = "foo of v0.0.2" ] && \
+  [ "$(stat -c %u foo)" = "4242" ] && \
+  [ "$(stat -c %g foo)" = "8484" ] && \
+  [ -z "$(git status -s)" ]
+`, map[string]string{
+		"ServerURL": serverURL,
+	})
+	require.NoError(t, err)
+	t.Logf("dockerfile=%s", dockerfile)
+
+	dir, err := integration.Tmpdir(t,
+		fstest.CreateFile("Dockerfile", []byte(dockerfile), 0600),
+	)
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	c, err := client.New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
+		LocalDirs: map[string]string{
+			builder.DefaultLocalNameDockerfile: dir,
+			builder.DefaultLocalNameContext:    dir,
+		},
+	}, nil)
+	require.NoError(t, err)
+}
+
+func applyTemplate(tmpl string, x interface{}) (string, error) {
+	var buf bytes.Buffer
+	parsed, err := template.New("").Parse(tmpl)
+	if err != nil {
+		return "", err
+	}
+	if err := parsed.Execute(&buf, x); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}

--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -1500,6 +1500,44 @@ guide – Leverage build cache](https://docs.docker.com/develop/develop-images/d
 - If `<dest>` doesn't exist, it is created along with all missing directories
   in its path.
 
+### Adding a git repository `ADD <git ref> <dir>`
+
+> **Note**
+>
+> Available in [`docker/dockerfile-upstream:master-labs`](#syntax).
+> Will be included in `docker/dockerfile:1.5-labs`.
+
+This form allows adding a git repository to an image directly, without using the `git` command inside the image:
+```
+ADD [--keep-git-dir=<boolean>] <git ref> <dir>
+```
+
+```dockerfile
+# syntax=docker/dockerfile-upstream:master-labs
+FROM alpine
+ADD --keep-git-dir=true https://github.com/moby/buildkit.git#v0.10.1 /buildkit
+```
+
+The `--keep-git-dir=true` flag adds the `.git` directory. This flag defaults to false.
+
+### Adding a private git repository
+To add a private repo via SSH, create a Dockerfile with the following form:
+```dockerfile
+# syntax = docker/dockerfile-upstream:master-labs
+FROM alpine
+ADD git@git.example.com:foo/bar.git /bar
+```
+
+This Dockerfile can be built with `docker build --ssh` or `buildctl build --ssh`, e.g.,
+
+```console
+$ docker build --ssh default
+```
+
+```console
+$ buildctl build --frontend=dockerfile.v0 --local context=. --local dockerfile=. --ssh default
+```
+
 ## ADD --link
 
 See [`COPY --link`](#copy---link).

--- a/frontend/dockerfile/instructions/commands.go
+++ b/frontend/dockerfile/instructions/commands.go
@@ -224,9 +224,10 @@ func (s *SourcesAndDest) ExpandRaw(expander SingleWordExpander) error {
 type AddCommand struct {
 	withNameAndCode
 	SourcesAndDest
-	Chown string
-	Chmod string
-	Link  bool
+	Chown      string
+	Chmod      string
+	Link       bool
+	KeepGitDir bool // whether to keep .git dir, only meaningful for git sources
 }
 
 // Expand variables

--- a/frontend/dockerfile/instructions/parse.go
+++ b/frontend/dockerfile/instructions/parse.go
@@ -281,6 +281,7 @@ func parseAdd(req parseRequest) (*AddCommand, error) {
 	flChown := req.flags.AddString("chown", "")
 	flChmod := req.flags.AddString("chmod", "")
 	flLink := req.flags.AddBool("link", false)
+	flKeepGitDir := req.flags.AddBool("keep-git-dir", false)
 	if err := req.flags.Parse(); err != nil {
 		return nil, err
 	}
@@ -296,6 +297,7 @@ func parseAdd(req parseRequest) (*AddCommand, error) {
 		Chown:           flChown.Value,
 		Chmod:           flChmod.Value,
 		Link:            flLink.Value == "true",
+		KeepGitDir:      flKeepGitDir.Value == "true",
 	}, nil
 }
 

--- a/frontend/dockerfile/release/labs/tags
+++ b/frontend/dockerfile/release/labs/tags
@@ -1,1 +1,1 @@
-dfrunsecurity
+dfrunsecurity dfaddgit

--- a/util/gitutil/git_ref.go
+++ b/util/gitutil/git_ref.go
@@ -1,0 +1,95 @@
+package gitutil
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/containerd/containerd/errdefs"
+)
+
+// GitRef represents a git ref.
+//
+// Examples:
+// - "https://github.com/foo/bar.git#baz/qux:quux/quuz" is parsed into:
+//   {Remote: "https://github.com/foo/bar.git", ShortName: "bar", Commit:"baz/qux", SubDir: "quux/quuz"}.
+type GitRef struct {
+	// Remote is the remote repository path.
+	Remote string
+
+	// ShortName is the directory name of the repo.
+	// e.g., "bar" for "https://github.com/foo/bar.git"
+	ShortName string
+
+	// Commit is a commit hash, a tag, or branch name.
+	// Commit is optional.
+	Commit string
+
+	// SubDir is a directory path inside the repo.
+	// SubDir is optional.
+	SubDir string
+
+	// IndistinguishableFromLocal is true for a ref that is indistinguishable from a local file path,
+	// e.g., "github.com/foo/bar".
+	//
+	// Deprecated.
+	// Instead, use a distinguishable form such as "https://github.com/foo/bar.git".
+	//
+	// The dockerfile frontend still accepts this form only for build contexts.
+	IndistinguishableFromLocal bool
+
+	// UnencryptedTCP is true for a ref that needs an unencrypted TCP connection,
+	// e.g., "git://..." and "http://..." .
+	//
+	// Discouraged, although not deprecated.
+	// Instead, consider using an encrypted TCP connection such as "git@github.com/foo/bar.git" or "https://github.com/foo/bar.git".
+	UnencryptedTCP bool
+}
+
+// var gitURLPathWithFragmentSuffix = regexp.MustCompile(`\.git(?:#.+)?$`)
+
+// ParseGitRef parses a git ref.
+func ParseGitRef(ref string) (*GitRef, error) {
+	res := &GitRef{}
+
+	if strings.HasPrefix(ref, "github.com/") {
+		res.IndistinguishableFromLocal = true // Deprecated
+	} else {
+		_, proto := ParseProtocol(ref)
+		switch proto {
+		case UnknownProtocol:
+			return nil, errdefs.ErrInvalidArgument
+		}
+		switch proto {
+		case HTTPProtocol, GitProtocol:
+			res.UnencryptedTCP = true // Discouraged, but not deprecated
+		}
+		switch proto {
+		// An HTTP(S) URL is considered to be a valid git ref only when it has the ".git[...]" suffix.
+		case HTTPProtocol, HTTPSProtocol:
+			var gitURLPathWithFragmentSuffix = regexp.MustCompile(`\.git(?:#.+)?$`)
+			if !gitURLPathWithFragmentSuffix.MatchString(ref) {
+				return nil, errdefs.ErrInvalidArgument
+			}
+		}
+	}
+
+	refSplitBySharp := strings.SplitN(ref, "#", 2)
+	res.Remote = refSplitBySharp[0]
+	if len(res.Remote) == 0 {
+		return res, errdefs.ErrInvalidArgument
+	}
+
+	if len(refSplitBySharp) > 1 {
+		refSplitBySharpSplitByColon := strings.SplitN(refSplitBySharp[1], ":", 2)
+		res.Commit = refSplitBySharpSplitByColon[0]
+		if len(res.Commit) == 0 {
+			return res, errdefs.ErrInvalidArgument
+		}
+		if len(refSplitBySharpSplitByColon) > 1 {
+			res.SubDir = refSplitBySharpSplitByColon[1]
+		}
+	}
+	repoSplitBySlash := strings.Split(res.Remote, "/")
+	res.ShortName = strings.TrimSuffix(repoSplitBySlash[len(repoSplitBySlash)-1], ".git")
+	return res, nil
+}

--- a/util/gitutil/git_ref_test.go
+++ b/util/gitutil/git_ref_test.go
@@ -1,0 +1,77 @@
+package gitutil
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseGitRef(t *testing.T) {
+	cases := map[string]*GitRef{
+		"https://example.com/":    nil,
+		"https://example.com/foo": nil,
+		"https://example.com/foo.git": {
+			Remote:    "https://example.com/foo.git",
+			ShortName: "foo",
+		},
+		"https://example.com/foo.git#deadbeef": {
+			Remote:    "https://example.com/foo.git",
+			ShortName: "foo",
+			Commit:    "deadbeef",
+		},
+		"https://example.com/foo.git#release/1.2": {
+			Remote:    "https://example.com/foo.git",
+			ShortName: "foo",
+			Commit:    "release/1.2",
+		},
+		"https://example.com/foo.git/":    nil,
+		"https://example.com/foo.git.bar": nil,
+		"git://example.com/foo": {
+			Remote:         "git://example.com/foo",
+			ShortName:      "foo",
+			UnencryptedTCP: true,
+		},
+		"github.com/moby/buildkit": {
+			Remote: "github.com/moby/buildkit", ShortName: "buildkit",
+			IndistinguishableFromLocal: true,
+		},
+		"https://github.com/moby/buildkit": nil,
+		"https://github.com/moby/buildkit.git": {
+			Remote:    "https://github.com/moby/buildkit.git",
+			ShortName: "buildkit",
+		},
+		"git@github.com:moby/buildkit": {
+			Remote:    "git@github.com:moby/buildkit",
+			ShortName: "buildkit",
+		},
+		"git@github.com:moby/buildkit.git": {
+			Remote:    "git@github.com:moby/buildkit.git",
+			ShortName: "buildkit",
+		},
+		"git@bitbucket.org:atlassianlabs/atlassian-docker.git": {
+			Remote:    "git@bitbucket.org:atlassianlabs/atlassian-docker.git",
+			ShortName: "atlassian-docker",
+		},
+		"https://github.com/foo/bar.git#baz/qux:quux/quuz": {
+			Remote:    "https://github.com/foo/bar.git",
+			ShortName: "bar",
+			Commit:    "baz/qux",
+			SubDir:    "quux/quuz",
+		},
+		"http://github.com/docker/docker.git:#branch": nil,
+	}
+	for ref, expected := range cases {
+		got, err := ParseGitRef(ref)
+		if expected == nil {
+			if err == nil {
+				t.Errorf("expected an error for ParseGitRef(%q)", ref)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("got an unexpected error: ParseGitRef(%q): %v", ref, err)
+			}
+			if !reflect.DeepEqual(got, expected) {
+				t.Errorf("expected ParseGitRef(%q) to return %#v, got %#v", ref, expected, got)
+			}
+		}
+	}
+}


### PR DESCRIPTION
e.g.,
```dockerfile
# syntax=docker/dockerfile-upstream:master-labs
FROM alpine
ADD --keep-git-dir=true https://github.com/moby/buildkit.git#v0.10.1 /buildkit
```

Close #775

Expected to be used with:
- https://github.com/moby/buildkit/pull/2943