### PR TITLE
exporter: containerimage: Add an option to unlazy image blobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Keys supported by image output:
 * `force-compression=true`: forcefully apply `compression` option to all layers (including already existing layers).
 * `buildinfo=true`: inline build info in [image config](docs/build-repro.md#image-config) (default `true`).
 * `buildinfo-attrs=true`: inline build info attributes in [image config](docs/build-repro.md#image-config) (default `false`).
+* `store=true`: stores the result images to the worker's (e.g. containerd) image store as well as ensures that the image has all blobs in the content store (default `true`). Ignored if the worker doesn't have image store (e.g. OCI worker).
 
 If credentials are required, `buildctl` will attempt to read Docker configuration file `$DOCKER_CONFIG/config.json`.
 `$DOCKER_CONFIG` defaults to `~/.docker`.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2968,8 +2968,10 @@ func testStargzLazyRegistryCacheImportExport(t *testing.T, sb integration.Sandbo
 			{
 				Type: ExporterImage,
 				Attrs: map[string]string{
-					"name": target,
-					"push": "true",
+					"name":                                   target,
+					"push":                                   "true",
+					"store":                                  "true",
+					"unsafe-internal-store-allow-incomplete": "true",
 				},
 			},
 		},
@@ -3111,10 +3113,12 @@ func testStargzLazyInlineCacheImportExport(t *testing.T, sb integration.Sandbox)
 			{
 				Type: ExporterImage,
 				Attrs: map[string]string{
-					"name":           target,
-					"push":           "true",
-					"oci-mediatypes": "true",
-					"compression":    "estargz",
+					"name":                                   target,
+					"push":                                   "true",
+					"oci-mediatypes":                         "true",
+					"compression":                            "estargz",
+					"store":                                  "true",
+					"unsafe-internal-store-allow-incomplete": "true",
 				},
 			},
 		},
@@ -3257,9 +3261,11 @@ func testStargzLazyPull(t *testing.T, sb integration.Sandbox) {
 			{
 				Type: ExporterImage,
 				Attrs: map[string]string{
-					"name":           target,
-					"push":           "true",
-					"oci-mediatypes": "true",
+					"name":                                   target,
+					"push":                                   "true",
+					"oci-mediatypes":                         "true",
+					"store":                                  "true",
+					"unsafe-internal-store-allow-incomplete": "true",
 				},
 			},
 		},
@@ -3354,8 +3360,10 @@ func testLazyImagePush(t *testing.T, sb integration.Sandbox) {
 			{
 				Type: ExporterImage,
 				Attrs: map[string]string{
-					"name": target,
-					"push": "true",
+					"name":                                   target,
+					"push":                                   "true",
+					"store":                                  "true",
+					"unsafe-internal-store-allow-incomplete": "true",
 				},
 			},
 		},
@@ -3392,8 +3400,10 @@ func testLazyImagePush(t *testing.T, sb integration.Sandbox) {
 			{
 				Type: ExporterImage,
 				Attrs: map[string]string{
-					"name": target2,
-					"push": "true",
+					"name":                                   target2,
+					"push":                                   "true",
+					"store":                                  "true",
+					"unsafe-internal-store-allow-incomplete": "true",
 				},
 			},
 		},
@@ -3424,8 +3434,10 @@ func testLazyImagePush(t *testing.T, sb integration.Sandbox) {
 			{
 				Type: ExporterImage,
 				Attrs: map[string]string{
-					"name": target3,
-					"push": "true",
+					"name":                                   target3,
+					"push":                                   "true",
+					"store":                                  "true",
+					"unsafe-internal-store-allow-incomplete": "true",
 				},
 			},
 		},
@@ -4838,8 +4850,10 @@ func testMergeOpCache(t *testing.T, sb integration.Sandbox, mode string) {
 			{
 				Type: ExporterImage,
 				Attrs: map[string]string{
-					"name": busyboxTarget,
-					"push": "true",
+					"name":                                   busyboxTarget,
+					"push":                                   "true",
+					"store":                                  "true",
+					"unsafe-internal-store-allow-incomplete": "true",
 				},
 			},
 		},
@@ -4939,8 +4953,10 @@ func testMergeOpCache(t *testing.T, sb integration.Sandbox, mode string) {
 			{
 				Type: ExporterImage,
 				Attrs: map[string]string{
-					"name": target,
-					"push": "true",
+					"name":                                   target,
+					"push":                                   "true",
+					"store":                                  "true",
+					"unsafe-internal-store-allow-incomplete": "true",
 				},
 			},
 		},
@@ -4993,8 +5009,10 @@ func testMergeOpCache(t *testing.T, sb integration.Sandbox, mode string) {
 		Exports: []ExportEntry{{
 			Type: ExporterImage,
 			Attrs: map[string]string{
-				"name": target,
-				"push": "true",
+				"name":                                   target,
+				"push":                                   "true",
+				"store":                                  "true",
+				"unsafe-internal-store-allow-incomplete": "true",
 			},
 		}},
 		CacheImports: cacheImports,
@@ -5029,8 +5047,10 @@ func testMergeOpCache(t *testing.T, sb integration.Sandbox, mode string) {
 		Exports: []ExportEntry{{
 			Type: ExporterImage,
 			Attrs: map[string]string{
-				"name": target,
-				"push": "true",
+				"name":                                   target,
+				"push":                                   "true",
+				"store":                                  "true",
+				"unsafe-internal-store-allow-incomplete": "true",
 			},
 		}},
 		CacheExports: cacheExports,
@@ -5100,8 +5120,10 @@ func testMergeOpCache(t *testing.T, sb integration.Sandbox, mode string) {
 		Exports: []ExportEntry{{
 			Type: ExporterImage,
 			Attrs: map[string]string{
-				"name": target,
-				"push": "true",
+				"name":                                   target,
+				"push":                                   "true",
+				"store":                                  "true",
+				"unsafe-internal-store-allow-incomplete": "true",
 			},
 		}},
 		CacheExports: cacheExports,
@@ -5144,8 +5166,10 @@ func testMergeOpCache(t *testing.T, sb integration.Sandbox, mode string) {
 		Exports: []ExportEntry{{
 			Type: ExporterImage,
 			Attrs: map[string]string{
-				"name": target,
-				"push": "true",
+				"name":                                   target,
+				"push":                                   "true",
+				"store":                                  "true",
+				"unsafe-internal-store-allow-incomplete": "true",
 			},
 		}},
 		CacheImports: cacheImports,

--- a/client/mergediff_test.go
+++ b/client/mergediff_test.go
@@ -1272,8 +1272,9 @@ func (tc verifyContents) Run(t *testing.T, sb integration.Sandbox) {
 					{
 						Type: ExporterImage,
 						Attrs: map[string]string{
-							"name": imageTarget,
-							"push": "true",
+							"name":                                   imageTarget,
+							"push":                                   "true",
+							"unsafe-internal-store-allow-incomplete": "true",
 						},
 					},
 				},


### PR DESCRIPTION
Some blobs in the result image can be lazy (i.e. not existing in the local content store).
This doesn't allow non-buildkit containerd clients (e.g. ctr, nerdctl, ...) fetching the resulting image from containerd.
Unpack doesn't solve this because it only unlazies the default platform of the image.

```console
# mkdir -p /tmp/ctx && cat <<EOF > /tmp/ctx/Dockerfile
FROM ubuntu:20.04
CMD echo hello
EOF
# buildctl build --progress=plain --frontend=dockerfile.v0 \
               --local context=/tmp/ctx --local dockerfile=/tmp/ctx \
               --opt platform=linux/amd64,linux/arm64 \
               --output=type=image,unpack=true,name=foo
# ctr image export --all-platforms /tmp/out3.tar foo
ctr: failed to get reader: content digest sha256:185e8a4c100571f111d924b5d4399d89f163bf95d71ce2c6a33f656a66c52f0a: not found
```

This commit fixes this by adding a new option `ensure-blobs` to containerimage exporter.
This option unlazies blobs of the build result.
