### PR TITLE
buildctl: support exporting SolveResponse as a JSON file

### DIFF
--- a/client/graph.go
+++ b/client/graph.go
@@ -55,5 +55,5 @@ type SolveStatus struct {
 
 type SolveResponse struct {
 	// ExporterResponse is also used for CacheExporter
-	ExporterResponse map[string]string
+	ExporterResponse map[string]string `json:"exporterResponse"`
 }


### PR DESCRIPTION
e.g.,
```console
$ buildctl build  --frontend dockerfile.v0  --local dockerfile=. --local context=. --output type=image,name=foo --response-file resp.json
$ cat resp.json
{
  "exporterResponse": {
    "containerimage.buildinfo": "eyJmcm9udGVuZCI6ImRvY2tlcmZpbGUudjAiLCJzb3VyY2VzIjpbeyJ0eXBlIjoiZG9ja2VyLWltYWdlIiwicmVmIjoiZG9ja2VyLmlvL2xpYnJhcnkvYWxwaW5lOmxhdGVzdCIsInBpbiI6InNoYTI1Njo0ZWRiZDJiZWI1Zjc4YjEwMTQwMjhmNGZiYjk5ZjMyMzdkOTU2MTEwMGI2ODgxYWFiYmY1YWNjZTJjNGY5NDU0In0seyJ0eXBlIjoiaHR0cCIsInJlZiI6Imh0dHBzOi8vcmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbS9tb2J5L2J1aWxka2l0L3YwLjEwLjEvUkVBRE1FLm1kIiwicGluIjoic2hhMjU2OjZlNGI5NGZjMjcwZTcwOGUxMDY4YmUyOGJkMzU1MWRjNjkxN2E0ZmM1YTYxMjkzZDUxYmIzNmU2Yjc1YzRiNTMifV19",
    "containerimage.config.digest": "sha256:715a5c56573fe9c46812f100bb6f359436a3ee627e521310b6ca2bfea2d837a3",
    "containerimage.descriptor": "eyJtZWRpYVR5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwiZGlnZXN0Ijoic2hhMjU2OmRhNWZiMjhiMjgwZGY1MGExMGQxMTg0ZjJmMTU4ZGE2OGNhMmY5YTZkYjUxY2ZkYzFiNmM0YTk5NGFjNTIyMjMiLCJzaXplIjo3MzZ9",
    "containerimage.digest": "sha256:da5fb28b280df50a10d1184f2f158da68ca2f9a6db51cfdc1b6c4a994ac52223",
    "image.name": "foo"
  }
}
```

This can be used for inspecting metadata that aren't placed in `--metadata-file`.
e.g., `consumedPin` data discussed in https://github.com/moby/buildkit/issues/2794#issuecomment-1094895736