### PR TITLE
dockerfile: support Dockerfile.pin for pinning sources

### DIFF
--- a/docs/build-repro.md
+++ b/docs/build-repro.md
@@ -127,3 +127,36 @@ jq '.' metadata.json
   "containerimage.digest": "sha256:..."
 }
 ```
+
+### Reproducible build with `Dockerfile.pin`
+
+<!-- TODO: dockerfile-upstream:master -> dockerfile:1.5 after the release of 1.5 -->>
+`Dockerfile.pin` is supported in the `docker/dockerfile-upstream:master` syntax.
+```dockerfile
+# syntax=docker/dockerfile-upstream:master`
+```
+
+When `Dockerfile.pin` exists in the context, the Dockerfile builder does:
+- Pinning the digest of `docker-image` sources (`FROM ...`)
+- Pinning the digest of `http` sources (`ADD https://...`)
+- Recording the consumed entries to the exporter response `pin.consumed`
+
+The content of `Dockerfile.pin` is a subset of the build info structure:
+```json
+{
+    "sources": [
+      {
+        "type": "docker-image",
+        "ref": "docker.io/library/alpine:latest",
+        "pin": "sha256:4edbd2beb5f78b1014028f4fbb99f3237d9561100b6881aabbf5acce2c4f9454"
+      },
+      {
+        "type": "http",
+        "ref": "https://raw.githubusercontent.com/moby/buildkit/v0.10.1/README.md",
+        "pin": "sha256:6e4b94fc270e708e1068be28bd3551dc6917a4fc5a61293d51bb36e6b75c4b53"
+      }
+    ]
+}
+```
+
+In the future, Dockerfile should also support `ADD https://example.com/repo.git /dir` and pinning its commit hash.

--- a/exporter/containerimage/exptypes/types.go
+++ b/exporter/containerimage/exptypes/types.go
@@ -13,6 +13,7 @@ const (
 	ExporterInlineCache          = "containerimage.inlinecache"
 	ExporterBuildInfo            = "containerimage.buildinfo"
 	ExporterPlatformsKey         = "refs.platforms"
+	ExporterPinConsumed          = "pin.consumed" // base64-encoded JSON of util/pin/types.Consumed
 )
 
 type Platforms struct {

--- a/frontend/dockerfile/dockerfile_pin_test.go
+++ b/frontend/dockerfile/dockerfile_pin_test.go
@@ -1,0 +1,138 @@
+package dockerfile
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/containerd/continuity/fs/fstest"
+	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/exporter/containerimage/exptypes"
+	"github.com/moby/buildkit/frontend/dockerfile/builder"
+	pintypes "github.com/moby/buildkit/util/pin/types"
+	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/stretchr/testify/require"
+)
+
+var pinTests = integration.TestFuncs(
+	testPin,
+)
+
+func init() {
+	allTests = append(allTests, pinTests...)
+}
+
+func testPin(t *testing.T, sb integration.Sandbox) {
+	f := getFrontend(t, sb)
+	dockerfile := `
+FROM alpine
+ADD https://raw.githubusercontent.com/moby/buildkit/v0.10.1/README.md /README.md
+`
+	type testCase struct {
+		title         string
+		dockerfilePin string
+		valid         bool
+		validateResp  func(*testing.T, *client.SolveResponse)
+	}
+	testCases := []testCase{
+		{
+			title: "Valid",
+			dockerfilePin: `{
+    "sources": [
+      {
+        "type": "docker-image",
+        "ref": "docker.io/library/alpine:latest",
+        "pin": "sha256:4edbd2beb5f78b1014028f4fbb99f3237d9561100b6881aabbf5acce2c4f9454"
+      },
+      {
+        "type": "http",
+        "ref": "https://raw.githubusercontent.com/moby/buildkit/v0.10.1/README.md",
+        "pin": "sha256:6e4b94fc270e708e1068be28bd3551dc6917a4fc5a61293d51bb36e6b75c4b53"
+      }
+    ]
+}
+`,
+			valid: true,
+			validateResp: func(t *testing.T, resp *client.SolveResponse) {
+				require.Contains(t, resp.ExporterResponse, exptypes.ExporterPinConsumed)
+				dtpc, err := base64.StdEncoding.DecodeString(resp.ExporterResponse[exptypes.ExporterPinConsumed])
+				require.NoError(t, err)
+				var pc pintypes.Consumed
+				err = json.Unmarshal(dtpc, &pc)
+				require.NoError(t, err)
+				require.Len(t, pc.Sources, 2)
+				require.Equal(t, "sha256:4edbd2beb5f78b1014028f4fbb99f3237d9561100b6881aabbf5acce2c4f9454", pc.Sources[0].Pin)
+				require.Equal(t, "sha256:6e4b94fc270e708e1068be28bd3551dc6917a4fc5a61293d51bb36e6b75c4b53", pc.Sources[1].Pin)
+			},
+		},
+		{
+			title: "InvalidDockerImagePin",
+			dockerfilePin: `{
+    "sources": [
+      {
+        "type": "docker-image",
+        "ref": "docker.io/library/alpine:latest",
+        "pin": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      },
+      {
+        "type": "http",
+        "ref": "https://raw.githubusercontent.com/moby/buildkit/v0.10.1/README.md",
+        "pin": "sha256:6e4b94fc270e708e1068be28bd3551dc6917a4fc5a61293d51bb36e6b75c4b53"
+      }
+    ]
+}
+`,
+			valid: false,
+		},
+		{
+			title: "InvalidHTTPPin",
+			dockerfilePin: `{
+    "sources": [
+      {
+        "type": "docker-image",
+        "ref": "docker.io/library/alpine:latest",
+        "pin": "sha256:4edbd2beb5f78b1014028f4fbb99f3237d9561100b6881aabbf5acce2c4f9454"
+      },
+      {
+        "type": "http",
+        "ref": "https://raw.githubusercontent.com/moby/buildkit/v0.10.1/README.md",
+        "pin": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      }
+    ]
+}
+`,
+			valid: false,
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.title, func(t *testing.T) {
+			dir, err := tmpdir(
+				fstest.CreateFile("Dockerfile", []byte(dockerfile), 0600),
+				fstest.CreateFile("Dockerfile.pin", []byte(tc.dockerfilePin), 0600),
+			)
+			require.NoError(t, err)
+			defer os.RemoveAll(dir)
+
+			c, err := client.New(sb.Context(), sb.Address())
+			require.NoError(t, err)
+			defer c.Close()
+
+			res, err := f.Solve(sb.Context(), c, client.SolveOpt{
+				LocalDirs: map[string]string{
+					builder.DefaultLocalNameDockerfile: dir,
+					builder.DefaultLocalNameContext:    dir,
+				},
+			}, nil)
+			if !tc.valid {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tc.validateResp != nil {
+				tc.validateResp(t, res)
+			}
+		})
+	}
+}

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -322,7 +322,7 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 		if strings.HasPrefix(k, "frontend.") {
 			exporterResponse[k] = string(v)
 		}
-		if strings.HasPrefix(k, exptypes.ExporterBuildInfo) {
+		if strings.HasPrefix(k, exptypes.ExporterBuildInfo) || strings.HasPrefix(k, exptypes.ExporterPinConsumed) {
 			exporterResponse[k] = base64.StdEncoding.EncodeToString(v)
 		}
 	}

--- a/util/pin/pin.go
+++ b/util/pin/pin.go
@@ -1,0 +1,116 @@
+package pin
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/docker/distribution/reference"
+	"github.com/moby/buildkit/client/llb"
+	binfotypes "github.com/moby/buildkit/util/buildinfo/types"
+	pintypes "github.com/moby/buildkit/util/pin/types"
+	"github.com/moby/buildkit/util/urlutil"
+	digest "github.com/opencontainers/go-digest"
+)
+
+// Applier applies the pins.
+// Appliers implements the llb.ImageMetaResolver interface.
+type Applier struct {
+	Pin               pintypes.Pin
+	ImageMetaResolver llb.ImageMetaResolver
+	consumed          pintypes.Consumed
+	consumedMu        sync.Mutex
+}
+
+// ResolveImageConfig resolves "docker-image" sources.
+// ImageMetaResolver falls back to a.ImageMetaResolver when the ref is not present in a.Pin .
+// ResolveImageConfig implements the llb.ImageMetaResolver interface.
+func (a *Applier) ResolveImageConfig(ctx context.Context, ref string, opt llb.ResolveImageConfigOpt) (digest.Digest, []byte, error) {
+	refParsed, err := reference.ParseNormalizedNamed(ref)
+	if err != nil {
+		return "", nil, err
+	}
+	refQuery := reference.TagNameOnly(refParsed).String()
+
+	var (
+		hit       *binfotypes.Source
+		pinnedRef string
+	)
+	for _, f := range a.Pin.Sources {
+		f := f
+		if f.Type != binfotypes.SourceTypeDockerImage {
+			continue
+		}
+		if f.Ref != refQuery {
+			continue
+		}
+		fRefParsed, err := reference.ParseNormalizedNamed(f.Ref)
+		if err != nil {
+			return "", nil, err
+		}
+		fDigest, err := digest.Parse(f.Pin)
+		if err != nil {
+			return "", nil, err
+		}
+		pinned, err := reference.WithDigest(fRefParsed, fDigest)
+		if err != nil {
+			return "", nil, err
+		}
+		if hit != nil {
+			return "", nil, fmt.Errorf("found multiple pin entries for %q", refQuery)
+		}
+		hit = &f
+		pinnedRef = pinned.String()
+	}
+	if hit != nil {
+		a.consumedMu.Lock()
+		a.consumed.Sources = append(a.consumed.Sources, *hit)
+		a.consumedMu.Unlock()
+	}
+	if pinnedRef != "" {
+		ref = pinnedRef
+	}
+	return a.ImageMetaResolver.ResolveImageConfig(ctx, ref, opt)
+}
+
+// HTTPChecksum returns the checksum if url is present in a.Pin.
+// Otherwise returns an empty string without an error.
+func (a *Applier) HTTPChecksum(url string) (digest.Digest, error) {
+	urlQuery := urlutil.RedactCredentials(url)
+	var (
+		hit *binfotypes.Source
+		d   digest.Digest
+	)
+	for _, f := range a.Pin.Sources {
+		f := f
+		if f.Type != binfotypes.SourceTypeHTTP {
+			continue
+		}
+		if f.Ref != urlQuery {
+			continue
+		}
+		if hit != nil {
+			return "", fmt.Errorf("found multiple pin entries for %q", urlQuery)
+		}
+		hit = &f
+		var err error
+		d, err = digest.Parse(f.Pin)
+		if err != nil {
+			return d, err
+		}
+	}
+	if hit != nil {
+		a.consumedMu.Lock()
+		a.consumed.Sources = append(a.consumed.Sources, *hit)
+		a.consumedMu.Unlock()
+	}
+	return d, nil
+}
+
+func (a *Applier) Consumed() pintypes.Consumed {
+	a.consumedMu.Lock()
+	defer a.consumedMu.Unlock()
+	return a.consumed
+}
+
+var _ llb.ImageMetaResolver = &Applier{}

--- a/util/pin/types/pintypes.go
+++ b/util/pin/types/pintypes.go
@@ -1,0 +1,17 @@
+// Package pintypes provides pin types
+package pintypes
+
+import binfotypes "github.com/moby/buildkit/util/buildinfo/types"
+
+// Source corresponds to buildinfo Source.
+type Source = binfotypes.Source
+
+// Pin provides pinning information to ensure determinism of sources.
+type Pin struct {
+	// Sources do not need to cover all the sources.
+	// Sources may contain unreferenced sources too.
+	Sources []Source `json:"sources,omitempty"`
+}
+
+// Consumed defines the consumed pins
+type Consumed = Pin


### PR DESCRIPTION
Closes #2794


When `Dockerfile.pin` (initially proposed as `Dockerfile.sum` in #2794) exists in the context, the `dockerfile.v0` builder does:
- Pinning the digest of `docker-image` sources (`FROM ...`)
- Pinning the digest of `http` sources (`ADD https://...`)
- Recording the consumed `Dockerfile.pin` entries to the exporter response `pin.consumed`

The content of `Dockerfile.pin` is a subset of `BuildInfo`:
```json
{
    "sources": [
      {
        "type": "docker-image",
        "ref": "docker.io/library/alpine:latest",
        "pin": "sha256:4edbd2beb5f78b1014028f4fbb99f3237d9561100b6881aabbf5acce2c4f9454"
      },
      {
        "type": "http",
        "ref": "https://raw.githubusercontent.com/moby/buildkit/v0.10.1/README.md",
        "pin": "sha256:6e4b94fc270e708e1068be28bd3551dc6917a4fc5a61293d51bb36e6b75c4b53"
      }
    ]
}
```

In the future, Dockerfile should also support `ADD <gitref>.` and pinning its commit hash.
- https://github.com/moby/buildkit/issues/2799

## Usage

```console
$ cat Dockerfile
FROM alpine
ADD https://raw.githubusercontent.com/moby/buildkit/v0.10.1/README.md /README.md

$ cat Dockerfile.pin
{
    "sources": [
      {
        "type": "docker-image",
        "ref": "docker.io/library/alpine:latest",
        "pin": "sha256:4edbd2beb5f78b1014028f4fbb99f3237d9561100b6881aabbf5acce2c4f9454"
      },
      {
        "type": "http",
        "ref": "https://raw.githubusercontent.com/moby/buildkit/v0.10.1/README.md",
        "pin": "sha256:6e4b94fc270e708e1068be28bd3551dc6917a4fc5a61293d51bb36e6b75c4b53"
      }
    ]
}

$ sudo buildctl build --frontend dockerfile.v0  --local dockerfile=. --local context=.
```

When a `docker-image` pin is wrong:
```console
$ sudo buildctl build --frontend dockerfile.v0  --local dockerfile=. --local context=.
[+] Building 1.6s (3/3) FINISHED                                                                                                           
 => [internal] load build definition from Dockerfile                                                                                  0.0s
 => => transferring dockerfile: 603B                                                                                                  0.0s
 => [internal] load .dockerignore                                                                                                     0.0s
 => => transferring context: 2B                                                                                                       0.0s
 => ERROR [internal] load metadata for docker.io/library/alpine:latest                                                                1.4s
------
 > [internal] load metadata for docker.io/library/alpine:latest:
------
Dockerfile:1
--------------------
   1 | >>> FROM alpine
   2 |     ADD https://raw.githubusercontent.com/moby/buildkit/v0.10.1/README.md /README.md
   3 |     
--------------------
error: failed to solve: alpine: docker.io/library/alpine:latest@sha256:fedbd2beb5f78b1014028f4fbb99f3237d9561100b6881aabbf5acce2c4f9454: not found
```

When an `http` pin is wrong:
```console
$ sudo buildctl build --frontend dockerfile.v0  --local dockerfile=. --local context=.
[+] Building 0.6s (5/6)                                                                                                                    
 => [internal] load build definition from Dockerfile                                                                                  0.0s
 => => transferring dockerfile: 603B                                                                                                  0.0s
 => [internal] load .dockerignore                                                                                                     0.0s
 => => transferring context: 2B                                                                                                       0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                      0.0s
 => [1/2] FROM docker.io/library/alpine@sha256:4edbd2beb5f78b1014028f4fbb99f3237d9561100b6881aabbf5acce2c4f9454                       0.0s
 => => resolve docker.io/library/alpine@sha256:4edbd2beb5f78b1014028f4fbb99f3237d9561100b6881aabbf5acce2c4f9454                       0.0s
 => ERROR https://raw.githubusercontent.com/moby/buildkit/v0.10.1/README.md                                                           0.3s
------
 > https://raw.githubusercontent.com/moby/buildkit/v0.10.1/README.md:
------
error: failed to solve: digest mismatch sha256:6e4b94fc270e708e1068be28bd3551dc6917a4fc5a61293d51bb36e6b75c4b53: sha256:fe4b94fc270e708e1068be28bd3551dc6917a4fc5a61293d51bb36e6b75c4b53
```


- - -
Changes from [`pin-poc.20220411-0`](https://github.com/AkihiroSuda/buildkit_poc/commits/pin-poc.20220411-0) in #2794 
- The pinning result was moved from the build info to a separate exporter response
- The filename was changed from `Dockerfile.sum` to `Dockerfile.pin`