### PR TITLE
client/llb: allow metadata override in DefinitionOp

### DIFF
--- a/client/llb/definition.go
+++ b/client/llb/definition.go
@@ -159,6 +159,7 @@ func (d *DefinitionOp) Marshal(ctx context.Context, c *Constraints) (digest.Dige
 	defer d.mu.Unlock()
 
 	meta := d.metas[d.dgst]
+	meta = mergeMetadata(meta, c.Metadata)
 	return d.dgst, d.defs[d.dgst], &meta, d.sources[d.dgst], nil
 }
 


### PR DESCRIPTION
This allows clients to receive LLB from frontends and then modify the
metadata, such as wrapping it in a ProgressGroup.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>