### PR TITLE
remotecache: update spec documentation

### DIFF
--- a/cache/remotecache/v1/doc.go
+++ b/cache/remotecache/v1/doc.go
@@ -1,6 +1,6 @@
 package cacheimport
 
-// Distibutable build cache
+// Distributable build cache
 //
 // Main manifest is OCI image index
 // https://github.com/opencontainers/image-spec/blob/master/image-index.md .
@@ -13,7 +13,7 @@ package cacheimport
 // Cache config file layout:
 //
 //{
-//  "layers": [
+//  "layers": [                       <- layers contains references to blobs
 //    {
 //      "blob": "sha256:deadbeef",    <- digest of layer blob in index
 //      "parent": -1                  <- index of parent layer, -1 if no parent
@@ -24,20 +24,26 @@ package cacheimport
 //    }
 //  ],
 //
-//  "records": [
+//  "records": [                       <- records contains chains of cache keys
 //    {
 //      "digest": "sha256:deadbeef",   <- base digest for the record
 //    },
 //    {
 //      "digest": "sha256:deadbeef",
 //      "output": 1,                   <- optional output index
-//      "layers": [                    <- optional array or layer chains
+//      "layers": [                    <- optional array of layer pointers
 //        {
 //          "createdat": "",
-//          "layer": 1,                <- index to the layer
+//          "layer": 1,                <- index to the layers array, layer is loaded with all of its parents
 //        }
 //      ],
-//      "inputs": [                    <- dependant records
+//      "chains": [                    <- optional array of layer pointer lists
+//        {
+//          "createdat": "",
+//          "layers": [1],             <- indexes to the layers array, all layers are loaded in specified order without parents
+//        }
+//      ],
+//      "inputs": [                    <- dependant records, this is how cache keys are linked together
 //        [                            <- index of the dependency (0)
 //          {
 //            "selector": "sel",       <- optional selector


### PR DESCRIPTION
Fixes some typos and defines `"chains"` key that was added in `v0.10`.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>