### PR TITLE
Port SSH connhelper from github.com/docker/cli/cli/connhelper/ssh

### DIFF
--- a/client/connhelper/ssh/ssh.go
+++ b/client/connhelper/ssh/ssh.go
@@ -1,0 +1,74 @@
+// Package ssh provides connhelper for ssh://<SSH URL>
+package ssh
+
+import (
+	"context"
+	"net"
+	"net/url"
+
+	"github.com/docker/cli/cli/connhelper/commandconn"
+	"github.com/moby/buildkit/client/connhelper"
+	"github.com/pkg/errors"
+)
+
+func init() {
+	connhelper.Register("ssh", Helper)
+}
+
+// Helper returns helper for connecting through an SSH URL.
+func Helper(u *url.URL) (*connhelper.ConnectionHelper, error) {
+	sp, err := SpecFromURL(u)
+	if err != nil {
+		return nil, err
+	}
+	return &connhelper.ConnectionHelper{
+		ContextDialer: func(ctx context.Context, addr string) (net.Conn, error) {
+			ctxFlags := []string{}
+			if sp.User != "" {
+				ctxFlags = append(ctxFlags, "-l", sp.User)
+			}
+			if sp.Port != "" {
+				ctxFlags = append(ctxFlags, "-p", sp.Port)
+			}
+			ctxFlags = append(ctxFlags, "--", sp.Host)
+			// using background context because context remains active for the duration of the process, after dial has completed
+			return commandconn.New(context.Background(), "ssh", append(ctxFlags, []string{"buildctl", "dial-stdio"}...)...)
+		},
+	}, nil
+}
+
+// Spec
+type Spec struct {
+	User string
+	Host string
+	Port string
+}
+
+// SpecFromURL creates Spec from URL.
+// URL is like ssh://<user>@host:<port>
+// Only <host> part is mandatory.
+func SpecFromURL(u *url.URL) (*Spec, error) {
+	sp := Spec{
+		Host: u.Hostname(),
+		Port: u.Port(),
+	}
+	if user := u.User; user != nil {
+		sp.User = user.Username()
+		if _, ok := user.Password(); ok {
+			return nil, errors.New("plain-text password is not supported")
+		}
+	}
+	if sp.Host == "" {
+		return nil, errors.Errorf("no host specified")
+	}
+	if u.Path != "" {
+		return nil, errors.Errorf("extra path after the host: %q", u.Path)
+	}
+	if u.RawQuery != "" {
+		return nil, errors.Errorf("extra query after the host: %q", u.RawQuery)
+	}
+	if u.Fragment != "" {
+		return nil, errors.Errorf("extra fragment after the host: %q", u.Fragment)
+	}
+	return &sp, nil
+}

--- a/client/connhelper/ssh/ssh_test.go
+++ b/client/connhelper/ssh/ssh_test.go
@@ -12,14 +12,16 @@ func TestSpecFromURL(t *testing.T) {
 		"ssh://foo": {
 			Host: "foo",
 		},
-		"ssh://me@foo:10022": {
-			User: "me", Host: "foo", Port: "10022",
+		"ssh://me@foo:10022/s/o/c/k/e/t.sock": {
+			User: "me", Host: "foo", Port: "10022", Socket: "/s/o/c/k/e/t.sock",
 		},
 		"ssh://me:passw0rd@foo": nil,
-		"ssh://foo/bar":         nil,
-		"ssh://foo?bar":         nil,
-		"ssh://foo#bar":         nil,
-		"ssh://":                nil,
+		"ssh://foo/bar": {
+			Host: "foo", Socket: "/bar",
+		},
+		"ssh://foo?bar": nil,
+		"ssh://foo#bar": nil,
+		"ssh://":        nil,
 	}
 	for s, expected := range cases {
 		u, err := url.Parse(s)

--- a/client/connhelper/ssh/ssh_test.go
+++ b/client/connhelper/ssh/ssh_test.go
@@ -1,0 +1,37 @@
+package ssh
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSpecFromURL(t *testing.T) {
+	cases := map[string]*Spec{
+		"ssh://foo": {
+			Host: "foo",
+		},
+		"ssh://me@foo:10022": {
+			User: "me", Host: "foo", Port: "10022",
+		},
+		"ssh://me:passw0rd@foo": nil,
+		"ssh://foo/bar":         nil,
+		"ssh://foo?bar":         nil,
+		"ssh://foo#bar":         nil,
+		"ssh://":                nil,
+	}
+	for s, expected := range cases {
+		u, err := url.Parse(s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err := SpecFromURL(u)
+		if expected != nil {
+			require.NoError(t, err)
+			require.EqualValues(t, expected, got, s)
+		} else {
+			require.Error(t, err, s)
+		}
+	}
+}

--- a/cmd/buildctl/main.go
+++ b/cmd/buildctl/main.go
@@ -7,6 +7,7 @@ import (
 	_ "github.com/moby/buildkit/client/connhelper/dockercontainer"
 	_ "github.com/moby/buildkit/client/connhelper/kubepod"
 	_ "github.com/moby/buildkit/client/connhelper/podmancontainer"
+	_ "github.com/moby/buildkit/client/connhelper/ssh"
 	bccommon "github.com/moby/buildkit/cmd/buildctl/common"
 	"github.com/moby/buildkit/solver/errdefs"
 	"github.com/moby/buildkit/util/apicaps"


### PR DESCRIPTION
Fixes #2032

Note: second commit adds a new feature: `ssh://.../path/to/socket` to change the `--addr` that gets passed to `buildctl`. This is not allowed by Docker CLI's implementation so maybe should not be here.
I needed this as I run `buildkitd` rootless meaning socket is not under `/run/buildkit` root path. It's not *needed* per se as a workaround is:
```shell
#!/bin/sh -eu

exec $HOME/bin/buildctl --addr unix:///run/user/1000/buildkit/buildkitd.sock "$@"
```
I'm leaving this second commit in for discussion but I expect you'll want me to remove it.