### PR TITLE
Fix builtin dockerfile frontend performance

### DIFF
--- a/frontend/gateway/forwarder/forward.go
+++ b/frontend/gateway/forwarder/forward.go
@@ -26,7 +26,7 @@ import (
 )
 
 func llbBridgeToGatewayClient(ctx context.Context, llbBridge frontend.FrontendLLBBridge, opts map[string]string, inputs map[string]*opspb.Definition, w worker.Infos, sid string, sm *session.Manager) (*bridgeClient, error) {
-	return &bridgeClient{
+	bc := &bridgeClient{
 		opts:              opts,
 		inputs:            inputs,
 		FrontendLLBBridge: llbBridge,
@@ -35,7 +35,9 @@ func llbBridgeToGatewayClient(ctx context.Context, llbBridge frontend.FrontendLL
 		workers:           w,
 		final:             map[*ref]struct{}{},
 		workerRefByID:     make(map[string]*worker.WorkerRef),
-	}, nil
+	}
+	bc.buildOpts = bc.loadBuildOpts()
+	return bc, nil
 }
 
 type bridgeClient struct {
@@ -49,6 +51,7 @@ type bridgeClient struct {
 	refs          []*ref
 	workers       worker.Infos
 	workerRefByID map[string]*worker.WorkerRef
+	buildOpts     client.BuildOpts
 }
 
 func (c *bridgeClient) Solve(ctx context.Context, req client.SolveRequest) (*client.Result, error) {
@@ -87,14 +90,15 @@ func (c *bridgeClient) Solve(ctx context.Context, req client.SolveRequest) (*cli
 
 	return cRes, nil
 }
-func (c *bridgeClient) BuildOpts() client.BuildOpts {
-	workers := make([]client.WorkerInfo, 0, len(c.workers.WorkerInfos()))
-	for _, w := range c.workers.WorkerInfos() {
-		workers = append(workers, client.WorkerInfo{
+func (c *bridgeClient) loadBuildOpts() client.BuildOpts {
+	wis := c.workers.WorkerInfos()
+	workers := make([]client.WorkerInfo, len(wis))
+	for i, w := range wis {
+		workers[i] = client.WorkerInfo{
 			ID:        w.ID,
 			Labels:    w.Labels,
 			Platforms: w.Platforms,
-		})
+		}
 	}
 
 	return client.BuildOpts{
@@ -105,6 +109,10 @@ func (c *bridgeClient) BuildOpts() client.BuildOpts {
 		Caps:      gwpb.Caps.CapSet(gwpb.Caps.All()),
 		LLBCaps:   opspb.Caps.CapSet(opspb.Caps.All()),
 	}
+}
+
+func (c *bridgeClient) BuildOpts() client.BuildOpts {
+	return c.buildOpts
 }
 
 func (c *bridgeClient) Inputs(ctx context.Context) (map[string]llb.State, error) {

--- a/worker/workercontroller.go
+++ b/worker/workercontroller.go
@@ -64,7 +64,7 @@ func (c *Controller) WorkerInfos() []client.WorkerInfo {
 		out = append(out, client.WorkerInfo{
 			ID:              w.ID(),
 			Labels:          w.Labels(),
-			Platforms:       w.Platforms(true),
+			Platforms:       w.Platforms(false),
 			BuildkitVersion: w.BuildkitVersion(),
 		})
 	}


### PR DESCRIPTION
Dockerfile frontend makes many calls to BuildOpts() function
after named build context support was added. Previously it 
only did one per build. The assumption is that BuildOpts()
is fast and does not need to be cached on the caller side.

In current implementation BuildOpts() listed the workers
in a way that triggered the platform emulation check to be
triggered to with could take 50-100ms to complete what adds
up if there are many Dockerfile stages.

This commit adds caching to BuildOpts. If frontend was
loaded through an external image then it was already cached
and this issue did not appear.

The second commit disables rechecking emulators in this case even for the first attempt. This was added in https://github.com/moby/buildkit/pull/1381 but I think rechecking it with every build is not needed. I made them in separate commits in case we only want to backport the first commit.