### PR TITLE
Avoid losing source location information when vertices duplicate

### DIFF
--- a/client/llb/sourcemap.go
+++ b/client/llb/sourcemap.go
@@ -61,7 +61,7 @@ func (smc *sourceMapCollector) Add(dgst digest.Digest, ls []*SourceLocation) {
 		}
 		smc.index[l.SourceMap] = idx
 	}
-	smc.locations[dgst] = ls
+	smc.locations[dgst] = append(smc.locations[dgst], ls...)
 }
 
 func (smc *sourceMapCollector) Marshal(ctx context.Context, co ...ConstraintsOpt) (*pb.Source, error) {

--- a/client/llb/state.go
+++ b/client/llb/state.go
@@ -199,10 +199,10 @@ func marshal(ctx context.Context, v Vertex, def *Definition, s *sourceMapCollect
 	if opMeta != nil {
 		def.Metadata[dgst] = mergeMetadata(def.Metadata[dgst], *opMeta)
 	}
+	s.Add(dgst, sls)
 	if _, ok := cache[dgst]; ok {
 		return def, nil
 	}
-	s.Add(dgst, sls)
 	def.Def = append(def.Def, dt)
 	cache[dgst] = struct{}{}
 	return def, nil

--- a/client/llb/state_test.go
+++ b/client/llb/state_test.go
@@ -99,6 +99,44 @@ func TestStateSourceMapMarshal(t *testing.T) {
 	require.Equal(t, int32(0), def.Source.Locations[dgst.String()].Locations[2].SourceIndex)
 	require.Equal(t, 1, len(def.Source.Locations[dgst.String()].Locations[2].Ranges))
 	require.Equal(t, int32(9), def.Source.Locations[dgst.String()].Locations[2].Ranges[0].Start.Line)
+
+	s = Merge([]State{s, Image("myimage",
+		sm1.Location([]*pb.Range{{Start: pb.Position{Line: 10}}}),
+	)})
+	def, err = s.Marshal(context.TODO())
+	require.NoError(t, err)
+	require.Equal(t, 3, len(def.Def))
+	dgst = digest.FromBytes(def.Def[0])
+
+	require.Equal(t, 2, len(def.Source.Infos))
+	require.Equal(t, 2, len(def.Source.Locations))
+
+	require.Equal(t, "foo", def.Source.Infos[0].Filename)
+	require.Equal(t, []byte("data1"), def.Source.Infos[0].Data)
+	require.Nil(t, def.Source.Infos[0].Definition)
+
+	require.Equal(t, "bar", def.Source.Infos[1].Filename)
+	require.Equal(t, []byte("data2"), def.Source.Infos[1].Data)
+	require.Nil(t, def.Source.Infos[1].Definition)
+
+	require.NotNil(t, def.Source.Locations[dgst.String()])
+	require.Equal(t, 4, len(def.Source.Locations[dgst.String()].Locations))
+
+	require.Equal(t, int32(0), def.Source.Locations[dgst.String()].Locations[0].SourceIndex)
+	require.Equal(t, 1, len(def.Source.Locations[dgst.String()].Locations[0].Ranges))
+	require.Equal(t, int32(7), def.Source.Locations[dgst.String()].Locations[0].Ranges[0].Start.Line)
+
+	require.Equal(t, int32(1), def.Source.Locations[dgst.String()].Locations[1].SourceIndex)
+	require.Equal(t, 1, len(def.Source.Locations[dgst.String()].Locations[1].Ranges))
+	require.Equal(t, int32(8), def.Source.Locations[dgst.String()].Locations[1].Ranges[0].Start.Line)
+
+	require.Equal(t, int32(0), def.Source.Locations[dgst.String()].Locations[2].SourceIndex)
+	require.Equal(t, 1, len(def.Source.Locations[dgst.String()].Locations[2].Ranges))
+	require.Equal(t, int32(9), def.Source.Locations[dgst.String()].Locations[2].Ranges[0].Start.Line)
+
+	require.Equal(t, int32(0), def.Source.Locations[dgst.String()].Locations[3].SourceIndex)
+	require.Equal(t, 1, len(def.Source.Locations[dgst.String()].Locations[3].Ranges))
+	require.Equal(t, int32(10), def.Source.Locations[dgst.String()].Locations[3].Ranges[0].Start.Line)
 }
 
 func TestPlatformFromImage(t *testing.T) {


### PR DESCRIPTION
When a LLB contains duplicated vertcies with different source information, it's possible that some of the location infomations are lost.
This is make it difficult to do source-level debugging for some vertecies.
This commit fixes this issue.

e.g.

```Dockerfile
FROM ghcr.io/stargz-containers/ubuntu:20.04-org AS a
FROM ghcr.io/stargz-containers/ubuntu:20.04-org AS b
FROM scratch
COPY --from=a / /
COPY --from=b / /
```

### master branch

Location info of `FROM` at line 2 is lost.

```json
{
  "locations": {
    "sha256:20ed82fdf481a640454f8113dde5f2e292c725b9b0dff5082c6a3b0c9470e186": {
      "locations": [
        {
          "ranges": [
            {
              "start": {
                "Line": 1
              },
              "end": {
                "Line": 1
              }
            }
          ]
        }
      ]
    },
    "sha256:f1768aff48a1c6860a01777144ff6eea79748963a56aa490f61680e2e37c732c": {
      "locations": [
        {
          "ranges": [
            {
              "start": {
                "Line": 4
              },
              "end": {
                "Line": 4
              }
            }
          ]
        }
      ]
    },
    "sha256:f956b50ddb2ae43f5917de1a5a8841764da7dd502b3c97891575288327a44785": {
      "locations": [
        {
          "ranges": [
            {
              "start": {
                "Line": 5
              },
              "end": {
                "Line": 5
              }
            }
          ]
        }
      ]
    }
  },
  "infos": [
    {
      "filename": "dummy",
      "data": "RlJPTSBnaGNyLmlvL3N0YXJnei1jb250YWluZXJzL3VidW50dToyMC4wNC1vcmcgQVMgYQpGUk9NIGdoY3IuaW8vc3Rhcmd6LWNvbnRhaW5lcnMvdWJ1bnR1OjIwLjA0LW9yZyBBUyBiCkZST00gc2NyYXRjaApDT1BZIC0tZnJvbT1hIC8gLwpDT1BZIC0tZnJvbT1iIC8gLwo="
    }
  ]
}
```

### PR

All information is preserved.

```json
{
  "locations": {
    "sha256:20ed82fdf481a640454f8113dde5f2e292c725b9b0dff5082c6a3b0c9470e186": {
      "locations": [
        {
          "ranges": [
            {
              "start": {
                "Line": 2
              },
              "end": {
                "Line": 2
              }
            }
          ]
        },
        {
          "ranges": [
            {
              "start": {
                "Line": 1
              },
              "end": {
                "Line": 1
              }
            }
          ]
        }
      ]
    },
    "sha256:f1768aff48a1c6860a01777144ff6eea79748963a56aa490f61680e2e37c732c": {
      "locations": [
        {
          "ranges": [
            {
              "start": {
                "Line": 4
              },
              "end": {
                "Line": 4
              }
            }
          ]
        }
      ]
    },
    "sha256:f956b50ddb2ae43f5917de1a5a8841764da7dd502b3c97891575288327a44785": {
      "locations": [
        {
          "ranges": [
            {
              "start": {
                "Line": 5
              },
              "end": {
                "Line": 5
              }
            }
          ]
        }
      ]
    }
  },
  "infos": [
    {
      "filename": "dummy",
      "data": "RlJPTSBnaGNyLmlvL3N0YXJnei1jb250YWluZXJzL3VidW50dToyMC4wNC1vcmcgQVMgYQpGUk9NIGdoY3IuaW8vc3Rhcmd6LWNvbnRhaW5lcnMvdWJ1bnR1OjIwLjA0LW9yZyBBUyBiCkZST00gc2NyYXRjaApDT1BZIC0tZnJvbT1hIC8gLwpDT1BZIC0tZnJvbT1iIC8gLwo="
    }
  ]
}
```
