### PR TITLE
dockerfile: allow ssh git urls for named contexts

### DIFF
--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -824,6 +824,10 @@ func contextByName(ctx context.Context, c client.Client, name string, platform *
 	if len(vv) != 2 {
 		return nil, nil, nil, errors.Errorf("invalid context specifier %s for %s", v, name)
 	}
+	// allow git@ without protocol for SSH URLs for backwards compatibility
+	if strings.HasPrefix(vv[0], "git@") {
+		vv[0] = "git"
+	}
 	switch vv[0] {
 	case "docker-image":
 		ref := strings.TrimPrefix(vv[1], "//")


### PR DESCRIPTION
Fixes https://github.com/docker/buildx/issues/1125

Test frontend:
```
#syntax=tonistiigi/dockerfile:1.4-git-ssh-fix
```

In a follow up we should consider defining `ssh://` URLs. This is supported in LLB but not in Dockerfile. I tried to enable it but quite a lot of things broke.

@ciaranmcnulty

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>