### PR TITLE
util/resolver/authorizer.go: Add basic auth support for  exist. login

### DIFF
--- a/util/resolver/authorizer.go
+++ b/util/resolver/authorizer.go
@@ -88,6 +88,20 @@ func (a *authHandlerNS) get(ctx context.Context, host string, sm *session.Manage
 		}
 	}
 
+	// if no handler found or linked, then a new one needs to be created
+	session, username, password, err := sessionauth.CredentialsFunc(sm, g)(host)
+	if err == nil {
+		if username != "" {
+			common := auth.TokenOptions{
+				Username: username,
+				Secret:   password,
+			}
+			a.handlers[host+"/"+session] = newAuthHandler(host, nil, auth.BasicAuth, nil, common)
+			a.handlers[host+"/"+session].lastUsed = time.Now()
+			return a.handlers[host+"/"+session]
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
The authorized coded is missing support for the following scenario:

1. docker login to private registry (e.g. harbor)
2. buildctl build --output type=image,name=privateregistry/project/repo,push=true

When the private registry is first contacted, there is no authHandler being
created with the user id and password from the .docker/config.json file. The
implementation falls back to oauth authentication which might fail especially
if locally created ca/certificates are used.

This commit adds support for this scenario in the get authHandler function.

Signed-off-by: Patrick Eckner <pap9ck@gmail.com>