### PR TITLE
authprovider: support registrytoken field in docker auth config

### DIFF
--- a/session/auth/authprovider/authprovider.go
+++ b/session/auth/authprovider/authprovider.go
@@ -182,9 +182,9 @@ func (ap *authProvider) VerifyTokenAuthority(ctx context.Context, req *auth.Veri
 }
 
 func (ap *authProvider) getAuthConfig(host string) (*types.AuthConfig, error) {
+	ap.mu.Lock()
+	defer ap.mu.Unlock()
 	if _, exists := ap.authConfigCache[host]; !exists {
-		ap.mu.Lock()
-		defer ap.mu.Unlock()
 		if host == "registry-1.docker.io" {
 			host = "https://index.docker.io/v1/"
 		}

--- a/session/auth/authprovider/authprovider.go
+++ b/session/auth/authprovider/authprovider.go
@@ -18,6 +18,7 @@ import (
 	remoteserrors "github.com/containerd/containerd/remotes/errors"
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/configfile"
+	"github.com/docker/cli/cli/config/types"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/auth"
 	"github.com/moby/buildkit/util/progress/progresswriter"
@@ -62,6 +63,16 @@ func (ap *authProvider) Register(server *grpc.Server) {
 }
 
 func (ap *authProvider) FetchToken(ctx context.Context, req *auth.FetchTokenRequest) (rr *auth.FetchTokenResponse, err error) {
+	ac, err := ap.getAuthConfig(req.Host)
+	if err != nil {
+		return nil, err
+	}
+
+	// check for statically configured bearer token
+	if ac.RegistryToken != "" {
+		return toTokenResponse(ac.RegistryToken, time.Time{}, 0), nil
+	}
+
 	creds, err := ap.credentials(req.Host)
 	if err != nil {
 		return nil, err
@@ -117,12 +128,7 @@ func (ap *authProvider) FetchToken(ctx context.Context, req *auth.FetchTokenRequ
 }
 
 func (ap *authProvider) credentials(host string) (*auth.CredentialsResponse, error) {
-	ap.mu.Lock()
-	defer ap.mu.Unlock()
-	if host == "registry-1.docker.io" {
-		host = "https://index.docker.io/v1/"
-	}
-	ac, err := ap.config.GetAuthConfig(host)
+	ac, err := ap.getAuthConfig(host)
 	if err != nil {
 		return nil, err
 	}
@@ -171,6 +177,19 @@ func (ap *authProvider) VerifyTokenAuthority(ctx context.Context, req *auth.Veri
 	copy((*priv)[:], key)
 
 	return &auth.VerifyTokenAuthorityResponse{Signed: sign.Sign(nil, req.Payload, priv)}, nil
+}
+
+func (ap *authProvider) getAuthConfig(host string) (*types.AuthConfig, error) {
+	ap.mu.Lock()
+	defer ap.mu.Unlock()
+	if host == "registry-1.docker.io" {
+		host = "https://index.docker.io/v1/"
+	}
+	ac, err := ap.config.GetAuthConfig(host)
+	if err != nil {
+		return nil, err
+	}
+	return &ac, nil
 }
 
 func (ap *authProvider) getAuthorityKey(host string, salt []byte) (ed25519.PrivateKey, error) {


### PR DESCRIPTION
The Docker CLI supports a field called "registrytoken" within the auth
config that may contain a previously resolved bearer token. If a
value is present, it is used verbatim and OAuth token retrieval using
username/password or identity token is skipped.

Support this same functionality in the buildkit client by checking for
this field's value prior to credential based auth in `FetchToken`. If a
value is set for `AuthConfig.RegistryToken`, short circuit and return
the token value as is.

This feature helps to support registry setups that integrate with third
party auth systems such as GitLab's JWT OmniAuth provider.