### PR TITLE
[v0.10 backport] dockerfile: fix named contexts test for dockerd

### DIFF
--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -5342,6 +5342,8 @@ COPY --from=base /out /
 	require.NoError(t, err)
 	require.True(t, len(dt) > 0)
 
+	integration.SkipIfDockerd(t, sb, "direct push")
+
 	// Now test with an image with custom envs
 	dockerfile = []byte(`
 FROM alpine:latest


### PR DESCRIPTION
- backport of https://github.com/moby/buildkit/pull/2854
- relates to https://github.com/moby/moby/pull/43571

(cherry picked from commit 3bed8e2ea3183ed9c2f0d19f956c405a160014ec)
