### PR TITLE
Add annotations support to output

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,10 @@ Keys supported by image output:
 * `buildinfo=true`: inline build info in [image config](docs/build-repro.md#image-config) (default `true`).
 * `buildinfo-attrs=true`: inline build info attributes in [image config](docs/build-repro.md#image-config) (default `false`).
 * `store=true`: stores the result images to the worker's (e.g. containerd) image store as well as ensures that the image has all blobs in the content store (default `true`). Ignored if the worker doesn't have image store (e.g. OCI worker).
+* `annotation.key=value`: attaches an annotation with the respective `key` and `value` to the built image.
+  * Using the extended syntaxes, `annotation-<type>.key=value`, `annotation[<platform>].key=value` and both combined with `annotation-<type>[<platform>].key=value`, allows configuring exactly where to attach the annotation.
+  * `<type>` specifies what object to attach to, and can be any of `manifest` (the default), `manifest-descriptor`, `index` and `index-descriptor`
+  * `<platform>` specifies which objects to attach to (by default, all), and is the same key passed into the `platform` opt, see [`docs/multi-platform.md`](docs/multi-platform.md).
 
 If credentials are required, `buildctl` will attempt to read Docker configuration file `$DOCKER_CONFIG/config.json`.
 `$DOCKER_CONFIG` defaults to `~/.docker`.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -162,6 +162,7 @@ func TestIntegration(t *testing.T) {
 		testStargzLazyRegistryCacheImportExport,
 		testCallInfo,
 		testPullWithLayerLimit,
+		testExportAnnotations,
 	)
 	tests = append(tests, diffOpTestCases()...)
 	integration.Run(t, tests, mirrors)
@@ -5877,6 +5878,222 @@ func testCallInfo(t *testing.T, sb integration.Sandbox) {
 	defer c.Close()
 	_, err = c.Info(sb.Context())
 	require.NoError(t, err)
+}
+
+func testExportAnnotations(t *testing.T, sb integration.Sandbox) {
+	requiresLinux(t)
+	c, err := New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	amd64 := platforms.MustParse("linux/amd64")
+	arm64 := platforms.MustParse("linux/arm64")
+	ps := []ocispecs.Platform{amd64, arm64}
+
+	frontend := func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
+		res := gateway.NewResult()
+		expPlatforms := &exptypes.Platforms{
+			Platforms: make([]exptypes.Platform, len(ps)),
+		}
+		for i, p := range ps {
+			st := llb.Scratch().File(
+				llb.Mkfile("platform", 0600, []byte(platforms.Format(p))),
+			)
+
+			def, err := st.Marshal(ctx)
+			if err != nil {
+				return nil, err
+			}
+
+			r, err := c.Solve(ctx, gateway.SolveRequest{
+				Definition: def.ToPB(),
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			ref, err := r.SingleRef()
+			if err != nil {
+				return nil, err
+			}
+
+			_, err = ref.ToState()
+			if err != nil {
+				return nil, err
+			}
+
+			k := platforms.Format(p)
+			res.AddRef(k, ref)
+
+			expPlatforms.Platforms[i] = exptypes.Platform{
+				ID:       k,
+				Platform: p,
+			}
+		}
+		dt, err := json.Marshal(expPlatforms)
+		if err != nil {
+			return nil, err
+		}
+		res.AddMeta(exptypes.ExporterPlatformsKey, dt)
+
+		res.AddMeta(exptypes.AnnotationIndexKey("gi"), []byte("generic index"))
+		res.AddMeta(exptypes.AnnotationIndexDescriptorKey("gid"), []byte("generic index descriptor"))
+		res.AddMeta(exptypes.AnnotationManifestKey(nil, "gm"), []byte("generic manifest"))
+		res.AddMeta(exptypes.AnnotationManifestDescriptorKey(nil, "gmd"), []byte("generic manifest descriptor"))
+		res.AddMeta(exptypes.AnnotationManifestKey(&amd64, "m"), []byte("amd64 manifest"))
+		res.AddMeta(exptypes.AnnotationManifestKey(&arm64, "m"), []byte("arm64 manifest"))
+		res.AddMeta(exptypes.AnnotationManifestDescriptorKey(&amd64, "md"), []byte("amd64 manifest descriptor"))
+		res.AddMeta(exptypes.AnnotationManifestDescriptorKey(&arm64, "md"), []byte("arm64 manifest descriptor"))
+		res.AddMeta(exptypes.AnnotationKey{Key: "gd"}.String(), []byte("generic default"))
+
+		return res, nil
+	}
+
+	// testing for image exporter
+
+	target := "testannotations:latest"
+
+	_, err = c.Build(sb.Context(), SolveOpt{
+		Exports: []ExportEntry{
+			{
+				Type: ExporterImage,
+				Attrs: map[string]string{
+					"name":                                            target,
+					"annotation-index.gio":                            "generic index opt",
+					"annotation-manifest.gmo":                         "generic manifest opt",
+					"annotation-manifest-descriptor.gmdo":             "generic manifest descriptor opt",
+					"annotation-manifest[linux/amd64].mo":             "amd64 manifest opt",
+					"annotation-manifest-descriptor[linux/amd64].mdo": "amd64 manifest descriptor opt",
+					"annotation-manifest[linux/arm64].mo":             "arm64 manifest opt",
+					"annotation-manifest-descriptor[linux/arm64].mdo": "arm64 manifest descriptor opt",
+				},
+			},
+		},
+	}, "", frontend, nil)
+	require.NoError(t, err)
+
+	ctx := namespaces.WithNamespace(sb.Context(), "buildkit")
+	cdAddress := sb.ContainerdAddress()
+	if cdAddress != "" {
+		client, err := newContainerd(cdAddress)
+		require.NoError(t, err)
+		defer client.Close()
+
+		img, err := client.GetImage(ctx, target)
+		require.NoError(t, err)
+
+		var index ocispecs.Index
+		indexBytes, err := content.ReadBlob(ctx, client.ContentStore(), img.Target())
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(indexBytes, &index))
+
+		require.Equal(t, "generic index", index.Annotations["gi"])
+		require.Equal(t, "generic index opt", index.Annotations["gio"])
+		for _, desc := range index.Manifests {
+			require.Equal(t, "generic manifest descriptor", desc.Annotations["gmd"])
+			require.Equal(t, "generic manifest descriptor opt", desc.Annotations["gmdo"])
+			switch {
+			case platforms.Only(amd64).Match(*desc.Platform):
+				require.Equal(t, "amd64 manifest descriptor", desc.Annotations["md"])
+				require.Equal(t, "amd64 manifest descriptor opt", desc.Annotations["mdo"])
+			case platforms.Only(arm64).Match(*desc.Platform):
+				require.Equal(t, "arm64 manifest descriptor", desc.Annotations["md"])
+				require.Equal(t, "arm64 manifest descriptor opt", desc.Annotations["mdo"])
+			default:
+				require.Fail(t, "unrecognized platform")
+			}
+		}
+
+		mfst, err := images.Manifest(ctx, client.ContentStore(), img.Target(), platforms.Only(amd64))
+		require.NoError(t, err)
+		require.Equal(t, "generic default", mfst.Annotations["gd"])
+		require.Equal(t, "generic manifest", mfst.Annotations["gm"])
+		require.Equal(t, "generic manifest opt", mfst.Annotations["gmo"])
+		require.Equal(t, "amd64 manifest", mfst.Annotations["m"])
+		require.Equal(t, "amd64 manifest opt", mfst.Annotations["mo"])
+
+		mfst, err = images.Manifest(ctx, client.ContentStore(), img.Target(), platforms.Only(arm64))
+		require.NoError(t, err)
+		require.Equal(t, "generic manifest", mfst.Annotations["gm"])
+		require.Equal(t, "generic manifest opt", mfst.Annotations["gmo"])
+		require.Equal(t, "arm64 manifest", mfst.Annotations["m"])
+		require.Equal(t, "arm64 manifest opt", mfst.Annotations["mo"])
+	}
+
+	// testing for oci exporter
+
+	destDir, err := os.MkdirTemp("", "buildkit")
+	require.NoError(t, err)
+	defer os.RemoveAll(destDir)
+
+	out := filepath.Join(destDir, "out.tar")
+	outW, err := os.Create(out)
+	require.NoError(t, err)
+
+	_, err = c.Build(sb.Context(), SolveOpt{
+		Exports: []ExportEntry{
+			{
+				Type:   ExporterOCI,
+				Output: fixedWriteCloser(outW),
+				Attrs: map[string]string{
+					"annotation-index.gio":                            "generic index opt",
+					"annotation-index-descriptor.gido":                "generic index descriptor opt",
+					"annotation-manifest.gmo":                         "generic manifest opt",
+					"annotation-manifest-descriptor.gmdo":             "generic manifest descriptor opt",
+					"annotation-manifest[linux/amd64].mo":             "amd64 manifest opt",
+					"annotation-manifest-descriptor[linux/amd64].mdo": "amd64 manifest descriptor opt",
+					"annotation-manifest[linux/arm64].mo":             "arm64 manifest opt",
+					"annotation-manifest-descriptor[linux/arm64].mdo": "arm64 manifest descriptor opt",
+				},
+			},
+		},
+	}, "", frontend, nil)
+	require.NoError(t, err)
+
+	dt, err := os.ReadFile(out)
+	require.NoError(t, err)
+
+	m, err := testutil.ReadTarToMap(dt, false)
+	require.NoError(t, err)
+
+	var layout ocispecs.Index
+	err = json.Unmarshal(m["index.json"].Data, &layout)
+	require.Equal(t, "generic index descriptor", layout.Manifests[0].Annotations["gid"])
+	require.Equal(t, "generic index descriptor opt", layout.Manifests[0].Annotations["gido"])
+	require.NoError(t, err)
+
+	var index ocispecs.Index
+	err = json.Unmarshal(m["blobs/sha256/"+layout.Manifests[0].Digest.Hex()].Data, &index)
+	require.Equal(t, "generic index", index.Annotations["gi"])
+	require.Equal(t, "generic index opt", index.Annotations["gio"])
+	require.NoError(t, err)
+
+	for _, desc := range index.Manifests {
+		var mfst ocispecs.Manifest
+		err = json.Unmarshal(m["blobs/sha256/"+desc.Digest.Hex()].Data, &mfst)
+		require.NoError(t, err)
+
+		require.Equal(t, "generic default", mfst.Annotations["gd"])
+		require.Equal(t, "generic manifest", mfst.Annotations["gm"])
+		require.Equal(t, "generic manifest descriptor", desc.Annotations["gmd"])
+		require.Equal(t, "generic manifest opt", mfst.Annotations["gmo"])
+		require.Equal(t, "generic manifest descriptor opt", desc.Annotations["gmdo"])
+
+		switch {
+		case platforms.Only(amd64).Match(*desc.Platform):
+			require.Equal(t, "amd64 manifest", mfst.Annotations["m"])
+			require.Equal(t, "amd64 manifest descriptor", desc.Annotations["md"])
+			require.Equal(t, "amd64 manifest opt", mfst.Annotations["mo"])
+			require.Equal(t, "amd64 manifest descriptor opt", desc.Annotations["mdo"])
+		case platforms.Only(arm64).Match(*desc.Platform):
+			require.Equal(t, "arm64 manifest", mfst.Annotations["m"])
+			require.Equal(t, "arm64 manifest descriptor", desc.Annotations["md"])
+			require.Equal(t, "arm64 manifest opt", mfst.Annotations["mo"])
+			require.Equal(t, "arm64 manifest descriptor opt", desc.Annotations["mdo"])
+		default:
+			require.Fail(t, "unrecognized platform")
+		}
+	}
 }
 
 func tmpdir(appliers ...fstest.Applier) (string, error) {

--- a/exporter/containerimage/annotations.go
+++ b/exporter/containerimage/annotations.go
@@ -1,0 +1,131 @@
+package containerimage
+
+import (
+	"fmt"
+
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/platforms"
+	"github.com/moby/buildkit/exporter/containerimage/exptypes"
+)
+
+type Annotations struct {
+	Index              map[string]string
+	IndexDescriptor    map[string]string
+	Manifest           map[string]string
+	ManifestDescriptor map[string]string
+}
+
+// AnnotationsGroup is a map of annotations keyed by the reference key
+type AnnotationsGroup map[string]*Annotations
+
+func ParseAnnotations(data map[string][]byte) (AnnotationsGroup, map[string][]byte, error) {
+	ag := make(AnnotationsGroup)
+	rest := make(map[string][]byte)
+
+	for k, v := range data {
+		a, ok, err := exptypes.ParseAnnotationKey(k)
+		if !ok {
+			rest[k] = v
+			continue
+		}
+		if err != nil {
+			return nil, nil, err
+		}
+
+		p := a.PlatformString()
+
+		if ag[p] == nil {
+			ag[p] = &Annotations{
+				IndexDescriptor:    make(map[string]string),
+				Index:              make(map[string]string),
+				Manifest:           make(map[string]string),
+				ManifestDescriptor: make(map[string]string),
+			}
+		}
+
+		switch a.Type {
+		case exptypes.AnnotationIndex:
+			ag[p].Index[a.Key] = string(v)
+		case exptypes.AnnotationIndexDescriptor:
+			ag[p].IndexDescriptor[a.Key] = string(v)
+		case exptypes.AnnotationManifest:
+			ag[p].Manifest[a.Key] = string(v)
+		case exptypes.AnnotationManifestDescriptor:
+			ag[p].ManifestDescriptor[a.Key] = string(v)
+		default:
+			return nil, nil, fmt.Errorf("unrecognized annotation type %s", a.Type)
+		}
+	}
+	return ag, rest, nil
+}
+
+func (ag AnnotationsGroup) Platform(p *ocispecs.Platform) *Annotations {
+	res := &Annotations{
+		IndexDescriptor:    make(map[string]string),
+		Index:              make(map[string]string),
+		Manifest:           make(map[string]string),
+		ManifestDescriptor: make(map[string]string),
+	}
+
+	ps := []string{""}
+	if p != nil {
+		ps = append(ps, platforms.Format(*p))
+	}
+
+	for _, a := range ag {
+		for k, v := range a.Index {
+			res.Index[k] = v
+		}
+		for k, v := range a.IndexDescriptor {
+			res.IndexDescriptor[k] = v
+		}
+	}
+	for _, pk := range ps {
+		if _, ok := ag[pk]; !ok {
+			continue
+		}
+
+		for k, v := range ag[pk].Manifest {
+			res.Manifest[k] = v
+		}
+		for k, v := range ag[pk].ManifestDescriptor {
+			res.ManifestDescriptor[k] = v
+		}
+	}
+	return res
+}
+
+func (ag AnnotationsGroup) Merge(other AnnotationsGroup) AnnotationsGroup {
+	if other == nil {
+		return ag
+	}
+
+	for k, v := range other {
+		if _, ok := ag[k]; ok {
+			ag[k].merge(v)
+		} else {
+			ag[k] = v
+		}
+	}
+	return ag
+}
+
+func (a *Annotations) merge(other *Annotations) {
+	if other == nil {
+		return
+	}
+
+	for k, v := range other.Index {
+		a.Index[k] = v
+	}
+	for k, v := range other.IndexDescriptor {
+		a.IndexDescriptor[k] = v
+	}
+	for k, v := range other.Manifest {
+		a.Manifest[k] = v
+	}
+	for k, v := range other.ManifestDescriptor {
+		a.ManifestDescriptor[k] = v
+	}
+}

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -30,28 +30,16 @@ import (
 	"github.com/opencontainers/image-spec/identity"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 const (
-	keyImageName        = "name"
-	keyPush             = "push"
-	keyPushByDigest     = "push-by-digest"
-	keyInsecure         = "registry.insecure"
-	keyUnpack           = "unpack"
-	keyDanglingPrefix   = "dangling-name-prefix"
-	keyNameCanonical    = "name-canonical"
-	keyLayerCompression = "compression"
-	keyForceCompression = "force-compression"
-	keyCompressionLevel = "compression-level"
-	keyBuildInfo        = "buildinfo"
-	keyBuildInfoAttrs   = "buildinfo-attrs"
-	ociTypes            = "oci-mediatypes"
-	// preferNondistLayersKey is an exporter option which can be used to mark a layer as non-distributable if the layer reference was
-	// already found to use a non-distributable media type.
-	// When this option is not set, the exporter will change the media type of the layer to a distributable one.
-	preferNondistLayersKey = "prefer-nondist-layers"
-	keyStore               = "store"
+	keyPush           = "push"
+	keyPushByDigest   = "push-by-digest"
+	keyInsecure       = "registry.insecure"
+	keyUnpack         = "unpack"
+	keyDanglingPrefix = "dangling-name-prefix"
+	keyNameCanonical  = "name-canonical"
+	keyStore          = "store"
 
 	// keyUnsafeInternalStoreAllowIncomplete should only be used for tests. This option allows exporting image to the image store
 	// as well as lacking some blobs in the content store. Some integration tests for lazyref behaviour depends on this option.
@@ -82,17 +70,23 @@ func New(opt Opt) (exporter.Exporter, error) {
 
 func (e *imageExporter) Resolve(ctx context.Context, opt map[string]string) (exporter.ExporterInstance, error) {
 	i := &imageExporterInstance{
-		imageExporter:    e,
-		layerCompression: compression.Default,
-		buildInfo:        true,
-		store:            true,
+		imageExporter: e,
+		opts: ImageWriterOpts{
+			RefCfg: cacheconfig.RefConfig{
+				Compression: compression.New(compression.Default),
+			},
+			BuildInfo: true,
+		},
+		store: true,
 	}
 
-	var esgz bool
+	opt, err := i.opts.Parse(opt)
+	if err != nil {
+		return nil, err
+	}
+
 	for k, v := range opt {
 		switch k {
-		case keyImageName:
-			i.targetName = v
 		case keyPush:
 			if v == "" {
 				i.push = true
@@ -153,16 +147,6 @@ func (e *imageExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 				return nil, errors.Wrapf(err, "non-bool value specified for %s", k)
 			}
 			i.storeAllowIncomplete = b
-		case ociTypes:
-			if v == "" {
-				i.ociTypes = true
-				continue
-			}
-			b, err := strconv.ParseBool(v)
-			if err != nil {
-				return nil, errors.Wrapf(err, "non-bool value specified for %s", k)
-			}
-			i.ociTypes = b
 		case keyDanglingPrefix:
 			i.danglingPrefix = v
 		case keyNameCanonical:
@@ -175,63 +159,6 @@ func (e *imageExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 				return nil, errors.Wrapf(err, "non-bool value specified for %s", k)
 			}
 			i.nameCanonical = b
-		case keyLayerCompression:
-			switch v {
-			case "gzip":
-				i.layerCompression = compression.Gzip
-			case "estargz":
-				i.layerCompression = compression.EStargz
-				esgz = true
-			case "zstd":
-				i.layerCompression = compression.Zstd
-			case "uncompressed":
-				i.layerCompression = compression.Uncompressed
-			default:
-				return nil, errors.Errorf("unsupported layer compression type: %v", v)
-			}
-		case keyForceCompression:
-			if v == "" {
-				i.forceCompression = true
-				continue
-			}
-			b, err := strconv.ParseBool(v)
-			if err != nil {
-				return nil, errors.Wrapf(err, "non-bool value %s specified for %s", v, k)
-			}
-			i.forceCompression = b
-		case keyCompressionLevel:
-			ii, err := strconv.ParseInt(v, 10, 64)
-			if err != nil {
-				return nil, errors.Wrapf(err, "non-integer value %s specified for %s", v, k)
-			}
-			v := int(ii)
-			i.compressionLevel = &v
-		case keyBuildInfo:
-			if v == "" {
-				i.buildInfo = true
-				continue
-			}
-			b, err := strconv.ParseBool(v)
-			if err != nil {
-				return nil, errors.Wrapf(err, "non-bool value specified for %s", k)
-			}
-			i.buildInfo = b
-		case keyBuildInfoAttrs:
-			if v == "" {
-				i.buildInfoAttrs = false
-				continue
-			}
-			b, err := strconv.ParseBool(v)
-			if err != nil {
-				return nil, errors.Wrapf(err, "non-bool value specified for %s", k)
-			}
-			i.buildInfoAttrs = b
-		case preferNondistLayersKey:
-			b, err := strconv.ParseBool(v)
-			if err != nil {
-				return nil, errors.Wrapf(err, "non-bool value %s specified for %s", v, k)
-			}
-			i.preferNondistLayers = b
 		default:
 			if i.meta == nil {
 				i.meta = make(map[string][]byte)
@@ -239,32 +166,21 @@ func (e *imageExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 			i.meta[k] = []byte(v)
 		}
 	}
-	if esgz && !i.ociTypes {
-		logrus.Warn("forcibly turning on oci-mediatype mode for estargz")
-		i.ociTypes = true
-	}
 	return i, nil
 }
 
 type imageExporterInstance struct {
 	*imageExporter
-	targetName           string
+	opts                 ImageWriterOpts
 	push                 bool
 	pushByDigest         bool
 	unpack               bool
 	store                bool
 	storeAllowIncomplete bool
 	insecure             bool
-	ociTypes             bool
 	nameCanonical        bool
 	danglingPrefix       string
-	layerCompression     compression.Type
-	forceCompression     bool
-	compressionLevel     *int
-	buildInfo            bool
-	buildInfoAttrs       bool
 	meta                 map[string][]byte
-	preferNondistLayers  bool
 }
 
 func (e *imageExporterInstance) Name() string {
@@ -273,16 +189,8 @@ func (e *imageExporterInstance) Name() string {
 
 func (e *imageExporterInstance) Config() exporter.Config {
 	return exporter.Config{
-		Compression: e.compression(),
+		Compression: e.opts.RefCfg.Compression,
 	}
-}
-
-func (e *imageExporterInstance) compression() compression.Config {
-	c := compression.New(e.layerCompression).SetForce(e.forceCompression)
-	if e.compressionLevel != nil {
-		c = c.SetLevel(*e.compressionLevel)
-	}
-	return c
 }
 
 func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source, sessionID string) (map[string]string, error) {
@@ -299,8 +207,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source,
 	}
 	defer done(context.TODO())
 
-	refCfg := e.refCfg()
-	desc, err := e.opt.ImageWriter.Commit(ctx, src, e.ociTypes, refCfg, e.buildInfo, e.buildInfoAttrs, sessionID)
+	desc, err := e.opt.ImageWriter.Commit(ctx, src, sessionID, &e.opts)
 	if err != nil {
 		return nil, err
 	}
@@ -311,18 +218,18 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source,
 
 	resp := make(map[string]string)
 
-	if n, ok := src.Metadata["image.name"]; e.targetName == "*" && ok {
-		e.targetName = string(n)
+	if n, ok := src.Metadata["image.name"]; e.opts.ImageName == "*" && ok {
+		e.opts.ImageName = string(n)
 	}
 
 	nameCanonical := e.nameCanonical
-	if e.targetName == "" && e.danglingPrefix != "" {
-		e.targetName = e.danglingPrefix + "@" + desc.Digest.String()
+	if e.opts.ImageName == "" && e.danglingPrefix != "" {
+		e.opts.ImageName = e.danglingPrefix + "@" + desc.Digest.String()
 		nameCanonical = false
 	}
 
-	if e.targetName != "" {
-		targetNames := strings.Split(e.targetName, ",")
+	if e.opts.ImageName != "" {
+		targetNames := strings.Split(e.opts.ImageName, ",")
 		for _, targetName := range targetNames {
 			if e.opt.Images != nil && e.store {
 				tagDone := oneOffProgress(ctx, "naming to "+targetName)
@@ -356,7 +263,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source,
 
 				if !e.storeAllowIncomplete {
 					if src.Ref != nil {
-						remotes, err := src.Ref.GetRemotes(ctx, false, refCfg, false, session.NewGroup(sessionID))
+						remotes, err := src.Ref.GetRemotes(ctx, false, e.opts.RefCfg, false, session.NewGroup(sessionID))
 						if err != nil {
 							return nil, err
 						}
@@ -369,7 +276,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source,
 					}
 					if len(src.Refs) > 0 {
 						for _, r := range src.Refs {
-							remotes, err := r.GetRemotes(ctx, false, refCfg, false, session.NewGroup(sessionID))
+							remotes, err := r.GetRemotes(ctx, false, e.opts.RefCfg, false, session.NewGroup(sessionID))
 							if err != nil {
 								return nil, err
 							}
@@ -387,7 +294,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source,
 				annotations := map[digest.Digest]map[string]string{}
 				mprovider := contentutil.NewMultiProvider(e.opt.ImageWriter.ContentStore())
 				if src.Ref != nil {
-					remotes, err := src.Ref.GetRemotes(ctx, false, refCfg, false, session.NewGroup(sessionID))
+					remotes, err := src.Ref.GetRemotes(ctx, false, e.opts.RefCfg, false, session.NewGroup(sessionID))
 					if err != nil {
 						return nil, err
 					}
@@ -399,7 +306,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source,
 				}
 				if len(src.Refs) > 0 {
 					for _, r := range src.Refs {
-						remotes, err := r.GetRemotes(ctx, false, refCfg, false, session.NewGroup(sessionID))
+						remotes, err := r.GetRemotes(ctx, false, e.opts.RefCfg, false, session.NewGroup(sessionID))
 						if err != nil {
 							return nil, err
 						}
@@ -416,7 +323,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source,
 				}
 			}
 		}
-		resp["image.name"] = e.targetName
+		resp["image.name"] = e.opts.ImageName
 	}
 
 	resp[exptypes.ExporterImageDigestKey] = desc.Digest.String()
@@ -432,13 +339,6 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source,
 	resp[exptypes.ExporterImageDescriptorKey] = base64.StdEncoding.EncodeToString(dtdesc)
 
 	return resp, nil
-}
-
-func (e *imageExporterInstance) refCfg() cacheconfig.RefConfig {
-	return cacheconfig.RefConfig{
-		Compression:            e.compression(),
-		PreferNonDistributable: e.preferNondistLayers,
-	}
 }
 
 func (e *imageExporterInstance) unpackImage(ctx context.Context, img images.Image, src exporter.Source, s session.Group) (err0 error) {
@@ -468,7 +368,7 @@ func (e *imageExporterInstance) unpackImage(ctx context.Context, img images.Imag
 		}
 	}
 
-	remotes, err := topLayerRef.GetRemotes(ctx, true, e.refCfg(), false, s)
+	remotes, err := topLayerRef.GetRemotes(ctx, true, e.opts.RefCfg, false, s)
 	if err != nil {
 		return err
 	}

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -71,7 +71,7 @@ func New(opt Opt) (exporter.Exporter, error) {
 func (e *imageExporter) Resolve(ctx context.Context, opt map[string]string) (exporter.ExporterInstance, error) {
 	i := &imageExporterInstance{
 		imageExporter: e,
-		opts: ImageWriterOpts{
+		opts: ImageCommitOpts{
 			RefCfg: cacheconfig.RefConfig{
 				Compression: compression.New(compression.Default),
 			},
@@ -172,7 +172,7 @@ func (e *imageExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 
 type imageExporterInstance struct {
 	*imageExporter
-	opts                 ImageWriterOpts
+	opts                 ImageCommitOpts
 	push                 bool
 	pushByDigest         bool
 	unpack               bool

--- a/exporter/containerimage/exptypes/annotations.go
+++ b/exporter/containerimage/exptypes/annotations.go
@@ -1,0 +1,115 @@
+package exptypes
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/containerd/containerd/platforms"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+const (
+	AnnotationIndex              = "index"
+	AnnotationIndexDescriptor    = "index-descriptor"
+	AnnotationManifest           = "manifest"
+	AnnotationManifestDescriptor = "manifest-descriptor"
+)
+
+var (
+	keyAnnotationRegexp = regexp.MustCompile(`^annotation(?:-([a-z-]+))?(?:\[([A-Za-z0-9_/-]+)\])?\.(\S+)$`)
+)
+
+type AnnotationKey struct {
+	Type     string
+	Platform *ocispecs.Platform
+	Key      string
+}
+
+func (k AnnotationKey) String() string {
+	prefix := "annotation"
+
+	switch k.Type {
+	case "":
+	case AnnotationManifest, AnnotationManifestDescriptor:
+		prefix += fmt.Sprintf("-%s", k.Type)
+		if p := k.PlatformString(); p != "" {
+			prefix += fmt.Sprintf("[%s]", p)
+		}
+	case AnnotationIndex, AnnotationIndexDescriptor:
+		prefix += "-" + k.Type
+	default:
+		panic("unknown annotation type")
+	}
+
+	return fmt.Sprintf("%s.%s", prefix, k.Key)
+}
+
+func (k AnnotationKey) PlatformString() string {
+	if k.Platform == nil {
+		return ""
+	}
+	return platforms.Format(*k.Platform)
+}
+
+func AnnotationIndexKey(key string) string {
+	return AnnotationKey{
+		Type: AnnotationIndex,
+		Key:  key,
+	}.String()
+}
+
+func AnnotationIndexDescriptorKey(key string) string {
+	return AnnotationKey{
+		Type: AnnotationIndexDescriptor,
+		Key:  key,
+	}.String()
+}
+
+func AnnotationManifestKey(p *ocispecs.Platform, key string) string {
+	return AnnotationKey{
+		Type:     AnnotationManifest,
+		Platform: p,
+		Key:      key,
+	}.String()
+}
+
+func AnnotationManifestDescriptorKey(p *ocispecs.Platform, key string) string {
+	return AnnotationKey{
+		Type:     AnnotationManifestDescriptor,
+		Platform: p,
+		Key:      key,
+	}.String()
+}
+
+func ParseAnnotationKey(result string) (AnnotationKey, bool, error) {
+	groups := keyAnnotationRegexp.FindStringSubmatch(result)
+	if groups == nil {
+		return AnnotationKey{}, false, nil
+	}
+
+	tp, platform, key := groups[1], groups[2], groups[3]
+	switch tp {
+	case AnnotationIndex, AnnotationIndexDescriptor, AnnotationManifest, AnnotationManifestDescriptor:
+	case "":
+		tp = AnnotationManifest
+	default:
+		return AnnotationKey{}, true, errors.Errorf("unrecognized annotation type %s", tp)
+	}
+
+	var ociPlatform *ocispecs.Platform
+	if platform != "" {
+		p, err := platforms.Parse(platform)
+		if err != nil {
+			return AnnotationKey{}, true, err
+		}
+		ociPlatform = &p
+	}
+
+	annotation := AnnotationKey{
+		Type:     tp,
+		Platform: ociPlatform,
+		Key:      key,
+	}
+	return annotation, true, nil
+}

--- a/exporter/containerimage/opts.go
+++ b/exporter/containerimage/opts.go
@@ -1,0 +1,109 @@
+package containerimage
+
+import (
+	"strconv"
+
+	cacheconfig "github.com/moby/buildkit/cache/config"
+	"github.com/moby/buildkit/util/compression"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	keyImageName        = "name"
+	keyLayerCompression = "compression"
+	keyCompressionLevel = "compression-level"
+	keyForceCompression = "force-compression"
+	keyOCITypes         = "oci-mediatypes"
+	keyBuildInfo        = "buildinfo"
+	keyBuildInfoAttrs   = "buildinfo-attrs"
+
+	// preferNondistLayersKey is an exporter option which can be used to mark a layer as non-distributable if the layer reference was
+	// already found to use a non-distributable media type.
+	// When this option is not set, the exporter will change the media type of the layer to a distributable one.
+	preferNondistLayersKey = "prefer-nondist-layers"
+)
+
+type ImageWriterOpts struct {
+	ImageName      string
+	RefCfg         cacheconfig.RefConfig
+	OCITypes       bool
+	BuildInfo      bool
+	BuildInfoAttrs bool
+}
+
+func (c *ImageWriterOpts) Parse(opt map[string]string) (map[string]string, error) {
+	rest := make(map[string]string)
+
+	esgz := false
+
+	for k, v := range opt {
+		var err error
+		switch k {
+		case keyImageName:
+			c.ImageName = v
+		case keyLayerCompression:
+			switch v {
+			case "gzip":
+				c.RefCfg.Compression.Type = compression.Gzip
+			case "estargz":
+				c.RefCfg.Compression.Type = compression.EStargz
+				esgz = true
+			case "zstd":
+				c.RefCfg.Compression.Type = compression.Zstd
+			case "uncompressed":
+				c.RefCfg.Compression.Type = compression.Uncompressed
+			default:
+				err = errors.Errorf("unsupported layer compression type: %v", v)
+			}
+		case keyCompressionLevel:
+			ii, err2 := strconv.ParseInt(v, 10, 64)
+			if err != nil {
+				err = errors.Wrapf(err2, "non-int value %s specified for %s", v, k)
+				break
+			}
+			v := int(ii)
+			c.RefCfg.Compression.Level = &v
+		case keyForceCompression:
+			err = parseBoolWithDefault(&c.RefCfg.Compression.Force, k, v, true)
+		case keyOCITypes:
+			err = parseBoolWithDefault(&c.OCITypes, k, v, true)
+		case keyBuildInfo:
+			err = parseBoolWithDefault(&c.BuildInfo, k, v, true)
+		case keyBuildInfoAttrs:
+			err = parseBoolWithDefault(&c.BuildInfoAttrs, k, v, false)
+		case preferNondistLayersKey:
+			err = parseBool(&c.RefCfg.PreferNonDistributable, k, v)
+		default:
+			rest[k] = v
+		}
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if esgz && !c.OCITypes {
+		logrus.Warn("forcibly turning on oci-mediatype mode for estargz")
+		c.OCITypes = true
+	}
+
+	return rest, nil
+}
+
+func parseBool(dest *bool, key string, value string) error {
+	b, err := strconv.ParseBool(value)
+	if err != nil {
+		return errors.Wrapf(err, "non-bool value specified for %s", key)
+	}
+	*dest = b
+	return nil
+}
+
+func parseBoolWithDefault(dest *bool, key string, value string, defaultValue bool) error {
+	if value == "" {
+		*dest = defaultValue
+		return nil
+	}
+	return parseBool(dest, key, value)
+}

--- a/exporter/containerimage/opts.go
+++ b/exporter/containerimage/opts.go
@@ -30,12 +30,20 @@ type ImageWriterOpts struct {
 	OCITypes       bool
 	BuildInfo      bool
 	BuildInfoAttrs bool
+	Annotations    AnnotationsGroup
 }
 
-func (c *ImageWriterOpts) Parse(opt map[string]string) (map[string]string, error) {
+func (c *ImageWriterOpts) Load(opt map[string]string) (map[string]string, error) {
 	rest := make(map[string]string)
 
 	esgz := false
+
+	as, optb, err := ParseAnnotations(toBytesMap(opt))
+	if err != nil {
+		return nil, err
+	}
+	c.Annotations = as
+	opt = toStringMap(optb)
 
 	for k, v := range opt {
 		var err error
@@ -106,4 +114,20 @@ func parseBoolWithDefault(dest *bool, key string, value string, defaultValue boo
 		return nil
 	}
 	return parseBool(dest, key, value)
+}
+
+func toBytesMap(m map[string]string) map[string][]byte {
+	result := make(map[string][]byte)
+	for k, v := range m {
+		result[k] = []byte(v)
+	}
+	return result
+}
+
+func toStringMap(m map[string][]byte) map[string]string {
+	result := make(map[string]string)
+	for k, v := range m {
+		result[k] = string(v)
+	}
+	return result
 }

--- a/exporter/containerimage/opts.go
+++ b/exporter/containerimage/opts.go
@@ -21,10 +21,10 @@ const (
 	// preferNondistLayersKey is an exporter option which can be used to mark a layer as non-distributable if the layer reference was
 	// already found to use a non-distributable media type.
 	// When this option is not set, the exporter will change the media type of the layer to a distributable one.
-	preferNondistLayersKey = "prefer-nondist-layers"
+	keyPreferNondistLayers = "prefer-nondist-layers"
 )
 
-type ImageWriterOpts struct {
+type ImageCommitOpts struct {
 	ImageName      string
 	RefCfg         cacheconfig.RefConfig
 	OCITypes       bool
@@ -33,7 +33,7 @@ type ImageWriterOpts struct {
 	Annotations    AnnotationsGroup
 }
 
-func (c *ImageWriterOpts) Load(opt map[string]string) (map[string]string, error) {
+func (c *ImageCommitOpts) Load(opt map[string]string) (map[string]string, error) {
 	rest := make(map[string]string)
 
 	esgz := false
@@ -80,7 +80,7 @@ func (c *ImageWriterOpts) Load(opt map[string]string) (map[string]string, error)
 			err = parseBoolWithDefault(&c.BuildInfo, k, v, true)
 		case keyBuildInfoAttrs:
 			err = parseBoolWithDefault(&c.BuildInfoAttrs, k, v, false)
-		case preferNondistLayersKey:
+		case keyPreferNondistLayers:
 			err = parseBool(&c.RefCfg.PreferNonDistributable, k, v)
 		default:
 			rest[k] = v

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -50,7 +50,7 @@ type ImageWriter struct {
 	opt WriterOpt
 }
 
-func (ic *ImageWriter) Commit(ctx context.Context, inp exporter.Source, oci bool, refCfg cacheconfig.RefConfig, buildInfo bool, buildInfoAttrs bool, sessionID string) (*ocispecs.Descriptor, error) {
+func (ic *ImageWriter) Commit(ctx context.Context, inp exporter.Source, sessionID string, opts *ImageWriterOpts) (*ocispecs.Descriptor, error) {
 	platformsBytes, ok := inp.Metadata[exptypes.ExporterPlatformsKey]
 
 	if len(inp.Refs) > 0 && !ok {
@@ -58,21 +58,21 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp exporter.Source, oci bool
 	}
 
 	if len(inp.Refs) == 0 {
-		remotes, err := ic.exportLayers(ctx, refCfg, session.NewGroup(sessionID), inp.Ref)
+		remotes, err := ic.exportLayers(ctx, opts.RefCfg, session.NewGroup(sessionID), inp.Ref)
 		if err != nil {
 			return nil, err
 		}
 
 		var dtbi []byte
-		if buildInfo {
+		if opts.BuildInfo {
 			if dtbi, err = buildinfo.Format(inp.Metadata[exptypes.ExporterBuildInfo], buildinfo.FormatOpts{
-				RemoveAttrs: !buildInfoAttrs,
+				RemoveAttrs: !opts.BuildInfoAttrs,
 			}); err != nil {
 				return nil, err
 			}
 		}
 
-		mfstDesc, configDesc, err := ic.commitDistributionManifest(ctx, inp.Ref, inp.Metadata[exptypes.ExporterImageConfigKey], &remotes[0], oci, inp.Metadata[exptypes.ExporterInlineCache], dtbi)
+		mfstDesc, configDesc, err := ic.commitDistributionManifest(ctx, inp.Ref, inp.Metadata[exptypes.ExporterImageConfigKey], &remotes[0], opts.OCITypes, inp.Metadata[exptypes.ExporterInlineCache], dtbi)
 		if err != nil {
 			return nil, err
 		}
@@ -100,7 +100,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp exporter.Source, oci bool
 		refs = append(refs, r)
 	}
 
-	remotes, err := ic.exportLayers(ctx, refCfg, session.NewGroup(sessionID), refs...)
+	remotes, err := ic.exportLayers(ctx, opts.RefCfg, session.NewGroup(sessionID), refs...)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +120,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp exporter.Source, oci bool
 		},
 	}
 
-	if !oci {
+	if !opts.OCITypes {
 		idx.MediaType = images.MediaTypeDockerSchema2ManifestList
 	}
 
@@ -135,15 +135,15 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp exporter.Source, oci bool
 		inlineCache := inp.Metadata[fmt.Sprintf("%s/%s", exptypes.ExporterInlineCache, p.ID)]
 
 		var dtbi []byte
-		if buildInfo {
+		if opts.BuildInfo {
 			if dtbi, err = buildinfo.Format(inp.Metadata[fmt.Sprintf("%s/%s", exptypes.ExporterBuildInfo, p.ID)], buildinfo.FormatOpts{
-				RemoveAttrs: !buildInfoAttrs,
+				RemoveAttrs: !opts.BuildInfoAttrs,
 			}); err != nil {
 				return nil, err
 			}
 		}
 
-		desc, _, err := ic.commitDistributionManifest(ctx, r, config, &remotes[remotesMap[p.ID]], oci, inlineCache, dtbi)
+		desc, _, err := ic.commitDistributionManifest(ctx, r, config, &remotes[remotesMap[p.ID]], opts.OCITypes, inlineCache, dtbi)
 		if err != nil {
 			return nil, err
 		}

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -50,7 +50,7 @@ type ImageWriter struct {
 	opt WriterOpt
 }
 
-func (ic *ImageWriter) Commit(ctx context.Context, inp exporter.Source, sessionID string, opts *ImageWriterOpts) (*ocispecs.Descriptor, error) {
+func (ic *ImageWriter) Commit(ctx context.Context, inp exporter.Source, sessionID string, opts *ImageCommitOpts) (*ocispecs.Descriptor, error) {
 	platformsBytes, ok := inp.Metadata[exptypes.ExporterPlatformsKey]
 
 	if len(inp.Refs) > 0 && !ok {

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -17,12 +17,12 @@ type ExporterInstance interface {
 	Export(ctx context.Context, src Source, sessionID string) (map[string]string, error)
 }
 
+type Config struct {
+	Compression compression.Config
+}
+
 type Source struct {
 	Ref      cache.ImmutableRef
 	Refs     map[string]cache.ImmutableRef
 	Metadata map[string][]byte
-}
-
-type Config struct {
-	Compression compression.Config
 }

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -57,12 +57,13 @@ func (e *imageExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 			RefCfg: cacheconfig.RefConfig{
 				Compression: compression.New(compression.Default),
 			},
-			BuildInfo: true,
-			OCITypes:  e.opt.Variant == VariantOCI,
+			BuildInfo:   true,
+			OCITypes:    e.opt.Variant == VariantOCI,
+			Annotations: make(containerimage.AnnotationsGroup),
 		},
 	}
 
-	opt, err := i.opts.Parse(opt)
+	opt, err := i.opts.Load(opt)
 	if err != nil {
 		return nil, err
 	}
@@ -104,13 +105,20 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source,
 		src.Metadata[k] = v
 	}
 
+	opts := e.opts
+	as, _, err := containerimage.ParseAnnotations(src.Metadata)
+	if err != nil {
+		return nil, err
+	}
+	opts.Annotations = as.Merge(opts.Annotations)
+
 	ctx, done, err := leaseutil.WithLease(ctx, e.opt.LeaseManager, leaseutil.MakeTemporary)
 	if err != nil {
 		return nil, err
 	}
 	defer done(context.TODO())
 
-	desc, err := e.opt.ImageWriter.Commit(ctx, src, sessionID, &e.opts)
+	desc, err := e.opt.ImageWriter.Commit(ctx, src, sessionID, &opts)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -53,7 +53,7 @@ func New(opt Opt) (exporter.Exporter, error) {
 func (e *imageExporter) Resolve(ctx context.Context, opt map[string]string) (exporter.ExporterInstance, error) {
 	i := &imageExporterInstance{
 		imageExporter: e,
-		opts: containerimage.ImageWriterOpts{
+		opts: containerimage.ImageCommitOpts{
 			RefCfg: cacheconfig.RefConfig{
 				Compression: compression.New(compression.Default),
 			},
@@ -79,7 +79,7 @@ func (e *imageExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 
 type imageExporterInstance struct {
 	*imageExporter
-	opts containerimage.ImageWriterOpts
+	opts containerimage.ImageCommitOpts
 	meta map[string][]byte
 }
 

--- a/solver/pb/caps.go
+++ b/solver/pb/caps.go
@@ -74,6 +74,8 @@ const (
 
 	CapMergeOp apicaps.CapID = "mergeop"
 	CapDiffOp  apicaps.CapID = "diffop"
+
+	CapAnnotations apicaps.CapID = "exporter.image.annotations"
 )
 
 func init() {
@@ -392,18 +394,27 @@ func init() {
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})
+
 	Caps.Init(apicaps.Cap{
 		ID:      CapRemoteCacheS3,
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})
+
 	Caps.Init(apicaps.Cap{
 		ID:      CapMergeOp,
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})
+
 	Caps.Init(apicaps.Cap{
 		ID:      CapDiffOp,
+		Enabled: true,
+		Status:  apicaps.CapStatusExperimental,
+	})
+
+	Caps.Init(apicaps.Cap{
+		ID:      CapAnnotations,
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})


### PR DESCRIPTION
Fixes #1220

This PR introduces support for creating and attaching annotations to the exporter. These annotations can be specified via frontends, or via the exporter output parameters (with the latter overriding the former).

For now, this is just the containerimage exporter, but we should probably add it to the other exporters as well, at the very least the oci exporter :eyes: