### PR TITLE
NewDockerAuthProvider: take docker config instead of loading it

### DIFF
--- a/cmd/buildctl/build.go
+++ b/cmd/buildctl/build.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/containerd/continuity"
+	"github.com/docker/cli/cli/config"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/cmd/buildctl/build"
@@ -139,7 +140,8 @@ func buildAction(clicontext *cli.Context) error {
 		logrus.Infof("tracing logs to %s", traceFile.Name())
 	}
 
-	attachable := []session.Attachable{authprovider.NewDockerAuthProvider(os.Stderr)}
+	dockerConfig := config.LoadDefaultConfigFile(os.Stderr)
+	attachable := []session.Attachable{authprovider.NewDockerAuthProvider(dockerConfig)}
 
 	if ssh := clicontext.StringSlice("ssh"); len(ssh) > 0 {
 		configs, err := build.ParseSSH(ssh)

--- a/session/auth/authprovider/authprovider.go
+++ b/session/auth/authprovider/authprovider.go
@@ -6,7 +6,6 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -31,10 +30,10 @@ import (
 
 const defaultExpiration = 60
 
-func NewDockerAuthProvider(stderr io.Writer) session.Attachable {
+func NewDockerAuthProvider(cfg *configfile.ConfigFile) session.Attachable {
 	return &authProvider{
 		authConfigCache: map[string]*types.AuthConfig{},
-		config:          config.LoadDefaultConfigFile(stderr),
+		config:          cfg,
 		seeds:           &tokenSeeds{dir: config.Dir()},
 		loggerCache:     map[string]struct{}{},
 	}


### PR DESCRIPTION
Hiya - I've got a use case for passing the Docker config content over the wire (SSH) to a central server that talks back to SSH-tunneled Buildkit sockets. To do this I need to pass the Docker config directly to the auth provider instead of loading it from the local machine, since in this case that would be the central server, which doesn't have any config.

Thanks for making Buildkit!

*edit: I don't actually need this anymore, but I think it's a reasonable refactor since it lets the caller choose whether they want to do I/O. I'll leave it open, but feel free to close if it's not worth it.*