### PR TITLE
ci: add concurrency check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 name: build
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   schedule:
     - cron: '0 10 * * *'  # everyday at 10am

--- a/.github/workflows/buildx-image.yml
+++ b/.github/workflows/buildx-image.yml
@@ -9,6 +9,10 @@
 #         moby/buildkit:v0.8.1-rootless > moby/buildkit:buildx-stable-1-rootless
 name: buildx-image
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/dockerd.yml
+++ b/.github/workflows/dockerd.yml
@@ -1,5 +1,9 @@
 name: dockerd
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   # TODO: add event to build on command in PR (e.g., /test-dockerd)
   workflow_dispatch:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,5 +1,9 @@
 name: validate
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
add concurrency check in our workflows to ensure that only a single workflow using the same concurrency group will run at a time. it allows to reduce job build queue in our pipeline (we are limited to 20 concurrent jobs atm with the [Free plan](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits)).

more info: https://docs.github.com/en/actions/using-jobs/using-concurrency

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>