### PR TITLE
Add return stack traces

### DIFF
--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -565,7 +565,10 @@ func unaryInterceptor(globalCtx context.Context, tp trace.TracerProvider) grpc.U
 
 		resp, err = withTrace(ctx, req, info, handler)
 		if err != nil {
-			logrus.Errorf("%s returned error: %+v", info.FullMethod, stack.Formatter(err))
+			logrus.Errorf("%s returned error: %v", info.FullMethod, err)
+			if logrus.GetLevel() >= logrus.DebugLevel {
+				fmt.Fprintf(os.Stderr, "%+v", stack.Formatter(grpcerrors.FromGRPC(err)))
+			}
 		}
 		return
 	}


### PR DESCRIPTION
Have an option to send the `Solve()` daemon-side stacktraces to the client along with an error. Enabled via `--send-stacktraces` or config file option.

Should not be enabled in most cases. However, when running tests, this can be very useful. If the error occurs in the daemon, the output logs now can tell where the error occurred.

Discussed with @tonistiigi [here](https://github.com/moby/buildkit/pull/2827#issuecomment-1151705920)

I probably should make this a Draft PR, but it gets across what I was trying to do, and is functional. Happy to change into some other format, if that is better.

We also probably should enable it for all usage inside CI, if this is good.