### PR TITLE
dockerfile: add `(ADD|COPY) --timestamp=<RFC3339Nano>`

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/containerd/containerd/platforms"
 	"github.com/docker/distribution/reference"
@@ -647,6 +648,7 @@ func dispatch(d *dispatchState, cmd command, opt dispatchOpt) error {
 			chown:        c.Chown,
 			chmod:        c.Chmod,
 			link:         c.Link,
+			timestamp:    c.Timestamp,
 			location:     c.Location(),
 			opt:          opt,
 		})
@@ -692,6 +694,7 @@ func dispatch(d *dispatchState, cmd command, opt dispatchOpt) error {
 			chown:        c.Chown,
 			chmod:        c.Chmod,
 			link:         c.Link,
+			timestamp:    c.Timestamp,
 			location:     c.Location(),
 			opt:          opt,
 		})
@@ -1024,6 +1027,7 @@ func dispatchCopy(d *dispatchState, cfg copyConfig) error {
 			opts := append([]llb.CopyOption{&llb.CopyInfo{
 				Mode:           mode,
 				CreateDestPath: true,
+				CreatedTime:    cfg.timestamp,
 			}}, copyOpt...)
 
 			if a == nil {
@@ -1040,6 +1044,7 @@ func dispatchCopy(d *dispatchState, cfg copyConfig) error {
 				CreateDestPath:      true,
 				AllowWildcard:       true,
 				AllowEmptyWildcard:  true,
+				CreatedTime:         cfg.timestamp,
 			}}, copyOpt...)
 
 			if a == nil {
@@ -1063,6 +1068,7 @@ func dispatchCopy(d *dispatchState, cfg copyConfig) error {
 		opts := append([]llb.CopyOption{&llb.CopyInfo{
 			Mode:           mode,
 			CreateDestPath: true,
+			CreatedTime:    cfg.timestamp,
 		}}, copyOpt...)
 
 		if a == nil {
@@ -1124,6 +1130,7 @@ type copyConfig struct {
 	chown        string
 	chmod        string
 	link         bool
+	timestamp    *time.Time
 	location     []parser.Range
 	opt          dispatchOpt
 }

--- a/frontend/dockerfile/docs/syntax.md
+++ b/frontend/dockerfile/docs/syntax.md
@@ -24,6 +24,25 @@ The images are published on two channels: *latest* and *labs*. The latest channe
 incrementing the major component of a version and you may want to pin the image to a specific revision. Even when syntaxes
 change in between releases on labs channel, the old versions are guaranteed to be backward compatible.
 
+## Timestamped copies `COPY --timestamp`, `ADD --timestamp`
+
+<!-- TODO: dockerfile-upstream:master -> dockerfile:1.5 after the release of 1.5 -->
+To use this instruction, set the frontend to `docker/dockerfile-upstream:master`:
+
+```dockerfile
+# syntax=docker/dockerfile-upstream:master`
+```
+
+This instruction allows you to specify a tiemstamp in the RFC3339Nano format.
+
+```dockerfile
+# syntax=docker/dockerfile-upstream:master`
+FROM busybox AS base
+RUN echo hello >/hello
+
+FROM scratch
+COPY --from=base --timestamp="2006-01-02T15:04:05Z" /hello /hello
+```
 
 ## Linked copies `COPY --link`, `ADD --link`
 

--- a/frontend/dockerfile/instructions/commands.go
+++ b/frontend/dockerfile/instructions/commands.go
@@ -2,6 +2,7 @@ package instructions
 
 import (
 	"strings"
+	"time"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/strslice"
@@ -224,9 +225,10 @@ func (s *SourcesAndDest) ExpandRaw(expander SingleWordExpander) error {
 type AddCommand struct {
 	withNameAndCode
 	SourcesAndDest
-	Chown string
-	Chmod string
-	Link  bool
+	Chown     string
+	Chmod     string
+	Link      bool
+	Timestamp *time.Time
 }
 
 // Expand variables
@@ -247,10 +249,11 @@ func (c *AddCommand) Expand(expander SingleWordExpander) error {
 type CopyCommand struct {
 	withNameAndCode
 	SourcesAndDest
-	From  string
-	Chown string
-	Chmod string
-	Link  bool
+	From      string
+	Chown     string
+	Chmod     string
+	Link      bool
+	Timestamp *time.Time
 }
 
 // Expand variables

--- a/frontend/dockerfile/instructions/parse.go
+++ b/frontend/dockerfile/instructions/parse.go
@@ -274,6 +274,17 @@ func parseSourcesAndDest(req parseRequest, command string) (*SourcesAndDest, err
 	}, nil
 }
 
+func parseTimestamp(s string) (*time.Time, error) {
+	if s == "" {
+		return nil, nil
+	}
+	timestamp, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse timestamp %q, the string format must be like \"2006-01-02T15:04:05Z\" (RFC3339Nano)", s)
+	}
+	return &timestamp, nil
+}
+
 func parseAdd(req parseRequest) (*AddCommand, error) {
 	if len(req.args) < 2 {
 		return nil, errNoDestinationArgument("ADD")
@@ -281,11 +292,17 @@ func parseAdd(req parseRequest) (*AddCommand, error) {
 	flChown := req.flags.AddString("chown", "")
 	flChmod := req.flags.AddString("chmod", "")
 	flLink := req.flags.AddBool("link", false)
+	flTimestamp := req.flags.AddString("timestamp", "")
 	if err := req.flags.Parse(); err != nil {
 		return nil, err
 	}
 
 	sourcesAndDest, err := parseSourcesAndDest(req, "ADD")
+	if err != nil {
+		return nil, err
+	}
+
+	timestamp, err := parseTimestamp(flTimestamp.Value)
 	if err != nil {
 		return nil, err
 	}
@@ -296,6 +313,7 @@ func parseAdd(req parseRequest) (*AddCommand, error) {
 		Chown:           flChown.Value,
 		Chmod:           flChmod.Value,
 		Link:            flLink.Value == "true",
+		Timestamp:       timestamp,
 	}, nil
 }
 
@@ -307,11 +325,17 @@ func parseCopy(req parseRequest) (*CopyCommand, error) {
 	flFrom := req.flags.AddString("from", "")
 	flChmod := req.flags.AddString("chmod", "")
 	flLink := req.flags.AddBool("link", false)
+	flTimestamp := req.flags.AddString("timestamp", "")
 	if err := req.flags.Parse(); err != nil {
 		return nil, err
 	}
 
 	sourcesAndDest, err := parseSourcesAndDest(req, "COPY")
+	if err != nil {
+		return nil, err
+	}
+
+	timestamp, err := parseTimestamp(flTimestamp.Value)
 	if err != nil {
 		return nil, err
 	}
@@ -323,6 +347,7 @@ func parseCopy(req parseRequest) (*CopyCommand, error) {
 		Chown:           flChown.Value,
 		Chmod:           flChmod.Value,
 		Link:            flLink.Value == "true",
+		Timestamp:       timestamp,
 	}, nil
 }
 

--- a/frontend/dockerfile/instructions/parse_test.go
+++ b/frontend/dockerfile/instructions/parse_test.go
@@ -239,3 +239,17 @@ func TestRunCmdFlagsUsed(t *testing.T) {
 	require.IsType(t, c, &RunCommand{})
 	require.Equal(t, []string{"mount"}, c.(*RunCommand).FlagsUsed)
 }
+
+func TestParseTimestamp(t *testing.T) {
+	x, err := parseTimestamp("")
+	require.NoError(t, err)
+	require.Nil(t, x)
+
+	x, err = parseTimestamp("2006-01-02T15:04:05Z")
+	require.NoError(t, err)
+	require.NotNil(t, x)
+
+	_, err = parseTimestamp("2006-01-02")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "the string format must be like \"2006-01-02T15:04:05Z\"")
+}


### PR DESCRIPTION
`(ADD|COPY) --timestamp=<RFC3339Nano>` would be useful for more reproducible builds.

e.g.,
```dockerfile
FROM busybox AS base
RUN echo hello >/hello

FROM scratch
COPY --from=base --timestamp="2006-01-02T15:04:05Z" /hello /hello
```

Closes #2910
