### PR TITLE
Add support for SOURCE_DATE_EPOCH

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -179,6 +179,7 @@ func TestIntegration(t *testing.T) {
 		testSourceDateEpochLayerTimestamps,
 		testSourceDateEpochClamp,
 		testSourceDateEpochReset,
+		testSourceDateEpochLocalExporter,
 	)
 	tests = append(tests, diffOpTestCases()...)
 	integration.Run(t, tests, mirrors)
@@ -2511,6 +2512,56 @@ func testSourceDateEpochReset(t *testing.T, sb integration.Sandbox) {
 
 	require.Equal(t, tms[0], tms[2])
 	require.NotEqual(t, tms[2], tms[1])
+
+	checkAllReleasable(t, c, sb, true)
+}
+
+func testSourceDateEpochLocalExporter(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerd(t, sb, "oci exporter")
+	requiresLinux(t)
+	c, err := New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	busybox := llb.Image("busybox:latest")
+	st := llb.Scratch()
+
+	run := func(cmd string) {
+		st = busybox.Run(llb.Shlex(cmd), llb.Dir("/wd")).AddMount("/wd", st)
+	}
+
+	run(`sh -c "echo -n first > foo"`)
+	run(`sh -c "echo -n second > bar"`)
+
+	def, err := st.Marshal(sb.Context())
+	require.NoError(t, err)
+
+	destDir, err := os.MkdirTemp("", "buildkit")
+	require.NoError(t, err)
+	defer os.RemoveAll(destDir)
+
+	tm := time.Date(2015, time.October, 21, 7, 28, 0, 0, time.UTC)
+
+	_, err = c.Solve(sb.Context(), def, SolveOpt{
+		FrontendAttrs: map[string]string{
+			"build-arg:SOURCE_DATE_EPOCH": fmt.Sprintf("%d", tm.Unix()),
+		},
+		Exports: []ExportEntry{
+			{
+				Type:      ExporterLocal,
+				OutputDir: destDir,
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	fi, err := os.Stat(filepath.Join(destDir, "foo"))
+	require.NoError(t, err)
+	require.Equal(t, fi.ModTime().Format(time.RFC3339), tm.UTC().Format(time.RFC3339))
+
+	fi, err = os.Stat(filepath.Join(destDir, "bar"))
+	require.NoError(t, err)
+	require.Equal(t, fi.ModTime().Format(time.RFC3339), tm.UTC().Format(time.RFC3339))
 
 	checkAllReleasable(t, c, sb, true)
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -176,6 +176,9 @@ func TestIntegration(t *testing.T) {
 		testExportAnnotationsMediaTypes,
 		testExportAttestations,
 		testAttestationDefaultSubject,
+		testSourceDateEpochLayerTimestamps,
+		testSourceDateEpochClamp,
+		testSourceDateEpochReset,
 	)
 	tests = append(tests, diffOpTestCases()...)
 	integration.Run(t, tests, mirrors)
@@ -2280,6 +2283,234 @@ func testOCIExporter(t *testing.T, sb integration.Sandbox) {
 			require.True(t, ok)
 		}
 	}
+
+	checkAllReleasable(t, c, sb, true)
+}
+
+func testSourceDateEpochLayerTimestamps(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerd(t, sb, "oci exporter")
+	requiresLinux(t)
+	c, err := New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	busybox := llb.Image("busybox:latest")
+	st := llb.Scratch()
+
+	run := func(cmd string) {
+		st = busybox.Run(llb.Shlex(cmd), llb.Dir("/wd")).AddMount("/wd", st)
+	}
+
+	run(`sh -c "echo -n first > foo"`)
+	run(`sh -c "echo -n second > bar"`)
+
+	def, err := st.Marshal(sb.Context())
+	require.NoError(t, err)
+
+	destDir, err := os.MkdirTemp("", "buildkit")
+	require.NoError(t, err)
+	defer os.RemoveAll(destDir)
+
+	out := filepath.Join(destDir, "out.tar")
+	outW, err := os.Create(out)
+	require.NoError(t, err)
+
+	tm := time.Date(2015, time.October, 21, 7, 28, 0, 0, time.UTC)
+
+	_, err = c.Solve(sb.Context(), def, SolveOpt{
+		FrontendAttrs: map[string]string{
+			"build-arg:SOURCE_DATE_EPOCH": fmt.Sprintf("%d", tm.Unix()),
+		},
+		Exports: []ExportEntry{
+			{
+				Type:   ExporterOCI,
+				Output: fixedWriteCloser(outW),
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	dt, err := os.ReadFile(out)
+	require.NoError(t, err)
+
+	tms, err := readImageTimestamps(dt)
+	require.NoError(t, err)
+
+	require.Equal(t, len(tms), 3)
+
+	expected := tm.UTC().Format(time.RFC3339Nano)
+	require.Equal(t, expected, tms[0])
+	require.Equal(t, expected, tms[1])
+	require.Equal(t, expected, tms[2])
+
+	checkAllReleasable(t, c, sb, true)
+}
+
+func testSourceDateEpochClamp(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerd(t, sb, "oci exporter")
+	requiresLinux(t)
+	c, err := New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	var bboxConfig []byte
+	_, err = c.Build(sb.Context(), SolveOpt{}, "", func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
+		_, bboxConfig, err = c.ResolveImageConfig(ctx, "docker.io/library/busybox:latest", llb.ResolveImageConfigOpt{})
+		if err != nil {
+			return nil, err
+		}
+		return nil, nil
+	}, nil)
+	require.NoError(t, err)
+
+	m := map[string]json.RawMessage{}
+	require.NoError(t, json.Unmarshal(bboxConfig, &m))
+	delete(m, "created")
+	bboxConfig, err = json.Marshal(m)
+	require.NoError(t, err)
+
+	busybox, err := llb.Image("busybox:latest").WithImageConfig(bboxConfig)
+	require.NoError(t, err)
+
+	def, err := busybox.Marshal(sb.Context())
+	require.NoError(t, err)
+
+	destDir, err := os.MkdirTemp("", "buildkit")
+	require.NoError(t, err)
+	defer os.RemoveAll(destDir)
+
+	out := filepath.Join(destDir, "out.tar")
+	outW, err := os.Create(out)
+	require.NoError(t, err)
+
+	_, err = c.Solve(sb.Context(), def, SolveOpt{
+		Exports: []ExportEntry{
+			{
+				Type: ExporterOCI,
+				Attrs: map[string]string{
+					exptypes.ExporterImageConfigKey: string(bboxConfig),
+				},
+				Output: fixedWriteCloser(outW),
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	dt, err := os.ReadFile(out)
+	require.NoError(t, err)
+
+	busyboxTms, err := readImageTimestamps(dt)
+	require.NoError(t, err)
+
+	require.True(t, len(busyboxTms) > 1)
+	bboxLayerLen := len(busyboxTms) - 1
+
+	tm, err := time.Parse(time.RFC3339Nano, busyboxTms[1])
+	require.NoError(t, err)
+
+	next := tm.Add(time.Hour).Truncate(time.Second)
+
+	st := busybox.Run(llb.Shlex("touch /foo"))
+
+	def, err = st.Marshal(sb.Context())
+	require.NoError(t, err)
+
+	out = filepath.Join(destDir, "out.tar")
+	outW, err = os.Create(out)
+	require.NoError(t, err)
+
+	_, err = c.Solve(sb.Context(), def, SolveOpt{
+		FrontendAttrs: map[string]string{
+			"build-arg:SOURCE_DATE_EPOCH": fmt.Sprintf("%d", next.Unix()),
+		},
+		Exports: []ExportEntry{
+			{
+				Type: ExporterOCI,
+				Attrs: map[string]string{
+					exptypes.ExporterImageConfigKey: string(bboxConfig),
+				},
+				Output: fixedWriteCloser(outW),
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	dt, err = os.ReadFile(out)
+	require.NoError(t, err)
+
+	tms, err := readImageTimestamps(dt)
+	require.NoError(t, err)
+
+	require.Equal(t, len(tms), bboxLayerLen+2)
+
+	expected := next.UTC().Format(time.RFC3339Nano)
+	require.Equal(t, expected, tms[0])
+	require.Equal(t, busyboxTms[1], tms[1])
+	require.Equal(t, expected, tms[bboxLayerLen+1])
+
+	checkAllReleasable(t, c, sb, true)
+}
+
+// testSourceDateEpochReset tests that the SOURCE_DATE_EPOCH is reset if exporter option is set
+func testSourceDateEpochReset(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerd(t, sb, "oci exporter")
+	requiresLinux(t)
+	c, err := New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	busybox := llb.Image("busybox:latest")
+	st := llb.Scratch()
+
+	run := func(cmd string) {
+		st = busybox.Run(llb.Shlex(cmd), llb.Dir("/wd")).AddMount("/wd", st)
+	}
+
+	run(`sh -c "echo -n first > foo"`)
+	run(`sh -c "echo -n second > bar"`)
+
+	def, err := st.Marshal(sb.Context())
+	require.NoError(t, err)
+
+	destDir, err := os.MkdirTemp("", "buildkit")
+	require.NoError(t, err)
+	defer os.RemoveAll(destDir)
+
+	out := filepath.Join(destDir, "out.tar")
+	outW, err := os.Create(out)
+	require.NoError(t, err)
+
+	tm := time.Date(2015, time.October, 21, 7, 28, 0, 0, time.UTC)
+
+	_, err = c.Solve(sb.Context(), def, SolveOpt{
+		FrontendAttrs: map[string]string{
+			"build-arg:SOURCE_DATE_EPOCH": fmt.Sprintf("%d", tm.Unix()),
+		},
+		Exports: []ExportEntry{
+			{
+				Type:   ExporterOCI,
+				Attrs:  map[string]string{"source-date-epoch": ""},
+				Output: fixedWriteCloser(outW),
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	dt, err := os.ReadFile(out)
+	require.NoError(t, err)
+
+	tms, err := readImageTimestamps(dt)
+	require.NoError(t, err)
+
+	require.Equal(t, len(tms), 3)
+
+	expected := tm.UTC().Format(time.RFC3339Nano)
+	require.NotEqual(t, expected, tms[0])
+	require.NotEqual(t, expected, tms[1])
+	require.NotEqual(t, expected, tms[2])
+
+	require.Equal(t, tms[0], tms[2])
+	require.NotEqual(t, tms[2], tms[1])
 
 	checkAllReleasable(t, c, sb, true)
 }
@@ -6795,6 +7026,51 @@ func makeSSHAgentSock(t *testing.T, agent agent.Agent) (p string, err error) {
 	go s.run(agent)
 
 	return sockPath, nil
+}
+
+func readImageTimestamps(dt []byte) ([]string, error) {
+	m, err := testutil.ReadTarToMap(dt, false)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, ok := m["oci-layout"]; !ok {
+		return nil, errors.Errorf("no oci-layout")
+	}
+
+	var index ocispecs.Index
+	if err := json.Unmarshal(m["index.json"].Data, &index); err != nil {
+		return nil, err
+	}
+	if len(index.Manifests) != 1 {
+		return nil, errors.Errorf("invalid manifest count %d", len(index.Manifests))
+	}
+
+	var mfst ocispecs.Manifest
+	if err := json.Unmarshal(m["blobs/sha256/"+index.Manifests[0].Digest.Hex()].Data, &mfst); err != nil {
+		return nil, err
+	}
+	// don't unmarshal to image type so we get the original string value
+	type history struct {
+		Created string `json:"created"`
+	}
+
+	img := struct {
+		History []history `json:"history"`
+		Created string    `json:"created"`
+	}{}
+
+	if err := json.Unmarshal(m["blobs/sha256/"+mfst.Config.Digest.Hex()].Data, &img); err != nil {
+		return nil, err
+	}
+
+	out := []string{
+		img.Created,
+	}
+	for _, h := range img.History {
+		out = append(out, h.Created)
+	}
+	return out, nil
 }
 
 type server struct {

--- a/control/control.go
+++ b/control/control.go
@@ -267,6 +267,17 @@ func (c *Controller) Solve(ctx context.Context, req *controlapi.SolveRequest) (*
 	if err != nil {
 		return nil, err
 	}
+
+	// if SOURCE_DATE_EPOCH is set, enable it for the exporter
+	if epoch, ok := req.FrontendAttrs["build-arg:SOURCE_DATE_EPOCH"]; ok {
+		if _, ok := req.ExporterAttrs["source-date-epoch"]; !ok {
+			if req.ExporterAttrs == nil {
+				req.ExporterAttrs = make(map[string]string)
+			}
+			req.ExporterAttrs["source-date-epoch"] = epoch
+		}
+	}
+
 	if req.Exporter != "" {
 		exp, err := w.Exporter(req.Exporter, c.opt.SessionManager)
 		if err != nil {

--- a/control/control.go
+++ b/control/control.go
@@ -12,6 +12,7 @@ import (
 	"github.com/moby/buildkit/client"
 	controlgateway "github.com/moby/buildkit/control/gateway"
 	"github.com/moby/buildkit/exporter"
+	"github.com/moby/buildkit/exporter/util/epoch"
 	"github.com/moby/buildkit/frontend"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/grpchijack"
@@ -269,12 +270,12 @@ func (c *Controller) Solve(ctx context.Context, req *controlapi.SolveRequest) (*
 	}
 
 	// if SOURCE_DATE_EPOCH is set, enable it for the exporter
-	if epoch, ok := req.FrontendAttrs["build-arg:SOURCE_DATE_EPOCH"]; ok {
-		if _, ok := req.ExporterAttrs["source-date-epoch"]; !ok {
+	if epochVal, ok := req.FrontendAttrs["build-arg:SOURCE_DATE_EPOCH"]; ok {
+		if _, ok := req.ExporterAttrs[epoch.KeySourceDateEpoch]; !ok {
 			if req.ExporterAttrs == nil {
 				req.ExporterAttrs = make(map[string]string)
 			}
-			req.ExporterAttrs["source-date-epoch"] = epoch
+			req.ExporterAttrs[epoch.KeySourceDateEpoch] = epochVal
 		}
 	}
 

--- a/exporter/containerimage/exptypes/types.go
+++ b/exporter/containerimage/exptypes/types.go
@@ -13,6 +13,7 @@ const (
 	ExporterInlineCache          = "containerimage.inlinecache"
 	ExporterBuildInfo            = "containerimage.buildinfo"
 	ExporterPlatformsKey         = "refs.platforms"
+	ExporterEpochKey             = "source.date.epoch"
 )
 
 type Platforms struct {

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -19,6 +19,7 @@ import (
 	cacheconfig "github.com/moby/buildkit/cache/config"
 	"github.com/moby/buildkit/exporter"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
+	"github.com/moby/buildkit/exporter/util/epoch"
 	gatewaypb "github.com/moby/buildkit/frontend/gateway/pb"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/snapshot"
@@ -72,12 +73,10 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 	}
 
 	if opts.Epoch == nil {
-		if v, ok := inp.Metadata[exptypes.ExporterEpochKey]; ok {
-			epoch, err := parseTime("", string(v))
-			if err != nil {
-				return nil, errors.Wrapf(err, "invalid SOURCE_DATE_EPOCH from frontend: %q", v)
-			}
-			opts.Epoch = epoch
+		if tm, ok, err := epoch.ParseSource(inp); err != nil {
+			return nil, err
+		} else if ok {
+			opts.Epoch = tm
 		}
 	}
 

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -71,6 +71,16 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 		}
 	}
 
+	if opts.Epoch == nil {
+		if v, ok := inp.Metadata[exptypes.ExporterEpochKey]; ok {
+			epoch, err := parseTime("", string(v))
+			if err != nil {
+				return nil, errors.Wrapf(err, "invalid SOURCE_DATE_EPOCH from frontend: %q", v)
+			}
+			opts.Epoch = epoch
+		}
+	}
+
 	if len(inp.Refs) == 0 {
 		remotes, err := ic.exportLayers(ctx, opts.RefCfg, session.NewGroup(sessionID), inp.Ref)
 		if err != nil {
@@ -86,7 +96,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 			}
 		}
 
-		mfstDesc, configDesc, err := ic.commitDistributionManifest(ctx, opts, inp.Ref, inp.Metadata[exptypes.ExporterImageConfigKey], &remotes[0], opts.Annotations.Platform(nil), inp.Metadata[exptypes.ExporterInlineCache], dtbi)
+		mfstDesc, configDesc, err := ic.commitDistributionManifest(ctx, opts, inp.Ref, inp.Metadata[exptypes.ExporterImageConfigKey], &remotes[0], opts.Annotations.Platform(nil), inp.Metadata[exptypes.ExporterInlineCache], dtbi, opts.Epoch)
 		if err != nil {
 			return nil, err
 		}
@@ -166,7 +176,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 			}
 		}
 
-		desc, _, err := ic.commitDistributionManifest(ctx, opts, r, config, &remotes[remotesMap[p.ID]], opts.Annotations.Platform(&p.Platform), inlineCache, dtbi)
+		desc, _, err := ic.commitDistributionManifest(ctx, opts, r, config, &remotes[remotesMap[p.ID]], opts.Annotations.Platform(&p.Platform), inlineCache, dtbi, opts.Epoch)
 		if err != nil {
 			return nil, err
 		}
@@ -353,7 +363,7 @@ func (ic *ImageWriter) extractAttestations(ctx context.Context, opts *ImageCommi
 	return statements, nil
 }
 
-func (ic *ImageWriter) commitDistributionManifest(ctx context.Context, opts *ImageCommitOpts, ref cache.ImmutableRef, config []byte, remote *solver.Remote, annotations *Annotations, inlineCache []byte, buildInfo []byte) (*ocispecs.Descriptor, *ocispecs.Descriptor, error) {
+func (ic *ImageWriter) commitDistributionManifest(ctx context.Context, opts *ImageCommitOpts, ref cache.ImmutableRef, config []byte, remote *solver.Remote, annotations *Annotations, inlineCache []byte, buildInfo []byte, epoch *time.Time) (*ocispecs.Descriptor, *ocispecs.Descriptor, error) {
 	if len(config) == 0 {
 		var err error
 		config, err = defaultImageConfig()
@@ -375,7 +385,7 @@ func (ic *ImageWriter) commitDistributionManifest(ctx context.Context, opts *Ima
 
 	remote, history = normalizeLayersAndHistory(ctx, remote, history, ref, opts.OCITypes)
 
-	config, err = patchImageConfig(config, remote.Descriptors, history, inlineCache, buildInfo)
+	config, err = patchImageConfig(config, remote.Descriptors, history, inlineCache, buildInfo, epoch)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -619,7 +629,7 @@ func parseHistoryFromConfig(dt []byte) ([]ocispecs.History, error) {
 	return config.History, nil
 }
 
-func patchImageConfig(dt []byte, descs []ocispecs.Descriptor, history []ocispecs.History, cache []byte, buildInfo []byte) ([]byte, error) {
+func patchImageConfig(dt []byte, descs []ocispecs.Descriptor, history []ocispecs.History, cache []byte, buildInfo []byte, epoch *time.Time) ([]byte, error) {
 	m := map[string]json.RawMessage{}
 	if err := json.Unmarshal(dt, &m); err != nil {
 		return nil, errors.Wrap(err, "failed to parse image config for patch")
@@ -636,11 +646,34 @@ func patchImageConfig(dt []byte, descs []ocispecs.Descriptor, history []ocispecs
 	}
 	m["rootfs"] = dt
 
+	if epoch != nil {
+		for i, h := range history {
+			if h.Created == nil || h.Created.After(*epoch) {
+				history[i].Created = epoch
+			}
+		}
+	}
+
 	dt, err = json.Marshal(history)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to marshal history")
 	}
 	m["history"] = dt
+
+	// if epoch is set then clamp creation time
+	if v, ok := m["created"]; ok && epoch != nil {
+		var tm time.Time
+		if err := json.Unmarshal(v, &tm); err != nil {
+			return nil, errors.Wrapf(err, "failed to unmarshal creation time %q", m["created"])
+		}
+		if tm.After(*epoch) {
+			dt, err = json.Marshal(&epoch)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to marshal creation time")
+			}
+			m["created"] = dt
+		}
+	}
 
 	if _, ok := m["created"]; !ok {
 		var tm *time.Time

--- a/exporter/util/epoch/parse.go
+++ b/exporter/util/epoch/parse.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	keySourceDateEpoch = "source-date-epoch"
+	KeySourceDateEpoch = "source-date-epoch"
 )
 
 func ParseAttr(opt map[string]string) (*time.Time, map[string]string, error) {
@@ -20,7 +20,7 @@ func ParseAttr(opt map[string]string) (*time.Time, map[string]string, error) {
 
 	for k, v := range opt {
 		switch k {
-		case keySourceDateEpoch:
+		case KeySourceDateEpoch:
 			var err error
 			tm, err = parseTime(k, v)
 			if err != nil {

--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -2416,6 +2416,7 @@ RUN echo "I'm building for $TARGETPLATFORM"
 | `BUILDKIT_MULTI_PLATFORM`             | Bool    | Opt into determnistic output regardless of multi-platform output or not. |
 | `BUILDKIT_SANDBOX_HOSTNAME`           | String  | Set the hostname (default `buildkitsandbox`)                             |
 | `BUILDKIT_SYNTAX`                     | String  | Set frontend image                                                       |
+| `SOURCE_DATE_EPOCH`                   | Int     | Set the UNIX timestamp for created image and layers. More info from [reproducible builds](https://reproducible-builds.org/docs/source-date-epoch/). Supported since Dockerfile 1.5, BuildKit 0.11 (unreleased) |
 
 #### Example: keep `.git` dir
 

--- a/solver/pb/caps.go
+++ b/solver/pb/caps.go
@@ -82,6 +82,9 @@ const (
 
 	CapAnnotations  apicaps.CapID = "exporter.image.annotations"
 	CapAttestations apicaps.CapID = "exporter.image.attestations"
+
+	// CapSourceDateEpoch is the capability to automatically handle the date epoch
+	CapSourceDateEpoch apicaps.CapID = "exporter.sourcedateepoch"
 )
 
 func init() {
@@ -451,6 +454,13 @@ func init() {
 
 	Caps.Init(apicaps.Cap{
 		ID:      CapAttestations,
+		Enabled: true,
+		Status:  apicaps.CapStatusExperimental,
+	})
+
+	Caps.Init(apicaps.Cap{
+		ID:      CapSourceDateEpoch,
+		Name:    "source date epoch",
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})


### PR DESCRIPTION
addresses #1058

Allows reproducible timestamps for layer and image timestamps.

Implemented as a frontend-opt because in the future, the same option could be detected by frontend for custom behavior
and the same value should also apply timestamps for FileOps. Definition for `SOURCE_DATE_EPOCH` can be found in https://reproducible-builds.org/docs/source-date-epoch/

In local and tar exporter, setting the build-arg sets overwrites the timestamp for the output files.

There is also a secondary implementation inside the Dockerfile frontend. This allows getting reproducible image manifests even on old buildkit, by just defining `#syntax` to point to new Dockerfile image.

In Dockerfiles the build-arg can also be exposed to inner processes by defining `ARG SOURCE_DATE_EPOCH` inside the stage.

This is the first stop toward better reproducible builds support that can be followed up with:
- Overwrite timestamp for files created with  FileOp, eg. `COPY/ADD` in Dockerfiles #2911 @AkihiroSuda 
- Possibly allow setting timestamp from Dockerfile, eg. `#epoch=` . Frontend side of this is already implemented and the frontend can pass the epoch value to the exporter(it can not overwrite the value if it has already been set by the user).
- Add some special case that allows using setting epoch to git commit timestamp when building from git. Currently need to do `--build-arg SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)`
- Maybe allow configuring differ or overwriting files created by ExecOp
