### PR TITLE
dockerfile: fix created timestamp

### DIFF
--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -861,6 +861,7 @@ func contextByName(ctx context.Context, c client.Client, sessionID, name string,
 		if err := json.Unmarshal(data, &img); err != nil {
 			return nil, nil, nil, err
 		}
+		img.Created = nil
 
 		st := llb.Image(ref, imgOpt...)
 		st, err = st.WithImageConfig(data)


### PR DESCRIPTION
Thanks to @ciaranmcnulty for raising this on the docker community slack [here](https://dockercommunity.slack.com/archives/C7S7A40MP/p1655805439087709).

Images built using docker-image:// passed through buildkit named contexts had the wrong Image.Created timestamp, using the timestamp from the used image, instead of the current datetime.

To fix, we perform the same input cleanup as in Dockerfile2LLB, and explicitly set the timestamp to nil.