### PR TITLE
fix cancellation error not being detected and erroneously cached

### DIFF
--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -278,7 +278,7 @@ func (gf *gatewayFrontend) Solve(ctx context.Context, llbBridge frontend.Fronten
 	err = w.Executor().Run(ctx, "", mountWithSession(rootFS, session.NewGroup(sid)), mnts, executor.ProcessInfo{Meta: meta, Stdin: lbf.Stdin, Stdout: lbf.Stdout, Stderr: os.Stderr}, nil)
 
 	if err != nil {
-		if errdefs.IsCanceled(err) && lbf.isErrServerClosed {
+		if errdefs.IsCanceled(ctx, err) && lbf.isErrServerClosed {
 			err = errors.Errorf("frontend grpc server closed unexpectedly")
 		}
 		// An existing error (set via Return rpc) takes

--- a/solver/errdefs/context.go
+++ b/solver/errdefs/context.go
@@ -3,11 +3,25 @@ package errdefs
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/moby/buildkit/util/grpcerrors"
 	"google.golang.org/grpc/codes"
 )
 
-func IsCanceled(err error) bool {
-	return errors.Is(err, context.Canceled) || grpcerrors.Code(err) == codes.Canceled
+func IsCanceled(ctx context.Context, err error) bool {
+	if errors.Is(err, context.Canceled) || grpcerrors.Code(err) == codes.Canceled {
+		return true
+	}
+	// grpc does not set cancel correctly when stream gets cancelled and then Recv is called
+	if err != nil && ctx.Err() == context.Canceled {
+		// when this error comes from containerd it is not typed at all, just concatenated string
+		if strings.Contains(err.Error(), "EOF") {
+			return true
+		}
+		if strings.Contains(err.Error(), context.Canceled.Error()) {
+			return true
+		}
+	}
+	return false
 }

--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -3,7 +3,6 @@ package solver
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -704,7 +703,7 @@ func (s *sharedOp) CalcSlowCache(ctx context.Context, index Index, p PreprocessF
 		if err != nil {
 			select {
 			case <-ctx.Done():
-				if strings.Contains(err.Error(), context.Canceled.Error()) {
+				if errdefs.IsCanceled(ctx, err) {
 					complete = false
 					releaseError(err)
 					err = errors.Wrap(ctx.Err(), err.Error())
@@ -770,7 +769,7 @@ func (s *sharedOp) CacheMap(ctx context.Context, index int) (resp *cacheMapResp,
 		if err != nil {
 			select {
 			case <-ctx.Done():
-				if strings.Contains(err.Error(), context.Canceled.Error()) {
+				if errdefs.IsCanceled(ctx, err) {
 					complete = false
 					releaseError(err)
 					err = errors.Wrap(ctx.Err(), err.Error())
@@ -846,7 +845,7 @@ func (s *sharedOp) Exec(ctx context.Context, inputs []Result) (outputs []Result,
 		if err != nil {
 			select {
 			case <-ctx.Done():
-				if strings.Contains(err.Error(), context.Canceled.Error()) {
+				if errdefs.IsCanceled(ctx, err) {
 					complete = false
 					releaseError(err)
 					err = errors.Wrap(ctx.Err(), err.Error())

--- a/solver/llbsolver/bridge.go
+++ b/solver/llbsolver/bridge.go
@@ -3,7 +3,6 @@ package llbsolver
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -290,7 +289,7 @@ func (rp *resultProxy) Result(ctx context.Context) (res solver.CachedResult, err
 		if err != nil {
 			select {
 			case <-ctx.Done():
-				if strings.Contains(err.Error(), context.Canceled.Error()) {
+				if errdefs.IsCanceled(ctx, err) {
 					return v, err
 				}
 			default:

--- a/source/containerimage/pull.go
+++ b/source/containerimage/pull.go
@@ -272,7 +272,7 @@ func (p *puller) CacheKey(ctx context.Context, g session.Group, index int) (cach
 			return nil, p.cacheKeyErr
 		}
 		defer func() {
-			if !errdefs.IsCanceled(err) {
+			if !errdefs.IsCanceled(ctx, err) {
 				p.cacheKeyErr = err
 			}
 		}()


### PR DESCRIPTION
This should fix the `EOF` errors happening more frequently in the CI.

The problem is that when context is canceled in the middle of a fetch stream(grpc stream pushing to containerd), in certain conditions it ends with `EOF` errors instead of cancel error what actually triggered the case. This is deep in containerd libraries so can't be fixed here so instead we need to have more exception cases on checking the errors.

The errors are cached both in solver and in the image resolver so I combined them both to use same helper function.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>