### PR TITLE
Clone ResultProxy at gateway boundaries

### DIFF
--- a/solver/llbsolver/bridge.go
+++ b/solver/llbsolver/bridge.go
@@ -188,8 +188,8 @@ func (b *llbBridge) Solve(ctx context.Context, req frontend.SolveRequest, sid st
 }
 
 type resultProxy struct {
-	cb         func(context.Context) (solver.CachedResult, solver.BuildSources, error)
-	def        *pb.Definition
+	b          *llbBridge
+	req        frontend.SolveRequest
 	g          flightcontrol.Group
 	mu         sync.Mutex
 	released   bool
@@ -200,27 +200,11 @@ type resultProxy struct {
 }
 
 func newResultProxy(b *llbBridge, req frontend.SolveRequest) *resultProxy {
-	rp := &resultProxy{
-		def: req.Definition,
-	}
-	rp.cb = func(ctx context.Context) (solver.CachedResult, solver.BuildSources, error) {
-		res, bsrc, err := b.loadResult(ctx, req.Definition, req.CacheImports)
-		var ee *llberrdefs.ExecError
-		if errors.As(err, &ee) {
-			ee.EachRef(func(res solver.Result) error {
-				rp.errResults = append(rp.errResults, res)
-				return nil
-			})
-			// acquire ownership so ExecError finalizer doesn't attempt to release as well
-			ee.OwnerBorrowed = true
-		}
-		return res, bsrc, err
-	}
-	return rp
+	return &resultProxy{req: req, b: b}
 }
 
 func (rp *resultProxy) Definition() *pb.Definition {
-	return rp.def
+	return rp.req.Definition
 }
 
 func (rp *resultProxy) BuildSources() solver.BuildSources {
@@ -255,12 +239,12 @@ func (rp *resultProxy) wrapError(err error) error {
 	}
 	var ve *errdefs.VertexError
 	if errors.As(err, &ve) {
-		if rp.def.Source != nil {
-			locs, ok := rp.def.Source.Locations[string(ve.Digest)]
+		if rp.req.Definition.Source != nil {
+			locs, ok := rp.req.Definition.Source.Locations[string(ve.Digest)]
 			if ok {
 				for _, loc := range locs.Locations {
 					err = errdefs.WithSource(err, errdefs.Source{
-						Info:   rp.def.Source.Infos[loc.SourceIndex],
+						Info:   rp.req.Definition.Source.Infos[loc.SourceIndex],
 						Ranges: loc.Ranges,
 					})
 				}
@@ -268,6 +252,20 @@ func (rp *resultProxy) wrapError(err error) error {
 		}
 	}
 	return err
+}
+
+func (rp *resultProxy) loadResult(ctx context.Context) (solver.CachedResult, solver.BuildSources, error) {
+	res, bsrc, err := rp.b.loadResult(ctx, rp.req.Definition, rp.req.CacheImports)
+	var ee *llberrdefs.ExecError
+	if errors.As(err, &ee) {
+		ee.EachRef(func(res solver.Result) error {
+			rp.errResults = append(rp.errResults, res)
+			return nil
+		})
+		// acquire ownership so ExecError finalizer doesn't attempt to release as well
+		ee.OwnerBorrowed = true
+	}
+	return res, bsrc, err
 }
 
 func (rp *resultProxy) Result(ctx context.Context) (res solver.CachedResult, err error) {
@@ -285,7 +283,7 @@ func (rp *resultProxy) Result(ctx context.Context) (res solver.CachedResult, err
 			return rp.v, rp.err
 		}
 		rp.mu.Unlock()
-		v, bsrc, err := rp.cb(ctx)
+		v, bsrc, err := rp.loadResult(ctx)
 		if err != nil {
 			select {
 			case <-ctx.Done():


### PR DESCRIPTION
Previously, a frontend returning two identical references caused a
double-release error, as the gateway expects each ref to be unique.
However, there are scenarios where a frontend might reasonably be
expected to provide identical refs, e.g. for 2 platforms that have
binary compatibility, or for the upcoming attestations use-case.

To solve this issue, we refactor the ResultProxy implementation to
support cloning. Since the underlying Result supports reference
counting, we can avoid needing to add another layer of refcounts, and
simply clone the underlying refs.

Additionally, we then use the new Cloning functionality in the gateway
and forwarder (e.g. dockerfile) frontends, and ensure that the same
ResultProxy is never returned twice in a result. This means that
identical refs over the wire are translated into the correct
shared-memory structures.