### PR TITLE
Update reference.md

### DIFF
--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -1053,11 +1053,11 @@ image, consider setting a value for a single command instead:
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y ...
 ```
  
-Or using [`ARG`](#arg), which is not persisted in the final image:
+Or parametrized using [`ARG`](#arg), which is not persisted in the final image:
 
 ```dockerfile
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y ...
+RUN DEBIAN_FRONTEND=$DEBIAN_FRONTEND apt-get update && apt-get install -y ...
 ```
 
 > **Alternative syntax**


### PR DESCRIPTION
Fixed typo, added intent, to why ARG should be used in conjunction with RUN statement local environment variables

Signed-off-by: Henrik Holst <6200749+hholst80@users.noreply.github.com>