### PR TITLE
Always respect value of evaluate field in the gateway api

### DIFF
--- a/solver/llbsolver/bridge.go
+++ b/solver/llbsolver/bridge.go
@@ -143,9 +143,6 @@ func (b *llbBridge) Solve(ctx context.Context, req frontend.SolveRequest, sid st
 
 	if req.Definition != nil && req.Definition.Def != nil {
 		res = &frontend.Result{Ref: newResultProxy(b, req)}
-		if req.Evaluate {
-			_, err = res.Ref.Result(ctx)
-		}
 	} else if req.Frontend != "" {
 		f, ok := b.frontends[req.Frontend]
 		if !ok {
@@ -157,6 +154,9 @@ func (b *llbBridge) Solve(ctx context.Context, req frontend.SolveRequest, sid st
 		}
 	} else {
 		return &frontend.Result{}, nil
+	}
+	if req.Evaluate {
+		_, err = res.Ref.Result(ctx)
 	}
 
 	if len(res.Refs) > 0 {


### PR DESCRIPTION
Always use the value of the evaluate field to force result generation, which previously was not performed for frontends. This improves API consistency, and ensures the value is used regardless of whether the solver uses a frontend, or a raw definition.