### PR TITLE
Ensure exporter progress logs are properly keyed

### DIFF
--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -242,7 +242,7 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 			inp.Refs = m
 		}
 		if _, ok := asInlineCache(exp.CacheExporter); ok {
-			if err := inBuilderContext(ctx, j, "preparing layers for inline cache", "", func(ctx context.Context, _ session.Group) error {
+			if err := inBuilderContext(ctx, j, "preparing layers for inline cache", j.SessionID+"-cache-inline", func(ctx context.Context, _ session.Group) error {
 				if cr != nil {
 					dtic, err := inlineCache(ctx, exp.CacheExporter, cr, e.Config().Compression, session.NewGroup(sessionID))
 					if err != nil {
@@ -267,7 +267,7 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 				return nil, err
 			}
 		}
-		if err := inBuilderContext(ctx, j, e.Name(), "", func(ctx context.Context, _ session.Group) error {
+		if err := inBuilderContext(ctx, j, e.Name(), j.SessionID+"-export", func(ctx context.Context, _ session.Group) error {
 			exporterResponse, err = e.Export(ctx, inp, j.SessionID)
 			return err
 		}); err != nil {
@@ -278,7 +278,7 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 	g := session.NewGroup(j.SessionID)
 	var cacheExporterResponse map[string]string
 	if e := exp.CacheExporter; e != nil {
-		if err := inBuilderContext(ctx, j, "exporting cache", "", func(ctx context.Context, _ session.Group) error {
+		if err := inBuilderContext(ctx, j, "exporting cache", j.SessionID+"-cache", func(ctx context.Context, _ session.Group) error {
 			prepareDone := oneOffProgress(ctx, "preparing build cache for export")
 			if err := res.EachRef(func(res solver.ResultProxy) error {
 				r, err := res.Result(ctx)


### PR DESCRIPTION
Fixes an issue with bake's progress output, where multiple exporters of the same type might be invoked, resulting in the logs writing over each other within the same section. Additionally, this will be important in the context of #2760, where the progress logs per output need to be appropriately separated.

Sample bake file:

```hcl
group "default" {
  targets = ["foo", "bar", "baz"]
}

target "foo" {
  target = "foo"
  tags = [
    "docker.io/x/y:foo"
  ]
  output = ["type=image,push=true,registry.insecure=true"]
}

target "bar" {
  target = "bar"
  tags = [
    "docker.io/x/y:bar"
  ]
  output = ["type=image,push=true,registry.insecure=true"]
}

target "baz" {
  target = "baz"
  tags = [
    "docker.io/x/y:baz"
  ]
  output = ["type=image,push=true,registry.insecure=true"]
}
```

Before:

```
...
 => [bar] exporting to image                                                                                                0.2s
 => => exporting layers                                                                                                     0.1s
 => => exporting manifest sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa                           0.0s
 => => exporting manifest sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa                           0.0s
 => => exporting config sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb                             0.0s
 => => exporting config sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb                             0.0s
 => => exporting manifest sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa                           0.0s
 => => pushing layers                                                                                                       0.0s
 => => exporting config sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb                             0.0s
 => => pushing manifest for docker.io/x/y:baz@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa       0.0s
 => => pushing manifest for docker.io/x/y:foo@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa       0.0s
 => => pushing manifest for docker.io/x/y:bar@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa       0.0s
```

After:
```
...
 => [bar] exporting to image                                                                                                0.1s
 => => exporting layers                                                                                                     0.0s
 => => exporting manifest sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa                           0.0s
 => => exporting config sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb                             0.0s
 => => pushing layers                                                                                                       0.0s
 => => pushing manifest for docker.io/x/y:bar@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa       0.0s
 => [foo] exporting to image                                                                                                0.1s
 => => exporting layers                                                                                                     0.0s
 => => exporting manifest sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa                           0.0s
 => => exporting config sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb                             0.0s
 => => pushing layers                                                                                                       0.0s
 => => pushing manifest for docker.io/x/y:foo@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa       0.0s
 => [baz] exporting to image                                                                                                0.1s
 => => exporting layers                                                                                                     0.0s
 => => exporting manifest sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa                           0.0s
 => => exporting config sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb                             0.0s
 => => pushing layers                                                                                                       0.0s
 => => pushing manifest for docker.io/x/y:baz@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa       0.0s
```
