### PR TITLE
docs: clarify USER command explanation

### DIFF
--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -1757,8 +1757,9 @@ USER <UID>[:<GID>]
 ```
 
 The `USER` instruction sets the user name (or UID) and optionally the user
-group (or GID) to use when running the image and for any `RUN`, `CMD` and
-`ENTRYPOINT` instructions that follow it in the `Dockerfile`.
+group (or GID) to use as the default user and group for the remainder of the
+current stage. The specified user is used for `RUN` instructions and at
+runtime, runs the relevant `ENTRYPOINT` and `CMD` commands.
 
 > Note that when specifying a group for the user, the user will have _only_ the
 > specified group membership. Any other configured group memberships will be ignored.
@@ -1778,7 +1779,6 @@ RUN net user /add patrick
 # Set it for subsequent commands
 USER patrick
 ```
-
 
 ## WORKDIR
 


### PR DESCRIPTION
Clarify the USER command to remove phrasing that suggests the ENTRYPOINT and CMD commands must follow the USER (the order doesn't actually matter).

Fixes #2955.