### PR TITLE
rootless: containerd worker: Add fallback when buildkitd cannot access to conainerd

### DIFF
--- a/cmd/buildkitd/main_containerd_worker.go
+++ b/cmd/buildkitd/main_containerd_worker.go
@@ -228,7 +228,7 @@ func containerdWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([
 
 	cfg := common.config.Workers.Containerd
 
-	if (cfg.Enabled == nil && !validContainerdSocket(cfg.Address)) || (cfg.Enabled != nil && !*cfg.Enabled) {
+	if (cfg.Enabled == nil && !validContainerdSocket(cfg)) || (cfg.Enabled != nil && !*cfg.Enabled) {
 		return nil, nil
 	}
 
@@ -281,7 +281,8 @@ func containerdWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([
 	return []worker.Worker{w}, nil
 }
 
-func validContainerdSocket(socket string) bool {
+func validContainerdSocket(cfg config.ContainerdConfig) bool {
+	socket := cfg.Address
 	if strings.HasPrefix(socket, "tcp://") {
 		// FIXME(AkihiroSuda): prohibit tcp?
 		return true
@@ -292,6 +293,14 @@ func validContainerdSocket(socket string) bool {
 		logrus.Warnf("skipping containerd worker, as %q does not exist", socketPath)
 		return false
 	}
-	// TODO: actually dial and call introspection API
+	c, err := ctd.New(socketPath, ctd.WithDefaultNamespace(cfg.Namespace))
+	if err != nil {
+		logrus.Warnf("skipping containerd worker, as failed to connect client to %q: %v", socketPath, err)
+		return false
+	}
+	if _, err := c.Server(context.Background()); err != nil {
+		logrus.Warnf("skipping containerd worker, as failed to call introspection API on %q: %v", socketPath, err)
+		return false
+	}
 	return true
 }


### PR DESCRIPTION
As discussed in https://github.com/moby/buildkit/issues/2965, the current rootless containerd worker doesn't allow fallbacks when it can't access to the containerd socket (e.g. by permission denied). But we should perform a fallback to keep the backward compatibility with the previous version of buildkitd.

This commit fixes this issue by adding a fallback logic for the case when buildkitd failed to access to the containerd socket.

main

```console
$ rootlesskit buildkitd --addr=unix:///tmp/buildkit/buildkitd.sock
INFO[2022-07-19T01:49:45Z] auto snapshotter: using overlayfs            
INFO[2022-07-19T01:49:45Z] found worker "8envtv9nxu2808m374pct8b4z", labels=map[org.mobyproject.buildkit.worker.executor:oci org.mobyproject.buildkit.worker.hostname:2f891249d0b4 org.mobyproject.buildkit.worker.network:host org.mobyproject.buildkit.worker.oci.process-mode:sandbox org.mobyproject.buildkit.worker.snapshotter:overlayfs], platforms=[linux/amd64 linux/amd64/v2 linux/amd64/v3 linux/386] 
buildkitd: failed to dial "/run/containerd/containerd.sock": connection error: desc = "transport: error while dialing: dial unix /run/containerd/containerd.sock: connect: permission denied"
failed to connect client to "/run/containerd/containerd.sock" . make sure containerd is running
github.com/moby/buildkit/worker/containerd.NewWorkerOpt
	/go/src/github.com/moby/buildkit/worker/containerd/containerd.go:33
main.containerdWorkerInitializer
	/go/src/github.com/moby/buildkit/cmd/buildkitd/main_containerd_worker.go:262
main.newWorkerController
	/go/src/github.com/moby/buildkit/cmd/buildkitd/main.go:690
main.newController
	/go/src/github.com/moby/buildkit/cmd/buildkitd/main.go:633
main.main.func3
	/go/src/github.com/moby/buildkit/cmd/buildkitd/main.go:263
github.com/urfave/cli.HandleAction
	/go/src/github.com/moby/buildkit/vendor/github.com/urfave/cli/app.go:526
github.com/urfave/cli.(*App).Run
	/go/src/github.com/moby/buildkit/vendor/github.com/urfave/cli/app.go:288
main.main
	/go/src/github.com/moby/buildkit/cmd/buildkitd/main.go:313
runtime.main
	/usr/local/go/src/runtime/proc.go:255
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1581
[rootlesskit:child ] error: command [buildkitd --addr=unix:///tmp/buildkit/buildkitd.sock] exited: exit status 1
[rootlesskit:parent] error: child exited: exit status 1
```

PR

```console
$ rootlesskit buildkitd --addr=unix:///tmp/buildkit/buildkitd.sock
INFO[2022-07-19T01:49:15Z] auto snapshotter: using overlayfs            
INFO[2022-07-19T01:49:16Z] found worker "8envtv9nxu2808m374pct8b4z", labels=map[org.mobyproject.buildkit.worker.executor:oci org.mobyproject.buildkit.worker.hostname:2f891249d0b4 org.mobyproject.buildkit.worker.network:host org.mobyproject.buildkit.worker.oci.process-mode:sandbox org.mobyproject.buildkit.worker.snapshotter:overlayfs], platforms=[linux/amd64 linux/amd64/v2 linux/amd64/v3 linux/386] 
WARN[2022-07-19T01:49:16Z] skipping containerd worker, as failed to connect client to "/run/containerd/containerd.sock": failed to dial "/run/containerd/containerd.sock": connection error: desc = "transport: error while dialing: dial unix /run/containerd/containerd.sock: connect: permission denied" 
INFO[2022-07-19T01:49:16Z] found 1 workers, default="8envtv9nxu2808m374pct8b4z" 
WARN[2022-07-19T01:49:16Z] currently, only the default worker can be used. 
INFO[2022-07-19T01:49:16Z] running server on /tmp/buildkit/buildkitd.sock 
```
