### PR TITLE
docs(dockerfile): remove frontmatter section

### DIFF
--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -1,10 +1,4 @@
----
-title: Dockerfile reference
-description: "Dockerfiles use a simple DSL which allows you to automate the steps you would normally manually take to create an image."
-keywords: build, dockerfile, reference
-redirect_from:
-- /reference/builder/
----
+# Dockerfile reference
 
 Docker can build images automatically by reading the instructions from a
 `Dockerfile`. A `Dockerfile` is a text document that contains all the commands a


### PR DESCRIPTION
As discussed with @thaJeztah, it's better to use a stub file and maintain the frontmatter section upstream.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>