### PR TITLE
Add oci-layout to platformSpecificSource

### DIFF
--- a/client/llb/source.go
+++ b/client/llb/source.go
@@ -609,7 +609,7 @@ func Chown(uid, gid int) HTTPOption {
 }
 
 func platformSpecificSource(id string) bool {
-	return strings.HasPrefix(id, "docker-image://")
+	return strings.HasPrefix(id, "docker-image://") || strings.HasPrefix(id, "oci-layout://")
 }
 
 func addCap(c *Constraints, id apicaps.CapID) {


### PR DESCRIPTION
oci-layout source is platform-scpecific, we should use provided
platform to resolve correct image.

Now I can see the problem with building for another arch and seems we reuse image with host arch for build: https://github.com/linuxkit/linuxkit/pull/3797#issuecomment-1189217020