### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/cache/contenthash/checksum_test.go
+++ b/cache/contenthash/checksum_test.go
@@ -42,14 +42,12 @@ const (
 
 func TestChecksumSymlinkNoParentScan(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := os.MkdirTemp("", "buildkit-state")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
-	cm, _ := setupCacheManager(t, tmpdir, "native", snapshotter)
-	defer cm.Close()
+	cm, cleanup := setupCacheManager(t, tmpdir, "native", snapshotter)
+	t.Cleanup(cleanup)
 
 	ch := []string{
 		"ADD aa dir",
@@ -71,14 +69,12 @@ func TestChecksumSymlinkNoParentScan(t *testing.T) {
 
 func TestChecksumHardlinks(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := os.MkdirTemp("", "buildkit-state")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
-	cm, _ := setupCacheManager(t, tmpdir, "native", snapshotter)
-	defer cm.Close()
+	cm, cleanup := setupCacheManager(t, tmpdir, "native", snapshotter)
+	t.Cleanup(cleanup)
 
 	ch := []string{
 		"ADD abc dir",
@@ -154,14 +150,12 @@ func TestChecksumHardlinks(t *testing.T) {
 
 func TestChecksumWildcardOrFilter(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := os.MkdirTemp("", "buildkit-state")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
-	cm, _ := setupCacheManager(t, tmpdir, "native", snapshotter)
-	defer cm.Close()
+	cm, cleanup := setupCacheManager(t, tmpdir, "native", snapshotter)
+	t.Cleanup(cleanup)
 
 	ch := []string{
 		"ADD bar file data1",
@@ -211,14 +205,16 @@ func TestChecksumWildcardOrFilter(t *testing.T) {
 
 func TestChecksumWildcardWithBadMountable(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := os.MkdirTemp("", "buildkit-state")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
-	cm, _ := setupCacheManager(t, tmpdir, "native", snapshotter)
-	defer cm.Close()
+	t.Cleanup(func() {
+		require.NoError(t, snapshotter.Close())
+	})
+
+	cm, cleanup := setupCacheManager(t, tmpdir, "native", snapshotter)
+	t.Cleanup(cleanup)
 
 	ref := createRef(t, cm, nil)
 
@@ -231,14 +227,12 @@ func TestChecksumWildcardWithBadMountable(t *testing.T) {
 
 func TestSymlinksNoFollow(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := os.MkdirTemp("", "buildkit-state")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
-	cm, _ := setupCacheManager(t, tmpdir, "native", snapshotter)
-	defer cm.Close()
+	cm, cleanup := setupCacheManager(t, tmpdir, "native", snapshotter)
+	t.Cleanup(cleanup)
 
 	ch := []string{
 		"ADD target file data0",
@@ -290,14 +284,12 @@ func TestSymlinksNoFollow(t *testing.T) {
 
 func TestChecksumBasicFile(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := os.MkdirTemp("", "buildkit-state")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
-	cm, _ := setupCacheManager(t, tmpdir, "native", snapshotter)
-	defer cm.Close()
+	cm, cleanup := setupCacheManager(t, tmpdir, "native", snapshotter)
+	t.Cleanup(cleanup)
 
 	ch := []string{
 		"ADD foo file data0",
@@ -448,14 +440,12 @@ func TestChecksumIncludeExclude(t *testing.T) {
 func testChecksumIncludeExclude(t *testing.T, wildcard bool) {
 	t.Parallel()
 
-	tmpdir, err := os.MkdirTemp("", "buildkit-state")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
-	cm, _ := setupCacheManager(t, tmpdir, "native", snapshotter)
-	defer cm.Close()
+	cm, cleanup := setupCacheManager(t, tmpdir, "native", snapshotter)
+	t.Cleanup(cleanup)
 
 	ch := []string{
 		"ADD foo file data0",
@@ -583,14 +573,12 @@ func testChecksumIncludeExclude(t *testing.T, wildcard bool) {
 
 func TestChecksumIncludeDoubleStar(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := os.MkdirTemp("", "buildkit-state")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
-	cm, _ := setupCacheManager(t, tmpdir, "native", snapshotter)
-	defer cm.Close()
+	cm, cleanup := setupCacheManager(t, tmpdir, "native", snapshotter)
+	t.Cleanup(cleanup)
 
 	ch := []string{
 		"ADD prefix dir",
@@ -651,14 +639,12 @@ func TestChecksumIncludeDoubleStar(t *testing.T) {
 
 func TestChecksumIncludeSymlink(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := os.MkdirTemp("", "buildkit-state")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
-	cm, _ := setupCacheManager(t, tmpdir, "native", snapshotter)
-	defer cm.Close()
+	cm, cleanup := setupCacheManager(t, tmpdir, "native", snapshotter)
+	t.Cleanup(cleanup)
 
 	ch := []string{
 		"ADD data dir",
@@ -724,14 +710,16 @@ func TestChecksumIncludeSymlink(t *testing.T) {
 
 func TestHandleChange(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := os.MkdirTemp("", "buildkit-state")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
-	cm, _ := setupCacheManager(t, tmpdir, "native", snapshotter)
-	defer cm.Close()
+	t.Cleanup(func() {
+		require.NoError(t, snapshotter.Close())
+	})
+
+	cm, cleanup := setupCacheManager(t, tmpdir, "native", snapshotter)
+	t.Cleanup(cleanup)
 
 	ch := []string{
 		"ADD foo file data0",
@@ -802,14 +790,16 @@ func TestHandleChange(t *testing.T) {
 
 func TestHandleRecursiveDir(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := os.MkdirTemp("", "buildkit-state")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
-	cm, _ := setupCacheManager(t, tmpdir, "native", snapshotter)
-	defer cm.Close()
+	t.Cleanup(func() {
+		require.NoError(t, snapshotter.Close())
+	})
+
+	cm, cleanup := setupCacheManager(t, tmpdir, "native", snapshotter)
+	t.Cleanup(cleanup)
 
 	ch := []string{
 		"ADD d0 dir",
@@ -851,14 +841,16 @@ func TestHandleRecursiveDir(t *testing.T) {
 
 func TestChecksumUnorderedFiles(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := os.MkdirTemp("", "buildkit-state")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
-	cm, _ := setupCacheManager(t, tmpdir, "native", snapshotter)
-	defer cm.Close()
+	t.Cleanup(func() {
+		require.NoError(t, snapshotter.Close())
+	})
+
+	cm, cleanup := setupCacheManager(t, tmpdir, "native", snapshotter)
+	t.Cleanup(cleanup)
 
 	ch := []string{
 		"ADD d0 dir",
@@ -904,14 +896,12 @@ func TestChecksumUnorderedFiles(t *testing.T) {
 
 func TestSymlinkInPathScan(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := os.MkdirTemp("", "buildkit-state")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
-	cm, _ := setupCacheManager(t, tmpdir, "native", snapshotter)
-	defer cm.Close()
+	cm, cleanup := setupCacheManager(t, tmpdir, "native", snapshotter)
+	t.Cleanup(cleanup)
 
 	ch := []string{
 		"ADD d0 dir",
@@ -935,14 +925,12 @@ func TestSymlinkInPathScan(t *testing.T) {
 
 func TestSymlinkNeedsScan(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := os.MkdirTemp("", "buildkit-state")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
-	cm, _ := setupCacheManager(t, tmpdir, "native", snapshotter)
-	defer cm.Close()
+	cm, cleanup := setupCacheManager(t, tmpdir, "native", snapshotter)
+	t.Cleanup(cleanup)
 
 	ch := []string{
 		"ADD c0 dir",
@@ -968,14 +956,12 @@ func TestSymlinkNeedsScan(t *testing.T) {
 
 func TestSymlinkAbsDirSuffix(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := os.MkdirTemp("", "buildkit-state")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
-	cm, _ := setupCacheManager(t, tmpdir, "native", snapshotter)
-	defer cm.Close()
+	cm, cleanup := setupCacheManager(t, tmpdir, "native", snapshotter)
+	t.Cleanup(cleanup)
 
 	ch := []string{
 		"ADD c0 dir",
@@ -995,14 +981,12 @@ func TestSymlinkAbsDirSuffix(t *testing.T) {
 
 func TestSymlinkThroughParent(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := os.MkdirTemp("", "buildkit-state")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
-	cm, _ := setupCacheManager(t, tmpdir, "native", snapshotter)
-	defer cm.Close()
+	cm, cleanup := setupCacheManager(t, tmpdir, "native", snapshotter)
+	t.Cleanup(cleanup)
 
 	ch := []string{
 		"ADD lib dir",
@@ -1050,14 +1034,16 @@ func TestSymlinkThroughParent(t *testing.T) {
 
 func TestSymlinkInPathHandleChange(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := os.MkdirTemp("", "buildkit-state")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
-	cm, _ := setupCacheManager(t, tmpdir, "native", snapshotter)
-	defer cm.Close()
+	t.Cleanup(func() {
+		require.NoError(t, snapshotter.Close())
+	})
+
+	cm, cleanup := setupCacheManager(t, tmpdir, "native", snapshotter)
+	t.Cleanup(cleanup)
 
 	ch := []string{
 		"ADD d1 dir",
@@ -1113,14 +1099,12 @@ func TestSymlinkInPathHandleChange(t *testing.T) {
 
 func TestPersistence(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := os.MkdirTemp("", "buildkit-state")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
-	cm, closeBolt := setupCacheManager(t, tmpdir, "native", snapshotter)
-	defer cm.Close()
+	cm, cleanup := setupCacheManager(t, tmpdir, "native", snapshotter)
+	t.Cleanup(cleanup)
 
 	ch := []string{
 		"ADD foo file data0",
@@ -1154,12 +1138,10 @@ func TestPersistence(t *testing.T) {
 	time.Sleep(100 * time.Millisecond) // saving happens on the background
 
 	// we can't close snapshotter and open it twice (especially, its internal bbolt store)
-	cm.Close()
-	closeBolt()
+	cleanup()
 	getDefaultManager().lru.Purge()
-	cm, closeBolt = setupCacheManager(t, tmpdir, "native", snapshotter)
-	defer closeBolt()
-	defer cm.Close()
+	cm, cleanup = setupCacheManager(t, tmpdir, "native", snapshotter)
+	t.Cleanup(cleanup)
 
 	ref, err = cm.Get(context.TODO(), id, nil)
 	require.NoError(t, err)
@@ -1228,6 +1210,8 @@ func setupCacheManager(t *testing.T, tmpdir string, snapshotterName string, snap
 
 	return cm, func() {
 		db.Close()
+		md.Close()
+		cm.Close()
 	}
 }
 

--- a/cache/metadata/metadata_test.go
+++ b/cache/metadata/metadata_test.go
@@ -1,7 +1,6 @@
 package metadata
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -12,9 +11,7 @@ import (
 func TestGetSetSearch(t *testing.T) {
 	t.Parallel()
 
-	tmpdir, err := os.MkdirTemp("", "buildkit-storage")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	dbPath := filepath.Join(tmpdir, "storage.db")
 
@@ -111,9 +108,7 @@ func TestGetSetSearch(t *testing.T) {
 func TestIndexes(t *testing.T) {
 	t.Parallel()
 
-	tmpdir, err := os.MkdirTemp("", "buildkit-storage")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	dbPath := filepath.Join(tmpdir, "storage.db")
 
@@ -171,9 +166,7 @@ func TestIndexes(t *testing.T) {
 func TestExternalData(t *testing.T) {
 	t.Parallel()
 
-	tmpdir, err := os.MkdirTemp("", "buildkit-storage")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	dbPath := filepath.Join(tmpdir, "storage.db")
 

--- a/client/build_test.go
+++ b/client/build_test.go
@@ -133,9 +133,7 @@ func testClientGatewaySolve(t *testing.T, sb integration.Sandbox) {
 		return r, nil
 	}
 
-	tmpdir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	testStr := "This is a test"
 
@@ -687,17 +685,14 @@ func testClientGatewayContainerMounts(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 	defer c.Close()
 
-	tmpdir, err := os.MkdirTemp("", "buildkit-buildctl")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	err = os.WriteFile(filepath.Join(tmpdir, "local-file"), []byte("local"), 0644)
 	require.NoError(t, err)
 
 	a := agent.NewKeyring()
-	sockPath, clean, err := makeSSHAgentSock(a)
+	sockPath, err := makeSSHAgentSock(t, a)
 	require.NoError(t, err)
-	defer clean()
 
 	ssh, err := sshprovider.NewSSHAgentProvider([]sshprovider.AgentConfig{{
 		ID:    t.Name(),

--- a/cmd/buildctl/buildctl_test.go
+++ b/cmd/buildctl/buildctl_test.go
@@ -36,9 +36,7 @@ func testUsage(t *testing.T, sb integration.Sandbox) {
 }
 
 func TestWriteMetadataFile(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	cases := []struct {
 		name             string

--- a/executor/oci/resolvconf_test.go
+++ b/executor/oci/resolvconf_test.go
@@ -26,11 +26,8 @@ nameserver 8.8.4.4
 nameserver 2001:4860:4860::8888
 nameserver 2001:4860:4860::8844`
 
-	dir, err := os.MkdirTemp("", "buildkit-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 	ctx := context.Background()
-	p, err := GetResolvConf(ctx, dir, nil, nil)
+	p, err := GetResolvConf(ctx, t.TempDir(), nil, nil)
 	require.NoError(t, err)
 	b, err := os.ReadFile(p)
 	require.NoError(t, err)

--- a/frontend/dockerfile/dockerfile_heredoc_test.go
+++ b/frontend/dockerfile/dockerfile_heredoc_test.go
@@ -67,19 +67,17 @@ FROM scratch
 COPY --from=build /dest /
 `)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", []byte(dockerfile), 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(destDir)
+	destDir := t.TempDir()
 
 	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
 		Exports: []client.ExportEntry{
@@ -140,19 +138,17 @@ COPY <<"EOF" rawslashfile3
 EOF
 `)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", []byte(dockerfile), 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(destDir)
+	destDir := t.TempDir()
 
 	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
 		Exports: []client.ExportEntry{
@@ -212,19 +208,17 @@ FROM scratch
 COPY --from=build /dest /dest
 `)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", []byte(dockerfile), 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(destDir)
+	destDir := t.TempDir()
 
 	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
 		Exports: []client.ExportEntry{
@@ -262,19 +256,17 @@ FROM scratch
 COPY --from=build /dest /dest
 `)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", []byte(dockerfile), 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(destDir)
+	destDir := t.TempDir()
 
 	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
 		Exports: []client.ExportEntry{
@@ -313,19 +305,17 @@ FROM scratch
 COPY --from=build /dest /dest
 `)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", []byte(dockerfile), 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(destDir)
+	destDir := t.TempDir()
 
 	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
 		Exports: []client.ExportEntry{
@@ -378,19 +368,17 @@ FROM scratch
 COPY --from=build /dest /
 `)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", []byte(dockerfile), 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(destDir)
+	destDir := t.TempDir()
 
 	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
 		Exports: []client.ExportEntry{
@@ -470,19 +458,17 @@ FROM scratch
 COPY --from=build /dest /
 `)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", []byte(dockerfile), 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(destDir)
+	destDir := t.TempDir()
 
 	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
 		Exports: []client.ExportEntry{
@@ -566,19 +552,17 @@ FROM scratch
 COPY --from=build /dest /
 `)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", []byte(dockerfile), 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(destDir)
+	destDir := t.TempDir()
 
 	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
 		Exports: []client.ExportEntry{
@@ -632,11 +616,11 @@ echo "hello world" >> /dest
 EOF
 `)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", dockerfile, 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -661,30 +645,18 @@ EOF
 	require.NoError(t, err)
 
 	dockerfile = []byte(fmt.Sprintf(`
-	FROM %s 
-	`, target))
-
-	dir, err = tmpdir(
-		fstest.CreateFile("Dockerfile", dockerfile, 0600),
-	)
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	dockerfile = []byte(fmt.Sprintf(`
 	FROM %s AS base
 	FROM scratch
 	COPY --from=base /dest /dest
 	`, target))
 
-	dir, err = tmpdir(
+	dir, err = integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", dockerfile, 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
-	destDir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(destDir)
+	destDir := t.TempDir()
 
 	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
 		Exports: []client.ExportEntry{

--- a/frontend/dockerfile/dockerfile_mount_test.go
+++ b/frontend/dockerfile/dockerfile_mount_test.go
@@ -39,12 +39,12 @@ FROM busybox
 RUN --mount=target=/context [ "$(cat /context/testfile)" == "contents0" ]
 `)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", dockerfile, 0600),
 		fstest.CreateFile("testfile", []byte("contents0"), 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -68,11 +68,11 @@ RUN --mount=target=/mytmp,type=tmpfs touch /mytmp/foo
 RUN [ ! -f /mytmp/foo ]
 `)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", dockerfile, 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -95,11 +95,11 @@ FROM scratch
 RUN --mont=target=/mytmp,type=tmpfs /bin/true
 `)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", dockerfile, 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -120,11 +120,11 @@ RUN --mont=target=/mytmp,type=tmpfs /bin/true
 	RUN --mount=typ=tmpfs /bin/true
 	`)
 
-	dir, err = tmpdir(
+	dir, err = integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", dockerfile, 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
 		LocalDirs: map[string]string{
@@ -141,11 +141,11 @@ RUN --mont=target=/mytmp,type=tmpfs /bin/true
 	RUN --mount=type=tmp /bin/true
 	`)
 
-	dir, err = tmpdir(
+	dir, err = integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", dockerfile, 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
 		LocalDirs: map[string]string{
@@ -173,20 +173,18 @@ from scratch
 COPY --from=second /unique /unique
 `)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", dockerfile, 0600),
 		fstest.CreateFile("cachebust", []byte("0"), 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(destDir)
+	destDir := t.TempDir()
 
 	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
 		Exports: []client.ExportEntry{
@@ -206,16 +204,14 @@ COPY --from=second /unique /unique
 	require.NoError(t, err)
 
 	// repeat with changed file that should be still cached by content
-	dir, err = tmpdir(
+	dir, err = integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", dockerfile, 0600),
 		fstest.CreateFile("cachebust", []byte("1"), 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
-	destDir, err = os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(destDir)
+	destDir = t.TempDir()
 
 	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
 		Exports: []client.ExportEntry{
@@ -244,11 +240,11 @@ FROM busybox
 RUN --mount=type=cache,target=/mycache,uid=1001,gid=1002,mode=0751 [ "$(stat -c "%u %g %f" /mycache)" == "1001 1002 41e9" ]
 `)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", dockerfile, 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -273,11 +269,11 @@ RUN --mount=type=cache,target=/mycache2 [ ! -f /mycache2/foo ]
 RUN --mount=type=cache,target=/mycache [ -f /mycache/foo ]
 `)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", dockerfile, 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -302,11 +298,11 @@ RUN --mount=type=cache,target=/mycache touch /mycache/foo
 RUN --mount=type=cache,target=$SOME_PATH [ -f $SOME_PATH/foo ]
 `)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", dockerfile, 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -331,11 +327,11 @@ RUN --mount=type=$MNT_TYPE,target=/mycache2 touch /mycache2/foo
 RUN --mount=type=cache,target=/mycache2 [ -f /mycache2/foo ]
 `)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", dockerfile, 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -365,11 +361,11 @@ FROM stage1
 RUN --mount=type=$MNT_TYPE2,id=$MNT_ID,target=/whatever [ -f /whatever/foo ]
 `)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", dockerfile, 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -396,11 +392,11 @@ RUN --mount=type=cache,id=mycache,target=/tmp/meta touch /tmp/meta/foo
 RUN --mount=type=cache,id=mycache,target=$META_PATH [ -f /tmp/meta/foo ]
 `)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", dockerfile, 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -427,11 +423,11 @@ ENV ttt=test
 RUN --mount=from=$ttt,type=cache,target=/tmp ls
 `)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", dockerfile, 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -457,19 +453,17 @@ FROM scratch
 COPY --from=base /tmpfssize /
 `)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", dockerfile, 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(destDir)
+	destDir := t.TempDir()
 
 	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
 		Exports: []client.ExportEntry{

--- a/frontend/dockerfile/dockerfile_runnetwork_test.go
+++ b/frontend/dockerfile/dockerfile_runnetwork_test.go
@@ -41,11 +41,11 @@ FROM busybox
 RUN ip link show eth0
 `)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", dockerfile, 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -77,11 +77,11 @@ RUN --network=none ! ip link show eth0
 		dockerfile += "RUN ip link show eth0"
 	}
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", []byte(dockerfile), 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -118,11 +118,11 @@ RUN --network=host nc 127.0.0.1 %s | grep foo
 		dockerfile += fmt.Sprintf(`RUN ! nc 127.0.0.1 %s | grep foo`, port)
 	}
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", []byte(dockerfile), 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -166,11 +166,11 @@ RUN nc 127.0.0.1 %s | grep foo
 RUN --network=none ! nc -z 127.0.0.1 %s
 `, port, port)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", []byte(dockerfile), 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)

--- a/frontend/dockerfile/dockerfile_runsecurity_test.go
+++ b/frontend/dockerfile/dockerfile_runsecurity_test.go
@@ -4,7 +4,6 @@
 package dockerfile
 
 import (
-	"os"
 	"testing"
 
 	"github.com/containerd/continuity/fs/fstest"
@@ -58,11 +57,11 @@ RUN --security=insecure ls -l /dev && dd if=/dev/zero of=disk.img bs=20M count=1
 	rm disk.img
 `)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", dockerfile, 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -97,11 +96,11 @@ RUN --security=insecure [ "$(printf '%x' $(( $(cat /proc/self/status | grep CapB
 RUN [ "$(cat /proc/self/status | grep CapBnd)" == "CapBnd:	00000000a80425fb" ]
 `)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", dockerfile, 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -135,11 +134,11 @@ FROM busybox
 RUN --security=sandbox [ "$(cat /proc/self/status | grep CapBnd)" == "CapBnd:	00000000a80425fb" ]
 `)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", dockerfile, 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -163,11 +162,11 @@ FROM busybox
 RUN [ "$(cat /proc/self/status | grep CapBnd)" == "CapBnd:	00000000a80425fb" ]
 `)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", dockerfile, 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)

--- a/frontend/dockerfile/dockerfile_secrets_test.go
+++ b/frontend/dockerfile/dockerfile_secrets_test.go
@@ -1,7 +1,6 @@
 package dockerfile
 
 import (
-	"os"
 	"testing"
 
 	"github.com/containerd/continuity/fs/fstest"
@@ -31,11 +30,11 @@ RUN --mount=type=secret,required=false,mode=741,uid=100,gid=102,target=/mysecret
 RUN [ ! -f /mysecret ] # check no stub left behind
 `)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", dockerfile, 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -61,11 +60,11 @@ FROM busybox
 RUN --mount=type=secret,required,id=mysecret foo
 `)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", dockerfile, 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)

--- a/frontend/dockerfile/dockerfile_ssh_test.go
+++ b/frontend/dockerfile/dockerfile_ssh_test.go
@@ -34,11 +34,11 @@ FROM busybox
 RUN --mount=type=ssh,mode=741,uid=100,gid=102 [ "$(stat -c "%u %g %f" $SSH_AUTH_SOCK)" = "100 102 c1e1" ]
 `)
 
-	dir, err := tmpdir(
+	dir, err := integration.Tmpdir(
+		t,
 		fstest.CreateFile("Dockerfile", dockerfile, 0600),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -54,9 +54,7 @@ RUN --mount=type=ssh,mode=741,uid=100,gid=102 [ "$(stat -c "%u %g %f" $SSH_AUTH_
 		},
 	)
 
-	tmpDir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	err = os.WriteFile(filepath.Join(tmpDir, "key"), dt, 0600)
 	require.NoError(t, err)

--- a/frontend/dockerfile/dockerignore/dockerignore_test.go
+++ b/frontend/dockerfile/dockerignore/dockerignore_test.go
@@ -7,12 +7,6 @@ import (
 )
 
 func TestReadAll(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "dockerignore-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
-
 	di, err := ReadAll(nil)
 	if err != nil {
 		t.Fatalf("Expected not to have error, got %v", err)
@@ -22,7 +16,7 @@ func TestReadAll(t *testing.T) {
 		t.Fatalf("Expected to have zero dockerignore entry, got %d", diLen)
 	}
 
-	diName := filepath.Join(tmpDir, ".dockerignore")
+	diName := filepath.Join(t.TempDir(), ".dockerignore")
 	content := "test1\n/test2\n/a/file/here\n\nlastfile\n# this is a comment\n! /inverted/abs/path\n!\n! \n"
 	err = os.WriteFile(diName, []byte(content), 0777)
 	if err != nil {

--- a/frontend/dockerfile/errors_test.go
+++ b/frontend/dockerfile/errors_test.go
@@ -2,7 +2,6 @@ package dockerfile
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/containerd/continuity/fs/fstest"
@@ -76,11 +75,11 @@ env bar=baz`,
 
 	for _, tc := range tcases {
 		t.Run(tc.name, func(t *testing.T) {
-			dir, err := tmpdir(
+			dir, err := integration.Tmpdir(
+				t,
 				fstest.CreateFile("Dockerfile", []byte(tc.dockerfile), 0600),
 			)
 			require.NoError(t, err)
-			defer os.RemoveAll(dir)
 
 			c, err := client.New(sb.Context(), sb.Address())
 			require.NoError(t, err)

--- a/frontend/frontend_test.go
+++ b/frontend/frontend_test.go
@@ -42,10 +42,6 @@ func testReturnNil(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(destDir)
-
 	frontend := func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
 		return nil, nil
 	}
@@ -71,10 +67,10 @@ func testRefReadFile(t *testing.T, sb integration.Sandbox) {
 	testcontent := []byte(`foobar`)
 
 	dir, err := tmpdir(
+		t,
 		fstest.CreateFile("test", testcontent, 0666),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	frontend := func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
 		def, err := llb.Local("mylocal").Marshal(ctx)
@@ -134,6 +130,7 @@ func testRefReadDir(t *testing.T, sb integration.Sandbox) {
 	defer c.Close()
 
 	dir, err := tmpdir(
+		t,
 		fstest.CreateDir("somedir", 0777),
 		fstest.CreateFile("somedir/foo1.txt", []byte(`foo1`), 0666),
 		fstest.CreateFile("somedir/foo2.txt", []byte{}, 0666),
@@ -142,7 +139,6 @@ func testRefReadDir(t *testing.T, sb integration.Sandbox) {
 		fstest.CreateDir("somedir/baz.dir", 0777),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	expMap := make(map[string]*fstypes.Stat)
 
@@ -252,10 +248,10 @@ func testRefStatFile(t *testing.T, sb integration.Sandbox) {
 	testcontent := []byte(`foobar`)
 
 	dir, err := tmpdir(
+		t,
 		fstest.CreateFile("test", testcontent, 0666),
 	)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	exp, err := fsutil.Stat(filepath.Join(dir, "test"))
 	require.NoError(t, err)
@@ -295,11 +291,8 @@ func testRefStatFile(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 }
 
-func tmpdir(appliers ...fstest.Applier) (string, error) {
-	tmpdir, err := os.MkdirTemp("", "buildkit-frontend")
-	if err != nil {
-		return "", err
-	}
+func tmpdir(t *testing.T, appliers ...fstest.Applier) (string, error) {
+	tmpdir := t.TempDir()
 	if err := fstest.Apply(appliers...).Apply(tmpdir); err != nil {
 		return "", err
 	}

--- a/session/content/content_test.go
+++ b/session/content/content_test.go
@@ -2,7 +2,6 @@ package content
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/containerd/containerd/content"
@@ -23,10 +22,7 @@ func TestContentAttachable(t *testing.T) {
 	attachableStores := make(map[string]content.Store)
 	testBlobs := make(map[string]map[digest.Digest][]byte)
 	for _, id := range ids {
-		tmpDir, err := os.MkdirTemp("", "contenttest")
-		require.NoError(t, err)
-		defer os.RemoveAll(tmpDir)
-		store, err := local.NewStore(tmpDir)
+		store, err := local.NewStore(t.TempDir())
 		require.NoError(t, err)
 		blob := []byte("test-content-attachable-" + id)
 		w, err := store.Writer(ctx, content.WithRef(string(blob)))

--- a/session/filesync/filesync_test.go
+++ b/session/filesync/filesync_test.go
@@ -16,13 +16,11 @@ import (
 func TestFileSyncIncludePatterns(t *testing.T) {
 	ctx := context.TODO()
 	t.Parallel()
-	tmpDir, err := os.MkdirTemp("", "fsynctest")
-	require.NoError(t, err)
 
-	destDir, err := os.MkdirTemp("", "fsynctest")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
+	destDir := t.TempDir()
 
-	err = os.WriteFile(filepath.Join(tmpDir, "foo"), []byte("content1"), 0600)
+	err := os.WriteFile(filepath.Join(tmpDir, "foo"), []byte("content1"), 0600)
 	require.NoError(t, err)
 
 	err = os.WriteFile(filepath.Join(tmpDir, "bar"), []byte("content2"), 0600)

--- a/solver/bboltcachestorage/storage_test.go
+++ b/solver/bboltcachestorage/storage_test.go
@@ -1,7 +1,6 @@
 package bboltcachestorage
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -11,20 +10,15 @@ import (
 )
 
 func TestBoltCacheStorage(t *testing.T) {
-	testutil.RunCacheStorageTests(t, func() (solver.CacheKeyStorage, func()) {
-		tmpDir, err := os.MkdirTemp("", "storage")
-		require.NoError(t, err)
-
-		cleanup := func() {
-			os.RemoveAll(tmpDir)
-		}
+	testutil.RunCacheStorageTests(t, func() solver.CacheKeyStorage {
+		tmpDir := t.TempDir()
 
 		st, err := NewStore(filepath.Join(tmpDir, "cache.db"))
-		if err != nil {
-			cleanup()
-		}
 		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, st.db.Close())
+		})
 
-		return st, cleanup
+		return st
 	})
 }

--- a/solver/jobs_test.go
+++ b/solver/jobs_test.go
@@ -1,7 +1,6 @@
 package solver
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -61,11 +60,8 @@ func testParallelism(t *testing.T, sb integration.Sandbox) {
 
 	timeStart := time.Now()
 	eg, egCtx := errgroup.WithContext(ctx)
-	tmpDir, err := os.MkdirTemp("", "solver-jobs-test-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
 	solveOpt := client.SolveOpt{
-		LocalDirs: map[string]string{"cache": tmpDir},
+		LocalDirs: map[string]string{"cache": t.TempDir()},
 	}
 	eg.Go(func() error {
 		_, err := c.Solve(egCtx, d1, solveOpt, nil)

--- a/solver/testutil/cachestorage_testsuite.go
+++ b/solver/testutil/cachestorage_testsuite.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func RunCacheStorageTests(t *testing.T, st func() (solver.CacheKeyStorage, func())) {
+func RunCacheStorageTests(t *testing.T, st func() solver.CacheKeyStorage) {
 	for _, tc := range []func(*testing.T, solver.CacheKeyStorage){
 		testResults,
 		testLinks,
@@ -27,11 +27,9 @@ func RunCacheStorageTests(t *testing.T, st func() (solver.CacheKeyStorage, func(
 	}
 }
 
-func runStorageTest(t *testing.T, fn func(t *testing.T, st solver.CacheKeyStorage), st func() (solver.CacheKeyStorage, func())) {
+func runStorageTest(t *testing.T, fn func(t *testing.T, st solver.CacheKeyStorage), st func() solver.CacheKeyStorage) {
 	require.True(t, t.Run(getFunctionName(fn), func(t *testing.T) {
-		s, cleanup := st()
-		defer cleanup()
-		fn(t, s)
+		fn(t, st())
 	}))
 }
 

--- a/solver/testutil/memorycachestorage_test.go
+++ b/solver/testutil/memorycachestorage_test.go
@@ -7,7 +7,5 @@ import (
 )
 
 func TestMemoryCacheStorage(t *testing.T) {
-	RunCacheStorageTests(t, func() (solver.CacheKeyStorage, func()) {
-		return solver.NewInMemoryCacheStorage(), func() {}
-	})
+	RunCacheStorageTests(t, solver.NewInMemoryCacheStorage)
 }

--- a/source/git/gitsource_test.go
+++ b/source/git/gitsource_test.go
@@ -51,17 +51,9 @@ func testRepeatedFetch(t *testing.T, keepGitDir bool) {
 	t.Parallel()
 	ctx := context.TODO()
 
-	tmpdir, err := os.MkdirTemp("", "buildkit-state")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	gs := setupGitSource(t, t.TempDir())
 
-	gs := setupGitSource(t, tmpdir)
-
-	repodir, err := os.MkdirTemp("", "buildkit-gitsource")
-	require.NoError(t, err)
-	defer os.RemoveAll(repodir)
-
-	repodir, err = setupGitRepo(repodir)
+	repodir, err := setupGitRepo(t.TempDir())
 	require.NoError(t, err)
 
 	id := &source.GitIdentifier{Remote: repodir, KeepGitDir: keepGitDir}
@@ -170,17 +162,9 @@ func testFetchBySHA(t *testing.T, keepGitDir bool) {
 	t.Parallel()
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := os.MkdirTemp("", "buildkit-state")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	gs := setupGitSource(t, t.TempDir())
 
-	gs := setupGitSource(t, tmpdir)
-
-	repodir, err := os.MkdirTemp("", "buildkit-gitsource")
-	require.NoError(t, err)
-	defer os.RemoveAll(repodir)
-
-	repodir, err = setupGitRepo(repodir)
+	repodir, err := setupGitRepo(t.TempDir())
 	require.NoError(t, err)
 
 	cmd := exec.Command("git", "rev-parse", "feature")
@@ -256,17 +240,9 @@ func testFetchByTag(t *testing.T, tag, expectedCommitSubject string, isAnnotated
 	t.Parallel()
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := os.MkdirTemp("", "buildkit-state")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	gs := setupGitSource(t, t.TempDir())
 
-	gs := setupGitSource(t, tmpdir)
-
-	repodir, err := os.MkdirTemp("", "buildkit-gitsource")
-	require.NoError(t, err)
-	defer os.RemoveAll(repodir)
-
-	repodir, err = setupGitRepo(repodir)
+	repodir, err := setupGitRepo(t.TempDir())
 	require.NoError(t, err)
 
 	id := &source.GitIdentifier{Remote: repodir, Ref: tag, KeepGitDir: keepGitDir}
@@ -350,22 +326,12 @@ func testMultipleRepos(t *testing.T, keepGitDir bool) {
 	t.Parallel()
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := os.MkdirTemp("", "buildkit-state")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	gs := setupGitSource(t, t.TempDir())
 
-	gs := setupGitSource(t, tmpdir)
-
-	repodir, err := os.MkdirTemp("", "buildkit-gitsource")
-	require.NoError(t, err)
-	defer os.RemoveAll(repodir)
-
-	repodir, err = setupGitRepo(repodir)
+	repodir, err := setupGitRepo(t.TempDir())
 	require.NoError(t, err)
 
-	repodir2, err := os.MkdirTemp("", "buildkit-gitsource")
-	require.NoError(t, err)
-	defer os.RemoveAll(repodir2)
+	repodir2 := t.TempDir()
 
 	err = runShell(repodir2,
 		"git init",
@@ -447,11 +413,7 @@ func TestCredentialRedaction(t *testing.T) {
 	t.Parallel()
 	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
 
-	tmpdir, err := os.MkdirTemp("", "buildkit-state")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
-
-	gs := setupGitSource(t, tmpdir)
+	gs := setupGitSource(t, t.TempDir())
 
 	url := "https://user:keepthissecret@non-existant-host/user/private-repo.git"
 	id := &source.GitIdentifier{Remote: url}
@@ -479,17 +441,11 @@ func testSubdir(t *testing.T, keepGitDir bool) {
 	t.Parallel()
 	ctx := context.TODO()
 
-	tmpdir, err := os.MkdirTemp("", "buildkit-state")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	gs := setupGitSource(t, t.TempDir())
 
-	gs := setupGitSource(t, tmpdir)
+	repodir := t.TempDir()
 
-	repodir, err := os.MkdirTemp("", "buildkit-gitsource")
-	require.NoError(t, err)
-	defer os.RemoveAll(repodir)
-
-	err = runShell(repodir,
+	err := runShell(repodir,
 		"git init",
 		"git config --local user.email test",
 		"git config --local user.name test",

--- a/worker/base/worker_test.go
+++ b/worker/base/worker_test.go
@@ -9,8 +9,7 @@ import (
 
 func TestID(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := os.MkdirTemp("", "worker-base-test-id")
-	require.NoError(t, err)
+	tmpdir := t.TempDir()
 
 	id0, err := ID(tmpdir)
 	require.NoError(t, err)
@@ -28,6 +27,4 @@ func TestID(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotEqual(t, id0, id2)
-
-	require.NoError(t, os.RemoveAll(tmpdir))
 }

--- a/worker/containerd/containerd_test.go
+++ b/worker/containerd/containerd_test.go
@@ -27,14 +27,12 @@ func TestContainerdWorkerIntegration(t *testing.T) {
 	))
 }
 
-func newWorkerOpt(t *testing.T, addr string) (base.WorkerOpt, func()) {
-	tmpdir, err := os.MkdirTemp("", "workertest")
-	require.NoError(t, err)
-	cleanup := func() { os.RemoveAll(tmpdir) }
+func newWorkerOpt(t *testing.T, addr string) base.WorkerOpt {
+	tmpdir := t.TempDir()
 	rootless := false
 	workerOpt, err := NewWorkerOpt(tmpdir, addr, "overlayfs", "buildkit-test", rootless, nil, nil, netproviders.Opt{Mode: "host"}, "", nil, "")
 	require.NoError(t, err)
-	return workerOpt, cleanup
+	return workerOpt
 }
 
 func checkRequirement(t *testing.T) {
@@ -47,8 +45,7 @@ func testContainerdWorkerExec(t *testing.T, sb integration.Sandbox) {
 	if sb.Rootless() {
 		t.Skip("requires root")
 	}
-	workerOpt, cleanupWorkerOpt := newWorkerOpt(t, sb.ContainerdAddress())
-	defer cleanupWorkerOpt()
+	workerOpt := newWorkerOpt(t, sb.ContainerdAddress())
 	w, err := base.NewWorker(context.TODO(), workerOpt)
 	require.NoError(t, err)
 
@@ -59,8 +56,7 @@ func testContainerdWorkerExecFailures(t *testing.T, sb integration.Sandbox) {
 	if sb.Rootless() {
 		t.Skip("requires root")
 	}
-	workerOpt, cleanupWorkerOpt := newWorkerOpt(t, sb.ContainerdAddress())
-	defer cleanupWorkerOpt()
+	workerOpt := newWorkerOpt(t, sb.ContainerdAddress())
 	w, err := base.NewWorker(context.TODO(), workerOpt)
 	require.NoError(t, err)
 

--- a/worker/runc/runc_test.go
+++ b/worker/runc/runc_test.go
@@ -28,10 +28,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newWorkerOpt(t *testing.T, processMode oci.ProcessMode) (base.WorkerOpt, func()) {
-	tmpdir, err := os.MkdirTemp("", "workertest")
-	require.NoError(t, err)
-	cleanup := func() { os.RemoveAll(tmpdir) }
+func newWorkerOpt(t *testing.T, processMode oci.ProcessMode) base.WorkerOpt {
+	tmpdir := t.TempDir()
 
 	snFactory := SnapshotterFactory{
 		Name: "overlayfs",
@@ -43,7 +41,7 @@ func newWorkerOpt(t *testing.T, processMode oci.ProcessMode) (base.WorkerOpt, fu
 	workerOpt, err := NewWorkerOpt(tmpdir, snFactory, rootless, processMode, nil, nil, netproviders.Opt{Mode: "host"}, nil, "", "", nil, "", "")
 	require.NoError(t, err)
 
-	return workerOpt, cleanup
+	return workerOpt
 }
 
 func checkRequirement(t *testing.T) {
@@ -62,8 +60,7 @@ func TestRuncWorker(t *testing.T) {
 	t.Parallel()
 	checkRequirement(t)
 
-	workerOpt, cleanupWorkerOpt := newWorkerOpt(t, oci.ProcessSandbox)
-	defer cleanupWorkerOpt()
+	workerOpt := newWorkerOpt(t, oci.ProcessSandbox)
 	w, err := base.NewWorker(context.TODO(), workerOpt)
 	require.NoError(t, err)
 
@@ -184,8 +181,7 @@ func TestRuncWorkerNoProcessSandbox(t *testing.T) {
 	t.Parallel()
 	checkRequirement(t)
 
-	workerOpt, cleanupWorkerOpt := newWorkerOpt(t, oci.NoProcessSandbox)
-	defer cleanupWorkerOpt()
+	workerOpt := newWorkerOpt(t, oci.NoProcessSandbox)
 	w, err := base.NewWorker(context.TODO(), workerOpt)
 	require.NoError(t, err)
 
@@ -215,8 +211,7 @@ func TestRuncWorkerExec(t *testing.T) {
 	t.Parallel()
 	checkRequirement(t)
 
-	workerOpt, cleanupWorkerOpt := newWorkerOpt(t, oci.ProcessSandbox)
-	defer cleanupWorkerOpt()
+	workerOpt := newWorkerOpt(t, oci.ProcessSandbox)
 	w, err := base.NewWorker(context.TODO(), workerOpt)
 	require.NoError(t, err)
 
@@ -227,8 +222,7 @@ func TestRuncWorkerExecFailures(t *testing.T) {
 	t.Parallel()
 	checkRequirement(t)
 
-	workerOpt, cleanupWorkerOpt := newWorkerOpt(t, oci.ProcessSandbox)
-	defer cleanupWorkerOpt()
+	workerOpt := newWorkerOpt(t, oci.ProcessSandbox)
 	w, err := base.NewWorker(context.TODO(), workerOpt)
 	require.NoError(t, err)
 


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := os.MkdirTemp("", "")
	require.NoError(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```