### PR TITLE
Add context to registry push errors

### DIFF
--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -301,7 +301,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source,
 			if e.push {
 				err := e.pushImage(ctx, src, sessionID, targetName, desc.Digest)
 				if err != nil {
-					return nil, err
+					return nil, errors.Wrapf(err, "failed to push %v", targetName)
 				}
 			}
 		}

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -299,34 +299,8 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source,
 				}
 			}
 			if e.push {
-				annotations := map[digest.Digest]map[string]string{}
-				mprovider := contentutil.NewMultiProvider(e.opt.ImageWriter.ContentStore())
-				if src.Ref != nil {
-					remotes, err := src.Ref.GetRemotes(ctx, false, e.opts.RefCfg, false, session.NewGroup(sessionID))
-					if err != nil {
-						return nil, err
-					}
-					remote := remotes[0]
-					for _, desc := range remote.Descriptors {
-						mprovider.Add(desc.Digest, remote.Provider)
-						addAnnotations(annotations, desc)
-					}
-				}
-				if len(src.Refs) > 0 {
-					for _, r := range src.Refs {
-						remotes, err := r.GetRemotes(ctx, false, e.opts.RefCfg, false, session.NewGroup(sessionID))
-						if err != nil {
-							return nil, err
-						}
-						remote := remotes[0]
-						for _, desc := range remote.Descriptors {
-							mprovider.Add(desc.Digest, remote.Provider)
-							addAnnotations(annotations, desc)
-						}
-					}
-				}
-
-				if err := push.Push(ctx, e.opt.SessionManager, sessionID, mprovider, e.opt.ImageWriter.ContentStore(), desc.Digest, targetName, e.insecure, e.opt.RegistryHosts, e.pushByDigest, annotations); err != nil {
+				err := e.pushImage(ctx, src, sessionID, targetName, desc.Digest)
+				if err != nil {
 					return nil, err
 				}
 			}
@@ -347,6 +321,37 @@ func (e *imageExporterInstance) Export(ctx context.Context, src exporter.Source,
 	resp[exptypes.ExporterImageDescriptorKey] = base64.StdEncoding.EncodeToString(dtdesc)
 
 	return resp, nil
+}
+
+func (e *imageExporterInstance) pushImage(ctx context.Context, src exporter.Source, sessionID string, targetName string, dgst digest.Digest) error {
+	annotations := map[digest.Digest]map[string]string{}
+	mprovider := contentutil.NewMultiProvider(e.opt.ImageWriter.ContentStore())
+	if src.Ref != nil {
+		remotes, err := src.Ref.GetRemotes(ctx, false, e.opts.RefCfg, false, session.NewGroup(sessionID))
+		if err != nil {
+			return err
+		}
+		remote := remotes[0]
+		for _, desc := range remote.Descriptors {
+			mprovider.Add(desc.Digest, remote.Provider)
+			addAnnotations(annotations, desc)
+		}
+	}
+	if len(src.Refs) > 0 {
+		for _, r := range src.Refs {
+			remotes, err := r.GetRemotes(ctx, false, e.opts.RefCfg, false, session.NewGroup(sessionID))
+			if err != nil {
+				return err
+			}
+			remote := remotes[0]
+			for _, desc := range remote.Descriptors {
+				mprovider.Add(desc.Digest, remote.Provider)
+				addAnnotations(annotations, desc)
+			}
+		}
+	}
+
+	return push.Push(ctx, e.opt.SessionManager, sessionID, mprovider, e.opt.ImageWriter.ContentStore(), dgst, targetName, e.insecure, e.opt.RegistryHosts, e.pushByDigest, annotations)
 }
 
 func (e *imageExporterInstance) unpackImage(ctx context.Context, img images.Image, src exporter.Source, s session.Group) (err0 error) {

--- a/util/grpcerrors/grpcerrors.go
+++ b/util/grpcerrors/grpcerrors.go
@@ -42,6 +42,14 @@ func ToGRPC(err error) error {
 		st = status.FromProto(pb)
 	}
 
+	// If the original error was wrapped with more context than the GRPCStatus error,
+	// copy the original message to the GRPCStatus error
+	if err.Error() != st.Message() {
+		pb := st.Proto()
+		pb.Message = err.Error()
+		st = status.FromProto(pb)
+	}
+
 	var details []proto.Message
 
 	for _, st := range stack.Traces(err) {


### PR DESCRIPTION
- Extract containerimage export push function
- Wrap push error with target name
- Use original error's message for gRPC error

Fixes #2019.

Registry push error from buildx before this change:
```
 => ERROR exporting to image                                                                                                                                                                                1.1s
 => => exporting layers                                                                                                                                                                                     0.0s
 => => exporting manifest sha256:d2cfb97f444d76147c440c6b86b333d388735b75b3644718cb5a4e0ad4e23762                                                                                                           0.0s
 => => exporting config sha256:35d75deef09995f6980a80122699b12059b946997dc2acf0d121970cd662c103                                                                                                             0.0s
 => => pushing layers                                                                                                                                                                                       1.1s
------
 > exporting to image:
------
ERROR: failed to solve: server message: insufficient_scope: authorization failed
```

and after:

```
 => ERROR exporting to image                                                                                                                                                                                1.4s
 => => exporting layers                                                                                                                                                                                     0.0s
 => => exporting manifest sha256:d2cfb97f444d76147c440c6b86b333d388735b75b3644718cb5a4e0ad4e23762                                                                                                           0.0s
 => => exporting config sha256:35d75deef09995f6980a80122699b12059b946997dc2acf0d121970cd662c103                                                                                                             0.0s
 => => pushing layers                                                                                                                                                                                       1.4s
------
 > exporting to image:
------
ERROR: failed to solve: failed to push docker.io/username/image: server message: insufficient_scope: authorization failed
```