### PR TITLE
Stop using legacy cache import/export in client

### DIFF
--- a/client/solve.go
+++ b/client/solve.go
@@ -436,6 +436,12 @@ func parseCacheOptions(ctx context.Context, isGateway bool, opt SolveOpt) (*cach
 			indexJSONPath := filepath.Join(csDir, "index.json")
 			indicesToUpdate[indexJSONPath] = "latest"
 		}
+		if ex.Type == "registry" {
+			regRef := ex.Attrs["ref"]
+			if regRef == "" {
+				return nil, errors.New("registry cache exporter requires ref")
+			}
+		}
 		cacheExports = append(cacheExports, &controlapi.CacheOptionsEntry{
 			Type:  ex.Type,
 			Attrs: ex.Attrs,
@@ -471,6 +477,12 @@ func parseCacheOptions(ctx context.Context, isGateway bool, opt SolveOpt) (*cach
 				}
 			}
 			contentStores["local:"+csDir] = cs
+		}
+		if im.Type == "registry" {
+			regRef := im.Attrs["ref"]
+			if regRef == "" {
+				return nil, errors.New("registry cache importer requires ref")
+			}
 		}
 		cacheImports = append(cacheImports, &controlapi.CacheOptionsEntry{
 			Type:  im.Type,

--- a/client/solve.go
+++ b/client/solve.go
@@ -414,14 +414,10 @@ func parseCacheOptions(ctx context.Context, isGateway bool, opt SolveOpt) (*cach
 	var (
 		cacheExports []*controlapi.CacheOptionsEntry
 		cacheImports []*controlapi.CacheOptionsEntry
-		// legacy API is used for registry caches, because the daemon might not support the new API
-		legacyExportRef  string
-		legacyImportRefs []string
 	)
 	contentStores := make(map[string]content.Store)
 	indicesToUpdate := make(map[string]string) // key: index.JSON file name, value: tag
 	frontendAttrs := make(map[string]string)
-	legacyExportAttrs := make(map[string]string)
 	for _, ex := range opt.CacheExports {
 		if ex.Type == "local" {
 			csDir := ex.Attrs["dest"]
@@ -440,19 +436,10 @@ func parseCacheOptions(ctx context.Context, isGateway bool, opt SolveOpt) (*cach
 			indexJSONPath := filepath.Join(csDir, "index.json")
 			indicesToUpdate[indexJSONPath] = "latest"
 		}
-		if ex.Type == "registry" && legacyExportRef == "" {
-			legacyExportRef = ex.Attrs["ref"]
-			for k, v := range ex.Attrs {
-				if k != "ref" {
-					legacyExportAttrs[k] = v
-				}
-			}
-		} else {
-			cacheExports = append(cacheExports, &controlapi.CacheOptionsEntry{
-				Type:  ex.Type,
-				Attrs: ex.Attrs,
-			})
-		}
+		cacheExports = append(cacheExports, &controlapi.CacheOptionsEntry{
+			Type:  ex.Type,
+			Attrs: ex.Attrs,
+		})
 	}
 	for _, im := range opt.CacheImports {
 		attrs := im.Attrs
@@ -485,22 +472,12 @@ func parseCacheOptions(ctx context.Context, isGateway bool, opt SolveOpt) (*cach
 			}
 			contentStores["local:"+csDir] = cs
 		}
-		if im.Type == "registry" {
-			legacyImportRef := attrs["ref"]
-			legacyImportRefs = append(legacyImportRefs, legacyImportRef)
-		} else {
-			cacheImports = append(cacheImports, &controlapi.CacheOptionsEntry{
-				Type:  im.Type,
-				Attrs: attrs,
-			})
-		}
+		cacheImports = append(cacheImports, &controlapi.CacheOptionsEntry{
+			Type:  im.Type,
+			Attrs: attrs,
+		})
 	}
 	if opt.Frontend != "" || isGateway {
-		// use legacy API for registry importers, because the frontend might not support the new API
-		if len(legacyImportRefs) > 0 {
-			frontendAttrs["cache-from"] = strings.Join(legacyImportRefs, ",")
-		}
-		// use new API for other importers
 		if len(cacheImports) > 0 {
 			s, err := json.Marshal(cacheImports)
 			if err != nil {
@@ -511,11 +488,6 @@ func parseCacheOptions(ctx context.Context, isGateway bool, opt SolveOpt) (*cach
 	}
 	res := cacheOptions{
 		options: controlapi.CacheOptions{
-			// old API (for registry caches, planned to be removed in early 2019)
-			ExportRefDeprecated:   legacyExportRef,
-			ExportAttrsDeprecated: legacyExportAttrs,
-			ImportRefsDeprecated:  legacyImportRefs,
-			// new API
 			Exports: cacheExports,
 			Imports: cacheImports,
 		},

--- a/control/control.go
+++ b/control/control.go
@@ -292,7 +292,7 @@ func (c *Controller) Solve(ctx context.Context, req *controlapi.SolveRequest) (*
 		}
 		cacheExporter, err = cacheExporterFunc(ctx, session.NewGroup(req.Session), e.Attrs)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrapf(err, "failed to configure %v cache exporter", e.Type)
 		}
 		if exportMode, supported := parseCacheExportMode(e.Attrs["mode"]); !supported {
 			bklog.G(ctx).Debugf("skipping invalid cache export mode: %s", e.Attrs["mode"])

--- a/solver/llbsolver/bridge.go
+++ b/solver/llbsolver/bridge.go
@@ -91,7 +91,7 @@ func (b *llbBridge) loadResult(ctx context.Context, def *pb.Definition, cacheImp
 						}
 						ci, desc, err := resolveCI(ctx, g, im.Attrs)
 						if err != nil {
-							return err
+							return errors.Wrapf(err, "failed to configure %v cache importer", im.Type)
 						}
 						cmNew, err = ci.Resolve(ctx, desc, cmID, w)
 						return err


### PR DESCRIPTION
Fixes #2974.

I've kept [the server-side code for translating the legacy request](https://github.com/moby/buildkit/blob/f8a60e2c1de918bc6a114fb9ae9381cd37407efb/control/control.go#L216-L243) for now so that this will continue to work with existing clients. We should be able to delete this once enough clients have been updated, perhaps in the following release?

I've also added some simple validation in the client for the `ref` attr on registry cache options, and some extra context around errors from the `ResolveCacheExporterFunc`s.