### PR TITLE
Pass platform arg for stage state to ContextByName

### DIFF
--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -448,7 +448,7 @@ func Build(ctx context.Context, c client.Client) (_ *client.Result, err error) {
 		Warn: func(msg, url string, detail [][]byte, location *parser.Range) {
 			c.Warn(ctx, defVtx, msg, warnOpts(sourceMap, location, detail, url))
 		},
-		ContextByName: contextByNameFunc(c, c.BuildOpts().SessionID, targetPlatforms[0]),
+		ContextByName: contextByNameFunc(c, c.BuildOpts().SessionID),
 	}
 
 	defer func() {
@@ -487,8 +487,9 @@ func Build(ctx context.Context, c client.Client) (_ *client.Result, err error) {
 				if i != 0 {
 					opt.Warn = nil
 				}
-				opt.ContextByName = contextByNameFunc(c, c.BuildOpts().SessionID, tp)
+				opt.ContextByName = contextByNameFunc(c, c.BuildOpts().SessionID)
 				st, img, bi, err := dockerfile2llb.Dockerfile2LLB(ctx, dtDockerfile, opt)
+
 				if err != nil {
 					return err
 				}
@@ -803,8 +804,8 @@ func warnOpts(sm *llb.SourceMap, r *parser.Range, detail [][]byte, url string) c
 	return opts
 }
 
-func contextByNameFunc(c client.Client, sessionID string, p *ocispecs.Platform) func(context.Context, string, string) (*llb.State, *dockerfile2llb.Image, *binfotypes.BuildInfo, error) {
-	return func(ctx context.Context, name, resolveMode string) (*llb.State, *dockerfile2llb.Image, *binfotypes.BuildInfo, error) {
+func contextByNameFunc(c client.Client, sessionID string) func(context.Context, string, string, *ocispecs.Platform) (*llb.State, *dockerfile2llb.Image, *binfotypes.BuildInfo, error) {
+	return func(ctx context.Context, name, resolveMode string, p *ocispecs.Platform) (*llb.State, *dockerfile2llb.Image, *binfotypes.BuildInfo, error) {
 		named, err := reference.ParseNormalizedNamed(name)
 		if err != nil {
 			return nil, nil, nil, errors.Wrapf(err, "invalid context name %s", name)

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -115,6 +115,7 @@ var allTests = integration.TestFuncs(
 	testUlimit,
 	testCgroupParent,
 	testNamedImageContext,
+	testNamedImageContextPlatform,
 	testNamedImageContextTimestamps,
 	testNamedLocalContext,
 	testNamedOCILayoutContext,
@@ -5186,6 +5187,79 @@ COPY --from=base /env_foobar /
 	dt, err = os.ReadFile(filepath.Join(destDir, "env_path"))
 	require.NoError(t, err)
 	require.Contains(t, string(dt), "/foobar:")
+}
+
+func testNamedImageContextPlatform(t *testing.T, sb integration.Sandbox) {
+	ctx := sb.Context()
+
+	c, err := client.New(ctx, sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	registry, err := sb.NewRegistry()
+	if errors.Is(err, integration.ErrRequirements) {
+		t.Skip(err.Error())
+	}
+	require.NoError(t, err)
+
+	// Build a base image and force buildkit to generate a manifest list.
+	dockerfile := []byte(`FROM --platform=$BUILDPLATFORM alpine:latest`)
+	target := registry + "/buildkit/testnamedimagecontextplatform:latest"
+
+	dir, err := integration.Tmpdir(
+		t,
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+	)
+	require.NoError(t, err)
+
+	f := getFrontend(t, sb)
+
+	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
+		FrontendAttrs: map[string]string{
+			"build-arg:BUILDKIT_MULTI_PLATFORM": "true",
+		},
+		LocalDirs: map[string]string{
+			builder.DefaultLocalNameDockerfile: dir,
+			builder.DefaultLocalNameContext:    dir,
+		},
+		Exports: []client.ExportEntry{
+			{
+				Type: client.ExporterImage,
+				Attrs: map[string]string{
+					"name": target,
+					"push": "true",
+				},
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	dockerfile = []byte(`
+FROM --platform=$BUILDPLATFORM busybox AS target
+RUN echo hello
+`)
+
+	dir, err = integration.Tmpdir(
+		t,
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+	)
+	require.NoError(t, err)
+
+	f = getFrontend(t, sb)
+
+	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
+		FrontendAttrs: map[string]string{
+			"context:busybox": "docker-image://" + target,
+			// random platform that would never exist so it doesn't conflict with the build machine
+			// here we specifically want to make sure that the platform chosen for the image source is the one in the dockerfile not the target platform.
+			"platform": "darwin/ppc64le",
+		},
+		LocalDirs: map[string]string{
+			builder.DefaultLocalNameDockerfile: dir,
+			builder.DefaultLocalNameContext:    dir,
+		},
+	}, nil)
+	require.NoError(t, err)
 }
 
 func testNamedImageContextTimestamps(t *testing.T, sb integration.Sandbox) {


### PR DESCRIPTION
Fixes image build contexts not respecting the platform specified in the
Dockerfile `FROM --platform` argument.
Before this change buildkit always resolves images using the target
platform, but `FROM` may specifiy something else (such as
$BUILDPLATFORM).
