### PR TITLE
`buildctl (du|prune|debug info)`: support `--format {{json .}}`

### DIFF
--- a/client/diskusage.go
+++ b/client/diskusage.go
@@ -10,18 +10,18 @@ import (
 )
 
 type UsageInfo struct {
-	ID      string
-	Mutable bool
-	InUse   bool
-	Size    int64
+	ID      string `json:"id"`
+	Mutable bool   `json:"mutable"`
+	InUse   bool   `json:"inUse"`
+	Size    int64  `json:"size"`
 
-	CreatedAt   time.Time
-	LastUsedAt  *time.Time
-	UsageCount  int
-	Parents     []string
-	Description string
-	RecordType  UsageRecordType
-	Shared      bool
+	CreatedAt   time.Time       `json:"createdAt"`
+	LastUsedAt  *time.Time      `json:"lastUsedAt"`
+	UsageCount  int             `json:"usageCount"`
+	Parents     []string        `json:"parents"`
+	Description string          `json:"description"`
+	RecordType  UsageRecordType `json:"recordType"`
+	Shared      bool            `json:"shared"`
 }
 
 func (c *Client) DiskUsage(ctx context.Context, opts ...DiskUsageOption) ([]*UsageInfo, error) {

--- a/client/info.go
+++ b/client/info.go
@@ -9,13 +9,13 @@ import (
 )
 
 type Info struct {
-	BuildkitVersion BuildkitVersion
+	BuildkitVersion BuildkitVersion `json:"buildkitVersion"`
 }
 
 type BuildkitVersion struct {
-	Package  string
-	Version  string
-	Revision string
+	Package  string `json:"package"`
+	Version  string `json:"version"`
+	Revision string `json:"revision"`
 }
 
 func (c *Client) Info(ctx context.Context) (*Info, error) {

--- a/cmd/buildctl/common/common.go
+++ b/cmd/buildctl/common/common.go
@@ -1,10 +1,14 @@
 package common
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
+	"text/template"
 	"time"
 
 	"github.com/moby/buildkit/client"
@@ -87,4 +91,26 @@ func ResolveClient(c *cli.Context) (*client.Client, error) {
 	defer cancel()
 
 	return client.New(ctx, c.GlobalString("addr"), opts...)
+}
+
+func ParseTemplate(format string) (*template.Template, error) {
+	// aliases is from https://github.com/containerd/nerdctl/blob/v0.17.1/cmd/nerdctl/fmtutil.go#L116-L126 (Apache License 2.0)
+	aliases := map[string]string{
+		"json": "{{json .}}",
+	}
+	if alias, ok := aliases[format]; ok {
+		format = alias
+	}
+	// funcs is from https://github.com/docker/cli/blob/v20.10.12/templates/templates.go#L12-L20 (Apache License 2.0)
+	funcs := template.FuncMap{
+		"json": func(v interface{}) string {
+			buf := &bytes.Buffer{}
+			enc := json.NewEncoder(buf)
+			enc.SetEscapeHTML(false)
+			enc.Encode(v)
+			// Remove the trailing new line added by the encoder
+			return strings.TrimSpace(buf.String())
+		},
+	}
+	return template.New("").Funcs(funcs).Parse(format)
 }

--- a/cmd/buildctl/debug/info.go
+++ b/cmd/buildctl/debug/info.go
@@ -13,6 +13,12 @@ var InfoCommand = cli.Command{
 	Name:   "info",
 	Usage:  "display internal information",
 	Action: info,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "format",
+			Usage: "Format the output using the given Go template, e.g, '{{json .}}'",
+		},
+	},
 }
 
 func info(clicontext *cli.Context) error {
@@ -24,6 +30,18 @@ func info(clicontext *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	if format := clicontext.String("format"); format != "" {
+		tmpl, err := bccommon.ParseTemplate(format)
+		if err != nil {
+			return err
+		}
+		if err := tmpl.Execute(clicontext.App.Writer, res); err != nil {
+			return err
+		}
+		_, err = fmt.Fprintf(clicontext.App.Writer, "\n")
+		return err
+	}
+
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
 	_, _ = fmt.Fprintf(w, "BuildKit:\t%s %s %s\n", res.BuildkitVersion.Package, res.BuildkitVersion.Version, res.BuildkitVersion.Revision)
 	return w.Flush()


### PR DESCRIPTION
- `buildctl du --format '{{json .}}'`: the template is applied to `[]*UsageInfo`
- `buildctl prune --format '{{json .}}'`: the template is applied to `UsageInfo`
- `buildctl debug info --format '{{json .}}'`: the template is applied to `*Info`

```console
$ buildctl du --format '{{json .}}'
[{"id":"s1d9pk3439ap6e5tt67bndctk","mutable":false,"inUse":false,"size":8979670,"createdAt":"2022-07-31T06:57:11.046458864Z","lastUsedAt":"2022-07-31T06:57:13.862022729Z","usageCount":1,"parents":null,"description":"pulled from docker.io/library/alpine@sha256:7580ece7963bfa863801466c0a488f11c86f85d9988051a9f9c68cb27f6b7872","recordType":"regular","shared":false},{"id":"u0nmub83lksjb9qu04y23v48m","mutable":true,"inUse":false,"size":2805760,"createdAt":"2022-07-31T06:57:11.68658936Z","lastUsedAt":"2022-07-31T06:57:13.858709691Z","usageCount":1,"parents":["s1d9pk3439ap6e5tt67bndctk"],"description":"mount / from exec /bin/sh -c apk add --no-cache neofetch","recordType":"regular","shared":false},{"id":"jeppep0j1cguag5v53l4lvq49","mutable":true,"inUse":false,"size":8192,"createdAt":"2022-07-31T06:57:07.579255711Z","lastUsedAt":"2022-07-31T06:57:13.861316848Z","usageCount":1,"parents":null,"description":"local source for dockerfile","recordType":"source.local","shared":false},{"id":"ur25i8ylum9326x9nas2lfyej","mutable":true,"inUse":false,"size":4096,"createdAt":"2022-07-31T06:57:07.580579468Z","lastUsedAt":"2022-07-31T06:57:13.860030835Z","usageCount":1,"parents":null,"description":"local source for context","recordType":"source.local","shared":false}]

$ buildctl prune --format '{{json .}}'
{"id":"u0nmub83lksjb9qu04y23v48m","mutable":true,"inUse":false,"size":2805760,"createdAt":"2022-07-31T06:57:11.68658936Z","lastUsedAt":"2022-07-31T06:57:13.858709691Z","usageCount":1,"parents":["s1d9pk3439ap6e5tt67bndctk"],"description":"mount / from exec /bin/sh -c apk add --no-cache neofetch","recordType":"","shared":false}
{"id":"jeppep0j1cguag5v53l4lvq49","mutable":true,"inUse":false,"size":8192,"createdAt":"2022-07-31T06:57:07.579255711Z","lastUsedAt":"2022-07-31T06:57:13.861316848Z","usageCount":1,"parents":null,"description":"local source for dockerfile","recordType":"","shared":false}
{"id":"ur25i8ylum9326x9nas2lfyej","mutable":true,"inUse":false,"size":4096,"createdAt":"2022-07-31T06:57:07.580579468Z","lastUsedAt":"2022-07-31T06:57:13.860030835Z","usageCount":1,"parents":null,"description":"local source for context","recordType":"","shared":false}
{"id":"s1d9pk3439ap6e5tt67bndctk","mutable":false,"inUse":false,"size":8979670,"createdAt":"2022-07-31T06:57:11.046458864Z","lastUsedAt":"2022-07-31T06:57:13.862022729Z","usageCount":1,"parents":null,"description":"pulled from docker.io/library/alpine@sha256:7580ece7963bfa863801466c0a488f11c86f85d9988051a9f9c68cb27f6b7872","recordType":"","shared":false}

$ buildctl debug info --format '{{json .}}'
{"buildkitVersion":{"package":"github.com/moby/buildkit","version":"v0.10.0-380-g874eef9b","revision":"874eef9b70dbaf4f074d2bc8f4dc64237f8e83a0"}}
```
