### PR TITLE
An image’s parent image is the image designated in the FROM directive in the image’s Dockerfile

### DIFF
--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -671,7 +671,7 @@ FROM [--platform=<platform>] <image>[@<digest>] [AS <name>]
 ```
 
 The `FROM` instruction initializes a new build stage and sets the
-[*Base Image*](https://docs.docker.com/glossary/#base-image) for subsequent instructions. As such, a
+[*Parent Image*](https://docs.docker.com/glossary/#parent-image) for subsequent instructions. As such, a
 valid `Dockerfile` must start with a `FROM` instruction. The image can be
 any valid image – it is especially easy to start by **pulling an image** from
 the [*Public Repositories*](https://docs.docker.com/docker-hub/repos/).


### PR DESCRIPTION
An image’s parent image is the image designated in the FROM directive in the image’s Dockerfile. 

Signed-off-by: echolixiaopeng <hi@xiaopeng.li>