### PR TITLE
do not close sessions after client solve if pre-initialized

### DIFF
--- a/client/solve.go
+++ b/client/solve.go
@@ -209,8 +209,10 @@ func (c *Client) solve(ctx context.Context, def *llb.Definition, runGateway runG
 				<-time.After(3 * time.Second)
 				cancelStatus()
 			}()
-			bklog.G(ctx).Debugf("stopping session")
-			s.Close()
+			if !opt.SessionPreInitialized {
+				bklog.G(ctx).Debugf("stopping session")
+				s.Close()
+			}
 		}()
 		var pbd *pb.Definition
 		if def != nil {


### PR DESCRIPTION
This fixes what appears to be a bug from an old refactor to allow
shared sessions:
https://github.com/moby/buildkit/commit/ef58b61d83f9030f54355ef0b68424ef8519fd75

Without this, the session cannot really be shared effectively since it always closed by the first solve.
As discussed in slack: https://dockercommunity.slack.com/archives/C7S7A40MP/p1658286226946059

There are no current users outside the openllb/hlb project, so should not have an impact:
https://sourcegraph.com/search?q=context:global+SessionPreInitialized+-file:%28%5E%7C/%29vendor/+&patternType=literal

cc @aaronlehmann 
