### PR TITLE
Add config, logging for healthcheck

### DIFF
--- a/session/grpc.go
+++ b/session/grpc.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"context"
+	"math"
 	"net"
 	"sync/atomic"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/grpcerrors"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/net/http2"
@@ -79,21 +81,55 @@ func monitorHealth(ctx context.Context, cc *grpc.ClientConn, cancelConn func()) 
 	defer cancelConn()
 	defer cc.Close()
 
-	ticker := time.NewTicker(1 * time.Second)
+	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 	healthClient := grpc_health_v1.NewHealthClient(cc)
+
+	failedBefore := false
+	consecutiveSuccessful := 0
+	defaultHealthcheckDuration := 30 * time.Second
+	lastHealthcheckDuration := time.Duration(0)
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			// This healthcheck can erroneously fail in some instances, such as receiving lots of data in a low-bandwidth scenario or too many concurrent builds.
+			// So, this healthcheck is purposely long, and can tolerate some failures on purpose.
+
+			healthcheckStart := time.Now()
+
+			timeout := time.Duration(math.Max(float64(defaultHealthcheckDuration), float64(lastHealthcheckDuration)*1.5))
+			ctx, cancel := context.WithTimeout(ctx, timeout)
 			_, err := healthClient.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
 			cancel()
-			if err != nil {
-				return
+
+			lastHealthcheckDuration = time.Since(healthcheckStart)
+			logFields := logrus.Fields{
+				"timeout":        timeout,
+				"actualDuration": lastHealthcheckDuration,
 			}
+
+			if err != nil {
+				if failedBefore {
+					bklog.G(ctx).Error("healthcheck failed fatally")
+					return
+				}
+
+				failedBefore = true
+				consecutiveSuccessful = 0
+				bklog.G(ctx).WithFields(logFields).Warn("healthcheck failed")
+			} else {
+				consecutiveSuccessful++
+
+				if consecutiveSuccessful >= 5 && failedBefore {
+					failedBefore = false
+					bklog.G(ctx).WithFields(logFields).Debug("reset healthcheck failure")
+				}
+			}
+
+			bklog.G(ctx).WithFields(logFields).Debug("healthcheck completed")
 		}
 	}
 }


### PR DESCRIPTION
This adds configuration values, and logging for the gRPC healthcheck ping. By adjusting these values larger, you can get builds with many/large files to work in a bandwidth-starved environment.

Sample configuration section:
```
[health]
  frequency = "10s"
  timeout = "1m"
  allowedFailures = 3
```
This config is completely optional, and leaving it blank (or omitting it) maintains the old behavior.

It also adds logging. A debug message for each completed healthcheck, and a warning for each failure. It also prints when it cancels the context, so if you do have odd cancellations in your use case, they have a chance at being traced back to here. Here is a small log snippet with some failing and recovering happening:

```
time="2022-08-02T22:28:02Z" level=debug msg="diff applied" d=91.038907ms digest="sha256:ab6db1bc80d0a6df92d04c3fad44b9443642fbc85878023bc8c011763fe44524" media=application/vnd.docker.image.rootfs.diff.tar.gzip size=2814645
time="2022-08-02T22:28:03Z" level=debug msg="healthcheck completed" actualDuration="734.564µs" timeout=17s
time="2022-08-02T22:28:04Z" level=debug msg="healthcheck completed" actualDuration="814.28µs" timeout=17s
time="2022-08-02T22:28:05Z" level=debug msg="healthcheck completed" actualDuration="720.232µs" timeout=17s
time="2022-08-02T22:28:06Z" level=debug msg="healthcheck completed" actualDuration=2.065139ms timeout=17s
time="2022-08-02T22:28:07Z" level=debug msg="healthcheck completed" actualDuration=2.041702ms timeout=17s
time="2022-08-02T22:28:07Z" level=debug msg="new ref for local: a5224clhf1nesi63z3zsno1zs" span="[context .] local context ."
time="2022-08-02T22:28:25Z" level=warning msg="healthcheck failed" actualDuration=17.000346522s allowedFailures=3 consecutiveFailures=1 timeout=17s
time="2022-08-02T22:28:42Z" level=warning msg="healthcheck failed" actualDuration=17.000424726s allowedFailures=3 consecutiveFailures=2 timeout=17s
time="2022-08-02T22:28:58Z" level=debug msg="healthcheck completed" actualDuration=16.496519198s timeout=17s
time="2022-08-02T22:29:15Z" level=warning msg="healthcheck failed" actualDuration=17.000784359s allowedFailures=3 consecutiveFailures=1 timeout=17s
time="2022-08-02T22:29:32Z" level=warning msg="healthcheck failed" actualDuration=17.000419603s allowedFailures=3 consecutiveFailures=2 timeout=17s
time="2022-08-02T22:29:48Z" level=debug msg="healthcheck completed" actualDuration=15.841662313s timeout=17s
time="2022-08-02T22:30:05Z" level=warning msg="healthcheck failed" actualDuration=17.000593778s allowedFailures=3 consecutiveFailures=1 timeout=17s
time="2022-08-02T22:30:22Z" level=warning msg="healthcheck failed" actualDuration=17.001052249s allowedFailures=3 consecutiveFailures=2 timeout=17s
time="2022-08-02T22:30:38Z" level=debug msg="healthcheck completed" actualDuration=16.517479546s timeout=17s
time="2022-08-02T22:30:55Z" level=warning msg="healthcheck failed" actualDuration=17.000286526s allowedFailures=3 consecutiveFailures=1 timeout=17s
time="2022-08-02T22:31:12Z" level=warning msg="healthcheck failed" actualDuration=17.000703879s allowedFailures=3 consecutiveFailures=2 timeout=17s
time="2022-08-02T22:31:29Z" level=warning msg="healthcheck failed" actualDuration=17.000178969s allowedFailures=3 consecutiveFailures=3 timeout=17s
time="2022-08-02T22:31:29Z" level=error msg="healthcheck failed too many times"
```