### PR TITLE
Add --parents opt-in flag for ADD/COPY (labs)

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -123,7 +123,7 @@ target "lint" {
   matrix = {
     buildtags = [
       { name = "default", tags = "", target = "golangci-lint" },
-      { name = "labs", tags = "dfrunsecurity", target = "golangci-lint" },
+      { name = "labs", tags = "dfrunsecurity dfparents", target = "golangci-lint" },
       { name = "nydus", tags = "nydus", target = "golangci-lint" },
       { name = "yaml", tags = "", target = "yamllint" },
       { name = "proto", tags = "", target = "protolint" },

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -756,6 +756,7 @@ func dispatch(d *dispatchState, cmd command, opt dispatchOpt) error {
 			chown:        c.Chown,
 			chmod:        c.Chmod,
 			link:         c.Link,
+			parents:      c.Parents,
 			location:     c.Location(),
 			opt:          opt,
 		})
@@ -1162,6 +1163,14 @@ func dispatchCopy(d *dispatchState, cfg copyConfig) error {
 				AllowEmptyWildcard:  true,
 			}}, copyOpt...)
 
+			if cfg.parents {
+				path := strings.TrimPrefix(src, "/")
+				opts = append(opts, &llb.CopyInfo{
+					IncludePatterns: []string{path},
+				})
+				src = "/"
+			}
+
 			if a == nil {
 				a = llb.Copy(cfg.source, src, dest, opts...)
 			} else {
@@ -1252,6 +1261,7 @@ type copyConfig struct {
 	link         bool
 	keepGitDir   bool
 	checksum     digest.Digest
+	parents      bool
 	location     []parser.Range
 	opt          dispatchOpt
 }

--- a/frontend/dockerfile/dockerfile_parents_test.go
+++ b/frontend/dockerfile/dockerfile_parents_test.go
@@ -1,0 +1,76 @@
+//go:build dfparents
+// +build dfparents
+
+package dockerfile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/containerd/continuity/fs/fstest"
+	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/frontend/dockerui"
+	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/stretchr/testify/require"
+)
+
+var parentsTests = integration.TestFuncs(
+	testCopyParents,
+)
+
+func init() {
+	allTests = append(allTests, parentsTests...)
+}
+
+func testCopyParents(t *testing.T, sb integration.Sandbox) {
+	f := getFrontend(t, sb)
+
+	dockerfile := []byte(`
+FROM scratch
+COPY --parents foo1/foo2/bar /
+
+WORKDIR /test
+COPY --parents foo1/foo2/ba* .
+`)
+
+	dir := integration.Tmpdir(
+		t,
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+		fstest.CreateDir("foo1", 0700),
+		fstest.CreateDir("foo1/foo2", 0700),
+		fstest.CreateFile("foo1/foo2/bar", []byte(`testing`), 0600),
+		fstest.CreateFile("foo1/foo2/baz", []byte(`testing2`), 0600),
+	)
+
+	c, err := client.New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	destDir := t.TempDir()
+
+	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
+		Exports: []client.ExportEntry{
+			{
+				Type:      client.ExporterLocal,
+				OutputDir: destDir,
+			},
+		},
+		LocalDirs: map[string]string{
+			dockerui.DefaultLocalNameDockerfile: dir,
+			dockerui.DefaultLocalNameContext:    dir,
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	dt, err := os.ReadFile(filepath.Join(destDir, "foo1/foo2/bar"))
+	require.NoError(t, err)
+	require.Equal(t, "testing", string(dt))
+
+	dt, err = os.ReadFile(filepath.Join(destDir, "test/foo1/foo2/bar"))
+	require.NoError(t, err)
+	require.Equal(t, "testing", string(dt))
+	dt, err = os.ReadFile(filepath.Join(destDir, "test/foo1/foo2/baz"))
+	require.NoError(t, err)
+	require.Equal(t, "testing2", string(dt))
+}

--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -1552,6 +1552,46 @@ path, using `--link` is always recommended. The performance of `--link` is
 equivalent or better than the default behavior and, it creates much better
 conditions for cache reuse.
 
+
+## COPY --parents
+
+> **Note**
+>
+> Available in [`docker/dockerfile-upstream:master-labs`](#syntax).
+> Will be included in `docker/dockerfile:1.6-labs`.
+
+```dockerfile
+COPY [--parents[=<boolean>]] <src>... <dest>
+```
+
+The `--parents` flag preserves parent directories for `src` entries. This flag defaults to `false`.
+
+```dockerfile
+# syntax=docker/dockerfile-upstream:master-labs
+FROM scratch
+
+COPY ./x/a.txt ./y/a.txt /no_parents/
+COPY --parents ./x/a.txt ./y/a.txt /parents/
+
+# /no_parents/a.txt
+# /parents/x/a.txt
+# /parents/y/a.txt
+```
+
+This behavior is analogous to the [Linux `cp` utility's](https://www.man7.org/linux/man-pages/man1/cp.1.html)
+`--parents` flag.
+
+Note that, without the `--parents` flag specified, any filename collision will
+fail the Linux `cp` operation with an explicit error message
+(`cp: will not overwrite just-created './x/a.txt' with './y/a.txt'`), where the
+Buildkit will silently overwrite the target file at the destination.
+
+While it is possible to preserve the directory structure for `COPY`
+instructions consisting of only one `src` entry, usually it is more beneficial
+to keep the layer count in the resulting image as low as possible. Therefore,
+with the `--parents` flag, the Buildkit is capable of packing multiple
+`COPY` instructions together, keeping the directory structure intact.
+
 ## ENTRYPOINT
 
 ENTRYPOINT has two forms:

--- a/frontend/dockerfile/instructions/commands.go
+++ b/frontend/dockerfile/instructions/commands.go
@@ -270,10 +270,11 @@ func (c *AddCommand) Expand(expander SingleWordExpander) error {
 type CopyCommand struct {
 	withNameAndCode
 	SourcesAndDest
-	From  string
-	Chown string
-	Chmod string
-	Link  bool
+	From    string
+	Chown   string
+	Chmod   string
+	Link    bool
+	Parents bool // parents preserves directory structure
 }
 
 func (c *CopyCommand) Expand(expander SingleWordExpander) error {

--- a/frontend/dockerfile/instructions/parse.go
+++ b/frontend/dockerfile/instructions/parse.go
@@ -34,6 +34,8 @@ type parseRequest struct {
 var parseRunPreHooks []func(*RunCommand, parseRequest) error
 var parseRunPostHooks []func(*RunCommand, parseRequest) error
 
+var parentsEnabled = false
+
 func nodeArgs(node *parser.Node) []string {
 	result := []string{}
 	for ; node.Next != nil; node = node.Next {
@@ -315,6 +317,7 @@ func parseCopy(req parseRequest) (*CopyCommand, error) {
 	flFrom := req.flags.AddString("from", "")
 	flChmod := req.flags.AddString("chmod", "")
 	flLink := req.flags.AddBool("link", false)
+	flParents := req.flags.AddBool("parents", false)
 	if err := req.flags.Parse(); err != nil {
 		return nil, err
 	}
@@ -331,6 +334,7 @@ func parseCopy(req parseRequest) (*CopyCommand, error) {
 		Chown:           flChown.Value,
 		Chmod:           flChmod.Value,
 		Link:            flLink.Value == "true",
+		Parents:         (flParents.Value == "true") && parentsEnabled, // silently ignore if not -labs
 	}, nil
 }
 

--- a/frontend/dockerfile/instructions/parse_parents.go
+++ b/frontend/dockerfile/instructions/parse_parents.go
@@ -1,0 +1,8 @@
+//go:build dfparents
+// +build dfparents
+
+package instructions
+
+func init() {
+	parentsEnabled = true
+}

--- a/frontend/dockerfile/release/labs/tags
+++ b/frontend/dockerfile/release/labs/tags
@@ -1,1 +1,1 @@
-dfrunsecurity
+dfrunsecurity dfparents


### PR DESCRIPTION
`.parents_test.sh`:
```sh
#!/usr/bin/env sh
set -e

TMP_DIR=$(mktemp -dt parents_test.XXXXXXXX)

echo "Created \"$TMP_DIR\""
trap "echo \"Removing \\\"$TMP_DIR\\\"\"; rm -rf \"$TMP_DIR\"" EXIT

mkdir -p $TMP_DIR/src/dir1
mkdir -p $TMP_DIR/src/dir2/subdir2

touch $TMP_DIR/src/dir1/file1-1.py
touch $TMP_DIR/src/dir1/file1-2.go
touch $TMP_DIR/src/dir2/subdir2/file2-1.go
touch $TMP_DIR/src/dir2/subdir2/file2-2.js
touch $TMP_DIR/src/dir2/subdir2/file2-3.go

cat << DOCKERFILE > $TMP_DIR/dockerfile
# syntax=dyefimov/dockerfile:copy_parents-labs

FROM scratch

COPY ./src/*/*/*.go ./dst1/
COPY --parents ./src/*/*/*.go ./dst2/

CMD ["echo", "hello-world"]
DOCKERFILE

echo "======================================================="
SOCKET_DIR=$(realpath $(dirname $0))/.tmp
mkdir -p $SOCKET_DIR
sudo buildctl \
    --addr=unix://$SOCKET_DIR/buildkitd.socket \
    build \
        --frontend=dockerfile.v0 \
        --local context=$TMP_DIR \
        --local dockerfile=$TMP_DIR \
        --no-cache \
        --output=type=docker,name=parents_test | docker load

echo "======================================================="
echo "source:"
find $TMP_DIR -printf '%P\n' | grep -v '^[[:space:]]*$' | sort

echo "======================================================="
docker container rm -f parents_test > /dev/null 2>&1
docker container create --name=parents_test parents_test > /dev/null 2>&1
echo "COPY:"
docker container export parents_test | tar tf - | grep "dst1" | sed 's#^dst1/##' | grep -v '^[[:space:]]*$' | sort
echo "COPY --parents:"
docker container export parents_test | tar tf - | grep "dst2" | sed 's#^dst2/##' | grep -v '^[[:space:]]*$' | sort
docker container rm -f parents_test > /dev/null 2>&1

echo "======================================================="
```

`.parents_test.sh` output:
```sh
$ ./.parents_test.sh 
Created "/tmp/parents_test.KCR1qmQ3"
=======================================================
[+] Building 7.4s (8/8) FINISHED                                                                               
 => [internal] load build definition from Dockerfile                                                      0.0s
 => => transferring dockerfile: 196B                                                                      0.0s
 => [internal] load .dockerignore                                                                         0.0s
 => => transferring context: 2B                                                                           0.0s
 => resolve image config for docker.io/dyefimov/dockerfile:copy_parents-labs                              0.8s
 => CACHED docker-image://docker.io/dyefimov/dockerfile:copy_parents-labs@sha256:d610b759d921bc35515d468  0.0s
 => => resolve docker.io/dyefimov/dockerfile:copy_parents-labs@sha256:d610b759d921bc35515d468718f2609cd6  0.0s
 => [internal] load build context                                                                         0.0s
 => => transferring context: 185B                                                                         0.0s
 => [1/2] COPY ./src/*/*/*.go ./dst1/                                                                     2.6s
 => [2/2] COPY --parents ./src/*/*/*.go ./dst2/                                                           3.0s
 => exporting to oci image format                                                                         0.3s
 => => exporting layers                                                                                   0.3s
 => => exporting manifest sha256:24b4391d73d9094f6cd20457fdee6ac7fad2805988d095faabf6b9fe72ffacb6         0.0s
 => => exporting config sha256:5f6fa8bc19204a198bbb3b996f7fceb8a2674275b3182f7e804266ebc223c302           0.0s
 => => sending tarball                                                                                    0.0s
0fd58aaab3ea: Loading layer [==================================================>]     145B/145B
2fb6a3b6052f: Loading layer [==================================================>]     193B/193B
The image parents_test:latest already exists, renaming the old one with ID sha256:de30362eb4cd1c143121ff861bc844e83218abe87788889a4d707ef26209d363 to empty string
Loaded image: parents_test:latest
=======================================================
source:
dockerfile
src
src/dir1
src/dir1/file1-1.py
src/dir1/file1-2.go
src/dir2
src/dir2/subdir2
src/dir2/subdir2/file2-1.go
src/dir2/subdir2/file2-2.js
src/dir2/subdir2/file2-3.go
=======================================================
COPY:
file2-1.go
file2-3.go
COPY --parents:
src/
src/dir2/
src/dir2/subdir2/
src/dir2/subdir2/file2-1.go
src/dir2/subdir2/file2-3.go
=======================================================
Removing "/tmp/parents_test.KCR1qmQ3"
```

Signed-off-by: Dmitrii Efimov <5221640+DYefimov@users.noreply.github.com>