### PR TITLE
ignore if kill can't find pid that is already gone

### DIFF
--- a/examples/buildctl-daemonless/buildctl-daemonless.sh
+++ b/examples/buildctl-daemonless/buildctl-daemonless.sh
@@ -19,7 +19,7 @@ set -eu
 # * addr
 # * log
 tmp=$(mktemp -d /tmp/buildctl-daemonless.XXXXXX)
-trap "kill \$(cat $tmp/pid); wait \$(cat $tmp/pid) || true; rm -rf $tmp" EXIT
+trap "kill \$(cat $tmp/pid) || true; wait \$(cat $tmp/pid) || true; rm -rf $tmp" EXIT
 
 startBuildkitd() {
     addr=


### PR DESCRIPTION
we use [buildctl-daemonless.sh](https://github.com/moby/buildkit/blob/master/examples/buildctl-daemonless/buildctl-daemonless.sh) inside a [rootless-pod](https://github.com/moby/buildkit/blob/master/examples/kubernetes/pod.rootless.yaml) based on `moby/buildkit:master-rootless` to perform our builds and call it via a CI/CD tool, which returns a non-zero exit code, as the trap cannot kill the process, as it is already gone, in case everything went fine

so we need to catch the error code from kill, which tries to kill a process that doesn't exist anymore and the suggestion is to just add `|| true`, because we don't care about the exit code of kill

```
#17 DONE 4.2s
sh: can't kill pid 65: No such process
command terminated with exit code 1
```

not sure if this script is automatically baked in the moby/buildkit:master-rootless image or I need to do something else

Signed-off-by: Steve Lohr <schdief.law@gmail.com>