### PR TITLE
Add "sharing=locked" to Apt cache example

### DIFF
--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -894,10 +894,17 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 # syntax=docker/dockerfile:1
 FROM ubuntu
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt \
-  --mount=type=cache,target=/var/lib/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
   apt update && apt-get --no-install-recommends install -y gcc
 ```
+
+Apt needs exclusive access to its data, so the caches use the option
+`sharing=locked`, which will make sure multiple parallel builds using
+the same cache mount will wait for each other and not access the same
+cache files at the same time. You could also use `sharing=private` if
+you prefer to have each build create another cache directory in this
+case.
 
 ### RUN --mount=type=tmpfs
 


### PR DESCRIPTION
I was wondering how using `--mount=type=cache` for Apt data would work on a CI server where builds might happen in parallel, considering that just two parallel Apt commands on a desktop system won't work. I found my answers in moby/buildkit#1662 and moby/buildkit#455, and thought it might be useful to gather them in the reference for future users.