### PR TITLE
support .conflist CNI configs

### DIFF
--- a/util/network/cniprovider/cni.go
+++ b/util/network/cniprovider/cni.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"runtime"
+	"strings"
 
 	cni "github.com/containerd/go-cni"
 	"github.com/gofrs/flock"
@@ -35,7 +36,11 @@ func New(opt Opt) (network.Provider, error) {
 		cniOptions = append(cniOptions, cni.WithLoNetwork)
 	}
 
-	cniOptions = append(cniOptions, cni.WithConfFile(opt.ConfigPath))
+	if strings.HasSuffix(opt.ConfigPath, ".conflist") {
+		cniOptions = append(cniOptions, cni.WithConfListFile(opt.ConfigPath))
+	} else {
+		cniOptions = append(cniOptions, cni.WithConfFile(opt.ConfigPath))
+	}
 
 	cniHandle, err := cni.New(cniOptions...)
 	if err != nil {


### PR DESCRIPTION
👋 I'm using Buildkit's CNI support in a project of mine and found that I need to additionally configure the [`firewall` plugin](https://www.cni.dev/plugins/current/meta/firewall/), otherwise starting Docker seems to break network connectivity.

Configuring this plugin requires me to switch to a "chained CNI config" which is a special type of config:

* it has to be named `.conflist` in order for `cnitool` to recognize it as one
* it has to be passed to `go-cni` using `cni.WithConfListFile` rather than `cni.WithConfFile`

I opted to double down on `cnitool`'s behavior here to keep the distinction from bubbling up to separate fields in `buildkitd.toml`, but I'm happy to do that instead.