### PR TITLE
ci: align test flags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ env:
   CACHE_GHA_SCOPE_IT: "integration-tests"
   CACHE_GHA_SCOPE_BINARIES: "binaries"
   CACHE_GHA_SCOPE_CROSS: "cross"
+  TESTFLAGS: "-v --parallel=6 --timeout=30m"
   BUILDX_VERSION: "v0.8.2"  # leave empty to use the one available on GitHub virtual environment
 
 jobs:
@@ -112,7 +113,6 @@ jobs:
       -
         name: Test pkg=${{ matrix.pkg }} ; typ=${{ matrix.typ }} ; skipit=${{ matrix.skip-integration-tests }} ; worker=${{ matrix.worker }}
         run: |
-          export TESTFLAGS="-v --parallel=6 --timeout=20m"
           if [ -n "${{ matrix.worker }}" ]; then
             export TESTFLAGS="${TESTFLAGS} --run=//worker=${{ matrix.worker }}$"
           fi
@@ -190,7 +190,7 @@ jobs:
           SKIP_INTEGRATION_TESTS: 1
         run: |
           mkdir -p ./coverage
-          go test -coverprofile=./coverage/coverage-${{ github.job }}-${{ matrix.os }}.txt -covermode=atomic ./...
+          go test -coverprofile=./coverage/coverage-${{ github.job }}-${{ matrix.os }}.txt -covermode=atomic ${TESTFLAGS} ./...
         shell: bash
       -
         name: Upload coverage file

--- a/.github/workflows/dockerd.yml
+++ b/.github/workflows/dockerd.yml
@@ -17,6 +17,7 @@ env:
   REPO_SLUG_ORIGIN: "moby/buildkit:latest"
   CACHE_GHA_SCOPE_IT: "integration-tests"
   CACHE_GHA_SCOPE_BINARIES: "binaries"
+  TESTFLAGS: "-v --parallel=1 --timeout=30m"
   BUILDX_VERSION: "v0.8.2"  # leave empty to use the one available on GitHub virtual environment
 
 jobs:
@@ -141,6 +142,6 @@ jobs:
           TEST_DOCKERD: "1"
           TEST_DOCKERD_BINARY: "./build/dockerd"
           TESTPKGS: "${{ matrix.pkg }}"
-          TESTFLAGS: "-v --parallel=1 --timeout=30m --run=//worker=dockerd$"
+          TESTFLAGS: "${{ env.TESTFLAGS }} --run=//worker=dockerd$"
           SKIP_INTEGRATION_TESTS: "${{ matrix.skip-integration-tests }}"
           CACHE_FROM: "type=gha,scope=${{ env.CACHE_GHA_SCOPE_IT }} type=gha,scope=${{ env.CACHE_GHA_SCOPE_BINARIES }}"


### PR DESCRIPTION
follow-up https://github.com/moby/buildkit/pull/3024#issuecomment-1215501319

Align test flags for linux and windows runners.

I tested with an extended matrix for windows runners: https://github.com/crazy-max/buildkit/actions/runs/2866740805

* `windows-2019` / `go 1.18.1`: `github.com/moby/buildkit/util/flightcontrol	713.146s	coverage: 65.8% of statements`
* `windows-2022` / `go 1.18.1`: `github.com/moby/buildkit/util/flightcontrol	444.752s	coverage: 65.8% of statements`
* `windows-2019` / `go 1.18.2`: `github.com/moby/buildkit/util/flightcontrol	804.799s	coverage: 65.8% of statements`
* `windows-2022` / `go 1.18.2`: `github.com/moby/buildkit/util/flightcontrol	338.622s	coverage: 65.8% of statements`
* `windows-2019` / `go 1.18.3`: `github.com/moby/buildkit/util/flightcontrol	600.374s	coverage: 65.8% of statements`
* `windows-2022` / `go 1.18.3`: `github.com/moby/buildkit/util/flightcontrol	416.163s	coverage: 65.2% of statements`
* `windows-2019` / `go 1.18.4`: `github.com/moby/buildkit/util/flightcontrol	4.589s	coverage: 65.8% of statements`
* `windows-2022` / `go 1.18.4`: `github.com/moby/buildkit/util/flightcontrol	286.434s	coverage: 65.8% of statements`
* `windows-2019` / `go 1.18.5`: `github.com/moby/buildkit/util/flightcontrol	647.428s	coverage: 65.8% of statements`
* `windows-2022` / `go 1.18.5`: `github.com/moby/buildkit/util/flightcontrol	687.715s	coverage: 65.8% of statements`

And it seems to depend on the runner (workload?) and not Go or BuildKit.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>