### PR TITLE
ci: missing buildkitd debug flag for some steps

### DIFF
--- a/.github/workflows/buildx-image.yml
+++ b/.github/workflows/buildx-image.yml
@@ -48,6 +48,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
         with:
           version: ${{ env.BUILDX_VERSION }}
+          buildkitd-flags: --debug
       -
         name: Login to DockerHub
         if: github.event.inputs.dry-run != 'true'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -42,6 +42,7 @@ jobs:
         with:
           version: ${{ env.BUILDX_VERSION }}
           driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
+          buildkitd-flags: --debug
       -
         name: Run
         run: |


### PR DESCRIPTION
@jedevc found an issue with the frontend in the lint step: https://github.com/moby/buildkit/runs/7856267216?check_suite_focus=true#step:4:44

```
#5 DONE 4.8s
lint.Dockerfile:1
--------------------
   1 | >>> # syntax=docker/dockerfile-upstream:master
   2 |     
   3 |     FROM golang:1.18-alpine
--------------------
error: failed to solve: frontend grpc server closed unexpectedly
```

but debug logs are not available for this step unfortunately.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>