### PR TITLE
cni: set hostname as K8S_POD_NAME

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -293,7 +293,7 @@ func testBridgeNetworkingDNSNoRootless(t *testing.T, sb integration.Sandbox) {
 
 	client, err := llb.Image("busybox").
 		Run(
-			llb.Shlexf("sh -c 'until echo foo | nc " + name + ".dns.buildkit 1234 -w0; do sleep 0.1; done'"),
+			llb.Shlexf("sh -c 'until echo foo | nc " + name + " 1234 -w0; do sleep 0.1; done'"),
 		).
 		Marshal(sb.Context())
 	require.NoError(t, err)

--- a/executor/containerdexecutor/executor.go
+++ b/executor/containerdexecutor/executor.go
@@ -146,7 +146,7 @@ func (w *containerdExecutor) Run(ctx context.Context, id string, root executor.M
 	if !ok {
 		return errors.Errorf("unknown network mode %s", meta.NetMode)
 	}
-	namespace, err := provider.New()
+	namespace, err := provider.New(meta.Hostname)
 	if err != nil {
 		return err
 	}

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -161,7 +161,7 @@ func (w *runcExecutor) Run(ctx context.Context, id string, root executor.Mount, 
 	if !ok {
 		return errors.Errorf("unknown network mode %s", meta.NetMode)
 	}
-	namespace, err := provider.New()
+	namespace, err := provider.New(meta.Hostname)
 	if err != nil {
 		return err
 	}

--- a/hack/fixtures/dns-cni.conflist
+++ b/hack/fixtures/dns-cni.conflist
@@ -1,0 +1,28 @@
+{
+  "cniVersion": "0.4.0",
+  "name": "buildkitdns",
+  "plugins": [
+    {
+      "type": "bridge",
+      "bridge": "buildkitdns0",
+      "isDefaultGateway": true,
+      "ipMasq": true,
+      "hairpinMode": true,
+      "ipam": {
+        "type": "host-local",
+        "ranges": [
+          [
+            { "subnet": "10.11.0.0/16" }
+          ]
+        ]
+      }
+    },
+    {
+      "type": "firewall"
+    },
+    {
+      "type": "dnsname",
+      "domainName": "dns.buildkit"
+    }
+  ]
+}

--- a/util/network/cniprovider/cni.go
+++ b/util/network/cniprovider/cni.go
@@ -67,32 +67,42 @@ func (c *cniProvider) initNetwork() error {
 		}
 		defer l.Unlock()
 	}
-	ns, err := c.New()
+	ns, err := c.New("test")
 	if err != nil {
 		return err
 	}
 	return ns.Close()
 }
 
-func (c *cniProvider) New() (network.Namespace, error) {
+func (c *cniProvider) New(hostname string) (network.Namespace, error) {
 	id := identity.NewID()
 	nativeID, err := createNetNS(c, id)
 	if err != nil {
 		return nil, err
 	}
 
-	if _, err := c.CNI.Setup(context.TODO(), id, nativeID); err != nil {
+	nsOpts := []cni.NamespaceOpts{
+		// NB: K8S_POD_NAME is a semi-well-known arg set by k8s and podman and
+		// leveraged by the dnsname CNI plugin. a more generic name would be nice.
+		cni.WithArgs("K8S_POD_NAME", hostname),
+
+		// must be set for plugins that don't understand K8S_POD_NAME
+		cni.WithArgs("IgnoreUnknown", "1"),
+	}
+
+	if _, err := c.CNI.Setup(context.TODO(), id, nativeID, nsOpts...); err != nil {
 		deleteNetNS(nativeID)
 		return nil, errors.Wrap(err, "CNI setup error")
 	}
 
-	return &cniNS{nativeID: nativeID, id: id, handle: c.CNI}, nil
+	return &cniNS{nativeID: nativeID, id: id, handle: c.CNI, opts: nsOpts}, nil
 }
 
 type cniNS struct {
 	handle   cni.CNI
 	id       string
 	nativeID string
+	opts     []cni.NamespaceOpts
 }
 
 func (ns *cniNS) Set(s *specs.Spec) error {
@@ -100,7 +110,7 @@ func (ns *cniNS) Set(s *specs.Spec) error {
 }
 
 func (ns *cniNS) Close() error {
-	err := ns.handle.Remove(context.TODO(), ns.id, ns.nativeID)
+	err := ns.handle.Remove(context.TODO(), ns.id, ns.nativeID, ns.opts...)
 	if err1 := unmountNetNS(ns.nativeID); err1 != nil && err == nil {
 		err = err1
 	}

--- a/util/network/host.go
+++ b/util/network/host.go
@@ -15,7 +15,7 @@ func NewHostProvider() Provider {
 type host struct {
 }
 
-func (h *host) New() (Namespace, error) {
+func (h *host) New(hostname string) (Namespace, error) {
 	return &hostNS{}, nil
 }
 

--- a/util/network/network.go
+++ b/util/network/network.go
@@ -8,7 +8,7 @@ import (
 
 // Provider interface for Network
 type Provider interface {
-	New() (Namespace, error)
+	New(hostname string) (Namespace, error)
 }
 
 // Namespace of network for workers

--- a/util/network/none.go
+++ b/util/network/none.go
@@ -11,7 +11,7 @@ func NewNoneProvider() Provider {
 type none struct {
 }
 
-func (h *none) New() (Namespace, error) {
+func (h *none) New(hostname string) (Namespace, error) {
 	return &noneNS{}, nil
 }
 

--- a/util/testutil/integration/containerd.go
+++ b/util/testutil/integration/containerd.go
@@ -80,6 +80,10 @@ func (c *containerd) Name() string {
 	return c.name
 }
 
+func (c *containerd) Rootless() bool {
+	return c.uid != 0
+}
+
 func (c *containerd) New(ctx context.Context, cfg *BackendConfig) (b Backend, cl func() error, err error) {
 	if err := lookupBinary(c.containerd); err != nil {
 		return nil, nil, err

--- a/util/testutil/integration/dockerd.go
+++ b/util/testutil/integration/dockerd.go
@@ -35,6 +35,10 @@ func (c dockerd) Name() string {
 	return dockerdBinary
 }
 
+func (c dockerd) Rootless() bool {
+	return false
+}
+
 func (c dockerd) New(ctx context.Context, cfg *BackendConfig) (b Backend, cl func() error, err error) {
 	if err := requireRoot(); err != nil {
 		return nil, nil, err

--- a/util/testutil/integration/oci.go
+++ b/util/testutil/integration/oci.go
@@ -46,6 +46,10 @@ func (s *oci) Name() string {
 	return "oci"
 }
 
+func (s *oci) Rootless() bool {
+	return s.uid != 0
+}
+
 func (s *oci) New(ctx context.Context, cfg *BackendConfig) (Backend, func() error, error) {
 	if err := lookupBinary("buildkitd"); err != nil {
 		return nil, nil, err

--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -60,6 +60,7 @@ type BackendConfig struct {
 type Worker interface {
 	New(context.Context, *BackendConfig) (Backend, func() error, error)
 	Name() string
+	Rootless() bool
 }
 
 type ConfigUpdater interface {
@@ -166,6 +167,10 @@ func Run(t *testing.T, testCases []Test, opt ...TestOpt) {
 				name := fn + "/worker=" + br.Name() + mv.functionSuffix()
 				func(fn, testName string, br Worker, tc Test, mv matrixValue) {
 					ok := t.Run(testName, func(t *testing.T) {
+						if strings.Contains(fn, "NoRootless") && br.Rootless() {
+							// skip sandbox setup
+							t.Skip("rootless")
+						}
 						ctx := appcontext.Context()
 						if !strings.HasSuffix(fn, "NoParallel") {
 							t.Parallel()


### PR DESCRIPTION
This PR passes the hostname along to the network provider. The CNI provider sets it as `K8S_POD_NAME`, the rest ignore it.

My goal is to be able to use the [`dnsname` CNI plugin](https://github.com/containers/dnsname) for inter-container networking in Buildkit. Using DNS works great because it lets me keep non-reproducible values like IP addresses out of LLB, maximizing cache reuse for builds that depend on services.

The `dnsname` plugin uses the "container name" as its address, which it reads from an arg called `K8S_POD_NAME`. This arg seems to be used by other CNI plugins too. It's kind of a bummer that this arg name isn't something more generic. This plugin is actually designed for `podman` which sets the same arg; it seems to be a de-facto standard at this point. :/

The hostname seems like the closest thing to a "container name," and it seems reasonable for a network provider to be interested in the hostname, so I threaded the value through and called it done. I'm not married to this approach, but if it seems reasonable I can start working on a test for it.

I also considered adding support for arbitrary [CNI options](https://github.com/containerd/go-cni/blob/31de2455ae5d8bfc743572bfe73587ca7468f865/namespace_opts.go), since folks like me might want port mapping someday, but I'm not sure if y'all would want to commit to that (or even this, frankly).