### PR TITLE
fix bug that cann't recognize ONBUILD in schemaV1 img

### DIFF
--- a/exporter/containerimage/image/docker_image.go
+++ b/exporter/containerimage/image/docker_image.go
@@ -1,0 +1,55 @@
+package image
+
+import (
+	"time"
+
+	"github.com/docker/docker/api/types/strslice"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// HealthConfig holds configuration settings for the HEALTHCHECK feature.
+type HealthConfig struct {
+	// Test is the test to perform to check that the container is healthy.
+	// An empty slice means to inherit the default.
+	// The options are:
+	// {} : inherit healthcheck
+	// {"NONE"} : disable healthcheck
+	// {"CMD", args...} : exec arguments directly
+	// {"CMD-SHELL", command} : run command with system's default shell
+	Test []string `json:",omitempty"`
+
+	// Zero means to inherit. Durations are expressed as integer nanoseconds.
+	Interval    time.Duration `json:",omitempty"` // Interval is the time to wait between checks.
+	Timeout     time.Duration `json:",omitempty"` // Timeout is the time to wait before considering the check to have hung.
+	StartPeriod time.Duration `json:",omitempty"` // The start period for the container to initialize before the retries starts to count down.
+
+	// Retries is the number of consecutive failures needed to consider a container as unhealthy.
+	// Zero means inherit.
+	Retries int `json:",omitempty"`
+}
+
+// ImageConfig is a docker compatible config for an image
+type ImageConfig struct {
+	ocispecs.ImageConfig
+
+	Healthcheck *HealthConfig `json:",omitempty"` // Healthcheck describes how to check the container is healthy
+	ArgsEscaped bool          `json:",omitempty"` // True if command is already escaped (Windows specific)
+
+	//	NetworkDisabled bool                `json:",omitempty"` // Is network disabled
+	//	MacAddress      string              `json:",omitempty"` // Mac Address of the container
+	OnBuild     []string          // ONBUILD metadata that were defined on the image Dockerfile
+	StopTimeout *int              `json:",omitempty"` // Timeout (in seconds) to stop a container
+	Shell       strslice.StrSlice `json:",omitempty"` // Shell for shell-form of RUN, CMD, ENTRYPOINT
+}
+
+// Image is the JSON structure which describes some basic information about the image.
+// This provides the `application/vnd.oci.image.config.v1+json` mediatype when marshalled to JSON.
+type Image struct {
+	ocispecs.Image
+
+	// Config defines the execution parameters which should be used as a base when running a container using the image.
+	Config ImageConfig `json:"config,omitempty"`
+
+	// Variant defines platform variant. To be added to OCI.
+	Variant string `json:"variant,omitempty"`
+}

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/go-connections/nat"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/client/llb/imagemetaresolver"
+	"github.com/moby/buildkit/exporter/containerimage/image"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/moby/buildkit/frontend/dockerfile/shell"
@@ -1280,7 +1281,7 @@ func dispatchEntrypoint(d *dispatchState, c *instructions.EntrypointCommand) err
 }
 
 func dispatchHealthcheck(d *dispatchState, c *instructions.HealthCheckCommand) error {
-	d.image.Config.Healthcheck = &HealthConfig{
+	d.image.Config.Healthcheck = &image.HealthConfig{
 		Test:        c.Health.Test,
 		Interval:    c.Health.Interval,
 		Timeout:     c.Health.Timeout,

--- a/frontend/dockerfile/dockerfile2llb/image.go
+++ b/frontend/dockerfile/dockerfile2llb/image.go
@@ -1,59 +1,14 @@
 package dockerfile2llb
 
 import (
-	"time"
-
-	"github.com/docker/docker/api/types/strslice"
+	"github.com/moby/buildkit/exporter/containerimage/image"
 	"github.com/moby/buildkit/util/system"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// HealthConfig holds configuration settings for the HEALTHCHECK feature.
-type HealthConfig struct {
-	// Test is the test to perform to check that the container is healthy.
-	// An empty slice means to inherit the default.
-	// The options are:
-	// {} : inherit healthcheck
-	// {"NONE"} : disable healthcheck
-	// {"CMD", args...} : exec arguments directly
-	// {"CMD-SHELL", command} : run command with system's default shell
-	Test []string `json:",omitempty"`
-
-	// Zero means to inherit. Durations are expressed as integer nanoseconds.
-	Interval    time.Duration `json:",omitempty"` // Interval is the time to wait between checks.
-	Timeout     time.Duration `json:",omitempty"` // Timeout is the time to wait before considering the check to have hung.
-	StartPeriod time.Duration `json:",omitempty"` // The start period for the container to initialize before the retries starts to count down.
-
-	// Retries is the number of consecutive failures needed to consider a container as unhealthy.
-	// Zero means inherit.
-	Retries int `json:",omitempty"`
-}
-
-// ImageConfig is a docker compatible config for an image
-type ImageConfig struct {
-	ocispecs.ImageConfig
-
-	Healthcheck *HealthConfig `json:",omitempty"` // Healthcheck describes how to check the container is healthy
-	ArgsEscaped bool          `json:",omitempty"` // True if command is already escaped (Windows specific)
-
-	//	NetworkDisabled bool                `json:",omitempty"` // Is network disabled
-	//	MacAddress      string              `json:",omitempty"` // Mac Address of the container
-	OnBuild     []string          // ONBUILD metadata that were defined on the image Dockerfile
-	StopTimeout *int              `json:",omitempty"` // Timeout (in seconds) to stop a container
-	Shell       strslice.StrSlice `json:",omitempty"` // Shell for shell-form of RUN, CMD, ENTRYPOINT
-}
-
 // Image is the JSON structure which describes some basic information about the image.
 // This provides the `application/vnd.oci.image.config.v1+json` mediatype when marshalled to JSON.
-type Image struct {
-	ocispecs.Image
-
-	// Config defines the execution parameters which should be used as a base when running a container using the image.
-	Config ImageConfig `json:"config,omitempty"`
-
-	// Variant defines platform variant. To be added to OCI.
-	Variant string `json:"variant,omitempty"`
-}
+type Image image.Image
 
 func clone(src Image) Image {
 	img := src

--- a/util/imageutil/schema1.go
+++ b/util/imageutil/schema1.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/remotes"
+	"github.com/moby/buildkit/exporter/containerimage/image"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -44,7 +45,7 @@ func convertSchema1ConfigMeta(in []byte) ([]byte, error) {
 		return nil, errors.Errorf("invalid schema1 manifest")
 	}
 
-	var img ocispecs.Image
+	var img image.Image
 	if err := json.Unmarshal([]byte(m.History[0].V1Compatibility), &img); err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal image from schema 1 history")
 	}

--- a/util/imageutil/schema1_test.go
+++ b/util/imageutil/schema1_test.go
@@ -1,0 +1,35 @@
+package imageutil
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestConvertSchema1ConfigMeta(t *testing.T) {
+	dt := []byte(`{
+	"schemaVersion": 1,
+	"name": "base-global/common",
+	"tag": "1.0.9.zb.standard",
+	"architecture": "amd64",
+	"fsLayers": [
+		{
+			"blobSum": "sha256:id1"
+		}
+	],
+	"history": [
+		{
+			"v1Compatibility": "{\"id\":\"id2\",\"parent\":\"id3\",\"created\":\"2018-07-26T11:56:23.157525618Z\",\"config\":{\"Hostname\":\"4f3d4451\",\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":null,\"Volumes\":{},\"OnBuild\":[\"ARG APP_NAME\",\"COPY ${APP_NAME}.tgz /home/admin/${APP_NAME}/target/${APP_NAME}.tgz\"],\"Labels\":{}},\"architecture\":\"amd64\",\"os\":\"linux\"}"
+		}
+	]
+}`)
+	result, err := convertSchema1ConfigMeta(dt)
+	if err != nil {
+		t.Errorf("convertSchema1ConfigMeta error %v", err)
+		return
+	}
+	if !bytes.Contains(result, []byte("OnBuild")) {
+		t.Errorf("convertSchema1ConfigMeta lost onbuild")
+	} else if !bytes.Contains(result, []byte("COPY ${APP_NAME}.tgz /home/admin/${APP_NAME}/target/${APP_NAME}.tg")) {
+		t.Errorf("convertSchema1ConfigMeta lost onbuild content")
+	}
+}


### PR DESCRIPTION
fix bug #3052

Original `convertSchema1ConfigMeta` fuction using
the wrong `ocispec.Image` type to unmarshal schemaV1
image config, Which miss OnBbuild field, the correct
`Image` type was defined in `frontend/dockerfile/dockerfile2llb/image.go`,
I move its definition to `exporter/containerimage/image`, then both 
package `util/imageutil` and `frontend/dockerfile` could 
use the correct `Image` type.

Signed-off-by: frank yang <yyb196@gmail.com>