### PR TITLE
Solve panic due to concurrent access to ExportSpans

### DIFF
--- a/util/tracing/detect/threadsafe.go
+++ b/util/tracing/detect/threadsafe.go
@@ -1,0 +1,26 @@
+package detect
+
+import (
+	"context"
+	"sync"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// threadSafeExporterWrapper wraps an OpenTelemetry SpanExporter and makes it thread-safe.
+type threadSafeExporterWrapper struct {
+	mu       sync.Mutex
+	exporter sdktrace.SpanExporter
+}
+
+func (tse *threadSafeExporterWrapper) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpan) error {
+	tse.mu.Lock()
+	defer tse.mu.Unlock()
+	return tse.exporter.ExportSpans(ctx, spans)
+}
+
+func (tse *threadSafeExporterWrapper) Shutdown(ctx context.Context) error {
+	tse.mu.Lock()
+	defer tse.mu.Unlock()
+	return tse.exporter.Shutdown(ctx)
+}


### PR DESCRIPTION
**Background:**
After enabling Open Telemetry export to Jaeger using the `JAEGER_TRACE` env var, started seeing occasional panics across our fleet of `buildkitd` containers. A [helpful pointer](https://github.com/open-telemetry/opentelemetry-go/issues/3063#issuecomment-1205459214) from the people at the OpenTelemetry Go repo indicated a possible concurrency problem. Wrapping the `ExportSpans` with a mutex solved the problem completely.

**Issue:** https://github.com/moby/buildkit/issues/3004

**Testing:** Before this fix, would get several panics a day. After, have gone for several weeks without any panics.
I've also run the suggested tests: `./hack/test integration gateway dockerfile`.
