### PR TITLE
Force oci-mediatypes for containerimage outputs that utilize annotations

### DIFF
--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -78,8 +78,7 @@ func (e *imageExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 			RefCfg: cacheconfig.RefConfig{
 				Compression: compression.New(compression.Default),
 			},
-			BuildInfo:   true,
-			Annotations: make(AnnotationsGroup),
+			BuildInfo: true,
 		},
 		store: true,
 	}
@@ -210,7 +209,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 	if err != nil {
 		return nil, err
 	}
-	opts.Annotations = as.Merge(opts.Annotations)
+	opts.AddAnnotations(as)
 
 	ctx, done, err := leaseutil.WithLease(ctx, e.opt.LeaseManager, leaseutil.MakeTemporary)
 	if err != nil {

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -99,12 +99,16 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 		return mfstDesc, nil
 	}
 
-	refCount := len(p.Platforms)
+	attestCount := 0
 	for _, attests := range inp.Attestations {
-		refCount += len(attests)
+		attestCount += len(attests)
 	}
-	if refCount != len(inp.Refs) {
-		return nil, errors.Errorf("number of required refs does not match references %d %d", refCount, len(inp.Refs))
+	if count := attestCount + len(p.Platforms); count != len(inp.Refs) {
+		return nil, errors.Errorf("number of required refs does not match references %d %d", count, len(inp.Refs))
+	}
+
+	if attestCount > 0 {
+		opts.EnableOCITypes("attestations")
 	}
 
 	refs := make([]cache.ImmutableRef, 0, len(inp.Refs))

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -57,9 +57,8 @@ func (e *imageExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 			RefCfg: cacheconfig.RefConfig{
 				Compression: compression.New(compression.Default),
 			},
-			BuildInfo:   true,
-			OCITypes:    e.opt.Variant == VariantOCI,
-			Annotations: make(containerimage.AnnotationsGroup),
+			BuildInfo: true,
+			OCITypes:  e.opt.Variant == VariantOCI,
 		},
 	}
 
@@ -110,7 +109,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 	if err != nil {
 		return nil, err
 	}
-	opts.Annotations = as.Merge(opts.Annotations)
+	opts.AddAnnotations(as)
 
 	ctx, done, err := leaseutil.WithLease(ctx, e.opt.LeaseManager, leaseutil.MakeTemporary)
 	if err != nil {

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -3954,14 +3954,14 @@ COPY --from=base arch /
 	desc, provider, err := contentutil.ProviderFromRef(target + "-img")
 	require.NoError(t, err)
 
-	imgMap, err := testutil.ReadIndex(sb.Context(), provider, desc)
+	imgs, err := testutil.ReadImages(sb.Context(), provider, desc)
 	require.NoError(t, err)
 
-	require.Equal(t, 2, len(imgMap))
+	require.Equal(t, 2, len(imgs.Images))
 
-	require.Equal(t, "amd64", string(imgMap.Find("linux/amd64").Layers[1]["arch"].Data))
-	dtamd := imgMap.Find("linux/amd64").Layers[0]["unique"].Data
-	dtarm := imgMap.Find("linux/arm/v7").Layers[0]["unique"].Data
+	require.Equal(t, "amd64", string(imgs.Find("linux/amd64").Layers[1]["arch"].Data))
+	dtamd := imgs.Find("linux/amd64").Layers[0]["unique"].Data
+	dtarm := imgs.Find("linux/arm/v7").Layers[0]["unique"].Data
 	require.NotEqual(t, dtamd, dtarm)
 
 	for i := 0; i < 2; i++ {
@@ -3994,14 +3994,14 @@ COPY --from=base arch /
 
 		require.Equal(t, desc.Digest, desc2.Digest)
 
-		imgMap, err = testutil.ReadIndex(sb.Context(), provider, desc2)
+		imgs, err = testutil.ReadImages(sb.Context(), provider, desc2)
 		require.NoError(t, err)
 
-		require.Equal(t, 2, len(imgMap))
+		require.Equal(t, 2, len(imgs.Images))
 
-		require.Equal(t, "arm", string(imgMap.Find("linux/arm/v7").Layers[1]["arch"].Data))
-		dtamd2 := imgMap.Find("linux/amd64").Layers[0]["unique"].Data
-		dtarm2 := imgMap.Find("linux/arm/v7").Layers[0]["unique"].Data
+		require.Equal(t, "arm", string(imgs.Find("linux/arm/v7").Layers[1]["arch"].Data))
+		dtamd2 := imgs.Find("linux/amd64").Layers[0]["unique"].Data
+		dtarm2 := imgs.Find("linux/arm/v7").Layers[0]["unique"].Data
 		require.Equal(t, string(dtamd), string(dtamd2))
 		require.Equal(t, string(dtarm), string(dtarm2))
 	}


### PR DESCRIPTION
Follow up to #2935, dependent on #3038.

The new annotations and attestations features both utilize annotations in the OCI image format. Many registries allow setting these annotation fields on docker formats, however, notably, GCR will reject these objects (see https://github.com/moby/buildkit/pull/1730) and only allow them for OCI media types.
    
To work around this, we enable oci-mediatypes when annotations that require OCI are enabled by the user, printing a warning to the user, similar to how we already do for stargz compression.

In the long-term, we should want to look at switching the default for oci-mediatypes to `true`, so enabling this for users who want to use the new annotations and attestations is a good way to test drive this, and try to catch any potential issues that might arise.