### PR TITLE
Fix no-newline-at-end-of-RUN output issue

### DIFF
--- a/util/progress/progressui/printer.go
+++ b/util/progress/progressui/printer.go
@@ -170,10 +170,10 @@ func (p *textMux) printVtx(t *trace, dgst digest.Digest) {
 		p.current = ""
 		v.count = 0
 
+		if v.logsPartial {
+			fmt.Fprintln(p.w, "")
+		}
 		if v.Error != "" {
-			if v.logsPartial {
-				fmt.Fprintln(p.w, "")
-			}
 			if strings.HasSuffix(v.Error, context.Canceled.Error()) {
 				fmt.Fprintf(p.w, "#%d CANCELED\n", v.index)
 			} else {


### PR DESCRIPTION
This edge case was already handled for `CANCELED` or `ERROR`, but not `DONE` (or `CACHED`, which shouldn't have logs, but 🤷).

Before:

```console
$ docker buildx build --progress=plain --no-cache - <<<$'FROM bash\nRUN echo -n no newline'
...
#5 [2/2] RUN echo -n no newline
#5 0.268 no newline#5 DONE 0.3s
...
```

After:

```console
$ docker buildx build --progress=plain --no-cache - <<<$'FROM bash\nRUN echo -n no newline'
...
#5 [2/2] RUN echo -n no newline
#5 0.268 no newline
#5 DONE 0.3s
...
```