### PR TITLE
llbsolver: increase test timeout for mount lock tests

### DIFF
--- a/solver/llbsolver/mounts/mount_test.go
+++ b/solver/llbsolver/mounts/mount_test.go
@@ -304,7 +304,7 @@ func TestCacheMountLockedRefs(t *testing.T) {
 
 	select {
 	case <-gotRef4:
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(2 * time.Second):
 		require.FailNow(t, "mount did not unlock")
 	}
 }


### PR DESCRIPTION
Follow up to https://github.com/moby/buildkit/pull/3031: some tests have a hardcoded time delay in them, so timeouts need to be increased there as well.

The `TestCacheMountLockedRefs` seems to often fail on windows, see an [example](https://github.com/moby/buildkit/runs/8095275332?check_suite_focus=true#step:5:974)). Hopefully no other tests should need increasing.