### PR TITLE
mount empty secrets

### DIFF
--- a/solver/llbsolver/mounts/mount.go
+++ b/solver/llbsolver/mounts/mount.go
@@ -258,7 +258,7 @@ func (mm *MountManager) getSecretMountable(ctx context.Context, m *pb.Mount, g s
 		}
 		return nil
 	})
-	if err != nil || dt == nil {
+	if err != nil {
 		return nil, err
 	}
 	return &secretMount{mount: m, data: dt, idmap: mm.cm.IdentityMapping()}, nil


### PR DESCRIPTION
This is a somewhat pedantic edge case, but I think we should create the mount point for secret files even if the source secret file is empty.  Otherwise, it is hard to debug why secrets are not showing up when requested in the LLB.  Currently, they are just silently ignored which was pretty confusing and caused me to waste time debugging my pipeline only to finally realize my secrets were corrupt and empty.

If allowing an empty secret mount is not acceptable, perhaps we could just add a warning to the buildkit log to indicate we are ignoring the empty mount, although I suspect other users might not have ready access to the buildkit logs and maybe continue to be confused like me.