### PR TITLE
dockerfile: allow heredocs for CMD instruction

### DIFF
--- a/frontend/dockerfile/parser/parser.go
+++ b/frontend/dockerfile/parser/parser.go
@@ -132,6 +132,7 @@ var (
 	// Directives allowed to contain heredocs
 	heredocDirectives = map[string]bool{
 		command.Add:  true,
+		command.Cmd:  true,
 		command.Copy: true,
 		command.Run:  true,
 	}


### PR DESCRIPTION
Revisits https://github.com/moby/buildkit/pull/2265, introducing support for using heredocs for the `CMD` instruction 

I came across a use case for this in #2773. In prototyping [jedevc/buildkit-syft-scanner](https://github.com/jedevc/buildkit-syft-scanner/blob/master/Dockerfile), the last couple of commands were always `COPY` and then set the `CMD` to the created script - the heredoc syntax simplifies this:

```
COPY <<-"EOF" /scan-script.sh
	#!/bin/sh
	...
EOF
CMD sh /scan-script.sh
```

Heredocs here work identically to the heredocs for RUN, with a couple of differences for shebang scripts:

- We create a new layer writing the script contents to `/mnt/pipes/`

  Usually `CMD` does not create a new layer, however, the file is required  to run the script as we would with `RUN`, since we want to avoid manual parsing of the shebang line.

- We have to use `/mnt/pipes` instead of `/dev/pipes`, since `/dev/pipes` is mounted at runtime.

Tests would be needed for this, but will hold off until getting some feedback first :smile: