### PR TITLE
[reference.md] remove duplicate entry from `different ENTRYPOINT / CMD combinations` table

### DIFF
--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -2044,7 +2044,6 @@ The table below shows what command is executed for different `ENTRYPOINT` / `CMD
 |:-------------------------------|:---------------------------|:-------------------------------|:-----------------------------------------------|
 | **No CMD**                     | *error, not allowed*       | /bin/sh -c exec_entry p1_entry | exec_entry p1_entry                            |
 | **CMD ["exec_cmd", "p1_cmd"]** | exec_cmd p1_cmd            | /bin/sh -c exec_entry p1_entry | exec_entry p1_entry exec_cmd p1_cmd            |
-| **CMD ["p1_cmd", "p2_cmd"]**   | p1_cmd p2_cmd              | /bin/sh -c exec_entry p1_entry | exec_entry p1_entry p1_cmd p2_cmd              |
 | **CMD exec_cmd p1_cmd**        | /bin/sh -c exec_cmd p1_cmd | /bin/sh -c exec_entry p1_entry | exec_entry p1_entry /bin/sh -c exec_cmd p1_cmd |
 
 > **Note**


### PR DESCRIPTION
I see 2nd and 3rd row deliver same meaning in `different ENTRYPOINT / CMD combinations:` table, hence one can be deleted to not confuse people.

Also last row contradicts below line from [CMD](https://docs.docker.com/engine/reference/builder/#cmd):

If CMD is used to provide default arguments for the ENTRYPOINT instruction, both the CMD and ENTRYPOINT instructions should be specified with the JSON array format. 

In last row of the table, CMD is not in JSON array format.

Please clarify/suggest what is correct behaviour. I can add suggested changes to this PR.

Signed-off-by: Jitender Kumar <jitender.kumar@intel.com>