### PR TITLE
docs(dockerfile): BuildKit does not discard Volume edits

### DIFF
--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -2094,7 +2094,8 @@ Keep the following things in mind about volumes in the `Dockerfile`.
   - a drive other than `C:`
 
 - **Changing the volume from within the Dockerfile**: If any build steps change the
-  data within the volume after it has been declared, those changes will be discarded.
+  data within the volume after it has been declared, those changes will be discarded
+  when using the legacy builder. When using Buildkit, the changes will instead be kept.
 
 - **JSON formatting**: The list is parsed as a JSON array.
   You must enclose words with double quotes (`"`) rather than single quotes (`'`).


### PR DESCRIPTION
A quick fix for https://github.com/moby/moby/issues/3639#issuecomment-482098988

Signed-off-by: Erik Sjölund <erik.sjolund@gmail.com>

