### PR TITLE
[v0.10 backport] frontend: fix Healthcheck intervals and retries not accepting default values

### DIFF
--- a/frontend/dockerfile/instructions/parse.go
+++ b/frontend/dockerfile/instructions/parse.go
@@ -37,7 +37,7 @@ func nodeArgs(node *parser.Node) []string {
 		if len(arg.Children) == 0 {
 			result = append(result, arg.Value)
 		} else if len(arg.Children) == 1 {
-			//sub command
+			// sub command
 			result = append(result, arg.Children[0].Value)
 			result = append(result, nodeArgs(arg.Children[0])...)
 		}
@@ -502,6 +502,9 @@ func parseOptInterval(f *Flag) (time.Duration, error) {
 	d, err := time.ParseDuration(s)
 	if err != nil {
 		return 0, err
+	}
+	if d == 0 {
+		return 0, nil
 	}
 	if d < container.MinimumDuration {
 		return 0, fmt.Errorf("Interval %#v cannot be less than %s", f.name, container.MinimumDuration)

--- a/frontend/dockerfile/instructions/parse.go
+++ b/frontend/dockerfile/instructions/parse.go
@@ -580,8 +580,8 @@ func parseHealthcheck(req parseRequest) (*HealthCheckCommand, error) {
 			if err != nil {
 				return nil, err
 			}
-			if retries < 1 {
-				return nil, fmt.Errorf("--retries must be at least 1 (not %d)", retries)
+			if retries < 0 {
+				return nil, fmt.Errorf("--retries cannot be negative (%d)", retries)
 			}
 			healthcheck.Retries = int(retries)
 		} else {

--- a/frontend/dockerfile/instructions/parse_test.go
+++ b/frontend/dockerfile/instructions/parse_test.go
@@ -136,6 +136,10 @@ func TestParseOptInterval(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "cannot be less than 1ms")
 
+	flInterval.Value = "0ms"
+	_, err = parseOptInterval(flInterval)
+	require.NoError(t, err)
+
 	flInterval.Value = "1ms"
 	_, err = parseOptInterval(flInterval)
 	require.NoError(t, err)

--- a/frontend/dockerfile/parser/testfiles/health/Dockerfile
+++ b/frontend/dockerfile/parser/testfiles/health/Dockerfile
@@ -8,3 +8,4 @@ HEALTHCHECK CMD
 HEALTHCHECK   CMD   a b
 HEALTHCHECK --timeout=3s CMD ["foo"]
 HEALTHCHECK CONNECT TCP 7000
+HEALTHCHECK --start-period=0s --interval=5s --timeout=0s --retries=0 CMD ["foo"]

--- a/frontend/dockerfile/parser/testfiles/health/result
+++ b/frontend/dockerfile/parser/testfiles/health/result
@@ -7,3 +7,4 @@
 (healthcheck "CMD" "a b")
 (healthcheck ["--timeout=3s"] "CMD" "foo")
 (healthcheck "CONNECT" "TCP 7000")
+(healthcheck ["--start-period=0s" "--interval=5s" "--timeout=0s" "--retries=0"] "CMD" "foo")


### PR DESCRIPTION
- backport of https://github.com/moby/buildkit/pull/3092
- fixes https://github.com/docker/cli/issues/3771


### frontend: allow 0 (default) value for healthcheck intervals

While these intervals have a minimum value when set:

    // MinimumDuration puts a minimum on user configured duration.
    // This is to prevent API error on time unit. For example, API may
    // set 3 as healthcheck interval with intention of 3 seconds, but
    // Docker interprets it as 3 nanoseconds.
    const MinimumDuration = 1 * time.Millisecond

It should be possible to set them to `0` (which is teh default). This patch
updates the Dockerfile parser to use the same logic as the docker daemon uses;

    if healthConfig.StartPeriod != 0 && healthConfig.StartPeriod < containertypes.MinimumDuration {
        return errors.Errorf("StartPeriod in Healthcheck cannot be less than %s", containertypes.MinimumDuration)
    }

### frontend: allow 0 (default) value for healthcheck retries

0 is the default value, so should be ok to explicitly use.