### PR TITLE
integration: skip for dockerd

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ env:
   CACHE_GHA_SCOPE_BINARIES: "binaries"
   CACHE_GHA_SCOPE_CROSS: "cross"
   TESTFLAGS: "-v --parallel=6 --timeout=30m"
-  BUILDX_VERSION: "v0.8.2"  # leave empty to use the one available on GitHub virtual environment
+  BUILDX_VERSION: "v0.9.1"  # leave empty to use the one available on GitHub virtual environment
   GO_VERSION: "1.19"
 
 jobs:

--- a/.github/workflows/buildx-image.yml
+++ b/.github/workflows/buildx-image.yml
@@ -31,7 +31,7 @@ on:
 
 env:
   REPO_SLUG_TARGET: "moby/buildkit"
-  BUILDX_VERSION: "v0.8.2"  # leave empty to use the one available on GitHub virtual environment
+  BUILDX_VERSION: "v0.9.1"  # leave empty to use the one available on GitHub virtual environment
 
 jobs:
   create:

--- a/.github/workflows/dockerd.yml
+++ b/.github/workflows/dockerd.yml
@@ -18,7 +18,7 @@ env:
   CACHE_GHA_SCOPE_IT: "integration-tests"
   CACHE_GHA_SCOPE_BINARIES: "binaries"
   TESTFLAGS: "-v --parallel=1 --timeout=30m"
-  BUILDX_VERSION: "v0.8.2"  # leave empty to use the one available on GitHub virtual environment
+  BUILDX_VERSION: "v0.9.1"  # leave empty to use the one available on GitHub virtual environment
 
 jobs:
   prepare:

--- a/.github/workflows/dockerd.yml
+++ b/.github/workflows/dockerd.yml
@@ -1,9 +1,5 @@
 name: dockerd
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 on:
   # TODO: add event to build on command in PR (e.g., /test-dockerd)
   workflow_dispatch:

--- a/.github/workflows/dockerd.yml
+++ b/.github/workflows/dockerd.yml
@@ -57,12 +57,12 @@ jobs:
           target: binary
           outputs: /tmp/moby
       -
-        # FIXME: remove symlink and rename bin. should be fixed upstream on moby.
         name: Rename binary
         if: steps.build.outputs.result == 'true'
         run: |
-          rm /tmp/moby/binary-daemon/dockerd
-          mv /tmp/moby/binary-daemon/dockerd-dev /tmp/moby/binary-daemon/dockerd
+          if [ -L "/tmp/moby/binary-daemon/dockerd" ]; then
+            mv -f $(readlink /tmp/moby/binary-daemon/dockerd) /tmp/moby/binary-daemon/dockerd
+          fi
       -
         name: Download
         if: steps.build.outputs.result != 'true'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,7 +19,7 @@ on:
 
 env:
   REPO_SLUG_ORIGIN: "moby/buildkit:latest"
-  BUILDX_VERSION: "v0.8.2"  # leave empty to use the one available on GitHub virtual environment
+  BUILDX_VERSION: "v0.9.1"  # leave empty to use the one available on GitHub virtual environment
 
 jobs:
   validate:

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1621,6 +1621,7 @@ func testLocalSourceWithDiffer(t *testing.T, sb integration.Sandbox, d llb.DiffT
 }
 
 func testOCILayoutSource(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerd(t, sb, "oci exporter")
 	requiresLinux(t)
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
@@ -1717,6 +1718,7 @@ func testOCILayoutSource(t *testing.T, sb integration.Sandbox) {
 }
 
 func testOCILayoutPlatformSource(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerd(t, sb, "oci exporter")
 	requiresLinux(t)
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
@@ -6086,6 +6088,7 @@ func testPullWithLayerLimit(t *testing.T, sb integration.Sandbox) {
 }
 
 func testCallInfo(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerd(t, sb, "not implemented")
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -6094,6 +6097,7 @@ func testCallInfo(t *testing.T, sb integration.Sandbox) {
 }
 
 func testExportAnnotations(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerd(t, sb, "oci exporter")
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -5264,6 +5264,7 @@ RUN echo hello
 }
 
 func testNamedImageContextTimestamps(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerd(t, sb, "direct push")
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())
@@ -5411,6 +5412,7 @@ COPY --from=base /o* /
 }
 
 func testNamedOCILayoutContext(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerd(t, sb, "oci exporter")
 	// how this test works:
 	// 1- we use a regular builder with a dockerfile to create an image two files: "out" with content "first", "out2" with content "second"
 	// 2- we save the output to an OCI layout dir


### PR DESCRIPTION
Carry changes from https://github.com/moby/buildkit/pull/3003 related to missing skip tests for dockerd worker. Also removes concurrency check in dockerd workflow otherwise we can only trigger one run at a time.