### PR TITLE
exporter/containerimage/image: Image: remove custom Variant field

### DIFF
--- a/exporter/containerimage/image/docker_image.go
+++ b/exporter/containerimage/image/docker_image.go
@@ -49,7 +49,4 @@ type Image struct {
 
 	// Config defines the execution parameters which should be used as a base when running a container using the image.
 	Config ImageConfig `json:"config,omitempty"`
-
-	// Variant defines platform variant. To be added to OCI.
-	Variant string `json:"variant,omitempty"`
 }

--- a/frontend/dockerfile/dockerfile2llb/image.go
+++ b/frontend/dockerfile/dockerfile2llb/image.go
@@ -24,8 +24,8 @@ func emptyImage(platform ocispecs.Platform) Image {
 		Image: ocispecs.Image{
 			Architecture: platform.Architecture,
 			OS:           platform.OS,
+			Variant:      platform.Variant,
 		},
-		Variant: platform.Variant,
 	}
 	img.RootFS.Type = "layers"
 	img.Config.WorkingDir = "/"


### PR DESCRIPTION
The OCI image spec now supports has a Variant field, so this custom field is no longer needed.
