### PR TITLE
Update uses of Image platform fields in OCI image-spec

### DIFF
--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -530,11 +530,10 @@ func (ic *ImageWriter) Applier() diff.Applier {
 func defaultImageConfig() ([]byte, error) {
 	pl := platforms.Normalize(platforms.DefaultSpec())
 
-	img := ocispecs.Image{
-		Architecture: pl.Architecture,
-		OS:           pl.OS,
-		Variant:      pl.Variant,
-	}
+	img := ocispecs.Image{}
+	img.Architecture = pl.Architecture
+	img.OS = pl.OS
+	img.Variant = pl.Variant
 	img.RootFS.Type = "layers"
 	img.Config.WorkingDir = "/"
 	img.Config.Env = []string{"PATH=" + system.DefaultPathEnv(pl.OS)}
@@ -543,13 +542,12 @@ func defaultImageConfig() ([]byte, error) {
 }
 
 func attestationsConfig(layers []ocispecs.Descriptor) ([]byte, error) {
-	img := ocispecs.Image{
-		Architecture: intotoPlatform.Architecture,
-		OS:           intotoPlatform.OS,
-		OSVersion:    intotoPlatform.OSVersion,
-		OSFeatures:   intotoPlatform.OSFeatures,
-		Variant:      intotoPlatform.Variant,
-	}
+	img := ocispecs.Image{}
+	img.Architecture = intotoPlatform.Architecture
+	img.OS = intotoPlatform.OS
+	img.OSVersion = intotoPlatform.OSVersion
+	img.OSFeatures = intotoPlatform.OSFeatures
+	img.Variant = intotoPlatform.Variant
 	img.RootFS.Type = "layers"
 	for _, layer := range layers {
 		img.RootFS.DiffIDs = append(img.RootFS.DiffIDs, digest.Digest(layer.Annotations["containerd.io/uncompressed"]))

--- a/frontend/dockerfile/dockerfile2llb/image.go
+++ b/frontend/dockerfile/dockerfile2llb/image.go
@@ -16,13 +16,10 @@ func clone(src image.Image) image.Image {
 }
 
 func emptyImage(platform ocispecs.Platform) image.Image {
-	img := image.Image{
-		Image: ocispecs.Image{
-			Architecture: platform.Architecture,
-			OS:           platform.OS,
-			Variant:      platform.Variant,
-		},
-	}
+	img := image.Image{}
+	img.Architecture = platform.Architecture
+	img.OS = platform.OS
+	img.Variant = platform.Variant
 	img.RootFS.Type = "layers"
 	img.Config.WorkingDir = "/"
 	img.Config.Env = []string{"PATH=" + system.DefaultPathEnv(platform.OS)}


### PR DESCRIPTION
The OCI image spec is considering to change the Image struct and embedding the
Platform type (see [opencontainers/image-spec#959](https://github.com/opencontainers/image-spec/pull/949)) in the go implementation.
BuildKit currently uses some struct-literals to propagate the platform fields,
which will break once those changes in the OCI spec are merged.

Ideally (once that change arrives) we would update the code to set the Platform
information as a whole, instead of assigning related fields individually, but
in some cases in the code, image platform information is only partially set
(for example, OSVersion and OSFeatures are not preserved in all cases). This
may be on purpose, so needs to be reviewed.

This patch keeps the current behavior (assigning only specific fields), but
removes the use of struct-literals to make the code compatible with the
upcoming changes in the image-spec module.


### NOTE:

I added cherry-pick labels for this, to prevent issues for projects that depend _both_ on BuildKit and other projects that may be using the image-spec, which (through go modules) may force them to update the image-spec version to a version with the linked patch.