### PR TITLE
[0.8] Update uses of Image platform fields in OCI image-spec

### DIFF
--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -315,13 +315,10 @@ func emptyImageConfig() ([]byte, error) {
 		Variant string `json:"variant,omitempty"`
 	}
 
-	img := image{
-		Image: ocispec.Image{
-			Architecture: pl.Architecture,
-			OS:           pl.OS,
-		},
-		Variant: pl.Variant,
-	}
+	img := image{}
+	img.Architecture = pl.Architecture
+	img.OS = pl.OS
+	img.Variant = pl.Variant
 	img.RootFS.Type = "layers"
 	img.Config.WorkingDir = "/"
 	img.Config.Env = []string{"PATH=" + system.DefaultPathEnv(pl.OS)}

--- a/frontend/dockerfile/dockerfile2llb/image.go
+++ b/frontend/dockerfile/dockerfile2llb/image.go
@@ -65,13 +65,10 @@ func clone(src Image) Image {
 }
 
 func emptyImage(platform specs.Platform) Image {
-	img := Image{
-		Image: specs.Image{
-			Architecture: platform.Architecture,
-			OS:           platform.OS,
-		},
-		Variant: platform.Variant,
-	}
+	img := Image{}
+	img.Architecture = platform.Architecture
+	img.OS = platform.OS
+	img.Variant = platform.Variant
 	img.RootFS.Type = "layers"
 	img.Config.WorkingDir = "/"
 	img.Config.Env = []string{"PATH=" + system.DefaultPathEnv(platform.OS)}


### PR DESCRIPTION
- equivalent of https://github.com/moby/buildkit/pull/3104 on master

The OCI image spec is considering to change the Image struct and embedding the Platform type (see opencontainers/image-spec#959) in the go implementation. BuildKit currently uses some struct-literals to propagate the platform fields, which will break once those changes in the OCI spec are merged.

Ideally (once that change arrives) we would update the code to set the Platform information as a whole, instead of assigning related fields individually, but in some cases in the code, image platform information is only partially set (for example, OSVersion and OSFeatures are not preserved in all cases). This may be on purpose, so needs to be reviewed.

This patch keeps the current behavior (assigning only specific fields), but removes the use of struct-literals to make the code compatible with the upcoming changes in the image-spec module.

(similar to commit f51b77934e2a3af1045a548050da57bcc25b2069)
