### PR TITLE
[v0.10 backport] ONBUILD in schemaV1 img, update uses of Image platform fields

### DIFF
--- a/exporter/containerimage/image/docker_image.go
+++ b/exporter/containerimage/image/docker_image.go
@@ -1,0 +1,55 @@
+package image
+
+import (
+	"time"
+
+	"github.com/docker/docker/api/types/strslice"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// HealthConfig holds configuration settings for the HEALTHCHECK feature.
+type HealthConfig struct {
+	// Test is the test to perform to check that the container is healthy.
+	// An empty slice means to inherit the default.
+	// The options are:
+	// {} : inherit healthcheck
+	// {"NONE"} : disable healthcheck
+	// {"CMD", args...} : exec arguments directly
+	// {"CMD-SHELL", command} : run command with system's default shell
+	Test []string `json:",omitempty"`
+
+	// Zero means to inherit. Durations are expressed as integer nanoseconds.
+	Interval    time.Duration `json:",omitempty"` // Interval is the time to wait between checks.
+	Timeout     time.Duration `json:",omitempty"` // Timeout is the time to wait before considering the check to have hung.
+	StartPeriod time.Duration `json:",omitempty"` // The start period for the container to initialize before the retries starts to count down.
+
+	// Retries is the number of consecutive failures needed to consider a container as unhealthy.
+	// Zero means inherit.
+	Retries int `json:",omitempty"`
+}
+
+// ImageConfig is a docker compatible config for an image
+type ImageConfig struct {
+	ocispecs.ImageConfig
+
+	Healthcheck *HealthConfig `json:",omitempty"` // Healthcheck describes how to check the container is healthy
+	ArgsEscaped bool          `json:",omitempty"` // True if command is already escaped (Windows specific)
+
+	//	NetworkDisabled bool                `json:",omitempty"` // Is network disabled
+	//	MacAddress      string              `json:",omitempty"` // Mac Address of the container
+	OnBuild     []string          // ONBUILD metadata that were defined on the image Dockerfile
+	StopTimeout *int              `json:",omitempty"` // Timeout (in seconds) to stop a container
+	Shell       strslice.StrSlice `json:",omitempty"` // Shell for shell-form of RUN, CMD, ENTRYPOINT
+}
+
+// Image is the JSON structure which describes some basic information about the image.
+// This provides the `application/vnd.oci.image.config.v1+json` mediatype when marshalled to JSON.
+type Image struct {
+	ocispecs.Image
+
+	// Config defines the execution parameters which should be used as a base when running a container using the image.
+	Config ImageConfig `json:"config,omitempty"`
+
+	// Variant defines platform variant. To be added to OCI.
+	Variant string `json:"variant,omitempty"`
+}

--- a/exporter/containerimage/image/docker_image.go
+++ b/exporter/containerimage/image/docker_image.go
@@ -49,7 +49,4 @@ type Image struct {
 
 	// Config defines the execution parameters which should be used as a base when running a container using the image.
 	Config ImageConfig `json:"config,omitempty"`
-
-	// Variant defines platform variant. To be added to OCI.
-	Variant string `json:"variant,omitempty"`
 }

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -215,7 +215,7 @@ func (ic *ImageWriter) exportLayers(ctx context.Context, refCfg cacheconfig.RefC
 func (ic *ImageWriter) commitDistributionManifest(ctx context.Context, ref cache.ImmutableRef, config []byte, remote *solver.Remote, oci bool, inlineCache []byte, buildInfo []byte) (*ocispecs.Descriptor, *ocispecs.Descriptor, error) {
 	if len(config) == 0 {
 		var err error
-		config, err = emptyImageConfig()
+		config, err = defaultImageConfig()
 		if err != nil {
 			return nil, nil, err
 		}
@@ -341,23 +341,13 @@ func (ic *ImageWriter) Applier() diff.Applier {
 	return ic.opt.Applier
 }
 
-func emptyImageConfig() ([]byte, error) {
+func defaultImageConfig() ([]byte, error) {
 	pl := platforms.Normalize(platforms.DefaultSpec())
 
-	type image struct {
-		ocispecs.Image
-
-		// Variant defines platform variant. To be added to OCI.
-		Variant string `json:"variant,omitempty"`
-	}
-
-	img := image{
-		Image: ocispecs.Image{
-			Architecture: pl.Architecture,
-			OS:           pl.OS,
-		},
-		Variant: pl.Variant,
-	}
+	img := ocispecs.Image{}
+	img.Architecture = pl.Architecture
+	img.OS = pl.OS
+	img.Variant = pl.Variant
 	img.RootFS.Type = "layers"
 	img.Config.WorkingDir = "/"
 	img.Config.Env = []string{"PATH=" + system.DefaultPathEnv(pl.OS)}

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/go-connections/nat"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/client/llb/imagemetaresolver"
+	"github.com/moby/buildkit/exporter/containerimage/image"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/moby/buildkit/frontend/dockerfile/shell"
@@ -1310,7 +1311,7 @@ func dispatchEntrypoint(d *dispatchState, c *instructions.EntrypointCommand) err
 }
 
 func dispatchHealthcheck(d *dispatchState, c *instructions.HealthCheckCommand) error {
-	d.image.Config.Healthcheck = &HealthConfig{
+	d.image.Config.Healthcheck = &image.HealthConfig{
 		Test:        c.Health.Test,
 		Interval:    c.Health.Interval,
 		Timeout:     c.Health.Timeout,

--- a/frontend/dockerfile/dockerfile2llb/image.go
+++ b/frontend/dockerfile/dockerfile2llb/image.go
@@ -20,13 +20,10 @@ func clone(src Image) Image {
 }
 
 func emptyImage(platform ocispecs.Platform) Image {
-	img := Image{
-		Image: ocispecs.Image{
-			Architecture: platform.Architecture,
-			OS:           platform.OS,
-			Variant:      platform.Variant,
-		},
-	}
+	img := Image{}
+	img.Architecture = platform.Architecture
+	img.OS = platform.OS
+	img.Variant = platform.Variant
 	img.RootFS.Type = "layers"
 	img.Config.WorkingDir = "/"
 	img.Config.Env = []string{"PATH=" + system.DefaultPathEnv(platform.OS)}

--- a/frontend/dockerfile/dockerfile2llb/image.go
+++ b/frontend/dockerfile/dockerfile2llb/image.go
@@ -1,59 +1,14 @@
 package dockerfile2llb
 
 import (
-	"time"
-
-	"github.com/docker/docker/api/types/strslice"
+	"github.com/moby/buildkit/exporter/containerimage/image"
 	"github.com/moby/buildkit/util/system"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// HealthConfig holds configuration settings for the HEALTHCHECK feature.
-type HealthConfig struct {
-	// Test is the test to perform to check that the container is healthy.
-	// An empty slice means to inherit the default.
-	// The options are:
-	// {} : inherit healthcheck
-	// {"NONE"} : disable healthcheck
-	// {"CMD", args...} : exec arguments directly
-	// {"CMD-SHELL", command} : run command with system's default shell
-	Test []string `json:",omitempty"`
-
-	// Zero means to inherit. Durations are expressed as integer nanoseconds.
-	Interval    time.Duration `json:",omitempty"` // Interval is the time to wait between checks.
-	Timeout     time.Duration `json:",omitempty"` // Timeout is the time to wait before considering the check to have hung.
-	StartPeriod time.Duration `json:",omitempty"` // The start period for the container to initialize before the retries starts to count down.
-
-	// Retries is the number of consecutive failures needed to consider a container as unhealthy.
-	// Zero means inherit.
-	Retries int `json:",omitempty"`
-}
-
-// ImageConfig is a docker compatible config for an image
-type ImageConfig struct {
-	ocispecs.ImageConfig
-
-	Healthcheck *HealthConfig `json:",omitempty"` // Healthcheck describes how to check the container is healthy
-	ArgsEscaped bool          `json:",omitempty"` // True if command is already escaped (Windows specific)
-
-	//	NetworkDisabled bool                `json:",omitempty"` // Is network disabled
-	//	MacAddress      string              `json:",omitempty"` // Mac Address of the container
-	OnBuild     []string          // ONBUILD metadata that were defined on the image Dockerfile
-	StopTimeout *int              `json:",omitempty"` // Timeout (in seconds) to stop a container
-	Shell       strslice.StrSlice `json:",omitempty"` // Shell for shell-form of RUN, CMD, ENTRYPOINT
-}
-
 // Image is the JSON structure which describes some basic information about the image.
 // This provides the `application/vnd.oci.image.config.v1+json` mediatype when marshalled to JSON.
-type Image struct {
-	ocispecs.Image
-
-	// Config defines the execution parameters which should be used as a base when running a container using the image.
-	Config ImageConfig `json:"config,omitempty"`
-
-	// Variant defines platform variant. To be added to OCI.
-	Variant string `json:"variant,omitempty"`
-}
+type Image image.Image
 
 func clone(src Image) Image {
 	img := src

--- a/frontend/dockerfile/dockerfile2llb/image.go
+++ b/frontend/dockerfile/dockerfile2llb/image.go
@@ -24,8 +24,8 @@ func emptyImage(platform ocispecs.Platform) Image {
 		Image: ocispecs.Image{
 			Architecture: platform.Architecture,
 			OS:           platform.OS,
+			Variant:      platform.Variant,
 		},
-		Variant: platform.Variant,
 	}
 	img.RootFS.Type = "layers"
 	img.Config.WorkingDir = "/"

--- a/util/imageutil/schema1.go
+++ b/util/imageutil/schema1.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/remotes"
+	"github.com/moby/buildkit/exporter/containerimage/image"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -44,7 +45,7 @@ func convertSchema1ConfigMeta(in []byte) ([]byte, error) {
 		return nil, errors.Errorf("invalid schema1 manifest")
 	}
 
-	var img ocispecs.Image
+	var img image.Image
 	if err := json.Unmarshal([]byte(m.History[0].V1Compatibility), &img); err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal image from schema 1 history")
 	}

--- a/util/imageutil/schema1_test.go
+++ b/util/imageutil/schema1_test.go
@@ -1,0 +1,35 @@
+package imageutil
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestConvertSchema1ConfigMeta(t *testing.T) {
+	dt := []byte(`{
+	"schemaVersion": 1,
+	"name": "base-global/common",
+	"tag": "1.0.9.zb.standard",
+	"architecture": "amd64",
+	"fsLayers": [
+		{
+			"blobSum": "sha256:id1"
+		}
+	],
+	"history": [
+		{
+			"v1Compatibility": "{\"id\":\"id2\",\"parent\":\"id3\",\"created\":\"2018-07-26T11:56:23.157525618Z\",\"config\":{\"Hostname\":\"4f3d4451\",\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":null,\"Volumes\":{},\"OnBuild\":[\"ARG APP_NAME\",\"COPY ${APP_NAME}.tgz /home/admin/${APP_NAME}/target/${APP_NAME}.tgz\"],\"Labels\":{}},\"architecture\":\"amd64\",\"os\":\"linux\"}"
+		}
+	]
+}`)
+	result, err := convertSchema1ConfigMeta(dt)
+	if err != nil {
+		t.Errorf("convertSchema1ConfigMeta error %v", err)
+		return
+	}
+	if !bytes.Contains(result, []byte("OnBuild")) {
+		t.Errorf("convertSchema1ConfigMeta lost onbuild")
+	} else if !bytes.Contains(result, []byte("COPY ${APP_NAME}.tgz /home/admin/${APP_NAME}/target/${APP_NAME}.tg")) {
+		t.Errorf("convertSchema1ConfigMeta lost onbuild content")
+	}
+}


### PR DESCRIPTION
Backports:

- https://github.com/moby/buildkit/pull/3053 (for a cleaner cherry-pick, and change itself looks fairly safe)
    - fixes https://github.com/moby/buildkit/issues/3052
- https://github.com/moby/buildkit/pull/3103
- https://github.com/moby/buildkit/pull/3104
  This patch is similar to f51b77934e2a3af1045a548050da57bcc25b2069, but contains   some changes from a163f58c77e571a760a85db8b12b2c8bc4563e61, which updated the exporter `emptyImageConfig` to use the OCI image-spec, instead of an ad-hoc type (which was no longer needed), and renamed it to `defaultImageConfig`.
