### PR TITLE
Add network namespace pool support

### DIFF
--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -53,7 +53,7 @@ type NetworkConfig struct {
 	Mode          string `toml:"networkMode"`
 	CNIConfigPath string `toml:"cniConfigPath"`
 	CNIBinaryPath string `toml:"cniBinaryPath"`
-	NetNSPoolSize int    `toml:"netNSPoolSize"`
+	CNIPoolSize   int    `toml:"cniPoolSize"`
 }
 
 type OCIConfig struct {

--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -53,6 +53,7 @@ type NetworkConfig struct {
 	Mode          string `toml:"networkMode"`
 	CNIConfigPath string `toml:"cniConfigPath"`
 	CNIBinaryPath string `toml:"cniBinaryPath"`
+	NetNSPoolSize int    `toml:"netNSPoolSize"`
 }
 
 type OCIConfig struct {

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -265,6 +265,7 @@ func main() {
 		if err != nil {
 			return err
 		}
+		defer controller.Close()
 
 		controller.Register(server)
 

--- a/cmd/buildkitd/main_containerd_worker.go
+++ b/cmd/buildkitd/main_containerd_worker.go
@@ -90,6 +90,11 @@ func init() {
 			Usage: "path of cni binary files",
 			Value: defaultConf.Workers.Containerd.NetworkConfig.CNIBinaryPath,
 		},
+		cli.IntFlag{
+			Name:  "containerd-netns-pool-size",
+			Usage: "size of network namespace pool",
+			Value: defaultConf.Workers.Containerd.NetworkConfig.NetNSPoolSize,
+		},
 		cli.StringFlag{
 			Name:  "containerd-worker-snapshotter",
 			Usage: "snapshotter name to use",
@@ -208,6 +213,9 @@ func applyContainerdFlags(c *cli.Context, cfg *config.Config) error {
 	if c.GlobalIsSet("containerd-cni-config-path") {
 		cfg.Workers.Containerd.NetworkConfig.CNIConfigPath = c.GlobalString("containerd-cni-config-path")
 	}
+	if c.GlobalIsSet("containerd-netns-pool-size") {
+		cfg.Workers.Containerd.NetworkConfig.NetNSPoolSize = c.GlobalInt("containerd-netns-pool-size")
+	}
 	if c.GlobalIsSet("containerd-cni-binary-dir") {
 		cfg.Workers.Containerd.NetworkConfig.CNIBinaryPath = c.GlobalString("containerd-cni-binary-dir")
 	}
@@ -247,6 +255,7 @@ func containerdWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([
 			Root:       common.config.Root,
 			ConfigPath: common.config.Workers.Containerd.CNIConfigPath,
 			BinaryDir:  common.config.Workers.Containerd.CNIBinaryPath,
+			PoolSize:   common.config.Workers.Containerd.NetNSPoolSize,
 		},
 	}
 

--- a/cmd/buildkitd/main_containerd_worker.go
+++ b/cmd/buildkitd/main_containerd_worker.go
@@ -91,9 +91,9 @@ func init() {
 			Value: defaultConf.Workers.Containerd.NetworkConfig.CNIBinaryPath,
 		},
 		cli.IntFlag{
-			Name:  "containerd-netns-pool-size",
-			Usage: "size of network namespace pool",
-			Value: defaultConf.Workers.Containerd.NetworkConfig.NetNSPoolSize,
+			Name:  "containerd-cni-pool-size",
+			Usage: "size of cni network namespace pool",
+			Value: defaultConf.Workers.Containerd.NetworkConfig.CNIPoolSize,
 		},
 		cli.StringFlag{
 			Name:  "containerd-worker-snapshotter",
@@ -213,8 +213,8 @@ func applyContainerdFlags(c *cli.Context, cfg *config.Config) error {
 	if c.GlobalIsSet("containerd-cni-config-path") {
 		cfg.Workers.Containerd.NetworkConfig.CNIConfigPath = c.GlobalString("containerd-cni-config-path")
 	}
-	if c.GlobalIsSet("containerd-netns-pool-size") {
-		cfg.Workers.Containerd.NetworkConfig.NetNSPoolSize = c.GlobalInt("containerd-netns-pool-size")
+	if c.GlobalIsSet("containerd-cni-pool-size") {
+		cfg.Workers.Containerd.NetworkConfig.CNIPoolSize = c.GlobalInt("containerd-cni-pool-size")
 	}
 	if c.GlobalIsSet("containerd-cni-binary-dir") {
 		cfg.Workers.Containerd.NetworkConfig.CNIBinaryPath = c.GlobalString("containerd-cni-binary-dir")
@@ -255,7 +255,7 @@ func containerdWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([
 			Root:       common.config.Root,
 			ConfigPath: common.config.Workers.Containerd.CNIConfigPath,
 			BinaryDir:  common.config.Workers.Containerd.CNIBinaryPath,
-			PoolSize:   common.config.Workers.Containerd.NetNSPoolSize,
+			PoolSize:   common.config.Workers.Containerd.CNIPoolSize,
 		},
 	}
 

--- a/cmd/buildkitd/main_oci_worker.go
+++ b/cmd/buildkitd/main_oci_worker.go
@@ -101,15 +101,15 @@ func init() {
 			Usage: "path of cni binary files",
 			Value: defaultConf.Workers.OCI.NetworkConfig.CNIBinaryPath,
 		},
+		cli.IntFlag{
+			Name:  "oci-cni-pool-size",
+			Usage: "size of cni network namespace pool",
+			Value: defaultConf.Workers.OCI.NetworkConfig.CNIPoolSize,
+		},
 		cli.StringFlag{
 			Name:  "oci-worker-binary",
 			Usage: "name of specified oci worker binary",
 			Value: defaultConf.Workers.OCI.Binary,
-		},
-		cli.IntFlag{
-			Name:  "oci-netns-pool-size",
-			Usage: "size of network namespace pool",
-			Value: defaultConf.Workers.OCI.NetworkConfig.NetNSPoolSize,
 		},
 		cli.StringFlag{
 			Name:  "oci-worker-apparmor-profile",
@@ -228,8 +228,8 @@ func applyOCIFlags(c *cli.Context, cfg *config.Config) error {
 	if c.GlobalIsSet("oci-cni-binary-dir") {
 		cfg.Workers.OCI.NetworkConfig.CNIBinaryPath = c.GlobalString("oci-cni-binary-dir")
 	}
-	if c.GlobalIsSet("oci-netns-pool-size") {
-		cfg.Workers.OCI.NetworkConfig.NetNSPoolSize = c.GlobalInt("oci-netns-pool-size")
+	if c.GlobalIsSet("oci-cni-pool-size") {
+		cfg.Workers.OCI.NetworkConfig.CNIPoolSize = c.GlobalInt("oci-cni-pool-size")
 	}
 	if c.GlobalIsSet("oci-worker-binary") {
 		cfg.Workers.OCI.Binary = c.GlobalString("oci-worker-binary")
@@ -290,7 +290,7 @@ func ociWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([]worker
 			Root:       common.config.Root,
 			ConfigPath: common.config.Workers.OCI.CNIConfigPath,
 			BinaryDir:  common.config.Workers.OCI.CNIBinaryPath,
-			PoolSize:   common.config.Workers.OCI.NetNSPoolSize,
+			PoolSize:   common.config.Workers.OCI.CNIPoolSize,
 		},
 	}
 

--- a/cmd/buildkitd/main_oci_worker.go
+++ b/cmd/buildkitd/main_oci_worker.go
@@ -106,6 +106,11 @@ func init() {
 			Usage: "name of specified oci worker binary",
 			Value: defaultConf.Workers.OCI.Binary,
 		},
+		cli.IntFlag{
+			Name:  "oci-netns-pool-size",
+			Usage: "size of network namespace pool",
+			Value: defaultConf.Workers.OCI.NetworkConfig.NetNSPoolSize,
+		},
 		cli.StringFlag{
 			Name:  "oci-worker-apparmor-profile",
 			Usage: "set the name of the apparmor profile applied to containers",
@@ -223,6 +228,9 @@ func applyOCIFlags(c *cli.Context, cfg *config.Config) error {
 	if c.GlobalIsSet("oci-cni-binary-dir") {
 		cfg.Workers.OCI.NetworkConfig.CNIBinaryPath = c.GlobalString("oci-cni-binary-dir")
 	}
+	if c.GlobalIsSet("oci-netns-pool-size") {
+		cfg.Workers.OCI.NetworkConfig.NetNSPoolSize = c.GlobalInt("oci-netns-pool-size")
+	}
 	if c.GlobalIsSet("oci-worker-binary") {
 		cfg.Workers.OCI.Binary = c.GlobalString("oci-worker-binary")
 	}
@@ -282,6 +290,7 @@ func ociWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([]worker
 			Root:       common.config.Root,
 			ConfigPath: common.config.Workers.OCI.CNIConfigPath,
 			BinaryDir:  common.config.Workers.OCI.CNIBinaryPath,
+			PoolSize:   common.config.Workers.OCI.NetNSPoolSize,
 		},
 	}
 

--- a/control/control.go
+++ b/control/control.go
@@ -90,6 +90,10 @@ func NewController(opt Opt) (*Controller, error) {
 	return c, nil
 }
 
+func (c *Controller) Close() error {
+	return c.opt.WorkerController.Close()
+}
+
 func (c *Controller) Register(server *grpc.Server) {
 	controlapi.RegisterControlServer(server, c)
 	c.gatewayForwarder.Register(server)

--- a/docs/buildkitd.toml.md
+++ b/docs/buildkitd.toml.md
@@ -57,9 +57,9 @@ insecure-entitlements = [ "network.host", "security.insecure" ]
   apparmor-profile = ""
   # limit the number of parallel build steps that can run at the same time
   max-parallelism = 4
-  # maintain a pool of reusable network namespaces to amortize the overhead
+  # maintain a pool of reusable CNI network namespaces to amortize the overhead
   # of allocating and releasing the namespaces
-  netNSPoolSize = 16
+  cniPoolSize = 16
 
   [worker.oci.labels]
     "foo" = "bar"
@@ -80,9 +80,9 @@ insecure-entitlements = [ "network.host", "security.insecure" ]
   gc = true
   # gckeepstorage sets storage limit for default gc profile, in MB.
   gckeepstorage = 9000
-  # maintain a pool of reusable network namespaces to amortize the overhead
+  # maintain a pool of reusable CNI network namespaces to amortize the overhead
   # of allocating and releasing the namespaces
-  netNSPoolSize = 16
+  cniPoolSize = 16
 
   [worker.containerd.labels]
     "foo" = "bar"

--- a/docs/buildkitd.toml.md
+++ b/docs/buildkitd.toml.md
@@ -57,6 +57,9 @@ insecure-entitlements = [ "network.host", "security.insecure" ]
   apparmor-profile = ""
   # limit the number of parallel build steps that can run at the same time
   max-parallelism = 4
+  # maintain a pool of reusable network namespaces to amortize the overhead
+  # of allocating and releasing the namespaces
+  netNSPoolSize = 16
 
   [worker.oci.labels]
     "foo" = "bar"
@@ -77,6 +80,10 @@ insecure-entitlements = [ "network.host", "security.insecure" ]
   gc = true
   # gckeepstorage sets storage limit for default gc profile, in MB.
   gckeepstorage = 9000
+  # maintain a pool of reusable network namespaces to amortize the overhead
+  # of allocating and releasing the namespaces
+  netNSPoolSize = 16
+
   [worker.containerd.labels]
     "foo" = "bar"
 

--- a/executor/containerdexecutor/executor.go
+++ b/executor/containerdexecutor/executor.go
@@ -146,7 +146,7 @@ func (w *containerdExecutor) Run(ctx context.Context, id string, root executor.M
 	if !ok {
 		return errors.Errorf("unknown network mode %s", meta.NetMode)
 	}
-	namespace, err := provider.New(meta.Hostname)
+	namespace, err := provider.New(ctx, meta.Hostname)
 	if err != nil {
 		return err
 	}

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -161,7 +161,7 @@ func (w *runcExecutor) Run(ctx context.Context, id string, root executor.Mount, 
 	if !ok {
 		return errors.Errorf("unknown network mode %s", meta.NetMode)
 	}
-	namespace, err := provider.New(meta.Hostname)
+	namespace, err := provider.New(ctx, meta.Hostname)
 	if err != nil {
 		return err
 	}

--- a/util/network/cniprovider/createns_unix.go
+++ b/util/network/cniprovider/createns_unix.go
@@ -23,3 +23,6 @@ func unmountNetNS(nativeID string) error {
 func deleteNetNS(nativeID string) error {
 	return errors.New("deleting netns for cni not supported")
 }
+
+func cleanOldNamespaces(_ *cniProvider) {
+}

--- a/util/network/cniprovider/createns_windows.go
+++ b/util/network/cniprovider/createns_windows.go
@@ -47,3 +47,7 @@ func deleteNetNS(nativeID string) error {
 
 	return ns.Delete()
 }
+
+func cleanOldNamespaces(_ *cniProvider) {
+	// not implemented on Windows
+}

--- a/util/network/host.go
+++ b/util/network/host.go
@@ -21,6 +21,10 @@ func (h *host) New(_ context.Context, hostname string) (Namespace, error) {
 	return &hostNS{}, nil
 }
 
+func (h *host) Close() error {
+	return nil
+}
+
 type hostNS struct {
 }
 

--- a/util/network/host.go
+++ b/util/network/host.go
@@ -4,6 +4,8 @@
 package network
 
 import (
+	"context"
+
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
@@ -15,7 +17,7 @@ func NewHostProvider() Provider {
 type host struct {
 }
 
-func (h *host) New(hostname string) (Namespace, error) {
+func (h *host) New(_ context.Context, hostname string) (Namespace, error) {
 	return &hostNS{}, nil
 }
 

--- a/util/network/network.go
+++ b/util/network/network.go
@@ -9,6 +9,7 @@ import (
 
 // Provider interface for Network
 type Provider interface {
+	io.Closer
 	New(ctx context.Context, hostname string) (Namespace, error)
 }
 

--- a/util/network/network.go
+++ b/util/network/network.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"context"
 	"io"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -8,7 +9,7 @@ import (
 
 // Provider interface for Network
 type Provider interface {
-	New(hostname string) (Namespace, error)
+	New(ctx context.Context, hostname string) (Namespace, error)
 }
 
 // Namespace of network for workers

--- a/util/network/none.go
+++ b/util/network/none.go
@@ -1,6 +1,8 @@
 package network
 
 import (
+	"context"
+
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -11,7 +13,7 @@ func NewNoneProvider() Provider {
 type none struct {
 }
 
-func (h *none) New(hostname string) (Namespace, error) {
+func (h *none) New(_ context.Context, hostname string) (Namespace, error) {
 	return &noneNS{}, nil
 }
 

--- a/util/network/none.go
+++ b/util/network/none.go
@@ -17,6 +17,10 @@ func (h *none) New(_ context.Context, hostname string) (Namespace, error) {
 	return &noneNS{}, nil
 }
 
+func (h *none) Close() error {
+	return nil
+}
+
 type noneNS struct {
 }
 

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -15,6 +15,7 @@ import (
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/docker/docker/pkg/idtools"
+	"github.com/hashicorp/go-multierror"
 	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/cache/metadata"
 	"github.com/moby/buildkit/client"
@@ -41,6 +42,7 @@ import (
 	"github.com/moby/buildkit/source/local"
 	"github.com/moby/buildkit/util/archutil"
 	"github.com/moby/buildkit/util/bklog"
+	"github.com/moby/buildkit/util/network"
 	"github.com/moby/buildkit/util/progress"
 	"github.com/moby/buildkit/util/progress/controller"
 	digest "github.com/opencontainers/go-digest"
@@ -57,24 +59,25 @@ const labelCreatedAt = "buildkit/createdat"
 // WorkerOpt is specific to a worker.
 // See also CommonOpt.
 type WorkerOpt struct {
-	ID              string
-	Labels          map[string]string
-	Platforms       []ocispecs.Platform
-	GCPolicy        []client.PruneInfo
-	BuildkitVersion client.BuildkitVersion
-	Executor        executor.Executor
-	Snapshotter     snapshot.Snapshotter
-	ContentStore    content.Store
-	Applier         diff.Applier
-	Differ          diff.Comparer
-	ImageStore      images.Store // optional
-	RegistryHosts   docker.RegistryHosts
-	IdentityMapping *idtools.IdentityMapping
-	LeaseManager    leases.Manager
-	GarbageCollect  func(context.Context) (gc.Stats, error)
-	ParallelismSem  *semaphore.Weighted
-	MetadataStore   *metadata.Store
-	MountPoolRoot   string
+	ID               string
+	Labels           map[string]string
+	Platforms        []ocispecs.Platform
+	GCPolicy         []client.PruneInfo
+	BuildkitVersion  client.BuildkitVersion
+	NetworkProviders map[pb.NetMode]network.Provider
+	Executor         executor.Executor
+	Snapshotter      snapshot.Snapshotter
+	ContentStore     content.Store
+	Applier          diff.Applier
+	Differ           diff.Comparer
+	ImageStore       images.Store // optional
+	RegistryHosts    docker.RegistryHosts
+	IdentityMapping  *idtools.IdentityMapping
+	LeaseManager     leases.Manager
+	GarbageCollect   func(context.Context) (gc.Stats, error)
+	ParallelismSem   *semaphore.Weighted
+	MetadataStore    *metadata.Store
+	MountPoolRoot    string
 }
 
 // Worker is a local worker instance with dedicated snapshotter, cache, and so on.
@@ -201,6 +204,16 @@ func NewWorker(ctx context.Context, opt WorkerOpt) (*Worker, error) {
 		ImageSource:     is,
 		OCILayoutSource: os,
 	}, nil
+}
+
+func (w *Worker) Close() error {
+	var rerr error
+	for _, provider := range w.NetworkProviders {
+		if err := provider.Close(); err != nil {
+			rerr = multierror.Append(rerr, err)
+		}
+	}
+	return rerr
 }
 
 func (w *Worker) ContentStore() content.Store {

--- a/worker/containerd/containerd.go
+++ b/worker/containerd/containerd.go
@@ -131,20 +131,21 @@ func newContainerd(root string, client *containerd.Client, snapshotterName, ns s
 	}
 
 	opt := base.WorkerOpt{
-		ID:             id,
-		Labels:         xlabels,
-		MetadataStore:  md,
-		Executor:       containerdexecutor.New(client, root, "", np, dns, apparmorProfile, traceSocket, rootless),
-		Snapshotter:    snap,
-		ContentStore:   cs,
-		Applier:        winlayers.NewFileSystemApplierWithWindows(cs, df),
-		Differ:         winlayers.NewWalkingDiffWithWindows(cs, df),
-		ImageStore:     client.ImageService(),
-		Platforms:      platforms,
-		LeaseManager:   lm,
-		GarbageCollect: gc,
-		ParallelismSem: parallelismSem,
-		MountPoolRoot:  filepath.Join(root, "cachemounts"),
+		ID:               id,
+		Labels:           xlabels,
+		MetadataStore:    md,
+		NetworkProviders: np,
+		Executor:         containerdexecutor.New(client, root, "", np, dns, apparmorProfile, traceSocket, rootless),
+		Snapshotter:      snap,
+		ContentStore:     cs,
+		Applier:          winlayers.NewFileSystemApplierWithWindows(cs, df),
+		Differ:           winlayers.NewWalkingDiffWithWindows(cs, df),
+		ImageStore:       client.ImageService(),
+		Platforms:        platforms,
+		LeaseManager:     lm,
+		GarbageCollect:   gc,
+		ParallelismSem:   parallelismSem,
+		MountPoolRoot:    filepath.Join(root, "cachemounts"),
 	}
 	return opt, nil
 }

--- a/worker/runc/runc.go
+++ b/worker/runc/runc.go
@@ -137,21 +137,22 @@ func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, proc
 	}
 
 	opt = base.WorkerOpt{
-		ID:              id,
-		Labels:          xlabels,
-		MetadataStore:   md,
-		Executor:        exe,
-		Snapshotter:     snap,
-		ContentStore:    c,
-		Applier:         winlayers.NewFileSystemApplierWithWindows(c, apply.NewFileSystemApplier(c)),
-		Differ:          winlayers.NewWalkingDiffWithWindows(c, walking.NewWalkingDiff(c)),
-		ImageStore:      nil, // explicitly
-		Platforms:       []ocispecs.Platform{platforms.Normalize(platforms.DefaultSpec())},
-		IdentityMapping: idmap,
-		LeaseManager:    lm,
-		GarbageCollect:  mdb.GarbageCollect,
-		ParallelismSem:  parallelismSem,
-		MountPoolRoot:   filepath.Join(root, "cachemounts"),
+		ID:               id,
+		Labels:           xlabels,
+		MetadataStore:    md,
+		NetworkProviders: np,
+		Executor:         exe,
+		Snapshotter:      snap,
+		ContentStore:     c,
+		Applier:          winlayers.NewFileSystemApplierWithWindows(c, apply.NewFileSystemApplier(c)),
+		Differ:           winlayers.NewWalkingDiffWithWindows(c, walking.NewWalkingDiff(c)),
+		ImageStore:       nil, // explicitly
+		Platforms:        []ocispecs.Platform{platforms.Normalize(platforms.DefaultSpec())},
+		IdentityMapping:  idmap,
+		LeaseManager:     lm,
+		GarbageCollect:   mdb.GarbageCollect,
+		ParallelismSem:   parallelismSem,
+		MountPoolRoot:    filepath.Join(root, "cachemounts"),
 	}
 	return opt, nil
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"io"
 
 	"github.com/containerd/containerd/content"
 	"github.com/moby/buildkit/cache"
@@ -17,6 +18,7 @@ import (
 )
 
 type Worker interface {
+	io.Closer
 	// ID needs to be unique in the cluster
 	ID() string
 	Labels() map[string]string

--- a/worker/workercontroller.go
+++ b/worker/workercontroller.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"github.com/containerd/containerd/filters"
+	"github.com/hashicorp/go-multierror"
 	"github.com/moby/buildkit/client"
 	"github.com/pkg/errors"
 )
@@ -11,6 +12,16 @@ import (
 type Controller struct {
 	// TODO: define worker interface and support remote ones
 	workers []Worker
+}
+
+func (c *Controller) Close() error {
+	var rerr error
+	for _, w := range c.workers {
+		if err := w.Close(); err != nil {
+			rerr = multierror.Append(rerr, err)
+		}
+	}
+	return rerr
 }
 
 // Add adds a local worker.


### PR DESCRIPTION
This adds `netNSPoolSize` pool options which allow setting a target network namespace pool size. buildkitd will create this number of network namespaces at startup (without blocking). When a container execution finishes, the network namespace gets returned to the pool. If the pool goes above the target size, there is a grace period to allow network namespaces to be reused, and if this passes without reuse, the extra namespaces will be released.