### PR TITLE
sshprovider: use stream.Context

### DIFF
--- a/session/sshforward/sshprovider/agentprovider.go
+++ b/session/sshforward/sshprovider/agentprovider.go
@@ -124,7 +124,7 @@ func (sp *socketProvider) ForwardAgent(stream sshforward.SSH_ForwardAgentServer)
 
 	s1, s2 := sockPair()
 
-	eg, ctx := errgroup.WithContext(context.TODO())
+	eg, ctx := errgroup.WithContext(stream.Context())
 
 	eg.Go(func() error {
 		return agent.ServeAgent(a, s1)


### PR DESCRIPTION
use stream.Context rather than a background context, to ensure the ssh agent forwarding server is cleaned up if the context is cancelled 

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>