### PR TITLE
buildctl: define oci-layout flag

### DIFF
--- a/cmd/buildctl/build.go
+++ b/cmd/buildctl/build.go
@@ -55,6 +55,10 @@ var buildCommand = cli.Command{
 			Name:  "local",
 			Usage: "Allow build access to the local directory",
 		},
+		cli.StringSliceFlag{
+			Name:  "oci-layout",
+			Usage: "Allow build access to the local OCI layout",
+		},
 		cli.StringFlag{
 			Name:  "frontend",
 			Usage: "Define frontend used for build",


### PR DESCRIPTION
This ensures that the new oci-layout can be loaded using buildctl (see https://github.com/moby/buildkit/pull/2827#discussion_r970570028).

Example usage:

```
buildctl --addr tcp://localhost:1234 build \
  --frontend=dockerfile.v0 \
  --local context=. --local dockerfile=. \
  --opt context:foo=oci-layout://foodir@sha256:79a06bdbfbf27b365be61ca38646b07b451681475c284ad79deed506ab192917 \
  --oci-layout foodir=./path/to/oci/dir
```

Previously, the `--oci-layout` flag was not registered with cobra, so could not be provided correctly.

CC @deitch @tonistiigi 