### PR TITLE
authprovider handle error token

### DIFF
--- a/session/auth/authprovider/authprovider.go
+++ b/session/auth/authprovider/authprovider.go
@@ -116,6 +116,13 @@ func (ap *authProvider) FetchToken(ctx context.Context, req *auth.FetchTokenRequ
 					return toTokenResponse(resp.Token, resp.IssuedAt, resp.ExpiresIn), nil
 				}
 			}
+			if err == authutil.ErrNoToken {
+				resp, err := authutil.FetchToken(ctx, http.DefaultClient, nil, to)
+				if err != nil {
+					return nil, err
+				}
+				return toTokenResponse(resp.Token, resp.IssuedAt, resp.ExpiresIn), nil
+			}
 			return nil, err
 		}
 		return toTokenResponse(resp.AccessToken, resp.IssuedAt, resp.ExpiresIn), nil


### PR DESCRIPTION
When the image registry does not implement the OAuth (/POST) endpoint standard, it is also necessary to try another Auth (/GET) endpoint. 

Not only depending on the HTTP status code to distinguish, but also to determine whether the returned content is normal.

Signed-off-by: arcosx <arcosx@outlook.com>