### PR TITLE
OCI layout context improvements

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1690,7 +1690,7 @@ func testOCILayoutSource(t *testing.T, sb integration.Sandbox) {
 	// since we are doing just one build with one remote here, we can give it any old ID,
 	// even something really imaginative, like "one"
 	csID := "one"
-	st = llb.OCILayout(csID + "@" + digest.String())
+	st = llb.OCILayout(csID + "/image@" + digest.String())
 
 	def, err = st.Marshal(context.TODO())
 	require.NoError(t, err)
@@ -1833,7 +1833,7 @@ func testOCILayoutPlatformSource(t *testing.T, sb integration.Sandbox) {
 			Platforms: make([]exptypes.Platform, len(platformsToTest)),
 		}
 		for i, platform := range platformsToTest {
-			st := llb.OCILayout(csID + "@" + digest.String())
+			st := llb.OCILayout(csID + "/image@" + digest.String())
 
 			def, err := st.Marshal(ctx, llb.Platform(platforms.MustParse(platform)))
 			if err != nil {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1690,7 +1690,7 @@ func testOCILayoutSource(t *testing.T, sb integration.Sandbox) {
 	// since we are doing just one build with one remote here, we can give it any old ID,
 	// even something really imaginative, like "one"
 	csID := "one"
-	st = llb.OCILayout(csID, digest)
+	st = llb.OCILayout(csID + "@" + digest.String())
 
 	def, err = st.Marshal(context.TODO())
 	require.NoError(t, err)
@@ -1833,7 +1833,7 @@ func testOCILayoutPlatformSource(t *testing.T, sb integration.Sandbox) {
 			Platforms: make([]exptypes.Platform, len(platformsToTest)),
 		}
 		for i, platform := range platformsToTest {
-			st := llb.OCILayout(csID, digest)
+			st := llb.OCILayout(csID + "@" + digest.String())
 
 			def, err := st.Marshal(ctx, llb.Platform(platforms.MustParse(platform)))
 			if err != nil {

--- a/client/llb/source.go
+++ b/client/llb/source.go
@@ -455,7 +455,7 @@ func Differ(t DiffType, required bool) LocalOption {
 	})
 }
 
-func OCILayout(contentStoreID string, dig digest.Digest, opts ...OCILayoutOption) State {
+func OCILayout(ref string, opts ...OCILayoutOption) State {
 	gi := &OCILayoutInfo{}
 
 	for _, o := range opts {
@@ -474,7 +474,7 @@ func OCILayout(contentStoreID string, dig digest.Digest, opts ...OCILayoutOption
 
 	addCap(&gi.Constraints, pb.CapSourceOCILayout)
 
-	source := NewSource(fmt.Sprintf("oci-layout://%s@%s", contentStoreID, dig), attrs, gi.Constraints)
+	source := NewSource(fmt.Sprintf("oci-layout://%s", ref), attrs, gi.Constraints)
 	return NewState(source.Output())
 }
 

--- a/cmd/buildctl/build/ocilayout.go
+++ b/cmd/buildctl/build/ocilayout.go
@@ -1,10 +1,16 @@
 package build
 
 import (
+	"context"
+	"encoding/json"
+	"os"
+	"path"
 	"strings"
+	"time"
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/content/local"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -16,7 +22,7 @@ func ParseOCILayout(layouts []string) (map[string]content.Store, error) {
 		if len(parts) != 2 {
 			return nil, errors.Errorf("oci-layout option must be 'id=path/to/layout', instead had invalid %s", idAndDir)
 		}
-		cs, err := local.NewStore(parts[1])
+		cs, err := newIndexedStore(parts[1])
 		if err != nil {
 			return nil, errors.Wrapf(err, "oci-layout context at %s failed to initialize", parts[1])
 		}
@@ -24,4 +30,69 @@ func ParseOCILayout(layouts []string) (map[string]content.Store, error) {
 	}
 
 	return contentStores, nil
+}
+
+func newIndexedStore(root string) (content.Store, error) {
+	store, err := local.NewStore(root)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := os.Open(path.Join(root, "index.json"))
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var idx ocispecs.Index
+	if err := json.NewDecoder(f).Decode(&idx); err != nil {
+		return nil, err
+	}
+
+	return &indexedStore{
+		Store: store,
+		index: idx,
+	}, nil
+}
+
+type indexedStore struct {
+	content.Store
+	index ocispecs.Index
+}
+
+func (s *indexedStore) Walk(ctx context.Context, fn content.WalkFunc, fs ...string) error {
+	found := false
+	for _, f := range fs {
+		if f == "index==true" {
+			found = true
+			break
+		}
+	}
+	if found && len(fs) > 1 {
+		return errors.New("index filter cannot be combined with other filters")
+	}
+
+	if !found {
+		return s.Store.Walk(ctx, fn, fs...)
+	}
+
+	for _, desc := range s.index.Manifests {
+		info := content.Info{
+			Digest: desc.Digest,
+			Size:   desc.Size,
+			Labels: desc.Annotations,
+		}
+		if createdAt, ok := desc.Annotations[ocispecs.AnnotationCreated]; ok {
+			createdAt, err := time.Parse(time.RFC3339, createdAt)
+			if err != nil {
+				return err
+			}
+			info.CreatedAt = createdAt
+		}
+
+		if err := fn(info); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/cmd/buildctl/build/ocilayout.go
+++ b/cmd/buildctl/build/ocilayout.go
@@ -1,16 +1,10 @@
 package build
 
 import (
-	"context"
-	"encoding/json"
-	"os"
-	"path"
 	"strings"
-	"time"
 
 	"github.com/containerd/containerd/content"
-	"github.com/containerd/containerd/content/local"
-	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/moby/buildkit/util/store"
 	"github.com/pkg/errors"
 )
 
@@ -22,7 +16,7 @@ func ParseOCILayout(layouts []string) (map[string]content.Store, error) {
 		if len(parts) != 2 {
 			return nil, errors.Errorf("oci-layout option must be 'id=path/to/layout', instead had invalid %s", idAndDir)
 		}
-		cs, err := newIndexedStore(parts[1])
+		cs, err := store.NewIndexedStore(parts[1])
 		if err != nil {
 			return nil, errors.Wrapf(err, "oci-layout context at %s failed to initialize", parts[1])
 		}
@@ -30,69 +24,4 @@ func ParseOCILayout(layouts []string) (map[string]content.Store, error) {
 	}
 
 	return contentStores, nil
-}
-
-func newIndexedStore(root string) (content.Store, error) {
-	store, err := local.NewStore(root)
-	if err != nil {
-		return nil, err
-	}
-
-	f, err := os.Open(path.Join(root, "index.json"))
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-
-	var idx ocispecs.Index
-	if err := json.NewDecoder(f).Decode(&idx); err != nil {
-		return nil, err
-	}
-
-	return &indexedStore{
-		Store: store,
-		index: idx,
-	}, nil
-}
-
-type indexedStore struct {
-	content.Store
-	index ocispecs.Index
-}
-
-func (s *indexedStore) Walk(ctx context.Context, fn content.WalkFunc, fs ...string) error {
-	found := false
-	for _, f := range fs {
-		if f == "index==true" {
-			found = true
-			break
-		}
-	}
-	if found && len(fs) > 1 {
-		return errors.New("index filter cannot be combined with other filters")
-	}
-
-	if !found {
-		return s.Store.Walk(ctx, fn, fs...)
-	}
-
-	for _, desc := range s.index.Manifests {
-		info := content.Info{
-			Digest: desc.Digest,
-			Size:   desc.Size,
-			Labels: desc.Annotations,
-		}
-		if createdAt, ok := desc.Annotations[ocispecs.AnnotationCreated]; ok {
-			createdAt, err := time.Parse(time.RFC3339, createdAt)
-			if err != nil {
-				return err
-			}
-			info.CreatedAt = createdAt
-		}
-
-		if err := fn(info); err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -935,7 +935,8 @@ func contextByName(ctx context.Context, c client.Client, sessionID, name string,
 			return nil, nil, nil, errors.Wrap(err, "could not parse oci-layout image config")
 		}
 
-		st := llb.OCILayout(named.String(),
+		st := llb.OCILayout(
+			reference.Path(named)+"/"+named.String(),
 			llb.WithCustomName("[context "+name+"] OCI load from client"),
 			llb.OCISessionID(c.BuildOpts().SessionID),
 		)

--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -30,7 +30,6 @@ import (
 	"github.com/moby/buildkit/solver/pb"
 	binfotypes "github.com/moby/buildkit/util/buildinfo/types"
 	"github.com/moby/buildkit/util/gitutil"
-	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
@@ -899,30 +898,29 @@ func contextByName(ctx context.Context, c client.Client, sessionID, name string,
 		}
 		return st, nil, nil, nil
 	case "oci-layout":
-		ref := strings.TrimPrefix(vv[1], "//")
-		// expected format is storeID@hash
-		parts := strings.SplitN(ref, "@", 2)
-		if len(parts) != 2 {
-			return nil, nil, nil, errors.Errorf("invalid oci-layout format '%s', must be oci-layout:///content-store@sha256:digest", vv[1])
-		}
-		storeID := parts[0]
-		dig, err := digest.Parse(parts[1])
+		refSpec := strings.TrimPrefix(vv[1], "//")
+		ref, err := reference.Parse(refSpec)
 		if err != nil {
-			return nil, nil, nil, errors.Errorf("invalid digest format '%s', must be oci-layout:///content-store@sha256:digest", vv[1])
+			return nil, nil, nil, errors.Wrapf(err, "could not parse oci-layout reference %q", refSpec)
+		}
+		named, ok := ref.(reference.Named)
+		if !ok {
+			return nil, nil, nil, fmt.Errorf("reference %q has no name", ref.String())
+		}
+		if reference.Domain(named) != "" {
+			return nil, nil, nil, fmt.Errorf("oci-layout reference %q has domain", ref.String())
+		}
+		if strings.Contains(reference.Path(named), "/") {
+			return nil, nil, nil, errors.Errorf("oci-layout reference %q name is multi-part", ref.String())
 		}
 
-		// the ref now is "content-store@sha256:digest"
-		// ResolveImageConfig will try to treat that as a valid reference,
-		// to be parsed with https://pkg.go.dev/github.com/containerd/containerd@v1.6.6/reference#Parse
-		// That will fail, because it will think that "content-store@sha256" is a host and "digest" is a port.
-		// To get it to pass, we need to jury-rig it with a host, so that it is a legitimate ref and can
-		// be processed.
-		// A reasonable format is storeID as host, so
-		//    storeID/image@digest
-		// We do not support any image lookup for now, so any image will do; it is ignored.
+		if _, ok := ref.(reference.Digested); !ok {
+			return nil, nil, nil, errors.Errorf("oci-layout reference %q does not have digest %s", ref.String())
+		}
 
-		usableRef := fmt.Sprintf("%s/%s@%s", storeID, "image", dig)
-		_, data, err := c.ResolveImageConfig(ctx, usableRef, llb.ResolveImageConfigOpt{
+		// We use store id as the host here, the image name will be ignored
+		// (since image lookup is not currently supported)
+		_, data, err := c.ResolveImageConfig(ctx, reference.Path(named)+"/"+named.String(), llb.ResolveImageConfigOpt{
 			Platform:     platform,
 			ResolveMode:  resolveMode,
 			LogName:      fmt.Sprintf("[context %s] load metadata for %s", name, ref),
@@ -934,10 +932,10 @@ func contextByName(ctx context.Context, c client.Client, sessionID, name string,
 
 		var img dockerfile2llb.Image
 		if err := json.Unmarshal(data, &img); err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, errors.Wrap(err, "could not parse oci-layout image config")
 		}
 
-		st := llb.OCILayout(storeID, dig,
+		st := llb.OCILayout(named.String(),
 			llb.WithCustomName("[context "+name+"] OCI load from client"),
 			llb.OCISessionID(c.BuildOpts().SessionID),
 		)

--- a/source/containerimage/ocilayout.go
+++ b/source/containerimage/ocilayout.go
@@ -63,12 +63,11 @@ func (r *ociLayoutResolver) Fetch(ctx context.Context, desc ocispecs.Descriptor)
 func (r *ociLayoutResolver) Resolve(ctx context.Context, refString string) (string, ocispecs.Descriptor, error) {
 	ref, err := reference.Parse(refString)
 	if err != nil {
-		return "", ocispecs.Descriptor{}, errors.Wrapf(err, "invalid reference '%s'", refString)
+		return "", ocispecs.Descriptor{}, errors.Wrapf(err, "invalid reference %q", refString)
 	}
-
-	dig := ref.Digest()
-	if dig == "" {
-		return "", ocispecs.Descriptor{}, errors.Errorf("reference must have format @sha256:<hash>: %s", refString)
+	dgst := ref.Digest()
+	if dgst == "" {
+		return "", ocispecs.Descriptor{}, errors.Errorf("reference %q must have digest", refString)
 	}
 
 	info, err := r.info(ctx, ref)
@@ -80,7 +79,7 @@ func (r *ociLayoutResolver) Resolve(ctx context.Context, refString string) (stri
 	// This is necessary because we do not know the media-type of the descriptor,
 	// and there are descriptor processing elements that expect it.
 	desc := ocispecs.Descriptor{
-		Digest: dig,
+		Digest: info.Digest,
 		Size:   info.Size,
 	}
 	rc, err := r.Fetch(ctx, desc)
@@ -91,12 +90,13 @@ func (r *ociLayoutResolver) Resolve(ctx context.Context, refString string) (stri
 	if err != nil {
 		return "", ocispecs.Descriptor{}, errors.Wrap(err, "unable to read root manifest")
 	}
-	// try it first as an index, then as a manifest
+
 	mediaType, err := imageutil.DetectManifestBlobMediaType(b)
 	if err != nil {
-		return "", ocispecs.Descriptor{}, errors.Wrapf(err, "reference %s contains neither an index nor a manifest", refString)
+		return "", ocispecs.Descriptor{}, errors.Wrapf(err, "reference %q contains neither an index nor a manifest", refString)
 	}
 	desc.MediaType = mediaType
+
 	return refString, desc, nil
 }
 

--- a/source/containerimage/pull.go
+++ b/source/containerimage/pull.go
@@ -106,19 +106,13 @@ func (is *Source) ResolveImageConfig(ctx context.Context, ref string, opt llb.Re
 		}
 		rslvr = resolver.DefaultPool.GetResolver(is.RegistryHosts, ref, "pull", sm, g).WithImageStore(is.ImageStore, rm)
 	case ResolverTypeOCILayout:
-		// with OCI layout, we always just "pull"
 		rm = source.ResolveModeForcePull
-		// get the content store ID from the ref
+
 		parsed, err := reference.Parse(ref)
 		if err != nil {
-			return "", nil, errors.Errorf("invalid oci-layout ref format '%s', must be content-store/image@sha256:digest", ref)
+			return "", nil, err
 		}
-		if parsed.Digest() == "" {
-			return "", nil, errors.Errorf("oci-layout ref format '%s' missing digest, must be content-store/image@sha256:digest", ref)
-		}
-		storeID := parsed.Hostname()
-
-		rslvr = getOCILayoutResolver(storeID, sm, "", g)
+		rslvr = getOCILayoutResolver(parsed.Hostname(), sm, "", g)
 	}
 	key += rm.String()
 	res, err := is.g.Do(ctx, key, func(ctx context.Context) (interface{}, error) {

--- a/source/containerimage/pull.go
+++ b/source/containerimage/pull.go
@@ -166,8 +166,8 @@ func (is *Source) Resolve(ctx context.Context, id source.Identifier, sm *session
 		}
 		mode = source.ResolveModeForcePull // with OCI layout, we always just "pull"
 		sessionID = ociIdentifier.SessionID
-		ref = reference.Spec{Locator: "oci-layout/dummy", Object: "@" + ociIdentifier.Manifest.String()}
-		storeID = ociIdentifier.Name
+		ref = reference.Spec{Locator: ociIdentifier.Name, Object: ociIdentifier.Object}
+		storeID = ociIdentifier.Hostname()
 		layerLimit = ociIdentifier.LayerLimit
 	default:
 		return nil, errors.Errorf("unknown resolver type: %v", is.ResolverType)

--- a/source/containerimage/pull.go
+++ b/source/containerimage/pull.go
@@ -166,8 +166,8 @@ func (is *Source) Resolve(ctx context.Context, id source.Identifier, sm *session
 		}
 		mode = source.ResolveModeForcePull // with OCI layout, we always just "pull"
 		sessionID = ociIdentifier.SessionID
-		ref = reference.Spec{Locator: ociIdentifier.Name, Object: ociIdentifier.Object}
-		storeID = ociIdentifier.Hostname()
+		ref = ociIdentifier.Ref
+		storeID = ociIdentifier.Store()
 		layerLimit = ociIdentifier.LayerLimit
 	default:
 		return nil, errors.Errorf("unknown resolver type: %v", is.ResolverType)

--- a/util/store/index.go
+++ b/util/store/index.go
@@ -1,0 +1,81 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"time"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/content/local"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+func NewIndexedStore(root string) (content.Store, error) {
+	store, err := local.NewStore(root)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := os.Open(path.Join(root, "index.json"))
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var idx ocispecs.Index
+	if err := json.NewDecoder(f).Decode(&idx); err != nil {
+		return nil, err
+	}
+
+	return &indexedStore{
+		Store: store,
+		index: idx,
+	}, nil
+}
+
+type indexedStore struct {
+	content.Store
+	index ocispecs.Index
+}
+
+func (s *indexedStore) Walk(ctx context.Context, fn content.WalkFunc, fs ...string) error {
+	found := false
+	for _, f := range fs {
+		if f == "index==true" {
+			found = true
+			break
+		}
+	}
+	if found && len(fs) > 1 {
+		return errors.New("index filter cannot be combined with other filters")
+	}
+
+	if !found {
+		return s.Store.Walk(ctx, fn, fs...)
+	}
+
+	for _, desc := range s.index.Manifests {
+		fmt.Println(desc)
+		info := content.Info{
+			Digest: desc.Digest,
+			Size:   desc.Size,
+			Labels: desc.Annotations,
+		}
+		if createdAt, ok := desc.Annotations[ocispecs.AnnotationCreated]; ok {
+			createdAt, err := time.Parse(time.RFC3339, createdAt)
+			if err != nil {
+				return err
+			}
+			info.CreatedAt = createdAt
+		}
+
+		if err := fn(info); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Follow up to #2827 with:

- Fix for consistently occurring 5-15s timeouts (depending on caching) when resolving OCI layout content (split out into #3122)
- Allow using tags instead of only digests (WIP)
- Refactoring for reference parsing to rely on containerd's and docker distribution's `reference.Parse` functions, instead of manual parsing wherever possible
  - One of these changes breaks API compatibility between the front-end and buildkit! (by prefixing the storeID hostname on the frontend, and storing it in LLB, instead of splitting that logic across the backend and the frontend). However, since we haven't released OCI sources in buildkit yet, I *think* this should be fine, but I've split it out into a separate commit so we can easily drop it if necessary. I don't this should affect the buildx release we've recently made.

CC @deitch