### PR TITLE
source: avoid hang if no session id for oci-layout

### DIFF
--- a/source/containerimage/ocilayout.go
+++ b/source/containerimage/ocilayout.go
@@ -11,7 +11,6 @@ import (
 	"github.com/moby/buildkit/session"
 	sessioncontent "github.com/moby/buildkit/session/content"
 	"github.com/moby/buildkit/util/imageutil"
-	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
@@ -46,40 +45,17 @@ func (r *ociLayoutResolver) Fetcher(ctx context.Context, ref string) (remotes.Fe
 
 // Fetch get an io.ReadCloser for the specific content
 func (r *ociLayoutResolver) Fetch(ctx context.Context, desc ocispecs.Descriptor) (io.ReadCloser, error) {
-	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	sessionID := r.sessionID
-
-	caller, err := r.sm.Get(timeoutCtx, sessionID, false)
-	if err != nil {
-		return r.fetchWithAnySession(ctx, desc)
-	}
-
-	return r.fetchWithSession(ctx, desc, caller)
-}
-
-func (r *ociLayoutResolver) fetchWithAnySession(ctx context.Context, desc ocispecs.Descriptor) (io.ReadCloser, error) {
 	var rc io.ReadCloser
-	err := r.sm.Any(ctx, r.g, func(ctx context.Context, _ string, caller session.Caller) error {
-		readCloser, err := r.fetchWithSession(ctx, desc, caller)
+	err := r.withCaller(ctx, func(ctx context.Context, caller session.Caller) error {
+		store := sessioncontent.NewCallerStore(caller, r.storeID)
+		readerAt, err := store.ReaderAt(ctx, desc)
 		if err != nil {
 			return err
 		}
-		rc = readCloser
+		rc = &readerAtWrapper{readerAt: readerAt}
 		return nil
 	})
 	return rc, err
-}
-
-func (r *ociLayoutResolver) fetchWithSession(ctx context.Context, desc ocispecs.Descriptor, caller session.Caller) (io.ReadCloser, error) {
-	store := sessioncontent.NewCallerStore(caller, r.storeID)
-	readerAt, err := store.ReaderAt(ctx, desc)
-	if err != nil {
-		return nil, err
-	}
-	// just wrap the ReaderAt with a Reader
-	//return io.NopCloser(&readerAtWrapper{readerAt: readerAt}), nil
-	return &readerAtWrapper{readerAt: readerAt}, nil
 }
 
 // Resolve attempts to resolve the reference into a name and descriptor.
@@ -89,23 +65,13 @@ func (r *ociLayoutResolver) Resolve(ctx context.Context, refString string) (stri
 	if err != nil {
 		return "", ocispecs.Descriptor{}, errors.Wrapf(err, "invalid reference '%s'", refString)
 	}
-	var (
-		dig  digest.Digest
-		info content.Info
-		rc   io.ReadCloser
-	)
-	if dig = ref.Digest(); dig == "" {
+
+	dig := ref.Digest()
+	if dig == "" {
 		return "", ocispecs.Descriptor{}, errors.Errorf("reference must have format @sha256:<hash>: %s", refString)
 	}
-	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
 
-	caller, err := r.sm.Get(timeoutCtx, r.sessionID, false)
-	if err != nil {
-		info, err = r.infoWithAnySession(ctx, dig)
-	} else {
-		info, err = r.infoWithSession(ctx, dig, caller)
-	}
+	info, err := r.info(ctx, ref)
 	if err != nil {
 		return "", ocispecs.Descriptor{}, errors.Wrap(err, "unable to get info about digest")
 	}
@@ -117,12 +83,7 @@ func (r *ociLayoutResolver) Resolve(ctx context.Context, refString string) (stri
 		Digest: dig,
 		Size:   info.Size,
 	}
-	caller, err = r.sm.Get(timeoutCtx, r.sessionID, false)
-	if err != nil {
-		rc, err = r.fetchWithAnySession(ctx, desc)
-	} else {
-		rc, err = r.fetchWithSession(ctx, desc, caller)
-	}
+	rc, err := r.Fetch(ctx, desc)
 	if err != nil {
 		return "", ocispecs.Descriptor{}, errors.Wrap(err, "unable to get root manifest")
 	}
@@ -139,26 +100,42 @@ func (r *ociLayoutResolver) Resolve(ctx context.Context, refString string) (stri
 	return refString, desc, nil
 }
 
-func (r *ociLayoutResolver) infoWithAnySession(ctx context.Context, dig digest.Digest) (content.Info, error) {
-	var info content.Info
-	err := r.sm.Any(ctx, r.g, func(ctx context.Context, _ string, caller session.Caller) error {
-		infoRet, err := r.infoWithSession(ctx, dig, caller)
+func (r *ociLayoutResolver) info(ctx context.Context, ref reference.Spec) (content.Info, error) {
+	var info *content.Info
+	err := r.withCaller(ctx, func(ctx context.Context, caller session.Caller) error {
+		store := sessioncontent.NewCallerStore(caller, r.storeID)
+
+		_, dgst := reference.SplitObject(ref.Object)
+		if dgst == "" {
+			return errors.Errorf("reference %q does not contain a digest", ref.String())
+		}
+		in, err := store.Info(ctx, dgst)
+		info = &in
+		return err
+	})
+	if err != nil {
+		return content.Info{}, err
+	}
+	if info == nil {
+		return content.Info{}, errors.Errorf("reference %q did not match any content", ref.String())
+	}
+	return *info, nil
+}
+
+func (r *ociLayoutResolver) withCaller(ctx context.Context, f func(context.Context, session.Caller) error) error {
+	if r.sessionID != "" {
+		timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		caller, err := r.sm.Get(timeoutCtx, r.sessionID, false)
 		if err != nil {
 			return err
 		}
-		info = infoRet
-		return nil
-	})
-	return info, err
-}
-
-func (r *ociLayoutResolver) infoWithSession(ctx context.Context, dig digest.Digest, caller session.Caller) (content.Info, error) {
-	store := sessioncontent.NewCallerStore(caller, r.storeID)
-	info, err := store.Info(ctx, dig)
-	if err != nil {
-		return info, err
+		return f(ctx, caller)
 	}
-	return info, nil
+	return r.sm.Any(ctx, r.g, func(ctx context.Context, _ string, caller session.Caller) error {
+		return f(ctx, caller)
+	})
 }
 
 // readerAtWrapper wraps a ReaderAt to give a Reader

--- a/source/containerimage/pull.go
+++ b/source/containerimage/pull.go
@@ -118,7 +118,7 @@ func (is *Source) ResolveImageConfig(ctx context.Context, ref string, opt llb.Re
 		}
 		storeID := parsed.Hostname()
 
-		rslvr = getOCILayoutResolver(storeID, sm, opt.SessionID, g)
+		rslvr = getOCILayoutResolver(storeID, sm, "", g)
 	}
 	key += rm.String()
 	res, err := is.g.Do(ctx, key, func(ctx context.Context) (interface{}, error) {


### PR DESCRIPTION
Split out timeout fix from: https://github.com/moby/buildkit/pull/3118.

In the scenario with no session id, then the oci-layout resolver would still attempt to load a caller with the empty session id. This inevitably failed, and would fallback to any caller, but this would take 5 seconds to fail with the configured timeout.

In a fresh pull of an OCI image context, this could take up to 15 seconds, as 3 separate calls to the relevant functions would be made.

This patch fixes the issue by correctly identifying this case, and directly falling through to any caller. Additionally, if a session id is present, it will always be loaded with no fallback available. To do this consistently, the helper methods are refactored into a more consistent withCaller function.

CC @deitch