### PR TITLE
README.md: Add Blubber to the list of frontends

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Currently, the following high-level languages has been implemented for LLB:
 -   [Nix](https://github.com/AkihiroSuda/buildkit-nix)
 -   [mopy (Python)](https://github.com/cmdjulian/mopy)
 -   [envd (starlark)](https://github.com/tensorchord/envd/)
+-   [Blubber](https://gitlab.wikimedia.org/repos/releng/blubber)
 -   (open a PR to add your own language)
 
 ### Exploring Dockerfiles


### PR DESCRIPTION
Wikimedia's Release Engineering Team wrote Blubber in 2017 to standardize its image builds. The canonical implementation was a YAML-to-Dockerfile transpiler but has recently been refactored to be used as a BuildKit frontend.