### PR TITLE
dockerfile: allow named context for docker-image://scratch

### DIFF
--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -848,6 +848,11 @@ func contextByName(ctx context.Context, c client.Client, sessionID, name string,
 	switch vv[0] {
 	case "docker-image":
 		ref := strings.TrimPrefix(vv[1], "//")
+		if ref == "scratch" {
+			st := llb.Scratch()
+			return &st, nil, nil, nil
+		}
+
 		imgOpt := []llb.ImageOption{
 			llb.WithCustomName("[context " + name + "] " + ref),
 		}


### PR DESCRIPTION
Mentioned by @ciaranmcnulty on [the community slack](https://dockercommunity.slack.com/archives/C7S7A40MP/p1664121664955829).

Previously, there was no simple way to create an empty named context, requiring external steps such as creating an empty directory. This change allows a single one-line context to represent the empty state.

Example usage:

```console
docker buildx build . --build-context alpine=docker-image://scratch
```