### PR TITLE
executor/oci: GetResolvConf(): simplify handling of resolv.conf

### DIFF
--- a/executor/oci/resolvconf_test.go
+++ b/executor/oci/resolvconf_test.go
@@ -5,19 +5,18 @@ import (
 	"os"
 	"testing"
 
-	"github.com/docker/docker/libnetwork/resolvconf"
 	"github.com/stretchr/testify/require"
 )
 
 // TestResolvConfNotExist modifies a global variable
 // It must not run in parallel.
 func TestResolvConfNotExist(t *testing.T) {
-	oldResolvconfGet := resolvconfGet
-	defer func() {
-		resolvconfGet = oldResolvconfGet
-	}()
-	resolvconfGet = func() (*resolvconf.File, error) {
-		return nil, os.ErrNotExist
+	oldResolvconfPath := resolvconfPath
+	t.Cleanup(func() {
+		resolvconfPath = oldResolvconfPath
+	})
+	resolvconfPath = func() string {
+		return "no-such-file"
 	}
 
 	defaultResolvConf := `


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/44234

We only need the content here, not the checksum, so simplifying the code by just using os.ReadFile(), using resolvconf.Path() for the location.

Also reversing the logic for custom options; The existing code was always parsing the host's resolv.conf to read the nameservers, searchdomain and options, but those options were only needed if they were not configured in DNSConfig. This patch reverses the logic to only parse the resolv.conf if no options are present in the passed DNSConfig.

There's some more optimisations to make (but changes in libnetwork are needed for that); resolvconf.FilterResolvDNS() still parse the resolv.conf file, even if we just generated it (in which case we're generating a resolv.conf, after which we're parsing the generated file again to update it, which is not ideal).
