### PR TITLE
oci exporter: support exporting directories

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2432,7 +2432,7 @@ func testOCIExporterUnpack(t *testing.T, sb integration.Sandbox) {
 				require.Contains(t, m, filename+"/")
 			} else {
 				require.Contains(t, m, filename)
-				if filename == "oci-layout" {
+				if filename == "index.json" {
 					// this file has a timestamp in it, so we can't compare
 					return nil
 				}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -96,6 +96,7 @@ func TestIntegration(t *testing.T) {
 		testResolveAndHosts,
 		testUser,
 		testOCIExporter,
+		testOCIExporterUnpack,
 		testWhiteoutParentDir,
 		testFrontendImageNaming,
 		testDuplicateWhiteouts,
@@ -2355,6 +2356,99 @@ func testOCIExporter(t *testing.T, sb integration.Sandbox) {
 	checkAllReleasable(t, c, sb, true)
 }
 
+func testOCIExporterUnpack(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerd(t, sb, "oci exporter")
+	requiresLinux(t)
+	c, err := New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	busybox := llb.Image("busybox:latest")
+	st := llb.Scratch()
+
+	run := func(cmd string) {
+		st = busybox.Run(llb.Shlex(cmd), llb.Dir("/wd")).AddMount("/wd", st)
+	}
+
+	run(`sh -c "echo -n first > foo"`)
+	run(`sh -c "echo -n second > bar"`)
+
+	def, err := st.Marshal(sb.Context())
+	require.NoError(t, err)
+
+	for _, exp := range []string{ExporterOCI, ExporterDocker} {
+		destDir := t.TempDir()
+		target := "example.com/buildkit/testoci:latest"
+
+		outTar := filepath.Join(destDir, "out.tar")
+		outW, err := os.Create(outTar)
+		require.NoError(t, err)
+		attrs := map[string]string{}
+		if exp == ExporterDocker {
+			attrs["name"] = target
+		}
+		_, err = c.Solve(sb.Context(), def, SolveOpt{
+			Exports: []ExportEntry{
+				{
+					Type:   exp,
+					Attrs:  attrs,
+					Output: fixedWriteCloser(outW),
+				},
+			},
+		}, nil)
+		require.NoError(t, err)
+
+		outDir := filepath.Join(destDir, "out.d")
+		attrs = map[string]string{
+			"unpack": "true",
+		}
+		if exp == ExporterDocker {
+			attrs["name"] = target
+		}
+		_, err = c.Solve(sb.Context(), def, SolveOpt{
+			Exports: []ExportEntry{
+				{
+					Type:      exp,
+					Attrs:     attrs,
+					OutputDir: outDir,
+				},
+			},
+		}, nil)
+		require.NoError(t, err)
+
+		dt, err := os.ReadFile(outTar)
+		require.NoError(t, err)
+		m, err := testutil.ReadTarToMap(dt, false)
+		require.NoError(t, err)
+
+		filepath.Walk(outDir, func(filename string, fi os.FileInfo, err error) error {
+			filename = strings.TrimPrefix(filename, outDir)
+			filename = strings.Trim(filename, "/")
+			if filename == "" || filename == "ingest" {
+				return nil
+			}
+
+			if fi.IsDir() {
+				require.Contains(t, m, filename+"/")
+			} else {
+				require.Contains(t, m, filename)
+				if filename == "oci-layout" {
+					// this file has a timestamp in it, so we can't compare
+					return nil
+				}
+				f, err := os.Open(path.Join(outDir, filename))
+				require.NoError(t, err)
+				data, err := io.ReadAll(f)
+				require.NoError(t, err)
+				require.Equal(t, m[filename].Data, data)
+			}
+			return nil
+		})
+	}
+
+	checkAllReleasable(t, c, sb, true)
+}
+
 func testSourceDateEpochLayerTimestamps(t *testing.T, sb integration.Sandbox) {
 	integration.SkipIfDockerd(t, sb, "oci exporter")
 	requiresLinux(t)
@@ -2692,7 +2786,6 @@ func testSourceDateEpochTarExporter(t *testing.T, sb integration.Sandbox) {
 
 	checkAllReleasable(t, c, sb, true)
 }
-
 func testFrontendMetadataReturn(t *testing.T, sb integration.Sandbox) {
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -96,7 +96,7 @@ func TestIntegration(t *testing.T) {
 		testResolveAndHosts,
 		testUser,
 		testOCIExporter,
-		testOCIExporterUnpack,
+		testOCIExporterContentStore,
 		testWhiteoutParentDir,
 		testFrontendImageNaming,
 		testDuplicateWhiteouts,
@@ -2356,7 +2356,7 @@ func testOCIExporter(t *testing.T, sb integration.Sandbox) {
 	checkAllReleasable(t, c, sb, true)
 }
 
-func testOCIExporterUnpack(t *testing.T, sb integration.Sandbox) {
+func testOCIExporterContentStore(t *testing.T, sb integration.Sandbox) {
 	integration.SkipIfDockerd(t, sb, "oci exporter")
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
@@ -2400,7 +2400,7 @@ func testOCIExporterUnpack(t *testing.T, sb integration.Sandbox) {
 
 		outDir := filepath.Join(destDir, "out.d")
 		attrs = map[string]string{
-			"unpack": "true",
+			"tar": "false",
 		}
 		if exp == ExporterDocker {
 			attrs["name"] = target

--- a/client/solve.go
+++ b/client/solve.go
@@ -142,10 +142,11 @@ func (c *Client) solve(ctx context.Context, def *llb.Definition, runGateway runG
 			contentStores[key] = store
 		}
 		for key, store := range opt.OCIStores {
-			if _, ok := contentStores[key]; ok {
-				return nil, errors.Errorf("content store key %q already exists", key)
+			key2 := "oci:" + key
+			if _, ok := contentStores[key2]; ok {
+				return nil, errors.Errorf("oci store key %q already exists", key)
 			}
-			contentStores[key] = store
+			contentStores[key2] = store
 		}
 
 		var supportFile bool

--- a/cmd/buildctl/build/output.go
+++ b/cmd/buildctl/build/output.go
@@ -41,7 +41,7 @@ func parseOutputCSV(s string) (client.ExportEntry, error) {
 	if v, ok := ex.Attrs["output"]; ok {
 		return ex, errors.Errorf("output=%s not supported for --output, you meant dest=%s?", v, v)
 	}
-	ex.Output, ex.OutputDir, err = resolveExporterDest(ex.Type, ex.Attrs["dest"])
+	ex.Output, ex.OutputDir, err = resolveExporterDest(ex.Type, ex.Attrs["dest"], ex.Attrs)
 	if err != nil {
 		return ex, errors.Wrap(err, "invalid output option: output")
 	}
@@ -65,19 +65,32 @@ func ParseOutput(exports []string) ([]client.ExportEntry, error) {
 }
 
 // resolveExporterDest returns at most either one of io.WriteCloser (single file) or a string (directory path).
-func resolveExporterDest(exporter, dest string) (func(map[string]string) (io.WriteCloser, error), string, error) {
+func resolveExporterDest(exporter, dest string, attrs map[string]string) (func(map[string]string) (io.WriteCloser, error), string, error) {
 	wrapWriter := func(wc io.WriteCloser) func(map[string]string) (io.WriteCloser, error) {
 		return func(m map[string]string) (io.WriteCloser, error) {
 			return wc, nil
 		}
 	}
+
+	var supportFile bool
+	var supportDir bool
 	switch exporter {
 	case client.ExporterLocal:
+		supportDir = true
+	case client.ExporterTar:
+		supportFile = true
+	case client.ExporterOCI, client.ExporterDocker:
+		unpack, ok := attrs["unpack"]
+		supportDir = ok && (unpack == "" || unpack == "true")
+		supportFile = !supportDir
+	}
+
+	if supportDir {
 		if dest == "" {
-			return nil, "", errors.New("output directory is required for local exporter")
+			return nil, "", errors.Errorf("output directory is required for %s exporter", exporter)
 		}
 		return nil, dest, nil
-	case client.ExporterOCI, client.ExporterDocker, client.ExporterTar:
+	} else if supportFile {
 		if dest != "" && dest != "-" {
 			fi, err := os.Stat(dest)
 			if err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -94,7 +107,8 @@ func resolveExporterDest(exporter, dest string) (func(map[string]string) (io.Wri
 			return nil, "", errors.Errorf("output file is required for %s exporter. refusing to write to console", exporter)
 		}
 		return wrapWriter(os.Stdout), "", nil
-	default: // e.g. client.ExporterImage
+	} else {
+		// e.g. client.ExporterImage
 		if dest != "" {
 			return nil, "", errors.Errorf("output %s is not supported by %s exporter", dest, exporter)
 		}

--- a/cmd/buildctl/build/output.go
+++ b/cmd/buildctl/build/output.go
@@ -4,6 +4,7 @@ import (
 	"encoding/csv"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/containerd/console"
@@ -80,9 +81,12 @@ func resolveExporterDest(exporter, dest string, attrs map[string]string) (func(m
 	case client.ExporterTar:
 		supportFile = true
 	case client.ExporterOCI, client.ExporterDocker:
-		unpack, ok := attrs["unpack"]
-		supportDir = ok && (unpack == "" || unpack == "true")
-		supportFile = !supportDir
+		tar, err := strconv.ParseBool(attrs["tar"])
+		if err != nil {
+			tar = true
+		}
+		supportFile = tar
+		supportDir = !tar
 	}
 
 	if supportDir {

--- a/exporter/local/export.go
+++ b/exporter/local/export.go
@@ -165,7 +165,7 @@ func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source
 				}
 			}
 
-			progress := newProgressHandler(ctx, lbl)
+			progress := NewProgressHandler(ctx, lbl)
 			if err := filesync.CopyToCaller(ctx, fs, caller, progress); err != nil {
 				return err
 			}
@@ -193,7 +193,7 @@ func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source
 	return nil, nil
 }
 
-func newProgressHandler(ctx context.Context, id string) func(int, bool) {
+func NewProgressHandler(ctx context.Context, id string) func(int, bool) {
 	limiter := rate.NewLimiter(rate.Every(100*time.Millisecond), 1)
 	pw, _, _ := progress.NewFromContext(ctx)
 	now := time.Now()

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -5,18 +5,22 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
 	archiveexporter "github.com/containerd/containerd/images/archive"
 	"github.com/containerd/containerd/leases"
+	"github.com/containerd/containerd/remotes"
 	"github.com/docker/distribution/reference"
+	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/moby/buildkit/cache"
 	cacheconfig "github.com/moby/buildkit/cache/config"
 	"github.com/moby/buildkit/exporter"
 	"github.com/moby/buildkit/exporter/containerimage"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/session"
+	sessioncontent "github.com/moby/buildkit/session/content"
 	"github.com/moby/buildkit/session/filesync"
 	"github.com/moby/buildkit/util/compression"
 	"github.com/moby/buildkit/util/contentutil"
@@ -33,6 +37,10 @@ type ExporterVariant string
 const (
 	VariantOCI    = "oci"
 	VariantDocker = "docker"
+)
+
+const (
+	keyUnpack = "unpack"
 )
 
 type Opt struct {
@@ -69,18 +77,32 @@ func (e *imageExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 	}
 
 	for k, v := range opt {
-		if i.meta == nil {
-			i.meta = make(map[string][]byte)
+		switch k {
+		case keyUnpack:
+			if v == "" {
+				i.unpack = true
+				continue
+			}
+			b, err := strconv.ParseBool(v)
+			if err != nil {
+				return nil, errors.Wrapf(err, "non-bool value specified for %s", k)
+			}
+			i.unpack = b
+		default:
+			if i.meta == nil {
+				i.meta = make(map[string][]byte)
+			}
+			i.meta[k] = []byte(v)
 		}
-		i.meta[k] = []byte(v)
 	}
 	return i, nil
 }
 
 type imageExporterInstance struct {
 	*imageExporter
-	opts containerimage.ImageCommitOpts
-	meta map[string][]byte
+	opts   containerimage.ImageCommitOpts
+	unpack bool
+	meta   map[string][]byte
 }
 
 func (e *imageExporterInstance) Name() string {
@@ -179,11 +201,6 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 		return nil, err
 	}
 
-	w, err := filesync.CopyFileWriter(ctx, resp, caller)
-	if err != nil {
-		return nil, err
-	}
-
 	mprovider := contentutil.NewMultiProvider(e.opt.ImageWriter.ContentStore())
 	if src.Ref != nil {
 		remotes, err := src.Ref.GetRemotes(ctx, false, e.opts.RefCfg, false, session.NewGroup(sessionID))
@@ -220,19 +237,41 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 		}
 	}
 
-	report := progress.OneOff(ctx, "sending tarball")
-	if err := archiveexporter.Export(ctx, mprovider, w, expOpts...); err != nil {
-		w.Close()
+	if e.unpack {
+		ctx = remotes.WithMediaTypeKeyPrefix(ctx, intoto.PayloadType, "intoto")
+		store := sessioncontent.NewCallerStore(caller, "export")
+		if err != nil {
+			return nil, err
+		}
+		err := contentutil.CopyChain(ctx, store, mprovider, *desc)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		w, err := filesync.CopyFileWriter(ctx, resp, caller)
+		if err != nil {
+			return nil, err
+		}
+
+		report := progress.OneOff(ctx, "sending tarball")
+		if err := archiveexporter.Export(ctx, mprovider, w, expOpts...); err != nil {
+			w.Close()
+			if grpcerrors.Code(err) == codes.AlreadyExists {
+				return resp, report(nil)
+			}
+			return nil, report(err)
+		}
+		err = w.Close()
 		if grpcerrors.Code(err) == codes.AlreadyExists {
 			return resp, report(nil)
 		}
-		return nil, report(err)
+		if err != nil {
+			return nil, report(err)
+		}
+		report(nil)
 	}
-	err = w.Close()
-	if grpcerrors.Code(err) == codes.AlreadyExists {
-		return resp, report(nil)
-	}
-	return resp, report(err)
+
+	return resp, nil
 }
 
 func normalizedNames(name string) ([]string, error) {

--- a/source/containerimage/ocilayout.go
+++ b/source/containerimage/ocilayout.go
@@ -47,7 +47,7 @@ func (r *ociLayoutResolver) Fetcher(ctx context.Context, ref string) (remotes.Fe
 func (r *ociLayoutResolver) Fetch(ctx context.Context, desc ocispecs.Descriptor) (io.ReadCloser, error) {
 	var rc io.ReadCloser
 	err := r.withCaller(ctx, func(ctx context.Context, caller session.Caller) error {
-		store := sessioncontent.NewCallerStore(caller, r.storeID)
+		store := sessioncontent.NewCallerStore(caller, "oci:"+r.storeID)
 		readerAt, err := store.ReaderAt(ctx, desc)
 		if err != nil {
 			return err
@@ -103,7 +103,7 @@ func (r *ociLayoutResolver) Resolve(ctx context.Context, refString string) (stri
 func (r *ociLayoutResolver) info(ctx context.Context, ref reference.Spec) (content.Info, error) {
 	var info *content.Info
 	err := r.withCaller(ctx, func(ctx context.Context, caller session.Caller) error {
-		store := sessioncontent.NewCallerStore(caller, r.storeID)
+		store := sessioncontent.NewCallerStore(caller, "oci:"+r.storeID)
 
 		_, dgst := reference.SplitObject(ref.Object)
 		if dgst == "" {


### PR DESCRIPTION
Fixes https://github.com/moby/buildkit/issues/1219.

This feature adds support for specifying `unpack=true` to the oci exporter options to unpack the resulting result for the client.

This requires changes to the client to ensure that when `unpack=true` is provided, we expose a directory instead of a single file.

Because of how the containerd API is designed, the image layout file structure is only directly exposed as part of the `archiveexporter.Export` method which produces a tar - so we need to unpack it on the buildkit server before syncing it back to the client. I can't quite work out if there's a better way to do this without needing to change the containerd API.