### PR TITLE
Improved opts parsing

### DIFF
--- a/docs/generate.go
+++ b/docs/generate.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/moby/buildkit/exporter/containerimage"
+	"github.com/moby/buildkit/util/opts"
+)
+
+func main() {
+	os, err := opts.Info(&containerimage.ContainerImageCommitOpts{})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(opts.GenMarkdown(os))
+}

--- a/exporter/containerimage/annotations.go
+++ b/exporter/containerimage/annotations.go
@@ -19,45 +19,50 @@ type Annotations struct {
 // AnnotationsGroup is a map of annotations keyed by the reference key
 type AnnotationsGroup map[string]*Annotations
 
-func ParseAnnotations(data map[string][]byte) (AnnotationsGroup, map[string][]byte, error) {
-	ag := make(AnnotationsGroup)
-	rest := make(map[string][]byte)
-
-	for k, v := range data {
-		a, ok, err := exptypes.ParseAnnotationKey(k)
-		if !ok {
-			rest[k] = v
-			continue
-		}
-		if err != nil {
-			return nil, nil, err
-		}
-
-		p := a.PlatformString()
-
-		if ag[p] == nil {
-			ag[p] = &Annotations{
-				IndexDescriptor:    make(map[string]string),
-				Index:              make(map[string]string),
-				Manifest:           make(map[string]string),
-				ManifestDescriptor: make(map[string]string),
-			}
-		}
-
-		switch a.Type {
-		case exptypes.AnnotationIndex:
-			ag[p].Index[a.Key] = string(v)
-		case exptypes.AnnotationIndexDescriptor:
-			ag[p].IndexDescriptor[a.Key] = string(v)
-		case exptypes.AnnotationManifest:
-			ag[p].Manifest[a.Key] = string(v)
-		case exptypes.AnnotationManifestDescriptor:
-			ag[p].ManifestDescriptor[a.Key] = string(v)
-		default:
-			return nil, nil, fmt.Errorf("unrecognized annotation type %s", a.Type)
+func ParseAnnotations(kvs map[string][]byte) (AnnotationsGroup, error) {
+	ag := AnnotationsGroup{}
+	for k, v := range kvs {
+		if err := ag.Load(k, string(v)); err != nil {
+			return nil, err
 		}
 	}
-	return ag, rest, nil
+	return ag, nil
+}
+
+func (ag AnnotationsGroup) Load(k, v string) error {
+	a, ok, err := exptypes.ParseAnnotationKey(k)
+	if !ok {
+		// FIXME: uh oh
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	p := a.PlatformString()
+
+	if ag[p] == nil {
+		ag[p] = &Annotations{
+			IndexDescriptor:    make(map[string]string),
+			Index:              make(map[string]string),
+			Manifest:           make(map[string]string),
+			ManifestDescriptor: make(map[string]string),
+		}
+	}
+
+	switch a.Type {
+	case exptypes.AnnotationIndex:
+		ag[p].Index[a.Key] = string(v)
+	case exptypes.AnnotationIndexDescriptor:
+		ag[p].IndexDescriptor[a.Key] = string(v)
+	case exptypes.AnnotationManifest:
+		ag[p].Manifest[a.Key] = string(v)
+	case exptypes.AnnotationManifestDescriptor:
+		ag[p].ManifestDescriptor[a.Key] = string(v)
+	default:
+		return fmt.Errorf("unrecognized annotation type %s", a.Type)
+	}
+	return nil
 }
 
 func (ag AnnotationsGroup) Platform(p *ocispecs.Platform) *Annotations {

--- a/exporter/tar/export.go
+++ b/exporter/tar/export.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -19,13 +18,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/tonistiigi/fsutil"
 	fstypes "github.com/tonistiigi/fsutil/types"
-)
-
-const (
-	// preferNondistLayersKey is an exporter option which can be used to mark a layer as non-distributable if the layer reference was
-	// already found to use a non-distributable media type.
-	// When this option is not set, the exporter will change the media type of the layer to a distributable one.
-	preferNondistLayersKey = "prefer-nondist-layers"
 )
 
 type Opt struct {
@@ -44,22 +36,11 @@ func New(opt Opt) (exporter.Exporter, error) {
 
 func (e *localExporter) Resolve(ctx context.Context, opt map[string]string) (exporter.ExporterInstance, error) {
 	li := &localExporterInstance{localExporter: e}
-
-	v, ok := opt[preferNondistLayersKey]
-	if ok {
-		b, err := strconv.ParseBool(v)
-		if err != nil {
-			return nil, errors.Wrapf(err, "non-bool value for %s: %s", preferNondistLayersKey, v)
-		}
-		li.preferNonDist = b
-	}
-
 	return li, nil
 }
 
 type localExporterInstance struct {
 	*localExporter
-	preferNonDist bool
 }
 
 func (e *localExporterInstance) Name() string {

--- a/util/opts/docs.go
+++ b/util/opts/docs.go
@@ -1,0 +1,85 @@
+package opts
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+)
+
+func GenMarkdown(opts []OptInfo) string {
+	w := bytes.NewBuffer(nil)
+	genMarkdown(w, opts, "")
+	return w.String()
+}
+
+func genMarkdown(w io.Writer, opts []OptInfo, prefix string) {
+	for _, opt := range opts {
+		if opt.Hidden {
+			continue
+		}
+
+		if opt.Key != "" || opt.Name != "" || opt.Help != "" {
+			hasContent := false
+			fmt.Fprint(w, prefix+"- ")
+			if opt.Name != "" {
+				fmt.Fprint(w, opt.Name)
+				hasContent = true
+			}
+
+			if opt.Key != "" {
+				if hasContent {
+					fmt.Fprint(w, " ")
+				}
+
+				choices := ""
+				if len(opt.Choices) > 1 {
+					choices = strings.Join(opt.Choices, "|")
+				} else if opt.Type == "bool" {
+					choices = "true|false"
+				} else if opt.Type != "" {
+					choices = opt.Type
+				}
+				if choices == "" {
+					fmt.Fprintf(w, "`%s`", opt.Key)
+				} else {
+					fmt.Fprintf(w, "`%s=<%s>`", opt.Key, choices)
+				}
+				hasContent = true
+			}
+			if opt.Default != nil {
+				s := fmt.Sprint(opt.Default)
+				if s != "" {
+					fmt.Fprintf(w, " (default %q)", s)
+				}
+			}
+
+			if hasContent {
+				fmt.Fprint(w, "\n\n")
+			}
+
+			if opt.Help != "" {
+				fmt.Fprint(w, prefix+indent(opt.Help, "  ")+"\n\n")
+			}
+		}
+
+		if opt.Children != nil {
+			if opt.Name == "" && opt.Help == "" {
+				genMarkdown(w, opt.Children, prefix)
+			} else {
+				genMarkdown(w, opt.Children, prefix+"  ")
+			}
+		}
+	}
+}
+
+func indent(s string, with string) string {
+	lines := strings.SplitAfter(s, "\n")
+	for i, line := range lines {
+		if len(line) == 1 {
+			continue
+		}
+		lines[i] = with + line
+	}
+	return strings.Join(lines, "")
+}

--- a/util/opts/info.go
+++ b/util/opts/info.go
@@ -1,0 +1,139 @@
+package opts
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type OptInfo struct {
+	Key     string
+	Type    string
+	Default any
+
+	Name string
+	Help string
+
+	Remain   bool
+	Required bool
+	Squash   bool
+	Hidden   bool
+	Choices  []string
+
+	Children []OptInfo
+
+	field      reflect.StructField
+	vfield     reflect.Value
+	marshaller setter
+}
+
+func Info(dest any) ([]OptInfo, error) {
+	v := reflect.ValueOf(dest)
+	for v.Kind() == reflect.Pointer {
+		v = v.Elem()
+	}
+	return getInfoRecurse(v, true)
+}
+
+const (
+	tagKey  = "opt"
+	nameKey = "name"
+	helpKey = "help"
+)
+
+func getInfo(value reflect.Value) ([]OptInfo, error) {
+	return getInfoRecurse(value, false)
+}
+
+func getInfoRecurse(value reflect.Value, recurse bool) ([]OptInfo, error) {
+	tp := value.Type()
+	if tp.Kind() != reflect.Struct {
+		return nil, errors.Errorf("is not struct")
+	}
+
+	var infos []OptInfo
+	for i := 0; i < tp.NumField(); i++ {
+		field := tp.Field(i)
+		vfield := value.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+
+		info := OptInfo{
+			field:  field,
+			vfield: vfield,
+		}
+
+		if field.Type.Kind() != reflect.Struct {
+			info.Key = strings.ToLower(field.Name)
+		}
+		var tag []string
+		if t, ok := field.Tag.Lookup(tagKey); ok {
+			tag = strings.Split(t, ",")
+		}
+		if tag != nil {
+			info.Key = tag[0]
+			if info.Key == "-" {
+				info.Key = ""
+			}
+			tag = tag[1:]
+		}
+
+		if t, ok := field.Tag.Lookup(nameKey); ok {
+			info.Name = t
+		}
+		if t, ok := field.Tag.Lookup(helpKey); ok {
+			info.Help = t
+		}
+
+		switch field.Type.Kind() {
+		case reflect.Struct, reflect.Slice, reflect.Array, reflect.Map:
+		default:
+			// TODO: pointers give weird results here
+			info.Type = strings.TrimLeft(fmt.Sprint(field.Type), "*")
+			info.Default = vfield.Interface()
+		}
+
+		for _, tag := range tag {
+			switch tag {
+			case "remain":
+				if info.Remain {
+					return nil, errors.New("cannot have multiple remain fields")
+				}
+				info.Remain = true
+			case "squash":
+				info.Squash = true
+				if recurse {
+					children, err := getInfoRecurse(vfield, recurse)
+					if err != nil {
+						return nil, err
+					}
+					info.Children = children
+				}
+			case "required":
+				info.Required = true
+			case "hidden":
+				info.Hidden = true
+			default:
+				choices := strings.Split(tag, "/")
+				if len(choices) > 1 {
+					info.Choices = choices
+				}
+			}
+		}
+
+		if method := value.Addr().MethodByName("Unmarshal" + field.Name); method.IsValid() && !method.IsZero() {
+			setter, ok := method.Interface().(setter)
+			if !ok {
+				return nil, errors.Errorf("expected custom Unmarshal to be setter but got (%s)", method.Type())
+			}
+			info.marshaller = setter
+		}
+
+		infos = append(infos, info)
+	}
+
+	return infos, nil
+}

--- a/util/opts/info_test.go
+++ b/util/opts/info_test.go
@@ -1,0 +1,97 @@
+package opts
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInfo(t *testing.T) {
+	type S struct {
+		P string `opt:"p"`
+	}
+	type T struct {
+		A string   `opt:"a"`
+		B int      `opt:"b" name:"B" help:"this is b"`
+		C string   `opt:"c,x/y"`
+		D []string `opt:"d,remain"`
+		E S        `opt:"e,squash"`
+		F bool     `opt:"f"`
+		G string   `opt:"g,required"`
+		X string   `opt:"-" name:"XXX" help:"this is invisible"`
+	}
+
+	infos, err := Info(&T{F: true})
+	require.NoError(t, err)
+	require.Equal(t, 8, len(infos))
+
+	require.Equal(t, "a", infos[0].Key)
+	require.Equal(t, "string", infos[0].Type)
+
+	require.Equal(t, "b", infos[1].Key)
+	require.Equal(t, "int", infos[1].Type)
+	require.Equal(t, "B", infos[1].Name)
+	require.Equal(t, "this is b", infos[1].Help)
+
+	require.Equal(t, "c", infos[2].Key)
+	require.Equal(t, "string", infos[2].Type)
+	require.Equal(t, []string{"x", "y"}, infos[2].Choices)
+
+	require.Equal(t, "d", infos[3].Key)
+	require.Equal(t, "", infos[3].Type)
+	require.Equal(t, true, infos[3].Remain)
+
+	require.Equal(t, "e", infos[4].Key)
+	require.Equal(t, "", infos[4].Type)
+	require.Equal(t, true, infos[4].Squash)
+	require.Equal(t, 1, len(infos[4].Children))
+	require.Equal(t, "p", infos[4].Children[0].Key)
+	require.Equal(t, "string", infos[4].Children[0].Type)
+
+	require.Equal(t, "f", infos[5].Key)
+	require.Equal(t, "bool", infos[5].Type)
+	require.Equal(t, true, infos[5].Default)
+
+	require.Equal(t, "g", infos[6].Key)
+	require.Equal(t, "string", infos[6].Type)
+	require.Equal(t, true, infos[6].Required)
+
+	require.Equal(t, "", infos[7].Key)
+	require.Equal(t, "string", infos[7].Type)
+	require.Equal(t, "XXX", infos[7].Name)
+	require.Equal(t, "this is invisible", infos[7].Help)
+}
+
+func TestInfoNestedStructs(t *testing.T) {
+	type R struct {
+		P string
+	}
+	type S struct {
+		R `opt:"r,squash"`
+	}
+	type T struct {
+		S `opt:"s,squash"`
+	}
+
+	infos, err := Info(&T{})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(infos))
+
+	require.Equal(t, "s", infos[0].Key)
+	require.Equal(t, 1, len(infos[0].Children))
+	require.Equal(t, "r", infos[0].Children[0].Key)
+	require.Equal(t, 1, len(infos[0].Children[0].Children))
+	require.Equal(t, "p", infos[0].Children[0].Children[0].Key)
+	require.Equal(t, "string", infos[0].Children[0].Children[0].Type)
+	require.Equal(t, 0, len(infos[0].Children[0].Children[0].Children))
+}
+
+func TestInfoPrivate(t *testing.T) {
+	target := struct {
+		x string
+	}{}
+
+	require.NotPanics(t, func() {
+		Info(&target)
+	})
+}

--- a/util/opts/unmarshal.go
+++ b/util/opts/unmarshal.go
@@ -1,0 +1,293 @@
+package opts
+
+import (
+	"encoding/csv"
+	"fmt"
+	"path"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+func Unmarshal(src map[string]string, dest any) error {
+	var kvs []kv
+	for k, v := range src {
+		kvs = append(kvs, kv{key: k, value: v})
+	}
+	return unmarshal(kvs, dest)
+}
+
+func UnmarshalCSV(src string, dest any) error {
+	if src == "" {
+		return nil
+	}
+
+	r := csv.NewReader(strings.NewReader(src))
+	entries, err := r.Read()
+	if err != nil {
+		return err
+	}
+
+	var kvs []kv
+	for _, entry := range entries {
+		var k, v string
+		parts := strings.SplitN(entry, "=", 2)
+		k = strings.ToLower(parts[0])
+		if len(parts) > 1 {
+			v = parts[1]
+		}
+		kvs = append(kvs, kv{key: k, value: v})
+	}
+	return unmarshal(kvs, dest)
+}
+
+type kv struct {
+	key   string
+	value string
+}
+
+func unmarshal(src []kv, dest any) error {
+	v := reflect.ValueOf(dest)
+
+	u := unmarshaler{}
+	if err := u.setup(v); err != nil {
+		return err
+	}
+
+	if src == nil {
+		return nil
+	}
+
+	handled := map[string]struct{}{}
+	for _, kv := range src {
+		key := kv.key
+		value := kv.value
+		handled[key] = struct{}{}
+
+		field, ok := u.fields[key]
+		if !ok {
+			for pat, f := range u.fields {
+				ok, err := path.Match(pat, key)
+				if err != nil {
+					return err
+				}
+				if ok {
+					field = f
+					break
+				}
+			}
+		}
+		if field == nil {
+			if u.remain == nil {
+				return errors.Errorf("key %q not present", key)
+			}
+			if err := u.remain(key, value); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if err := field(key, value); err != nil {
+			return err
+		}
+	}
+
+	for _, required := range u.required {
+		if _, ok := handled[required]; !ok {
+			return errors.Errorf("key %q was required but was not present", required)
+		}
+	}
+
+	return nil
+}
+
+type setter = func(key, value string) error
+
+type unmarshaler struct {
+	fields   map[string]setter
+	remain   setter
+	required []string
+}
+
+func (u *unmarshaler) setup(v reflect.Value) error {
+	if u.fields == nil {
+		u.fields = map[string]setter{}
+	}
+
+	for v.Kind() == reflect.Pointer {
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return errors.New("cannot unmarshal into non-struct")
+	}
+
+	infos, err := getInfo(v)
+	if err != nil {
+		return err
+	}
+
+	for _, info := range infos {
+		if info.Remain {
+			remain, err := makeRemain(info.field.Type, info.vfield)
+			if err != nil {
+				return err
+			}
+			u.remain = remain
+			continue
+		}
+
+		if info.Squash {
+			if err := u.setup(info.vfield); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if info.Required {
+			u.required = append(u.required, info.Key)
+		}
+
+		if info.Key == "" {
+			continue
+		}
+
+		if info.marshaller != nil {
+			u.fields[info.Key] = info.marshaller
+		} else {
+			setter, err := makeSetter(info.field.Type, info.vfield)
+			if err != nil {
+				return err
+			}
+			u.fields[info.Key] = setter
+		}
+
+		if info.Choices != nil {
+			u.fields[info.Key] = makeValidator(u.fields[info.Key], info)
+		}
+	}
+
+	return nil
+}
+
+func makeSetter(t reflect.Type, v reflect.Value) (setter, error) {
+	switch t.Kind() {
+	case reflect.String:
+		return func(key, value string) error {
+			v.SetString(value)
+			return nil
+		}, nil
+	case reflect.Bool:
+		return func(key, value string) error {
+			if value == "" {
+				v.SetBool(true)
+				return nil
+			}
+			valueBool, err := strconv.ParseBool(value)
+			if err != nil {
+				return err
+			}
+			v.SetBool(valueBool)
+			return nil
+		}, nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return func(key, value string) error {
+			valueInt, err := strconv.ParseInt(value, 10, 64)
+			if err != nil {
+				return err
+			}
+			v.SetInt(valueInt)
+			return nil
+		}, nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return func(key, value string) error {
+			valueUint, err := strconv.ParseUint(value, 10, 64)
+			if err != nil {
+				return err
+			}
+			v.SetUint(valueUint)
+			return nil
+		}, nil
+	case reflect.Float32, reflect.Float64:
+		return func(key, value string) error {
+			valueFloat, err := strconv.ParseFloat(value, 64)
+			if err != nil {
+				return err
+			}
+			v.SetFloat(valueFloat)
+			return nil
+		}, nil
+	case reflect.Pointer:
+		tmp := reflect.New(t.Elem())
+		setter, err := makeSetter(t.Elem(), tmp.Elem())
+		if err != nil {
+			return nil, err
+		}
+		return func(key, value string) error {
+			if err := setter(key, value); err != nil {
+				return err
+			}
+			v.Set(tmp)
+			return nil
+		}, nil
+	default:
+		return nil, errors.Errorf("unknown field type %q", v.Type())
+	}
+}
+
+func makeRemain(t reflect.Type, v reflect.Value) (setter, error) {
+	switch t.Kind() {
+	case reflect.String:
+		return func(key, value string) error {
+			s := v.String()
+			if len(s) > 0 {
+				s += ","
+			}
+			s += fmt.Sprintf("%s=%s", key, value)
+			v.SetString(s)
+			return nil
+		}, nil
+	case reflect.Slice:
+		if t.Elem().Kind() != reflect.String {
+			break
+		}
+		return func(key, value string) error {
+			ss := v.Interface().([]string)
+			ss = append(ss, fmt.Sprintf("%s=%s", key, value))
+			v.Set(reflect.ValueOf(ss))
+			return nil
+		}, nil
+	case reflect.Map:
+		if t.Elem().Kind() != reflect.String || t.Key().Kind() != reflect.String {
+			break
+		}
+		return func(key, value string) error {
+			ss := v.Interface().(map[string]string)
+			if ss == nil {
+				ss = map[string]string{}
+			}
+			ss[key] = value
+			v.Set(reflect.ValueOf(ss))
+			return nil
+		}, nil
+	}
+	return nil, errors.Errorf("remain cannot be %q", t)
+}
+
+func makeValidator(set setter, info OptInfo) setter {
+	if info.Choices == nil {
+		return set
+	}
+
+	choices := map[string]struct{}{}
+	for _, choice := range info.Choices {
+		choices[choice] = struct{}{}
+	}
+	return func(key, value string) error {
+		if _, ok := choices[value]; !ok {
+			return errors.Errorf("%q is not a valid choice for %s", value, info.Key)
+		}
+		return set(key, value)
+	}
+}

--- a/util/opts/unmarshal_test.go
+++ b/util/opts/unmarshal_test.go
@@ -1,0 +1,263 @@
+package opts
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNothing(t *testing.T) {
+	target := struct{}{}
+
+	require.NoError(t, UnmarshalCSV("", &target))
+}
+
+func TestLoadString(t *testing.T) {
+	target := struct {
+		X string
+	}{}
+
+	require.NoError(t, UnmarshalCSV("x=testing", &target))
+	require.Equal(t, "testing", target.X)
+}
+
+func TestLoadInts(t *testing.T) {
+	target := struct {
+		I int
+		J uint
+		K int32
+		L uint8
+	}{}
+
+	require.NoError(t, UnmarshalCSV("i=1,j=2,k=3,l=4", &target))
+	require.Equal(t, int(1), target.I)
+	require.Equal(t, uint(2), target.J)
+	require.Equal(t, int32(3), target.K)
+	require.Equal(t, uint8(4), target.L)
+}
+
+func TestLoadFloats(t *testing.T) {
+	target := struct {
+		F float32
+		G float64
+	}{}
+
+	require.NoError(t, UnmarshalCSV("f=3.14,g=2.71", &target))
+	require.Equal(t, float32(3.14), target.F)
+	require.Equal(t, float64(2.71), target.G)
+}
+
+func TestLoadBools(t *testing.T) {
+	target := struct {
+		B bool
+		C bool
+		D bool
+	}{}
+
+	require.NoError(t, UnmarshalCSV("b=true,c=false,d", &target))
+	require.Equal(t, true, target.B)
+	require.Equal(t, false, target.C)
+	require.Equal(t, true, target.D)
+}
+
+func TestLoadPointers(t *testing.T) {
+	target := struct {
+		B   *bool
+		I   *int
+		I64 *int64
+		S   *string
+	}{}
+
+	require.NoError(t, UnmarshalCSV("b=true,i=123,i64=456,s=foo", &target))
+	require.Equal(t, true, *target.B)
+	require.Equal(t, 123, *target.I)
+	require.Equal(t, int64(456), *target.I64)
+	require.Equal(t, "foo", *target.S)
+}
+
+func TestUnknown(t *testing.T) {
+	target := struct{}{}
+	require.Error(t, UnmarshalCSV("x=test", &target))
+}
+
+func TestCustomNames(t *testing.T) {
+	target := struct {
+		Foo string `opt:"bar"`
+	}{}
+
+	require.Error(t, UnmarshalCSV("foo=test", &target))
+	require.Equal(t, "", target.Foo)
+	require.NoError(t, UnmarshalCSV("bar=test", &target))
+	require.Equal(t, "test", target.Foo)
+}
+
+func TestGlobbedName(t *testing.T) {
+	target := struct {
+		Foo string `opt:"bar.*"`
+	}{}
+
+	require.NoError(t, UnmarshalCSV("bar.x=hello", &target))
+	require.Equal(t, "hello", target.Foo)
+	require.NoError(t, UnmarshalCSV("bar.y=world", &target))
+	require.Equal(t, "world", target.Foo)
+}
+
+func TestEmptyName(t *testing.T) {
+	target := struct {
+		Foo string `opt:"-"`
+	}{}
+
+	require.Error(t, UnmarshalCSV("foo=test", &target))
+	require.Equal(t, "", target.Foo)
+
+	require.Error(t, UnmarshalCSV("-=test", &target))
+	require.Equal(t, "", target.Foo)
+}
+
+func TestDefaults(t *testing.T) {
+	target := struct {
+		Foo string
+		Bar string
+	}{
+		Foo: "foo",
+		Bar: "bar",
+	}
+
+	require.NoError(t, UnmarshalCSV("foo=123", &target))
+	require.Equal(t, "123", target.Foo)
+	require.Equal(t, "bar", target.Bar)
+}
+
+func TestStructs(t *testing.T) {
+	target := struct {
+		W string
+		X struct {
+			Y string
+			Z string
+		}
+	}{}
+	require.Error(t, UnmarshalCSV("w=a,y=b,z=c", &target))
+
+	target2 := struct {
+		W string
+		X struct {
+			Y string
+			Z string
+		} `opt:",squash"`
+	}{}
+	require.NoError(t, UnmarshalCSV("w=a,y=b,z=c", &target2))
+	require.Equal(t, "a", target2.W)
+	require.Equal(t, "b", target2.X.Y)
+	require.Equal(t, "c", target2.X.Z)
+}
+
+func TestRemain(t *testing.T) {
+	src := "x=a,y=b,z=c"
+
+	target0 := struct {
+		Y    string
+		Rest int `opt:",remain"`
+	}{}
+	require.Error(t, UnmarshalCSV(src, &target0))
+
+	target1 := struct {
+		Y    string
+		Rest map[string]string `opt:",remain"`
+	}{}
+	require.NoError(t, UnmarshalCSV(src, &target1))
+	require.Equal(t, "b", target1.Y)
+	require.Equal(t, map[string]string{"x": "a", "z": "c"}, target1.Rest)
+
+	target2 := struct {
+		Y    string
+		Rest []string `opt:",remain"`
+	}{}
+	require.NoError(t, UnmarshalCSV(src, &target2))
+	require.Equal(t, "b", target2.Y)
+	require.Equal(t, []string{"x=a", "z=c"}, target2.Rest)
+
+	target3 := struct {
+		Y    string
+		Rest string `opt:",remain"`
+	}{}
+	require.NoError(t, UnmarshalCSV(src, &target3))
+	require.Equal(t, "b", target3.Y)
+	require.Equal(t, "x=a,z=c", target3.Rest)
+}
+
+func TestRequired(t *testing.T) {
+	target := struct {
+		X string `opt:"x,required"`
+		Y string `opt:"y"`
+	}{}
+
+	require.Error(t, UnmarshalCSV("y=b", &target))
+	require.Equal(t, "", target.X)
+	require.NoError(t, UnmarshalCSV("x=a", &target))
+	require.Equal(t, "a", target.X)
+}
+
+func TestChoices(t *testing.T) {
+	target := struct {
+		X string `opt:"x,y/z"`
+	}{}
+
+	require.Error(t, UnmarshalCSV("x=a", &target))
+	require.Equal(t, "", target.X)
+	require.Error(t, UnmarshalCSV("x=b", &target))
+	require.Equal(t, "", target.X)
+
+	require.NoError(t, UnmarshalCSV("x=y", &target))
+	require.Equal(t, "y", target.X)
+	require.NoError(t, UnmarshalCSV("x=z", &target))
+	require.Equal(t, "z", target.X)
+}
+
+type testCustomUnmarshalType struct {
+	X string `opt:"x"`
+}
+
+func (t *testCustomUnmarshalType) UnmarshalX(key, value string) error {
+	t.X = strings.ToUpper(value)
+	return nil
+}
+
+func TestCustomUnmarshal(t *testing.T) {
+	target := testCustomUnmarshalType{}
+	require.NoError(t, UnmarshalCSV("x=test", &target))
+	require.Equal(t, "TEST", target.X)
+}
+
+type testCustomUnmarshalGlobType struct {
+	X map[string]string `opt:"x.*"`
+}
+
+func (t *testCustomUnmarshalGlobType) UnmarshalX(key, value string) error {
+	if t.X == nil {
+		t.X = map[string]string{}
+	}
+	key = strings.SplitN(key, ".", 2)[1]
+	t.X[strings.ToUpper(key)] = strings.Repeat("x", len(value))
+	return nil
+}
+
+func TestCustomUnmarshalGlob(t *testing.T) {
+	target := testCustomUnmarshalGlobType{}
+	require.NoError(t, UnmarshalCSV("x.a=1,x.b=22,x.c=333", &target))
+	require.Equal(t, map[string]string{
+		"A": "x",
+		"B": "xx",
+		"C": "xxx",
+	}, target.X)
+}
+
+func TestUnmarshalPrivate(t *testing.T) {
+	target := struct {
+		x string
+	}{}
+
+	require.NotPanics(t, func() {
+		UnmarshalCSV("x=123", &target)
+	})
+}


### PR DESCRIPTION
This PR proposes changing the mechanism by which we parse CSV options. I'm still working on an exact API we'd use, but ideally we'd be able to replace our old-style switch statements with a new style of using struct tags, e.g., the container image common options in the exporter might look similar to:

```
type ImageCommitOpts struct {
	ImageName string `opt:"name" name:"Image name" help:"Location reference for the image result to be pushed to."`

	Compression struct {
		Type  string `opt:"compression,gzip/estargz/zstd/uncompressed" name:"Compression type"`
		Level *int   `opt:"compression-level" name:"Compression level"`
		Force bool   `opt:"compression-force" name:"Force compression"`
	} `opt:",squash" name:"Compression"`

	OCITypes bool `opt:"oci-mediatypes" name:"OCI Media Types" help:"Use OCI media types for image output"`

	BuildInfo struct {
		Enable bool `opt:"buildinfo" name:"Build Info" help:"Attach inline buildinfo"`
		Attrs  bool `opt:"buildinfo-attrs" name:"Build Info Attributes" help:"Attach inline buildinfo attributes"`
	} `opt:",squash" name:"Build Info"`

	PreferNonDistributable bool `opt:"prefer-nondist-layers"`

	Annotations AnnotationsGroup `opt:"annotation*" name:"Annotations"`

	Meta map[string]string `opt:"-,remain"`
}
```

Sorry for not sharing this work a bit earlier, I've been tinkering with the idea over the last couple of weeks, it's definitely not ready to be reviewed in detail, but high-level thoughts on design would be appreciated. This would be a *fairly* substantial change to how we parse opts, adding lots of fiddly reflection code to extract the arguments, etc, however this would reduce the complexity of everywhere we manually parse arguments.

This declarative structure has several key improvements over the current approach (that while possible, would be tricky with the current architecture):
- Consistent parsing of all sets of CSV options (e.g. in some places standalone booleans without an `=` like `push` evaluate to their default values, in other places not so much).
- Programmatic modification of options in clients (e.g. modifying the `--cache-to` [options in buildx to include github tokens](https://github.com/docker/buildx/blob/57d22a7bd18c2d004d69e4995f71368625044aed/util/buildflags/cache.go#L51-L53)) can be performed more consistently between client+server.
- We could generate automatic documentation for the options, similar to how we already do for the buildx [command line reference](https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#options).
- We could generate command line completion for CSV flags, improving user experience.
- We could automatically suggest corrections of misspelt flags.

The PR as opened includes a custom package for parsing the tag details, inspired by the `json` parsing facilities in go, and with support for default arguments, choices to select, `remain` and `squash` (as in `mapstructure`), `required` parameters, etc - additionally, there's functionality to extend the default unmarshalling behaviour for complex arguments like `annotation.*`/etc. I've also adapted the exporter package to use this new `struct` tagging style, as an example, and prototyped how I imagine we might go about automatically generating docs :tada:

Thoughts very much appreciated! 