### PR TITLE
integration: containerd snapshotter with dockerd

### DIFF
--- a/.github/workflows/dockerd.yml
+++ b/.github/workflows/dockerd.yml
@@ -7,7 +7,7 @@ on:
       version:
         description: 'Docker version'
         required: true
-        default: '20.10.13'
+        default: '20.10.19'
 
 env:
   REPO_SLUG_ORIGIN: "moby/buildkit:latest"
@@ -25,7 +25,7 @@ jobs:
         run: |
           version=${{ github.event.inputs.version }}
           if [ -z "$version" ]; then
-            version=20.10.13
+            version=20.10.19
           fi
           echo "DOCKER_VERSION=$version" >> $GITHUB_ENV
       -
@@ -85,6 +85,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        worker:
+          - dockerd
+          - dockerd-containerd
         pkg:
           - ./client
           - ./cmd/buildctl
@@ -124,13 +127,6 @@ jobs:
         run: |
           chmod +x ./build/dockerd
       -
-        name: Update daemon.json
-        run: |
-          sudo rm /etc/docker/daemon.json
-          sudo service docker restart
-          docker version
-          docker info
-      -
         name: Test
         run: |
           ./hack/test ${{ matrix.typ }}
@@ -138,6 +134,6 @@ jobs:
           TEST_DOCKERD: "1"
           TEST_DOCKERD_BINARY: "./build/dockerd"
           TESTPKGS: "${{ matrix.pkg }}"
-          TESTFLAGS: "${{ env.TESTFLAGS }} --run=//worker=dockerd$"
+          TESTFLAGS: "${{ env.TESTFLAGS }} --run=//worker=${{ matrix.worker }}$"
           SKIP_INTEGRATION_TESTS: "${{ matrix.skip-integration-tests }}"
           CACHE_FROM: "type=gha,scope=${{ env.CACHE_GHA_SCOPE_IT }} type=gha,scope=${{ env.CACHE_GHA_SCOPE_BINARIES }}"

--- a/client/build_test.go
+++ b/client/build_test.go
@@ -1615,6 +1615,7 @@ func testClientGatewayExecFileActionError(t *testing.T, sb integration.Sandbox) 
 // testClientGatewayContainerSecurityMode ensures that the correct security mode
 // is propagated to the gateway container
 func testClientGatewayContainerSecurityMode(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerdSnapshotter(t, sb, "security mode")
 	requiresLinux(t)
 
 	ctx := sb.Context()

--- a/client/build_test.go
+++ b/client/build_test.go
@@ -1615,7 +1615,7 @@ func testClientGatewayExecFileActionError(t *testing.T, sb integration.Sandbox) 
 // testClientGatewayContainerSecurityMode ensures that the correct security mode
 // is propagated to the gateway container
 func testClientGatewayContainerSecurityMode(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerdSnapshotter(t, sb, "security mode")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureSecurityMode)
 	requiresLinux(t)
 
 	ctx := sb.Context()
@@ -1642,7 +1642,6 @@ func testClientGatewayContainerSecurityMode(t *testing.T, sb integration.Sandbox
 		}
 		allowedEntitlements = []entitlements.Entitlement{}
 	} else {
-		integration.SkipIfDockerd(t, sb)
 		assertCaps = func(caps uint64) {
 			/*
 				$ capsh --decode=0000003fffffffff
@@ -1992,7 +1991,7 @@ func testClientGatewayContainerSignal(t *testing.T, sb integration.Sandbox) {
 }
 
 func testClientGatewayNilResult(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "hangs")
+	integration.CheckFeatureCompat(t, sb, "hangs: https://github.com/moby/buildkit/pull/3176#issuecomment-1323954327")
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -2027,7 +2026,7 @@ func testClientGatewayNilResult(t *testing.T, sb integration.Sandbox) {
 }
 
 func testClientGatewayEmptyImageExec(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "direct push")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()

--- a/client/build_test.go
+++ b/client/build_test.go
@@ -1991,6 +1991,7 @@ func testClientGatewayContainerSignal(t *testing.T, sb integration.Sandbox) {
 }
 
 func testClientGatewayNilResult(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerd(t, sb, "hangs")
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)

--- a/client/client_nydus_test.go
+++ b/client/client_nydus_test.go
@@ -28,7 +28,7 @@ func TestNydusIntegration(t *testing.T) {
 }
 
 func testBuildExportNydusWithHybrid(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "nydus build export")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush)
 	requiresLinux(t)
 
 	cdAddress := sb.ContainerdAddress()

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -5588,7 +5588,7 @@ func testMergeOp(t *testing.T, sb integration.Sandbox) {
 		File(llb.Mkfile("bar/D", 0644, []byte("D"))).
 		File(llb.Mkfile("bar/E", 0755, nil)).
 		File(llb.Mkfile("qaz", 0644, nil)),
-	// /foo from stateE is not here because it is deleted in stateB, which is part of a submerge of mergeD
+		// /foo from stateE is not here because it is deleted in stateB, which is part of a submerge of mergeD
 	)
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -238,7 +238,7 @@ func newContainerd(cdAddress string) (*containerd.Client, error) {
 
 // moby/buildkit#1336
 func testCacheExportCacheKeyLoop(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "remote cache export")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -303,7 +303,7 @@ func testBridgeNetworking(t *testing.T, sb integration.Sandbox) {
 }
 
 func testBridgeNetworkingDNSNoRootless(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "https://github.com/moby/buildkit/issues/3171")
+	integration.CheckFeatureCompat(t, sb, "hangs: https://github.com/moby/buildkit/issues/3171")
 	if os.Getenv("BUILDKIT_RUN_NETWORK_INTEGRATION_TESTS") == "" {
 		t.SkipNow()
 	}
@@ -774,7 +774,7 @@ func testNetworkMode(t *testing.T, sb integration.Sandbox) {
 }
 
 func testPushByDigest(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "direct push")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -819,7 +819,7 @@ func testPushByDigest(t *testing.T, sb integration.Sandbox) {
 }
 
 func testSecurityMode(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerdSnapshotter(t, sb, "security mode")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureSecurityMode)
 	command := `sh -c 'cat /proc/self/status | grep CapEff | cut -f 2 > /out'`
 	mode := llb.SecurityModeSandbox
 	var allowedEntitlements []entitlements.Entitlement
@@ -836,7 +836,6 @@ func testSecurityMode(t *testing.T, sb integration.Sandbox) {
 		}
 		allowedEntitlements = []entitlements.Entitlement{}
 	} else {
-		integration.SkipIfDockerd(t, sb)
 		assertCaps = func(caps uint64) {
 			/*
 				$ capsh --decode=0000003fffffffff
@@ -891,7 +890,7 @@ func testSecurityMode(t *testing.T, sb integration.Sandbox) {
 }
 
 func testSecurityModeSysfs(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerdSnapshotter(t, sb, "security mode")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureSecurityMode)
 	if sb.Rootless() {
 		t.SkipNow()
 	}
@@ -902,7 +901,6 @@ func testSecurityModeSysfs(t *testing.T, sb integration.Sandbox) {
 	if secMode == securitySandbox {
 		allowedEntitlements = []entitlements.Entitlement{}
 	} else {
-		integration.SkipIfDockerd(t, sb)
 		mode = llb.SecurityModeInsecure
 		allowedEntitlements = []entitlements.Entitlement{entitlements.EntitlementSecurityInsecure}
 	}
@@ -969,7 +967,7 @@ func testSecurityModeErrors(t *testing.T, sb integration.Sandbox) {
 }
 
 func testFrontendImageNaming(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "oci exporter", "direct push")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureOCIExporter, integration.FeatureDirectPush)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -1711,7 +1709,7 @@ func testLocalSourceWithDiffer(t *testing.T, sb integration.Sandbox, d llb.DiffT
 }
 
 func testOCILayoutSource(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "oci exporter")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureOCIExporter, integration.FeatureOCILayout)
 	requiresLinux(t)
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
@@ -1808,7 +1806,7 @@ func testOCILayoutSource(t *testing.T, sb integration.Sandbox) {
 }
 
 func testOCILayoutPlatformSource(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "oci exporter")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureOCIExporter, integration.FeatureOCILayout)
 	requiresLinux(t)
 	c, err := New(context.TODO(), sb.Address())
 	require.NoError(t, err)
@@ -2061,8 +2059,7 @@ func testBuildMultiMount(t *testing.T, sb integration.Sandbox) {
 }
 
 func testBuildExportScratch(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "image exporter")
-
+	integration.CheckFeatureCompat(t, sb, integration.FeatureImageExporter)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -2320,7 +2317,7 @@ func testUser(t *testing.T, sb integration.Sandbox) {
 }
 
 func testOCIExporter(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "oci exporter")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureOCIExporter)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -2421,7 +2418,7 @@ func testOCIExporter(t *testing.T, sb integration.Sandbox) {
 }
 
 func testOCIExporterContentStore(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "oci exporter")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureOCIExporter)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -2514,7 +2511,7 @@ func testOCIExporterContentStore(t *testing.T, sb integration.Sandbox) {
 }
 
 func testSourceDateEpochLayerTimestamps(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "oci exporter")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureOCIExporter, integration.FeatureSourceDateEpoch)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -2574,7 +2571,7 @@ func testSourceDateEpochLayerTimestamps(t *testing.T, sb integration.Sandbox) {
 }
 
 func testSourceDateEpochClamp(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "oci exporter")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureOCIExporter, integration.FeatureSourceDateEpoch)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -2683,7 +2680,7 @@ func testSourceDateEpochClamp(t *testing.T, sb integration.Sandbox) {
 
 // testSourceDateEpochReset tests that the SOURCE_DATE_EPOCH is reset if exporter option is set
 func testSourceDateEpochReset(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "oci exporter")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureOCIExporter, integration.FeatureSourceDateEpoch)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -2747,6 +2744,7 @@ func testSourceDateEpochReset(t *testing.T, sb integration.Sandbox) {
 }
 
 func testSourceDateEpochLocalExporter(t *testing.T, sb integration.Sandbox) {
+	integration.CheckFeatureCompat(t, sb, integration.FeatureSourceDateEpoch)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -2796,6 +2794,7 @@ func testSourceDateEpochLocalExporter(t *testing.T, sb integration.Sandbox) {
 }
 
 func testSourceDateEpochTarExporter(t *testing.T, sb integration.Sandbox) {
+	integration.CheckFeatureCompat(t, sb, integration.FeatureSourceDateEpoch)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -2851,7 +2850,6 @@ func testSourceDateEpochTarExporter(t *testing.T, sb integration.Sandbox) {
 	checkAllReleasable(t, c, sb, true)
 }
 func testFrontendMetadataReturn(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerdSnapshotter(t, sb, "oci exporter")
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -2957,7 +2955,7 @@ func testFrontendUseSolveResults(t *testing.T, sb integration.Sandbox) {
 }
 
 func testExporterTargetExists(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "oci exporter")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureOCIExporter)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -3078,8 +3076,7 @@ func testTarExporterSymlink(t *testing.T, sb integration.Sandbox) {
 }
 
 func testBuildExportWithForeignLayer(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "image exporter")
-
+	integration.CheckFeatureCompat(t, sb, integration.FeatureImageExporter)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -3186,8 +3183,7 @@ func testBuildExportWithForeignLayer(t *testing.T, sb integration.Sandbox) {
 }
 
 func testBuildExportWithUncompressed(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "image exporter")
-
+	integration.CheckFeatureCompat(t, sb, integration.FeatureImageExporter)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -3378,7 +3374,7 @@ func testBuildExportWithUncompressed(t *testing.T, sb integration.Sandbox) {
 }
 
 func testBuildExportZstd(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "oci export")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureOCIExporter)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -3474,7 +3470,7 @@ func testBuildExportZstd(t *testing.T, sb integration.Sandbox) {
 }
 
 func testPullZstdImage(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "direct push")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -3537,7 +3533,7 @@ func testPullZstdImage(t *testing.T, sb integration.Sandbox) {
 	require.Equal(t, dt, []byte("zstd"))
 }
 func testBuildPushAndValidate(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "direct push")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -3735,9 +3731,8 @@ func testBuildPushAndValidate(t *testing.T, sb integration.Sandbox) {
 }
 
 func testStargzLazyRegistryCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "remote cache export")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
 	requiresLinux(t)
-
 	cdAddress := sb.ContainerdAddress()
 	if cdAddress == "" || sb.Snapshotter() != "stargz" {
 		t.Skip("test requires containerd worker with stargz snapshotter")
@@ -3883,9 +3878,8 @@ func testStargzLazyRegistryCacheImportExport(t *testing.T, sb integration.Sandbo
 }
 
 func testStargzLazyInlineCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "remote cache export")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
 	requiresLinux(t)
-
 	cdAddress := sb.ContainerdAddress()
 	if cdAddress == "" || sb.Snapshotter() != "stargz" {
 		t.Skip("test requires containerd worker with stargz snapshotter")
@@ -4160,9 +4154,8 @@ func testStargzLazyPull(t *testing.T, sb integration.Sandbox) {
 }
 
 func testLazyImagePush(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "direct push")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush)
 	requiresLinux(t)
-
 	cdAddress := sb.ContainerdAddress()
 	if cdAddress == "" {
 		t.Skip("test requires containerd worker")
@@ -4300,7 +4293,7 @@ func testLazyImagePush(t *testing.T, sb integration.Sandbox) {
 }
 
 func testZstdLocalCacheExport(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "remote cache export")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -4359,7 +4352,7 @@ func testZstdLocalCacheExport(t *testing.T, sb integration.Sandbox) {
 }
 
 func testUncompressedLocalCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "remote cache export")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
 	dir := t.TempDir()
 	im := CacheOptionsEntry{
 		Type: "local",
@@ -4379,7 +4372,7 @@ func testUncompressedLocalCacheImportExport(t *testing.T, sb integration.Sandbox
 }
 
 func testUncompressedRegistryCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "remote cache export")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
 	registry, err := sb.NewRegistry()
 	if errors.Is(err, integration.ErrRequirements) {
 		t.Skip(err.Error())
@@ -4404,7 +4397,7 @@ func testUncompressedRegistryCacheImportExport(t *testing.T, sb integration.Sand
 }
 
 func testZstdLocalCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "remote cache export")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
 	dir := t.TempDir()
 	im := CacheOptionsEntry{
 		Type: "local",
@@ -4425,7 +4418,7 @@ func testZstdLocalCacheImportExport(t *testing.T, sb integration.Sandbox) {
 }
 
 func testZstdRegistryCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "remote cache export")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
 	registry, err := sb.NewRegistry()
 	if errors.Is(err, integration.ErrRequirements) {
 		t.Skip(err.Error())
@@ -4513,7 +4506,7 @@ func testBasicCacheImportExport(t *testing.T, sb integration.Sandbox, cacheOptio
 }
 
 func testBasicRegistryCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "remote cache export")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
 	registry, err := sb.NewRegistry()
 	if errors.Is(err, integration.ErrRequirements) {
 		t.Skip(err.Error())
@@ -4530,7 +4523,7 @@ func testBasicRegistryCacheImportExport(t *testing.T, sb integration.Sandbox) {
 }
 
 func testMultipleRegistryCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "remote cache export")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
 	registry, err := sb.NewRegistry()
 	if errors.Is(err, integration.ErrRequirements) {
 		t.Skip(err.Error())
@@ -4553,7 +4546,7 @@ func testMultipleRegistryCacheImportExport(t *testing.T, sb integration.Sandbox)
 }
 
 func testBasicLocalCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "remote cache export")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
 	dir := t.TempDir()
 	im := CacheOptionsEntry{
 		Type: "local",
@@ -4571,7 +4564,7 @@ func testBasicLocalCacheImportExport(t *testing.T, sb integration.Sandbox) {
 }
 
 func testBasicInlineCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "direct push")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush, integration.FeatureCacheImport)
 	requiresLinux(t)
 	registry, err := sb.NewRegistry()
 	if errors.Is(err, integration.ErrRequirements) {
@@ -5008,7 +5001,7 @@ func testCopyFromEmptyImage(t *testing.T, sb integration.Sandbox) {
 
 // containerd/containerd#2119
 func testDuplicateWhiteouts(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "oci exporter")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureOCIExporter)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -5078,7 +5071,7 @@ func testDuplicateWhiteouts(t *testing.T, sb integration.Sandbox) {
 
 // #276
 func testWhiteoutParentDir(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "oci exporter")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureOCIExporter)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -5143,7 +5136,7 @@ func testWhiteoutParentDir(t *testing.T, sb integration.Sandbox) {
 
 // #2490
 func testMoveParentDir(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "oci export")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureOCIExporter)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -5591,7 +5584,7 @@ func testMergeOp(t *testing.T, sb integration.Sandbox) {
 		File(llb.Mkfile("bar/D", 0644, []byte("D"))).
 		File(llb.Mkfile("bar/E", 0755, nil)).
 		File(llb.Mkfile("qaz", 0644, nil)),
-		// /foo from stateE is not here because it is deleted in stateB, which is part of a submerge of mergeD
+	// /foo from stateE is not here because it is deleted in stateB, which is part of a submerge of mergeD
 	)
 }
 
@@ -5609,7 +5602,7 @@ func testMergeOpCacheMax(t *testing.T, sb integration.Sandbox) {
 
 func testMergeOpCache(t *testing.T, sb integration.Sandbox, mode string) {
 	t.Helper()
-	integration.SkipIfDockerd(t, sb, "direct push")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush)
 	requiresLinux(t)
 
 	cdAddress := sb.ContainerdAddress()
@@ -6362,7 +6355,7 @@ func testBuildInfoExporter(t *testing.T, sb integration.Sandbox) {
 	}
 
 	var exports []ExportEntry
-	if integration.IsTestDockerd() {
+	if integration.IsTestDockerdMoby(sb) {
 		exports = []ExportEntry{{
 			Type: "moby",
 			Attrs: map[string]string{
@@ -6397,7 +6390,7 @@ func testBuildInfoExporter(t *testing.T, sb integration.Sandbox) {
 
 // moby/buildkit#2476
 func testBuildInfoInline(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "direct push")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -6500,7 +6493,7 @@ func testBuildInfoNoExport(t *testing.T, sb integration.Sandbox) {
 }
 
 func testPullWithLayerLimit(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "direct push")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -6615,7 +6608,7 @@ func testPullWithLayerLimit(t *testing.T, sb integration.Sandbox) {
 }
 
 func testCallInfo(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "not implemented")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureInfo)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -6624,7 +6617,7 @@ func testCallInfo(t *testing.T, sb integration.Sandbox) {
 }
 
 func testValidateDigestOrigin(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "direct push")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -6690,7 +6683,7 @@ func testValidateDigestOrigin(t *testing.T, sb integration.Sandbox) {
 }
 
 func testExportAnnotations(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "oci exporter")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureOCIExporter)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -6907,7 +6900,7 @@ func testExportAnnotations(t *testing.T, sb integration.Sandbox) {
 }
 
 func testExportAnnotationsMediaTypes(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "direct push")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -7021,7 +7014,7 @@ func testExportAnnotationsMediaTypes(t *testing.T, sb integration.Sandbox) {
 }
 
 func testExportAttestations(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "direct push")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -7339,7 +7332,7 @@ func testExportAttestations(t *testing.T, sb integration.Sandbox) {
 }
 
 func testAttestationDefaultSubject(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "direct push")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -7475,6 +7468,7 @@ func testAttestationDefaultSubject(t *testing.T, sb integration.Sandbox) {
 }
 
 func testAttestationBundle(t *testing.T, sb integration.Sandbox) {
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -7622,6 +7616,7 @@ func testAttestationBundle(t *testing.T, sb integration.Sandbox) {
 }
 
 func testSBOMScan(t *testing.T, sb integration.Sandbox) {
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush, integration.FeatureSBOM)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -7896,6 +7891,7 @@ EOF
 }
 
 func testSBOMScanSingleRef(t *testing.T, sb integration.Sandbox) {
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush, integration.FeatureSBOM)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -8050,7 +8046,7 @@ EOF
 }
 
 func testMultipleCacheExports(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "multiple cache exports")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureMultiCacheExport)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -819,6 +819,7 @@ func testPushByDigest(t *testing.T, sb integration.Sandbox) {
 }
 
 func testSecurityMode(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerdSnapshotter(t, sb, "security mode")
 	command := `sh -c 'cat /proc/self/status | grep CapEff | cut -f 2 > /out'`
 	mode := llb.SecurityModeSandbox
 	var allowedEntitlements []entitlements.Entitlement
@@ -890,6 +891,7 @@ func testSecurityMode(t *testing.T, sb integration.Sandbox) {
 }
 
 func testSecurityModeSysfs(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerdSnapshotter(t, sb, "security mode")
 	if sb.Rootless() {
 		t.SkipNow()
 	}
@@ -2849,6 +2851,7 @@ func testSourceDateEpochTarExporter(t *testing.T, sb integration.Sandbox) {
 	checkAllReleasable(t, c, sb, true)
 }
 func testFrontendMetadataReturn(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerdSnapshotter(t, sb, "oci exporter")
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -2863,7 +2866,7 @@ func testFrontendMetadataReturn(t *testing.T, sb integration.Sandbox) {
 	}
 
 	var exports []ExportEntry
-	if integration.IsTestDockerd() {
+	if integration.IsTestDockerdMoby(sb) {
 		exports = []ExportEntry{{
 			Type: "moby",
 			Attrs: map[string]string{
@@ -5507,7 +5510,7 @@ func testMergeOp(t *testing.T, sb integration.Sandbox) {
 	}
 
 	var imageTarget string
-	if integration.IsTestDockerd() {
+	if integration.IsTestDockerdMoby(sb) {
 		// do image export but use a fake url as the image should just end up in moby's
 		// local store
 		imageTarget = "fake.invalid:33333/buildkit/testmergeop:latest"
@@ -5999,7 +6002,7 @@ func requireContents(ctx context.Context, t *testing.T, c *Client, sb integratio
 
 	if imageTarget != "" {
 		var exports []ExportEntry
-		if integration.IsTestDockerd() {
+		if integration.IsTestDockerdMoby(sb) {
 			exports = []ExportEntry{{
 				Type: "moby",
 				Attrs: map[string]string{

--- a/client/mergediff_test.go
+++ b/client/mergediff_test.go
@@ -1192,10 +1192,10 @@ func (tc verifyContents) Run(t *testing.T, sb integration.Sandbox) {
 	}
 
 	switch tc.name {
-	case "TestDiffSelf", "TestDiffScratch":
-		integration.SkipIfDockerdSnapshotter(t, sb, "https://github.com/moby/buildkit/pull/3176")
 	case "TestDiffUpperScratch":
-		integration.SkipIfDockerdMoby(t, sb, "https://github.com/moby/buildkit/pull/2726#issuecomment-1070978499")
+		if integration.IsTestDockerdMoby(sb) {
+			t.Skip("failed to handle changes: lstat ... no such file or directory: https://github.com/moby/buildkit/pull/2726#issuecomment-1070978499")
+		}
 	}
 
 	requiresLinux(t)

--- a/client/mergediff_test.go
+++ b/client/mergediff_test.go
@@ -1191,11 +1191,11 @@ func (tc verifyContents) Run(t *testing.T, sb integration.Sandbox) {
 		t.Skip("rootless")
 	}
 
-	// FIXME: TestDiffUpperScratch broken on dockerd and seems flaky with containerd.
-	// 	see https://github.com/moby/buildkit/pull/2726#issuecomment-1070978499
-	// 	and https://github.com/moby/buildkit/pull/2725#issuecomment-1066521712
-	if integration.IsTestDockerd() && tc.name == "TestDiffUpperScratch" {
-		t.Skip("TestDiffUpperScratch is temporarily broken on dockerd")
+	switch tc.name {
+	case "TestDiffSelf", "TestDiffScratch":
+		integration.SkipIfDockerdSnapshotter(t, sb, "https://github.com/moby/buildkit/pull/3176")
+	case "TestDiffUpperScratch":
+		integration.SkipIfDockerdMoby(t, sb, "https://github.com/moby/buildkit/pull/2726#issuecomment-1070978499")
 	}
 
 	requiresLinux(t)

--- a/frontend/dockerfile/dockerfile_buildinfo_test.go
+++ b/frontend/dockerfile/dockerfile_buildinfo_test.go
@@ -78,7 +78,7 @@ COPY --from=alpine /bin/busybox /alpine-busybox
 	defer c.Close()
 
 	var exports []client.ExportEntry
-	if integration.IsTestDockerd() {
+	if integration.IsTestDockerdMoby(sb) {
 		exports = []client.ExportEntry{{
 			Type: "moby",
 			Attrs: map[string]string{
@@ -158,7 +158,7 @@ FROM busybox:latest
 	defer c.Close()
 
 	var exports []client.ExportEntry
-	if integration.IsTestDockerd() {
+	if integration.IsTestDockerdMoby(sb) {
 		exports = []client.ExportEntry{{
 			Type: "moby",
 			Attrs: map[string]string{
@@ -224,7 +224,7 @@ RUN echo $foo
 	defer c.Close()
 
 	var exports []client.ExportEntry
-	if integration.IsTestDockerd() {
+	if integration.IsTestDockerdMoby(sb) {
 		exports = []client.ExportEntry{{
 			Type: "moby",
 			Attrs: map[string]string{
@@ -265,7 +265,7 @@ RUN echo $foo
 
 // moby/buildkit#2476
 func testBuildInfoMultiPlatform(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "multi-platform")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureOCIExporter, integration.FeatureMultiPlatform)
 	f := getFrontend(t, sb)
 	f.RequiresBuildctl(t)
 
@@ -359,7 +359,7 @@ COPY --from=base /out /
 	defer c.Close()
 
 	var exports []client.ExportEntry
-	if integration.IsTestDockerd() {
+	if integration.IsTestDockerdMoby(sb) {
 		exports = []client.ExportEntry{{
 			Type: "moby",
 			Attrs: map[string]string{
@@ -446,7 +446,7 @@ COPY --from=base /o* /
 	require.NoError(t, err)
 
 	var exports []client.ExportEntry
-	if integration.IsTestDockerd() {
+	if integration.IsTestDockerdMoby(sb) {
 		exports = []client.ExportEntry{{
 			Type: "moby",
 			Attrs: map[string]string{

--- a/frontend/dockerfile/dockerfile_heredoc_test.go
+++ b/frontend/dockerfile/dockerfile_heredoc_test.go
@@ -600,7 +600,7 @@ COPY --from=build /dest /
 }
 
 func testOnBuildHeredoc(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "image export")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush)
 	f := getFrontend(t, sb)
 
 	registry, err := sb.NewRegistry()

--- a/frontend/dockerfile/dockerfile_outline_test.go
+++ b/frontend/dockerfile/dockerfile_outline_test.go
@@ -24,6 +24,7 @@ var outlineTests = integration.TestFuncs(
 )
 
 func testOutlineArgs(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerd(t, sb, "unsupported request frontend.outline")
 	f := getFrontend(t, sb)
 	if _, ok := f.(*clientFrontend); !ok {
 		t.Skip("only test with client frontend")
@@ -138,6 +139,7 @@ FROM second
 }
 
 func testOutlineSecrets(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerd(t, sb, "unsupported request frontend.outline")
 	f := getFrontend(t, sb)
 	if _, ok := f.(*clientFrontend); !ok {
 		t.Skip("only test with client frontend")
@@ -238,6 +240,7 @@ FROM second
 }
 
 func testOutlineDescribeDefinition(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerd(t, sb, "unsupported request frontend.outline")
 	f := getFrontend(t, sb)
 	if _, ok := f.(*clientFrontend); !ok {
 		t.Skip("only test with client frontend")

--- a/frontend/dockerfile/dockerfile_outline_test.go
+++ b/frontend/dockerfile/dockerfile_outline_test.go
@@ -24,7 +24,7 @@ var outlineTests = integration.TestFuncs(
 )
 
 func testOutlineArgs(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "unsupported request frontend.outline")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureFrontendOutline)
 	f := getFrontend(t, sb)
 	if _, ok := f.(*clientFrontend); !ok {
 		t.Skip("only test with client frontend")
@@ -139,7 +139,7 @@ FROM second
 }
 
 func testOutlineSecrets(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "unsupported request frontend.outline")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureFrontendOutline)
 	f := getFrontend(t, sb)
 	if _, ok := f.(*clientFrontend); !ok {
 		t.Skip("only test with client frontend")
@@ -240,7 +240,7 @@ FROM second
 }
 
 func testOutlineDescribeDefinition(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "unsupported request frontend.outline")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureFrontendOutline)
 	f := getFrontend(t, sb)
 	if _, ok := f.(*clientFrontend); !ok {
 		t.Skip("only test with client frontend")

--- a/frontend/dockerfile/dockerfile_provenance_test.go
+++ b/frontend/dockerfile/dockerfile_provenance_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func testProvenanceAttestation(t *testing.T, sb integration.Sandbox) {
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush, integration.FeatureProvenance)
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())
@@ -211,6 +212,7 @@ RUN echo "ok" > /foo
 }
 
 func testGitProvenanceAttestation(t *testing.T, sb integration.Sandbox) {
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush, integration.FeatureProvenance)
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())
@@ -353,6 +355,7 @@ COPY myapp.Dockerfile /
 }
 
 func testMultiPlatformProvenance(t *testing.T, sb integration.Sandbox) {
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush, integration.FeatureMultiPlatform, integration.FeatureProvenance)
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())
@@ -468,6 +471,7 @@ RUN echo "ok-$TARGETARCH" > /foo
 }
 
 func testClientFrontendProvenance(t *testing.T, sb integration.Sandbox) {
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush, integration.FeatureProvenance)
 	// Building with client frontend does not capture frontend provenance
 	// because frontend runs in client, not in BuildKit.
 	// This test builds Dockerfile inside a client frontend ensuring that
@@ -662,6 +666,7 @@ func testClientFrontendProvenance(t *testing.T, sb integration.Sandbox) {
 }
 
 func testClientLLBProvenance(t *testing.T, sb integration.Sandbox) {
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush, integration.FeatureProvenance)
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())
@@ -775,6 +780,7 @@ func testClientLLBProvenance(t *testing.T, sb integration.Sandbox) {
 }
 
 func testSecretSSHProvenance(t *testing.T, sb integration.Sandbox) {
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush, integration.FeatureProvenance)
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())

--- a/frontend/dockerfile/dockerfile_targets_test.go
+++ b/frontend/dockerfile/dockerfile_targets_test.go
@@ -23,7 +23,7 @@ var targetsTests = integration.TestFuncs(
 )
 
 func testTargetsList(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "unsupported request frontend.targets")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureFrontendTargets)
 	f := getFrontend(t, sb)
 	if _, ok := f.(*clientFrontend); !ok {
 		t.Skip("only test with client frontend")
@@ -124,7 +124,7 @@ FROM second AS binary
 }
 
 func testTargetsDescribeDefinition(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "unsupported request frontend.targets")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureFrontendTargets)
 	f := getFrontend(t, sb)
 	if _, ok := f.(*clientFrontend); !ok {
 		t.Skip("only test with client frontend")

--- a/frontend/dockerfile/dockerfile_targets_test.go
+++ b/frontend/dockerfile/dockerfile_targets_test.go
@@ -23,6 +23,7 @@ var targetsTests = integration.TestFuncs(
 )
 
 func testTargetsList(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerd(t, sb, "unsupported request frontend.targets")
 	f := getFrontend(t, sb)
 	if _, ok := f.(*clientFrontend); !ok {
 		t.Skip("only test with client frontend")
@@ -123,6 +124,7 @@ FROM second AS binary
 }
 
 func testTargetsDescribeDefinition(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerd(t, sb, "unsupported request frontend.targets")
 	f := getFrontend(t, sb)
 	if _, ok := f.(*clientFrontend); !ok {
 		t.Skip("only test with client frontend")

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -5362,6 +5362,7 @@ RUN echo foo >> /test
 }
 
 func testNamedImageContextScratch(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerd(t, sb, "docker-image://scratch named context")
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -403,7 +403,7 @@ RUN [ "$(cat testfile)" == "contents0" ]
 }
 
 func testExportCacheLoop(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "cache export")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -1258,7 +1258,7 @@ COPY --from=build /out .
 }
 
 func testDefaultShellAndPath(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "oci exporter")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureOCIExporter)
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -1346,7 +1346,7 @@ COPY Dockerfile .
 }
 
 func testExportMultiPlatform(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "oci exporter", "multi-platform")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureOCIExporter, integration.FeatureMultiPlatform)
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -2555,7 +2555,7 @@ ENV foo=bar
 }
 
 func testExposeExpansion(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "image export")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureImageExporter)
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -2793,7 +2793,7 @@ RUN ["ls"]
 	args, trace := f.DFCmdArgs(dir, dir)
 	defer os.RemoveAll(trace)
 
-	integration.SkipIfDockerd(t, sb, "image export")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureImageExporter)
 
 	target := "example.com/moby/dockerfilescratch:test"
 	cmd := sb.Cmd(args + " --output type=image,name=" + target)
@@ -2847,7 +2847,7 @@ RUN ["ls"]
 }
 
 func testUser(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "image export")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureImageExporter)
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -3677,7 +3677,7 @@ COPY --from=stage1 baz bax
 }
 
 func testLabels(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "image export")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureImageExporter)
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -3789,7 +3789,7 @@ RUN ls /files/file1
 }
 
 func testOnBuildCleared(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "direct push")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush)
 	f := getFrontend(t, sb)
 
 	registry, err := sb.NewRegistry()
@@ -3895,7 +3895,7 @@ ONBUILD RUN mkdir -p /out && echo -n 11 >> /out/foo
 }
 
 func testCacheMultiPlatformImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "direct push")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush)
 	f := getFrontend(t, sb)
 
 	registry, err := sb.NewRegistry()
@@ -4018,7 +4018,7 @@ COPY --from=base arch /
 }
 
 func testCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "remote cache export")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
 	f := getFrontend(t, sb)
 
 	registry, err := sb.NewRegistry()
@@ -4110,7 +4110,7 @@ COPY --from=base unique /
 }
 
 func testReproducibleIDs(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "image export")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureImageExporter)
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -5110,7 +5110,7 @@ COPY --from=base /out /
 	require.NoError(t, err)
 	require.True(t, len(dt) > 0)
 
-	integration.SkipIfDockerd(t, sb, "direct push")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush)
 
 	// Now test with an image with custom envs
 	dockerfile = []byte(`
@@ -5201,7 +5201,7 @@ COPY --from=base /env_foobar /
 }
 
 func testNamedImageContextPlatform(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "direct push")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush)
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())
@@ -5275,7 +5275,7 @@ RUN echo hello
 }
 
 func testNamedImageContextTimestamps(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "direct push")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush)
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())
@@ -5362,7 +5362,6 @@ RUN echo foo >> /test
 }
 
 func testNamedImageContextScratch(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "docker-image://scratch named context")
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())
@@ -5475,7 +5474,7 @@ COPY --from=base /o* /
 }
 
 func testNamedOCILayoutContext(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "oci exporter")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureOCIExporter, integration.FeatureOCILayout)
 	// how this test works:
 	// 1- we use a regular builder with a dockerfile to create an image two files: "out" with content "first", "out2" with content "second"
 	// 2- we save the output to an OCI layout dir
@@ -5613,7 +5612,7 @@ COPY --from=imported /test/outfoo /
 }
 
 func testNamedOCILayoutContextExport(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "oci exporter")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureOCIExporter, integration.FeatureOCILayout)
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())
@@ -5834,7 +5833,7 @@ COPY --from=build /foo /out /
 }
 
 func testNamedMultiplatformInputContext(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "multiplatform")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureMultiPlatform)
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())
@@ -5982,7 +5981,7 @@ COPY --from=build /foo /out /
 }
 
 func testSourceDateEpochWithoutExporter(t *testing.T, sb integration.Sandbox) {
-	integration.SkipIfDockerd(t, sb, "oci exporter")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureOCIExporter, integration.FeatureSourceDateEpoch)
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -6058,6 +6057,7 @@ COPY Dockerfile .
 }
 
 func testSBOMScannerImage(t *testing.T, sb integration.Sandbox) {
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush, integration.FeatureSBOM)
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())
@@ -6163,6 +6163,7 @@ EOF
 }
 
 func testSBOMScannerArgs(t *testing.T, sb integration.Sandbox) {
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush, integration.FeatureSBOM)
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())

--- a/go.mod
+++ b/go.mod
@@ -135,7 +135,6 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/moby/sys/mount v0.3.3 // indirect
 	github.com/moby/sys/sequential v0.5.0 // indirect
-	github.com/moby/term v0.0.0-20221120202655-abb19827d345 // indirect
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1051,9 +1051,8 @@ github.com/moby/sys/symlink v0.1.0/go.mod h1:GGDODQmbFOjFsXvfLVn3+ZRxkch54RkSiGq
 github.com/moby/sys/symlink v0.2.0/go.mod h1:7uZVF2dqJjG/NsClqul95CqKOBRQyYSNnJ6BMgR/gFs=
 github.com/moby/term v0.0.0-20200312100748-672ec06f55cd/go.mod h1:DdlQx2hp0Ss5/fLikoLlEeIYiATotOjgB//nb973jeo=
 github.com/moby/term v0.0.0-20200915141129-7f0af18e79f2/go.mod h1:TjQg8pa4iejrUrjiz0MCtMV38jdMNW4doKSiBrEvCQQ=
+github.com/moby/term v0.0.0-20210610120745-9d4ed1856297 h1:yH0SvLzcbZxcJXho2yh7CqdENGMQe73Cw3woZBpPli0=
 github.com/moby/term v0.0.0-20210610120745-9d4ed1856297/go.mod h1:vgPCkQMyxTZ7IDy8SXRufE172gr8+K/JE/7hHFxHW3A=
-github.com/moby/term v0.0.0-20221120202655-abb19827d345 h1:J9c53/kxIH+2nTKBEfZYFMlhghtHpIHSXpm5VRGHSnU=
-github.com/moby/term v0.0.0-20221120202655-abb19827d345/go.mod h1:15ce4BGCFxt7I5NQKT+HV0yEDxmf6fSysfEDiVo3zFM=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180320133207-05fbef0ca5da/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=

--- a/util/testutil/dockerd/daemon.go
+++ b/util/testutil/dockerd/daemon.go
@@ -1,0 +1,241 @@
+package dockerd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/moby/buildkit/identity"
+	"github.com/pkg/errors"
+)
+
+type LogT interface {
+	Logf(string, ...interface{})
+}
+
+type nopLog struct{}
+
+func (nopLog) Logf(string, ...interface{}) {}
+
+const (
+	shortLen             = 12
+	defaultDockerdBinary = "dockerd"
+)
+
+type Option func(*Daemon)
+
+type Daemon struct {
+	root          string
+	folder        string
+	Wait          chan error
+	id            string
+	cmd           *exec.Cmd
+	storageDriver string
+	execRoot      string
+	dockerdBinary string
+	Log           LogT
+	pidFile       string
+	sockPath      string
+	args          []string
+}
+
+var sockRoot = filepath.Join(os.TempDir(), "docker-integration")
+
+func NewDaemon(workingDir string, ops ...Option) (*Daemon, error) {
+	if err := os.MkdirAll(sockRoot, 0700); err != nil {
+		return nil, errors.Wrapf(err, "failed to create daemon socket root %q", sockRoot)
+	}
+
+	id := "d" + identity.NewID()[:shortLen]
+	daemonFolder, err := filepath.Abs(filepath.Join(workingDir, id))
+	if err != nil {
+		return nil, err
+	}
+	daemonRoot := filepath.Join(daemonFolder, "root")
+	if err := os.MkdirAll(daemonRoot, 0755); err != nil {
+		return nil, errors.Wrapf(err, "failed to create daemon root %q", daemonRoot)
+	}
+
+	d := &Daemon{
+		id:            id,
+		folder:        daemonFolder,
+		root:          daemonRoot,
+		storageDriver: os.Getenv("DOCKER_GRAPHDRIVER"),
+		// dxr stands for docker-execroot (shortened for avoiding unix(7) path length limitation)
+		execRoot:      filepath.Join(os.TempDir(), "dxr", id),
+		dockerdBinary: defaultDockerdBinary,
+		Log:           nopLog{},
+		sockPath:      filepath.Join(sockRoot, id+".sock"),
+	}
+
+	for _, op := range ops {
+		op(d)
+	}
+
+	return d, nil
+}
+
+func (d *Daemon) Sock() string {
+	return "unix://" + d.sockPath
+}
+
+func (d *Daemon) StartWithError(daemonLogs map[string]*bytes.Buffer, providedArgs ...string) error {
+	dockerdBinary, err := exec.LookPath(d.dockerdBinary)
+	if err != nil {
+		return errors.Wrapf(err, "[%s] could not find docker binary in $PATH", d.id)
+	}
+
+	if d.pidFile == "" {
+		d.pidFile = filepath.Join(d.folder, "docker.pid")
+	}
+
+	d.args = []string{
+		"--data-root", d.root,
+		"--exec-root", d.execRoot,
+		"--pidfile", d.pidFile,
+		"--containerd-namespace", d.id,
+		"--containerd-plugins-namespace", d.id + "p",
+		"--host", d.Sock(),
+	}
+	if root := os.Getenv("DOCKER_REMAP_ROOT"); root != "" {
+		d.args = append(d.args, "--userns-remap", root)
+	}
+
+	// If we don't explicitly set the log-level or debug flag(-D) then
+	// turn on debug mode
+	var foundLog, foundSd bool
+	for _, a := range providedArgs {
+		if strings.Contains(a, "--log-level") || strings.Contains(a, "-D") || strings.Contains(a, "--debug") {
+			foundLog = true
+		}
+		if strings.Contains(a, "--storage-driver") {
+			foundSd = true
+		}
+	}
+	if !foundLog {
+		d.args = append(d.args, "--debug")
+	}
+	if d.storageDriver != "" && !foundSd {
+		d.args = append(d.args, "--storage-driver", d.storageDriver)
+	}
+
+	d.args = append(d.args, providedArgs...)
+	d.cmd = exec.Command(dockerdBinary, d.args...)
+	d.cmd.Env = append(os.Environ(), "DOCKER_SERVICE_PREFER_OFFLINE_IMAGE=1", "BUILDKIT_DEBUG_EXEC_OUTPUT=1", "BUILDKIT_DEBUG_PANIC_ON_ERROR=1")
+
+	if daemonLogs != nil {
+		b := new(bytes.Buffer)
+		daemonLogs["stdout: "+d.cmd.Path] = b
+		d.cmd.Stdout = &lockingWriter{Writer: b}
+		b = new(bytes.Buffer)
+		daemonLogs["stderr: "+d.cmd.Path] = b
+		d.cmd.Stderr = &lockingWriter{Writer: b}
+	}
+
+	if err := d.cmd.Start(); err != nil {
+		return errors.Wrapf(err, "[%s] could not start daemon container", d.id)
+	}
+
+	wait := make(chan error, 1)
+
+	go func() {
+		ret := d.cmd.Wait()
+		d.Log.Logf("[%s] exiting daemon", d.id)
+		// If we send before logging, we might accidentally log _after_ the test is done.
+		// As of Go 1.12, this incurs a panic instead of silently being dropped.
+		wait <- ret
+		close(wait)
+	}()
+
+	d.Wait = wait
+
+	d.Log.Logf("[%s] daemon started\n", d.id)
+	return nil
+}
+
+var errDaemonNotStarted = errors.New("daemon not started")
+
+func (d *Daemon) StopWithError() (err error) {
+	if d.cmd == nil || d.Wait == nil {
+		return errDaemonNotStarted
+	}
+	defer func() {
+		if err != nil {
+			d.Log.Logf("[%s] error while stopping daemon: %v", d.id, err)
+		} else {
+			d.Log.Logf("[%s] daemon stopped", d.id)
+			if d.pidFile != "" {
+				_ = os.Remove(d.pidFile)
+			}
+		}
+		d.cmd = nil
+	}()
+
+	i := 1
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	tick := ticker.C
+
+	d.Log.Logf("[%s] stopping daemon", d.id)
+
+	if err := d.cmd.Process.Signal(os.Interrupt); err != nil {
+		if strings.Contains(err.Error(), "os: process already finished") {
+			return errDaemonNotStarted
+		}
+		return errors.Wrapf(err, "[%s] could not send signal", d.id)
+	}
+
+out1:
+	for {
+		select {
+		case err := <-d.Wait:
+			return err
+		case <-time.After(20 * time.Second):
+			// time for stopping jobs and run onShutdown hooks
+			d.Log.Logf("[%s] daemon stop timed out after 20 seconds", d.id)
+			break out1
+		}
+	}
+
+out2:
+	for {
+		select {
+		case err := <-d.Wait:
+			return err
+		case <-tick:
+			i++
+			if i > 5 {
+				d.Log.Logf("[%s] tried to interrupt daemon for %d times, now try to kill it", d.id, i)
+				break out2
+			}
+			d.Log.Logf("[%d] attempt #%d/5: daemon is still running with pid %d", i, d.cmd.Process.Pid)
+			if err := d.cmd.Process.Signal(os.Interrupt); err != nil {
+				return errors.Wrapf(err, "[%s] attempt #%d/5 could not send signal", d.id, i)
+			}
+		}
+	}
+
+	if err := d.cmd.Process.Kill(); err != nil {
+		d.Log.Logf("[%s] failed to kill daemon: %v", d.id, err)
+		return err
+	}
+
+	return nil
+}
+
+type lockingWriter struct {
+	mu sync.Mutex
+	io.Writer
+}
+
+func (w *lockingWriter) Write(dt []byte) (int, error) {
+	w.mu.Lock()
+	n, err := w.Writer.Write(dt)
+	w.mu.Unlock()
+	return n, err
+}

--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -46,6 +46,7 @@ type Sandbox interface {
 	Context() context.Context
 	Cmd(...string) *exec.Cmd
 	PrintLogs(*testing.T)
+	ClearLogs()
 	NewRegistry() (string, error)
 	Value(string) interface{} // chosen matrix value
 	Name() string

--- a/util/testutil/integration/sandbox.go
+++ b/util/testutil/integration/sandbox.go
@@ -219,6 +219,18 @@ func runBuildkitd(ctx context.Context, conf *BackendConfig, args []string, logs 
 	return address, cl, err
 }
 
+func getBackend(sb Sandbox) (*backend, error) {
+	sbx, ok := sb.(*sandbox)
+	if !ok {
+		return nil, errors.Errorf("invalid sandbox type %T", sb)
+	}
+	b, ok := sbx.Backend.(backend)
+	if !ok {
+		return nil, errors.Errorf("invalid backend type %T", b)
+	}
+	return &b, nil
+}
+
 func rootlessSupported(uid int) bool {
 	cmd := exec.Command("sudo", "-u", fmt.Sprintf("#%d", uid), "-i", "--", "exec", "unshare", "-U", "true") //nolint:gosec // test utility
 	b, err := cmd.CombinedOutput()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -589,8 +589,6 @@ github.com/moby/sys/sequential
 # github.com/moby/sys/signal v0.7.0
 ## explicit; go 1.16
 github.com/moby/sys/signal
-# github.com/moby/term v0.0.0-20221120202655-abb19827d345
-## explicit; go 1.18
 # github.com/morikuni/aec v1.0.0
 ## explicit
 github.com/morikuni/aec


### PR DESCRIPTION
Integration tests for `dockerd` worker with `containerd-snapshotter` was not enabled. This adds a new matrix item to the dockerd workflow to run tests using this snapshotter. Direct push is enabled with containerd snapshotter on most tests. Some of them have still issues (see comments review below).

Tested here: https://github.com/crazy-max/buildkit/actions/runs/3257273194 with Docker version `https://github.com/rumpl/moby.git#c8d`.

Also add missing skips for some tests with dockerd worker:

___

`TestTargetsDescribeDefinition`: https://github.com/crazy-max/buildkit/actions/runs/3235292532/jobs/5299596379#step:9:1016

```
 === CONT  TestIntegration/TestTargetsDescribeDefinition/worker=dockerd/frontend=client
    dockerfile_targets_test.go:165: 
        	Error Trace:	dockerfile_targets_test.go:165
        	            				client.go:208
        	            				build.go:62
        	            				solve.go:254
        	            				errgroup.go:57
        	            				asm_amd64.s:1594
        	Error:      	Should be true
        	Test:       	TestIntegration/TestTargetsDescribeDefinition/worker=dockerd/frontend=client
    dockerfile_targets_test.go:178: 
        	Error Trace:	dockerfile_targets_test.go:178
        	            				run.go:86
        	            				run.go:189
        	Error:      	Should be true
        	Test:       	TestIntegration/TestTargetsDescribeDefinition/worker=dockerd/frontend=client
    sandbox.go:234: stderr: /usr/bin/dockerd
```

___

`TestTargetsList`: https://github.com/crazy-max/buildkit/actions/runs/3235292532/jobs/5299596379#step:9:1361

```
=== CONT  TestIntegration/TestTargetsList/worker=dockerd/frontend=client
    dockerfile_targets_test.go:70: 
        	Error Trace:	dockerfile_targets_test.go:70
        	            				client.go:208
        	            				build.go:62
        	            				solve.go:254
        	            				errgroup.go:57
        	            				asm_amd64.s:1594
        	Error:      	Received unexpected error:
        	            	unsupported request frontend.targets: unsupported request frontend.targets
        	            	github.com/moby/buildkit/util/stack.Enable
        	            		/src/util/stack/stack.go:77
        	            	github.com/moby/buildkit/util/grpcerrors.FromGRPC
        	            		/src/util/grpcerrors/grpcerrors.go:196
        	            	github.com/moby/buildkit/util/grpcerrors.UnaryClientInterceptor
        	            		/src/util/grpcerrors/intercept.go:41
        	            	google.golang.org/grpc.(*ClientConn).Invoke
        	            		/src/vendor/google.golang.org/grpc/call.go:35
        	            	github.com/moby/buildkit/frontend/gateway/pb.(*lLBBridgeClient).Solve
        	            		/src/frontend/gateway/pb/gateway.pb.go:2714
        	            	github.com/moby/buildkit/client.(*gatewayClientForBuild).Solve
        	            		/src/client/build.go:92
        	            	github.com/moby/buildkit/frontend/gateway/grpcclient.(*grpcClient).Solve
        	            		/src/frontend/gateway/grpcclient/client.go:419
        	            	github.com/moby/buildkit/frontend/dockerfile.testTargetsList.func1
        	            		/src/frontend/dockerfile/dockerfile_targets_test.go:63
        	            	github.com/moby/buildkit/frontend/gateway/grpcclient.(*grpcClient).Run
        	            		/src/frontend/gateway/grpcclient/client.go:208
        	            	github.com/moby/buildkit/client.(*Client).Build.func2
        	            		/src/client/build.go:62
        	            	github.com/moby/buildkit/client.(*Client).solve.func3
        	            		/src/client/solve.go:254
        	            	golang.org/x/sync/errgroup.(*Group).Go.func1
        	            		/src/vendor/golang.org/x/sync/errgroup/errgroup.go:57
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1594
        	Test:       	TestIntegration/TestTargetsList/worker=dockerd/frontend=client
    dockerfile_targets_test.go:122: 
        	Error Trace:	dockerfile_targets_test.go:122
        	            				run.go:86
        	            				run.go:189
        	Error:      	Should be true
        	Test:       	TestIntegration/TestTargetsList/worker=dockerd/frontend=client
    sandbox.go:234: stdout: /usr/bin/dockerd
    sandbox.go:234: stderr: /usr/bin/dockerd
```

___

`TestOutlineSecrets`: https://github.com/crazy-max/buildkit/actions/runs/3235292532/jobs/5299596379#step:9:2078

```
=== CONT  TestIntegration/TestOutlineSecrets/worker=dockerd/frontend=client
    dockerfile_outline_test.go:190: 
        	Error Trace:	dockerfile_outline_test.go:190
        	            				client.go:208
        	            				build.go:62
        	            				solve.go:254
        	            				errgroup.go:57
        	            				asm_amd64.s:1594
        	Error:      	Received unexpected error:
        	            	unsupported request frontend.outline: unsupported request frontend.outline
        	            	github.com/moby/buildkit/util/stack.Enable
        	            		/src/util/stack/stack.go:77
        	            	github.com/moby/buildkit/util/grpcerrors.FromGRPC
        	            		/src/util/grpcerrors/grpcerrors.go:196
        	            	github.com/moby/buildkit/util/grpcerrors.UnaryClientInterceptor
        	            		/src/util/grpcerrors/intercept.go:41
        	            	google.golang.org/grpc.(*ClientConn).Invoke
        	            		/src/vendor/google.golang.org/grpc/call.go:35
        	            	github.com/moby/buildkit/frontend/gateway/pb.(*lLBBridgeClient).Solve
        	            		/src/frontend/gateway/pb/gateway.pb.go:2714
        	            	github.com/moby/buildkit/client.(*gatewayClientForBuild).Solve
        	            		/src/client/build.go:92
        	            	github.com/moby/buildkit/frontend/gateway/grpcclient.(*grpcClient).Solve
        	            		/src/frontend/gateway/grpcclient/client.go:419
        	            	github.com/moby/buildkit/frontend/dockerfile.testOutlineSecrets.func1
        	            		/src/frontend/dockerfile/dockerfile_outline_test.go:181
        	            	github.com/moby/buildkit/frontend/gateway/grpcclient.(*grpcClient).Run
        	            		/src/frontend/gateway/grpcclient/client.go:208
        	            	github.com/moby/buildkit/client.(*Client).Build.func2
        	            		/src/client/build.go:62
        	            	github.com/moby/buildkit/client.(*Client).solve.func3
        	            		/src/client/solve.go:254
        	            	golang.org/x/sync/errgroup.(*Group).Go.func1
        	            		/src/vendor/golang.org/x/sync/errgroup/errgroup.go:57
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1594
        	Test:       	TestIntegration/TestOutlineSecrets/worker=dockerd/frontend=client
    dockerfile_outline_test.go:237: 
        	Error Trace:	dockerfile_outline_test.go:237
        	            				run.go:86
        	            				run.go:189
        	Error:      	Should be true
        	Test:       	TestIntegration/TestOutlineSecrets/worker=dockerd/frontend=client
    sandbox.go:234: stderr: /usr/bin/dockerd
```

___

`TestNamedOCILayoutContextExport`: https://github.com/crazy-max/buildkit/actions/runs/3235292532/jobs/5299596379#step:9:2982

```
=== CONT  TestIntegration/TestNamedOCILayoutContextExport/worker=dockerd/frontend=client
    dockerfile_test.go:5637: 
        	Error Trace:	dockerfile_test.go:5637
        	            				run.go:86
        	            				run.go:189
        	Error:      	Received unexpected error:
        	            	exporter "oci" could not be found
        	            	github.com/moby/buildkit/util/stack.Enable
        	            		/src/util/stack/stack.go:77
        	            	github.com/moby/buildkit/util/grpcerrors.FromGRPC
        	            		/src/util/grpcerrors/grpcerrors.go:196
        	            	github.com/moby/buildkit/util/grpcerrors.UnaryClientInterceptor
        	            		/src/util/grpcerrors/intercept.go:41
        	            	google.golang.org/grpc.(*ClientConn).Invoke
        	            		/src/vendor/google.golang.org/grpc/call.go:35
        	            	github.com/moby/buildkit/api/services/control.(*controlClient).Solve
        	            		/src/api/services/control/control.pb.go:1535
        	            	github.com/moby/buildkit/client.(*Client).solve.func2
        	            		/src/client/solve.go:231
        	            	golang.org/x/sync/errgroup.(*Group).Go.func1
        	            		/src/vendor/golang.org/x/sync/errgroup/errgroup.go:57
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1594
        	            	failed to solve
        	            	github.com/moby/buildkit/client.(*Client).solve.func2
        	            		/src/client/solve.go:244
        	            	golang.org/x/sync/errgroup.(*Group).Go.func1
        	            		/src/vendor/golang.org/x/sync/errgroup/errgroup.go:57
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1594
        	Test:       	TestIntegration/TestNamedOCILayoutContextExport/worker=dockerd/frontend=client
    sandbox.go:234: stderr: /usr/bin/dockerd
```

___

`TestNamedImageContextScratch`: https://github.com/crazy-max/buildkit/actions/runs/3235292532/jobs/5299596379#step:9:3697

```
=== CONT  TestIntegration/TestNamedImageContextScratch/worker=dockerd/frontend=builtin
    dockerfile_test.go:5393: 
        	Error Trace:	dockerfile_test.go:5393
        	            				run.go:86
        	            				run.go:189
        	Error:      	Received unexpected error:
        	            	docker.io/library/scratch:latest: not found
        	            	github.com/moby/buildkit/util/stack.Enable
        	            		/src/util/stack/stack.go:77
        	            	github.com/moby/buildkit/util/grpcerrors.FromGRPC
        	            		/src/util/grpcerrors/grpcerrors.go:196
        	            	github.com/moby/buildkit/util/grpcerrors.UnaryClientInterceptor
        	            		/src/util/grpcerrors/intercept.go:41
        	            	google.golang.org/grpc.(*ClientConn).Invoke
        	            		/src/vendor/google.golang.org/grpc/call.go:35
        	            	github.com/moby/buildkit/api/services/control.(*controlClient).Solve
        	            		/src/api/services/control/control.pb.go:1535
        	            	github.com/moby/buildkit/client.(*Client).solve.func2
        	            		/src/client/solve.go:231
        	            	golang.org/x/sync/errgroup.(*Group).Go.func1
        	            		/src/vendor/golang.org/x/sync/errgroup/errgroup.go:57
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1594
        	            	failed to solve
        	            	github.com/moby/buildkit/client.(*Client).solve.func2
        	            		/src/client/solve.go:244
        	            	golang.org/x/sync/errgroup.(*Group).Go.func1
        	            		/src/vendor/golang.org/x/sync/errgroup/errgroup.go:57
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1594
        	Test:       	TestIntegration/TestNamedImageContextScratch/worker=dockerd/frontend=builtin
    sandbox.go:234: stdout: /usr/bin/dockerd
```

___

`TestNamedImageContextPlatform`: https://github.com/crazy-max/buildkit/actions/runs/3235292532/jobs/5299596379#step:9:4067

```
=== CONT  TestIntegration/TestNamedImageContextPlatform/worker=dockerd/frontend=client
2022/10/12 14:11:31 http2: server connection error from localhost: connection error: PROTOCOL_ERROR
    dockerfile_test.go:5237: 
        	Error Trace:	dockerfile_test.go:5237
        	            				run.go:86
        	            				run.go:189
        	Error:      	Received unexpected error:
        	            	exporter "image" could not be found
        	            	github.com/moby/buildkit/util/stack.Enable
        	            		/src/util/stack/stack.go:77
        	            	github.com/moby/buildkit/util/grpcerrors.FromGRPC
        	            		/src/util/grpcerrors/grpcerrors.go:196
        	            	github.com/moby/buildkit/util/grpcerrors.UnaryClientInterceptor
        	            		/src/util/grpcerrors/intercept.go:41
        	            	google.golang.org/grpc.(*ClientConn).Invoke
        	            		/src/vendor/google.golang.org/grpc/call.go:35
        	            	github.com/moby/buildkit/api/services/control.(*controlClient).Solve
        	            		/src/api/services/control/control.pb.go:1535
        	            	github.com/moby/buildkit/client.(*Client).solve.func2
        	            		/src/client/solve.go:231
        	            	golang.org/x/sync/errgroup.(*Group).Go.func1
        	            		/src/vendor/golang.org/x/sync/errgroup/errgroup.go:57
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1594
        	            	failed to solve
        	            	github.com/moby/buildkit/client.(*Client).solve.func2
        	            		/src/client/solve.go:244
        	            	golang.org/x/sync/errgroup.(*Group).Go.func1
        	            		/src/vendor/golang.org/x/sync/errgroup/errgroup.go:57
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1594
        	Test:       	TestIntegration/TestNamedImageContextPlatform/worker=dockerd/frontend=client
    sandbox.go:234: stdout: /usr/bin/dockerd
```

___

`TestAttestationDefaultSubject`: https://github.com/crazy-max/buildkit/actions/runs/3241141725/jobs/5312765705#step:9:1168

Same for `testExportAnnotationsMediaTypes` and `testExportAttestations`.

```
=== CONT  TestIntegration/TestAttestationDefaultSubject/worker=dockerd
    client_test.go:6739: 
        	Error Trace:	client_test.go:6739
        	            				run.go:86
        	            				run.go:189
        	Error:      	Received unexpected error:
        	            	exporter "image" could not be found
        	            	github.com/moby/buildkit/util/stack.Enable
        	            		/src/util/stack/stack.go:77
        	            	github.com/moby/buildkit/util/grpcerrors.FromGRPC
        	            		/src/util/grpcerrors/grpcerrors.go:196
        	            	github.com/moby/buildkit/util/grpcerrors.UnaryClientInterceptor
        	            		/src/util/grpcerrors/intercept.go:41
        	            	google.golang.org/grpc.(*ClientConn).Invoke
        	            		/src/vendor/google.golang.org/grpc/call.go:35
        	            	github.com/moby/buildkit/api/services/control.(*controlClient).Solve
        	            		/src/api/services/control/control.pb.go:1535
        	            	github.com/moby/buildkit/client.(*Client).solve.func2
        	            		/src/client/solve.go:231
        	            	golang.org/x/sync/errgroup.(*Group).Go.func1
        	            		/src/vendor/golang.org/x/sync/errgroup/errgroup.go:57
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1594
        	            	failed to solve
        	            	github.com/moby/buildkit/client.(*Client).solve.func2
        	            		/src/client/solve.go:244
        	            	golang.org/x/sync/errgroup.(*Group).Go.func1
        	            		/src/vendor/golang.org/x/sync/errgroup/errgroup.go:57
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1594
        	Test:       	TestIntegration/TestAttestationDefaultSubject/worker=dockerd
    sandbox.go:234: stdout: /usr/bin/dockerd
```

___

And another one related to #3171.