### PR TITLE
fix flaky s3 and azblob integration tests

### DIFF
--- a/hack/azblob_test/test1/Dockerfile
+++ b/hack/azblob_test/test1/Dockerfile
@@ -1,5 +1,4 @@
-FROM mcr.microsoft.com/mirror/docker/library/busybox:1.34 AS build
-
+FROM busybox AS build
 RUN cat /dev/urandom | head -c 100 | sha256sum > unique_first
 RUN cat /dev/urandom | head -c 100 | sha256sum > unique_second
 

--- a/hack/azblob_test/test2/Dockerfile
+++ b/hack/azblob_test/test2/Dockerfile
@@ -1,5 +1,4 @@
-FROM mcr.microsoft.com/mirror/docker/library/busybox:1.34 AS build
-
+FROM busybox AS build
 RUN cat /dev/urandom | head -c 100 | sha256sum > unique_first
 RUN cat /dev/urandom | head -c 100 | sha256sum > unique_second
 RUN cat /dev/urandom | head -c 100 | sha256sum > unique_third

--- a/hack/s3_test/test1/Dockerfile
+++ b/hack/s3_test/test1/Dockerfile
@@ -1,5 +1,4 @@
-FROM public.ecr.aws/debian/debian:bullseye-slim AS build
-
+FROM debian:bullseye-slim AS build
 RUN cat /dev/urandom | head -c 100 | sha256sum > unique_first
 RUN cat /dev/urandom | head -c 100 | sha256sum > unique_second
 

--- a/hack/s3_test/test2/Dockerfile
+++ b/hack/s3_test/test2/Dockerfile
@@ -1,5 +1,4 @@
-FROM public.ecr.aws/debian/debian:bullseye-slim AS build
-
+FROM debian:bullseye-slim AS build
 RUN cat /dev/urandom | head -c 100 | sha256sum > unique_first
 RUN cat /dev/urandom | head -c 100 | sha256sum > unique_second
 RUN cat /dev/urandom | head -c 100 | sha256sum > unique_third


### PR DESCRIPTION
`s3` and `azblob` integration tests are flaky when pulling images from `mcr.microsoft.com` and `public.ecr.aws` mirrors like: https://github.com/moby/buildkit/actions/runs/3245518525/jobs/5323188241#step:5:1889

```
#3 [internal] load metadata for mcr.microsoft.com/mirror/docker/library/busybox:1.34
time="2022-10-13T20:43:49Z" level=error msg="/moby.buildkit.v1.frontend.LLBBridge/Solve returned error: rpc error: code = Unknown desc = mcr.microsoft.com/mirror/docker/library/busybox:1.34: failed to copy: httpReadSeeker: failed open: unexpected status code https://mcr.microsoft.com/v2/mirror/docker/library/busybox/blobs/sha256:475448aba2e23f23c3959720ce0140cc5303d87109e18ca9c63e0b6ae7b943d8: 500 Internal Server Error"
time="2022-10-13T20:43:49Z" level=error msg="/moby.buildkit.v1.Control/Solve returned error: rpc error: code = Unknown desc = mcr.microsoft.com/mirror/docker/library/busybox:1.34: failed to copy: httpReadSeeker: failed open: unexpected status code https://mcr.microsoft.com/v2/mirror/docker/library/busybox/blobs/sha256:475448aba2e23f23c3959720ce0140cc5303d87109e18ca9c63e0b6ae7b943d8: 500 Internal Server Error"
#3 ERROR: failed to copy: httpReadSeeker: failed open: unexpected status code https://mcr.microsoft.com/v2/mirror/docker/library/busybox/blobs/sha256:475448aba2e23f23c3959720ce0140cc5303d87109e18ca9c63e0b6ae7b943d8: 500 Internal Server Error
```

Docker Hub should be more reliable.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>