### PR TITLE
dockerfile: release frontend for mips platforms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -449,6 +449,7 @@ jobs:
         run: |
           ./frontend/dockerfile/cmd/dockerfile-frontend/hack/release "${{ needs.frontend-base.outputs.typ }}" "${{ needs.frontend-base.outputs.tag }}" "$DF_REPO_SLUG_TARGET" "${{ needs.frontend-base.outputs.push }}"
         env:
+          PLATFORMS: ${{ env.PLATFORMS }},linux/mips,linux/mipsle,linux/mips64,linux/mips64le
           CACHE_FROM: type=gha,scope=frontend-${{ needs.frontend-base.outputs.typ }}
           CACHE_TO: type=gha,scope=frontend-${{ needs.frontend-base.outputs.typ }}
       -
@@ -457,4 +458,5 @@ jobs:
         run: |
           ./frontend/dockerfile/cmd/dockerfile-frontend/hack/release "${{ needs.frontend-base.outputs.typ }}" labs "$DF_REPO_SLUG_TARGET" "${{ needs.frontend-base.outputs.push }}"
         env:
+          PLATFORMS: ${{ env.PLATFORMS }},linux/mips,linux/mipsle,linux/mips64,linux/mips64le
           CACHE_FROM: type=gha,scope=frontend-${{ needs.frontend-base.outputs.typ }}

--- a/frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile
+++ b/frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile-upstream:master
 
 # xx is a helper for cross-compilation
-FROM --platform=$BUILDPLATFORM tonistiigi/xx:golang@sha256:810dc54d5144f133a218e88e319184bf8b9ce01d37d46ddb37573e90decd9eef AS xx
+FROM --platform=$BUILDPLATFORM tonistiigi/xx:master@sha256:d4254d9739ce2de9fb88e09bdc716aa0c65f0446a2a2143399f991d71136a3d4 AS xx
 
 FROM --platform=$BUILDPLATFORM golang:1.19-alpine AS base
 RUN apk add git bash


### PR DESCRIPTION
closes https://github.com/docker/buildx/issues/1295

Adds support for mips platforms of the dockerfile frontend image since https://github.com/tonistiigi/xx/pull/62 has been merged.

Not possible for the main Dockerfile atm as alpine only supports big-endian mips packages. Does not seem to have been updated for about a year: http://dl-cdn.alpinelinux.org/alpine/edge/releases/mips64/ so not sure that's a priority on their side.

If we want to add support in the main Dockerfile, I guess we have to use a debian base image for this arch.

cc @tianon 

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>