### PR TITLE
util/testutil/integration: remove DOCKER_SERVICE_PREFER_OFFLINE_IMAGE

### DIFF
--- a/util/testutil/integration/dockerd.go
+++ b/util/testutil/integration/dockerd.go
@@ -92,7 +92,7 @@ func (c dockerd) New(ctx context.Context, cfg *BackendConfig) (b Backend, cl fun
 		"--default-address-pool", "base=10.66.66.0/16,size=24",
 		"--debug",
 	}...)
-	cmd.Env = append(os.Environ(), "DOCKER_SERVICE_PREFER_OFFLINE_IMAGE=1", "BUILDKIT_DEBUG_EXEC_OUTPUT=1", "BUILDKIT_DEBUG_PANIC_ON_ERROR=1")
+	cmd.Env = append(os.Environ(), "BUILDKIT_DEBUG_EXEC_OUTPUT=1", "BUILDKIT_DEBUG_PANIC_ON_ERROR=1")
 	cmd.SysProcAttr = getSysProcAttr()
 
 	dockerdStop, err := startCmd(cmd, cfg.Logs)


### PR DESCRIPTION
This env-var was added in to prevent the Swarm integration tests (which load images, and because of that don't have a registry-digest) from pulling images; see https://github.com/moby/moby/commit/e2226223e614716749cdb7701a130c7449f5f854

Given that BuildKit integration tests don't run Swarm services, this env-var should not be needed here.
