### PR TITLE
Duplicate test runs

### DIFF
--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -89,7 +89,6 @@ var allTests = integration.TestFuncs(
 	testQuotedMetaArgs,
 	testIgnoreEntrypoint,
 	testSymlinkedDockerfile,
-	testDockerfileAddArchiveWildcard,
 	testEmptyWildcard,
 	testWorkdirCreatesDir,
 	testDockerfileAddArchiveWildcard,

--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -88,8 +88,14 @@ func (f testFunc) Run(t *testing.T, sb Sandbox) {
 
 func TestFuncs(funcs ...func(t *testing.T, sb Sandbox)) []Test {
 	var tests []Test
+	names := map[string]struct{}{}
 	for _, f := range funcs {
-		tests = append(tests, testFunc{name: getFunctionName(f), run: f})
+		name := getFunctionName(f)
+		if _, ok := names[name]; ok {
+			panic("duplicate test: " + name)
+		}
+		names[name] = struct{}{}
+		tests = append(tests, testFunc{name: name, run: f})
 	}
 	return tests
 }


### PR DESCRIPTION
As noticed in https://github.com/moby/buildkit/pull/3001#issuecomment-1282462464 by @DYefimov:

> FYI, there are two copies of testDockerfileAddArchiveWildcard inside the dockerfile_test.go allTests array:
https://github.com/moby/buildkit/blob/6bff1509/frontend/dockerfile/dockerfile_test.go#L92
https://github.com/moby/buildkit/blob/6bff1509/frontend/dockerfile/dockerfile_test.go#L95

Looks like a rebase mistake from a few years ago?

This PR removes the duplicate, and adds a panic to `TestFuncs that is triggered if a single function is added to a call of `TestFuncs` more than once to prevent this happening again in the future :tada: