### PR TITLE
lint: remove structcheck

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,6 +30,7 @@ linters:
     - errname
     - makezero
     - whitespace
+    - nolintlint
   disable-all: true
 
 linters-settings:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,7 +23,6 @@ linters:
     - ineffassign
     - misspell
     - staticcheck
-    - structcheck
     - typecheck
     - unused
     - varcheck

--- a/cache/contenthash/tarsum.go
+++ b/cache/contenthash/tarsum.go
@@ -37,10 +37,10 @@ func v0TarHeaderSelect(h *tar.Header) (orderedHeaders [][2]string) {
 
 func v1TarHeaderSelect(h *tar.Header) (orderedHeaders [][2]string) {
 	pax := h.PAXRecords
-	if len(h.Xattrs) > 0 { //nolint deprecated
+	if len(h.Xattrs) > 0 { //nolint:staticcheck // field deprecated in stdlib
 		if pax == nil {
 			pax = map[string]string{}
-			for k, v := range h.Xattrs { //nolint deprecated
+			for k, v := range h.Xattrs { //nolint:staticcheck // field deprecated in stdlib
 				pax["SCHILY.xattr."+k] = v
 			}
 		}

--- a/util/grpcerrors/grpcerrors.go
+++ b/util/grpcerrors/grpcerrors.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/containerd/typeurl"
 	gogotypes "github.com/gogo/protobuf/types"
-	"github.com/golang/protobuf/proto" // nolint:staticcheck
+	"github.com/golang/protobuf/proto" //nolint:staticcheck
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/moby/buildkit/util/stack"
 	"github.com/sirupsen/logrus"


### PR DESCRIPTION
`structcheck` is abandoned, and has been replaced by the `unused` linter. See https://golangci-lint.run/usage/linters/#structcheck for more information.

> The owner seems to have abandoned the linter. Replaced by unused.