### PR TITLE
Export attestations for local exporter

### DIFF
--- a/exporter/attestation/generate.go
+++ b/exporter/attestation/generate.go
@@ -1,0 +1,245 @@
+package attestation
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path"
+
+	"github.com/containerd/continuity/fs"
+	intoto "github.com/in-toto/in-toto-golang/in_toto"
+	"github.com/moby/buildkit/cache"
+	gatewaypb "github.com/moby/buildkit/frontend/gateway/pb"
+	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/snapshot"
+	"github.com/moby/buildkit/solver/result"
+	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
+)
+
+// Generate iterates over all provided result attestations and generates intoto
+// attestation statements.
+func Generate(ctx context.Context, s session.Group, refs map[string]cache.ImmutableRef, attestations []result.Attestation, defaultSubjects []intoto.Subject) ([]intoto.Statement, error) {
+	eg, ctx := errgroup.WithContext(ctx)
+	statements := make([]intoto.Statement, len(attestations))
+
+	for i, att := range attestations {
+		i, att := i, att
+		eg.Go(func() error {
+			var content []byte
+			if att.ContentFunc != nil {
+				var err error
+				content, err = att.ContentFunc()
+				if err != nil {
+					return err
+				}
+			} else {
+				if refs == nil {
+					return errors.Errorf("no refs map provided to lookup attestation keys")
+				}
+				ref, ok := refs[att.Ref]
+				if !ok {
+					return errors.Errorf("key %s not found in refs map", att.Ref)
+				}
+				mount, err := ref.Mount(ctx, true, s)
+				if err != nil {
+					return err
+				}
+				lm := snapshot.LocalMounter(mount)
+				src, err := lm.Mount()
+				if err != nil {
+					return err
+				}
+				defer lm.Unmount()
+
+				p, err := fs.RootPath(src, att.Path)
+				if err != nil {
+					return err
+				}
+				content, err = os.ReadFile(p)
+				if err != nil {
+					return errors.Wrap(err, "cannot read in-toto attestation")
+				}
+			}
+			if len(content) == 0 {
+				content = nil
+			}
+
+			switch att.Kind {
+			case gatewaypb.AttestationKindInToto:
+				stmt, err := generateInToto(ctx, content, att, defaultSubjects)
+				if err != nil {
+					return err
+				}
+				statements[i] = *stmt
+			case gatewaypb.AttestationKindBundle:
+				return errors.New("bundle attestation kind must be un-bundled first")
+			}
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+	return statements, nil
+}
+
+func generateInToto(ctx context.Context, content []byte, attestation result.Attestation, defaultSubjects []intoto.Subject) (*intoto.Statement, error) {
+	if len(attestation.InToto.Subjects) == 0 {
+		attestation.InToto.Subjects = []result.InTotoSubject{{
+			Kind: gatewaypb.InTotoSubjectKindSelf,
+		}}
+	}
+	subjects := []intoto.Subject{}
+	for _, subject := range attestation.InToto.Subjects {
+		subjectName := "_"
+		if subject.Name != "" {
+			subjectName = subject.Name
+		}
+
+		switch subject.Kind {
+		case gatewaypb.InTotoSubjectKindSelf:
+			for _, defaultSubject := range defaultSubjects {
+				subjectNames := []string{}
+				subjectNames = append(subjectNames, defaultSubject.Name)
+				if subjectName != "_" {
+					subjectNames = append(subjectNames, subjectName)
+				}
+
+				for _, name := range subjectNames {
+					subjects = append(subjects, intoto.Subject{
+						Name:   name,
+						Digest: defaultSubject.Digest,
+					})
+				}
+			}
+		case gatewaypb.InTotoSubjectKindRaw:
+			subjects = append(subjects, intoto.Subject{
+				Name:   subjectName,
+				Digest: result.ToDigestMap(subject.Digest...),
+			})
+		default:
+			return nil, errors.Errorf("unknown attestation subject type %T", subject)
+		}
+	}
+
+	stmt := intoto.Statement{
+		StatementHeader: intoto.StatementHeader{
+			Type:          intoto.StatementInTotoV01,
+			PredicateType: attestation.InToto.PredicateType,
+			Subject:       subjects,
+		},
+		Predicate: json.RawMessage(content),
+	}
+	return &stmt, nil
+}
+
+// Unbundle iterates over all provided result attestations and un-bundles any
+// bundled attestations by loading them from the provided refs map.
+func Unbundle(ctx context.Context, s session.Group, refs map[string]cache.ImmutableRef, bundled []result.Attestation) ([]result.Attestation, error) {
+	eg, ctx := errgroup.WithContext(ctx)
+	unbundled := make([][]result.Attestation, len(bundled))
+
+	for i, att := range bundled {
+		i, att := i, att
+		eg.Go(func() error {
+			switch att.Kind {
+			case gatewaypb.AttestationKindInToto:
+				unbundled[i] = append(unbundled[i], att)
+			case gatewaypb.AttestationKindBundle:
+				if att.ContentFunc != nil {
+					return errors.New("attestation bundle cannot have callback")
+				}
+				if refs == nil {
+					return errors.Errorf("no refs map provided to lookup attestation keys")
+				}
+				ref, ok := refs[att.Ref]
+				if !ok {
+					return errors.Errorf("key %s not found in refs map", att.Ref)
+				}
+
+				mount, err := ref.Mount(ctx, true, s)
+				if err != nil {
+					return err
+				}
+				lm := snapshot.LocalMounter(mount)
+				src, err := lm.Mount()
+				if err != nil {
+					return err
+				}
+				defer lm.Unmount()
+
+				atts, err := unbundle(ctx, src, att)
+				if err != nil {
+					return err
+				}
+				unbundled[i] = append(unbundled[i], atts...)
+			}
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
+	var joined []result.Attestation
+	for _, atts := range unbundled {
+		joined = append(joined, atts...)
+	}
+	return joined, nil
+}
+
+func unbundle(ctx context.Context, root string, bundle result.Attestation) ([]result.Attestation, error) {
+	dir, err := fs.RootPath(root, bundle.Path)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	var unbundled []result.Attestation
+	for _, entry := range entries {
+		p, err := fs.RootPath(dir, entry.Name())
+		if err != nil {
+			return nil, err
+		}
+		f, err := os.Open(p)
+		if err != nil {
+			return nil, err
+		}
+		dec := json.NewDecoder(f)
+		var stmt intoto.Statement
+		if err := dec.Decode(&stmt); err != nil {
+			return nil, errors.Wrap(err, "cannot decode in-toto statement")
+		}
+		if bundle.InToto.PredicateType != "" && stmt.PredicateType != bundle.InToto.PredicateType {
+			return nil, errors.Errorf("bundle entry %s does not match required predicate type %s", stmt.PredicateType, bundle.InToto.PredicateType)
+		}
+
+		predicate, err := json.Marshal(stmt.Predicate)
+		if err != nil {
+			return nil, err
+		}
+
+		subjects := make([]result.InTotoSubject, len(stmt.Subject))
+		for i, subject := range stmt.Subject {
+			subjects[i] = result.InTotoSubject{
+				Kind:   gatewaypb.InTotoSubjectKindRaw,
+				Name:   subject.Name,
+				Digest: result.FromDigestMap(subject.Digest),
+			}
+		}
+		unbundled = append(unbundled, result.Attestation{
+			Kind:        gatewaypb.AttestationKindInToto,
+			Path:        path.Join(bundle.Path, entry.Name()),
+			ContentFunc: func() ([]byte, error) { return predicate, nil },
+			InToto: result.InTotoAttestation{
+				PredicateType: stmt.PredicateType,
+				Subjects:      subjects,
+			},
+		})
+	}
+	return unbundled, nil
+}

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -13,19 +12,18 @@ import (
 	"github.com/containerd/containerd/diff"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/platforms"
-	"github.com/containerd/continuity/fs"
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/moby/buildkit/cache"
 	cacheconfig "github.com/moby/buildkit/cache/config"
 	"github.com/moby/buildkit/exporter"
+	"github.com/moby/buildkit/exporter/attestation"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/exporter/util/epoch"
-	gatewaypb "github.com/moby/buildkit/frontend/gateway/pb"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/snapshot"
 	"github.com/moby/buildkit/solver"
 	"github.com/moby/buildkit/solver/result"
-	"github.com/moby/buildkit/util/attestation"
+	attestationTypes "github.com/moby/buildkit/util/attestation"
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/buildinfo"
 	binfotypes "github.com/moby/buildkit/util/buildinfo/types"
@@ -129,18 +127,18 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 		return mfstDesc, nil
 	}
 
+	refCount := len(p.Platforms)
 	hasAttestations := false
-	attestCount := 0
 	for _, attests := range inp.Attestations {
 		hasAttestations = true
 		for _, attest := range attests {
-			if attest.ContentFunc == nil {
-				attestCount++
+			if attest.Ref != "" {
+				refCount++
 			}
 		}
 	}
-	if count := attestCount + len(p.Platforms); count != len(inp.Refs) {
-		return nil, errors.Errorf("number of required refs (%d) does not match number of references (%d)", count, len(inp.Refs))
+	if refCount != len(inp.Refs) {
+		return nil, errors.Errorf("number of required refs (%d) does not match number of references (%d)", refCount, len(inp.Refs))
 	}
 
 	if hasAttestations {
@@ -211,12 +209,31 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 		labels[fmt.Sprintf("containerd.io/gc.ref.content.%d", i)] = desc.Digest.String()
 
 		if attestations, ok := inp.Attestations[p.ID]; ok {
-			inTotos, err := ic.extractAttestations(ctx, opts, session.NewGroup(sessionID), desc, inp.Refs, attestations)
+			attestations, err := attestation.Unbundle(ctx, session.NewGroup(sessionID), inp.Refs, attestations)
 			if err != nil {
 				return nil, err
 			}
 
-			desc, err := ic.commitAttestationsManifest(ctx, opts, p, desc.Digest.String(), inTotos)
+			var defaultSubjects []intoto.Subject
+			for _, name := range strings.Split(opts.ImageName, ",") {
+				if name == "" {
+					continue
+				}
+				pl, err := purl.RefToPURL(name, &p.Platform)
+				if err != nil {
+					return nil, err
+				}
+				defaultSubjects = append(defaultSubjects, intoto.Subject{
+					Name:   pl,
+					Digest: result.ToDigestMap(desc.Digest),
+				})
+			}
+			stmts, err := attestation.Generate(ctx, session.NewGroup(sessionID), inp.Refs, attestations, defaultSubjects)
+			if err != nil {
+				return nil, err
+			}
+
+			desc, err := ic.commitAttestationsManifest(ctx, opts, p, desc.Digest.String(), stmts)
 			if err != nil {
 				return nil, err
 			}
@@ -287,168 +304,6 @@ func (ic *ImageWriter) exportLayers(ctx context.Context, refCfg cacheconfig.RefC
 	err := layersDone(eg.Wait())
 	tracing.FinishWithError(span, err)
 	return out, err
-}
-
-func (ic *ImageWriter) extractAttestations(ctx context.Context, opts *ImageCommitOpts, s session.Group, desc *ocispecs.Descriptor, refs map[string]cache.ImmutableRef, attestations []result.Attestation) ([]intoto.Statement, error) {
-	eg, ctx := errgroup.WithContext(ctx)
-	statements := make([][]intoto.Statement, len(attestations))
-
-	var purls []string
-	for _, name := range strings.Split(opts.ImageName, ",") {
-		if name == "" {
-			continue
-		}
-		p, err := purl.RefToPURL(name, desc.Platform)
-		if err != nil {
-			return nil, err
-		}
-		purls = append(purls, p)
-	}
-
-	if len(attestations) > 0 && refs == nil {
-		return nil, errors.Errorf("no refs map provided to lookup attestation keys")
-	}
-
-	for i, att := range attestations {
-		i, att := i, att
-		eg.Go(func() error {
-			var data []byte
-			var err error
-			var dir string
-			if att.ContentFunc != nil {
-				data, err = att.ContentFunc()
-				if err != nil {
-					return err
-				}
-			} else {
-				ref, ok := refs[att.Ref]
-				if !ok {
-					return errors.Errorf("key %s not found in refs map", att.Ref)
-				}
-				mount, err := ref.Mount(ctx, true, s)
-				if err != nil {
-					return err
-				}
-				lm := snapshot.LocalMounter(mount)
-				src, err := lm.Mount()
-				if err != nil {
-					return err
-				}
-				defer lm.Unmount()
-
-				switch att.Kind {
-				case gatewaypb.AttestationKindInToto:
-					p, err := fs.RootPath(src, att.Path)
-					if err != nil {
-						return err
-					}
-					data, err = os.ReadFile(p)
-					if err != nil {
-						return errors.Wrap(err, "cannot read in-toto attestation")
-					}
-					if len(data) == 0 {
-						data = nil
-					}
-				case gatewaypb.AttestationKindBundle:
-					dir, err = fs.RootPath(src, att.Path)
-					if err != nil {
-						return err
-					}
-				}
-			}
-
-			switch att.Kind {
-			case gatewaypb.AttestationKindInToto:
-				var subjects []intoto.Subject
-				if len(att.InToto.Subjects) == 0 {
-					att.InToto.Subjects = []result.InTotoSubject{{
-						Kind: gatewaypb.InTotoSubjectKindSelf,
-					}}
-				}
-				for _, subject := range att.InToto.Subjects {
-					name := "_"
-					if subject.Name != "" {
-						name = subject.Name
-					}
-
-					switch subject.Kind {
-					case gatewaypb.InTotoSubjectKindSelf:
-						names := []string{}
-						if name != "_" {
-							names = append(names, name)
-						}
-						names = append(names, purls...)
-						for _, name := range names {
-							subjects = append(subjects, intoto.Subject{
-								Name:   name,
-								Digest: result.DigestMap(desc.Digest),
-							})
-						}
-					case gatewaypb.InTotoSubjectKindRaw:
-						subjects = append(subjects, intoto.Subject{
-							Name:   name,
-							Digest: result.DigestMap(subject.Digest...),
-						})
-					default:
-						return errors.Errorf("unknown attestation subject type %T", subject)
-					}
-				}
-
-				stmt := intoto.Statement{
-					StatementHeader: intoto.StatementHeader{
-						Type:          intoto.StatementInTotoV01,
-						PredicateType: att.InToto.PredicateType,
-						Subject:       subjects,
-					},
-					Predicate: json.RawMessage(data),
-				}
-				statements[i] = append(statements[i], stmt)
-			case gatewaypb.AttestationKindBundle:
-				entries, err := os.ReadDir(dir)
-				if err != nil {
-					return err
-				}
-
-				for _, entry := range entries {
-					p, err := fs.RootPath(dir, entry.Name())
-					if err != nil {
-						return err
-					}
-					f, err := os.Open(p)
-					if err != nil {
-						return err
-					}
-					dec := json.NewDecoder(f)
-					var stmt intoto.Statement
-					if err := dec.Decode(&stmt); err != nil {
-						return errors.Wrap(err, "cannot decode in-toto statement")
-					}
-					if att.InToto.PredicateType != "" && stmt.PredicateType != att.InToto.PredicateType {
-						return errors.Errorf("bundle entry %s does not match required predicate type %s", stmt.PredicateType, att.InToto.PredicateType)
-					}
-					if stmt.Subject == nil {
-						for _, name := range purls {
-							stmt.Subject = append(stmt.Subject, intoto.Subject{
-								Name:   name,
-								Digest: result.DigestMap(desc.Digest),
-							})
-						}
-					}
-					statements[i] = append(statements[i], stmt)
-				}
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return nil, err
-	}
-
-	var allStatements []intoto.Statement
-	for _, statements := range statements {
-		allStatements = append(allStatements, statements...)
-	}
-	return allStatements, nil
 }
 
 func (ic *ImageWriter) commitDistributionManifest(ctx context.Context, opts *ImageCommitOpts, ref cache.ImmutableRef, config []byte, remote *solver.Remote, annotations *Annotations, inlineCache []byte, buildInfo []byte, epoch *time.Time, sg session.Group) (*ocispecs.Descriptor, *ocispecs.Descriptor, error) {
@@ -581,7 +436,7 @@ func (ic *ImageWriter) commitAttestationsManifest(ctx context.Context, opts *Ima
 		}
 		digest := digest.FromBytes(data)
 		desc := ocispecs.Descriptor{
-			MediaType: attestation.MediaTypeDockerSchema2AttestationType,
+			MediaType: attestationTypes.MediaTypeDockerSchema2AttestationType,
 			Digest:    digest,
 			Size:      int64(len(data)),
 			Annotations: map[string]string{
@@ -661,8 +516,8 @@ func (ic *ImageWriter) commitAttestationsManifest(ctx context.Context, opts *Ima
 		Size:      int64(len(mfstJSON)),
 		MediaType: manifestType,
 		Annotations: map[string]string{
-			attestation.DockerAnnotationReferenceType:   attestation.DockerAnnotationReferenceTypeDefault,
-			attestation.DockerAnnotationReferenceDigest: target,
+			attestationTypes.DockerAnnotationReferenceType:   attestationTypes.DockerAnnotationReferenceTypeDefault,
+			attestationTypes.DockerAnnotationReferenceDigest: target,
 		},
 	}, nil
 }

--- a/exporter/local/export.go
+++ b/exporter/local/export.go
@@ -3,24 +3,37 @@ package local
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"io/fs"
 	"os"
+	"path"
 	"strings"
 	"time"
 
 	"github.com/docker/docker/pkg/idtools"
+	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/exporter"
+	"github.com/moby/buildkit/exporter/attestation"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/exporter/util/epoch"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/filesync"
 	"github.com/moby/buildkit/snapshot"
+	"github.com/moby/buildkit/solver/result"
 	"github.com/moby/buildkit/util/progress"
+	"github.com/moby/buildkit/util/staticfs"
+	digest "github.com/opencontainers/go-digest"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/tonistiigi/fsutil"
 	fstypes "github.com/tonistiigi/fsutil/types"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/time/rate"
+)
+
+const (
+	keyAttestationPrefix = "attestation-prefix"
 )
 
 type Opt struct {
@@ -43,12 +56,22 @@ func (e *localExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 		return nil, err
 	}
 
-	return &localExporterInstance{localExporter: e, epoch: tm}, nil
+	i := &localExporterInstance{localExporter: e, epoch: tm}
+
+	for k, v := range opt {
+		switch k {
+		case keyAttestationPrefix:
+			i.attestationPrefix = v
+		}
+	}
+
+	return i, nil
 }
 
 type localExporterInstance struct {
 	*localExporter
-	epoch *time.Time
+	epoch             *time.Time
+	attestationPrefix string
 }
 
 func (e *localExporterInstance) Name() string {
@@ -90,7 +113,9 @@ func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source
 		}
 	}
 
-	export := func(ctx context.Context, k string, ref cache.ImmutableRef) func() error {
+	now := time.Now().Truncate(time.Second)
+
+	export := func(ctx context.Context, k string, p *ocispecs.Platform, ref cache.ImmutableRef, attestations []result.Attestation) func() error {
 		return func() error {
 			var src string
 			var err error
@@ -121,7 +146,6 @@ func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source
 
 			walkOpt := &fsutil.WalkOpt{}
 			var idMapFunc func(p string, st *fstypes.Stat) fsutil.MapResult
-
 			if idmap != nil {
 				idMapFunc = func(p string, st *fstypes.Stat) fsutil.MapResult {
 					uid, gid, err := idmap.ToContainer(idtools.Identity{
@@ -136,7 +160,6 @@ func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source
 					return fsutil.MapResultKeep
 				}
 			}
-
 			walkOpt.Map = func(p string, st *fstypes.Stat) fsutil.MapResult {
 				res := fsutil.MapResultKeep
 				if idMapFunc != nil {
@@ -148,7 +171,73 @@ func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source
 				return res
 			}
 
-			fs := fsutil.NewFS(src, walkOpt)
+			outputFS := fsutil.NewFS(src, walkOpt)
+
+			attestations, err = attestation.Unbundle(ctx, session.NewGroup(sessionID), inp.Refs, attestations)
+			if err != nil {
+				return err
+			}
+			if len(attestations) > 0 {
+				subjects := []intoto.Subject{}
+				err = outputFS.Walk(ctx, func(path string, info fs.FileInfo, err error) error {
+					if err != nil {
+						return err
+					}
+					if !info.Mode().IsRegular() {
+						return nil
+					}
+					f, err := outputFS.Open(path)
+					if err != nil {
+						return err
+					}
+					defer f.Close()
+					d := digest.Canonical.Digester()
+					if _, err := io.Copy(d.Hash(), f); err != nil {
+						return err
+					}
+					subjects = append(subjects, intoto.Subject{
+						Name:   path,
+						Digest: result.ToDigestMap(d.Digest()),
+					})
+					return nil
+				})
+				if err != nil {
+					return err
+				}
+
+				stmts, err := attestation.Generate(ctx, session.NewGroup(sessionID), inp.Refs, attestations, subjects)
+				if err != nil {
+					return err
+				}
+				stmtFS := staticfs.NewFS()
+
+				names := map[string]struct{}{}
+				for i, stmt := range stmts {
+					dt, err := json.Marshal(stmt)
+					if err != nil {
+						return errors.Wrap(err, "failed to marshal attestation")
+					}
+
+					if attestations[i].Path == "" {
+						return errors.New("attestation does not have set path")
+					}
+					name := e.attestationPrefix + path.Base(attestations[i].Path)
+					if _, ok := names[name]; ok {
+						return errors.Errorf("duplicate attestation path name %s", name)
+					}
+					names[name] = struct{}{}
+
+					st := fstypes.Stat{
+						Mode:    0600,
+						Path:    name,
+						ModTime: now.UnixNano(),
+					}
+					stmtFS.Add(name, st, dt)
+				}
+
+				outputFS = staticfs.NewMergeFS(outputFS, stmtFS)
+			}
+
 			lbl := "copying files"
 			if isMap {
 				lbl += " " + k
@@ -159,14 +248,15 @@ func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source
 				if e.epoch != nil {
 					st.ModTime = e.epoch.UnixNano()
 				}
-				fs, err = fsutil.SubDirFS([]fsutil.Dir{{FS: fs, Stat: st}})
+
+				outputFS, err = fsutil.SubDirFS([]fsutil.Dir{{FS: outputFS, Stat: st}})
 				if err != nil {
 					return err
 				}
 			}
 
 			progress := NewProgressHandler(ctx, lbl)
-			if err := filesync.CopyToCaller(ctx, fs, caller, progress); err != nil {
+			if err := filesync.CopyToCaller(ctx, outputFS, caller, progress); err != nil {
 				return err
 			}
 			return nil
@@ -181,10 +271,10 @@ func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source
 			if !ok {
 				return nil, errors.Errorf("failed to find ref for ID %s", p.ID)
 			}
-			eg.Go(export(ctx, p.ID, r))
+			eg.Go(export(ctx, p.ID, &p.Platform, r, inp.Attestations[p.ID]))
 		}
 	} else {
-		eg.Go(export(ctx, "", inp.Ref))
+		eg.Go(export(ctx, "", nil, inp.Ref, nil))
 	}
 
 	if err := eg.Wait(); err != nil {

--- a/exporter/tar/export.go
+++ b/exporter/tar/export.go
@@ -177,6 +177,7 @@ func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source
 			return nil, errors.Wrapf(err, "failed to parse platforms passed to exporter")
 		}
 	}
+	isMap := len(p.Platforms) > 1
 
 	var fs fsutil.FS
 
@@ -191,12 +192,18 @@ func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source
 			if err != nil {
 				return nil, err
 			}
+			if !isMap {
+				fs = d.FS
+				break
+			}
 			dirs = append(dirs, *d)
 		}
-		var err error
-		fs, err = fsutil.SubDirFS(dirs)
-		if err != nil {
-			return nil, err
+		if isMap {
+			var err error
+			fs, err = fsutil.SubDirFS(dirs)
+			if err != nil {
+				return nil, err
+			}
 		}
 	} else {
 		d, err := getDir(ctx, "", inp.Ref)

--- a/frontend/gateway/client/attestation.go
+++ b/frontend/gateway/client/attestation.go
@@ -3,9 +3,14 @@ package client
 import (
 	pb "github.com/moby/buildkit/frontend/gateway/pb"
 	"github.com/moby/buildkit/solver/result"
+	"github.com/pkg/errors"
 )
 
 func AttestationToPB(a *result.Attestation) (*pb.Attestation, error) {
+	if a.ContentFunc != nil {
+		return nil, errors.Errorf("attestation callback cannot be sent through gateway")
+	}
+
 	subjects := make([]*pb.InTotoSubject, len(a.InToto.Subjects))
 	for i, subject := range a.InToto.Subjects {
 		subjects[i] = &pb.InTotoSubject{

--- a/frontend/gateway/forwarder/forward.go
+++ b/frontend/gateway/forwarder/forward.go
@@ -185,6 +185,13 @@ func (c *bridgeClient) toFrontendResult(r *client.Result) (*frontend.Result, err
 		}
 		return rr.acquireResultProxy(), nil
 	})
+	for _, atts := range res.Attestations {
+		for _, att := range atts {
+			if att.ContentFunc != nil {
+				return nil, errors.Errorf("attestation callback cannot be sent through gateway")
+			}
+		}
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/solver/llbsolver/proc/provenance.go
+++ b/solver/llbsolver/proc/provenance.go
@@ -148,6 +148,7 @@ func ProvenanceProcessor(attrs map[string]string) llbsolver.Processor {
 				InToto: result.InTotoAttestation{
 					PredicateType: slsa.PredicateSLSAProvenance,
 				},
+				Path: "provenance.json",
 				ContentFunc: func() ([]byte, error) {
 					end := time.Now()
 					pr.Metadata.BuildFinishedOn = &end

--- a/solver/result/attestation.go
+++ b/solver/result/attestation.go
@@ -8,11 +8,11 @@ import (
 type Attestation struct {
 	Kind pb.AttestationKind
 
-	Ref  string
-	Path string
-
-	InToto      InTotoAttestation
+	Ref         string
+	Path        string
 	ContentFunc func() ([]byte, error)
+
+	InToto InTotoAttestation
 }
 
 type InTotoAttestation struct {
@@ -27,10 +27,18 @@ type InTotoSubject struct {
 	Digest []digest.Digest
 }
 
-func DigestMap(ds ...digest.Digest) map[string]string {
+func ToDigestMap(ds ...digest.Digest) map[string]string {
 	m := map[string]string{}
 	for _, d := range ds {
 		m[d.Algorithm().String()] = d.Encoded()
 	}
 	return m
+}
+
+func FromDigestMap(m map[string]string) []digest.Digest {
+	var ds []digest.Digest
+	for k, v := range m {
+		ds = append(ds, digest.NewDigestFromEncoded(digest.Algorithm(k), v))
+	}
+	return ds
 }

--- a/solver/result/result.go
+++ b/solver/result/result.go
@@ -41,15 +41,17 @@ func (r *Result[T]) AddRef(k string, ref T) {
 
 func (r *Result[T]) AddAttestation(k string, v Attestation, ref T) {
 	r.mu.Lock()
-	if r.Refs == nil {
-		r.Refs = map[string]T{}
+	if reflect.ValueOf(ref).IsValid() {
+		if r.Refs == nil {
+			r.Refs = map[string]T{}
+		}
+		if !strings.HasPrefix(v.Ref, attestationRefPrefix) {
+			v.Ref = attestationRefPrefix + identity.NewID()
+			r.Refs[v.Ref] = ref
+		}
 	}
 	if r.Attestations == nil {
 		r.Attestations = map[string][]Attestation{}
-	}
-	if v.ContentFunc == nil && !strings.HasPrefix(v.Ref, attestationRefPrefix) {
-		v.Ref = "attestation:" + identity.NewID()
-		r.Refs[v.Ref] = ref
 	}
 	r.Attestations[k] = append(r.Attestations[k], v)
 	r.mu.Unlock()

--- a/util/staticfs/merge.go
+++ b/util/staticfs/merge.go
@@ -1,0 +1,92 @@
+package staticfs
+
+import (
+	"context"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/tonistiigi/fsutil"
+	"golang.org/x/sync/errgroup"
+)
+
+type MergeFS struct {
+	Lower fsutil.FS
+	Upper fsutil.FS
+}
+
+var _ fsutil.FS = &MergeFS{}
+
+func NewMergeFS(lower, upper fsutil.FS) *MergeFS {
+	return &MergeFS{
+		Lower: lower,
+		Upper: upper,
+	}
+}
+
+type record struct {
+	path string
+	fi   fs.FileInfo
+	err  error
+}
+
+func (mfs *MergeFS) Walk(ctx context.Context, fn filepath.WalkFunc) error {
+	ch1 := make(chan *record, 10)
+	ch2 := make(chan *record, 10)
+
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		defer close(ch1)
+		return mfs.Lower.Walk(ctx, func(path string, info fs.FileInfo, err error) error {
+			ch1 <- &record{path: path, fi: info, err: err}
+			return nil
+		})
+	})
+	eg.Go(func() error {
+		defer close(ch2)
+		return mfs.Upper.Walk(ctx, func(path string, info fs.FileInfo, err error) error {
+			ch2 <- &record{path: path, fi: info, err: err}
+			return nil
+		})
+	})
+
+	eg.Go(func() error {
+		next1, ok1 := <-ch1
+		next2, ok2 := <-ch2
+
+		for {
+			if !ok1 && !ok2 {
+				break
+			}
+			if !ok2 || ok1 && next1.path < next2.path {
+				if err := fn(next1.path, next1.fi, next1.err); err != nil {
+					return err
+				}
+				next1, ok1 = <-ch1
+			} else if !ok1 || ok2 && next1.path >= next2.path {
+				if err := fn(next2.path, next2.fi, next2.err); err != nil {
+					return err
+				}
+				if ok1 && next2.path == next1.path {
+					next1, ok1 = <-ch1
+				}
+				next2, ok2 = <-ch2
+			}
+		}
+		return nil
+	})
+
+	return eg.Wait()
+}
+
+func (mfs *MergeFS) Open(p string) (io.ReadCloser, error) {
+	r, err := mfs.Upper.Open(p)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+		return mfs.Lower.Open(p)
+	}
+	return r, nil
+}

--- a/util/staticfs/merge_test.go
+++ b/util/staticfs/merge_test.go
@@ -1,0 +1,98 @@
+package staticfs
+
+import (
+	"context"
+	"io"
+	iofs "io/fs"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tonistiigi/fsutil/types"
+)
+
+func TestMerge(t *testing.T) {
+	fs1 := NewFS()
+	fs1.Add("foo", types.Stat{Mode: 0644}, []byte("foofoo"))
+	fs1.Add("bar", types.Stat{Mode: 0444}, []byte("barbarbar"))
+
+	fs2 := NewFS()
+	fs2.Add("abc", types.Stat{Mode: 0400}, []byte("abcabc"))
+	fs2.Add("foo", types.Stat{Mode: 0440}, []byte("foofoofoofoo"))
+
+	fs := NewMergeFS(fs1, fs2)
+
+	rc, err := fs.Open("foo")
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	require.Equal(t, []byte("foofoofoofoo"), data)
+	require.NoError(t, rc.Close())
+
+	rc, err = fs.Open("bar")
+	require.NoError(t, err)
+
+	data, err = io.ReadAll(rc)
+	require.NoError(t, err)
+	require.Equal(t, []byte("barbarbar"), data)
+
+	var files []string
+	err = fs.Walk(context.TODO(), func(path string, info iofs.FileInfo, err error) error {
+		require.NoError(t, err)
+		switch path {
+		case "foo":
+			require.Equal(t, int64(12), info.Size())
+			require.Equal(t, os.FileMode(0440), info.Mode())
+		case "bar":
+			require.Equal(t, int64(9), info.Size())
+			require.Equal(t, os.FileMode(0444), info.Mode())
+		case "abc":
+			require.Equal(t, int64(6), info.Size())
+			require.Equal(t, os.FileMode(0400), info.Mode())
+		default:
+			require.Fail(t, "unexpected path", path)
+		}
+		files = append(files, path)
+		return nil
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"abc", "bar", "foo"}, files)
+
+	// extra level
+	fs3 := NewFS()
+	fs3.Add("bax", types.Stat{Mode: 0600}, []byte("bax"))
+
+	fs = NewMergeFS(fs, fs3)
+
+	rc, err = fs.Open("bar")
+	require.NoError(t, err)
+
+	data, err = io.ReadAll(rc)
+	require.NoError(t, err)
+	require.Equal(t, []byte("barbarbar"), data)
+	require.NoError(t, rc.Close())
+
+	rc, err = fs.Open("bax")
+	require.NoError(t, err)
+
+	data, err = io.ReadAll(rc)
+	require.NoError(t, err)
+	require.Equal(t, []byte("bax"), data)
+	require.NoError(t, rc.Close())
+
+	_, err = fs.Open("bay")
+	require.Error(t, err)
+	require.True(t, os.IsNotExist(err))
+
+	files = nil
+	err = fs.Walk(context.TODO(), func(path string, info iofs.FileInfo, err error) error {
+		require.NoError(t, err)
+		files = append(files, path)
+		return nil
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"abc", "bar", "bax", "foo"}, files)
+}

--- a/util/staticfs/static.go
+++ b/util/staticfs/static.go
@@ -1,0 +1,64 @@
+package staticfs
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/tonistiigi/fsutil"
+	"github.com/tonistiigi/fsutil/types"
+)
+
+type File struct {
+	Stat types.Stat
+	Data []byte
+}
+
+type FS struct {
+	files map[string]File
+}
+
+var _ fsutil.FS = &FS{}
+
+func NewFS() *FS {
+	return &FS{
+		files: map[string]File{},
+	}
+}
+
+func (fs *FS) Add(p string, stat types.Stat, data []byte) {
+	stat.Size_ = int64(len(data))
+	if stat.Mode == 0 {
+		stat.Mode = 0644
+	}
+	stat.Path = p
+	fs.files[p] = File{
+		Stat: stat,
+		Data: data,
+	}
+}
+
+func (fs *FS) Walk(ctx context.Context, fn filepath.WalkFunc) error {
+	keys := make([]string, 0, len(fs.files))
+	for k := range fs.files {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, p := range keys {
+		st := fs.files[p].Stat
+		if err := fn(p, &fsutil.StatInfo{Stat: &st}, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (fs *FS) Open(p string) (io.ReadCloser, error) {
+	if f, ok := fs.files[p]; ok {
+		return io.NopCloser(bytes.NewReader(f.Data)), nil
+	}
+	return nil, os.ErrNotExist
+}

--- a/util/staticfs/static_test.go
+++ b/util/staticfs/static_test.go
@@ -1,0 +1,68 @@
+package staticfs
+
+import (
+	"context"
+	"io"
+	iofs "io/fs"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tonistiigi/fsutil/types"
+)
+
+func TestStatic(t *testing.T) {
+	fs := NewFS()
+	fs.Add("foo", types.Stat{Mode: 0644}, []byte("foofoo"))
+	fs.Add("bar", types.Stat{Mode: 0444}, []byte("barbarbar"))
+
+	rc, err := fs.Open("bar")
+	require.NoError(t, err)
+	require.NoError(t, rc.Close())
+
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	require.Equal(t, []byte("barbarbar"), data)
+
+	_, err = fs.Open("abc")
+	require.Error(t, err)
+	require.True(t, os.IsNotExist(err))
+
+	var files []string
+	err = fs.Walk(context.TODO(), func(path string, info iofs.FileInfo, err error) error {
+		require.NoError(t, err)
+		switch path {
+		case "foo":
+			require.Equal(t, int64(6), info.Size())
+			require.Equal(t, os.FileMode(0644), info.Mode())
+		case "bar":
+			require.Equal(t, int64(9), info.Size())
+			require.Equal(t, os.FileMode(0444), info.Mode())
+		default:
+			require.Fail(t, "unexpected path", path)
+		}
+		files = append(files, path)
+		return nil
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"bar", "foo"}, files)
+
+	fs.Add("abc", types.Stat{Mode: 0444}, []byte("abcabcabc"))
+
+	rc, err = fs.Open("abc")
+	require.NoError(t, err)
+
+	data, err = io.ReadAll(rc)
+	require.NoError(t, err)
+	require.Equal(t, []byte("abcabcabc"), data)
+	require.NoError(t, rc.Close())
+
+	rc, err = fs.Open("foo")
+	require.NoError(t, err)
+
+	data, err = io.ReadAll(rc)
+	require.NoError(t, err)
+	require.Equal(t, []byte("foofoo"), data)
+	require.NoError(t, rc.Close())
+}


### PR DESCRIPTION
Implements the `local` exporter part of #3184.

The attestation extraction logic is moved to a separate utils package, so that other exporters can use it. Additionally, the bundling logic is slightly reworked, to add an explicit Unbundle step before Extracting. This ensures that the Extract method can perform a one-to-one translation from result.Attestations to intoto.Statements, which allows for deriving intermediate properties such as the Path.

The attestation files are exported similar to another platform ref, with file names equivalent to the original attestation files had (though this should be pretty easy to change if we'd prefer a separate output location specified by the user).

I'm not quite sure what to put for the `subject` field for intoto (unless there's a canonical way of calculating the hash of a directory that I'm not aware of?), so for now I've left those empty.