### PR TITLE
frontend/dockerfile: some minor refactor and optimizations

### DIFF
--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -759,12 +759,10 @@ func parseExtraHosts(v string) ([]llb.HostIP, error) {
 		return nil, err
 	}
 	for _, field := range fields {
-		parts := strings.SplitN(field, "=", 2)
-		if len(parts) != 2 {
+		key, val, ok := strings.Cut(strings.ToLower(field), "=")
+		if !ok {
 			return nil, errors.Errorf("invalid key-value pair %s", field)
 		}
-		key := strings.ToLower(parts[0])
-		val := strings.ToLower(parts[1])
 		ip := net.ParseIP(val)
 		if ip == nil {
 			return nil, errors.Errorf("failed to parse IP %s", val)

--- a/frontend/dockerfile/instructions/bflag.go
+++ b/frontend/dockerfile/instructions/bflag.go
@@ -156,14 +156,7 @@ func (bf *BFlags) Parse() error {
 			return nil
 		}
 
-		arg = arg[2:]
-		value := ""
-
-		index := strings.Index(arg, "=")
-		if index >= 0 {
-			value = arg[index+1:]
-			arg = arg[:index]
-		}
+		arg, value, hasValue := strings.Cut(arg[2:], "=")
 
 		flag, ok := bf.flags[arg]
 		if !ok {
@@ -180,27 +173,27 @@ func (bf *BFlags) Parse() error {
 		switch flag.flagType {
 		case boolType:
 			// value == "" is only ok if no "=" was specified
-			if index >= 0 && value == "" {
+			if hasValue && value == "" {
 				return errors.Errorf("missing a value on flag: %s", arg)
 			}
 
-			lower := strings.ToLower(value)
-			if lower == "" {
+			switch strings.ToLower(value) {
+			case "true", "":
 				flag.Value = "true"
-			} else if lower == "true" || lower == "false" {
-				flag.Value = lower
-			} else {
+			case "false":
+				flag.Value = "false"
+			default:
 				return errors.Errorf("expecting boolean value for flag %s, not: %s", arg, value)
 			}
 
 		case stringType:
-			if index < 0 {
+			if !hasValue {
 				return errors.Errorf("missing a value on flag: %s", arg)
 			}
 			flag.Value = value
 
 		case stringsType:
-			if index < 0 {
+			if !hasValue {
 				return errors.Errorf("missing a value on flag: %s", arg)
 			}
 			flag.StringValues = append(flag.StringValues, value)

--- a/frontend/dockerfile/instructions/commands_runmount.go
+++ b/frontend/dockerfile/instructions/commands_runmount.go
@@ -44,31 +44,10 @@ func init() {
 	parseRunPostHooks = append(parseRunPostHooks, runMountPostHook)
 }
 
-func isValidMountType(s string) bool {
-	if s == "secret" {
-		if !isSecretMountsSupported() {
-			return false
-		}
-	}
-	if s == "ssh" {
-		if !isSSHMountsSupported() {
-			return false
-		}
-	}
-	_, ok := allowedMountTypes[s]
-	return ok
-}
-
 func allMountTypes() []string {
-	types := make([]string, 0, len(allowedMountTypes)+2)
+	types := make([]string, 0, len(allowedMountTypes))
 	for k := range allowedMountTypes {
 		types = append(types, k)
-	}
-	if isSecretMountsSupported() {
-		types = append(types, "secret")
-	}
-	if isSSHMountsSupported() {
-		types = append(types, "ssh")
 	}
 	return types
 }
@@ -196,10 +175,11 @@ func parseMount(value string, expander SingleWordExpander) (*Mount, error) {
 
 		switch key {
 		case "type":
-			if !isValidMountType(strings.ToLower(value)) {
+			v := strings.ToLower(value)
+			if _, ok := allowedMountTypes[v]; !ok {
 				return nil, suggest.WrapError(errors.Errorf("unsupported mount type %q", value), value, allMountTypes(), true)
 			}
-			m.Type = strings.ToLower(value)
+			m.Type = v
 		case "from":
 			m.From = value
 		case "source", "src":

--- a/frontend/dockerfile/instructions/commands_runmount.go
+++ b/frontend/dockerfile/instructions/commands_runmount.go
@@ -290,10 +290,6 @@ func parseMount(value string, expander SingleWordExpander) (*Mount, error) {
 		}
 	}
 
-	if m.CacheSharing != "" && m.Type != MountTypeCache {
-		return nil, errors.Errorf("invalid cache sharing set for %v mount", m.Type)
-	}
-
 	if m.Type == MountTypeSecret {
 		if m.From != "" {
 			return nil, errors.Errorf("secret mount should not have a from")
@@ -307,6 +303,10 @@ func parseMount(value string, expander SingleWordExpander) (*Mount, error) {
 		if m.Source != "" && m.CacheID != "" {
 			return nil, errors.Errorf("both source and id can't be set")
 		}
+	}
+
+	if m.CacheSharing != "" && m.Type != MountTypeCache {
+		return nil, errors.Errorf("invalid cache sharing set for %v mount", m.Type)
 	}
 
 	return m, nil

--- a/frontend/dockerfile/instructions/commands_runmount.go
+++ b/frontend/dockerfile/instructions/commands_runmount.go
@@ -52,6 +52,14 @@ func init() {
 	parseRunPostHooks = append(parseRunPostHooks, runMountPostHook)
 }
 
+func allShareModes() []string {
+	types := make([]string, 0, len(allowedSharingModes))
+	for k := range allowedSharingModes {
+		types = append(types, string(k))
+	}
+	return types
+}
+
 func allMountTypes() []string {
 	types := make([]string, 0, len(allowedMountTypes))
 	for k := range allowedMountTypes {
@@ -231,7 +239,7 @@ func parseMount(value string, expander SingleWordExpander) (*Mount, error) {
 		case "sharing":
 			v := ShareMode(strings.ToLower(value))
 			if _, ok := allowedSharingModes[v]; !ok {
-				return nil, errors.Errorf("unsupported sharing value %q", value)
+				return nil, suggest.WrapError(errors.Errorf("unsupported sharing value %q", value), value, allShareModes(), true)
 			}
 			m.CacheSharing = v
 		case "mode":

--- a/frontend/dockerfile/instructions/commands_runnetwork.go
+++ b/frontend/dockerfile/instructions/commands_runnetwork.go
@@ -4,13 +4,15 @@ import (
 	"github.com/pkg/errors"
 )
 
+type NetworkMode = string
+
 const (
-	NetworkDefault = "default"
-	NetworkNone    = "none"
-	NetworkHost    = "host"
+	NetworkDefault NetworkMode = "default"
+	NetworkNone    NetworkMode = "none"
+	NetworkHost    NetworkMode = "host"
 )
 
-var allowedNetwork = map[string]struct{}{
+var allowedNetwork = map[NetworkMode]struct{}{
 	NetworkDefault: {},
 	NetworkNone:    {},
 	NetworkHost:    {},
@@ -51,7 +53,7 @@ func runNetworkPostHook(cmd *RunCommand, req parseRequest) error {
 	return nil
 }
 
-func GetNetwork(cmd *RunCommand) string {
+func GetNetwork(cmd *RunCommand) NetworkMode {
 	return cmd.getExternalValue(networkKey).(*networkState).networkMode
 }
 

--- a/frontend/dockerfile/instructions/commands_secrets.go
+++ b/frontend/dockerfile/instructions/commands_secrets.go
@@ -1,5 +1,0 @@
-package instructions
-
-func isSecretMountsSupported() bool {
-	return true
-}

--- a/frontend/dockerfile/instructions/commands_ssh.go
+++ b/frontend/dockerfile/instructions/commands_ssh.go
@@ -1,5 +1,0 @@
-package instructions
-
-func isSSHMountsSupported() bool {
-	return true
-}

--- a/frontend/dockerfile/instructions/parse.go
+++ b/frontend/dockerfile/instructions/parse.go
@@ -357,12 +357,13 @@ func parseFrom(req parseRequest) (*Stage, error) {
 	}, nil
 }
 
-func parseBuildStageName(args []string) (string, error) {
-	stageName := ""
+var validStageName = regexp.MustCompile("^[a-z][a-z0-9-_.]*$")
+
+func parseBuildStageName(args []string) (stageName string, err error) {
 	switch {
 	case len(args) == 3 && strings.EqualFold(args[1], "as"):
 		stageName = strings.ToLower(args[2])
-		if ok, _ := regexp.MatchString("^[a-z][a-z0-9-_\\.]*$", stageName); !ok {
+		if !validStageName.MatchString(stageName) {
 			return "", errors.Errorf("invalid name for build stage: %q, name can't start with a number or contain symbols", args[2])
 		}
 	case len(args) != 1:

--- a/frontend/dockerfile/instructions/parse_test.go
+++ b/frontend/dockerfile/instructions/parse_test.go
@@ -64,10 +64,10 @@ func TestCommandsTooManyArguments(t *testing.T) {
 		"LABEL",
 	}
 
-	for _, command := range commands {
+	for _, cmd := range commands {
 		node := &parser.Node{
-			Original: command + "arg1 arg2 arg3",
-			Value:    strings.ToLower(command),
+			Original: cmd + "arg1 arg2 arg3",
+			Value:    strings.ToLower(cmd),
 			Next: &parser.Node{
 				Value: "arg1",
 				Next: &parser.Node{
@@ -79,7 +79,7 @@ func TestCommandsTooManyArguments(t *testing.T) {
 			},
 		}
 		_, err := ParseInstruction(node)
-		require.EqualError(t, err, errTooManyArguments(command).Error())
+		require.EqualError(t, err, errTooManyArguments(cmd).Error())
 	}
 }
 
@@ -226,8 +226,7 @@ func TestErrorCases(t *testing.T) {
 		}
 		n := ast.AST.Children[0]
 		_, err = ParseInstruction(n)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), c.expectedError)
+		require.ErrorContains(t, err, c.expectedError)
 	}
 }
 
@@ -242,4 +241,14 @@ func TestRunCmdFlagsUsed(t *testing.T) {
 	require.NoError(t, err)
 	require.IsType(t, c, &RunCommand{})
 	require.Equal(t, []string{"mount"}, c.(*RunCommand).FlagsUsed)
+}
+
+func BenchmarkParseBuildStageName(b *testing.B) {
+	b.ReportAllocs()
+	stageNames := []string{"STAGE_NAME", "StageName", "St4g3N4m3"}
+	for i := 0; i < b.N; i++ {
+		for _, s := range stageNames {
+			_, _ = parseBuildStageName([]string{"foo", "as", s})
+		}
+	}
 }

--- a/frontend/dockerfile/parser/parser.go
+++ b/frontend/dockerfile/parser/parser.go
@@ -49,8 +49,7 @@ func (node *Node) Location() []Range {
 // Dump dumps the AST defined by `node` as a list of sexps.
 // Returns a string suitable for printing.
 func (node *Node) Dump() string {
-	str := ""
-	str += strings.ToLower(node.Value)
+	str := strings.ToLower(node.Value)
 
 	if len(node.Flags) > 0 {
 		str += fmt.Sprintf(" %q", node.Flags)

--- a/frontend/dockerfile/shell/equal_env_unix.go
+++ b/frontend/dockerfile/shell/equal_env_unix.go
@@ -4,8 +4,8 @@
 package shell
 
 // EqualEnvKeys compare two strings and returns true if they are equal.
-// On Unix this comparison is case sensitive.
-// On Windows this comparison is case insensitive.
+// On Unix this comparison is case-sensitive.
+// On Windows this comparison is case-insensitive.
 func EqualEnvKeys(from, to string) bool {
 	return from == to
 }

--- a/frontend/dockerfile/shell/equal_env_windows.go
+++ b/frontend/dockerfile/shell/equal_env_windows.go
@@ -3,8 +3,8 @@ package shell
 import "strings"
 
 // EqualEnvKeys compare two strings and returns true if they are equal.
-// On Unix this comparison is case sensitive.
-// On Windows this comparison is case insensitive.
+// On Unix this comparison is case-sensitive.
+// On Windows this comparison is case-insensitive.
 func EqualEnvKeys(from, to string) bool {
-	return strings.ToUpper(from) == strings.ToUpper(to)
+	return strings.EqualFold(from, to)
 }

--- a/frontend/dockerfile/shell/lex_test.go
+++ b/frontend/dockerfile/shell/lex_test.go
@@ -27,12 +27,10 @@ func TestShellParserMandatoryEnvVars(t *testing.T) {
 	require.Equal(t, "plain", newWord)
 
 	_, err = shlex.ProcessWord(noEmpty, emptyEnvs)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "message herex")
+	require.ErrorContains(t, err, "message herex")
 
 	_, err = shlex.ProcessWord(noEmpty, unsetEnvs)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "message herex")
+	require.ErrorContains(t, err, "message herex")
 
 	// disallow unset
 	newWord, err = shlex.ProcessWord(noUnset, setEnvs)
@@ -41,11 +39,10 @@ func TestShellParserMandatoryEnvVars(t *testing.T) {
 
 	newWord, err = shlex.ProcessWord(noUnset, emptyEnvs)
 	require.NoError(t, err)
-	require.Equal(t, "", newWord)
+	require.Empty(t, newWord)
 
 	_, err = shlex.ProcessWord(noUnset, unsetEnvs)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "message herex")
+	require.ErrorContains(t, err, "message herex")
 }
 
 func TestShellParser4EnvVars(t *testing.T) {


### PR DESCRIPTION
See individual commits for details;

### frontend/dockerfile: remove isSSHMountsSupported, isSecretMountsSupported

These became obsolete in https://github.com/moby/buildkit/commit/906e34510de0f4e39a7f79173d110cff10c90f3b, which always enabled them.

### frontend/dockerfile: parseBuildStageName(): pre-compile regex

Before/After:
    BenchmarkParseBuildStageName-10     180793      5972   ns/op    8355 B/op     126 allocs/op
    BenchmarkParseBuildStageName-10    1980735       605.5 ns/op      48 B/op       3 allocs/op

Also renamed a variable that collided with an import.

### frontend/dockerfile/parser: remove redundant concat

### frontend/dockerfile/shell: use strings.Equalfold

Also fix some grammar issues in the GoDoc, and some nits in the tests.

Before/after:

     BenchmarkToUpper-10          11979394            96.31 ns/op          10 B/op           2 allocs/op
     BenchmarkEqualFold-10        40687216            29.65 ns/op           0 B/op           0 allocs/op

### frontend/dockerfile: define types for enums

This is makes it easier to discover what values are acceptable;

- Generated docs shows them nicely together.
- Intent is clearer (these are all the `MountType` options).
- Intent on fields and arguments is clearer (`func(t MountType)`, `struct Foo{Field: MountType}`),
  but still allows for using / passing a regular string (without casting); validation
  is already handled for these, so invalid strings would (should) already be handled.
- With these types, both docs at pkg.go.dev and IDEs allow for easier navigating
  (click the `MountType` in the examples above to navigate to the `MountType`
  definition, and the options (`const`s) below them.

<img width="355" alt="Screenshot 2022-10-19 at 22 06 33" src="https://user-images.githubusercontent.com/1804568/196799667-7203abc2-9917-4672-a064-0efcca306c24.png">

### frontend/dockerfile: provide suggestions for mount share mode

similar to df9781b46c4ed4f4e7146c2241c0cb513167c2c5

### frontend/dockerfile: move check for cache-sharing

The `m.Type == MountTypeSecret` has a more specific check for this option,
which would not be hit because this check was before it.

Move the check until after the validation for secret mounts, so that the
specific error can be returned, instead of the generic one.

### frontend/dockerfile: parseMount() use strings.Cut(), and some minor cleanup

- use strings.Cut() which simplifies handling of key/value pairs
- remove some redundant intermediate variables
- combined "fileInfoAllowed" if-statement for easier reading

### frontend/dockerfile: parseExtraHosts(): use strings.Cut()

### frontend/dockerfile: BFlags.Parse(): use strings.Cut()

Also some minor cleanup in the boolean value parsing; using a switch
instead of if/elseif/else.
