### PR TITLE
integration: more skips for dockerd

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -6722,6 +6722,7 @@ func testExportAnnotations(t *testing.T, sb integration.Sandbox) {
 }
 
 func testExportAnnotationsMediaTypes(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerd(t, sb, "direct push")
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -6835,6 +6836,7 @@ func testExportAnnotationsMediaTypes(t *testing.T, sb integration.Sandbox) {
 }
 
 func testExportAttestations(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerd(t, sb, "direct push")
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -7046,6 +7048,7 @@ func testExportAttestations(t *testing.T, sb integration.Sandbox) {
 }
 
 func testAttestationDefaultSubject(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerd(t, sb, "direct push")
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1814,9 +1814,6 @@ func testOCILayoutPlatformSource(t *testing.T, sb integration.Sandbox) {
 		} else {
 			err = os.WriteFile(fullFilename, tarItem.Data, 0644)
 			require.NoError(t, err)
-			if json.Valid(tarItem.Data) {
-				fmt.Println(fullFilename, string(tarItem.Data))
-			}
 		}
 	}
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -292,6 +292,7 @@ func testBridgeNetworking(t *testing.T, sb integration.Sandbox) {
 }
 
 func testBridgeNetworkingDNSNoRootless(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerd(t, sb, "https://github.com/moby/buildkit/issues/3171")
 	if os.Getenv("BUILDKIT_RUN_NETWORK_INTEGRATION_TESTS") == "" {
 		t.SkipNow()
 	}

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -5195,6 +5195,7 @@ COPY --from=base /env_foobar /
 }
 
 func testNamedImageContextPlatform(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerd(t, sb, "direct push")
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -5606,6 +5606,7 @@ COPY --from=imported /test/outfoo /
 }
 
 func testNamedOCILayoutContextExport(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerd(t, sb, "oci exporter")
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())


### PR DESCRIPTION
follow-up https://github.com/moby/buildkit/pull/3205#pullrequestreview-1149745020

More skips required for dockerd worker. Also removes `println` in `testOCILayoutPlatformSource`.