### PR TITLE
testNamedImageContextPlatform skip direct push with dockerd

### DIFF
--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -5195,6 +5195,7 @@ COPY --from=base /env_foobar /
 }
 
 func testNamedImageContextPlatform(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerd(t, sb, "direct push")
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())


### PR DESCRIPTION
- taken from https://github.com/moby/buildkit/pull/3206
