### PR TITLE
docs(dockerfile): add buildkit anchor to fix deep-links

### DIFF
--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -5,6 +5,8 @@ Docker can build images automatically by reading the instructions from a
 user could call on the command line to assemble an image. This page describes
 the commands you can use in a `Dockerfile`.
 
+<a name="buildkit"><!-- included for deep-links to old section --></a>
+
 ## Format
 
 Here is the format of the `Dockerfile`:


### PR DESCRIPTION
follow-up https://github.com/docker/docs/pull/15958#issuecomment-1290282588

Command line reference docs on docker/cli repo have links pointing to the old Dockerfile reference BuildKit section. As a temporary fix add `buildkit` anchor so we avoid errors with htmlproofer on docker/docs repo.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>