### PR TITLE
Add gosec to linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,7 @@ linters:
     - makezero
     - whitespace
     - nolintlint
+    - gosec
   disable-all: true
 
 linters-settings:
@@ -48,6 +49,14 @@ linters-settings:
       - pkg: "github.com/opencontainers/go-digest"
         alias: "digest"
     no-unaliased: true
+  gosec:
+    excludes:
+      - G101  # Potential hardcoded credentials (false positives)
+      - G402  # TLS MinVersion too low
+      - G601  # Implicit memory aliasing in for loop (false positives)
+      - G504  # Import blocklist: net/http/cgi
+    config:
+      G306: "0644"
 
 issues:
   exclude-rules:

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -567,7 +567,7 @@ func testSSHMount(t *testing.T, sb integration.Sandbox) {
 	def, err = out.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	k, err = rsa.GenerateKey(rand.Reader, 1024)
+	k, err = rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 
 	dt = pem.EncodeToMemory(
@@ -602,7 +602,7 @@ func testSSHMount(t *testing.T, sb integration.Sandbox) {
 
 	dt, err = os.ReadFile(filepath.Join(destDir, "out"))
 	require.NoError(t, err)
-	require.Contains(t, string(dt), "1024")
+	require.Contains(t, string(dt), "2048")
 	require.Contains(t, string(dt), "(RSA)")
 }
 

--- a/frontend/dockerfile/dockerfile_ssh_test.go
+++ b/frontend/dockerfile/dockerfile_ssh_test.go
@@ -44,7 +44,7 @@ RUN --mount=type=ssh,mode=741,uid=100,gid=102 [ "$(stat -c "%u %g %f" $SSH_AUTH_
 	require.NoError(t, err)
 	defer c.Close()
 
-	k, err := rsa.GenerateKey(rand.Reader, 1024)
+	k, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 
 	dt := pem.EncodeToMemory(

--- a/frontend/dockerfile/dockerignore/dockerignore_test.go
+++ b/frontend/dockerfile/dockerignore/dockerignore_test.go
@@ -18,7 +18,7 @@ func TestReadAll(t *testing.T) {
 
 	diName := filepath.Join(t.TempDir(), ".dockerignore")
 	content := "test1\n/test2\n/a/file/here\n\nlastfile\n# this is a comment\n! /inverted/abs/path\n!\n! \n"
-	err = os.WriteFile(diName, []byte(content), 0777)
+	err = os.WriteFile(diName, []byte(content), 0600)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/session/auth/auth.go
+++ b/session/auth/auth.go
@@ -2,8 +2,8 @@ package auth
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/subtle"
-	"math/rand"
 	"sync"
 
 	"github.com/moby/buildkit/session"

--- a/solver/scheduler_test.go
+++ b/solver/scheduler_test.go
@@ -3389,10 +3389,10 @@ func TestInputRequestDeadlock(t *testing.T) {
 
 func generateSubGraph(nodes int) (Edge, int) {
 	if nodes == 1 {
-		value := rand.Int() % 500
+		value := rand.Int() % 500 //nolint:gosec
 		return Edge{Vertex: vtxConst(value, vtxOpt{})}, value
 	}
-	spread := rand.Int()%5 + 2
+	spread := rand.Int()%5 + 2 //nolint:gosec
 	inc := int(math.Ceil(float64(nodes) / float64(spread)))
 	if inc > nodes {
 		inc = nodes
@@ -3414,7 +3414,7 @@ func generateSubGraph(nodes int) (Edge, int) {
 		value += v
 		added += inc
 	}
-	extra := rand.Int() % 500
+	extra := rand.Int() % 500 //nolint:gosec
 	value += extra
 	return Edge{Vertex: vtxSum(extra, vtxOpt{inputs: inputs})}, value
 }

--- a/source/git/gitsource_unix.go
+++ b/source/git/gitsource_unix.go
@@ -28,7 +28,7 @@ func gitMain() {
 	unix.Umask(0022)
 
 	// Reexec git command
-	cmd := exec.Command(os.Args[1], os.Args[2:]...)
+	cmd := exec.Command(os.Args[1], os.Args[2:]...) //nolint:gosec // reexec
 	cmd.SysProcAttr = &unix.SysProcAttr{
 		Setpgid:   true,
 		Pdeathsig: unix.SIGTERM,

--- a/util/archutil/check_unix.go
+++ b/util/archutil/check_unix.go
@@ -40,6 +40,7 @@ func check(arch, bin string) (string, error) {
 		return "", err
 	}
 
+	//nolint:gosec // inputs should be static strings
 	if _, err := io.Copy(f, r); err != nil {
 		f.Close()
 		return "", err

--- a/util/stack/stack.go
+++ b/util/stack/stack.go
@@ -151,7 +151,7 @@ func convertStack(s errors.StackTrace) *Stack {
 		if idx == -1 {
 			continue
 		}
-		line, err := strconv.Atoi(p[1][idx+1:])
+		line, err := strconv.ParseInt(p[1][idx+1:], 10, 32)
 		if err != nil {
 			continue
 		}

--- a/util/testutil/echoserver/server.go
+++ b/util/testutil/echoserver/server.go
@@ -11,7 +11,7 @@ type TestServer interface {
 }
 
 func NewTestServer(response string) (TestServer, error) {
-	ln, err := net.Listen("tcp", ":")
+	ln, err := net.Listen("tcp", ":") //nolint:gosec // server only used in tests
 	if err != nil {
 		return nil, err
 	}

--- a/util/testutil/integration/containerd.go
+++ b/util/testutil/integration/containerd.go
@@ -178,7 +178,7 @@ disabled_plugins = ["cri"]
 		}, c.extraEnv...), "containerd-rootless.sh", "-c", configFile)
 	}
 
-	cmd := exec.Command(containerdArgs[0], containerdArgs[1:]...)
+	cmd := exec.Command(containerdArgs[0], containerdArgs[1:]...) //nolint:gosec // test utility
 	cmd.Env = append(os.Environ(), c.extraEnv...)
 
 	ctdStop, err := startCmd(cmd, cfg.Logs)

--- a/util/testutil/integration/registry.go
+++ b/util/testutil/integration/registry.go
@@ -56,7 +56,7 @@ http:
 		}
 	}
 
-	cmd := exec.Command("registry", "serve", filepath.Join(dir, "config.yaml"))
+	cmd := exec.Command("registry", "serve", filepath.Join(dir, "config.yaml")) //nolint:gosec // test utility
 	rc, err := cmd.StderrPipe()
 	if err != nil {
 		return "", nil, err

--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -157,9 +157,7 @@ func Run(t *testing.T, testCases []Test, opt ...TestOpt) {
 	list := List()
 	if os.Getenv("BUILDKIT_WORKER_RANDOM") == "1" && len(list) > 0 {
 		rand.Seed(time.Now().UnixNano())
-		// using math/rand is fine in a test utility
-		// #nosec G404
-		list = []Worker{list[rand.Intn(len(list))]}
+		list = []Worker{list[rand.Intn(len(list))]} //nolint:gosec // using math/rand is fine in a test utility
 	}
 
 	for _, br := range list {

--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -157,6 +157,8 @@ func Run(t *testing.T, testCases []Test, opt ...TestOpt) {
 	list := List()
 	if os.Getenv("BUILDKIT_WORKER_RANDOM") == "1" && len(list) > 0 {
 		rand.Seed(time.Now().UnixNano())
+		// using math/rand is fine in a test utility
+		// #nosec G404
 		list = []Worker{list[rand.Intn(len(list))]}
 	}
 

--- a/util/testutil/integration/sandbox.go
+++ b/util/testutil/integration/sandbox.go
@@ -186,7 +186,7 @@ func runBuildkitd(ctx context.Context, conf *BackendConfig, args []string, logs 
 	address = getBuildkitdAddr(tmpdir)
 
 	args = append(args, "--root", tmpdir, "--addr", address, "--debug")
-	cmd := exec.Command(args[0], args[1:]...)
+	cmd := exec.Command(args[0], args[1:]...) //nolint:gosec // test utility
 	cmd.Env = append(os.Environ(), "BUILDKIT_DEBUG_EXEC_OUTPUT=1", "BUILDKIT_DEBUG_PANIC_ON_ERROR=1", "TMPDIR="+filepath.Join(tmpdir, "tmp"))
 	cmd.Env = append(cmd.Env, extraEnv...)
 	cmd.SysProcAttr = getSysProcAttr()
@@ -220,7 +220,7 @@ func runBuildkitd(ctx context.Context, conf *BackendConfig, args []string, logs 
 }
 
 func rootlessSupported(uid int) bool {
-	cmd := exec.Command("sudo", "-u", fmt.Sprintf("#%d", uid), "-i", "--", "exec", "unshare", "-U", "true")
+	cmd := exec.Command("sudo", "-u", fmt.Sprintf("#%d", uid), "-i", "--", "exec", "unshare", "-U", "true") //nolint:gosec // test utility
 	b, err := cmd.CombinedOutput()
 	if err != nil {
 		logrus.Warnf("rootless mode is not supported on this host: %v (%s)", err, string(b))

--- a/util/tracing/otlptracegrpc/connection.go
+++ b/util/tracing/otlptracegrpc/connection.go
@@ -121,6 +121,7 @@ func (c *Connection) indefiniteBackgroundConnection() {
 
 	// No strong seeding required, nano time can
 	// already help with pseudo uniqueness.
+	// #nosec G404
 	rng := rand.New(rand.NewSource(time.Now().UnixNano() + rand.Int63n(1024)))
 
 	// maxJitterNanos: 70% of the connectionReattemptPeriod

--- a/util/tracing/otlptracegrpc/connection.go
+++ b/util/tracing/otlptracegrpc/connection.go
@@ -119,10 +119,7 @@ func (c *Connection) indefiniteBackgroundConnection() {
 
 	connReattemptPeriod := defaultConnReattemptPeriod
 
-	// No strong seeding required, nano time can
-	// already help with pseudo uniqueness.
-	// #nosec G404
-	rng := rand.New(rand.NewSource(time.Now().UnixNano() + rand.Int63n(1024)))
+	rng := rand.New(rand.NewSource(time.Now().UnixNano() + rand.Int63n(1024))) //nolint:gosec // No strong seeding required, nano time can already help with pseudo uniqueness.
 
 	// maxJitterNanos: 70% of the connectionReattemptPeriod
 	maxJitterNanos := int64(0.7 * float64(connReattemptPeriod))

--- a/util/winlayers/applier.go
+++ b/util/winlayers/applier.go
@@ -137,12 +137,14 @@ func filter(in io.Reader, f func(*tar.Header) bool) (io.Reader, func(error)) {
 						return err
 					}
 					if h.Size > 0 {
+						//nolint:gosec // never read into memory
 						if _, err := io.Copy(tarWriter, tarReader); err != nil {
 							return err
 						}
 					}
 				} else {
 					if h.Size > 0 {
+						//nolint:gosec // never read into memory
 						if _, err := io.Copy(io.Discard, tarReader); err != nil {
 							return err
 						}

--- a/util/winlayers/differ.go
+++ b/util/winlayers/differ.go
@@ -250,6 +250,7 @@ func makeWindowsLayer(w io.Writer) (io.Writer, func(error), chan error) {
 					return err
 				}
 				if h.Size > 0 {
+					//nolint:gosec // never read into memory
 					if _, err := io.Copy(tarWriter, tarReader); err != nil {
 						return err
 					}


### PR DESCRIPTION
Replaces https://github.com/moby/buildkit/pull/2449.

For the default excludes rules:
- Potential hardcoded credentials and implicit memory aliasing for giving lots of false positives on correct behaviour (e.g. where the addressed value never leaves the loop, or we break immediately after).
- TLS MinVersion warnings (we need to coordinate with other projects upstream if we want to do this).
- `net/http/cgi` blocklist, since it [errors for a vulnerability in a version of Go that we don't target](https://github.com/securego/gosec/blob/7f2308bd85afa9531ddba4f46f1e58fd53da0615/rules/blocklist.go#L85) (1.16, we now use generics so buildkit won't even compile with that version).
