### PR TITLE
Fix error `the client connection is closing` with lazy local cache

### DIFF
--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -340,6 +340,17 @@ func (jl *Solver) loadUnlocked(v, parent Vertex, j *Job, cache map[Vertex]Vertex
 	st, ok := jl.actives[dgstWithoutCache]
 
 	if !ok {
+		for _, cache := range v.Options().CacheSources {
+			if sc, ok := cache.(CacheManagerForSession); ok {
+				if s := sc.RequiredSession(); s != "" {
+					// This vertex contains a cache specific to a session.
+					// Create an unique state to avoid used by other vertices.
+					// See also: https://github.com/docker/buildx/issues/1325
+					dgst = digest.FromBytes([]byte(fmt.Sprintf("%s-session-%s", dgst, s)))
+				}
+			}
+		}
+
 		st, ok = jl.actives[dgst]
 
 		// !ignorecache merges with ignorecache but ignorecache doesn't merge with !ignorecache

--- a/solver/llbsolver/bridge.go
+++ b/solver/llbsolver/bridge.go
@@ -369,6 +369,16 @@ func (lcm *lazyCacheManager) Save(key *solver.CacheKey, s solver.Result, created
 	return lcm.main.Save(key, s, createdAt)
 }
 
+func (lcm *lazyCacheManager) RequiredSession() string {
+	if err := lcm.wait(); err != nil {
+		return ""
+	}
+	if sc, ok := lcm.main.(solver.CacheManagerForSession); ok {
+		return sc.RequiredSession()
+	}
+	return ""
+}
+
 func (lcm *lazyCacheManager) wait() error {
 	<-lcm.waitCh
 	return lcm.err

--- a/solver/types.go
+++ b/solver/types.go
@@ -244,3 +244,11 @@ type CacheManager interface {
 	// Save saves a result based on a cache key
 	Save(key *CacheKey, s Result, createdAt time.Time) (*ExportableCacheKey, error)
 }
+
+// CacheManagerForSession is a CacheManager backed by a session.
+type CacheManagerForSession interface {
+	CacheManager
+
+	// RequiredSession returns the session that this cache manager depends on.
+	RequiredSession() string
+}


### PR DESCRIPTION
Fixes: https://github.com/docker/buildx/issues/1325#issuecomment-1253129431

As reported in https://github.com/docker/buildx/issues/1325, there seems a case where a build result with lazy local cache fails to unlazied on the following (or concurrent) build assigned the different session. This commit tries to fix this issue by avoiding session-specific importers being used from vertices that don't have access to them. This patch passes the session information of the session-specific importer of each vertex into the solver and avoids other vertices accessing that importer.

cc @tonistiigi @sipsma 