### PR TITLE
exporter: clarify exporter names

### DIFF
--- a/exporter/local/export.go
+++ b/exporter/local/export.go
@@ -52,7 +52,7 @@ type localExporterInstance struct {
 }
 
 func (e *localExporterInstance) Name() string {
-	return "exporting to client"
+	return "exporting to client directory"
 }
 
 func (e *localExporter) Config() *exporter.Config {

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -83,7 +84,7 @@ type imageExporterInstance struct {
 }
 
 func (e *imageExporterInstance) Name() string {
-	return "exporting to oci image format"
+	return fmt.Sprintf("exporting to %s image format", e.opt.Variant)
 }
 
 func (e *imageExporterInstance) Config() *exporter.Config {

--- a/exporter/tar/export.go
+++ b/exporter/tar/export.go
@@ -71,7 +71,7 @@ type localExporterInstance struct {
 }
 
 func (e *localExporterInstance) Name() string {
-	return "exporting to client"
+	return "exporting to client tarball"
 }
 
 func (e *localExporterInstance) Config() *exporter.Config {


### PR DESCRIPTION
This changes the output names in the buildkit progress output as follows:

`docker`:
- `"exporting to oci image format"` -> `"exporting to docker image format"`

`local`:
- `"exporting to client"` -> `"exporting to client directory"`

`tar`:
- `"exporting to client"` -> `"exporting to client tarball"`