### PR TITLE
Fix nil panic on scratch ref release.

### DIFF
--- a/client/build_test.go
+++ b/client/build_test.go
@@ -2088,6 +2088,7 @@ func testClientGatewayNilResult(t *testing.T, sb integration.Sandbox) {
 }
 
 func testClientGatewayEmptyImageExec(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerd(t, sb, "direct push")
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()

--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -353,7 +353,7 @@ func (lbf *llbBridgeForwarder) Discard() {
 	}
 
 	for id, workerRef := range lbf.workerRefByID {
-		workerRef.ImmutableRef.Release(context.TODO())
+		workerRef.Release(context.TODO())
 		delete(lbf.workerRefByID, id)
 	}
 	if lbf.err != nil && lbf.result != nil {

--- a/worker/result.go
+++ b/worker/result.go
@@ -26,6 +26,13 @@ func (wr *WorkerRef) ID() string {
 	return wr.Worker.ID() + "::" + refID
 }
 
+func (wr *WorkerRef) Release(ctx context.Context) error {
+	if wr.ImmutableRef == nil {
+		return nil
+	}
+	return wr.ImmutableRef.Release(ctx)
+}
+
 // GetRemotes method abstracts ImmutableRef's GetRemotes to allow a Worker to override.
 // This is needed for moby integration.
 // Use this method instead of calling ImmutableRef.GetRemotes() directly.


### PR DESCRIPTION
Signed-off-by: Erik Sipsma <erik@sipsma.dev>

Fixes https://github.com/moby/buildkit/issues/3134

Incredibly obscure case. I was *accidentally* pushing images with no layers and then pulling them and trying to do an exec, the only reason I hit it. But worth a fix since it's a panic.