### PR TITLE
ci: update codecov action to v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,7 +246,7 @@ jobs:
               .join(',');
       -
         name: Send to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           files: ${{ steps.files.outputs.result }}
 


### PR DESCRIPTION
Fix warning in our workflow:

```
upload-coverage
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: codecov/codecov-action
```

![image](https://user-images.githubusercontent.com/1951866/198815100-17b89bac-e099-426d-8dfc-95fad8c2a71f.png)

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>