### PR TITLE
ci: move frontend integration tests and build to a dedicated workflow

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -1,0 +1,197 @@
+# reusable workflow
+name: .test
+
+on:
+  workflow_call:
+    inputs:
+      cache_scope:
+        required: true
+        type: string
+      pkgs:
+        required: true
+        type: string
+      kinds:
+        required: true
+        type: string
+      tags:
+        required: false
+        type: string
+      codecov_flags:
+        required: false
+        type: string
+      includes:
+        required: false
+        type: string
+      env:
+        required: false
+        type: string
+
+env:
+  REPO_SLUG_ORIGIN: "moby/buildkit:latest"
+  TESTFLAGS: "-v --parallel=6 --timeout=30m"
+  BUILDX_VERSION: "latest"  # leave empty to use the one available on GitHub virtual environment
+  GO_VERSION: "1.19"
+
+jobs:
+  prepare:
+    runs-on: ubuntu-20.04
+    outputs:
+      pkgs: ${{ steps.set.outputs.pkgs }}
+      kinds: ${{ steps.set.outputs.kinds }}
+      tags: ${{ steps.set.outputs.tags }}
+      includes: ${{ steps.set.outputs.includes }}
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Expose GitHub Runtime
+        uses: crazy-max/ghaction-github-runtime@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          version: ${{ env.BUILDX_VERSION }}
+          driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
+          buildkitd-flags: --debug
+      -
+        name: Deps
+        run: |
+          npm install js-yaml
+      -
+        name: Set outputs
+        id: set
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const yaml = require('js-yaml');
+            await core.group(`Set pkgs matrix`, async () => {
+              const pkgs = `${{ inputs.pkgs }}`.trim().split(/\r?\n/);
+              core.info(JSON.stringify(pkgs, null, 2));
+              core.setOutput('pkgs', JSON.stringify(pkgs));
+            });
+            await core.group(`Set kinds matrix`, async () => {
+              const kinds = `${{ inputs.kinds }}`.trim().split(/\r?\n/);
+              core.info(JSON.stringify(kinds, null, 2));
+              core.setOutput('kinds', JSON.stringify(kinds));
+            });
+            await core.group(`Set tags matrix`, async () => {
+              const tags = `${{ inputs.tags }}`.trim().split(/\r?\n/);
+              core.info(JSON.stringify(tags, null, 2));
+              core.setOutput('tags', JSON.stringify(tags));
+            });
+            await core.group(`Set includes`, async () => {
+              const includes = yaml.load(`${{ inputs.includes }}`.trim());
+              core.info(JSON.stringify(includes, null, 2));
+              core.setOutput('includes', JSON.stringify(includes ?? []));
+            });
+      -
+        name: Build
+        run: |
+          ./hack/build_ci_first_pass integration-tests
+        env:
+          CACHE_FROM: type=gha,scope=${{ inputs.cache_scope }}
+          CACHE_TO: type=gha,scope=${{ inputs.cache_scope }}
+
+  run:
+    runs-on: ubuntu-20.04
+    needs:
+      - prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        pkg: ${{ fromJson(needs.prepare.outputs.pkgs) }}
+        kind: ${{ fromJson(needs.prepare.outputs.kinds) }}
+        tags: ${{ fromJson(needs.prepare.outputs.tags) }}
+        include: ${{ fromJson(needs.prepare.outputs.includes) }}
+        worker:
+          - containerd
+          - containerd-rootless
+          - containerd-1.6
+          - containerd-snapshotter-stargz
+          - oci
+          - oci-rootless
+          - oci-snapshotter-stargz
+    steps:
+      -
+        name: Environment variables
+        run: |
+          for l in "${{ inputs.env }}"; do
+            echo "${l?}" >> $GITHUB_ENV
+          done
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Expose GitHub Runtime
+        uses: crazy-max/ghaction-github-runtime@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          version: ${{ env.BUILDX_VERSION }}
+          driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
+          buildkitd-flags: --debug
+      -
+        name: Test
+        continue-on-error: ${{ matrix.tags == 'nydus' }}
+        run: |
+          if [ -n "${{ matrix.tags }}" ]; then
+            TESTFLAGS="${TESTFLAGS} --tags=${{ matrix.tags }}"
+            export BUILDKITD_TAGS="${{ matrix.tags }}"
+          fi
+          if [ -n "${{ matrix.worker }}" ]; then
+            export TESTFLAGS="${TESTFLAGS} --run=//worker=${{ matrix.worker }}$"
+          fi
+          ./hack/test ${{ matrix.kind }}
+          mv ./coverage/coverage.txt ./coverage/coverage-${{ github.job }}-$(echo "${{ matrix.pkg }}-${{ matrix.skip-integration-tests }}-${{ matrix.kind }}-${{ matrix.worker }}-${{ matrix.tags }}" | tr -dc '[:alnum:]-\n\r' | tr '[:upper:]' '[:lower:]').txt
+        env:
+          TEST_COVERAGE: 1
+          TESTPKGS: ${{ matrix.pkg }}
+          SKIP_INTEGRATION_TESTS: ${{ matrix.skip-integration-tests }}
+          CACHE_FROM: type=gha,scope=${{ inputs.cache_scope }}
+      -
+        name: Upload coverage file
+        continue-on-error: ${{ matrix.tags == 'nydus' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: ./coverage
+
+  upload-coverage:
+    runs-on: ubuntu-20.04
+    needs:
+      - run
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Download coverage files
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage
+          path: ./coverage
+      -
+        name: List coverage files
+        id: files
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            return require('fs').readdirSync('./coverage', {withFileTypes: true})
+              .filter(item => !item.isDirectory())
+              .map(item => `./coverage/${item.name}`)
+              .join(',');
+      -
+        name: Send to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: ${{ steps.files.outputs.result }}
+          flags: ${{ matrix.codecov_flags }}

--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -27,10 +27,10 @@ on:
         type: string
 
 env:
-  REPO_SLUG_ORIGIN: "moby/buildkit:latest"
-  TESTFLAGS: "-v --parallel=6 --timeout=30m"
-  BUILDX_VERSION: "latest"  # leave empty to use the one available on GitHub virtual environment
   GO_VERSION: "1.19"
+  SETUP_BUILDX_VERSION: "latest"
+  SETUP_BUILDKIT_IMAGE: "moby/buildkit:latest"
+  TESTFLAGS: "-v --parallel=6 --timeout=30m"
 
 jobs:
   prepare:
@@ -54,8 +54,8 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
-          version: ${{ env.BUILDX_VERSION }}
-          driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
+          version: ${{ env.SETUP_BUILDX_VERSION }}
+          driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
           buildkitd-flags: --debug
       -
         name: Deps
@@ -135,8 +135,8 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
-          version: ${{ env.BUILDX_VERSION }}
-          driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
+          version: ${{ env.SETUP_BUILDX_VERSION }}
+          driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
           buildkitd-flags: --debug
       -
         name: Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,50 +145,10 @@ jobs:
           name: coverage
           path: ./coverage
 
-  test-os:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          # - ubuntu-20.04
-          # - macOS-11
-          - windows-2022
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v3
-      -
-        name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: true
-      -
-        name: Go mod
-        run: |
-          go mod download
-      -
-        name: Test
-        env:
-          TMPDIR: ${{ runner.temp }}
-          SKIP_INTEGRATION_TESTS: 1
-        run: |
-          mkdir -p ./coverage
-          go test -coverprofile=./coverage/coverage-${{ github.job }}-${{ matrix.os }}.txt -covermode=atomic ${TESTFLAGS} ./...
-        shell: bash
-      -
-        name: Upload coverage file
-        uses: actions/upload-artifact@v3
-        with:
-          name: coverage
-          path: ./coverage
-
   upload-coverage:
     runs-on: ubuntu-20.04
     needs:
       - test
-      - test-os
     steps:
       -
         name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,8 @@ env:
   REPO_SLUG_ORIGIN: "moby/buildkit:latest"
   REPO_SLUG_TARGET: "moby/buildkit"
   PLATFORMS: "linux/amd64,linux/arm/v7,linux/arm64,linux/s390x,linux/ppc64le,linux/riscv64"
-  CACHE_GHA_SCOPE_IT: "build-integration-tests"
   CACHE_GHA_SCOPE_BINARIES: "binaries"
   CACHE_GHA_SCOPE_CROSS: "cross"
-  TESTFLAGS: "-v --parallel=6 --timeout=30m"
   BUILDX_VERSION: "latest"  # leave empty to use the one available on GitHub virtual environment
   GO_VERSION: "1.19"
 
@@ -57,124 +55,30 @@ jobs:
         env:
           CACHE_FROM: type=gha,scope=${{ env.CACHE_GHA_SCOPE_BINARIES }}
           CACHE_TO: type=gha,scope=${{ env.CACHE_GHA_SCOPE_BINARIES }}
-      -
-        name: Build ${{ env.CACHE_GHA_SCOPE_IT }}
-        run: |
-          ./hack/build_ci_first_pass integration-tests
-        env:
-          CACHE_FROM: type=gha,scope=${{ env.CACHE_GHA_SCOPE_IT }}
-          CACHE_TO: type=gha,scope=${{ env.CACHE_GHA_SCOPE_IT }}
 
   test:
-    runs-on: ubuntu-20.04
-    needs:
-      - base
-    strategy:
-      fail-fast: false
-      matrix:
-        pkg:
-          - ./client ./cmd/buildctl ./worker/containerd ./solver ./frontend
-        worker:
-          - containerd
-          - containerd-rootless
-          - containerd-1.6
-          - containerd-snapshotter-stargz
-          - oci
-          - oci-rootless
-          - oci-snapshotter-stargz
-        typ:
-          - integration
-        tags:
-          - ''
-        include:
-          - pkg: ./...
-            skip-integration-tests: 1
-            typ: integration gateway
-          - pkg: ./client
-            worker: containerd
-            tags: nydus
-            typ: integration
-          - pkg: ./client
-            worker: oci
-            tags: nydus
-            typ: integration
-          - pkg: ./...
-            tags: nydus
-            skip-integration-tests: 1
-            typ: integration
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v3
-      -
-        name: Expose GitHub Runtime
-        uses: crazy-max/ghaction-github-runtime@v2
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          version: ${{ env.BUILDX_VERSION }}
-          driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
-          buildkitd-flags: --debug
-      -
-        name: Test
-        continue-on-error: ${{ matrix.tags == 'nydus' }}
-        run: |
-          if [ -n "${{ matrix.tags }}" ]; then
-            TESTFLAGS="${TESTFLAGS} --tags=${{ matrix.tags }}"
-            export BUILDKITD_TAGS="${{ matrix.tags }}"
-          fi
-          if [ -n "${{ matrix.worker }}" ]; then
-            export TESTFLAGS="${TESTFLAGS} --run=//worker=${{ matrix.worker }}$"
-          fi
-          ./hack/test ${{ matrix.typ }}
-          mv ./coverage/coverage.txt ./coverage/coverage-${{ github.job }}-$(echo "${{ matrix.pkg }}-${{ matrix.skip-integration-tests }}-${{ matrix.typ }}-${{ matrix.worker }}-${{ matrix.tags }}" | tr -dc '[:alnum:]-\n\r' | tr '[:upper:]' '[:lower:]').txt
-        env:
-          TEST_COVERAGE: 1
-          TESTPKGS: ${{ matrix.pkg }}
-          SKIP_INTEGRATION_TESTS: ${{ matrix.skip-integration-tests }}
-          CACHE_FROM: type=gha,scope=${{ env.CACHE_GHA_SCOPE_IT }}
-      -
-        name: Upload coverage file
-        continue-on-error: ${{ matrix.tags == 'nydus' }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: coverage
-          path: ./coverage
-
-  upload-coverage:
-    runs-on: ubuntu-20.04
-    needs:
-      - test
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v3
-      -
-        name: Download coverage files
-        uses: actions/download-artifact@v3
-        with:
-          name: coverage
-          path: ./coverage
-      -
-        name: List coverage files
-        uses: actions/github-script@v6
-        id: files
-        with:
-          result-encoding: string
-          script: |
-            return require('fs').readdirSync('./coverage', {withFileTypes: true})
-              .filter(item => !item.isDirectory())
-              .map(item => `./coverage/${item.name}`)
-              .join(',');
-      -
-        name: Send to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          files: ${{ steps.files.outputs.result }}
+    uses: ./.github/workflows/.test.yml
+    with:
+      cache_scope: build-integration-tests
+      pkgs: ./client ./cmd/buildctl ./worker/containerd ./solver ./frontend
+      kinds: integration
+      codecov_flags: core
+      includes: |
+        - pkg: ./...
+          skip-integration-tests: 1
+          typ: integration gateway
+        - pkg: ./client
+          worker: containerd
+          tags: nydus
+          typ: integration
+        - pkg: ./client
+          worker: oci
+          tags: nydus
+          typ: integration
+        - pkg: ./...
+          tags: nydus
+          skip-integration-tests: 1
+          typ: integration
 
   cross:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,14 +6,13 @@ concurrency:
 
 on:
   schedule:
-    - cron: '0 10 * * *'  # everyday at 10am
+    - cron: '0 10 * * *'
   workflow_dispatch:
   push:
     branches:
       - 'master'
     tags:
       - 'v*'
-      - 'dockerfile/*'
   pull_request:
     paths-ignore:
       - 'README.md'
@@ -23,9 +22,8 @@ on:
 env:
   REPO_SLUG_ORIGIN: "moby/buildkit:latest"
   REPO_SLUG_TARGET: "moby/buildkit"
-  DF_REPO_SLUG_TARGET: "docker/dockerfile-upstream"
   PLATFORMS: "linux/amd64,linux/arm/v7,linux/arm64,linux/s390x,linux/ppc64le,linux/riscv64"
-  CACHE_GHA_SCOPE_IT: "integration-tests"
+  CACHE_GHA_SCOPE_IT: "build-integration-tests"
   CACHE_GHA_SCOPE_BINARIES: "binaries"
   CACHE_GHA_SCOPE_CROSS: "cross"
   TESTFLAGS: "-v --parallel=6 --timeout=30m"
@@ -69,13 +67,13 @@ jobs:
 
   test:
     runs-on: ubuntu-20.04
-    needs: [base]
+    needs:
+      - base
     strategy:
       fail-fast: false
       matrix:
         pkg:
           - ./client ./cmd/buildctl ./worker/containerd ./solver ./frontend
-          - ./frontend/dockerfile
         worker:
           - containerd
           - containerd-rootless
@@ -86,12 +84,8 @@ jobs:
           - oci-snapshotter-stargz
         typ:
           - integration
-          - dockerfile
         tags:
           - ''
-        exclude:
-          - pkg: ./client ./cmd/buildctl ./worker/containerd ./solver ./frontend
-            typ: dockerfile
         include:
           - pkg: ./...
             skip-integration-tests: 1
@@ -142,7 +136,7 @@ jobs:
           TEST_COVERAGE: 1
           TESTPKGS: ${{ matrix.pkg }}
           SKIP_INTEGRATION_TESTS: ${{ matrix.skip-integration-tests }}
-          CACHE_FROM: type=gha,scope=${{ env.CACHE_GHA_SCOPE_IT }} type=gha,scope=${{ env.CACHE_GHA_SCOPE_BINARIES }}
+          CACHE_FROM: type=gha,scope=${{ env.CACHE_GHA_SCOPE_IT }}
       -
         name: Upload coverage file
         continue-on-error: ${{ matrix.tags == 'nydus' }}
@@ -192,7 +186,9 @@ jobs:
 
   upload-coverage:
     runs-on: ubuntu-20.04
-    needs: [test, test-os]
+    needs:
+      - test
+      - test-os
     steps:
       -
         name: Checkout
@@ -275,7 +271,10 @@ jobs:
 
   image:
     runs-on: ubuntu-20.04
-    needs: [release-base, test, cross]
+    needs:
+      - release-base
+      - test
+      - cross
     strategy:
       fail-fast: false
       matrix:
@@ -318,7 +317,10 @@ jobs:
 
   binaries:
     runs-on: ubuntu-20.04
-    needs: [release-base, test, cross]
+    needs:
+      - release-base
+      - test
+      - cross
     steps:
       -
         name: Checkout
@@ -361,83 +363,3 @@ jobs:
           draft: true
           files: ./release-out/*
           name: ${{ needs.release-base.outputs.tag }}
-
-  frontend-base:
-    runs-on: ubuntu-20.04
-    if: github.event_name != 'schedule'
-    outputs:
-      typ: ${{ steps.prep.outputs.typ }}
-      push: ${{ steps.prep.outputs.push }}
-      matrix: ${{ steps.prep.outputs.matrix }}
-    steps:
-      -
-        name: Prepare
-        id: prep
-        run: |
-          TYP=master
-          TAG=mainline
-          PUSH=false
-          if [[ $GITHUB_REF == refs/tags/dockerfile/* ]]; then
-            TYP=tag
-            TAG=${GITHUB_REF#refs/tags/}
-            PUSH=push
-          elif [[ $GITHUB_REF == refs/heads/* ]]; then
-            PUSH=push
-          fi
-          echo "typ=${TYP}" >>${GITHUB_OUTPUT}
-          echo "push=${PUSH}" >>${GITHUB_OUTPUT}
-          if [ "${TYP}" = "master" ]; then
-            echo "matrix=$(jq -cn --arg tag "$TAG" '[$tag, "labs"]')" >>${GITHUB_OUTPUT}
-          else
-            echo "matrix=$(jq -cn --arg tag "$TAG" '[$tag]')" >>${GITHUB_OUTPUT}
-          fi
-
-  frontend-image:
-    runs-on: ubuntu-20.04
-    if: github.event_name != 'schedule'
-    needs: [frontend-base, test]
-    strategy:
-      fail-fast: false
-      matrix:
-        tag: ${{ fromJson(needs.frontend-base.outputs.matrix) }}
-    steps:
-      -
-        name: Prepare
-        run: |
-          if [ "${{ matrix.tag }}" = "labs" ]; then
-            echo "CACHE_SCOPE=frontend-labs" >>${GITHUB_ENV}
-          else
-            echo "CACHE_SCOPE=frontend-mainline" >>${GITHUB_ENV}
-          fi
-      -
-        name: Checkout
-        uses: actions/checkout@v3
-      -
-        name: Expose GitHub Runtime
-        uses: crazy-max/ghaction-github-runtime@v2
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          version: ${{ env.BUILDX_VERSION }}
-          driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
-          buildkitd-flags: --debug
-      -
-        name: Login to DockerHub
-        uses: docker/login-action@v2
-        if: needs.frontend-base.outputs.push == 'push'
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build
-        run: |
-          ./frontend/dockerfile/cmd/dockerfile-frontend/hack/release "${{ needs.frontend-base.outputs.typ }}" "${{ matrix.tag }}" "$DF_REPO_SLUG_TARGET" "${{ needs.frontend-base.outputs.push }}"
-        env:
-          RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
-          PLATFORMS: ${{ env.PLATFORMS }},linux/386,linux/mips,linux/mipsle,linux/mips64,linux/mips64le
-          CACHE_FROM: type=gha,scope=${{ env.CACHE_SCOPE }}
-          CACHE_TO: type=gha,scope=${{ env.CACHE_SCOPE }}

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -1,4 +1,4 @@
-name: build
+name: buildkit
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -20,13 +20,13 @@ on:
       - 'frontend/dockerfile/docs/**'
 
 env:
-  REPO_SLUG_ORIGIN: "moby/buildkit:latest"
-  REPO_SLUG_TARGET: "moby/buildkit"
+  GO_VERSION: "1.19"
+  SETUP_BUILDX_VERSION: "latest"
+  SETUP_BUILDKIT_IMAGE: "moby/buildkit:latest"
+  IMAGE_NAME: "moby/buildkit"
   PLATFORMS: "linux/amd64,linux/arm/v7,linux/arm64,linux/s390x,linux/ppc64le,linux/riscv64"
   CACHE_GHA_SCOPE_BINARIES: "binaries"
   CACHE_GHA_SCOPE_CROSS: "cross"
-  BUILDX_VERSION: "latest"  # leave empty to use the one available on GitHub virtual environment
-  GO_VERSION: "1.19"
 
 jobs:
   base:
@@ -45,8 +45,8 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
-          version: ${{ env.BUILDX_VERSION }}
-          driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
+          version: ${{ env.SETUP_BUILDX_VERSION }}
+          driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
           buildkitd-flags: --debug
       -
         name: Build ${{ env.CACHE_GHA_SCOPE_BINARIES }}
@@ -96,8 +96,8 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
-          version: ${{ env.BUILDX_VERSION }}
-          driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
+          version: ${{ env.SETUP_BUILDX_VERSION }}
+          driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
           buildkitd-flags: --debug
       -
         name: Cross
@@ -159,8 +159,8 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
-          version: ${{ env.BUILDX_VERSION }}
-          driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
+          version: ${{ env.SETUP_BUILDX_VERSION }}
+          driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
           buildkitd-flags: --debug
       -
         name: Login to DockerHub
@@ -172,7 +172,7 @@ jobs:
       -
         name: Build ${{ needs.release-base.outputs.tag }}
         run: |
-          ./hack/images "${{ needs.release-base.outputs.tag }}" "$REPO_SLUG_TARGET" "${{ needs.release-base.outputs.push }}"
+          ./hack/images "${{ needs.release-base.outputs.tag }}" "$IMAGE_NAME" "${{ needs.release-base.outputs.push }}"
         env:
           RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
           TARGET: ${{ matrix.target-stage }}
@@ -199,8 +199,8 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
-          version: ${{ env.BUILDX_VERSION }}
-          driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
+          version: ${{ env.SETUP_BUILDX_VERSION }}
+          driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
           buildkitd-flags: --debug
       -
         name: Build ${{ needs.release-base.outputs.tag }}

--- a/.github/workflows/buildx-image.yml
+++ b/.github/workflows/buildx-image.yml
@@ -30,8 +30,8 @@ on:
         default: 'true'
 
 env:
+  SETUP_BUILDX_VERSION: "latest"
   REPO_SLUG_TARGET: "moby/buildkit"
-  BUILDX_VERSION: "latest"  # leave empty to use the one available on GitHub virtual environment
 
 jobs:
   create:
@@ -47,7 +47,7 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
-          version: ${{ env.BUILDX_VERSION }}
+          version: ${{ env.SETUP_BUILDX_VERSION }}
           buildkitd-flags: --debug
       -
         name: Login to DockerHub

--- a/.github/workflows/dockerd.yml
+++ b/.github/workflows/dockerd.yml
@@ -7,50 +7,43 @@ on:
       version:
         description: 'Docker version'
         required: true
-        default: '20.10.19'
+        default: '23.0.1'
 
 env:
-  REPO_SLUG_ORIGIN: "moby/buildkit:latest"
+  SETUP_BUILDX_VERSION: "latest"
+  SETUP_BUILDKIT_IMAGE: "moby/buildkit:latest"
   CACHE_GHA_SCOPE_IT: "integration-tests"
   CACHE_GHA_SCOPE_BINARIES: "binaries"
   TESTFLAGS: "-v --parallel=1 --timeout=30m"
-  BUILDX_VERSION: "latest"  # leave empty to use the one available on GitHub virtual environment
 
 jobs:
   prepare:
     runs-on: ubuntu-20.04
     steps:
       -
-        name: Check version
-        run: |
-          version=${{ github.event.inputs.version }}
-          if [ -z "$version" ]; then
-            version=20.10.19
-          fi
-          echo "DOCKER_VERSION=$version" >> $GITHUB_ENV
-      -
-        name: Check build
+        name: Prepare
         uses: actions/github-script@v6
-        id: build
         with:
-          result-encoding: string
           script: |
+            const version = `${{ inputs.version }}` || '23.0.1';
+            let build = 'true';
             try {
-              new URL("${{ env.DOCKER_VERSION }}");
+              new URL(version);
             } catch (e) {
-              return false;
+              build = 'false';
             }
-            return true;
+            core.exportVariable('DOCKER_VERSION', version);
+            core.exportVariable('DOCKER_BUILD', build);
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
-          version: ${{ env.BUILDX_VERSION }}
-          driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
+          version: ${{ env.SETUP_BUILDX_VERSION }}
+          driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
           buildkitd-flags: --debug
       -
         name: Build
-        if: steps.build.outputs.result == 'true'
+        if: ${{ env.DOCKER_BUILD == 'true' }}
         uses: docker/build-push-action@v3
         with:
           context: ${{ env.DOCKER_VERSION }}
@@ -58,14 +51,14 @@ jobs:
           outputs: /tmp/moby
       -
         name: Rename binary
-        if: steps.build.outputs.result == 'true'
+        if: ${{ env.DOCKER_BUILD == 'true' }}
         run: |
           if [ -L "/tmp/moby/binary-daemon/dockerd" ]; then
             mv -f $(readlink /tmp/moby/binary-daemon/dockerd) /tmp/moby/dockerd
           fi
       -
         name: Download
-        if: steps.build.outputs.result != 'true'
+        if: ${{ env.DOCKER_BUILD != 'true' }}
         run: |
           mkdir -p /tmp/moby
           cd /tmp/moby
@@ -113,8 +106,8 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
-          version: ${{ env.BUILDX_VERSION }}
-          driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
+          version: ${{ env.SETUP_BUILDX_VERSION }}
+          driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
           buildkitd-flags: --debug
       -
         name: Download dockerd

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -21,129 +21,21 @@ env:
   REPO_SLUG_ORIGIN: "moby/buildkit:latest"
   REPO_SLUG_TARGET: "docker/dockerfile-upstream"
   PLATFORMS: "linux/386,linux/amd64,linux/arm/v7,linux/arm64,linux/mips,linux/mipsle,linux/mips64,linux/mips64le,linux/s390x,linux/ppc64le,linux/riscv64"
-  CACHE_GHA_SCOPE_IT: "frontend-integration-tests"
-  TESTFLAGS: "-v --parallel=6 --timeout=30m"
   BUILDX_VERSION: "latest"  # leave empty to use the one available on GitHub virtual environment
   GO_VERSION: "1.19"
 
 jobs:
-  base:
-    runs-on: ubuntu-20.04
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v3
-      -
-        name: Expose GitHub Runtime
-        uses: crazy-max/ghaction-github-runtime@v2
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          version: ${{ env.BUILDX_VERSION }}
-          driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
-          buildkitd-flags: --debug
-      -
-        name: Build ${{ env.CACHE_GHA_SCOPE_IT }}
-        run: |
-          ./hack/build_ci_first_pass integration-tests
-        env:
-          CACHE_FROM: type=gha,scope=${{ env.CACHE_GHA_SCOPE_IT }}
-          CACHE_TO: type=gha,scope=${{ env.CACHE_GHA_SCOPE_IT }}
-
   test:
-    runs-on: ubuntu-20.04
-    needs:
-      - base
-    strategy:
-      fail-fast: false
-      matrix:
-        pkg:
-          - ./frontend/dockerfile
-        worker:
-          - containerd
-          - containerd-rootless
-          - containerd-1.6
-          - containerd-snapshotter-stargz
-          - oci
-          - oci-rootless
-          - oci-snapshotter-stargz
-        typ:
-          - integration
-          - dockerfile
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v3
-      -
-        name: Expose GitHub Runtime
-        uses: crazy-max/ghaction-github-runtime@v2
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          version: ${{ env.BUILDX_VERSION }}
-          driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
-          buildkitd-flags: --debug
-      -
-        name: Test
-        continue-on-error: ${{ matrix.tags == 'nydus' }}
-        run: |
-          if [ -n "${{ matrix.worker }}" ]; then
-            export TESTFLAGS="${TESTFLAGS} --run=//worker=${{ matrix.worker }}$"
-          fi
-          ./hack/test ${{ matrix.typ }}
-          mv ./coverage/coverage.txt ./coverage/coverage-${{ github.job }}-$(echo "${{ matrix.pkg }}-${{ matrix.typ }}-${{ matrix.worker }}" | tr -dc '[:alnum:]-\n\r' | tr '[:upper:]' '[:lower:]').txt
-        env:
-          TEST_COVERAGE: 1
-          TESTPKGS: ${{ matrix.pkg }}
-          CACHE_FROM: type=gha,scope=${{ env.CACHE_GHA_SCOPE_IT }}
-      -
-        name: Upload coverage file
-        continue-on-error: ${{ matrix.tags == 'nydus' }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: frontend-coverage
-          path: ./coverage
+    uses: ./.github/workflows/.test.yml
+    with:
+      cache_scope: frontend-integration-tests
+      pkgs: ./frontend/dockerfile
+      kinds: |
+        integration
+        dockerfile
+      codecov_flags: dockerfile-frontend
 
-  upload-coverage:
-    runs-on: ubuntu-20.04
-    needs:
-      - test
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v3
-      -
-        name: Download coverage files
-        uses: actions/download-artifact@v3
-        with:
-          name: frontend-coverage
-          path: ./coverage
-      -
-        name: List coverage files
-        uses: actions/github-script@v6
-        id: files
-        with:
-          result-encoding: string
-          script: |
-            return require('fs').readdirSync('./coverage', {withFileTypes: true})
-              .filter(item => !item.isDirectory())
-              .map(item => `./coverage/${item.name}`)
-              .join(',');
-      -
-        name: Send to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          files: ${{ steps.files.outputs.result }}
-
-  prepare-image:
+  prepare:
     runs-on: ubuntu-20.04
     if: github.event_name != 'schedule'
     outputs:
@@ -177,10 +69,11 @@ jobs:
     runs-on: ubuntu-20.04
     needs:
       - test
+      - prepare
     strategy:
       fail-fast: false
       matrix:
-        tag: ${{ fromJson(needs.prepare-image.outputs.tags) }}
+        tag: ${{ fromJson(needs.prepare.outputs.tags) }}
     steps:
       -
         name: Prepare
@@ -209,14 +102,14 @@ jobs:
       -
         name: Login to DockerHub
         uses: docker/login-action@v2
-        if: needs.prepare-image.outputs.push == 'push'
+        if: needs.prepare.outputs.push == 'push'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build
         run: |
-          ./frontend/dockerfile/cmd/dockerfile-frontend/hack/release "${{ needs.prepare-image.outputs.typ }}" "${{ matrix.tag }}" "$REPO_SLUG_TARGET" "${{ needs.prepare-image.outputs.push }}"
+          ./frontend/dockerfile/cmd/dockerfile-frontend/hack/release "${{ needs.prepare.outputs.typ }}" "${{ matrix.tag }}" "$REPO_SLUG_TARGET" "${{ needs.prepare.outputs.push }}"
         env:
           RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
           CACHE_FROM: type=gha,scope=${{ env.CACHE_SCOPE }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,223 @@
+name: frontend
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - 'dockerfile/*'
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+      - 'docs/**'
+      - 'frontend/dockerfile/docs/**'
+
+env:
+  REPO_SLUG_ORIGIN: "moby/buildkit:latest"
+  REPO_SLUG_TARGET: "docker/dockerfile-upstream"
+  PLATFORMS: "linux/386,linux/amd64,linux/arm/v7,linux/arm64,linux/mips,linux/mipsle,linux/mips64,linux/mips64le,linux/s390x,linux/ppc64le,linux/riscv64"
+  CACHE_GHA_SCOPE_IT: "frontend-integration-tests"
+  TESTFLAGS: "-v --parallel=6 --timeout=30m"
+  BUILDX_VERSION: "latest"  # leave empty to use the one available on GitHub virtual environment
+  GO_VERSION: "1.19"
+
+jobs:
+  base:
+    runs-on: ubuntu-20.04
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Expose GitHub Runtime
+        uses: crazy-max/ghaction-github-runtime@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          version: ${{ env.BUILDX_VERSION }}
+          driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
+          buildkitd-flags: --debug
+      -
+        name: Build ${{ env.CACHE_GHA_SCOPE_IT }}
+        run: |
+          ./hack/build_ci_first_pass integration-tests
+        env:
+          CACHE_FROM: type=gha,scope=${{ env.CACHE_GHA_SCOPE_IT }}
+          CACHE_TO: type=gha,scope=${{ env.CACHE_GHA_SCOPE_IT }}
+
+  test:
+    runs-on: ubuntu-20.04
+    needs:
+      - base
+    strategy:
+      fail-fast: false
+      matrix:
+        pkg:
+          - ./frontend/dockerfile
+        worker:
+          - containerd
+          - containerd-rootless
+          - containerd-1.6
+          - containerd-snapshotter-stargz
+          - oci
+          - oci-rootless
+          - oci-snapshotter-stargz
+        typ:
+          - integration
+          - dockerfile
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Expose GitHub Runtime
+        uses: crazy-max/ghaction-github-runtime@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          version: ${{ env.BUILDX_VERSION }}
+          driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
+          buildkitd-flags: --debug
+      -
+        name: Test
+        continue-on-error: ${{ matrix.tags == 'nydus' }}
+        run: |
+          if [ -n "${{ matrix.worker }}" ]; then
+            export TESTFLAGS="${TESTFLAGS} --run=//worker=${{ matrix.worker }}$"
+          fi
+          ./hack/test ${{ matrix.typ }}
+          mv ./coverage/coverage.txt ./coverage/coverage-${{ github.job }}-$(echo "${{ matrix.pkg }}-${{ matrix.typ }}-${{ matrix.worker }}" | tr -dc '[:alnum:]-\n\r' | tr '[:upper:]' '[:lower:]').txt
+        env:
+          TEST_COVERAGE: 1
+          TESTPKGS: ${{ matrix.pkg }}
+          CACHE_FROM: type=gha,scope=${{ env.CACHE_GHA_SCOPE_IT }}
+      -
+        name: Upload coverage file
+        continue-on-error: ${{ matrix.tags == 'nydus' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: frontend-coverage
+          path: ./coverage
+
+  upload-coverage:
+    runs-on: ubuntu-20.04
+    needs:
+      - test
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Download coverage files
+        uses: actions/download-artifact@v3
+        with:
+          name: frontend-coverage
+          path: ./coverage
+      -
+        name: List coverage files
+        uses: actions/github-script@v6
+        id: files
+        with:
+          result-encoding: string
+          script: |
+            return require('fs').readdirSync('./coverage', {withFileTypes: true})
+              .filter(item => !item.isDirectory())
+              .map(item => `./coverage/${item.name}`)
+              .join(',');
+      -
+        name: Send to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: ${{ steps.files.outputs.result }}
+
+  prepare-image:
+    runs-on: ubuntu-20.04
+    if: github.event_name != 'schedule'
+    outputs:
+      typ: ${{ steps.prep.outputs.typ }}
+      push: ${{ steps.prep.outputs.push }}
+      tags: ${{ steps.prep.outputs.tags }}
+    steps:
+      -
+        name: Prepare
+        id: prep
+        run: |
+          TYP=master
+          TAG=mainline
+          PUSH=false
+          if [[ $GITHUB_REF == refs/tags/dockerfile/* ]]; then
+            TYP=tag
+            TAG=${GITHUB_REF#refs/tags/}
+            PUSH=push
+          elif [[ $GITHUB_REF == refs/heads/* ]]; then
+            PUSH=push
+          fi
+          echo "typ=${TYP}" >>${GITHUB_OUTPUT}
+          echo "push=${PUSH}" >>${GITHUB_OUTPUT}
+          if [ "${TYP}" = "master" ]; then
+            echo "tags=$(jq -cn --arg tag "$TAG" '[$tag, "labs"]')" >>${GITHUB_OUTPUT}
+          else
+            echo "tags=$(jq -cn --arg tag "$TAG" '[$tag]')" >>${GITHUB_OUTPUT}
+          fi
+
+  image:
+    runs-on: ubuntu-20.04
+    needs:
+      - test
+    strategy:
+      fail-fast: false
+      matrix:
+        tag: ${{ fromJson(needs.prepare-image.outputs.tags) }}
+    steps:
+      -
+        name: Prepare
+        run: |
+          if [[ "${{ matrix.tag }}" = "labs" ]] || [[ "${{ matrix.tag }}" == *-labs ]]; then
+            echo "CACHE_SCOPE=frontend-labs" >>${GITHUB_ENV}
+          else
+            echo "CACHE_SCOPE=frontend-mainline" >>${GITHUB_ENV}
+          fi
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Expose GitHub Runtime
+        uses: crazy-max/ghaction-github-runtime@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          version: ${{ env.BUILDX_VERSION }}
+          driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
+          buildkitd-flags: --debug
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v2
+        if: needs.prepare-image.outputs.push == 'push'
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build
+        run: |
+          ./frontend/dockerfile/cmd/dockerfile-frontend/hack/release "${{ needs.prepare-image.outputs.typ }}" "${{ matrix.tag }}" "$REPO_SLUG_TARGET" "${{ needs.prepare-image.outputs.push }}"
+        env:
+          RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
+          CACHE_FROM: type=gha,scope=${{ env.CACHE_SCOPE }}
+          CACHE_TO: type=gha,scope=${{ env.CACHE_SCOPE }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -18,11 +18,11 @@ on:
       - 'frontend/dockerfile/docs/**'
 
 env:
-  REPO_SLUG_ORIGIN: "moby/buildkit:latest"
-  REPO_SLUG_TARGET: "docker/dockerfile-upstream"
-  PLATFORMS: "linux/386,linux/amd64,linux/arm/v7,linux/arm64,linux/mips,linux/mipsle,linux/mips64,linux/mips64le,linux/s390x,linux/ppc64le,linux/riscv64"
-  BUILDX_VERSION: "latest"  # leave empty to use the one available on GitHub virtual environment
   GO_VERSION: "1.19"
+  SETUP_BUILDX_VERSION: "latest"
+  SETUP_BUILDKIT_TAG: "moby/buildkit:latest"
+  IMAGE_NAME: "docker/dockerfile-upstream"
+  PLATFORMS: "linux/386,linux/amd64,linux/arm/v7,linux/arm64,linux/mips,linux/mipsle,linux/mips64,linux/mips64le,linux/s390x,linux/ppc64le,linux/riscv64"
 
 jobs:
   test:
@@ -96,8 +96,8 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
-          version: ${{ env.BUILDX_VERSION }}
-          driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
+          version: ${{ env.SETUP_BUILDX_VERSION }}
+          driver-opts: image=${{ env.SETUP_BUILDKIT_TAG }}
           buildkitd-flags: --debug
       -
         name: Login to DockerHub
@@ -109,7 +109,7 @@ jobs:
       -
         name: Build
         run: |
-          ./frontend/dockerfile/cmd/dockerfile-frontend/hack/release "${{ needs.prepare.outputs.typ }}" "${{ matrix.tag }}" "$REPO_SLUG_TARGET" "${{ needs.prepare.outputs.push }}"
+          ./frontend/dockerfile/cmd/dockerfile-frontend/hack/release "${{ needs.prepare.outputs.typ }}" "${{ matrix.tag }}" "$IMAGE_NAME" "${{ needs.prepare.outputs.push }}"
         env:
           RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
           CACHE_FROM: type=gha,scope=${{ env.CACHE_SCOPE }}

--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -1,0 +1,62 @@
+name: test-os
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  schedule:
+    - cron: '0 10 * * *'
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+      - 'docs/**'
+      - 'frontend/dockerfile/docs/**'
+
+env:
+  GO_VERSION: "1.19"
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          # - ubuntu-20.04
+          # - macOS-11
+          - windows-2022
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      -
+        name: Go mod
+        run: |
+          go mod download
+      -
+        name: Test
+        env:
+          TMPDIR: ${{ runner.temp }}
+          SKIP_INTEGRATION_TESTS: 1
+        run: |
+          mkdir -p ./coverage
+          go test -coverprofile=./coverage/coverage.txt -covermode=atomic ${TESTFLAGS} ./...
+        shell: bash
+      -
+        name: Send to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage/coverage.txt
+          env_vars: RUNNER_OS
+          flags: unit

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,8 +15,8 @@ on:
   pull_request:
 
 env:
-  REPO_SLUG_ORIGIN: "moby/buildkit:latest"
-  BUILDX_VERSION: "latest"  # leave empty to use the one available on GitHub virtual environment
+  SETUP_BUILDX_VERSION: "latest"
+  SETUP_BUILDKIT_IMAGE: "moby/buildkit:latest"
 
 jobs:
   validate:
@@ -37,8 +37,8 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
-          version: ${{ env.BUILDX_VERSION }}
-          driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
+          version: ${{ env.SETUP_BUILDX_VERSION }}
+          driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
           buildkitd-flags: --debug
       -
         name: Run

--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 # BuildKit <!-- omit in toc -->
 
-[![GoDoc](https://godoc.org/github.com/moby/buildkit?status.svg)](https://godoc.org/github.com/moby/buildkit/client/llb)
-[![Build Status](https://github.com/moby/buildkit/workflows/build/badge.svg)](https://github.com/moby/buildkit/actions?query=workflow%3Abuild)
-[![Go Report Card](https://goreportcard.com/badge/github.com/moby/buildkit)](https://goreportcard.com/report/github.com/moby/buildkit)
-[![codecov](https://codecov.io/gh/moby/buildkit/branch/master/graph/badge.svg)](https://codecov.io/gh/moby/buildkit)
+[![GitHub Release](https://img.shields.io/github/release/moby/buildkit.svg?style=flat-square)](https://github.com/moby/buildkit/releases/latest)
+[![PkgGoDev](https://img.shields.io/badge/go.dev-docs-007d9c?style=flat-square&logo=go&logoColor=white)](https://pkg.go.dev/github.com/moby/buildkit/client/llb)
+[![CI BuildKit Status](https://img.shields.io/github/actions/workflow/status/moby/buildkit/buildkit.yml?label=buildkit&logo=github&style=flat-square)](https://github.com/moby/buildkit/actions?query=workflow%3Abuildkit)
+[![CI Frontend Status](https://img.shields.io/github/actions/workflow/status/moby/buildkit/frontend.yml?label=frontend&logo=github&style=flat-square)](https://github.com/moby/buildkit/actions?query=workflow%3Afrontend)
+[![Go Report Card](https://goreportcard.com/badge/github.com/moby/buildkit?style=flat-square)](https://goreportcard.com/report/github.com/moby/buildkit)
+[![Codecov](https://img.shields.io/codecov/c/github/moby/buildkit?logo=codecov&style=flat-square)](https://codecov.io/gh/moby/buildkit)
 
 BuildKit is a toolkit for converting source code to build artifacts in an efficient, expressive and repeatable manner.
 


### PR DESCRIPTION
Split dockerfile frontend integration tests and build in a dedicated workflow so we have a clear separation of concerns and also avoid building the frontend when a BuildKit tag is pushed and vice versa with a dockerfile tag.

Also create a reusable workflow for our tests and move test-os job to a dedicated workflow.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>