### PR TITLE
Docs updates and fixes

### DIFF
--- a/docs/buildkitd.toml.md
+++ b/docs/buildkitd.toml.md
@@ -1,12 +1,5 @@
 # buildkitd.toml
 
-## NAME
-
-buildkitd.toml - configuration file for buildkitd
-
-
-## DESCRIPTION
-
 The TOML file used to configure the buildkitd daemon settings has a short
 list of global settings followed by a series of sections for specific areas
 of daemon configuration.
@@ -14,13 +7,11 @@ of daemon configuration.
 The file path is `/etc/buildkit/buildkitd.toml` for rootful mode,
 `~/.config/buildkit/buildkitd.toml` for rootless mode.
 
-## EXAMPLE
+The following is a complete `buildkitd.toml` configuration example, please
+note some configuration is only good for edge cases, please take care of it
+carefully.
 
-The following is a complete **buildkitd.toml** configuration example,
-please note some of the configuration is only good for edge cases, please
-take care of it carefully.
-
-```
+```toml
 debug = true
 # root is where all buildkit state is stored.
 root = "/var/lib/buildkit"
@@ -104,7 +95,7 @@ insecure-entitlements = [ "network.host", "security.insecure" ]
   [[registry."docker.io".keypair]]
     key="/etc/config/key.pem"
     cert="/etc/config/cert.pem"
-    
+
 # optionally mirror configuration can be done by defining it as a registry.
 [registry."yourmirror.local:5000"]
   http = true

--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -158,7 +158,7 @@ The following parser directives are supported:
 - `syntax`
 - `escape`
 
-## syntax
+### syntax
 
 <a name="external-implementation-features"><!-- included for deep-links to old section --></a>
 
@@ -168,7 +168,7 @@ backend, and is ignored when using the classic builder backend.
 See [Custom Dockerfile syntax](https://docs.docker.com/build/buildkit/dockerfile-frontend/)
 page for more information.
 
-## escape
+### escape
 
 ```dockerfile
 # escape=\ (backslash)

--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -949,6 +949,12 @@ LABEL multi.label1="value1" \
       other="value3"
 ```
 
+> **Note**
+> 
+> Be sure to use double quotes and not single quotes. Particularly when you are
+> using string interpolation (e.g. `LABEL example="foo-$ENV_VAR"`), single
+> quotes will take the string as is without unpacking the variable's value.
+
 Labels included in base or parent images (images in the `FROM` line) are
 inherited by your image. If a label already exists but with a different value,
 the most-recently-applied value overrides any previously-set value.


### PR DESCRIPTION
I'm working on the new BuildKit section on Docker docs website and wants to include the `buildkitd.toml.md` page but needs to format it a bit before.

Also fixes parse directive toc in dockerfile reference.

And carry changes from https://github.com/docker/cli/pull/1467. More needs to be carry from docker/cli repo but can do that in a follow-up: https://github.com/docker/cli/pulls?q=is%3Aopen+is%3Apr+label%3Aarea%2Fbuilder+label%3Akind%2Fdocs (cc @dvdksn)