### PR TITLE
Use --network=host to use local dns in resolv.conf

### DIFF
--- a/executor/oci/resolvconf_test.go
+++ b/executor/oci/resolvconf_test.go
@@ -2,34 +2,150 @@ package oci
 
 import (
 	"context"
-	"os"
-	"testing"
-
+	"fmt"
 	"github.com/docker/docker/libnetwork/resolvconf"
 	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+	"time"
 )
 
-// TestResolvConfNotExist modifies a global variable
-// It must not run in parallel.
-func TestResolvConfNotExist(t *testing.T) {
-	oldResolvconfGet := resolvconfGet
-	defer func() {
-		resolvconfGet = oldResolvconfGet
-	}()
-	resolvconfGet = func() (*resolvconf.File, error) {
-		return nil, os.ErrNotExist
-	}
-
-	defaultResolvConf := `
+const defaultResolvConf = `
 nameserver 8.8.8.8
 nameserver 8.8.4.4
 nameserver 2001:4860:4860::8888
 nameserver 2001:4860:4860::8844`
 
-	ctx := context.Background()
-	p, err := GetResolvConf(ctx, t.TempDir(), nil, nil)
-	require.NoError(t, err)
-	b, err := os.ReadFile(p)
-	require.NoError(t, err)
-	require.Equal(t, string(b), defaultResolvConf)
+const dnsOption = `
+options ndots:0`
+
+const localDNSResolvConf = `
+nameserver 127.0.0.11
+options ndots:0`
+
+const regularResolvConf = `
+# DNS requests are forwarded to the host. DHCP DNS options are ignored.
+nameserver 192.168.65.5`
+
+// TestResolvConf modifies a global variable
+// It must not run in parallel.
+func TestResolvConf(t *testing.T) {
+	cases := []struct {
+		name               string
+		resolvconfGetFile  *resolvconf.File
+		resolvconfGetError error
+		execution          int
+		hostNetMode        []bool
+		expected           []string
+	}{
+		{
+			name:               "TestResolvConfNotExist",
+			resolvconfGetFile:  nil,
+			resolvconfGetError: os.ErrNotExist,
+			execution:          1,
+			hostNetMode:        []bool{false},
+			expected:           []string{defaultResolvConf},
+		},
+		{
+			name:               "TestNetModeIsHostResolvConfNotExist",
+			resolvconfGetFile:  nil,
+			resolvconfGetError: os.ErrNotExist,
+			execution:          1,
+			hostNetMode:        []bool{true},
+			expected:           []string{defaultResolvConf},
+		},
+		{
+			name: "TestNetModeIsHostWithoutLocalDNS",
+			resolvconfGetFile: &resolvconf.File{
+				Content: []byte(regularResolvConf),
+			},
+			resolvconfGetError: nil,
+			execution:          1,
+			hostNetMode:        []bool{true},
+			expected:           []string{regularResolvConf},
+		},
+		{
+			name: "TestNetModeIsHostWithLocalDNS",
+			resolvconfGetFile: &resolvconf.File{
+				Content: []byte(localDNSResolvConf),
+			},
+			resolvconfGetError: nil,
+			execution:          1,
+			hostNetMode:        []bool{true},
+			expected:           []string{localDNSResolvConf},
+		},
+		{
+			name: "TestNetModeNotHostWithoutLocalDNS",
+			resolvconfGetFile: &resolvconf.File{
+				Content: []byte(regularResolvConf),
+			},
+			resolvconfGetError: nil,
+			execution:          1,
+			hostNetMode:        []bool{false},
+			expected:           []string{regularResolvConf},
+		},
+		{
+			name: "TestNetModeNotHostWithLocalDNS",
+			resolvconfGetFile: &resolvconf.File{
+				Content: []byte(localDNSResolvConf),
+			},
+			resolvconfGetError: nil,
+			execution:          1,
+			hostNetMode:        []bool{false},
+			expected:           []string{fmt.Sprintf("%s%s", dnsOption, defaultResolvConf)},
+		},
+		{
+			name: "TestRegenerateResolvconfToRemoveLocalDNS",
+			resolvconfGetFile: &resolvconf.File{
+				Content: []byte(localDNSResolvConf),
+			},
+			resolvconfGetError: nil,
+			execution:          2,
+			hostNetMode:        []bool{true, false},
+			expected: []string{
+				localDNSResolvConf,
+				fmt.Sprintf("%s%s", dnsOption, defaultResolvConf),
+			},
+		},
+		{
+			name: "TestRegenerateResolvconfToAddLocalDNS",
+			resolvconfGetFile: &resolvconf.File{
+				Content: []byte(localDNSResolvConf),
+			},
+			resolvconfGetError: nil,
+			execution:          2,
+			hostNetMode:        []bool{false, true},
+			expected: []string{
+				fmt.Sprintf("%s%s", dnsOption, defaultResolvConf),
+				localDNSResolvConf,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			oldResolvconfGet := resolvconfGet
+			defer func() {
+				resolvconfGet = oldResolvconfGet
+			}()
+			resolvconfGet = func() (*resolvconf.File, error) {
+				return tc.resolvconfGetFile, tc.resolvconfGetError
+			}
+
+			ctx := context.Background()
+			tempDir := t.TempDir()
+
+			for i := 0; i < tc.execution; i++ {
+				if i > 0 {
+					time.Sleep(100 * time.Millisecond)
+				}
+
+				p, err := GetResolvConf(ctx, tempDir, nil, nil, tc.hostNetMode[i])
+				require.NoError(t, err)
+				b, err := os.ReadFile(p)
+				require.NoError(t, err)
+				require.Equal(t, tc.expected[i], string(b))
+			}
+		})
+	}
 }

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -167,11 +167,13 @@ func (w *runcExecutor) Run(ctx context.Context, id string, root executor.Mount, 
 	}
 	defer namespace.Close()
 
+	hostNetMode := false
 	if meta.NetMode == pb.NetMode_HOST {
 		bklog.G(ctx).Info("enabling HostNetworking")
+		hostNetMode = true
 	}
 
-	resolvConf, err := oci.GetResolvConf(ctx, w.root, w.idmap, w.dns)
+	resolvConf, err := oci.GetResolvConf(ctx, w.root, w.idmap, w.dns, hostNetMode)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
fix #3210 

This is still a draft, there are some parts that need to be clarified.

1. I need to modify the vendor -- `github.com/docker/docker/libnetwork/resolvconf/resolvconf.go` in order to keep the localhost DNS. Are these changes (see below temp changes for this vendor) make sense for the upstream repo? 
2. For these changes I need to extend the `generate` logic so that when users update the `--network` option, `resolv.conf` will be updated accordingly.

@tonistiigi could you please take a look? Thanks!