### PR TITLE
dockerfile: enhance parser documentation

### DIFF
--- a/frontend/dockerfile/instructions/commands.go
+++ b/frontend/dockerfile/instructions/commands.go
@@ -10,7 +10,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-// KeyValuePair represent an arbitrary named value (useful in slice instead of map[string] string to preserve ordering)
+// KeyValuePair represents an arbitrary named value.
+//
+// This is useful for commands containing key-value maps that want to preserve
+// the order of insertion, instead of map[string]string which does not.
 type KeyValuePair struct {
 	Key   string
 	Value string
@@ -20,11 +23,15 @@ func (kvp *KeyValuePair) String() string {
 	return kvp.Key + "=" + kvp.Value
 }
 
-// KeyValuePairOptional is the same as KeyValuePair but Value is optional
+// KeyValuePairOptional is identical to KeyValuePair, but allows for optional values.
 type KeyValuePairOptional struct {
 	Key     string
 	Value   *string
 	Comment string
+}
+
+func (kvpo *KeyValuePairOptional) String() string {
+	return kvpo.Key + "=" + kvpo.ValueString()
 }
 
 func (kvpo *KeyValuePairOptional) ValueString() string {
@@ -35,7 +42,11 @@ func (kvpo *KeyValuePairOptional) ValueString() string {
 	return v
 }
 
-// Command is implemented by every command present in a dockerfile
+// Command interface is implemented by every possible command in a Dockerfile.
+//
+// The interface only exposes the minimal common elements shared between every
+// command, while more detailed information per-command can be extracted using
+// runtime type analysis, e.g. type-switches.
 type Command interface {
 	Name() string
 	Location() []parser.Range
@@ -69,17 +80,18 @@ func newWithNameAndCode(req parseRequest) withNameAndCode {
 	return withNameAndCode{code: strings.TrimSpace(req.original), name: req.command, location: req.location}
 }
 
-// SingleWordExpander is a provider for variable expansion where 1 word => 1 output
+// SingleWordExpander is a provider for variable expansion where a single word
+// corresponds to a single output.
 type SingleWordExpander func(word string) (string, error)
 
-// SupportsSingleWordExpansion interface marks a command as supporting variable
-// expansion
+// SupportsSingleWordExpansion interface allows a command to support variable.
 type SupportsSingleWordExpansion interface {
 	Expand(expander SingleWordExpander) error
 }
 
-// SupportsSingleWordExpansionRaw interface marks a command as supporting
-// variable expansion, while ensuring that quotes are preserved
+// SupportsSingleWordExpansionRaw interface allows a command to support
+// variable expansion, while ensuring that minimal transformations are applied
+// during expansion, so that quotes and other special characters are preserved.
 type SupportsSingleWordExpansionRaw interface {
 	ExpandRaw(expander SingleWordExpander) error
 }
@@ -122,18 +134,22 @@ func expandSliceInPlace(values []string, expander SingleWordExpander) error {
 	return nil
 }
 
-// EnvCommand : ENV key1 value1 [keyN valueN...]
+// EnvCommand allows setting an variable in the container's environment.
+//
+//	ENV key1 value1 [keyN valueN...]
 type EnvCommand struct {
 	withNameAndCode
-	Env KeyValuePairs // kvp slice instead of map to preserve ordering
+	Env KeyValuePairs
 }
 
-// Expand variables
 func (c *EnvCommand) Expand(expander SingleWordExpander) error {
 	return expandKvpsInPlace(c.Env, expander)
 }
 
-// MaintainerCommand : MAINTAINER maintainer_name
+// MaintainerCommand (deprecated) allows specifying a maintainer details for
+// the image.
+//
+//	MAINTAINER maintainer_name
 type MaintainerCommand struct {
 	withNameAndCode
 	Maintainer string
@@ -155,16 +171,15 @@ func NewLabelCommand(k string, v string, NoExp bool) *LabelCommand {
 	return cmd
 }
 
-// LabelCommand : LABEL some json data describing the image
+// LabelCommand sets an image label in the output
 //
-// Sets the Label variable foo to bar,
+//	LABEL some json data describing the image
 type LabelCommand struct {
 	withNameAndCode
-	Labels   KeyValuePairs // kvp slice instead of map to preserve ordering
+	Labels   KeyValuePairs
 	noExpand bool
 }
 
-// Expand variables
 func (c *LabelCommand) Expand(expander SingleWordExpander) error {
 	if c.noExpand {
 		return nil
@@ -174,16 +189,16 @@ func (c *LabelCommand) Expand(expander SingleWordExpander) error {
 
 // SourceContent represents an anonymous file object
 type SourceContent struct {
-	Path   string
-	Data   string
-	Expand bool
+	Path   string // path to the file
+	Data   string // string content from the file
+	Expand bool   // whether to expand file contents
 }
 
 // SourcesAndDest represent a collection of sources and a destination
 type SourcesAndDest struct {
-	DestPath       string
-	SourcePaths    []string
-	SourceContents []SourceContent
+	DestPath       string          // destination to write output
+	SourcePaths    []string        // file path sources
+	SourceContents []SourceContent // anonymous file sources
 }
 
 func (s *SourcesAndDest) Expand(expander SingleWordExpander) error {
@@ -216,10 +231,12 @@ func (s *SourcesAndDest) ExpandRaw(expander SingleWordExpander) error {
 	return nil
 }
 
-// AddCommand : ADD foo /path
+// AddCommand adds files from the provided sources to the target destination.
 //
-// Add the file 'foo' to '/path'. Tarball and Remote URL (http, https) handling
-// exist here. If you do not wish to have this automatic handling, use COPY.
+//	ADD foo /path
+//
+// ADD supports tarball and remote URL handling, which may not always be
+// desired - if you do not wish to have this automatic handling, use COPY.
 type AddCommand struct {
 	withNameAndCode
 	SourcesAndDest
@@ -230,7 +247,6 @@ type AddCommand struct {
 	Checksum   digest.Digest
 }
 
-// Expand variables
 func (c *AddCommand) Expand(expander SingleWordExpander) error {
 	expandedChown, err := expander(c.Chown)
 	if err != nil {
@@ -241,9 +257,11 @@ func (c *AddCommand) Expand(expander SingleWordExpander) error {
 	return c.SourcesAndDest.Expand(expander)
 }
 
-// CopyCommand : COPY foo /path
+// CopyCommand copies files from the provided sources to the target destination.
 //
-// Same as 'ADD' but without the tar and remote url handling.
+//	COPY foo /path
+//
+// Same as 'ADD' but without the magic additional tarball and remote URL handling.
 type CopyCommand struct {
 	withNameAndCode
 	SourcesAndDest
@@ -253,7 +271,6 @@ type CopyCommand struct {
 	Link  bool
 }
 
-// Expand variables
 func (c *CopyCommand) Expand(expander SingleWordExpander) error {
 	expandedChown, err := expander(c.Chown)
 	if err != nil {
@@ -264,21 +281,24 @@ func (c *CopyCommand) Expand(expander SingleWordExpander) error {
 	return c.SourcesAndDest.Expand(expander)
 }
 
-// OnbuildCommand : ONBUILD <some other command>
+// OnbuildCommand allows specifying a command to be run on builds the use the
+// resulting build image as a base image.
+//
+//	ONBUILD <some other command>
 type OnbuildCommand struct {
 	withNameAndCode
 	Expression string
 }
 
-// WorkdirCommand : WORKDIR /tmp
+// WorkdirCommand sets the current working directory for all future commands in
+// the stage
 //
-// Set the working directory for future RUN/CMD/etc statements.
+//	WORKDIR /tmp
 type WorkdirCommand struct {
 	withNameAndCode
 	Path string
 }
 
-// Expand variables
 func (c *WorkdirCommand) Expand(expander SingleWordExpander) error {
 	p, err := expander(c.Path)
 	if err != nil {
@@ -302,15 +322,13 @@ type ShellDependantCmdLine struct {
 	PrependShell bool
 }
 
-// RunCommand : RUN some command yo
+// RunCommand runs a command.
 //
-// run a command and commit the image. Args are automatically prepended with
-// the current SHELL which defaults to 'sh -c' under linux or 'cmd /S /C' under
-// Windows, in the event there is only one argument The difference in processing:
+//	RUN "echo hi"       # sh -c "echo hi"
 //
-// RUN echo hi          # sh -c echo hi       (Linux)
-// RUN echo hi          # cmd /S /C echo hi   (Windows)
-// RUN [ "echo", "hi" ] # echo hi
+// or
+//
+//	RUN ["echo", "hi"]  # echo hi
 type RunCommand struct {
 	withNameAndCode
 	withExternalData
@@ -325,55 +343,54 @@ func (c *RunCommand) Expand(expander SingleWordExpander) error {
 	return nil
 }
 
-// CmdCommand : CMD foo
+// CmdCommand sets the default command to run in the container on start.
 //
-// Set the default command to run in the container (which may be empty).
-// Argument handling is the same as RUN.
+//	CMD "echo hi"       # sh -c "echo hi"
+//
+// or
+//
+//	CMD ["echo", "hi"]  # echo hi
 type CmdCommand struct {
 	withNameAndCode
 	ShellDependantCmdLine
 }
 
-// HealthCheckCommand : HEALTHCHECK foo
+// HealthCheckCommand sets the default healthcheck command to run in the container.
 //
-// Set the default healthcheck command to run in the container (which may be empty).
-// Argument handling is the same as RUN.
+//	HEALTHCHECK <health-config>
 type HealthCheckCommand struct {
 	withNameAndCode
 	Health *container.HealthConfig
 }
 
-// EntrypointCommand : ENTRYPOINT /usr/sbin/nginx
+// EntrypointCommand sets the default entrypoint of the container to use the
+// provided command.
 //
-// Set the entrypoint to /usr/sbin/nginx. Will accept the CMD as the arguments
-// to /usr/sbin/nginx. Uses the default shell if not in JSON format.
+//	ENTRYPOINT /usr/sbin/nginx
 //
-// Handles command processing similar to CMD and RUN, only req.runConfig.Entrypoint
-// is initialized at newBuilder time instead of through argument parsing.
+// Entrypoint uses the default shell if not in JSON format.
 type EntrypointCommand struct {
 	withNameAndCode
 	ShellDependantCmdLine
 }
 
-// ExposeCommand : EXPOSE 6667/tcp 7000/tcp
+// ExposeCommand marks a container port that can be exposed at runtime.
 //
-// Expose ports for links and port mappings. This all ends up in
-// req.runConfig.ExposedPorts for runconfig.
+//	EXPOSE 6667/tcp 7000/tcp
 type ExposeCommand struct {
 	withNameAndCode
 	Ports []string
 }
 
-// UserCommand : USER foo
+// UserCommand sets the user for the rest of the stage, and when starting the
+// container at run-time.
 //
-// Set the user to 'foo' for future commands and when running the
-// ENTRYPOINT/CMD at container run time.
+//	USER user
 type UserCommand struct {
 	withNameAndCode
 	User string
 }
 
-// Expand variables
 func (c *UserCommand) Expand(expander SingleWordExpander) error {
 	p, err := expander(c.User)
 	if err != nil {
@@ -383,28 +400,26 @@ func (c *UserCommand) Expand(expander SingleWordExpander) error {
 	return nil
 }
 
-// VolumeCommand : VOLUME /foo
+// VolumeCommand exposes the specified volume for use in the build environment.
 //
-// Expose the volume /foo for use. Will also accept the JSON array form.
+//	VOLUME /foo
 type VolumeCommand struct {
 	withNameAndCode
 	Volumes []string
 }
 
-// Expand variables
 func (c *VolumeCommand) Expand(expander SingleWordExpander) error {
 	return expandSliceInPlace(c.Volumes, expander)
 }
 
-// StopSignalCommand : STOPSIGNAL signal
+// StopSignalCommand sets the signal that will be used to kill the container.
 //
-// Set the signal that will be used to kill the container.
+//	STOPSIGNAL signal
 type StopSignalCommand struct {
 	withNameAndCode
 	Signal string
 }
 
-// Expand variables
 func (c *StopSignalCommand) Expand(expander SingleWordExpander) error {
 	p, err := expander(c.Signal)
 	if err != nil {
@@ -422,17 +437,16 @@ func (c *StopSignalCommand) CheckPlatform(platform string) error {
 	return nil
 }
 
-// ArgCommand : ARG name[=value]
+// ArgCommand adds the specified variable to the list of variables that can be
+// passed to the builder using the --build-arg flag for expansion and
+// substitution.
 //
-// Adds the variable foo to the trusted list of variables that can be passed
-// to builder using the --build-arg flag for expansion/substitution or passing to 'run'.
-// Dockerfile author may optionally set a default value of this variable.
+//	ARG name[=value]
 type ArgCommand struct {
 	withNameAndCode
 	Args []KeyValuePairOptional
 }
 
-// Expand variables
 func (c *ArgCommand) Expand(expander SingleWordExpander) error {
 	for i, v := range c.Args {
 		p, err := expander(v.Key)
@@ -452,32 +466,42 @@ func (c *ArgCommand) Expand(expander SingleWordExpander) error {
 	return nil
 }
 
-// ShellCommand : SHELL powershell -command
+// ShellCommand sets a custom shell to use.
 //
-// Set the non-default shell to use.
+//	SHELL bash -e -c
 type ShellCommand struct {
 	withNameAndCode
 	Shell strslice.StrSlice
 }
 
-// Stage represents a single stage in a multi-stage build
+// Stage represents a bundled collection of commands.
+//
+// Each stage begins with a FROM command (which is consumed into the Stage),
+// indicating the source or stage to derive from, and ends either at the
+// end-of-the file, or the start of the next stage.
+//
+// Stages can be named, and can be additionally configured to use a specific
+// platform, in the case of a multi-arch base image.
 type Stage struct {
-	Name       string
-	Commands   []Command
-	BaseName   string
-	SourceCode string
-	Platform   string
-	Location   []parser.Range
-	Comment    string
+	Name     string    // name of the stage
+	Commands []Command // commands contained within the stage
+	BaseName string    // name of the base stage or source
+	Platform string    // platform of base source to use
+
+	Comment string // doc-comment directly above the stage
+
+	SourceCode string         // contents of the defining FROM command
+	Location   []parser.Range // location of the defining FROM command
 }
 
-// AddCommand to the stage
+// AddCommand appends a command to the stage.
 func (s *Stage) AddCommand(cmd Command) {
 	// todo: validate cmd type
 	s.Commands = append(s.Commands, cmd)
 }
 
-// IsCurrentStage check if the stage name is the current stage
+// IsCurrentStage returns true if the provided stage name is the name of the
+// current stage, and false otherwise.
 func IsCurrentStage(s []Stage, name string) bool {
 	if len(s) == 0 {
 		return false
@@ -485,7 +509,7 @@ func IsCurrentStage(s []Stage, name string) bool {
 	return s[len(s)-1].Name == name
 }
 
-// CurrentStage return the last stage in a slice
+// CurrentStage returns the last stage from a list of stages.
 func CurrentStage(s []Stage) (*Stage, error) {
 	if len(s) == 0 {
 		return nil, errors.New("no build stage in current context")
@@ -493,7 +517,7 @@ func CurrentStage(s []Stage) (*Stage, error) {
 	return &s[len(s)-1], nil
 }
 
-// HasStage looks for the presence of a given stage name
+// HasStage looks for the presence of a given stage name from a list of stages.
 func HasStage(s []Stage, name string) (int, bool) {
 	for i, stage := range s {
 		// Stage name is case-insensitive by design

--- a/frontend/dockerfile/instructions/parse.go
+++ b/frontend/dockerfile/instructions/parse.go
@@ -1,3 +1,7 @@
+// The instructions package contains the definitions of the high-level
+// Dockerfile commands, as well as low-level primitives for extracting these
+// commands from a pre-parsed Abstract Syntax Tree.
+
 package instructions
 
 import (

--- a/frontend/dockerfile/parser/parser.go
+++ b/frontend/dockerfile/parser/parser.go
@@ -1,4 +1,5 @@
-// Package parser implements a parser and parse tree dumper for Dockerfiles.
+// The parser package implements a parser that transforms a raw byte-stream
+// into a low-level Abstract Syntax Tree.
 package parser
 
 import (
@@ -273,13 +274,15 @@ func newNodeFromLine(line string, d *directives, comments []string) (*Node, erro
 	}, nil
 }
 
-// Result is the result of parsing a Dockerfile
+// Result contains the bundled outputs from parsing a Dockerfile.
 type Result struct {
 	AST         *Node
 	EscapeToken rune
 	Warnings    []Warning
 }
 
+// Warning contains information to identify and locate a warning generated
+// during parsing.
 type Warning struct {
 	Short    string
 	Detail   [][]byte
@@ -300,8 +303,8 @@ func (r *Result) PrintWarnings(out io.Writer) {
 	}
 }
 
-// Parse reads lines from a Reader, parses the lines into an AST and returns
-// the AST and escape token
+// Parse consumes lines from a provided Reader, parses each line into an AST
+// and returns the results of doing so.
 func Parse(rwc io.Reader) (*Result, error) {
 	d := newDefaultDirectives()
 	currentLine := 0
@@ -420,7 +423,7 @@ func Parse(rwc io.Reader) (*Result, error) {
 	}, withLocation(handleScannerError(scanner.Err()), currentLine, 0)
 }
 
-// Extracts a heredoc from a possible heredoc regex match
+// heredocFromMatch extracts a heredoc from a possible heredoc regex match.
 func heredocFromMatch(match []string) (*Heredoc, error) {
 	if len(match) == 0 {
 		return nil, nil
@@ -474,9 +477,14 @@ func heredocFromMatch(match []string) (*Heredoc, error) {
 	}, nil
 }
 
+// ParseHeredoc parses a heredoc word from a target string, returning the
+// components from the doc.
 func ParseHeredoc(src string) (*Heredoc, error) {
 	return heredocFromMatch(reHeredoc.FindStringSubmatch(src))
 }
+
+// MustParseHeredoc is a variant of ParseHeredoc that discards the error, if
+// there was one present.
 func MustParseHeredoc(src string) *Heredoc {
 	heredoc, _ := ParseHeredoc(src)
 	return heredoc
@@ -502,6 +510,7 @@ func heredocsFromLine(line string) ([]Heredoc, error) {
 	return docs, nil
 }
 
+// ChompHeredocContent chomps leading tabs from the heredoc.
 func ChompHeredocContent(src string) string {
 	return reLeadingTabs.ReplaceAllString(src, "")
 }


### PR DESCRIPTION
:tada: Replaces #2952.

The parser documentation hasn't been updated in some time, so this patch adds some additional doc strings where relevant, and attempts to clean up the entire package to be more readable from a developer documentation point-of-view.