### PR TITLE
BUILDKIT_SBOM_SCAN build args

### DIFF
--- a/cmd/buildctl/build.go
+++ b/cmd/buildctl/build.go
@@ -278,26 +278,13 @@ func buildAction(clicontext *cli.Context) error {
 			}
 		}()
 
-		solveAttr := map[string]string{}
-		frontendAttr := map[string]string{}
-		for k, v := range solveOpt.FrontendAttrs {
-			if strings.HasPrefix(k, "attest:") || strings.HasPrefix(k, "build-arg:BUILDKIT_ATTEST_") {
-				frontendAttr[k] = v
-			} else {
-				solveAttr[k] = v
-			}
-		}
-
 		sreq := gateway.SolveRequest{
 			Frontend:    solveOpt.Frontend,
-			FrontendOpt: solveAttr,
+			FrontendOpt: solveOpt.FrontendAttrs,
 		}
 		if def != nil {
 			sreq.Definition = def.ToPB()
 		}
-		solveOpt.Frontend = ""
-		solveOpt.FrontendAttrs = frontendAttr
-
 		resp, err := c.Build(ctx, solveOpt, "buildctl", func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
 			_, isSubRequest := sreq.FrontendOpt["requestid"]
 			if isSubRequest {

--- a/examples/dockerfile2llb/main.go
+++ b/examples/dockerfile2llb/main.go
@@ -41,7 +41,7 @@ func xmain() error {
 
 	caps := pb.Caps.CapSet(pb.Caps.All())
 
-	state, img, err := dockerfile2llb.Dockerfile2LLB(appcontext.Context(), df, dockerfile2llb.ConvertOpt{
+	state, img, _, err := dockerfile2llb.Dockerfile2LLB(appcontext.Context(), df, dockerfile2llb.ConvertOpt{
 		MetaResolver: imagemetaresolver.Default(),
 		Target:       opt.target,
 		LLBCaps:      &caps,

--- a/frontend/attestations/sbom/sbom.go
+++ b/frontend/attestations/sbom/sbom.go
@@ -1,4 +1,4 @@
-package attest
+package sbom
 
 import (
 	"context"

--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -21,8 +21,8 @@ import (
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/frontend"
-	"github.com/moby/buildkit/frontend/attest"
 	"github.com/moby/buildkit/frontend/attestations"
+	"github.com/moby/buildkit/frontend/attestations/sbom"
 	"github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb"
 	"github.com/moby/buildkit/frontend/dockerfile/dockerignore"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
@@ -489,7 +489,7 @@ func Build(ctx context.Context, c client.Client) (_ *client.Result, err error) {
 		}
 	}
 
-	var scanner attest.Scanner
+	var scanner sbom.Scanner
 	attests, err := attestations.Parse(opts)
 	if err != nil {
 		return nil, err
@@ -506,7 +506,7 @@ func Build(ctx context.Context, c client.Client) (_ *client.Result, err error) {
 		ref = reference.TagNameOnly(ref)
 		exportMap = true
 
-		scanner, err = attest.CreateSBOMScanner(ctx, c, ref.String())
+		scanner, err = sbom.CreateSBOMScanner(ctx, c, ref.String())
 		if err != nil {
 			return nil, err
 		}

--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -434,8 +434,9 @@ func Build(ctx context.Context, c client.Client) (_ *client.Result, err error) {
 		return nil, err
 	}
 
+	target := opts[keyTarget]
 	convertOpt := dockerfile2llb.ConvertOpt{
-		Target:           opts[keyTarget],
+		Target:           target,
 		MetaResolver:     c,
 		BuildArgs:        filter(opts, buildArgPrefix),
 		Labels:           filter(opts, labelPrefix),
@@ -511,6 +512,7 @@ func Build(ctx context.Context, c client.Client) (_ *client.Result, err error) {
 			return nil, err
 		}
 	}
+	scanTargets := make([]*dockerfile2llb.SBOMTargets, len(targetPlatforms))
 
 	eg, ctx2 = errgroup.WithContext(ctx)
 
@@ -523,8 +525,7 @@ func Build(ctx context.Context, c client.Client) (_ *client.Result, err error) {
 					opt.Warn = nil
 				}
 				opt.ContextByName = contextByNameFunc(c, c.BuildOpts().SessionID)
-				st, img, err := dockerfile2llb.Dockerfile2LLB(ctx2, dtDockerfile, opt)
-
+				st, img, scanTarget, err := dockerfile2llb.Dockerfile2LLB(ctx2, dtDockerfile, opt)
 				if err != nil {
 					return err
 				}
@@ -601,6 +602,7 @@ func Build(ctx context.Context, c client.Client) (_ *client.Result, err error) {
 						Platform: p,
 					}
 				}
+				scanTargets[i] = scanTarget
 				return nil
 			})
 		}(i, tp)
@@ -611,17 +613,8 @@ func Build(ctx context.Context, c client.Client) (_ *client.Result, err error) {
 	}
 
 	if scanner != nil {
-		for _, p := range expPlatforms.Platforms {
-			ref, ok := res.Refs[p.ID]
-			if !ok {
-				return nil, errors.Errorf("could not find ref %s", p.ID)
-			}
-			st, err := ref.ToState()
-			if err != nil {
-				return nil, err
-			}
-
-			att, st, err := scanner(ctx, p.ID, st, nil)
+		for i, p := range expPlatforms.Platforms {
+			att, st, err := scanner(ctx, p.ID, scanTargets[i].Core, scanTargets[i].Extras)
 			if err != nil {
 				return nil, err
 			}

--- a/frontend/dockerfile/dockerfile2llb/convert_test.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_test.go
@@ -31,7 +31,7 @@ ENV FOO bar
 COPY f1 f2 /sub/
 RUN ls -l
 `
-	_, _, err := Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
+	_, _, _, err := Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
 	assert.NoError(t, err)
 
 	df = `FROM scratch AS foo
@@ -40,7 +40,7 @@ FROM foo
 COPY --from=foo f1 /
 COPY --from=0 f2 /
 	`
-	_, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
+	_, _, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
 	assert.NoError(t, err)
 
 	df = `FROM scratch AS foo
@@ -49,12 +49,12 @@ FROM foo
 COPY --from=foo f1 /
 COPY --from=0 f2 /
 	`
-	_, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{
+	_, _, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{
 		Target: "Foo",
 	})
 	assert.NoError(t, err)
 
-	_, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{
+	_, _, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{
 		Target: "nosuch",
 	})
 	assert.Error(t, err)
@@ -62,21 +62,21 @@ COPY --from=0 f2 /
 	df = `FROM scratch
 	ADD http://github.com/moby/buildkit/blob/master/README.md /
 		`
-	_, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
+	_, _, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
 	assert.NoError(t, err)
 
 	df = `FROM scratch
 	COPY http://github.com/moby/buildkit/blob/master/README.md /
 		`
-	_, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
+	_, _, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
 	assert.EqualError(t, err, "source can't be a URL for COPY")
 
 	df = `FROM "" AS foo`
-	_, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
+	_, _, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
 	assert.Error(t, err)
 
 	df = `FROM ${BLANK} AS foo`
-	_, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
+	_, _, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
 	assert.Error(t, err)
 }
 
@@ -174,7 +174,7 @@ func TestDockerfileCircularDependencies(t *testing.T) {
 	df := `FROM busybox AS stage0
 COPY --from=stage0 f1 /sub/
 `
-	_, _, err := Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
+	_, _, _, err := Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
 	assert.EqualError(t, err, "circular dependency detected on stage: stage0")
 
 	// multiple stages with circular dependency
@@ -185,6 +185,6 @@ COPY --from=stage0 f2 /sub/
 FROM busybox AS stage2
 COPY --from=stage1 f2 /sub/
 `
-	_, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
+	_, _, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
 	assert.EqualError(t, err, "circular dependency detected on stage: stage0")
 }

--- a/solver/llbsolver/proc/sbom.go
+++ b/solver/llbsolver/proc/sbom.go
@@ -7,7 +7,7 @@ import (
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/frontend"
-	"github.com/moby/buildkit/frontend/attest"
+	"github.com/moby/buildkit/frontend/attestations/sbom"
 	"github.com/moby/buildkit/solver"
 	"github.com/moby/buildkit/solver/llbsolver"
 	"github.com/pkg/errors"
@@ -16,7 +16,7 @@ import (
 func SBOMProcessor(scannerRef string) llbsolver.Processor {
 	return func(ctx context.Context, res *llbsolver.Result, s *llbsolver.Solver, j *solver.Job) (*llbsolver.Result, error) {
 		// skip sbom generation if we already have an sbom
-		if attest.HasSBOM(res.Result) {
+		if sbom.HasSBOM(res.Result) {
 			return res, nil
 		}
 
@@ -32,7 +32,7 @@ func SBOMProcessor(scannerRef string) llbsolver.Processor {
 			}
 		}
 
-		scanner, err := attest.CreateSBOMScanner(ctx, s.Bridge(j), scannerRef)
+		scanner, err := sbom.CreateSBOMScanner(ctx, s.Bridge(j), scannerRef)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
:hammer_and_wrench: Fixes #3185 
:arrow_up: Follows up #2983 
    
This patch adds `BUILDKIT_SBOM_SCAN_CONTEXT` and `BUILDKIT_SBOM_SCAN_STAGE` which can configure scanning of the build context and intermediate dockerfile stages respectively.
    
To use these, the underlying Dockerfile must declare these args, and optionally assign a default value. `BUILDKIT_SBOM_SCAN_CONTEXT` must either be set in the global meta args before a FROM or in the target stage, while `BUILDKIT_SBOM_SCAN_STAGE` must be set in each target stage.
    
The user can additionally override the values set in the Dockerfile to change the behavior.