### PR TITLE
Add depot.dev to the list of BuildKit users

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ BuildKit is used by the following projects:
 -   [Gitpod](https://github.com/gitpod-io/gitpod)
 -   [Dagger](https://dagger.io)
 -   [envd](https://github.com/tensorchord/envd/)
+-   [Depot](https://depot.dev)
 
 ## Quick start
 


### PR DESCRIPTION
Adds [Depot](https://depot.dev) to the list of BuildKit users - we're running hosted BuildKit on behalf of our customers. 🙂 

Signed-off-by: Jacob Gillespie <jacobwgillespie@gmail.com>