### PR TITLE
Do not unpack when there are no layers present.

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -96,6 +96,7 @@ func TestIntegration(t *testing.T) {
 		testBuildHTTPSource,
 		testBuildPushAndValidate,
 		testBuildExportWithUncompressed,
+		testBuildExportScratch,
 		testResolveAndHosts,
 		testUser,
 		testOCIExporter,
@@ -1974,6 +1975,58 @@ func testBuildMultiMount(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 
 	checkAllReleasable(t, c, sb, true)
+}
+
+func testBuildExportScratch(t *testing.T, sb integration.Sandbox) {
+	integration.SkipIfDockerd(t, sb, "image exporter")
+
+	requiresLinux(t)
+	c, err := New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	st := llb.Scratch()
+	def, err := st.Marshal(sb.Context())
+	require.NoError(t, err)
+
+	registry, err := sb.NewRegistry()
+	if errors.Is(err, integration.ErrRequirements) {
+		t.Skip(err.Error())
+	}
+	require.NoError(t, err)
+
+	target := registry + "/buildkit/build/exporter:withnocompressed"
+
+	_, err = c.Solve(sb.Context(), def, SolveOpt{
+		Exports: []ExportEntry{
+			{
+				Type: ExporterImage,
+				Attrs: map[string]string{
+					"name":        target,
+					"push":        "true",
+					"compression": "uncompressed",
+				},
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	ctx := namespaces.WithNamespace(sb.Context(), "buildkit")
+	cdAddress := sb.ContainerdAddress()
+	var client *containerd.Client
+	if cdAddress != "" {
+		client, err = newContainerd(cdAddress)
+		require.NoError(t, err)
+		defer client.Close()
+
+		img, err := client.GetImage(ctx, target)
+		require.NoError(t, err)
+		mfst, err := images.Manifest(ctx, client.ContentStore(), img.Target(), nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, len(mfst.Layers))
+		err = client.ImageService().Delete(ctx, target, images.SynchronousDelete())
+		require.NoError(t, err)
+	}
 }
 
 func testBuildHTTPSource(t *testing.T, sb integration.Sandbox) {

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -265,7 +265,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 				}
 				tagDone(nil)
 
-				if e.unpack {
+				if src.Ref != nil && e.unpack {
 					if err := e.unpackImage(ctx, img, src, session.NewGroup(sessionID)); err != nil {
 						return nil, err
 					}


### PR DESCRIPTION
Fixes: https://github.com/moby/buildkit/issues/3212 When trying to build scratch images and unpacking is true, containerd worker results in a panic. In order to avoid this, unpack only when num layers are greater than 0.

Signed-off-by: Manu Gupta <manugupt1@gmail.com>