### PR TITLE
containerdexecutor: clean up task if Start() fails

### DIFF
--- a/executor/containerdexecutor/executor.go
+++ b/executor/containerdexecutor/executor.go
@@ -205,7 +205,7 @@ func (w *containerdExecutor) Run(ctx context.Context, id string, root executor.M
 	}
 
 	defer func() {
-		if _, err1 := task.Delete(context.TODO()); err == nil && err1 != nil {
+		if _, err1 := task.Delete(context.TODO(), containerd.WithProcessKill); err == nil && err1 != nil {
 			err = errors.Wrapf(err1, "failed to delete task %s", id)
 		}
 	}()


### PR DESCRIPTION
Deleting a containerd task whose status is Created fails with a "precondition failed" error. This is because (aside from Windows) a process is spawned when the task is created, and deleting the task while the process is running would leak the process if it was allowed. Change the deferred `task.Delete` call to pass the `WithProcessKill` delete option so the cleanup has a chance to succeed in the event that the `p.Start` call inside `runProcess` returns an error.

Signed-off-by: Cory Snider <csnider@mirantis.com>