### PR TITLE
[0.10 backport] Make SELinux labels opt-in (`--oci-worker-selinux=<BOOL>`)

### DIFF
--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -81,6 +81,9 @@ type OCIConfig struct {
 	// The profile should already be loaded (by a higher level system) before creating a worker.
 	ApparmorProfile string `toml:"apparmor-profile"`
 
+	// SELinux enables applying SELinux labels.
+	SELinux bool `toml:"selinux"`
+
 	// MaxParallelism is the maximum number of parallel build steps that can be run at the same time.
 	MaxParallelism int `toml:"max-parallelism"`
 }
@@ -98,6 +101,9 @@ type ContainerdConfig struct {
 	// ApparmorProfile is the name of the apparmor profile that should be used to constrain build containers.
 	// The profile should already be loaded (by a higher level system) before creating a worker.
 	ApparmorProfile string `toml:"apparmor-profile"`
+
+	// SELinux enables applying SELinux labels.
+	SELinux bool `toml:"selinux"`
 
 	MaxParallelism int `toml:"max-parallelism"`
 

--- a/cmd/buildkitd/main_containerd_worker.go
+++ b/cmd/buildkitd/main_containerd_worker.go
@@ -99,6 +99,10 @@ func init() {
 			Name:  "containerd-worker-apparmor-profile",
 			Usage: "set the name of the apparmor profile applied to containers",
 		},
+		cli.BoolFlag{
+			Name:  "containerd-worker-selinux",
+			Usage: "apply SELinux labels",
+		},
 	}
 	n := "containerd-worker-rootless"
 	u := "enable rootless mode"
@@ -217,6 +221,9 @@ func applyContainerdFlags(c *cli.Context, cfg *config.Config) error {
 	if c.GlobalIsSet("containerd-worker-apparmor-profile") {
 		cfg.Workers.Containerd.ApparmorProfile = c.GlobalString("containerd-worker-apparmor-profile")
 	}
+	if c.GlobalIsSet("containerd-worker-selinux") {
+		cfg.Workers.Containerd.SELinux = c.GlobalBool("containerd-worker-selinux")
+	}
 
 	return nil
 }
@@ -259,7 +266,7 @@ func containerdWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([
 	if cfg.Snapshotter != "" {
 		snapshotter = cfg.Snapshotter
 	}
-	opt, err := containerd.NewWorkerOpt(common.config.Root, cfg.Address, snapshotter, cfg.Namespace, cfg.Rootless, cfg.Labels, dns, nc, common.config.Workers.Containerd.ApparmorProfile, parallelismSem, common.traceSocket, ctd.WithTimeout(60*time.Second))
+	opt, err := containerd.NewWorkerOpt(common.config.Root, cfg.Address, snapshotter, cfg.Namespace, cfg.Rootless, cfg.Labels, dns, nc, common.config.Workers.Containerd.ApparmorProfile, common.config.Workers.Containerd.SELinux, parallelismSem, common.traceSocket, ctd.WithTimeout(60*time.Second))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/buildkitd/main_oci_worker.go
+++ b/cmd/buildkitd/main_oci_worker.go
@@ -110,6 +110,10 @@ func init() {
 			Name:  "oci-worker-apparmor-profile",
 			Usage: "set the name of the apparmor profile applied to containers",
 		},
+		cli.BoolFlag{
+			Name:  "oci-worker-selinux",
+			Usage: "apply SELinux labels",
+		},
 	}
 	n := "oci-worker-rootless"
 	u := "enable rootless mode"
@@ -232,6 +236,10 @@ func applyOCIFlags(c *cli.Context, cfg *config.Config) error {
 	if c.GlobalIsSet("oci-worker-apparmor-profile") {
 		cfg.Workers.OCI.ApparmorProfile = c.GlobalString("oci-worker-apparmor-profile")
 	}
+	if c.GlobalIsSet("oci-worker-selinux") {
+		cfg.Workers.OCI.SELinux = c.GlobalBool("oci-worker-selinux")
+	}
+
 	return nil
 }
 
@@ -290,7 +298,7 @@ func ociWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([]worker
 		parallelismSem = semaphore.NewWeighted(int64(cfg.MaxParallelism))
 	}
 
-	opt, err := runc.NewWorkerOpt(common.config.Root, snFactory, cfg.Rootless, processMode, cfg.Labels, idmapping, nc, dns, cfg.Binary, cfg.ApparmorProfile, parallelismSem, common.traceSocket, cfg.DefaultCgroupParent)
+	opt, err := runc.NewWorkerOpt(common.config.Root, snFactory, cfg.Rootless, processMode, cfg.Labels, idmapping, nc, dns, cfg.Binary, cfg.ApparmorProfile, cfg.SELinux, parallelismSem, common.traceSocket, cfg.DefaultCgroupParent)
 	if err != nil {
 		return nil, err
 	}

--- a/executor/oci/spec.go
+++ b/executor/oci/spec.go
@@ -50,7 +50,7 @@ func (pm ProcessMode) String() string {
 
 // GenerateSpec generates spec using containerd functionality.
 // opts are ignored for s.Process, s.Hostname, and s.Mounts .
-func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mount, id, resolvConf, hostsFile string, namespace network.Namespace, cgroupParent string, processMode ProcessMode, idmap *idtools.IdentityMapping, apparmorProfile string, tracingSocket string, opts ...oci.SpecOpts) (*specs.Spec, func(), error) {
+func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mount, id, resolvConf, hostsFile string, namespace network.Namespace, cgroupParent string, processMode ProcessMode, idmap *idtools.IdentityMapping, apparmorProfile string, selinuxB bool, tracingSocket string, opts ...oci.SpecOpts) (*specs.Spec, func(), error) {
 	c := &containers.Container{
 		ID: id,
 	}
@@ -81,7 +81,7 @@ func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mou
 		return nil, nil, err
 	}
 
-	if securityOpts, err := generateSecurityOpts(meta.SecurityMode, apparmorProfile); err == nil {
+	if securityOpts, err := generateSecurityOpts(meta.SecurityMode, apparmorProfile, selinuxB); err == nil {
 		opts = append(opts, securityOpts...)
 	} else {
 		return nil, nil, err

--- a/executor/oci/spec_windows.go
+++ b/executor/oci/spec_windows.go
@@ -15,7 +15,7 @@ func generateMountOpts(resolvConf, hostsFile string) ([]oci.SpecOpts, error) {
 }
 
 // generateSecurityOpts may affect mounts, so must be called after generateMountOpts
-func generateSecurityOpts(mode pb.SecurityMode, apparmorProfile string) ([]oci.SpecOpts, error) {
+func generateSecurityOpts(mode pb.SecurityMode, apparmorProfile string, selinuxB bool) ([]oci.SpecOpts, error) {
 	if mode == pb.SecurityMode_INSECURE {
 		return nil, errors.New("no support for running in insecure mode on Windows")
 	}

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -48,6 +48,7 @@ type Opt struct {
 	DNS             *oci.DNSConfig
 	OOMScoreAdj     *int
 	ApparmorProfile string
+	SELinux         bool
 	TracingSocket   string
 }
 
@@ -67,6 +68,7 @@ type runcExecutor struct {
 	running          map[string]chan error
 	mu               sync.Mutex
 	apparmorProfile  string
+	selinux          bool
 	tracingSocket    string
 }
 
@@ -131,6 +133,7 @@ func New(opt Opt, networkProviders map[pb.NetMode]network.Provider) (executor.Ex
 		oomScoreAdj:      opt.OOMScoreAdj,
 		running:          make(map[string]chan error),
 		apparmorProfile:  opt.ApparmorProfile,
+		selinux:          opt.SELinux,
 		tracingSocket:    opt.TracingSocket,
 	}
 	return w, nil
@@ -251,7 +254,7 @@ func (w *runcExecutor) Run(ctx context.Context, id string, root executor.Mount, 
 		}
 	}
 
-	spec, cleanup, err := oci.GenerateSpec(ctx, meta, mounts, id, resolvConf, hostsFile, namespace, w.cgroupParent, w.processMode, w.idmap, w.apparmorProfile, w.tracingSocket, opts...)
+	spec, cleanup, err := oci.GenerateSpec(ctx, meta, mounts, id, resolvConf, hostsFile, namespace, w.cgroupParent, w.processMode, w.idmap, w.apparmorProfile, w.selinux, w.tracingSocket, opts...)
 	if err != nil {
 		return err
 	}

--- a/worker/containerd/containerd.go
+++ b/worker/containerd/containerd.go
@@ -18,8 +18,8 @@ import (
 	"github.com/moby/buildkit/util/leaseutil"
 	"github.com/moby/buildkit/util/network/netproviders"
 	"github.com/moby/buildkit/util/winlayers"
-	"github.com/moby/buildkit/worker"
 	"github.com/moby/buildkit/worker/base"
+	wlabel "github.com/moby/buildkit/worker/label"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/semaphore"
@@ -67,16 +67,16 @@ func newContainerd(root string, client *containerd.Client, snapshotterName, ns s
 		hostname = "unknown"
 	}
 	xlabels := map[string]string{
-		worker.LabelExecutor:    "containerd",
-		worker.LabelSnapshotter: snapshotterName,
-		worker.LabelHostname:    hostname,
-		worker.LabelNetwork:     npResolvedMode,
+		wlabel.Executor:    "containerd",
+		wlabel.Snapshotter: snapshotterName,
+		wlabel.Hostname:    hostname,
+		wlabel.Network:     npResolvedMode,
 	}
 	if apparmorProfile != "" {
-		xlabels[worker.LabelApparmorProfile] = apparmorProfile
+		xlabels[wlabel.ApparmorProfile] = apparmorProfile
 	}
-	xlabels[worker.LabelContainerdNamespace] = ns
-	xlabels[worker.LabelContainerdUUID] = serverInfo.UUID
+	xlabels[wlabel.ContainerdNamespace] = ns
+	xlabels[wlabel.ContainerdUUID] = serverInfo.UUID
 	for k, v := range labels {
 		xlabels[k] = v
 	}

--- a/worker/containerd/containerd.go
+++ b/worker/containerd/containerd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/containerd/containerd"
@@ -26,16 +27,16 @@ import (
 )
 
 // NewWorkerOpt creates a WorkerOpt.
-func NewWorkerOpt(root string, address, snapshotterName, ns string, rootless bool, labels map[string]string, dns *oci.DNSConfig, nopt netproviders.Opt, apparmorProfile string, parallelismSem *semaphore.Weighted, traceSocket string, opts ...containerd.ClientOpt) (base.WorkerOpt, error) {
+func NewWorkerOpt(root string, address, snapshotterName, ns string, rootless bool, labels map[string]string, dns *oci.DNSConfig, nopt netproviders.Opt, apparmorProfile string, selinux bool, parallelismSem *semaphore.Weighted, traceSocket string, opts ...containerd.ClientOpt) (base.WorkerOpt, error) {
 	opts = append(opts, containerd.WithDefaultNamespace(ns))
 	client, err := containerd.New(address, opts...)
 	if err != nil {
 		return base.WorkerOpt{}, errors.Wrapf(err, "failed to connect client to %q . make sure containerd is running", address)
 	}
-	return newContainerd(root, client, snapshotterName, ns, rootless, labels, dns, nopt, apparmorProfile, parallelismSem, traceSocket)
+	return newContainerd(root, client, snapshotterName, ns, rootless, labels, dns, nopt, apparmorProfile, selinux, parallelismSem, traceSocket)
 }
 
-func newContainerd(root string, client *containerd.Client, snapshotterName, ns string, rootless bool, labels map[string]string, dns *oci.DNSConfig, nopt netproviders.Opt, apparmorProfile string, parallelismSem *semaphore.Weighted, traceSocket string) (base.WorkerOpt, error) {
+func newContainerd(root string, client *containerd.Client, snapshotterName, ns string, rootless bool, labels map[string]string, dns *oci.DNSConfig, nopt netproviders.Opt, apparmorProfile string, selinux bool, parallelismSem *semaphore.Weighted, traceSocket string) (base.WorkerOpt, error) {
 	if strings.Contains(snapshotterName, "/") {
 		return base.WorkerOpt{}, errors.Errorf("bad snapshotter name: %q", snapshotterName)
 	}
@@ -67,10 +68,11 @@ func newContainerd(root string, client *containerd.Client, snapshotterName, ns s
 		hostname = "unknown"
 	}
 	xlabels := map[string]string{
-		wlabel.Executor:    "containerd",
-		wlabel.Snapshotter: snapshotterName,
-		wlabel.Hostname:    hostname,
-		wlabel.Network:     npResolvedMode,
+		wlabel.Executor:       "containerd",
+		wlabel.Snapshotter:    snapshotterName,
+		wlabel.Hostname:       hostname,
+		wlabel.Network:        npResolvedMode,
+		wlabel.SELinuxEnabled: strconv.FormatBool(selinux),
 	}
 	if apparmorProfile != "" {
 		xlabels[wlabel.ApparmorProfile] = apparmorProfile
@@ -134,7 +136,7 @@ func newContainerd(root string, client *containerd.Client, snapshotterName, ns s
 		ID:             id,
 		Labels:         xlabels,
 		MetadataStore:  md,
-		Executor:       containerdexecutor.New(client, root, "", np, dns, apparmorProfile, traceSocket, rootless),
+		Executor:       containerdexecutor.New(client, root, "", np, dns, apparmorProfile, selinux, traceSocket, rootless),
 		Snapshotter:    snap,
 		ContentStore:   cs,
 		Applier:        winlayers.NewFileSystemApplierWithWindows(cs, df),

--- a/worker/containerd/containerd_test.go
+++ b/worker/containerd/containerd_test.go
@@ -33,7 +33,7 @@ func newWorkerOpt(t *testing.T, addr string) (base.WorkerOpt, func()) {
 	require.NoError(t, err)
 	cleanup := func() { os.RemoveAll(tmpdir) }
 	rootless := false
-	workerOpt, err := NewWorkerOpt(tmpdir, addr, "overlayfs", "buildkit-test", rootless, nil, nil, netproviders.Opt{Mode: "host"}, "", nil, "")
+	workerOpt, err := NewWorkerOpt(tmpdir, addr, "overlayfs", "buildkit-test", rootless, nil, nil, netproviders.Opt{Mode: "host"}, "", false, nil, "")
 	require.NoError(t, err)
 	return workerOpt, cleanup
 }

--- a/worker/label/label.go
+++ b/worker/label/label.go
@@ -1,0 +1,15 @@
+package label
+
+// Pre-defined label keys
+const (
+	prefix = "org.mobyproject.buildkit.worker."
+
+	Executor            = prefix + "executor"    // "oci" or "containerd"
+	Snapshotter         = prefix + "snapshotter" // containerd snapshotter name ("overlay", "native", ...)
+	Hostname            = prefix + "hostname"
+	Network             = prefix + "network" // "cni" or "host"
+	ApparmorProfile     = prefix + "apparmor.profile"
+	OCIProcessMode      = prefix + "oci.process-mode"     // OCI worker: process mode ("sandbox", "no-sandbox")
+	ContainerdUUID      = prefix + "containerd.uuid"      // containerd worker: containerd UUID
+	ContainerdNamespace = prefix + "containerd.namespace" // containerd worker: containerd namespace
+)

--- a/worker/label/label.go
+++ b/worker/label/label.go
@@ -9,6 +9,7 @@ const (
 	Hostname            = prefix + "hostname"
 	Network             = prefix + "network" // "cni" or "host"
 	ApparmorProfile     = prefix + "apparmor.profile"
+	SELinuxEnabled      = prefix + "selinux.enabled"      // "true" or "false"
 	OCIProcessMode      = prefix + "oci.process-mode"     // OCI worker: process mode ("sandbox", "no-sandbox")
 	ContainerdUUID      = prefix + "containerd.uuid"      // containerd worker: containerd UUID
 	ContainerdNamespace = prefix + "containerd.namespace" // containerd worker: containerd namespace

--- a/worker/runc/runc.go
+++ b/worker/runc/runc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/containerd/containerd/content/local"
 	"github.com/containerd/containerd/diff/apply"
@@ -34,7 +35,7 @@ type SnapshotterFactory struct {
 }
 
 // NewWorkerOpt creates a WorkerOpt.
-func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, processMode oci.ProcessMode, labels map[string]string, idmap *idtools.IdentityMapping, nopt netproviders.Opt, dns *oci.DNSConfig, binary, apparmorProfile string, parallelismSem *semaphore.Weighted, traceSocket, defaultCgroupParent string) (base.WorkerOpt, error) {
+func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, processMode oci.ProcessMode, labels map[string]string, idmap *idtools.IdentityMapping, nopt netproviders.Opt, dns *oci.DNSConfig, binary, apparmorProfile string, selinux bool, parallelismSem *semaphore.Weighted, traceSocket, defaultCgroupParent string) (base.WorkerOpt, error) {
 	var opt base.WorkerOpt
 	name := "runc-" + snFactory.Name
 	root = filepath.Join(root, name)
@@ -65,6 +66,7 @@ func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, proc
 		IdentityMapping:     idmap,
 		DNS:                 dns,
 		ApparmorProfile:     apparmorProfile,
+		SELinux:             selinux,
 		TracingSocket:       traceSocket,
 		DefaultCgroupParent: defaultCgroupParent,
 	}, np)
@@ -109,6 +111,7 @@ func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, proc
 		wlabel.Hostname:       hostname,
 		wlabel.Network:        npResolvedMode,
 		wlabel.OCIProcessMode: processMode.String(),
+		wlabel.SELinuxEnabled: strconv.FormatBool(selinux),
 	}
 	if apparmorProfile != "" {
 		xlabels[wlabel.ApparmorProfile] = apparmorProfile

--- a/worker/runc/runc.go
+++ b/worker/runc/runc.go
@@ -20,8 +20,8 @@ import (
 	"github.com/moby/buildkit/util/leaseutil"
 	"github.com/moby/buildkit/util/network/netproviders"
 	"github.com/moby/buildkit/util/winlayers"
-	"github.com/moby/buildkit/worker"
 	"github.com/moby/buildkit/worker/base"
+	wlabel "github.com/moby/buildkit/worker/label"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	bolt "go.etcd.io/bbolt"
 	"golang.org/x/sync/semaphore"
@@ -104,14 +104,14 @@ func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, proc
 		hostname = "unknown"
 	}
 	xlabels := map[string]string{
-		worker.LabelExecutor:       "oci",
-		worker.LabelSnapshotter:    snFactory.Name,
-		worker.LabelHostname:       hostname,
-		worker.LabelNetwork:        npResolvedMode,
-		worker.LabelOCIProcessMode: processMode.String(),
+		wlabel.Executor:       "oci",
+		wlabel.Snapshotter:    snFactory.Name,
+		wlabel.Hostname:       hostname,
+		wlabel.Network:        npResolvedMode,
+		wlabel.OCIProcessMode: processMode.String(),
 	}
 	if apparmorProfile != "" {
-		xlabels[worker.LabelApparmorProfile] = apparmorProfile
+		xlabels[wlabel.ApparmorProfile] = apparmorProfile
 	}
 
 	for k, v := range labels {

--- a/worker/runc/runc_test.go
+++ b/worker/runc/runc_test.go
@@ -41,7 +41,7 @@ func newWorkerOpt(t *testing.T, processMode oci.ProcessMode) (base.WorkerOpt, fu
 		},
 	}
 	rootless := false
-	workerOpt, err := NewWorkerOpt(tmpdir, snFactory, rootless, processMode, nil, nil, netproviders.Opt{Mode: "host"}, nil, "", "", nil, "", "")
+	workerOpt, err := NewWorkerOpt(tmpdir, snFactory, rootless, processMode, nil, nil, netproviders.Opt{Mode: "host"}, nil, "", "", false, nil, "", "")
 	require.NoError(t, err)
 
 	return workerOpt, cleanup

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -41,16 +41,3 @@ type Infos interface {
 	GetDefault() (Worker, error)
 	WorkerInfos() []client.WorkerInfo
 }
-
-// Pre-defined label keys
-const (
-	labelPrefix              = "org.mobyproject.buildkit.worker."
-	LabelExecutor            = labelPrefix + "executor"    // "oci" or "containerd"
-	LabelSnapshotter         = labelPrefix + "snapshotter" // containerd snapshotter name ("overlay", "native", ...)
-	LabelHostname            = labelPrefix + "hostname"
-	LabelNetwork             = labelPrefix + "network" // "cni" or "host"
-	LabelApparmorProfile     = labelPrefix + "apparmor.profile"
-	LabelOCIProcessMode      = labelPrefix + "oci.process-mode"     // OCI worker: process mode ("sandbox", "no-sandbox")
-	LabelContainerdUUID      = labelPrefix + "containerd.uuid"      // containerd worker: containerd UUID
-	LabelContainerdNamespace = labelPrefix + "containerd.namespace" // containerd worker: containerd namespace
-)


### PR DESCRIPTION
Cherry-pick
- #3014
- #3203


Cherry-picking #3203 was not clean, and resolved by removing `NetworkProviders: np`
<details>

<p>

```console
$ git cherry-pick -xsS bd57e5f6b8d0f9583c1f20cbe4867b0138848920
Auto-merging cmd/buildkitd/config/config.go
Auto-merging cmd/buildkitd/main_containerd_worker.go
Auto-merging cmd/buildkitd/main_oci_worker.go
Auto-merging executor/containerdexecutor/executor.go
Auto-merging executor/runcexecutor/executor.go
Auto-merging worker/containerd/containerd.go
CONFLICT (content): Merge conflict in worker/containerd/containerd.go
Auto-merging worker/containerd/containerd_test.go
Auto-merging worker/runc/runc.go
Auto-merging worker/runc/runc_test.go
error: could not apply bd57e5f6... Make SELinux labels opt-in (`--oci-worker-selinux=<BOOL>`)
hint: After resolving the conflicts, mark them with
hint: "git add/rm <pathspec>", then run
hint: "git cherry-pick --continue".
hint: You can instead skip this commit with "git cherry-pick --skip".
hint: To abort and get back to the state before "git cherry-pick",
hint: run "git cherry-pick --abort".

$ git diff
diff --cc worker/containerd/containerd.go
index 7ccb8174,a829d457..00000000
--- a/worker/containerd/containerd.go
+++ b/worker/containerd/containerd.go
@@@ -131,20 -133,21 +133,38 @@@ func newContainerd(root string, client 
        }
  
        opt := base.WorkerOpt{
++<<<<<<< HEAD
 +              ID:             id,
 +              Labels:         xlabels,
 +              MetadataStore:  md,
 +              Executor:       containerdexecutor.New(client, root, "", np, dns, apparmorProfile, traceSocket, rootless),
 +              Snapshotter:    snap,
 +              ContentStore:   cs,
 +              Applier:        winlayers.NewFileSystemApplierWithWindows(cs, df),
 +              Differ:         winlayers.NewWalkingDiffWithWindows(cs, df),
 +              ImageStore:     client.ImageService(),
 +              Platforms:      platforms,
 +              LeaseManager:   lm,
 +              GarbageCollect: gc,
 +              ParallelismSem: parallelismSem,
 +              MountPoolRoot:  filepath.Join(root, "cachemounts"),
++=======
+               ID:               id,
+               Labels:           xlabels,
+               MetadataStore:    md,
+               NetworkProviders: np,
+               Executor:         containerdexecutor.New(client, root, "", np, dns, apparmorProfile, selinux, traceSocket, rootless),
+               Snapshotter:      snap,
+               ContentStore:     cs,
+               Applier:          winlayers.NewFileSystemApplierWithWindows(cs, df),
+               Differ:           winlayers.NewWalkingDiffWithWindows(cs, df),
+               ImageStore:       client.ImageService(),
+               Platforms:        platforms,
+               LeaseManager:     lm,
+               GarbageCollect:   gc,
+               ParallelismSem:   parallelismSem,
+               MountPoolRoot:    filepath.Join(root, "cachemounts"),
++>>>>>>> bd57e5f6 (Make SELinux labels opt-in (`--oci-worker-selinux=<BOOL>`))
        }
        return opt, nil
  }
```

</p>

</details>