### PR TITLE
fix link to community slack

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -150,7 +150,7 @@ otherwise cleanup our project.
     <td>
       <p>
         Register for the Docker Community Slack (dockercommunity.slack.com)
-        <a href="https://dockr.ly/slack" target="_blank">Click here for an invite to docker community slack</a>.
+        <a href="https://dockr.ly/comm-slack" target="_blank">Click here for an invite to docker community slack</a>.
         You'll find us in <code>#buildkit</code> channel, and the <code>#moby-project</code> channel for general discussions.
       </p>
     </td>

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Read the proposal from https://github.com/moby/moby/issues/32925
 
 Introductory blog post https://blog.mobyproject.org/introducing-buildkit-17e056cc5317
 
-Join `#buildkit` channel on [Docker Community Slack](http://dockr.ly/slack)
+Join `#buildkit` channel on [Docker Community Slack](https://dockr.ly/comm-slack)
 
 > **Note**
 >

--- a/docs/images-readme.md
+++ b/docs/images-readme.md
@@ -4,7 +4,7 @@ BuildKit is a concurrent, cache-efficient, and Dockerfile-agnostic builder toolk
 
 Report issues at https://github.com/moby/buildkit
 
-Join `#buildkit` channel on [Docker Community Slack](http://dockr.ly/slack)
+Join `#buildkit` channel on [Docker Community Slack](https://dockr.ly/comm-slack)
 
 # Tags
 


### PR DESCRIPTION
follow-up https://github.com/moby/buildkit/issues/3131

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>