### PR TITLE
chore: use double spaces when marshalling manifests/indexes

### DIFF
--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -205,7 +205,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 		labels[fmt.Sprintf("containerd.io/gc.ref.content.%d", len(p.Platforms)+i)] = mfst.Digest.String()
 	}
 
-	idxBytes, err := json.MarshalIndent(idx, "", "   ")
+	idxBytes, err := json.MarshalIndent(idx, "", "  ")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to marshal index")
 	}
@@ -482,7 +482,7 @@ func (ic *ImageWriter) commitDistributionManifest(ctx context.Context, opts *Ima
 		labels[fmt.Sprintf("containerd.io/gc.ref.content.%d", i+1)] = desc.Digest.String()
 	}
 
-	mfstJSON, err := json.MarshalIndent(mfst, "", "   ")
+	mfstJSON, err := json.MarshalIndent(mfst, "", "  ")
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to marshal manifest")
 	}
@@ -594,7 +594,7 @@ func (ic *ImageWriter) commitAttestationsManifest(ctx context.Context, opts *Ima
 		labels[fmt.Sprintf("containerd.io/gc.ref.content.%d", i+1)] = desc.Digest.String()
 	}
 
-	mfstJSON, err := json.MarshalIndent(mfst, "", "   ")
+	mfstJSON, err := json.MarshalIndent(mfst, "", "  ")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to marshal manifest")
 	}

--- a/util/imageutil/schema1.go
+++ b/util/imageutil/schema1.go
@@ -69,7 +69,7 @@ func convertSchema1ConfigMeta(in []byte) ([]byte, error) {
 		}
 	}
 
-	dt, err := json.MarshalIndent(img, "", "   ")
+	dt, err := json.MarshalIndent(img, "", "  ")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to marshal schema1 config")
 	}


### PR DESCRIPTION
Use double spaces for JSON marshalling instead of triple spaces.

I noticed this first in https://github.com/moby/buildkit/pull/3240/files#diff-93b81ebb2d74a7ff89a643dfd137603e309b87754076de895b0c15dd4626a169L208, but there's a few other guilty culprits, as well as [this one in buildx](https://github.com/docker/buildx/blob/1f6612b118018028ab2ed5b01b85d500eb7cb556/util/imagetools/create.go#L141) found by @crazy-max.

I *assume* this is a mistake that's somehow been propagated via copy-paste-fu, instead of an intentional design decision?