### PR TITLE
Skip boltdb update call when queue is empty

### DIFF
--- a/cache/metadata/metadata.go
+++ b/cache/metadata/metadata.go
@@ -317,6 +317,9 @@ func (s *StorageItem) Queue(fn func(b *bolt.Bucket) error) {
 func (s *StorageItem) Commit() error {
 	s.qmu.Lock()
 	defer s.qmu.Unlock()
+	if len(s.queue) == 0 {
+		return nil
+	}
 	return errors.WithStack(s.Update(func(b *bolt.Bucket) error {
 		for _, fn := range s.queue {
 			if err := fn(b); err != nil {


### PR DESCRIPTION
This prevents unnecessary calls (and disk writes) to the metadata cache db when there are no items in the queue.

Some quick testing on my laptop with a cache containing 26,000 items; this change reduced buildkit startup time from roughly 46 seconds down to 2 seconds.