### PR TITLE
integration: remove containerd 1.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,6 @@ jobs:
           - containerd
           - containerd-rootless
           - containerd-1.5
-          - containerd-1.4
           - containerd-snapshotter-stargz
           - oci
           - oci-rootless

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -3345,11 +3345,6 @@ func testPullZstdImage(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	if sb.Name() == "containerd-1.4" {
-		// containerd 1.4 doesn't support zstd compression
-		return
-	}
-
 	ensurePruneAll(t, c, sb)
 
 	st = llb.Scratch().File(llb.Copy(llb.Image(target), "/data", "/zdata"))
@@ -4242,10 +4237,6 @@ func testUncompressedRegistryCacheImportExport(t *testing.T, sb integration.Sand
 
 func testZstdLocalCacheImportExport(t *testing.T, sb integration.Sandbox) {
 	integration.SkipIfDockerd(t, sb, "remote cache export")
-	if sb.Name() == "containerd-1.4" {
-		// containerd 1.4 doesn't support zstd compression
-		return
-	}
 	dir := t.TempDir()
 	im := CacheOptionsEntry{
 		Type: "local",
@@ -4267,10 +4258,6 @@ func testZstdLocalCacheImportExport(t *testing.T, sb integration.Sandbox) {
 
 func testZstdRegistryCacheImportExport(t *testing.T, sb integration.Sandbox) {
 	integration.SkipIfDockerd(t, sb, "remote cache export")
-	if sb.Name() == "containerd-1.4" {
-		// containerd 1.4 doesn't support zstd compression
-		return
-	}
 	registry, err := sb.NewRegistry()
 	if errors.Is(err, integration.ErrRequirements) {
 		t.Skip(err.Error())


### PR DESCRIPTION
containerd 1.4 has reached EOL on March 3, 2022

https://github.com/containerd/containerd/blob/main/RELEASES.md
