### PR TITLE
feat: add skip tls verify configuration when fetching token from slef…

### DIFF
--- a/cmd/buildctl/build.go
+++ b/cmd/buildctl/build.go
@@ -38,6 +38,10 @@ var buildCommand = cli.Command{
 	`,
 	Action: buildAction,
 	Flags: []cli.Flag{
+		cli.BoolFlag{
+			Name:  "skip-token-tls-verify",
+			Usage: "Skip TLS verify when fetching token.",
+		},
 		cli.StringSliceFlag{
 			Name:  "output,o",
 			Usage: "Define exports for build result, e.g. --output type=image,name=docker.io/username/image,push=true",
@@ -148,7 +152,7 @@ func buildAction(clicontext *cli.Context) error {
 	}
 
 	dockerConfig := config.LoadDefaultConfigFile(os.Stderr)
-	attachable := []session.Attachable{authprovider.NewDockerAuthProvider(dockerConfig)}
+	attachable := []session.Attachable{authprovider.NewDockerAuthProvider(dockerConfig, clicontext.Bool("skip-token-tls-verify"))}
 
 	if ssh := clicontext.StringSlice("ssh"); len(ssh) > 0 {
 		configs, err := build.ParseSSH(ssh)

--- a/util/httputil/httputil.go
+++ b/util/httputil/httputil.go
@@ -1,0 +1,17 @@
+package httputil
+
+import (
+	"crypto/tls"
+	"net/http"
+)
+
+func SkipTLSClient(insecure bool) *http.Client {
+	if !insecure {
+		return http.DefaultClient
+	}
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+}


### PR DESCRIPTION
add --skip-token-tls-verify flag in client to skip tls verify when fetching token.

ref issus: #3218 