### PR TITLE
[v0.10 backport] moby/moby/master -> moby/moby/v20.10.21

### DIFF
--- a/docs/build-repro.md
+++ b/docs/build-repro.md
@@ -36,7 +36,7 @@ The structure is base64 encoded and has the following format when decoded:
     },
     {
       "type": "http",
-      "ref": "https://raw.githubusercontent.com/moby/moby/master/README.md",
+      "ref": "https://raw.githubusercontent.com/moby/moby/v20.10.21/README.md",
       "pin": "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c"
     }
   ]

--- a/frontend/dockerfile/dockerfile_buildinfo_test.go
+++ b/frontend/dockerfile/dockerfile_buildinfo_test.go
@@ -55,7 +55,7 @@ func testBuildInfoSources(t *testing.T, sb integration.Sandbox) {
 	dockerfile := `
 FROM alpine:latest@sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300 AS alpine
 FROM busybox:latest
-ADD https://raw.githubusercontent.com/moby/moby/master/README.md /
+ADD https://raw.githubusercontent.com/moby/moby/v20.10.21/README.md /
 COPY --from=alpine /bin/busybox /alpine-busybox
 `
 
@@ -127,7 +127,7 @@ COPY --from=alpine /bin/busybox /alpine-busybox
 	assert.NotEmpty(t, sources[1].Pin)
 
 	assert.Equal(t, binfotypes.SourceTypeHTTP, sources[2].Type)
-	assert.Equal(t, "https://raw.githubusercontent.com/moby/moby/master/README.md", sources[2].Ref)
+	assert.Equal(t, "https://raw.githubusercontent.com/moby/moby/v20.10.21/README.md", sources[2].Ref)
 	assert.Equal(t, "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c", sources[2].Pin)
 }
 
@@ -261,7 +261,7 @@ func testBuildInfoMultiPlatform(t *testing.T, sb integration.Sandbox) {
 FROM busybox:latest
 ARG foo
 RUN echo $foo
-ADD https://raw.githubusercontent.com/moby/moby/master/README.md /
+ADD https://raw.githubusercontent.com/moby/moby/v20.10.21/README.md /
 `
 
 	dir, err := tmpdir(
@@ -314,7 +314,7 @@ ADD https://raw.githubusercontent.com/moby/moby/master/README.md /
 		assert.NotEmpty(t, sources[0].Pin)
 
 		assert.Equal(t, binfotypes.SourceTypeHTTP, sources[1].Type)
-		assert.Equal(t, "https://raw.githubusercontent.com/moby/moby/master/README.md", sources[1].Ref)
+		assert.Equal(t, "https://raw.githubusercontent.com/moby/moby/v20.10.21/README.md", sources[1].Ref)
 		assert.Equal(t, "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c", sources[1].Pin)
 	}
 }
@@ -478,7 +478,7 @@ func testBuildInfoDeps(t *testing.T, sb integration.Sandbox) {
 	dockerfile := []byte(`
 FROM alpine
 ENV FOO=bar
-ADD https://raw.githubusercontent.com/moby/moby/master/README.md /
+ADD https://raw.githubusercontent.com/moby/moby/v20.10.21/README.md /
 RUN echo first > /out
 `)
 
@@ -591,7 +591,7 @@ COPY --from=build /foo /out /
 	assert.NotEmpty(t, bi.Sources[0].Pin)
 
 	assert.Equal(t, binfotypes.SourceTypeHTTP, bi.Sources[1].Type)
-	assert.Equal(t, "https://raw.githubusercontent.com/moby/moby/master/README.md", bi.Sources[1].Ref)
+	assert.Equal(t, "https://raw.githubusercontent.com/moby/moby/v20.10.21/README.md", bi.Sources[1].Ref)
 	assert.Equal(t, "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c", bi.Sources[1].Pin)
 
 	require.Contains(t, bi.Deps, "base")
@@ -757,7 +757,7 @@ func testBuildInfoDepsMainNoSource(t *testing.T, sb integration.Sandbox) {
 	dockerfile := []byte(`
 FROM alpine
 ENV FOO=bar
-ADD https://raw.githubusercontent.com/moby/moby/master/README.md /
+ADD https://raw.githubusercontent.com/moby/moby/v20.10.21/README.md /
 RUN echo first > /out
 `)
 
@@ -864,7 +864,7 @@ RUN echo "foo is $FOO" > /foo
 	require.Equal(t, 1, len(bi.Sources))
 
 	assert.Equal(t, binfotypes.SourceTypeHTTP, bi.Sources[0].Type)
-	assert.Equal(t, "https://raw.githubusercontent.com/moby/moby/master/README.md", bi.Sources[0].Ref)
+	assert.Equal(t, "https://raw.githubusercontent.com/moby/moby/v20.10.21/README.md", bi.Sources[0].Ref)
 	assert.Equal(t, "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c", bi.Sources[0].Pin)
 
 	require.Contains(t, bi.Deps, "base")

--- a/util/buildinfo/buildinfo_test.go
+++ b/util/buildinfo/buildinfo_test.go
@@ -24,7 +24,7 @@ func TestMergeSources(t *testing.T) {
 		"docker-image://docker.io/moby/buildkit:v0.9.0@sha256:8dc668e7f66db1c044aadbed306020743516a94848793e0f81f94a087ee78cab":    "sha256:8dc668e7f66db1c044aadbed306020743516a94848793e0f81f94a087ee78cab",
 		"docker-image://docker.io/tonistiigi/xx@sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04":           "sha256:21a61be4744f6531cb5f33b0e6f40ede41fa3a1b8c82d5946178f80cc84bfc04",
 		"git://https://github.com/crazy-max/buildkit-buildsources-test.git#master":                                                 "259a5aa5aa5bb3562d12cc631fe399f4788642c1",
-		"https://raw.githubusercontent.com/moby/moby/master/README.md":                                                             "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c",
+		"https://raw.githubusercontent.com/moby/moby/v20.10.21/README.md":                                                          "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c",
 	}
 
 	frontendSources := []binfotypes.Source{
@@ -85,7 +85,7 @@ func TestMergeSources(t *testing.T) {
 		},
 		{
 			Type: binfotypes.SourceTypeHTTP,
-			Ref:  "https://raw.githubusercontent.com/moby/moby/master/README.md",
+			Ref:  "https://raw.githubusercontent.com/moby/moby/v20.10.21/README.md",
 			Pin:  "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c",
 		},
 	}, srcs)
@@ -184,7 +184,7 @@ func TestDedupSources(t *testing.T) {
 				},
 				{
 					Type: "http",
-					Ref:  "https://raw.githubusercontent.com/moby/moby/master/README.md",
+					Ref:  "https://raw.githubusercontent.com/moby/moby/v20.10.21/README.md",
 					Pin:  "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c",
 				},
 			},
@@ -208,7 +208,7 @@ func TestDedupSources(t *testing.T) {
 				},
 				{
 					Type: "http",
-					Ref:  "https://raw.githubusercontent.com/moby/moby/master/README.md",
+					Ref:  "https://raw.githubusercontent.com/moby/moby/v20.10.21/README.md",
 					Pin:  "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c",
 				},
 			},
@@ -233,7 +233,7 @@ func TestDedupSources(t *testing.T) {
 				},
 				{
 					Type: "http",
-					Ref:  "https://raw.githubusercontent.com/moby/moby/master/README.md",
+					Ref:  "https://raw.githubusercontent.com/moby/moby/v20.10.21/README.md",
 					Pin:  "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c",
 				},
 			},
@@ -262,7 +262,7 @@ func TestDedupSources(t *testing.T) {
 				},
 				{
 					Type: "http",
-					Ref:  "https://raw.githubusercontent.com/moby/moby/master/README.md",
+					Ref:  "https://raw.githubusercontent.com/moby/moby/v20.10.21/README.md",
 					Pin:  "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c",
 				},
 			},
@@ -384,7 +384,7 @@ func TestFormat(t *testing.T) {
 			},
 			{
 				Type: "http",
-				Ref:  "https://raw.githubusercontent.com/moby/moby/master/README.md",
+				Ref:  "https://raw.githubusercontent.com/moby/moby/v20.10.21/README.md",
 				Pin:  "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c",
 			},
 		},
@@ -445,7 +445,7 @@ func TestFormat(t *testing.T) {
 					},
 					{
 						Type: "http",
-						Ref:  "https://raw.githubusercontent.com/moby/moby/master/README.md",
+						Ref:  "https://raw.githubusercontent.com/moby/moby/v20.10.21/README.md",
 						Pin:  "sha256:419455202b0ef97e480d7f8199b26a721a417818bc0e2d106975f74323f25e6c",
 					},
 				},


### PR DESCRIPTION
- backport of https://github.com/moby/buildkit/pull/3275
- relates to https://github.com/moby/moby/pull/44452

Some tests were depending on the sha256sum of https://raw.githubusercontent.com/moby/moby/master/README.md

(cherry picked from commit ae97234682b1c6ccd746df7397259c43b40aa81c)
