### PR TITLE
Introduce annotation sanity checks

### DIFF
--- a/exporter/containerimage/annotations.go
+++ b/exporter/containerimage/annotations.go
@@ -100,20 +100,27 @@ func (ag AnnotationsGroup) Merge(other AnnotationsGroup) AnnotationsGroup {
 	if other == nil {
 		return ag
 	}
+	if ag == nil {
+		ag = make(AnnotationsGroup)
+	}
 
 	for k, v := range other {
-		if _, ok := ag[k]; ok {
-			ag[k].merge(v)
-		} else {
-			ag[k] = v
-		}
+		ag[k] = ag[k].merge(v)
 	}
 	return ag
 }
 
-func (a *Annotations) merge(other *Annotations) {
+func (a *Annotations) merge(other *Annotations) *Annotations {
 	if other == nil {
-		return
+		return a
+	}
+	if a == nil {
+		a = &Annotations{
+			IndexDescriptor:    make(map[string]string),
+			Index:              make(map[string]string),
+			Manifest:           make(map[string]string),
+			ManifestDescriptor: make(map[string]string),
+		}
 	}
 
 	for k, v := range other.Index {
@@ -128,4 +135,6 @@ func (a *Annotations) merge(other *Annotations) {
 	for k, v := range other.ManifestDescriptor {
 		a.ManifestDescriptor[k] = v
 	}
+
+	return a
 }

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -207,7 +207,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 	if err != nil {
 		return nil, err
 	}
-	opts.AddAnnotations(as)
+	opts.Annotations = opts.Annotations.Merge(as)
 
 	ctx, done, err := leaseutil.WithLease(ctx, e.opt.LeaseManager, leaseutil.MakeTemporary)
 	if err != nil {

--- a/exporter/containerimage/opts.go
+++ b/exporter/containerimage/opts.go
@@ -92,24 +92,9 @@ func (c *ImageCommitOpts) Load(opt map[string]string) (map[string]string, error)
 		c.EnableForceCompression(c.RefCfg.Compression.Type.String())
 	}
 
-	c.AddAnnotations(as)
+	c.Annotations = c.Annotations.Merge(as)
 
 	return rest, nil
-}
-
-func (c *ImageCommitOpts) AddAnnotations(annotations AnnotationsGroup) {
-	if annotations == nil {
-		return
-	}
-	if c.Annotations == nil {
-		c.Annotations = AnnotationsGroup{}
-	}
-	c.Annotations = c.Annotations.Merge(annotations)
-	for _, a := range annotations {
-		if len(a.Index)+len(a.IndexDescriptor)+len(a.ManifestDescriptor) > 0 {
-			c.EnableOCITypes("annotations")
-		}
-	}
 }
 
 func (c *ImageCommitOpts) EnableOCITypes(reason string) {

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -102,7 +102,12 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 			}
 		}
 
-		mfstDesc, configDesc, err := ic.commitDistributionManifest(ctx, opts, inp.Ref, inp.Metadata[exptypes.ExporterImageConfigKey], &remotes[0], opts.Annotations.Platform(nil), inp.Metadata[exptypes.ExporterInlineCache], dtbi, opts.Epoch, session.NewGroup(sessionID))
+		annotations := opts.Annotations.Platform(nil)
+		if len(annotations.Index) > 0 || len(annotations.IndexDescriptor) > 0 {
+			return nil, errors.Errorf("index annotations not supported for single platform export")
+		}
+
+		mfstDesc, configDesc, err := ic.commitDistributionManifest(ctx, opts, inp.Ref, inp.Metadata[exptypes.ExporterImageConfigKey], &remotes[0], annotations, inp.Metadata[exptypes.ExporterInlineCache], dtbi, opts.Epoch, session.NewGroup(sessionID))
 		if err != nil {
 			return nil, err
 		}

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -80,10 +80,17 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 		}
 	}
 
-	for _, a := range opts.Annotations {
+	for pk, a := range opts.Annotations {
+		if pk != "" {
+			if inp.Refs == nil {
+				return nil, errors.Errorf("invalid annotation: no platforms defined")
+			}
+			if _, ok := inp.Refs[pk]; !ok {
+				return nil, errors.Errorf("invalid annotation: no platform %s found in source", pk)
+			}
+		}
 		if len(a.Index)+len(a.IndexDescriptor)+len(a.ManifestDescriptor) > 0 {
 			opts.EnableOCITypes("annotations")
-			break
 		}
 	}
 

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -80,6 +80,13 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 		}
 	}
 
+	for _, a := range opts.Annotations {
+		if len(a.Index)+len(a.IndexDescriptor)+len(a.ManifestDescriptor) > 0 {
+			opts.EnableOCITypes("annotations")
+			break
+		}
+	}
+
 	if len(inp.Refs) == 0 {
 		remotes, err := ic.exportLayers(ctx, opts.RefCfg, session.NewGroup(sessionID), inp.Ref)
 		if err != nil {

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -108,7 +108,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 	if err != nil {
 		return nil, err
 	}
-	opts.AddAnnotations(as)
+	opts.Annotations = opts.Annotations.Merge(as)
 
 	ctx, done, err := leaseutil.WithLease(ctx, e.opt.LeaseManager, leaseutil.MakeTemporary)
 	if err != nil {


### PR DESCRIPTION
:hammer_and_wrench: Fixes https://github.com/moby/buildkit/issues/3277, by preventing confusion around what functionality is supported.

This PR resolves two issues with annotation attachment, where inputs will be accepted even if they are not used - we should explicitly error in these cases.
1. Index + Index descriptor annotations are not supported for single platform builds produced by the Dockerfile so we should explicitly error (@tonistiigi, should we have a user accessible way to force this? We can the `FrontendAttrs["multi-platform"]` key, but could we also expose a `build-arg`? Automatically detecting annotations like attestations and using `ForceRefsProcessor` is possible but kind of ugly here, since we'd have to parse exporter options before doing a solve).
2. Valid platforms that are part of annotations but are not built as part of the resulting image cannot be included and so should explicitly error.
