### PR TITLE
Allow to use checksum in ADD from ENV

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -680,19 +680,25 @@ func dispatch(d *dispatchState, cmd command, opt dispatchOpt) error {
 	case *instructions.WorkdirCommand:
 		err = dispatchWorkdir(d, c, true, &opt)
 	case *instructions.AddCommand:
-		err = dispatchCopy(d, copyConfig{
-			params:       c.SourcesAndDest,
-			source:       opt.buildContext,
-			isAddCommand: true,
-			cmdToPrint:   c,
-			chown:        c.Chown,
-			chmod:        c.Chmod,
-			link:         c.Link,
-			keepGitDir:   c.KeepGitDir,
-			checksum:     c.Checksum,
-			location:     c.Location(),
-			opt:          opt,
-		})
+		var checksum digest.Digest
+		if c.Checksum != "" {
+			checksum, err = digest.Parse(c.Checksum)
+		}
+		if err == nil {
+			err = dispatchCopy(d, copyConfig{
+				params:       c.SourcesAndDest,
+				source:       opt.buildContext,
+				isAddCommand: true,
+				cmdToPrint:   c,
+				chown:        c.Chown,
+				chmod:        c.Chmod,
+				link:         c.Link,
+				keepGitDir:   c.KeepGitDir,
+				checksum:     checksum,
+				location:     c.Location(),
+				opt:          opt,
+			})
+		}
 		if err == nil {
 			for _, src := range c.SourcePaths {
 				if !strings.HasPrefix(src, "http://") && !strings.HasPrefix(src, "https://") {

--- a/frontend/dockerfile/dockerfile_addchecksum_test.go
+++ b/frontend/dockerfile/dockerfile_addchecksum_test.go
@@ -60,6 +60,26 @@ ADD --checksum=%s %s /tmp/foo
 		}, nil)
 		require.NoError(t, err)
 	})
+	t.Run("DigestFromEnv", func(t *testing.T) {
+		dockerfile := []byte(fmt.Sprintf(`
+FROM scratch
+ENV DIGEST=%s
+ENV LINK=%s
+ADD --checksum=${DIGEST} ${LINK} /tmp/foo
+`, digest.FromBytes(resp.Content).String(), server.URL+"/foo"))
+		dir, err := integration.Tmpdir(
+			t,
+			fstest.CreateFile("Dockerfile", dockerfile, 0600),
+		)
+		require.NoError(t, err)
+		_, err = f.Solve(sb.Context(), c, client.SolveOpt{
+			LocalDirs: map[string]string{
+				builder.DefaultLocalNameDockerfile: dir,
+				builder.DefaultLocalNameContext:    dir,
+			},
+		}, nil)
+		require.NoError(t, err)
+	})
 	t.Run("DigestMismatch", func(t *testing.T) {
 		dockerfile := []byte(fmt.Sprintf(`
 FROM scratch

--- a/frontend/dockerfile/instructions/commands.go
+++ b/frontend/dockerfile/instructions/commands.go
@@ -6,7 +6,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
-	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
 
@@ -244,7 +243,7 @@ type AddCommand struct {
 	Chmod      string
 	Link       bool
 	KeepGitDir bool // whether to keep .git dir, only meaningful for git sources
-	Checksum   digest.Digest
+	Checksum   string
 }
 
 func (c *AddCommand) Expand(expander SingleWordExpander) error {
@@ -253,6 +252,12 @@ func (c *AddCommand) Expand(expander SingleWordExpander) error {
 		return err
 	}
 	c.Chown = expandedChown
+
+	expandedChecksum, err := expander(c.Checksum)
+	if err != nil {
+		return err
+	}
+	c.Checksum = expandedChecksum
 
 	return c.SourcesAndDest.Expand(expander)
 }

--- a/frontend/dockerfile/instructions/parse.go
+++ b/frontend/dockerfile/instructions/parse.go
@@ -17,7 +17,6 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/command"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/moby/buildkit/util/suggest"
-	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
 
@@ -297,14 +296,6 @@ func parseAdd(req parseRequest) (*AddCommand, error) {
 		return nil, err
 	}
 
-	var checksum digest.Digest
-	if flChecksum.Value != "" {
-		checksum, err = digest.Parse(flChecksum.Value)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	return &AddCommand{
 		withNameAndCode: newWithNameAndCode(req),
 		SourcesAndDest:  *sourcesAndDest,
@@ -312,7 +303,7 @@ func parseAdd(req parseRequest) (*AddCommand, error) {
 		Chmod:           flChmod.Value,
 		Link:            flLink.Value == "true",
 		KeepGitDir:      flKeepGitDir.Value == "true",
-		Checksum:        checksum,
+		Checksum:        flChecksum.Value,
 	}, nil
 }
 


### PR DESCRIPTION
We cannot use checksum from environment variables (for example with `ADD --checksum=${HASH} ${LINK} /tmp/foo`), which made this option useless in cases when we define url using environment variables and adjust them using some logic around.
Let's add checksum field to Expand function to fill it before sending out.

PR contains implementation and test