### PR TITLE
sbom: fix minor inconsistencies in sbom protocol

### DIFF
--- a/frontend/attestations/parse.go
+++ b/frontend/attestations/parse.go
@@ -13,8 +13,7 @@ const (
 )
 
 const (
-	// TODO: update this before next buildkit release
-	defaultSBOMGenerator = "jedevc/buildkit-syft-scanner:master@sha256:de630f621eb0ab1bb1245cea76d01c5bddfe78af4f5b9adecde424cb7ec5605e"
+	defaultSBOMGenerator = "docker/buildkit-syft-scanner:stable-1"
 )
 
 func Filter(v map[string]string) map[string]string {

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -6187,7 +6187,7 @@ COPY <<-"EOF" /scan.sh
 	  "predicate": {"core": true}
 	}
 	BUNDLE
-	if [ -d "${BUILDKIT_SCAN_SOURCE_EXTRAS:?}" ]; then
+	if [ "${BUILDKIT_SCAN_SOURCE_EXTRAS}" ]; then
 		for src in "${BUILDKIT_SCAN_SOURCE_EXTRAS}"/*; do
 			cat <<BUNDLE > $BUILDKIT_SCAN_DESTINATION/$(basename $src).spdx.json
 			{


### PR DESCRIPTION
:warning: Requires updates in [buildkit-syft-scanner](https://github.com/jedevc/buildkit-syft-scanner)

Since we construct the args for the image based on the Entrypoint + Cmd, we shouldn't error out early if no Cmd is set, but only if neither Entrypoint or Cmd are set.

Additionally, we should avoid setting BUILDKIT_SCAN_SOURCE_EXTRAS if no extras have been specified.