### PR TITLE
add build history APIs

### DIFF
--- a/api/services/control/control.pb.go
+++ b/api/services/control/control.pb.go
@@ -6,6 +6,7 @@ package moby_buildkit_v1
 import (
 	context "context"
 	fmt "fmt"
+	rpc "github.com/gogo/googleapis/google/rpc"
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	github_com_gogo_protobuf_types "github.com/gogo/protobuf/types"
@@ -34,6 +35,34 @@ var _ = time.Kitchen
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
+
+type BuildHistoryEventType int32
+
+const (
+	BuildHistoryEventType_STARTED  BuildHistoryEventType = 0
+	BuildHistoryEventType_COMPLETE BuildHistoryEventType = 1
+	BuildHistoryEventType_DELETED  BuildHistoryEventType = 2
+)
+
+var BuildHistoryEventType_name = map[int32]string{
+	0: "STARTED",
+	1: "COMPLETE",
+	2: "DELETED",
+}
+
+var BuildHistoryEventType_value = map[string]int32{
+	"STARTED":  0,
+	"COMPLETE": 1,
+	"DELETED":  2,
+}
+
+func (x BuildHistoryEventType) String() string {
+	return proto.EnumName(BuildHistoryEventType_name, int32(x))
+}
+
+func (BuildHistoryEventType) EnumDescriptor() ([]byte, []int) {
+	return fileDescriptor_0c5120591600887d, []int{0}
+}
 
 type PruneRequest struct {
 	Filter               []string `protobuf:"bytes,1,rep,name=filter,proto3" json:"filter,omitempty"`
@@ -1326,7 +1355,427 @@ func (m *InfoResponse) GetBuildkitVersion() *types.BuildkitVersion {
 	return nil
 }
 
+type BuildHistoryRequest struct {
+	ActiveOnly           bool     `protobuf:"varint,1,opt,name=ActiveOnly,proto3" json:"ActiveOnly,omitempty"`
+	Ref                  string   `protobuf:"bytes,2,opt,name=Ref,proto3" json:"Ref,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *BuildHistoryRequest) Reset()         { *m = BuildHistoryRequest{} }
+func (m *BuildHistoryRequest) String() string { return proto.CompactTextString(m) }
+func (*BuildHistoryRequest) ProtoMessage()    {}
+func (*BuildHistoryRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_0c5120591600887d, []int{19}
+}
+func (m *BuildHistoryRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *BuildHistoryRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_BuildHistoryRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *BuildHistoryRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_BuildHistoryRequest.Merge(m, src)
+}
+func (m *BuildHistoryRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *BuildHistoryRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_BuildHistoryRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_BuildHistoryRequest proto.InternalMessageInfo
+
+func (m *BuildHistoryRequest) GetActiveOnly() bool {
+	if m != nil {
+		return m.ActiveOnly
+	}
+	return false
+}
+
+func (m *BuildHistoryRequest) GetRef() string {
+	if m != nil {
+		return m.Ref
+	}
+	return ""
+}
+
+type BuildHistoryEvent struct {
+	Type                 BuildHistoryEventType `protobuf:"varint,1,opt,name=type,proto3,enum=moby.buildkit.v1.BuildHistoryEventType" json:"type,omitempty"`
+	Record               *BuildHistoryRecord   `protobuf:"bytes,2,opt,name=record,proto3" json:"record,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}              `json:"-"`
+	XXX_unrecognized     []byte                `json:"-"`
+	XXX_sizecache        int32                 `json:"-"`
+}
+
+func (m *BuildHistoryEvent) Reset()         { *m = BuildHistoryEvent{} }
+func (m *BuildHistoryEvent) String() string { return proto.CompactTextString(m) }
+func (*BuildHistoryEvent) ProtoMessage()    {}
+func (*BuildHistoryEvent) Descriptor() ([]byte, []int) {
+	return fileDescriptor_0c5120591600887d, []int{20}
+}
+func (m *BuildHistoryEvent) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *BuildHistoryEvent) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_BuildHistoryEvent.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *BuildHistoryEvent) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_BuildHistoryEvent.Merge(m, src)
+}
+func (m *BuildHistoryEvent) XXX_Size() int {
+	return m.Size()
+}
+func (m *BuildHistoryEvent) XXX_DiscardUnknown() {
+	xxx_messageInfo_BuildHistoryEvent.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_BuildHistoryEvent proto.InternalMessageInfo
+
+func (m *BuildHistoryEvent) GetType() BuildHistoryEventType {
+	if m != nil {
+		return m.Type
+	}
+	return BuildHistoryEventType_STARTED
+}
+
+func (m *BuildHistoryEvent) GetRecord() *BuildHistoryRecord {
+	if m != nil {
+		return m.Record
+	}
+	return nil
+}
+
+type BuildHistoryRecord struct {
+	Ref                  string                      `protobuf:"bytes,1,opt,name=Ref,proto3" json:"Ref,omitempty"`
+	Frontend             string                      `protobuf:"bytes,2,opt,name=Frontend,proto3" json:"Frontend,omitempty"`
+	FrontendAttrs        map[string]string           `protobuf:"bytes,3,rep,name=FrontendAttrs,proto3" json:"FrontendAttrs,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	Exporters            []*Exporter                 `protobuf:"bytes,4,rep,name=Exporters,proto3" json:"Exporters,omitempty"`
+	Error                *rpc.Status                 `protobuf:"bytes,5,opt,name=error,proto3" json:"error,omitempty"`
+	CreatedAt            *time.Time                  `protobuf:"bytes,6,opt,name=CreatedAt,proto3,stdtime" json:"CreatedAt,omitempty"`
+	CompletedAt          *time.Time                  `protobuf:"bytes,7,opt,name=CompletedAt,proto3,stdtime" json:"CompletedAt,omitempty"`
+	Logs                 *Descriptor                 `protobuf:"bytes,8,opt,name=logs,proto3" json:"logs,omitempty"`
+	ExporterResponse     map[string]string           `protobuf:"bytes,9,rep,name=ExporterResponse,proto3" json:"ExporterResponse,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	Result               *BuildResultInfo            `protobuf:"bytes,10,opt,name=Result,proto3" json:"Result,omitempty"`
+	Results              map[string]*BuildResultInfo `protobuf:"bytes,11,rep,name=Results,proto3" json:"Results,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	Generation           int32                       `protobuf:"varint,12,opt,name=Generation,proto3" json:"Generation,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}                    `json:"-"`
+	XXX_unrecognized     []byte                      `json:"-"`
+	XXX_sizecache        int32                       `json:"-"`
+}
+
+func (m *BuildHistoryRecord) Reset()         { *m = BuildHistoryRecord{} }
+func (m *BuildHistoryRecord) String() string { return proto.CompactTextString(m) }
+func (*BuildHistoryRecord) ProtoMessage()    {}
+func (*BuildHistoryRecord) Descriptor() ([]byte, []int) {
+	return fileDescriptor_0c5120591600887d, []int{21}
+}
+func (m *BuildHistoryRecord) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *BuildHistoryRecord) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_BuildHistoryRecord.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *BuildHistoryRecord) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_BuildHistoryRecord.Merge(m, src)
+}
+func (m *BuildHistoryRecord) XXX_Size() int {
+	return m.Size()
+}
+func (m *BuildHistoryRecord) XXX_DiscardUnknown() {
+	xxx_messageInfo_BuildHistoryRecord.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_BuildHistoryRecord proto.InternalMessageInfo
+
+func (m *BuildHistoryRecord) GetRef() string {
+	if m != nil {
+		return m.Ref
+	}
+	return ""
+}
+
+func (m *BuildHistoryRecord) GetFrontend() string {
+	if m != nil {
+		return m.Frontend
+	}
+	return ""
+}
+
+func (m *BuildHistoryRecord) GetFrontendAttrs() map[string]string {
+	if m != nil {
+		return m.FrontendAttrs
+	}
+	return nil
+}
+
+func (m *BuildHistoryRecord) GetExporters() []*Exporter {
+	if m != nil {
+		return m.Exporters
+	}
+	return nil
+}
+
+func (m *BuildHistoryRecord) GetError() *rpc.Status {
+	if m != nil {
+		return m.Error
+	}
+	return nil
+}
+
+func (m *BuildHistoryRecord) GetCreatedAt() *time.Time {
+	if m != nil {
+		return m.CreatedAt
+	}
+	return nil
+}
+
+func (m *BuildHistoryRecord) GetCompletedAt() *time.Time {
+	if m != nil {
+		return m.CompletedAt
+	}
+	return nil
+}
+
+func (m *BuildHistoryRecord) GetLogs() *Descriptor {
+	if m != nil {
+		return m.Logs
+	}
+	return nil
+}
+
+func (m *BuildHistoryRecord) GetExporterResponse() map[string]string {
+	if m != nil {
+		return m.ExporterResponse
+	}
+	return nil
+}
+
+func (m *BuildHistoryRecord) GetResult() *BuildResultInfo {
+	if m != nil {
+		return m.Result
+	}
+	return nil
+}
+
+func (m *BuildHistoryRecord) GetResults() map[string]*BuildResultInfo {
+	if m != nil {
+		return m.Results
+	}
+	return nil
+}
+
+func (m *BuildHistoryRecord) GetGeneration() int32 {
+	if m != nil {
+		return m.Generation
+	}
+	return 0
+}
+
+type Descriptor struct {
+	MediaType            string                                     `protobuf:"bytes,1,opt,name=media_type,json=mediaType,proto3" json:"media_type,omitempty"`
+	Digest               github_com_opencontainers_go_digest.Digest `protobuf:"bytes,2,opt,name=digest,proto3,customtype=github.com/opencontainers/go-digest.Digest" json:"digest"`
+	Size_                int64                                      `protobuf:"varint,3,opt,name=size,proto3" json:"size,omitempty"`
+	Annotations          map[string]string                          `protobuf:"bytes,5,rep,name=annotations,proto3" json:"annotations,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	XXX_NoUnkeyedLiteral struct{}                                   `json:"-"`
+	XXX_unrecognized     []byte                                     `json:"-"`
+	XXX_sizecache        int32                                      `json:"-"`
+}
+
+func (m *Descriptor) Reset()         { *m = Descriptor{} }
+func (m *Descriptor) String() string { return proto.CompactTextString(m) }
+func (*Descriptor) ProtoMessage()    {}
+func (*Descriptor) Descriptor() ([]byte, []int) {
+	return fileDescriptor_0c5120591600887d, []int{22}
+}
+func (m *Descriptor) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *Descriptor) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_Descriptor.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *Descriptor) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Descriptor.Merge(m, src)
+}
+func (m *Descriptor) XXX_Size() int {
+	return m.Size()
+}
+func (m *Descriptor) XXX_DiscardUnknown() {
+	xxx_messageInfo_Descriptor.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_Descriptor proto.InternalMessageInfo
+
+func (m *Descriptor) GetMediaType() string {
+	if m != nil {
+		return m.MediaType
+	}
+	return ""
+}
+
+func (m *Descriptor) GetSize_() int64 {
+	if m != nil {
+		return m.Size_
+	}
+	return 0
+}
+
+func (m *Descriptor) GetAnnotations() map[string]string {
+	if m != nil {
+		return m.Annotations
+	}
+	return nil
+}
+
+type BuildResultInfo struct {
+	Result               *Descriptor   `protobuf:"bytes,1,opt,name=Result,proto3" json:"Result,omitempty"`
+	Attestations         []*Descriptor `protobuf:"bytes,2,rep,name=Attestations,proto3" json:"Attestations,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
+	XXX_unrecognized     []byte        `json:"-"`
+	XXX_sizecache        int32         `json:"-"`
+}
+
+func (m *BuildResultInfo) Reset()         { *m = BuildResultInfo{} }
+func (m *BuildResultInfo) String() string { return proto.CompactTextString(m) }
+func (*BuildResultInfo) ProtoMessage()    {}
+func (*BuildResultInfo) Descriptor() ([]byte, []int) {
+	return fileDescriptor_0c5120591600887d, []int{23}
+}
+func (m *BuildResultInfo) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *BuildResultInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_BuildResultInfo.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *BuildResultInfo) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_BuildResultInfo.Merge(m, src)
+}
+func (m *BuildResultInfo) XXX_Size() int {
+	return m.Size()
+}
+func (m *BuildResultInfo) XXX_DiscardUnknown() {
+	xxx_messageInfo_BuildResultInfo.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_BuildResultInfo proto.InternalMessageInfo
+
+func (m *BuildResultInfo) GetResult() *Descriptor {
+	if m != nil {
+		return m.Result
+	}
+	return nil
+}
+
+func (m *BuildResultInfo) GetAttestations() []*Descriptor {
+	if m != nil {
+		return m.Attestations
+	}
+	return nil
+}
+
+type Exporter struct {
+	Type                 string            `protobuf:"bytes,1,opt,name=Type,proto3" json:"Type,omitempty"`
+	Attrs                map[string]string `protobuf:"bytes,2,rep,name=Attrs,proto3" json:"Attrs,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
+	XXX_unrecognized     []byte            `json:"-"`
+	XXX_sizecache        int32             `json:"-"`
+}
+
+func (m *Exporter) Reset()         { *m = Exporter{} }
+func (m *Exporter) String() string { return proto.CompactTextString(m) }
+func (*Exporter) ProtoMessage()    {}
+func (*Exporter) Descriptor() ([]byte, []int) {
+	return fileDescriptor_0c5120591600887d, []int{24}
+}
+func (m *Exporter) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *Exporter) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_Exporter.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *Exporter) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Exporter.Merge(m, src)
+}
+func (m *Exporter) XXX_Size() int {
+	return m.Size()
+}
+func (m *Exporter) XXX_DiscardUnknown() {
+	xxx_messageInfo_Exporter.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_Exporter proto.InternalMessageInfo
+
+func (m *Exporter) GetType() string {
+	if m != nil {
+		return m.Type
+	}
+	return ""
+}
+
+func (m *Exporter) GetAttrs() map[string]string {
+	if m != nil {
+		return m.Attrs
+	}
+	return nil
+}
+
 func init() {
+	proto.RegisterEnum("moby.buildkit.v1.BuildHistoryEventType", BuildHistoryEventType_name, BuildHistoryEventType_value)
 	proto.RegisterType((*PruneRequest)(nil), "moby.buildkit.v1.PruneRequest")
 	proto.RegisterType((*DiskUsageRequest)(nil), "moby.buildkit.v1.DiskUsageRequest")
 	proto.RegisterType((*DiskUsageResponse)(nil), "moby.buildkit.v1.DiskUsageResponse")
@@ -1352,112 +1801,152 @@ func init() {
 	proto.RegisterType((*ListWorkersResponse)(nil), "moby.buildkit.v1.ListWorkersResponse")
 	proto.RegisterType((*InfoRequest)(nil), "moby.buildkit.v1.InfoRequest")
 	proto.RegisterType((*InfoResponse)(nil), "moby.buildkit.v1.InfoResponse")
+	proto.RegisterType((*BuildHistoryRequest)(nil), "moby.buildkit.v1.BuildHistoryRequest")
+	proto.RegisterType((*BuildHistoryEvent)(nil), "moby.buildkit.v1.BuildHistoryEvent")
+	proto.RegisterType((*BuildHistoryRecord)(nil), "moby.buildkit.v1.BuildHistoryRecord")
+	proto.RegisterMapType((map[string]string)(nil), "moby.buildkit.v1.BuildHistoryRecord.ExporterResponseEntry")
+	proto.RegisterMapType((map[string]string)(nil), "moby.buildkit.v1.BuildHistoryRecord.FrontendAttrsEntry")
+	proto.RegisterMapType((map[string]*BuildResultInfo)(nil), "moby.buildkit.v1.BuildHistoryRecord.ResultsEntry")
+	proto.RegisterType((*Descriptor)(nil), "moby.buildkit.v1.Descriptor")
+	proto.RegisterMapType((map[string]string)(nil), "moby.buildkit.v1.Descriptor.AnnotationsEntry")
+	proto.RegisterType((*BuildResultInfo)(nil), "moby.buildkit.v1.BuildResultInfo")
+	proto.RegisterType((*Exporter)(nil), "moby.buildkit.v1.Exporter")
+	proto.RegisterMapType((map[string]string)(nil), "moby.buildkit.v1.Exporter.AttrsEntry")
 }
 
 func init() { proto.RegisterFile("control.proto", fileDescriptor_0c5120591600887d) }
 
 var fileDescriptor_0c5120591600887d = []byte{
-	// 1597 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x58, 0xcb, 0x6e, 0x1c, 0x45,
-	0x17, 0x4e, 0xcf, 0x7d, 0xce, 0x8c, 0xfd, 0x3b, 0x95, 0xfc, 0x51, 0xab, 0x7f, 0xfd, 0xb6, 0xd3,
-	0x09, 0xc2, 0x8a, 0x92, 0x1e, 0xc7, 0x10, 0x08, 0xe6, 0xa2, 0x64, 0x3c, 0x86, 0x38, 0x8a, 0x45,
-	0x52, 0xce, 0x45, 0xca, 0x02, 0xa9, 0x67, 0xa6, 0x3c, 0x6e, 0xb9, 0xa7, 0xab, 0xa9, 0xaa, 0x76,
-	0x62, 0x1e, 0x80, 0x35, 0x3b, 0x1e, 0x80, 0x05, 0x2b, 0x76, 0x48, 0x3c, 0x01, 0x52, 0x96, 0xac,
-	0xb3, 0x30, 0x28, 0x0f, 0x80, 0x58, 0xb2, 0x44, 0x75, 0xe9, 0x71, 0xcf, 0xcd, 0xb7, 0xb0, 0x9a,
-	0x3a, 0x55, 0xe7, 0x7c, 0x7d, 0x2e, 0x5f, 0x55, 0x9d, 0x1a, 0x98, 0xe9, 0xd0, 0x48, 0x30, 0x1a,
-	0x7a, 0x31, 0xa3, 0x82, 0xa2, 0xb9, 0x3e, 0x6d, 0xef, 0x7b, 0xed, 0x24, 0x08, 0xbb, 0xbb, 0x81,
-	0xf0, 0xf6, 0x6e, 0x3a, 0x37, 0x7a, 0x81, 0xd8, 0x49, 0xda, 0x5e, 0x87, 0xf6, 0x1b, 0x3d, 0xda,
-	0xa3, 0x0d, 0xa5, 0xd8, 0x4e, 0xb6, 0x95, 0xa4, 0x04, 0x35, 0xd2, 0x00, 0xce, 0x42, 0x8f, 0xd2,
-	0x5e, 0x48, 0x0e, 0xb5, 0x44, 0xd0, 0x27, 0x5c, 0xf8, 0xfd, 0xd8, 0x28, 0x5c, 0xcf, 0xe0, 0xc9,
-	0x8f, 0x35, 0xd2, 0x8f, 0x35, 0x38, 0x0d, 0xf7, 0x08, 0x6b, 0xc4, 0xed, 0x06, 0x8d, 0xb9, 0xd1,
-	0x6e, 0x4c, 0xd5, 0xf6, 0xe3, 0xa0, 0x21, 0xf6, 0x63, 0xc2, 0x1b, 0x2f, 0x28, 0xdb, 0x25, 0x4c,
-	0x1b, 0xb8, 0xdf, 0x5a, 0x50, 0x7f, 0xc8, 0x92, 0x88, 0x60, 0xf2, 0x75, 0x42, 0xb8, 0x40, 0x97,
-	0xa0, 0xb4, 0x1d, 0x84, 0x82, 0x30, 0xdb, 0x5a, 0xcc, 0x2f, 0x55, 0xb1, 0x91, 0xd0, 0x1c, 0xe4,
-	0xfd, 0x30, 0xb4, 0x73, 0x8b, 0xd6, 0x52, 0x05, 0xcb, 0x21, 0x5a, 0x82, 0xfa, 0x2e, 0x21, 0x71,
-	0x2b, 0x61, 0xbe, 0x08, 0x68, 0x64, 0xe7, 0x17, 0xad, 0xa5, 0x7c, 0xb3, 0xf0, 0xea, 0x60, 0xc1,
-	0xc2, 0x43, 0x2b, 0xc8, 0x85, 0xaa, 0x94, 0x9b, 0xfb, 0x82, 0x70, 0xbb, 0x90, 0x51, 0x3b, 0x9c,
-	0x76, 0xaf, 0xc1, 0x5c, 0x2b, 0xe0, 0xbb, 0x4f, 0xb8, 0xdf, 0x3b, 0xce, 0x17, 0xf7, 0x3e, 0x9c,
-	0xcf, 0xe8, 0xf2, 0x98, 0x46, 0x9c, 0xa0, 0x5b, 0x50, 0x62, 0xa4, 0x43, 0x59, 0x57, 0x29, 0xd7,
-	0x56, 0xfe, 0xef, 0x8d, 0xd6, 0xc6, 0x33, 0x06, 0x52, 0x09, 0x1b, 0x65, 0xf7, 0xfb, 0x3c, 0xd4,
-	0x32, 0xf3, 0x68, 0x16, 0x72, 0x1b, 0x2d, 0xdb, 0x5a, 0xb4, 0x96, 0xaa, 0x38, 0xb7, 0xd1, 0x42,
-	0x36, 0x94, 0x37, 0x13, 0xe1, 0xb7, 0x43, 0x62, 0x62, 0x4f, 0x45, 0x74, 0x11, 0x8a, 0x1b, 0xd1,
-	0x13, 0x4e, 0x54, 0xe0, 0x15, 0xac, 0x05, 0x84, 0xa0, 0xb0, 0x15, 0x7c, 0x43, 0x74, 0x98, 0x58,
-	0x8d, 0x91, 0x03, 0xa5, 0x87, 0x3e, 0x23, 0x91, 0xb0, 0x8b, 0x12, 0xb7, 0x99, 0xb3, 0x2d, 0x6c,
-	0x66, 0x50, 0x13, 0xaa, 0x6b, 0x8c, 0xf8, 0x82, 0x74, 0xef, 0x0a, 0xbb, 0xb4, 0x68, 0x2d, 0xd5,
-	0x56, 0x1c, 0x4f, 0x93, 0xc2, 0x4b, 0x49, 0xe1, 0x3d, 0x4e, 0x49, 0xd1, 0xac, 0xbc, 0x3a, 0x58,
-	0x38, 0xf7, 0xdd, 0xef, 0x32, 0x77, 0x03, 0x33, 0x74, 0x07, 0xe0, 0x81, 0xcf, 0xc5, 0x13, 0xae,
-	0x40, 0xca, 0xc7, 0x82, 0x14, 0x14, 0x40, 0xc6, 0x06, 0xcd, 0x03, 0xa8, 0x24, 0xac, 0xd1, 0x24,
-	0x12, 0x76, 0x45, 0xf9, 0x9e, 0x99, 0x41, 0x8b, 0x50, 0x6b, 0x11, 0xde, 0x61, 0x41, 0xac, 0x4a,
-	0x5d, 0x55, 0xe9, 0xc9, 0x4e, 0x49, 0x04, 0x9d, 0xc1, 0xc7, 0xfb, 0x31, 0xb1, 0x41, 0x29, 0x64,
-	0x66, 0x64, 0x2d, 0xb7, 0x76, 0x7c, 0x46, 0xba, 0x76, 0x4d, 0xa5, 0xcb, 0x48, 0x32, 0xbf, 0x3a,
-	0x13, 0xdc, 0xae, 0xab, 0x22, 0xa7, 0xa2, 0xfb, 0x43, 0x09, 0xea, 0x5b, 0x92, 0xe3, 0x29, 0x1d,
-	0xe6, 0x20, 0x8f, 0xc9, 0xb6, 0xa9, 0x8d, 0x1c, 0x22, 0x0f, 0xa0, 0x45, 0xb6, 0x83, 0x28, 0x50,
-	0x5e, 0xe5, 0x54, 0xe0, 0xb3, 0x5e, 0xdc, 0xf6, 0x0e, 0x67, 0x71, 0x46, 0x03, 0x39, 0x50, 0x59,
-	0x7f, 0x19, 0x53, 0x26, 0x29, 0x95, 0x57, 0x30, 0x03, 0x19, 0x3d, 0x83, 0x99, 0x74, 0x7c, 0x57,
-	0x08, 0x26, 0x89, 0x2a, 0x69, 0x74, 0x73, 0x9c, 0x46, 0x59, 0xa7, 0xbc, 0x21, 0x9b, 0xf5, 0x48,
-	0xb0, 0x7d, 0x3c, 0x8c, 0x23, 0x23, 0xdc, 0x22, 0x9c, 0x4b, 0x0f, 0x55, 0xf9, 0x71, 0x2a, 0x4a,
-	0x77, 0x3e, 0x67, 0x34, 0x12, 0x24, 0xea, 0xaa, 0xd2, 0x57, 0xf1, 0x40, 0x96, 0xee, 0xa4, 0x63,
-	0xed, 0x4e, 0xf9, 0x44, 0xee, 0x0c, 0xd9, 0x18, 0x77, 0x86, 0xe6, 0xd0, 0x2a, 0x14, 0xd7, 0xfc,
-	0xce, 0x0e, 0x51, 0x55, 0xae, 0xad, 0xcc, 0x8f, 0x03, 0xaa, 0xe5, 0x2f, 0x55, 0x59, 0xb9, 0xda,
-	0xa8, 0xe7, 0xb0, 0x36, 0x41, 0x5f, 0x41, 0x7d, 0x3d, 0x12, 0x81, 0x08, 0x49, 0x5f, 0x55, 0xac,
-	0x2a, 0x2b, 0xd6, 0x5c, 0x7d, 0x7d, 0xb0, 0xf0, 0xc1, 0xd4, 0x83, 0x27, 0x11, 0x41, 0xd8, 0x20,
-	0x19, 0x2b, 0x2f, 0x03, 0x81, 0x87, 0xf0, 0xd0, 0x73, 0x98, 0x4d, 0x9d, 0xdd, 0x88, 0xe2, 0x44,
-	0x70, 0x1b, 0x54, 0xd4, 0x2b, 0x27, 0x8c, 0x5a, 0x1b, 0xe9, 0xb0, 0x47, 0x90, 0x9c, 0x3b, 0x80,
-	0xc6, 0x6b, 0x25, 0x39, 0xb5, 0x4b, 0xf6, 0x53, 0x4e, 0xed, 0x92, 0x7d, 0xb9, 0xad, 0xf7, 0xfc,
-	0x30, 0xd1, 0xdb, 0xbd, 0x8a, 0xb5, 0xb0, 0x9a, 0xbb, 0x6d, 0x49, 0x84, 0xf1, 0xf4, 0x9e, 0x0a,
-	0xe1, 0x11, 0x5c, 0x98, 0xe0, 0xea, 0x04, 0x88, 0xab, 0x59, 0x88, 0x71, 0x4e, 0x1f, 0x42, 0xba,
-	0x3f, 0xe5, 0xa1, 0x9e, 0x2d, 0x18, 0x5a, 0x86, 0x0b, 0x3a, 0x4e, 0x4c, 0xb6, 0x5b, 0x24, 0x66,
-	0xa4, 0x23, 0x4f, 0x09, 0x03, 0x3e, 0x69, 0x09, 0xad, 0xc0, 0xc5, 0x8d, 0xbe, 0x99, 0xe6, 0x19,
-	0x93, 0x9c, 0xda, 0x8f, 0x13, 0xd7, 0x10, 0x85, 0xff, 0x6a, 0x28, 0x95, 0x89, 0x8c, 0x51, 0x5e,
-	0x15, 0xec, 0xa3, 0xa3, 0x59, 0xe5, 0x4d, 0xb4, 0xd5, 0x75, 0x9b, 0x8c, 0x8b, 0x3e, 0x85, 0xb2,
-	0x5e, 0x48, 0x37, 0xe6, 0x95, 0xa3, 0x3f, 0xa1, 0xc1, 0x52, 0x1b, 0x69, 0xae, 0xe3, 0xe0, 0x76,
-	0xf1, 0x14, 0xe6, 0xc6, 0xc6, 0xb9, 0x07, 0xce, 0x74, 0x97, 0x4f, 0x43, 0x01, 0xf7, 0x47, 0x0b,
-	0xce, 0x8f, 0x7d, 0x48, 0xde, 0x1a, 0xea, 0xdc, 0xd4, 0x10, 0x6a, 0x8c, 0x5a, 0x50, 0xd4, 0x3b,
-	0x3f, 0xa7, 0x1c, 0xf6, 0x4e, 0xe0, 0xb0, 0x97, 0xd9, 0xf6, 0xda, 0xd8, 0xb9, 0x0d, 0x70, 0x36,
-	0xb2, 0xba, 0xbf, 0x58, 0x30, 0x63, 0x76, 0x99, 0xb9, 0x62, 0x7d, 0x98, 0x4b, 0xb7, 0x50, 0x3a,
-	0x67, 0x2e, 0xdb, 0x5b, 0x53, 0x37, 0xa8, 0x56, 0xf3, 0x46, 0xed, 0xb4, 0x8f, 0x63, 0x70, 0xce,
-	0x5a, 0xca, 0xab, 0x11, 0xd5, 0x53, 0x79, 0x7e, 0x19, 0x66, 0xb6, 0x84, 0x2f, 0x12, 0x3e, 0xf5,
-	0xe6, 0x70, 0xff, 0xb2, 0x60, 0x36, 0xd5, 0x31, 0xd1, 0xbd, 0x0f, 0x95, 0x3d, 0xc2, 0x04, 0x79,
-	0x49, 0xb8, 0x89, 0xca, 0x1e, 0x8f, 0xea, 0xa9, 0xd2, 0xc0, 0x03, 0x4d, 0xb4, 0x0a, 0x15, 0xae,
-	0x70, 0x48, 0x5a, 0xa8, 0xf9, 0x69, 0x56, 0xe6, 0x7b, 0x03, 0x7d, 0xd4, 0x80, 0x42, 0x48, 0x7b,
-	0xdc, 0xec, 0x99, 0xff, 0x4d, 0xb3, 0x7b, 0x40, 0x7b, 0x58, 0x29, 0xa2, 0x8f, 0xa1, 0xf2, 0xc2,
-	0x67, 0x51, 0x10, 0xf5, 0xd2, 0x5d, 0xb0, 0x30, 0xcd, 0xe8, 0x99, 0xd6, 0xc3, 0x03, 0x03, 0xd9,
-	0xe9, 0x94, 0xf4, 0x1a, 0xba, 0x0f, 0xa5, 0x6e, 0xd0, 0x23, 0x5c, 0xe8, 0x94, 0x34, 0x57, 0xe4,
-	0x21, 0xff, 0xfa, 0x60, 0xe1, 0x5a, 0xe6, 0x14, 0xa7, 0x31, 0x89, 0x64, 0xb3, 0xeb, 0x07, 0x11,
-	0x61, 0xbc, 0xd1, 0xa3, 0x37, 0xb4, 0x89, 0xd7, 0x52, 0x3f, 0xd8, 0x20, 0x48, 0xac, 0x40, 0x9f,
-	0xd5, 0xea, 0xbc, 0x38, 0x1b, 0x96, 0x46, 0x90, 0xdb, 0x20, 0xf2, 0xfb, 0xc4, 0xdc, 0xcd, 0x6a,
-	0x2c, 0x1b, 0x87, 0x8e, 0xe4, 0x79, 0x57, 0xb5, 0x54, 0x15, 0x6c, 0x24, 0xb4, 0x0a, 0x65, 0x2e,
-	0x7c, 0x26, 0xcf, 0x9c, 0xe2, 0x09, 0x3b, 0x9e, 0xd4, 0x00, 0x7d, 0x06, 0xd5, 0x0e, 0xed, 0xc7,
-	0x21, 0x91, 0xd6, 0xa5, 0x13, 0x5a, 0x1f, 0x9a, 0x48, 0xea, 0x11, 0xc6, 0x28, 0x53, 0xbd, 0x56,
-	0x15, 0x6b, 0x01, 0x7d, 0x08, 0x33, 0x31, 0xa3, 0x3d, 0x46, 0x38, 0xff, 0x82, 0xd1, 0x24, 0x36,
-	0x37, 0xec, 0x79, 0x79, 0x78, 0x3f, 0xcc, 0x2e, 0xe0, 0x61, 0x3d, 0xf7, 0xcf, 0x1c, 0xd4, 0xb3,
-	0x14, 0x19, 0x6b, 0x42, 0xef, 0x43, 0x49, 0x13, 0x4e, 0x73, 0xfd, 0x6c, 0x39, 0xd6, 0x08, 0x13,
-	0x73, 0x6c, 0x43, 0xb9, 0x93, 0x30, 0xd5, 0xa1, 0xea, 0xbe, 0x35, 0x15, 0x65, 0xa4, 0x82, 0x0a,
-	0x3f, 0x54, 0x39, 0xce, 0x63, 0x2d, 0xc8, 0xa6, 0x75, 0xf0, 0x4e, 0x39, 0x5d, 0xd3, 0x3a, 0x30,
-	0xcb, 0xd6, 0xaf, 0xfc, 0x56, 0xf5, 0xab, 0x9c, 0xba, 0x7e, 0xee, 0xaf, 0x16, 0x54, 0x07, 0x7b,
-	0x2b, 0x93, 0x5d, 0xeb, 0xad, 0xb3, 0x3b, 0x94, 0x99, 0xdc, 0xd9, 0x32, 0x73, 0x09, 0x4a, 0x5c,
-	0x30, 0xe2, 0xf7, 0xf5, 0x93, 0x0a, 0x1b, 0x49, 0x9e, 0x62, 0x7d, 0xde, 0x53, 0x15, 0xaa, 0x63,
-	0x39, 0x74, 0xff, 0xb6, 0x60, 0x66, 0x68, 0xbb, 0xff, 0xab, 0xb1, 0x5c, 0x84, 0x62, 0x48, 0xf6,
-	0x88, 0x7e, 0xf4, 0xe5, 0xb1, 0x16, 0xe4, 0x2c, 0xdf, 0xa1, 0x4c, 0x28, 0xe7, 0xea, 0x58, 0x0b,
-	0xd2, 0xe7, 0x2e, 0x11, 0x7e, 0x10, 0xaa, 0x73, 0xa9, 0x8e, 0x8d, 0x24, 0x7d, 0x4e, 0x58, 0x68,
-	0x1a, 0x5f, 0x39, 0x44, 0x2e, 0x14, 0x82, 0x68, 0x9b, 0x1a, 0xda, 0xa8, 0xce, 0x66, 0x8b, 0x26,
-	0xac, 0x43, 0x36, 0xa2, 0x6d, 0x8a, 0xd5, 0x1a, 0xba, 0x0c, 0x25, 0xe6, 0x47, 0x3d, 0x92, 0x76,
-	0xbd, 0x55, 0xa9, 0x85, 0xe5, 0x0c, 0x36, 0x0b, 0xae, 0x0b, 0x75, 0xf5, 0x70, 0xdc, 0x24, 0x5c,
-	0x3e, 0x53, 0x24, 0xad, 0xbb, 0xbe, 0xf0, 0x55, 0xd8, 0x75, 0xac, 0xc6, 0xee, 0x75, 0x40, 0x0f,
-	0x02, 0x2e, 0x9e, 0xa9, 0x07, 0x2f, 0x3f, 0xee, 0x55, 0xb9, 0x05, 0x17, 0x86, 0xb4, 0xcd, 0xb5,
-	0xf0, 0xc9, 0xc8, 0xbb, 0xf2, 0xea, 0xf8, 0x89, 0xab, 0xde, 0xd5, 0x9e, 0x36, 0x1c, 0x79, 0x5e,
-	0xce, 0x40, 0x4d, 0xc5, 0xa5, 0xbf, 0xed, 0xfa, 0x50, 0xd7, 0xa2, 0x01, 0x7f, 0x04, 0xff, 0x49,
-	0x81, 0x9e, 0x12, 0xa6, 0xde, 0x08, 0x96, 0xca, 0xcb, 0xbb, 0xd3, 0xbe, 0xd2, 0x1c, 0x56, 0xc7,
-	0xa3, 0xf6, 0x2b, 0x3f, 0x17, 0xa0, 0xbc, 0xa6, 0xff, 0xa4, 0x40, 0x8f, 0xa1, 0x3a, 0x78, 0x28,
-	0x23, 0x77, 0x1c, 0x72, 0xf4, 0xc5, 0xed, 0x5c, 0x39, 0x52, 0xc7, 0x38, 0x7d, 0x0f, 0x8a, 0xea,
-	0x2f, 0x03, 0x34, 0xe1, 0xa6, 0xcb, 0xfe, 0x97, 0xe0, 0x1c, 0xfd, 0x04, 0x5f, 0xb6, 0x24, 0x92,
-	0x6a, 0x13, 0x26, 0x21, 0x65, 0x1b, 0x7c, 0x67, 0xe1, 0x98, 0xfe, 0x02, 0x6d, 0x42, 0xc9, 0x9c,
-	0x9d, 0x93, 0x54, 0xb3, 0xcd, 0x80, 0xb3, 0x38, 0x5d, 0x41, 0x83, 0x2d, 0x5b, 0x68, 0x73, 0xf0,
-	0x66, 0x9b, 0xe4, 0x5a, 0x96, 0x78, 0xce, 0x31, 0xeb, 0x4b, 0xd6, 0xb2, 0x85, 0x9e, 0x43, 0x2d,
-	0x43, 0x2d, 0x34, 0x81, 0x42, 0xe3, 0x3c, 0x75, 0xde, 0x39, 0x46, 0xcb, 0x44, 0xbe, 0x0e, 0x05,
-	0x49, 0x29, 0x34, 0x21, 0xd9, 0x19, 0xe6, 0x4d, 0x72, 0x33, 0xcb, 0xc4, 0x66, 0xfd, 0xd5, 0x9b,
-	0x79, 0xeb, 0xb7, 0x37, 0xf3, 0xd6, 0x1f, 0x6f, 0xe6, 0xad, 0x76, 0x49, 0x9d, 0x55, 0xef, 0xfd,
-	0x13, 0x00, 0x00, 0xff, 0xff, 0x96, 0x5c, 0xf7, 0x1b, 0xef, 0x12, 0x00, 0x00,
+	// 2060 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x18, 0x4d, 0x6f, 0x1b, 0xc7,
+	0x35, 0xcb, 0x6f, 0x3e, 0xae, 0x14, 0x79, 0xec, 0x04, 0x8b, 0x6d, 0x23, 0xc9, 0x1b, 0x1b, 0x15,
+	0x8c, 0x78, 0xa9, 0xa8, 0x49, 0xed, 0xc8, 0xad, 0x6b, 0x51, 0x54, 0x6d, 0xb9, 0x16, 0xec, 0x8c,
+	0xe4, 0x18, 0x08, 0x90, 0x16, 0x2b, 0x72, 0x44, 0x2f, 0xb4, 0xdc, 0xdd, 0xce, 0x0c, 0x95, 0x28,
+	0x3f, 0xa0, 0x40, 0x2f, 0x45, 0x2f, 0x45, 0x7b, 0xe8, 0xad, 0x87, 0x9e, 0x7a, 0xe8, 0xa9, 0xbf,
+	0xa0, 0x80, 0x8f, 0x3d, 0xe7, 0xe0, 0x16, 0xfe, 0x01, 0x45, 0x8f, 0x3d, 0x16, 0xf3, 0xb1, 0xe4,
+	0x90, 0x5c, 0x4a, 0x94, 0xed, 0xd3, 0xce, 0x9b, 0x79, 0xef, 0xed, 0xfb, 0x9c, 0xf7, 0xde, 0xc0,
+	0x42, 0x27, 0x89, 0x39, 0x4d, 0x22, 0x3f, 0xa5, 0x09, 0x4f, 0xd0, 0x52, 0x3f, 0x39, 0x3c, 0xf5,
+	0x0f, 0x07, 0x61, 0xd4, 0x3d, 0x0e, 0xb9, 0x7f, 0xf2, 0xb1, 0x7b, 0xb3, 0x17, 0xf2, 0xe7, 0x83,
+	0x43, 0xbf, 0x93, 0xf4, 0x9b, 0xbd, 0xa4, 0x97, 0x34, 0x25, 0xe2, 0xe1, 0xe0, 0x48, 0x42, 0x12,
+	0x90, 0x2b, 0xc5, 0xc0, 0x5d, 0xe9, 0x25, 0x49, 0x2f, 0x22, 0x23, 0x2c, 0x1e, 0xf6, 0x09, 0xe3,
+	0x41, 0x3f, 0xd5, 0x08, 0x1f, 0x19, 0xfc, 0xc4, 0xcf, 0x9a, 0xd9, 0xcf, 0x9a, 0x2c, 0x89, 0x4e,
+	0x08, 0x6d, 0xa6, 0x87, 0xcd, 0x24, 0x65, 0x1a, 0xbb, 0x39, 0x13, 0x3b, 0x48, 0xc3, 0x26, 0x3f,
+	0x4d, 0x09, 0x6b, 0x7e, 0x9d, 0xd0, 0x63, 0x42, 0x35, 0xc1, 0xc6, 0xa4, 0xb8, 0x4a, 0x9e, 0x20,
+	0x0d, 0x99, 0x5e, 0x36, 0x69, 0xda, 0x69, 0x32, 0x1e, 0xf0, 0x81, 0xfe, 0x89, 0xf7, 0x6b, 0x0b,
+	0xec, 0x27, 0x74, 0x10, 0x13, 0x4c, 0x7e, 0x35, 0x20, 0x8c, 0xa3, 0xf7, 0xa1, 0x72, 0x14, 0x46,
+	0x9c, 0x50, 0xc7, 0x5a, 0x2d, 0xae, 0xd5, 0xb1, 0x86, 0xd0, 0x12, 0x14, 0x83, 0x28, 0x72, 0x0a,
+	0xab, 0xd6, 0x5a, 0x0d, 0x8b, 0x25, 0x5a, 0x03, 0xfb, 0x98, 0x90, 0xb4, 0x3d, 0xa0, 0x01, 0x0f,
+	0x93, 0xd8, 0x29, 0xae, 0x5a, 0x6b, 0xc5, 0x56, 0xe9, 0xc5, 0xcb, 0x15, 0x0b, 0x8f, 0x9d, 0x20,
+	0x0f, 0xea, 0x02, 0x6e, 0x9d, 0x72, 0xc2, 0x9c, 0x92, 0x81, 0x36, 0xda, 0xf6, 0x6e, 0xc0, 0x52,
+	0x3b, 0x64, 0xc7, 0x4f, 0x59, 0xd0, 0x3b, 0x4f, 0x16, 0xef, 0x21, 0x5c, 0x32, 0x70, 0x59, 0x9a,
+	0xc4, 0x8c, 0xa0, 0x4f, 0xa1, 0x42, 0x49, 0x27, 0xa1, 0x5d, 0x89, 0xdc, 0xd8, 0xf8, 0xc0, 0x9f,
+	0xf4, 0xa7, 0xaf, 0x09, 0x04, 0x12, 0xd6, 0xc8, 0xde, 0x1f, 0x8a, 0xd0, 0x30, 0xf6, 0xd1, 0x22,
+	0x14, 0x76, 0xdb, 0x8e, 0xb5, 0x6a, 0xad, 0xd5, 0x71, 0x61, 0xb7, 0x8d, 0x1c, 0xa8, 0xee, 0x0d,
+	0x78, 0x70, 0x18, 0x11, 0xad, 0x7b, 0x06, 0xa2, 0x2b, 0x50, 0xde, 0x8d, 0x9f, 0x32, 0x22, 0x15,
+	0xaf, 0x61, 0x05, 0x20, 0x04, 0xa5, 0xfd, 0xf0, 0x5b, 0xa2, 0xd4, 0xc4, 0x72, 0x8d, 0x5c, 0xa8,
+	0x3c, 0x09, 0x28, 0x89, 0xb9, 0x53, 0x16, 0x7c, 0x5b, 0x05, 0xc7, 0xc2, 0x7a, 0x07, 0xb5, 0xa0,
+	0xbe, 0x4d, 0x49, 0xc0, 0x49, 0x77, 0x8b, 0x3b, 0x95, 0x55, 0x6b, 0xad, 0xb1, 0xe1, 0xfa, 0xca,
+	0x5b, 0x7e, 0x16, 0x48, 0xfe, 0x41, 0x16, 0x48, 0xad, 0xda, 0x8b, 0x97, 0x2b, 0xef, 0xfc, 0xee,
+	0x5f, 0xc2, 0x76, 0x43, 0x32, 0x74, 0x0f, 0xe0, 0x51, 0xc0, 0xf8, 0x53, 0x26, 0x99, 0x54, 0xcf,
+	0x65, 0x52, 0x92, 0x0c, 0x0c, 0x1a, 0xb4, 0x0c, 0x20, 0x8d, 0xb0, 0x9d, 0x0c, 0x62, 0xee, 0xd4,
+	0xa4, 0xec, 0xc6, 0x0e, 0x5a, 0x85, 0x46, 0x9b, 0xb0, 0x0e, 0x0d, 0x53, 0xe9, 0xea, 0xba, 0x34,
+	0x8f, 0xb9, 0x25, 0x38, 0x28, 0x0b, 0x1e, 0x9c, 0xa6, 0xc4, 0x01, 0x89, 0x60, 0xec, 0x08, 0x5f,
+	0xee, 0x3f, 0x0f, 0x28, 0xe9, 0x3a, 0x0d, 0x69, 0x2e, 0x0d, 0x09, 0xfb, 0x2a, 0x4b, 0x30, 0xc7,
+	0x96, 0x4e, 0xce, 0x40, 0xef, 0xcf, 0x15, 0xb0, 0xf7, 0x45, 0x5e, 0x64, 0xe1, 0xb0, 0x04, 0x45,
+	0x4c, 0x8e, 0xb4, 0x6f, 0xc4, 0x12, 0xf9, 0x00, 0x6d, 0x72, 0x14, 0xc6, 0xa1, 0x94, 0xaa, 0x20,
+	0x15, 0x5f, 0xf4, 0xd3, 0x43, 0x7f, 0xb4, 0x8b, 0x0d, 0x0c, 0xe4, 0x42, 0x6d, 0xe7, 0x9b, 0x34,
+	0xa1, 0x22, 0xa4, 0x8a, 0x92, 0xcd, 0x10, 0x46, 0xcf, 0x60, 0x21, 0x5b, 0x6f, 0x71, 0x4e, 0x45,
+	0xa0, 0x8a, 0x30, 0xfa, 0x78, 0x3a, 0x8c, 0x4c, 0xa1, 0xfc, 0x31, 0x9a, 0x9d, 0x98, 0xd3, 0x53,
+	0x3c, 0xce, 0x47, 0x68, 0xb8, 0x4f, 0x18, 0x13, 0x12, 0x4a, 0xf7, 0xe3, 0x0c, 0x14, 0xe2, 0xfc,
+	0x8c, 0x26, 0x31, 0x27, 0x71, 0x57, 0xba, 0xbe, 0x8e, 0x87, 0xb0, 0x10, 0x27, 0x5b, 0x2b, 0x71,
+	0xaa, 0x73, 0x89, 0x33, 0x46, 0xa3, 0xc5, 0x19, 0xdb, 0x43, 0x9b, 0x50, 0xde, 0x0e, 0x3a, 0xcf,
+	0x89, 0xf4, 0x72, 0x63, 0x63, 0x79, 0x9a, 0xa1, 0x3c, 0x7e, 0x2c, 0xdd, 0xca, 0x64, 0xa2, 0xbe,
+	0x83, 0x15, 0x09, 0xfa, 0x05, 0xd8, 0x3b, 0x31, 0x0f, 0x79, 0x44, 0xfa, 0xd2, 0x63, 0x75, 0xe1,
+	0xb1, 0xd6, 0xe6, 0x77, 0x2f, 0x57, 0x7e, 0x34, 0xf3, 0xb2, 0x1a, 0xf0, 0x30, 0x6a, 0x12, 0x83,
+	0xca, 0x37, 0x58, 0xe0, 0x31, 0x7e, 0xe8, 0x4b, 0x58, 0xcc, 0x84, 0xdd, 0x8d, 0xd3, 0x01, 0x67,
+	0x0e, 0x48, 0xad, 0x37, 0xe6, 0xd4, 0x5a, 0x11, 0x29, 0xb5, 0x27, 0x38, 0xb9, 0xf7, 0x00, 0x4d,
+	0xfb, 0x4a, 0xc4, 0xd4, 0x31, 0x39, 0xcd, 0x62, 0xea, 0x98, 0x9c, 0x8a, 0xb4, 0x3e, 0x09, 0xa2,
+	0x81, 0x4a, 0xf7, 0x3a, 0x56, 0xc0, 0x66, 0xe1, 0xb6, 0x25, 0x38, 0x4c, 0x9b, 0xf7, 0x42, 0x1c,
+	0x3e, 0x87, 0xcb, 0x39, 0xa2, 0xe6, 0xb0, 0xb8, 0x66, 0xb2, 0x98, 0x8e, 0xe9, 0x11, 0x4b, 0xef,
+	0xaf, 0x45, 0xb0, 0x4d, 0x87, 0xa1, 0x75, 0xb8, 0xac, 0xf4, 0xc4, 0xe4, 0xa8, 0x4d, 0x52, 0x4a,
+	0x3a, 0xe2, 0x96, 0xd0, 0xcc, 0xf3, 0x8e, 0xd0, 0x06, 0x5c, 0xd9, 0xed, 0xeb, 0x6d, 0x66, 0x90,
+	0x14, 0x64, 0x3e, 0xe6, 0x9e, 0xa1, 0x04, 0xde, 0x53, 0xac, 0xa4, 0x25, 0x0c, 0xa2, 0xa2, 0x74,
+	0xd8, 0x67, 0x67, 0x47, 0x95, 0x9f, 0x4b, 0xab, 0xfc, 0x96, 0xcf, 0x17, 0xfd, 0x04, 0xaa, 0xea,
+	0x20, 0x4b, 0xcc, 0x0f, 0xcf, 0xfe, 0x85, 0x62, 0x96, 0xd1, 0x08, 0x72, 0xa5, 0x07, 0x73, 0xca,
+	0x17, 0x20, 0xd7, 0x34, 0xee, 0x03, 0x70, 0x67, 0x8b, 0x7c, 0x91, 0x10, 0xf0, 0xfe, 0x62, 0xc1,
+	0xa5, 0xa9, 0x1f, 0x89, 0xaa, 0x21, 0xef, 0x4d, 0xc5, 0x42, 0xae, 0x51, 0x1b, 0xca, 0x2a, 0xf3,
+	0x0b, 0x52, 0x60, 0x7f, 0x0e, 0x81, 0x7d, 0x23, 0xed, 0x15, 0xb1, 0x7b, 0x1b, 0xe0, 0xf5, 0x82,
+	0xd5, 0xfb, 0xbb, 0x05, 0x0b, 0x3a, 0xcb, 0x74, 0x89, 0x0d, 0x60, 0x29, 0x4b, 0xa1, 0x6c, 0x4f,
+	0x17, 0xdb, 0x4f, 0x67, 0x26, 0xa8, 0x42, 0xf3, 0x27, 0xe9, 0x94, 0x8c, 0x53, 0xec, 0xdc, 0xed,
+	0x2c, 0xae, 0x26, 0x50, 0x2f, 0x24, 0xf9, 0x55, 0x58, 0xd8, 0x97, 0x4d, 0xce, 0xcc, 0xca, 0xe1,
+	0xfd, 0xd7, 0x82, 0xc5, 0x0c, 0x47, 0x6b, 0xf7, 0x09, 0xd4, 0x4e, 0x08, 0xe5, 0xe4, 0x1b, 0xc2,
+	0xb4, 0x56, 0xce, 0xb4, 0x56, 0x5f, 0x48, 0x0c, 0x3c, 0xc4, 0x44, 0x9b, 0x50, 0x53, 0x0d, 0x15,
+	0xc9, 0x1c, 0xb5, 0x3c, 0x8b, 0x4a, 0xff, 0x6f, 0x88, 0x8f, 0x9a, 0x50, 0x8a, 0x92, 0x1e, 0xd3,
+	0x39, 0xf3, 0xbd, 0x59, 0x74, 0x8f, 0x92, 0x1e, 0x96, 0x88, 0xe8, 0x0e, 0xd4, 0xbe, 0x0e, 0x68,
+	0x1c, 0xc6, 0xbd, 0x2c, 0x0b, 0x56, 0x66, 0x11, 0x3d, 0x53, 0x78, 0x78, 0x48, 0x20, 0x3a, 0x9d,
+	0x8a, 0x3a, 0x43, 0x0f, 0xa1, 0xd2, 0x0d, 0x7b, 0x84, 0x71, 0x65, 0x92, 0xd6, 0x86, 0xb8, 0xe4,
+	0xbf, 0x7b, 0xb9, 0x72, 0xc3, 0xb8, 0xc5, 0x93, 0x94, 0xc4, 0xa2, 0x41, 0x0e, 0xc2, 0x98, 0x50,
+	0xd1, 0x40, 0xde, 0x54, 0x24, 0x7e, 0x5b, 0x7e, 0xb0, 0xe6, 0x20, 0x78, 0x85, 0xea, 0xae, 0x96,
+	0xf7, 0xc5, 0xeb, 0xf1, 0x52, 0x1c, 0x44, 0x1a, 0xc4, 0x41, 0x9f, 0xe8, 0xda, 0x2c, 0xd7, 0xa2,
+	0x71, 0xe8, 0x88, 0x38, 0xef, 0xca, 0x96, 0xaa, 0x86, 0x35, 0x84, 0x36, 0xa1, 0xca, 0x78, 0x40,
+	0xc5, 0x9d, 0x53, 0x9e, 0xb3, 0xe3, 0xc9, 0x08, 0xd0, 0x5d, 0xa8, 0x77, 0x92, 0x7e, 0x1a, 0x11,
+	0x41, 0x5d, 0x99, 0x93, 0x7a, 0x44, 0x22, 0x42, 0x8f, 0x50, 0x9a, 0x50, 0xd9, 0x6b, 0xd5, 0xb1,
+	0x02, 0xd0, 0x2d, 0x58, 0x48, 0x69, 0xd2, 0xa3, 0x84, 0xb1, 0xfb, 0x34, 0x19, 0xa4, 0xba, 0xc2,
+	0x5e, 0x12, 0x97, 0xf7, 0x13, 0xf3, 0x00, 0x8f, 0xe3, 0x79, 0xff, 0x29, 0x80, 0x6d, 0x86, 0xc8,
+	0x54, 0x13, 0xfa, 0x10, 0x2a, 0x2a, 0xe0, 0x54, 0xac, 0xbf, 0x9e, 0x8d, 0x15, 0x87, 0x5c, 0x1b,
+	0x3b, 0x50, 0xed, 0x0c, 0xa8, 0xec, 0x50, 0x55, 0xdf, 0x9a, 0x81, 0x42, 0x53, 0x9e, 0xf0, 0x20,
+	0x92, 0x36, 0x2e, 0x62, 0x05, 0x88, 0xa6, 0x75, 0x38, 0xdb, 0x5c, 0xac, 0x69, 0x1d, 0x92, 0x99,
+	0xfe, 0xab, 0xbe, 0x91, 0xff, 0x6a, 0x17, 0xf6, 0x9f, 0xf7, 0x0f, 0x0b, 0xea, 0xc3, 0xdc, 0x32,
+	0xac, 0x6b, 0xbd, 0xb1, 0x75, 0xc7, 0x2c, 0x53, 0x78, 0x3d, 0xcb, 0xbc, 0x0f, 0x15, 0xc6, 0x29,
+	0x09, 0xfa, 0x6a, 0xa4, 0xc2, 0x1a, 0x12, 0xb7, 0x58, 0x9f, 0xf5, 0xa4, 0x87, 0x6c, 0x2c, 0x96,
+	0xde, 0xff, 0x2c, 0x58, 0x18, 0x4b, 0xf7, 0xb7, 0xaa, 0xcb, 0x15, 0x28, 0x47, 0xe4, 0x84, 0xa8,
+	0xa1, 0xaf, 0x88, 0x15, 0x20, 0x76, 0xd9, 0xf3, 0x84, 0x72, 0x29, 0x9c, 0x8d, 0x15, 0x20, 0x64,
+	0xee, 0x12, 0x1e, 0x84, 0x91, 0xbc, 0x97, 0x6c, 0xac, 0x21, 0x21, 0xf3, 0x80, 0x46, 0xba, 0xf1,
+	0x15, 0x4b, 0xe4, 0x41, 0x29, 0x8c, 0x8f, 0x12, 0x1d, 0x36, 0xb2, 0xb3, 0xd9, 0x4f, 0x06, 0xb4,
+	0x43, 0x76, 0xe3, 0xa3, 0x04, 0xcb, 0x33, 0x74, 0x15, 0x2a, 0x34, 0x88, 0x7b, 0x24, 0xeb, 0x7a,
+	0xeb, 0x02, 0x0b, 0x8b, 0x1d, 0xac, 0x0f, 0x3c, 0x0f, 0x6c, 0x39, 0x38, 0xee, 0x11, 0x26, 0xc6,
+	0x14, 0x11, 0xd6, 0xdd, 0x80, 0x07, 0x52, 0x6d, 0x1b, 0xcb, 0xb5, 0xf7, 0x11, 0xa0, 0x47, 0x21,
+	0xe3, 0xcf, 0xe4, 0x90, 0xcc, 0xce, 0x9b, 0x2a, 0xf7, 0xe1, 0xf2, 0x18, 0xb6, 0x2e, 0x0b, 0x3f,
+	0x9e, 0x98, 0x2b, 0xaf, 0x4d, 0xdf, 0xb8, 0x72, 0x16, 0xf7, 0x15, 0xe1, 0xc4, 0x78, 0xb9, 0x00,
+	0x0d, 0xa9, 0x97, 0xfa, 0xb7, 0x17, 0x80, 0xad, 0x40, 0xcd, 0xfc, 0x73, 0x78, 0x37, 0x63, 0xf4,
+	0x05, 0xa1, 0x72, 0x46, 0xb0, 0xa4, 0x5d, 0x7e, 0x30, 0xeb, 0x2f, 0xad, 0x71, 0x74, 0x3c, 0x49,
+	0xef, 0xdd, 0x87, 0xcb, 0x12, 0xe7, 0x41, 0xc8, 0x78, 0x42, 0x4f, 0x33, 0xad, 0x97, 0x01, 0xb6,
+	0x3a, 0x3c, 0x3c, 0x21, 0x8f, 0xe3, 0x48, 0x95, 0xd1, 0x1a, 0x36, 0x76, 0xb2, 0x12, 0x59, 0x18,
+	0x95, 0xc8, 0xdf, 0x5a, 0x70, 0xc9, 0xe4, 0xb4, 0x73, 0x22, 0x2e, 0x84, 0x3b, 0x50, 0xe2, 0x59,
+	0xa7, 0xb2, 0x98, 0x27, 0xe6, 0x14, 0x89, 0x68, 0x66, 0xb0, 0x24, 0x32, 0x6c, 0xa9, 0x52, 0xe3,
+	0xda, 0xd9, 0xe4, 0x13, 0xb6, 0xfc, 0x5b, 0x15, 0xd0, 0xf4, 0x71, 0xce, 0x58, 0x68, 0xce, 0x55,
+	0x85, 0x89, 0xb9, 0xea, 0xab, 0xc9, 0xb9, 0x4a, 0x15, 0xdf, 0x5b, 0xf3, 0x48, 0x32, 0xc7, 0x74,
+	0x75, 0x1b, 0xea, 0x59, 0xff, 0x92, 0x95, 0x68, 0x77, 0x9a, 0xf5, 0xb0, 0xc5, 0x19, 0x21, 0xa3,
+	0xb5, 0xac, 0xa6, 0xa8, 0x6a, 0x86, 0xb2, 0x5b, 0x83, 0xa6, 0x1d, 0x5f, 0x77, 0x0e, 0xba, 0xce,
+	0xdc, 0xbd, 0xd8, 0x93, 0x41, 0x69, 0xf2, 0xb9, 0xa0, 0x05, 0x8d, 0xed, 0xec, 0x2a, 0xbc, 0xc0,
+	0x7b, 0x81, 0x49, 0x84, 0xd6, 0x75, 0xeb, 0xa2, 0x2e, 0xdf, 0xef, 0x4f, 0xab, 0x98, 0xbd, 0x0d,
+	0x24, 0x54, 0xf7, 0x2e, 0x47, 0x39, 0xcd, 0x63, 0x5d, 0x1a, 0x68, 0x73, 0x2e, 0xdb, 0xcf, 0xd9,
+	0x41, 0xa2, 0xcf, 0xa0, 0x82, 0x09, 0x1b, 0x44, 0x5c, 0x3e, 0x42, 0x34, 0x36, 0xae, 0xce, 0xe0,
+	0xae, 0x90, 0x64, 0x36, 0x6a, 0x02, 0xf4, 0x73, 0xa8, 0xaa, 0x15, 0x73, 0x1a, 0xb3, 0xa6, 0xed,
+	0x1c, 0xc9, 0x34, 0x8d, 0x1e, 0x19, 0x34, 0x24, 0x12, 0xee, 0x3e, 0x89, 0x89, 0x7e, 0x1c, 0xb3,
+	0x57, 0xad, 0xb5, 0x32, 0x36, 0x76, 0xde, 0xc2, 0x34, 0xf9, 0x36, 0x7a, 0x65, 0xf7, 0x2b, 0xb0,
+	0x4d, 0xf9, 0x73, 0x68, 0x6f, 0x8d, 0xcf, 0xa2, 0x73, 0xd8, 0xd3, 0x68, 0xc5, 0xff, 0x54, 0x00,
+	0x18, 0x85, 0x02, 0xfa, 0x00, 0xa0, 0x4f, 0xba, 0x61, 0xf0, 0x4b, 0x3e, 0x9a, 0x76, 0xea, 0x72,
+	0x47, 0x8e, 0x3c, 0xa3, 0xbe, 0xb4, 0xf0, 0xc6, 0x7d, 0x29, 0x82, 0x12, 0x0b, 0xbf, 0x25, 0xba,
+	0x86, 0xca, 0x35, 0x7a, 0x0c, 0x8d, 0x20, 0x8e, 0x13, 0x2e, 0x3d, 0x90, 0x4d, 0x82, 0x37, 0xcf,
+	0x0a, 0x5e, 0x7f, 0x6b, 0x84, 0xaf, 0x1c, 0x6c, 0x72, 0x70, 0xef, 0xc2, 0xd2, 0x24, 0xc2, 0x85,
+	0x26, 0x95, 0xdf, 0x58, 0xf0, 0xee, 0x84, 0xf5, 0xd0, 0x27, 0xc3, 0x00, 0xb6, 0xe6, 0x48, 0xae,
+	0x2c, 0x76, 0xef, 0x81, 0xbd, 0xc5, 0xb9, 0x48, 0x58, 0xa5, 0x9b, 0x9a, 0x45, 0xce, 0xa6, 0x1d,
+	0xa3, 0xf0, 0x7e, 0x6f, 0x8d, 0x5e, 0xc7, 0x72, 0x07, 0xd2, 0x3b, 0xe3, 0x03, 0xe9, 0xf5, 0xd9,
+	0xf7, 0xda, 0xdb, 0x9c, 0x43, 0x6f, 0xfc, 0x14, 0xde, 0xcb, 0xad, 0x29, 0xa8, 0x01, 0xd5, 0xfd,
+	0x83, 0x2d, 0x7c, 0xb0, 0xd3, 0x5e, 0x7a, 0x07, 0xd9, 0x50, 0xdb, 0x7e, 0xbc, 0xf7, 0xe4, 0xd1,
+	0xce, 0xc1, 0xce, 0x92, 0x25, 0x8e, 0xda, 0x3b, 0x62, 0xdd, 0x5e, 0x2a, 0x6c, 0xfc, 0xb1, 0x0c,
+	0xd5, 0x6d, 0xf5, 0xd4, 0x8f, 0x0e, 0xa0, 0x3e, 0x7c, 0x3a, 0x46, 0x5e, 0x8e, 0x75, 0x26, 0xde,
+	0xa0, 0xdd, 0x0f, 0xcf, 0xc4, 0xd1, 0x77, 0xce, 0x03, 0x28, 0xcb, 0x47, 0x74, 0x94, 0x33, 0xfb,
+	0x99, 0xaf, 0xeb, 0xee, 0xd9, 0x8f, 0xd2, 0xeb, 0x96, 0xe0, 0x24, 0x07, 0xe7, 0x3c, 0x4e, 0xe6,
+	0x93, 0x97, 0xbb, 0x72, 0xce, 0xc4, 0x8d, 0xf6, 0xa0, 0xa2, 0xa7, 0x89, 0x3c, 0x54, 0x73, 0x3c,
+	0x76, 0x57, 0x67, 0x23, 0x28, 0x66, 0xeb, 0x16, 0xda, 0x1b, 0xbe, 0x62, 0xe6, 0x89, 0x66, 0xb6,
+	0x62, 0xee, 0x39, 0xe7, 0x6b, 0xd6, 0xba, 0x85, 0xbe, 0x84, 0x86, 0xd1, 0x6c, 0xa1, 0x9c, 0x46,
+	0x60, 0xba, 0x73, 0x73, 0xaf, 0x9f, 0x83, 0xa5, 0x35, 0xdf, 0x81, 0x92, 0x4c, 0xa4, 0x1c, 0x63,
+	0x1b, 0xbd, 0x58, 0x9e, 0x98, 0x63, 0xbd, 0xd9, 0xa1, 0xea, 0x1e, 0x49, 0x6c, 0x46, 0x1f, 0xba,
+	0x7e, 0x5e, 0x49, 0x98, 0x19, 0x36, 0x53, 0x41, 0xbc, 0x6e, 0xb5, 0xec, 0x17, 0xaf, 0x96, 0xad,
+	0x7f, 0xbe, 0x5a, 0xb6, 0xfe, 0xfd, 0x6a, 0xd9, 0x3a, 0xac, 0xc8, 0xda, 0xfb, 0xc3, 0xff, 0x07,
+	0x00, 0x00, 0xff, 0xff, 0x0d, 0xf5, 0x52, 0x93, 0x99, 0x1a, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -1479,6 +1968,7 @@ type ControlClient interface {
 	Session(ctx context.Context, opts ...grpc.CallOption) (Control_SessionClient, error)
 	ListWorkers(ctx context.Context, in *ListWorkersRequest, opts ...grpc.CallOption) (*ListWorkersResponse, error)
 	Info(ctx context.Context, in *InfoRequest, opts ...grpc.CallOption) (*InfoResponse, error)
+	ListenBuildHistory(ctx context.Context, in *BuildHistoryRequest, opts ...grpc.CallOption) (Control_ListenBuildHistoryClient, error)
 }
 
 type controlClient struct {
@@ -1620,6 +2110,38 @@ func (c *controlClient) Info(ctx context.Context, in *InfoRequest, opts ...grpc.
 	return out, nil
 }
 
+func (c *controlClient) ListenBuildHistory(ctx context.Context, in *BuildHistoryRequest, opts ...grpc.CallOption) (Control_ListenBuildHistoryClient, error) {
+	stream, err := c.cc.NewStream(ctx, &_Control_serviceDesc.Streams[3], "/moby.buildkit.v1.Control/ListenBuildHistory", opts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &controlListenBuildHistoryClient{stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+type Control_ListenBuildHistoryClient interface {
+	Recv() (*BuildHistoryEvent, error)
+	grpc.ClientStream
+}
+
+type controlListenBuildHistoryClient struct {
+	grpc.ClientStream
+}
+
+func (x *controlListenBuildHistoryClient) Recv() (*BuildHistoryEvent, error) {
+	m := new(BuildHistoryEvent)
+	if err := x.ClientStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
 // ControlServer is the server API for Control service.
 type ControlServer interface {
 	DiskUsage(context.Context, *DiskUsageRequest) (*DiskUsageResponse, error)
@@ -1629,6 +2151,7 @@ type ControlServer interface {
 	Session(Control_SessionServer) error
 	ListWorkers(context.Context, *ListWorkersRequest) (*ListWorkersResponse, error)
 	Info(context.Context, *InfoRequest) (*InfoResponse, error)
+	ListenBuildHistory(*BuildHistoryRequest, Control_ListenBuildHistoryServer) error
 }
 
 // UnimplementedControlServer can be embedded to have forward compatible implementations.
@@ -1655,6 +2178,9 @@ func (*UnimplementedControlServer) ListWorkers(ctx context.Context, req *ListWor
 }
 func (*UnimplementedControlServer) Info(ctx context.Context, req *InfoRequest) (*InfoResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Info not implemented")
+}
+func (*UnimplementedControlServer) ListenBuildHistory(req *BuildHistoryRequest, srv Control_ListenBuildHistoryServer) error {
+	return status.Errorf(codes.Unimplemented, "method ListenBuildHistory not implemented")
 }
 
 func RegisterControlServer(s *grpc.Server, srv ControlServer) {
@@ -1801,6 +2327,27 @@ func _Control_Info_Handler(srv interface{}, ctx context.Context, dec func(interf
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Control_ListenBuildHistory_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(BuildHistoryRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(ControlServer).ListenBuildHistory(m, &controlListenBuildHistoryServer{stream})
+}
+
+type Control_ListenBuildHistoryServer interface {
+	Send(*BuildHistoryEvent) error
+	grpc.ServerStream
+}
+
+type controlListenBuildHistoryServer struct {
+	grpc.ServerStream
+}
+
+func (x *controlListenBuildHistoryServer) Send(m *BuildHistoryEvent) error {
+	return x.ServerStream.SendMsg(m)
+}
+
 var _Control_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "moby.buildkit.v1.Control",
 	HandlerType: (*ControlServer)(nil),
@@ -1838,6 +2385,11 @@ var _Control_serviceDesc = grpc.ServiceDesc{
 			Handler:       _Control_Session_Handler,
 			ServerStreams: true,
 			ClientStreams: true,
+		},
+		{
+			StreamName:    "ListenBuildHistory",
+			Handler:       _Control_ListenBuildHistory_Handler,
+			ServerStreams: true,
 		},
 	},
 	Metadata: "control.proto",
@@ -3058,6 +3610,445 @@ func (m *InfoResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *BuildHistoryRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *BuildHistoryRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *BuildHistoryRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if len(m.Ref) > 0 {
+		i -= len(m.Ref)
+		copy(dAtA[i:], m.Ref)
+		i = encodeVarintControl(dAtA, i, uint64(len(m.Ref)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.ActiveOnly {
+		i--
+		if m.ActiveOnly {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *BuildHistoryEvent) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *BuildHistoryEvent) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *BuildHistoryEvent) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if m.Record != nil {
+		{
+			size, err := m.Record.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintControl(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.Type != 0 {
+		i = encodeVarintControl(dAtA, i, uint64(m.Type))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *BuildHistoryRecord) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *BuildHistoryRecord) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *BuildHistoryRecord) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if m.Generation != 0 {
+		i = encodeVarintControl(dAtA, i, uint64(m.Generation))
+		i--
+		dAtA[i] = 0x60
+	}
+	if len(m.Results) > 0 {
+		for k := range m.Results {
+			v := m.Results[k]
+			baseI := i
+			if v != nil {
+				{
+					size, err := v.MarshalToSizedBuffer(dAtA[:i])
+					if err != nil {
+						return 0, err
+					}
+					i -= size
+					i = encodeVarintControl(dAtA, i, uint64(size))
+				}
+				i--
+				dAtA[i] = 0x12
+			}
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = encodeVarintControl(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = encodeVarintControl(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x5a
+		}
+	}
+	if m.Result != nil {
+		{
+			size, err := m.Result.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintControl(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x52
+	}
+	if len(m.ExporterResponse) > 0 {
+		for k := range m.ExporterResponse {
+			v := m.ExporterResponse[k]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = encodeVarintControl(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = encodeVarintControl(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = encodeVarintControl(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4a
+		}
+	}
+	if m.Logs != nil {
+		{
+			size, err := m.Logs.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintControl(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x42
+	}
+	if m.CompletedAt != nil {
+		n19, err19 := github_com_gogo_protobuf_types.StdTimeMarshalTo(*m.CompletedAt, dAtA[i-github_com_gogo_protobuf_types.SizeOfStdTime(*m.CompletedAt):])
+		if err19 != nil {
+			return 0, err19
+		}
+		i -= n19
+		i = encodeVarintControl(dAtA, i, uint64(n19))
+		i--
+		dAtA[i] = 0x3a
+	}
+	if m.CreatedAt != nil {
+		n20, err20 := github_com_gogo_protobuf_types.StdTimeMarshalTo(*m.CreatedAt, dAtA[i-github_com_gogo_protobuf_types.SizeOfStdTime(*m.CreatedAt):])
+		if err20 != nil {
+			return 0, err20
+		}
+		i -= n20
+		i = encodeVarintControl(dAtA, i, uint64(n20))
+		i--
+		dAtA[i] = 0x32
+	}
+	if m.Error != nil {
+		{
+			size, err := m.Error.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintControl(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x2a
+	}
+	if len(m.Exporters) > 0 {
+		for iNdEx := len(m.Exporters) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Exporters[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintControl(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x22
+		}
+	}
+	if len(m.FrontendAttrs) > 0 {
+		for k := range m.FrontendAttrs {
+			v := m.FrontendAttrs[k]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = encodeVarintControl(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = encodeVarintControl(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = encodeVarintControl(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if len(m.Frontend) > 0 {
+		i -= len(m.Frontend)
+		copy(dAtA[i:], m.Frontend)
+		i = encodeVarintControl(dAtA, i, uint64(len(m.Frontend)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Ref) > 0 {
+		i -= len(m.Ref)
+		copy(dAtA[i:], m.Ref)
+		i = encodeVarintControl(dAtA, i, uint64(len(m.Ref)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Descriptor) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Descriptor) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Descriptor) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if len(m.Annotations) > 0 {
+		for k := range m.Annotations {
+			v := m.Annotations[k]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = encodeVarintControl(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = encodeVarintControl(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = encodeVarintControl(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x2a
+		}
+	}
+	if m.Size_ != 0 {
+		i = encodeVarintControl(dAtA, i, uint64(m.Size_))
+		i--
+		dAtA[i] = 0x18
+	}
+	if len(m.Digest) > 0 {
+		i -= len(m.Digest)
+		copy(dAtA[i:], m.Digest)
+		i = encodeVarintControl(dAtA, i, uint64(len(m.Digest)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.MediaType) > 0 {
+		i -= len(m.MediaType)
+		copy(dAtA[i:], m.MediaType)
+		i = encodeVarintControl(dAtA, i, uint64(len(m.MediaType)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *BuildResultInfo) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *BuildResultInfo) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *BuildResultInfo) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if len(m.Attestations) > 0 {
+		for iNdEx := len(m.Attestations) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Attestations[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintControl(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if m.Result != nil {
+		{
+			size, err := m.Result.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintControl(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Exporter) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Exporter) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Exporter) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if len(m.Attrs) > 0 {
+		for k := range m.Attrs {
+			v := m.Attrs[k]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = encodeVarintControl(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = encodeVarintControl(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = encodeVarintControl(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if len(m.Type) > 0 {
+		i -= len(m.Type)
+		copy(dAtA[i:], m.Type)
+		i = encodeVarintControl(dAtA, i, uint64(len(m.Type)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintControl(dAtA []byte, offset int, v uint64) int {
 	offset -= sovControl(v)
 	base := offset
@@ -3620,6 +4611,199 @@ func (m *InfoResponse) Size() (n int) {
 	if m.BuildkitVersion != nil {
 		l = m.BuildkitVersion.Size()
 		n += 1 + l + sovControl(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *BuildHistoryRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.ActiveOnly {
+		n += 2
+	}
+	l = len(m.Ref)
+	if l > 0 {
+		n += 1 + l + sovControl(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *BuildHistoryEvent) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Type != 0 {
+		n += 1 + sovControl(uint64(m.Type))
+	}
+	if m.Record != nil {
+		l = m.Record.Size()
+		n += 1 + l + sovControl(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *BuildHistoryRecord) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Ref)
+	if l > 0 {
+		n += 1 + l + sovControl(uint64(l))
+	}
+	l = len(m.Frontend)
+	if l > 0 {
+		n += 1 + l + sovControl(uint64(l))
+	}
+	if len(m.FrontendAttrs) > 0 {
+		for k, v := range m.FrontendAttrs {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + sovControl(uint64(len(k))) + 1 + len(v) + sovControl(uint64(len(v)))
+			n += mapEntrySize + 1 + sovControl(uint64(mapEntrySize))
+		}
+	}
+	if len(m.Exporters) > 0 {
+		for _, e := range m.Exporters {
+			l = e.Size()
+			n += 1 + l + sovControl(uint64(l))
+		}
+	}
+	if m.Error != nil {
+		l = m.Error.Size()
+		n += 1 + l + sovControl(uint64(l))
+	}
+	if m.CreatedAt != nil {
+		l = github_com_gogo_protobuf_types.SizeOfStdTime(*m.CreatedAt)
+		n += 1 + l + sovControl(uint64(l))
+	}
+	if m.CompletedAt != nil {
+		l = github_com_gogo_protobuf_types.SizeOfStdTime(*m.CompletedAt)
+		n += 1 + l + sovControl(uint64(l))
+	}
+	if m.Logs != nil {
+		l = m.Logs.Size()
+		n += 1 + l + sovControl(uint64(l))
+	}
+	if len(m.ExporterResponse) > 0 {
+		for k, v := range m.ExporterResponse {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + sovControl(uint64(len(k))) + 1 + len(v) + sovControl(uint64(len(v)))
+			n += mapEntrySize + 1 + sovControl(uint64(mapEntrySize))
+		}
+	}
+	if m.Result != nil {
+		l = m.Result.Size()
+		n += 1 + l + sovControl(uint64(l))
+	}
+	if len(m.Results) > 0 {
+		for k, v := range m.Results {
+			_ = k
+			_ = v
+			l = 0
+			if v != nil {
+				l = v.Size()
+				l += 1 + sovControl(uint64(l))
+			}
+			mapEntrySize := 1 + len(k) + sovControl(uint64(len(k))) + l
+			n += mapEntrySize + 1 + sovControl(uint64(mapEntrySize))
+		}
+	}
+	if m.Generation != 0 {
+		n += 1 + sovControl(uint64(m.Generation))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *Descriptor) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.MediaType)
+	if l > 0 {
+		n += 1 + l + sovControl(uint64(l))
+	}
+	l = len(m.Digest)
+	if l > 0 {
+		n += 1 + l + sovControl(uint64(l))
+	}
+	if m.Size_ != 0 {
+		n += 1 + sovControl(uint64(m.Size_))
+	}
+	if len(m.Annotations) > 0 {
+		for k, v := range m.Annotations {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + sovControl(uint64(len(k))) + 1 + len(v) + sovControl(uint64(len(v)))
+			n += mapEntrySize + 1 + sovControl(uint64(mapEntrySize))
+		}
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *BuildResultInfo) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Result != nil {
+		l = m.Result.Size()
+		n += 1 + l + sovControl(uint64(l))
+	}
+	if len(m.Attestations) > 0 {
+		for _, e := range m.Attestations {
+			l = e.Size()
+			n += 1 + l + sovControl(uint64(l))
+		}
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *Exporter) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Type)
+	if l > 0 {
+		n += 1 + l + sovControl(uint64(l))
+	}
+	if len(m.Attrs) > 0 {
+		for k, v := range m.Attrs {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + sovControl(uint64(len(k))) + 1 + len(v) + sovControl(uint64(len(v)))
+			n += mapEntrySize + 1 + sovControl(uint64(mapEntrySize))
+		}
 	}
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
@@ -7355,6 +8539,1538 @@ func (m *InfoResponse) Unmarshal(dAtA []byte) error {
 			if err := m.BuildkitVersion.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipControl(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthControl
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *BuildHistoryRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowControl
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: BuildHistoryRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: BuildHistoryRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ActiveOnly", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowControl
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.ActiveOnly = bool(v != 0)
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Ref", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowControl
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthControl
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthControl
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Ref = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipControl(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthControl
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *BuildHistoryEvent) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowControl
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: BuildHistoryEvent: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: BuildHistoryEvent: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Type", wireType)
+			}
+			m.Type = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowControl
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Type |= BuildHistoryEventType(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Record", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowControl
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthControl
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthControl
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Record == nil {
+				m.Record = &BuildHistoryRecord{}
+			}
+			if err := m.Record.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipControl(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthControl
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *BuildHistoryRecord) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowControl
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: BuildHistoryRecord: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: BuildHistoryRecord: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Ref", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowControl
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthControl
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthControl
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Ref = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Frontend", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowControl
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthControl
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthControl
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Frontend = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field FrontendAttrs", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowControl
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthControl
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthControl
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.FrontendAttrs == nil {
+				m.FrontendAttrs = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowControl
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowControl
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return ErrInvalidLengthControl
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return ErrInvalidLengthControl
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowControl
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return ErrInvalidLengthControl
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue < 0 {
+						return ErrInvalidLengthControl
+					}
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := skipControl(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return ErrInvalidLengthControl
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.FrontendAttrs[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Exporters", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowControl
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthControl
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthControl
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Exporters = append(m.Exporters, &Exporter{})
+			if err := m.Exporters[len(m.Exporters)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Error", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowControl
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthControl
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthControl
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Error == nil {
+				m.Error = &rpc.Status{}
+			}
+			if err := m.Error.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CreatedAt", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowControl
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthControl
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthControl
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.CreatedAt == nil {
+				m.CreatedAt = new(time.Time)
+			}
+			if err := github_com_gogo_protobuf_types.StdTimeUnmarshal(m.CreatedAt, dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CompletedAt", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowControl
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthControl
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthControl
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.CompletedAt == nil {
+				m.CompletedAt = new(time.Time)
+			}
+			if err := github_com_gogo_protobuf_types.StdTimeUnmarshal(m.CompletedAt, dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Logs", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowControl
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthControl
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthControl
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Logs == nil {
+				m.Logs = &Descriptor{}
+			}
+			if err := m.Logs.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 9:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ExporterResponse", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowControl
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthControl
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthControl
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ExporterResponse == nil {
+				m.ExporterResponse = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowControl
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowControl
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return ErrInvalidLengthControl
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return ErrInvalidLengthControl
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowControl
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return ErrInvalidLengthControl
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue < 0 {
+						return ErrInvalidLengthControl
+					}
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := skipControl(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return ErrInvalidLengthControl
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.ExporterResponse[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 10:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Result", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowControl
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthControl
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthControl
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Result == nil {
+				m.Result = &BuildResultInfo{}
+			}
+			if err := m.Result.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 11:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Results", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowControl
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthControl
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthControl
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Results == nil {
+				m.Results = make(map[string]*BuildResultInfo)
+			}
+			var mapkey string
+			var mapvalue *BuildResultInfo
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowControl
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowControl
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return ErrInvalidLengthControl
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return ErrInvalidLengthControl
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var mapmsglen int
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowControl
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						mapmsglen |= int(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					if mapmsglen < 0 {
+						return ErrInvalidLengthControl
+					}
+					postmsgIndex := iNdEx + mapmsglen
+					if postmsgIndex < 0 {
+						return ErrInvalidLengthControl
+					}
+					if postmsgIndex > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = &BuildResultInfo{}
+					if err := mapvalue.Unmarshal(dAtA[iNdEx:postmsgIndex]); err != nil {
+						return err
+					}
+					iNdEx = postmsgIndex
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := skipControl(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return ErrInvalidLengthControl
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Results[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 12:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Generation", wireType)
+			}
+			m.Generation = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowControl
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Generation |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipControl(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthControl
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *Descriptor) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowControl
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: Descriptor: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: Descriptor: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MediaType", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowControl
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthControl
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthControl
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.MediaType = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Digest", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowControl
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthControl
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthControl
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Digest = github_com_opencontainers_go_digest.Digest(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Size_", wireType)
+			}
+			m.Size_ = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowControl
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Size_ |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Annotations", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowControl
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthControl
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthControl
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Annotations == nil {
+				m.Annotations = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowControl
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowControl
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return ErrInvalidLengthControl
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return ErrInvalidLengthControl
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowControl
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return ErrInvalidLengthControl
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue < 0 {
+						return ErrInvalidLengthControl
+					}
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := skipControl(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return ErrInvalidLengthControl
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Annotations[mapkey] = mapvalue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipControl(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthControl
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *BuildResultInfo) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowControl
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: BuildResultInfo: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: BuildResultInfo: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Result", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowControl
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthControl
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthControl
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Result == nil {
+				m.Result = &Descriptor{}
+			}
+			if err := m.Result.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Attestations", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowControl
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthControl
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthControl
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Attestations = append(m.Attestations, &Descriptor{})
+			if err := m.Attestations[len(m.Attestations)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipControl(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthControl
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *Exporter) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowControl
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: Exporter: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: Exporter: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Type", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowControl
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthControl
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthControl
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Type = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Attrs", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowControl
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthControl
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthControl
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Attrs == nil {
+				m.Attrs = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowControl
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowControl
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return ErrInvalidLengthControl
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return ErrInvalidLengthControl
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowControl
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return ErrInvalidLengthControl
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue < 0 {
+						return ErrInvalidLengthControl
+					}
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := skipControl(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return ErrInvalidLengthControl
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Attrs[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/api/services/control/control.proto
+++ b/api/services/control/control.proto
@@ -6,6 +6,8 @@ import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 import "google/protobuf/timestamp.proto";
 import "github.com/moby/buildkit/solver/pb/ops.proto";
 import "github.com/moby/buildkit/api/types/worker.proto";
+// import "github.com/containerd/containerd/api/types/descriptor.proto";
+import "github.com/gogo/googleapis/google/rpc/status.proto";
 
 option (gogoproto.sizer_all) = true;
 option (gogoproto.marshaler_all) = true;
@@ -19,6 +21,8 @@ service Control {
 	rpc Session(stream BytesMessage) returns (stream BytesMessage);
 	rpc ListWorkers(ListWorkersRequest) returns (ListWorkersResponse);
 	rpc Info(InfoRequest) returns (InfoResponse);
+
+	rpc ListenBuildHistory(BuildHistoryRequest) returns (stream BuildHistoryEvent);
 }
 
 message PruneRequest {
@@ -162,4 +166,57 @@ message InfoRequest {}
 
 message InfoResponse {
 	moby.buildkit.v1.types.BuildkitVersion buildkitVersion = 1;
+}
+
+message BuildHistoryRequest {
+	bool ActiveOnly = 1;
+	string Ref = 2;
+}
+
+enum BuildHistoryEventType {
+	STARTED = 0;
+	COMPLETE = 1;
+	DELETED = 2;
+}
+
+
+message BuildHistoryEvent {
+	BuildHistoryEventType type = 1;
+	BuildHistoryRecord record = 2;
+}
+
+message BuildHistoryRecord {
+	string Ref = 1;
+	string Frontend = 2;
+	map<string, string> FrontendAttrs = 3;
+	repeated Exporter Exporters = 4;
+	google.rpc.Status error = 5;
+	google.protobuf.Timestamp CreatedAt = 6 [(gogoproto.stdtime) = true];
+	google.protobuf.Timestamp CompletedAt = 7 [(gogoproto.stdtime) = true];
+	Descriptor logs = 8;
+	map<string, string> ExporterResponse = 9;
+	BuildResultInfo Result = 10;
+	map<string, BuildResultInfo> Results = 11;
+	int32 Generation = 12;
+	// TODO: tags
+	// TODO: steps/cache summary
+	// TODO: unclipped logs
+	// TODO: pinning
+}
+
+message Descriptor {
+	string media_type = 1;
+	string digest = 2 [(gogoproto.customtype) = "github.com/opencontainers/go-digest.Digest", (gogoproto.nullable) = false];
+	int64 size = 3;
+	map<string, string> annotations = 5;
+}
+
+message BuildResultInfo {
+	Descriptor Result = 1;
+	repeated Descriptor Attestations = 2;
+}
+
+message Exporter {
+	string Type = 1;
+	map<string, string> Attrs = 2;
 }

--- a/client/client.go
+++ b/client/client.go
@@ -168,12 +168,12 @@ func (c *Client) setupDelegatedTracing(ctx context.Context, td TracerDelegate) e
 	return td.SetSpanExporter(ctx, e)
 }
 
-func (c *Client) controlClient() controlapi.ControlClient {
+func (c *Client) ControlClient() controlapi.ControlClient {
 	return controlapi.NewControlClient(c.conn)
 }
 
 func (c *Client) Dialer() session.Dialer {
-	return grpchijack.Dialer(c.controlClient())
+	return grpchijack.Dialer(c.ControlClient())
 }
 
 func (c *Client) Close() error {

--- a/client/diskusage.go
+++ b/client/diskusage.go
@@ -31,7 +31,7 @@ func (c *Client) DiskUsage(ctx context.Context, opts ...DiskUsageOption) ([]*Usa
 	}
 
 	req := &controlapi.DiskUsageRequest{Filter: info.Filter}
-	resp, err := c.controlClient().DiskUsage(ctx, req)
+	resp, err := c.ControlClient().DiskUsage(ctx, req)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to call diskusage")
 	}

--- a/client/info.go
+++ b/client/info.go
@@ -19,7 +19,7 @@ type BuildkitVersion struct {
 }
 
 func (c *Client) Info(ctx context.Context) (*Info, error) {
-	res, err := c.controlClient().Info(ctx, &controlapi.InfoRequest{})
+	res, err := c.ControlClient().Info(ctx, &controlapi.InfoRequest{})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to call info")
 	}

--- a/client/prune.go
+++ b/client/prune.go
@@ -23,7 +23,7 @@ func (c *Client) Prune(ctx context.Context, ch chan UsageInfo, opts ...PruneOpti
 	if info.All {
 		req.All = true
 	}
-	cl, err := c.controlClient().Prune(ctx, req)
+	cl, err := c.ControlClient().Prune(ctx, req)
 	if err != nil {
 		return errors.Wrap(err, "failed to call prune")
 	}

--- a/client/workers.go
+++ b/client/workers.go
@@ -28,7 +28,7 @@ func (c *Client) ListWorkers(ctx context.Context, opts ...ListWorkersOption) ([]
 	}
 
 	req := &controlapi.ListWorkersRequest{Filter: info.Filter}
-	resp, err := c.controlClient().ListWorkers(ctx, req)
+	resp, err := c.ControlClient().ListWorkers(ctx, req)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list workers")
 	}

--- a/cmd/buildctl/debug.go
+++ b/cmd/buildctl/debug.go
@@ -13,5 +13,7 @@ var debugCommand = cli.Command{
 		debug.DumpMetadataCommand,
 		debug.WorkersCommand,
 		debug.InfoCommand,
+		debug.MonitorCommand,
+		debug.LogsCommand,
 	},
 }

--- a/cmd/buildctl/debug/logs.go
+++ b/cmd/buildctl/debug/logs.go
@@ -1,0 +1,71 @@
+package debug
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	controlapi "github.com/moby/buildkit/api/services/control"
+	"github.com/moby/buildkit/client"
+	bccommon "github.com/moby/buildkit/cmd/buildctl/common"
+	"github.com/moby/buildkit/util/appcontext"
+	"github.com/moby/buildkit/util/progress/progresswriter"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
+)
+
+var LogsCommand = cli.Command{
+	Name:   "logs",
+	Usage:  "display build logs",
+	Action: logs,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "progress",
+			Usage: "progress output type",
+			Value: "auto",
+		},
+	},
+}
+
+func logs(clicontext *cli.Context) error {
+	args := clicontext.Args()
+	if len(args) == 0 {
+		return fmt.Errorf("build ref must be specified")
+	}
+	ref := args[0]
+
+	c, err := bccommon.ResolveClient(clicontext)
+	if err != nil {
+		return err
+	}
+
+	ctx := appcontext.Context()
+
+	cl, err := c.ControlClient().Status(ctx, &controlapi.StatusRequest{
+		Ref: ref,
+	})
+	if err != nil {
+		return err
+	}
+
+	pw, err := progresswriter.NewPrinter(ctx, os.Stdout, clicontext.String("progress"))
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		<-pw.Done()
+	}()
+
+	for {
+		resp, err := cl.Recv()
+		if err != nil {
+			close(pw.Status())
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+		pw.Status() <- client.NewSolveStatus(resp)
+	}
+}

--- a/cmd/buildctl/debug/monitor.go
+++ b/cmd/buildctl/debug/monitor.go
@@ -1,0 +1,52 @@
+package debug
+
+import (
+	"fmt"
+
+	controlapi "github.com/moby/buildkit/api/services/control"
+	bccommon "github.com/moby/buildkit/cmd/buildctl/common"
+	"github.com/moby/buildkit/util/appcontext"
+	"github.com/urfave/cli"
+)
+
+var MonitorCommand = cli.Command{
+	Name:   "monitor",
+	Usage:  "display build events",
+	Action: monitor,
+	Flags: []cli.Flag{
+		cli.BoolFlag{
+			Name:  "completed",
+			Usage: "show completed builds",
+		},
+		cli.StringFlag{
+			Name:  "ref",
+			Usage: "show events for a specific build",
+		},
+	},
+}
+
+func monitor(clicontext *cli.Context) error {
+	c, err := bccommon.ResolveClient(clicontext)
+	if err != nil {
+		return err
+	}
+	completed := clicontext.Bool("completed")
+
+	ctx := appcontext.Context()
+
+	cl, err := c.ControlClient().ListenBuildHistory(ctx, &controlapi.BuildHistoryRequest{
+		ActiveOnly: !completed,
+		Ref:        clicontext.String("ref"),
+	})
+	if err != nil {
+		return err
+	}
+
+	for {
+		ev, err := cl.Recv()
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%s %s\n", ev.Type.String(), ev.Record.Ref)
+	}
+}

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -59,6 +59,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
+	"go.etcd.io/bbolt"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/propagation"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -649,6 +650,11 @@ func newController(c *cli.Context, cfg *config.Config) (*control.Controller, err
 		return nil, err
 	}
 
+	historyDB, err := bbolt.Open(filepath.Join(cfg.Root, "history.db"), 0600, nil)
+	if err != nil {
+		return nil, err
+	}
+
 	resolverFn := resolverFunc(cfg)
 
 	w, err := wc.GetDefault()
@@ -680,6 +686,8 @@ func newController(c *cli.Context, cfg *config.Config) (*control.Controller, err
 		CacheKeyStorage:           cacheStorage,
 		Entitlements:              cfg.Entitlements,
 		TraceCollector:            tc,
+		HistoryDB:                 historyDB,
+		LeaseManager:              w.LeaseManager(),
 	})
 }
 

--- a/solver/llbsolver/history.go
+++ b/solver/llbsolver/history.go
@@ -1,0 +1,210 @@
+package llbsolver
+
+import (
+	"context"
+	"sync"
+
+	"github.com/containerd/containerd/leases"
+	controlapi "github.com/moby/buildkit/api/services/control"
+	"github.com/pkg/errors"
+	bolt "go.etcd.io/bbolt"
+)
+
+const (
+	recordsBucket = "_records"
+)
+
+type HistoryQueueOpt struct {
+	DB           *bolt.DB
+	LeaseManager leases.Manager
+}
+
+type HistoryQueue struct {
+	mu       sync.Mutex
+	initOnce sync.Once
+	HistoryQueueOpt
+	ps     *pubsub[*controlapi.BuildHistoryEvent]
+	active map[string]*controlapi.BuildHistoryRecord
+}
+
+func NewHistoryQueue(opt HistoryQueueOpt) *HistoryQueue {
+	return &HistoryQueue{
+		HistoryQueueOpt: opt,
+		ps: &pubsub[*controlapi.BuildHistoryEvent]{
+			m: map[*channel[*controlapi.BuildHistoryEvent]]struct{}{},
+		},
+		active: map[string]*controlapi.BuildHistoryRecord{},
+	}
+}
+
+func (h *HistoryQueue) init() error {
+	var err error
+	h.initOnce.Do(func() {
+		err = h.DB.Update(func(tx *bolt.Tx) error {
+			_, err := tx.CreateBucketIfNotExists([]byte(recordsBucket))
+			return err
+		})
+	})
+	return err
+}
+
+func (h *HistoryQueue) leaseID(id string) string {
+	return "ref_" + id
+}
+
+func (h *HistoryQueue) addResource(ctx context.Context, l leases.Lease, desc *controlapi.Descriptor) error {
+	if desc == nil {
+		return nil
+	}
+	return h.LeaseManager.AddResource(ctx, l, leases.Resource{
+		ID:   string(desc.Digest),
+		Type: "content",
+	})
+}
+
+func (h *HistoryQueue) Update(ctx context.Context, e *controlapi.BuildHistoryEvent) error {
+	h.init()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if e.Type == controlapi.BuildHistoryEventType_STARTED {
+		h.active[e.Record.Ref] = e.Record
+		h.ps.Send(e)
+	}
+
+	if e.Type == controlapi.BuildHistoryEventType_COMPLETE {
+		delete(h.active, e.Record.Ref)
+		if err := h.DB.Update(func(tx *bolt.Tx) (err error) {
+			b := tx.Bucket([]byte(recordsBucket))
+			if b == nil {
+				return nil
+			}
+			dt, err := e.Record.Marshal()
+			if err != nil {
+				return err
+			}
+
+			l, err := h.LeaseManager.Create(ctx, leases.WithID(h.leaseID(e.Record.Ref)))
+			if err != nil {
+				return err
+			}
+
+			defer func() {
+				if err != nil {
+					h.LeaseManager.Delete(ctx, l)
+				}
+			}()
+
+			if err := h.addResource(ctx, l, e.Record.Logs); err != nil {
+				return err
+			}
+
+			return b.Put([]byte(e.Record.Ref), dt)
+		}); err != nil {
+			return err
+		}
+		h.ps.Send(e)
+	}
+	return nil
+}
+
+func (h *HistoryQueue) Listen(ctx context.Context, ref string, active bool, f func(*controlapi.BuildHistoryEvent) error) error {
+	h.init()
+
+	h.mu.Lock()
+	sub := h.ps.Subscribe()
+	defer sub.close()
+
+	for _, e := range h.active {
+		sub.ps.Send(&controlapi.BuildHistoryEvent{
+			Type:   controlapi.BuildHistoryEventType_STARTED,
+			Record: e,
+		})
+	}
+	h.mu.Unlock()
+
+	if !active {
+		if err := h.DB.View(func(tx *bolt.Tx) error {
+			b := tx.Bucket([]byte(recordsBucket))
+			if b == nil {
+				return nil
+			}
+			return b.ForEach(func(key, dt []byte) error {
+				var br controlapi.BuildHistoryRecord
+				if err := br.Unmarshal(dt); err != nil {
+					return errors.Wrapf(err, "failed to unmarshal build record %s", key)
+				}
+				if err := f(&controlapi.BuildHistoryEvent{
+					Record: &br,
+					Type:   controlapi.BuildHistoryEventType_COMPLETE,
+				}); err != nil {
+					return err
+				}
+				return nil
+			})
+		}); err != nil {
+			return err
+		}
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case e := <-sub.ch:
+			if err := f(e); err != nil {
+				return err
+			}
+		case <-sub.done:
+			return nil
+		}
+	}
+}
+
+type pubsub[T any] struct {
+	mu sync.Mutex
+	m  map[*channel[T]]struct{}
+}
+
+func (p *pubsub[T]) Subscribe() *channel[T] {
+	p.mu.Lock()
+	c := &channel[T]{
+		ps:   p,
+		ch:   make(chan T, 32),
+		done: make(chan struct{}),
+	}
+	p.m[c] = struct{}{}
+	p.mu.Unlock()
+	return c
+}
+
+func (p *pubsub[T]) Send(v T) {
+	p.mu.Lock()
+	for c := range p.m {
+		go c.send(v)
+	}
+	p.mu.Unlock()
+}
+
+type channel[T any] struct {
+	ps        *pubsub[T]
+	ch        chan T
+	done      chan struct{}
+	closeOnce sync.Once
+}
+
+func (p *channel[T]) send(v T) {
+	select {
+	case p.ch <- v:
+	case <-p.done:
+	}
+}
+
+func (p *channel[T]) close() {
+	p.closeOnce.Do(func() {
+		p.ps.mu.Lock()
+		delete(p.ps.m, p)
+		p.ps.mu.Unlock()
+		close(p.done)
+	})
+}

--- a/solver/pb/generate.go
+++ b/solver/pb/generate.go
@@ -1,3 +1,3 @@
 package pb
 
-//go:generate protoc -I=. -I=../../vendor/ --gogofaster_out=. ops.proto
+//go:generate protoc -I=. -I=../../vendor/ -I=../../vendor/github.com/gogo/protobuf/ --gogofaster_out=. ops.proto

--- a/util/grpcerrors/grpcerrors.go
+++ b/util/grpcerrors/grpcerrors.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/containerd/typeurl"
+	rpc "github.com/gogo/googleapis/google/rpc"
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/golang/protobuf/proto" //nolint:staticcheck
 	"github.com/golang/protobuf/ptypes/any"
@@ -194,6 +195,20 @@ func FromGRPC(err error) error {
 	}
 
 	return stack.Enable(err)
+}
+
+func ToRPCStatus(st *spb.Status) *rpc.Status {
+	details := make([]*gogotypes.Any, len(st.Details))
+
+	for i, d := range st.Details {
+		details[i] = gogoAny(d)
+	}
+
+	return &rpc.Status{
+		Code:    int32(st.Code),
+		Message: st.Message,
+		Details: details,
+	}
 }
 
 type grpcStatusError struct {

--- a/util/progress/multireader.go
+++ b/util/progress/multireader.go
@@ -12,6 +12,7 @@ type MultiReader struct {
 	initialized bool
 	done        chan struct{}
 	writers     map[*progressWriter]func()
+	sent        []*Progress
 }
 
 func NewMultiReader(pr Reader) *MultiReader {
@@ -31,9 +32,59 @@ func (mr *MultiReader) Reader(ctx context.Context) Reader {
 	pw, _, ctx := NewFromContext(ctx)
 
 	w := pw.(*progressWriter)
-	mr.writers[w] = closeWriter
+
+	isBehind := len(mr.sent) > 0
+
+	if !isBehind {
+		mr.writers[w] = closeWriter
+	}
 
 	go func() {
+		if isBehind {
+			close := func() {
+				w.Close()
+				closeWriter()
+			}
+			i := 0
+			for {
+				mr.mu.Lock()
+				sent := mr.sent
+				count := len(sent) - i
+				if count == 0 {
+					select {
+					case <-ctx.Done():
+						close()
+						mr.mu.Unlock()
+						return
+					case <-mr.done:
+						close()
+						mr.mu.Unlock()
+						return
+					default:
+					}
+					mr.writers[w] = closeWriter
+					mr.mu.Unlock()
+					break
+				}
+				mr.mu.Unlock()
+				for i, p := range sent[i:] {
+					w.writeRawProgress(p)
+					if i%100 == 0 {
+						select {
+						case <-ctx.Done():
+							close()
+							return
+						case <-mr.done:
+							close()
+							return
+						default:
+						}
+					}
+				}
+				i += count
+			}
+		}
+
 		select {
 		case <-ctx.Done():
 		case <-mr.done:
@@ -61,6 +112,7 @@ func (mr *MultiReader) handle() error {
 					w.Close()
 					c()
 				}
+				close(mr.done)
 				mr.mu.Unlock()
 				return nil
 			}
@@ -72,6 +124,7 @@ func (mr *MultiReader) handle() error {
 				w.writeRawProgress(p)
 			}
 		}
+		mr.sent = append(mr.sent, p...)
 		mr.mu.Unlock()
 	}
 }

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -220,6 +220,10 @@ func (w *Worker) ContentStore() content.Store {
 	return w.WorkerOpt.ContentStore
 }
 
+func (w *Worker) LeaseManager() leases.Manager {
+	return w.WorkerOpt.LeaseManager
+}
+
 func (w *Worker) ID() string {
 	return w.WorkerOpt.ID
 }
@@ -378,7 +382,7 @@ func (w *Worker) Exporter(name string, sm *session.Manager) (exporter.Exporter, 
 			SessionManager: sm,
 			ImageWriter:    w.imageWriter,
 			RegistryHosts:  w.RegistryHosts,
-			LeaseManager:   w.LeaseManager,
+			LeaseManager:   w.LeaseManager(),
 		})
 	case client.ExporterLocal:
 		return localexporter.New(localexporter.Opt{
@@ -393,14 +397,14 @@ func (w *Worker) Exporter(name string, sm *session.Manager) (exporter.Exporter, 
 			SessionManager: sm,
 			ImageWriter:    w.imageWriter,
 			Variant:        ociexporter.VariantOCI,
-			LeaseManager:   w.LeaseManager,
+			LeaseManager:   w.LeaseManager(),
 		})
 	case client.ExporterDocker:
 		return ociexporter.New(ociexporter.Opt{
 			SessionManager: sm,
 			ImageWriter:    w.imageWriter,
 			Variant:        ociexporter.VariantDocker,
-			LeaseManager:   w.LeaseManager,
+			LeaseManager:   w.LeaseManager(),
 		})
 	default:
 		return nil, errors.Errorf("exporter %q could not be found", name)

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/leases"
 	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
@@ -38,6 +39,7 @@ type Worker interface {
 	ContentStore() content.Store
 	Executor() executor.Executor
 	CacheManager() cache.Manager
+	LeaseManager() leases.Manager
 }
 
 type Infos interface {


### PR DESCRIPTION
fixes #3050

For testing 2 new commands added to `buildctl`:

```
buildctl debug monitor [--completed]
```

Will listen on event on new builds coming in and completing. If `--completed` is passed, then shows previous builds stored on disk.

```
buildctl debug logs [refid] [--progress=auto]
```

Shows logs for an active build. RefID can be obtained with the `monitor` command. Eventually, this would also work for completed builds.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>