### PR TITLE
Refactor reference parsing for oci-layout

### DIFF
--- a/client/llb/source.go
+++ b/client/llb/source.go
@@ -455,7 +455,7 @@ func Differ(t DiffType, required bool) LocalOption {
 	})
 }
 
-func OCILayout(contentStoreID string, dig digest.Digest, opts ...OCILayoutOption) State {
+func OCILayout(store string, digest digest.Digest, opts ...OCILayoutOption) State {
 	gi := &OCILayoutInfo{}
 
 	for _, o := range opts {
@@ -474,7 +474,7 @@ func OCILayout(contentStoreID string, dig digest.Digest, opts ...OCILayoutOption
 
 	addCap(&gi.Constraints, pb.CapSourceOCILayout)
 
-	source := NewSource(fmt.Sprintf("oci-layout://%s@%s", contentStoreID, dig), attrs, gi.Constraints)
+	source := NewSource(fmt.Sprintf("oci-layout://%s@%s", store, digest), attrs, gi.Constraints)
 	return NewState(source.Output())
 }
 

--- a/source/containerimage/ocilayout.go
+++ b/source/containerimage/ocilayout.go
@@ -63,12 +63,11 @@ func (r *ociLayoutResolver) Fetch(ctx context.Context, desc ocispecs.Descriptor)
 func (r *ociLayoutResolver) Resolve(ctx context.Context, refString string) (string, ocispecs.Descriptor, error) {
 	ref, err := reference.Parse(refString)
 	if err != nil {
-		return "", ocispecs.Descriptor{}, errors.Wrapf(err, "invalid reference '%s'", refString)
+		return "", ocispecs.Descriptor{}, errors.Wrapf(err, "invalid reference %q", refString)
 	}
-
-	dig := ref.Digest()
-	if dig == "" {
-		return "", ocispecs.Descriptor{}, errors.Errorf("reference must have format @sha256:<hash>: %s", refString)
+	dgst := ref.Digest()
+	if dgst == "" {
+		return "", ocispecs.Descriptor{}, errors.Errorf("reference %q must have digest", refString)
 	}
 
 	info, err := r.info(ctx, ref)
@@ -80,7 +79,7 @@ func (r *ociLayoutResolver) Resolve(ctx context.Context, refString string) (stri
 	// This is necessary because we do not know the media-type of the descriptor,
 	// and there are descriptor processing elements that expect it.
 	desc := ocispecs.Descriptor{
-		Digest: dig,
+		Digest: info.Digest,
 		Size:   info.Size,
 	}
 	rc, err := r.Fetch(ctx, desc)
@@ -91,12 +90,13 @@ func (r *ociLayoutResolver) Resolve(ctx context.Context, refString string) (stri
 	if err != nil {
 		return "", ocispecs.Descriptor{}, errors.Wrap(err, "unable to read root manifest")
 	}
-	// try it first as an index, then as a manifest
+
 	mediaType, err := imageutil.DetectManifestBlobMediaType(b)
 	if err != nil {
-		return "", ocispecs.Descriptor{}, errors.Wrapf(err, "reference %s contains neither an index nor a manifest", refString)
+		return "", ocispecs.Descriptor{}, errors.Wrapf(err, "reference %q contains neither an index nor a manifest", refString)
 	}
 	desc.MediaType = mediaType
+
 	return refString, desc, nil
 }
 

--- a/source/identifier.go
+++ b/source/identifier.go
@@ -292,23 +292,22 @@ func (*HTTPIdentifier) ID() string {
 
 type OCIIdentifier struct {
 	Name       string
-	Manifest   digest.Digest
+	Digest     digest.Digest
 	Platform   *ocispecs.Platform
 	SessionID  string
 	LayerLimit *int
 }
 
 func NewOCIIdentifier(str string) (*OCIIdentifier, error) {
-	// OCI identifier arg is of the format: path@hash
-	parts := strings.SplitN(str, "@", 2)
-	if len(parts) != 2 {
-		return nil, errors.New("OCI must be in format of storeID@manifest-hash")
+	store, digSrc, found := strings.Cut(str, "@")
+	if !found {
+		return nil, errors.Errorf("invalid OCI identifier %s", str)
 	}
-	dig, err := digest.Parse(parts[1])
+	dig, err := digest.Parse(digSrc)
 	if err != nil {
-		return nil, errors.Wrap(err, "OCI must be in format of storeID@manifest-hash, invalid digest")
+		return nil, errors.Wrapf(err, "invalid digest in OCI identifier %s", str)
 	}
-	return &OCIIdentifier{Name: parts[0], Manifest: dig}, nil
+	return &OCIIdentifier{Name: store, Digest: dig}, nil
 }
 
 func (*OCIIdentifier) ID() string {


### PR DESCRIPTION
:cherries: Cherry-picked off of https://github.com/moby/buildkit/pull/3118 (since it seems unlikely we'll take the functionality in the way that it's implemented for v0.11)

This PR introduces improvements to the user-facing error messages of the dockerfile oci-layout functionality. Essentially, we achieve this by using all of containerd's/distribution's reference parsers instead of doing manual string manipulation.

The main internal-api change that this introduces is combining the reference with the digest together in the OCILayout llb - we can just pass the whole thing together, instead of needing to later reconstruct it back together.

Signed-off-by: Justin Chadwell <me@jedevc.com>