### PR TITLE
chore: remove fmt.Errorf across the codebase in preference of errors.Errorf/Wrap

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,6 +32,7 @@ linters:
     - whitespace
     - nolintlint
     - gosec
+    - forbidigo
   disable-all: true
 
 linters-settings:
@@ -42,6 +43,9 @@ linters-settings:
       # The io/ioutil package has been deprecated.
       # https://go.dev/doc/go1.16#ioutil
       - io/ioutil
+  forbidigo:
+    forbid:
+      - '^fmt\.Errorf(# use errors\.Errorf instead)?$'
   importas:
     alias:
       - pkg: "github.com/opencontainers/image-spec/specs-go/v1"

--- a/cache/compression_nydus.go
+++ b/cache/compression_nydus.go
@@ -7,7 +7,6 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 
 	"github.com/containerd/containerd/content"
@@ -50,11 +49,11 @@ func needsForceCompression(ctx context.Context, cs content.Store, source ocispec
 func MergeNydus(ctx context.Context, ref ImmutableRef, comp compression.Config, s session.Group) (*ocispecs.Descriptor, error) {
 	iref, ok := ref.(*immutableRef)
 	if !ok {
-		return nil, fmt.Errorf("unsupported ref")
+		return nil, errors.Errorf("unsupported ref type %T", ref)
 	}
 	refs := iref.layerChain()
 	if len(refs) == 0 {
-		return nil, fmt.Errorf("refs can't be empty")
+		return nil, errors.Errorf("refs can't be empty")
 	}
 
 	// Extracts nydus bootstrap from nydus format for each layer.

--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -1454,7 +1454,7 @@ func ensurePrune(ctx context.Context, t *testing.T, cm Manager, pruneNum, maxRet
 func getCompressor(w io.Writer, compressionType compression.Type, customized bool) (io.WriteCloser, error) {
 	switch compressionType {
 	case compression.Uncompressed:
-		return nil, fmt.Errorf("compression is not requested: %v", compressionType)
+		return nil, errors.Errorf("compression is not requested: %v", compressionType)
 	case compression.Gzip:
 		if customized {
 			gz, _ := gzip.NewWriterLevel(w, gzip.NoCompression)
@@ -1495,7 +1495,7 @@ func getCompressor(w io.Writer, compressionType compression.Type, customized boo
 		}
 		return zstd.NewWriter(w)
 	default:
-		return nil, fmt.Errorf("unknown compression type: %q", compressionType)
+		return nil, errors.Errorf("unknown compression type: %q", compressionType)
 	}
 }
 

--- a/cache/refs.go
+++ b/cache/refs.go
@@ -836,11 +836,11 @@ func getBlobDesc(ctx context.Context, cs content.Store, dgst digest.Digest) (oci
 		return ocispecs.Descriptor{}, err
 	}
 	if info.Labels == nil {
-		return ocispecs.Descriptor{}, fmt.Errorf("no blob metadata is stored for %q", info.Digest)
+		return ocispecs.Descriptor{}, errors.Errorf("no blob metadata is stored for %q", info.Digest)
 	}
 	mt, ok := info.Labels[blobMediaTypeLabel]
 	if !ok {
-		return ocispecs.Descriptor{}, fmt.Errorf("no media type is stored for %q", info.Digest)
+		return ocispecs.Descriptor{}, errors.Errorf("no media type is stored for %q", info.Digest)
 	}
 	desc := ocispecs.Descriptor{
 		Digest:    info.Digest,
@@ -1550,12 +1550,12 @@ func readonlyOverlay(opt []string) []string {
 func newSharableMountPool(tmpdirRoot string) (sharableMountPool, error) {
 	if tmpdirRoot != "" {
 		if err := os.MkdirAll(tmpdirRoot, 0700); err != nil {
-			return sharableMountPool{}, fmt.Errorf("failed to prepare mount pool: %w", err)
+			return sharableMountPool{}, errors.Wrap(err, "failed to prepare mount pool")
 		}
 		// If tmpdirRoot is specified, remove existing mounts to avoid conflict.
 		files, err := os.ReadDir(tmpdirRoot)
 		if err != nil {
-			return sharableMountPool{}, fmt.Errorf("failed to read mount pool: %w", err)
+			return sharableMountPool{}, errors.Wrap(err, "failed to read mount pool")
 		}
 		for _, file := range files {
 			if file.IsDir() {

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -279,7 +279,7 @@ func main() {
 				case "network.host":
 					cfg.Entitlements = append(cfg.Entitlements, e)
 				default:
-					return fmt.Errorf("invalid entitlement : %v", e)
+					return errors.Errorf("invalid entitlement : %s", e)
 				}
 			}
 		}

--- a/exporter/containerimage/annotations.go
+++ b/exporter/containerimage/annotations.go
@@ -1,9 +1,8 @@
 package containerimage
 
 import (
-	"fmt"
-
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
 
 	"github.com/containerd/containerd/platforms"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
@@ -54,7 +53,7 @@ func ParseAnnotations(data map[string][]byte) (AnnotationsGroup, map[string][]by
 		case exptypes.AnnotationManifestDescriptor:
 			ag[p].ManifestDescriptor[a.Key] = string(v)
 		default:
-			return nil, nil, fmt.Errorf("unrecognized annotation type %s", a.Type)
+			return nil, nil, errors.Errorf("unrecognized annotation type %s", a.Type)
 		}
 	}
 	return ag, rest, nil

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -910,7 +910,7 @@ func dispatchRun(d *dispatchState, c *instructions.RunCommand, proxy *llb.ProxyE
 	var args []string = c.CmdLine
 	if len(c.Files) > 0 {
 		if len(args) != 1 || !c.PrependShell {
-			return fmt.Errorf("parsing produced an invalid run command: %v", args)
+			return errors.Errorf("parsing produced an invalid run command: %v", args)
 		}
 
 		if heredoc := parser.MustParseHeredoc(args[0]); heredoc != nil {

--- a/frontend/dockerfile/dockerignore/dockerignore.go
+++ b/frontend/dockerfile/dockerignore/dockerignore.go
@@ -3,10 +3,11 @@ package dockerignore
 import (
 	"bufio"
 	"bytes"
-	"fmt"
 	"io"
 	"path/filepath"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 // ReadAll reads a .dockerignore file and returns the list of file patterns
@@ -58,7 +59,7 @@ func ReadAll(reader io.Reader) ([]string, error) {
 		excludes = append(excludes, pattern)
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("Error reading .dockerignore: %v", err)
+		return nil, errors.Wrap(err, "error reading .dockerignore")
 	}
 	return excludes, nil
 }

--- a/frontend/dockerfile/instructions/bflag.go
+++ b/frontend/dockerfile/instructions/bflag.go
@@ -1,10 +1,10 @@
 package instructions
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/moby/buildkit/util/suggest"
+	"github.com/pkg/errors"
 )
 
 // FlagType is the type of the build flag
@@ -88,7 +88,7 @@ func (bf *BFlags) AddStrings(name string) *Flag {
 // Note, any error will be generated when Parse() is called (see Parse).
 func (bf *BFlags) addFlag(name string, flagType FlagType) *Flag {
 	if _, ok := bf.flags[name]; ok {
-		bf.Err = fmt.Errorf("Duplicate flag defined: %s", name)
+		bf.Err = errors.Errorf("Duplicate flag defined: %s", name)
 		return nil
 	}
 
@@ -123,7 +123,8 @@ func (bf *BFlags) Used() []string {
 func (fl *Flag) IsTrue() bool {
 	if fl.flagType != boolType {
 		// Should never get here
-		panic(fmt.Errorf("Trying to use IsTrue on a non-boolean: %s", fl.name))
+		err := errors.Errorf("Trying to use IsTrue on a non-boolean: %s", fl.name)
+		panic(err)
 	}
 	return fl.Value == "true"
 }
@@ -143,12 +144,12 @@ func (bf *BFlags) Parse() error {
 	// go ahead and bubble it back up here since we didn't do it
 	// earlier in the processing
 	if bf.Err != nil {
-		return fmt.Errorf("error setting up flags: %s", bf.Err)
+		return errors.Wrap(bf.Err, "error setting up flags")
 	}
 
 	for _, arg := range bf.Args {
 		if !strings.HasPrefix(arg, "--") {
-			return fmt.Errorf("arg should start with -- : %s", arg)
+			return errors.Errorf("arg should start with -- : %s", arg)
 		}
 
 		if arg == "--" {
@@ -166,11 +167,12 @@ func (bf *BFlags) Parse() error {
 
 		flag, ok := bf.flags[arg]
 		if !ok {
-			return suggest.WrapError(fmt.Errorf("unknown flag: %s", arg), arg, allFlags(bf.flags), true)
+			err := errors.Errorf("unknown flag: %s", arg)
+			return suggest.WrapError(err, arg, allFlags(bf.flags), true)
 		}
 
 		if _, ok = bf.used[arg]; ok && flag.flagType != stringsType {
-			return fmt.Errorf("duplicate flag specified: %s", arg)
+			return errors.Errorf("duplicate flag specified: %s", arg)
 		}
 
 		bf.used[arg] = flag
@@ -179,7 +181,7 @@ func (bf *BFlags) Parse() error {
 		case boolType:
 			// value == "" is only ok if no "=" was specified
 			if index >= 0 && value == "" {
-				return fmt.Errorf("missing a value on flag: %s", arg)
+				return errors.Errorf("missing a value on flag: %s", arg)
 			}
 
 			lower := strings.ToLower(value)
@@ -188,18 +190,18 @@ func (bf *BFlags) Parse() error {
 			} else if lower == "true" || lower == "false" {
 				flag.Value = lower
 			} else {
-				return fmt.Errorf("expecting boolean value for flag %s, not: %s", arg, value)
+				return errors.Errorf("expecting boolean value for flag %s, not: %s", arg, value)
 			}
 
 		case stringType:
 			if index < 0 {
-				return fmt.Errorf("missing a value on flag: %s", arg)
+				return errors.Errorf("missing a value on flag: %s", arg)
 			}
 			flag.Value = value
 
 		case stringsType:
 			if index < 0 {
-				return fmt.Errorf("missing a value on flag: %s", arg)
+				return errors.Errorf("missing a value on flag: %s", arg)
 			}
 			flag.StringValues = append(flag.StringValues, value)
 

--- a/frontend/dockerfile/instructions/errors_unix.go
+++ b/frontend/dockerfile/instructions/errors_unix.go
@@ -3,8 +3,8 @@
 
 package instructions
 
-import "fmt"
+import "github.com/pkg/errors"
 
 func errNotJSON(command, _ string) error {
-	return fmt.Errorf("%s requires the arguments to be in JSON form", command)
+	return errors.Errorf("%s requires the arguments to be in JSON form", command)
 }

--- a/frontend/dockerfile/instructions/errors_windows.go
+++ b/frontend/dockerfile/instructions/errors_windows.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 func errNotJSON(command, original string) error {
@@ -23,5 +25,5 @@ func errNotJSON(command, original string) error {
 		strings.Contains(original, "]") {
 		extra = fmt.Sprintf(`. It looks like '%s' includes a file path without an escaped back-slash. JSON requires back-slashes to be escaped such as ["c:\\path\\to\\file.exe", "/parameter"]`, original)
 	}
-	return fmt.Errorf("%s requires the arguments to be in JSON form%s", command, extra)
+	return errors.Errorf("%s requires the arguments to be in JSON form%s", command, extra)
 }

--- a/frontend/dockerfile/instructions/parse.go
+++ b/frontend/dockerfile/instructions/parse.go
@@ -385,7 +385,7 @@ func parseOnBuild(req parseRequest) (*OnbuildCommand, error) {
 	case "ONBUILD":
 		return nil, errors.New("Chaining ONBUILD via `ONBUILD ONBUILD` isn't allowed")
 	case "MAINTAINER", "FROM":
-		return nil, fmt.Errorf("%s isn't allowed as an ONBUILD trigger", triggerInstruction)
+		return nil, errors.Errorf("%s isn't allowed as an ONBUILD trigger", triggerInstruction)
 	}
 
 	original := regexp.MustCompile(`(?i)^\s*ONBUILD\s*`).ReplaceAllString(req.original, "")
@@ -515,7 +515,7 @@ func parseOptInterval(f *Flag) (time.Duration, error) {
 		return 0, nil
 	}
 	if d < container.MinimumDuration {
-		return 0, fmt.Errorf("Interval %#v cannot be less than %s", f.name, container.MinimumDuration)
+		return 0, errors.Errorf("Interval %#v cannot be less than %s", f.name, container.MinimumDuration)
 	}
 	return d, nil
 }
@@ -562,7 +562,7 @@ func parseHealthcheck(req parseRequest) (*HealthCheckCommand, error) {
 
 			healthcheck.Test = strslice.StrSlice(append([]string{typ}, cmdSlice...))
 		default:
-			return nil, fmt.Errorf("Unknown type %#v in HEALTHCHECK (try CMD)", typ)
+			return nil, errors.Errorf("Unknown type %#v in HEALTHCHECK (try CMD)", typ)
 		}
 
 		interval, err := parseOptInterval(flInterval)
@@ -589,7 +589,7 @@ func parseHealthcheck(req parseRequest) (*HealthCheckCommand, error) {
 				return nil, err
 			}
 			if retries < 0 {
-				return nil, fmt.Errorf("--retries cannot be negative (%d)", retries)
+				return nil, errors.Errorf("--retries cannot be negative (%d)", retries)
 			}
 			healthcheck.Retries = int(retries)
 		} else {

--- a/frontend/dockerfile/parser/line_parsers.go
+++ b/frontend/dockerfile/parser/line_parsers.go
@@ -8,7 +8,6 @@ package parser
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -153,7 +152,7 @@ func parseNameVal(rest string, key string, d *directives) (*Node, error) {
 	if !strings.Contains(words[0], "=") {
 		parts := reWhitespace.Split(rest, 2)
 		if len(parts) < 2 {
-			return nil, fmt.Errorf(key + " must have two arguments")
+			return nil, errors.Errorf("%s must have two arguments", key)
 		}
 		return newKeyValueNode(parts[0], parts[1]), nil
 	}
@@ -162,7 +161,7 @@ func parseNameVal(rest string, key string, d *directives) (*Node, error) {
 	var prevNode *Node
 	for _, word := range words {
 		if !strings.Contains(word, "=") {
-			return nil, fmt.Errorf("Syntax error - can't find = in %q. Must be of the form: name=value", word)
+			return nil, errors.Errorf("Syntax error - can't find = in %q. Must be of the form: name=value", word)
 		}
 
 		parts := strings.SplitN(word, "=", 2)
@@ -273,7 +272,7 @@ func parseString(rest string, d *directives) (*Node, map[string]bool, error) {
 func parseJSON(rest string, d *directives) (*Node, map[string]bool, error) {
 	rest = strings.TrimLeftFunc(rest, unicode.IsSpace)
 	if !strings.HasPrefix(rest, "[") {
-		return nil, nil, fmt.Errorf(`Error parsing "%s" as a JSON array`, rest)
+		return nil, nil, errors.Errorf("Error parsing %q as a JSON array", rest)
 	}
 
 	var myJSON []interface{}

--- a/frontend/dockerfile/parser/parser.go
+++ b/frontend/dockerfile/parser/parser.go
@@ -431,7 +431,7 @@ func heredocFromMatch(match []string) (*Heredoc, error) {
 		return nil, err
 	}
 	if len(wordsRaw) != len(words) {
-		return nil, fmt.Errorf("internal lexing of heredoc produced inconsistent results: %s", rest)
+		return nil, errors.Errorf("internal lexing of heredoc produced inconsistent results: %s", rest)
 	}
 
 	word := words[0]

--- a/identity/randomid.go
+++ b/identity/randomid.go
@@ -2,9 +2,10 @@ package identity
 
 import (
 	cryptorand "crypto/rand"
-	"fmt"
 	"io"
 	"math/big"
+
+	"github.com/pkg/errors"
 )
 
 var (
@@ -45,7 +46,7 @@ func NewID() string {
 	var p [randomIDEntropyBytes]byte
 
 	if _, err := io.ReadFull(idReader, p[:]); err != nil {
-		panic(fmt.Errorf("failed to read random bytes: %v", err))
+		panic(errors.Wrap(err, "failed to read random bytes: %v"))
 	}
 
 	p[0] |= 0x80 // set high bit to avoid the need for padding

--- a/snapshot/snapshotter_test.go
+++ b/snapshot/snapshotter_test.go
@@ -5,7 +5,6 @@ package snapshot
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,6 +23,7 @@ import (
 	"github.com/containerd/continuity/fs/fstest"
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/util/leaseutil"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	bolt "go.etcd.io/bbolt"
 )
@@ -52,7 +52,7 @@ func newSnapshotter(ctx context.Context, t *testing.T, snapshotterName string) (
 			return nil, nil, err
 		}
 	default:
-		return nil, nil, fmt.Errorf("unhandled snapshotter: %s", snapshotterName)
+		return nil, nil, errors.Errorf("unhandled snapshotter: %s", snapshotterName)
 	}
 	t.Cleanup(func() {
 		require.NoError(t, ctdSnapshotter.Close())

--- a/util/archutil/generate.go
+++ b/util/archutil/generate.go
@@ -7,18 +7,19 @@ import (
 	"bytes"
 	"compress/gzip"
 	"flag"
-	"fmt"
 	"html/template"
 	"io"
 	"os"
 	"path/filepath"
+
+	"github.com/pkg/errors"
 )
 
 // saves baseimage binaries statically into go code
 func main() {
 	flag.Parse()
 	if len(flag.Args()) == 0 {
-		panic(fmt.Errorf("arch is required"))
+		panic(errors.New("arch is required"))
 	}
 
 	for _, arch := range flag.Args() {

--- a/util/compression/compression.go
+++ b/util/compression/compression.go
@@ -3,7 +3,6 @@ package compression
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 
 	cdcompression "github.com/containerd/containerd/archive/compression"
@@ -95,7 +94,7 @@ func parse(t string) (Type, error) {
 	case Zstd.String():
 		return Zstd, nil
 	default:
-		return nil, fmt.Errorf("unsupported compression type %s", t)
+		return nil, errors.Errorf("unsupported compression type %s", t)
 	}
 }
 
@@ -108,7 +107,7 @@ func fromMediaType(mediaType string) (Type, error) {
 	case mediaTypeImageLayerZstd, ocispecs.MediaTypeImageLayerNonDistributableZstd:
 		return Zstd, nil
 	default:
-		return nil, fmt.Errorf("unsupported media type %s", mediaType)
+		return nil, errors.Errorf("unsupported media type %s", mediaType)
 	}
 }
 

--- a/util/compression/estargz.go
+++ b/util/compression/estargz.go
@@ -34,7 +34,7 @@ func (c estargzType) Compress(ctx context.Context, comp Config) (compressorFunc 
 				return nil, err
 			}
 			if ct != Gzip {
-				return nil, fmt.Errorf("unsupported media type for estargz compressor %q", requiredMediaType)
+				return nil, errors.Errorf("unsupported media type for estargz compressor %q", requiredMediaType)
 			}
 			done := make(chan struct{})
 			pr, pw := io.Pipe()

--- a/util/entitlements/security/security_linux.go
+++ b/util/entitlements/security/security_linux.go
@@ -145,7 +145,7 @@ func getCurrentCaps() ([]string, error) {
 func getAllCaps() ([]string, error) {
 	availableCaps, err := getCurrentCaps()
 	if err != nil {
-		return nil, fmt.Errorf("error getting current capabilities: %s", err)
+		return nil, errors.Errorf("error getting current capabilities: %s", err)
 	}
 
 	// see if any of the base linux35Caps are not available to be granted

--- a/util/overlay/overlay_linux.go
+++ b/util/overlay/overlay_linux.go
@@ -182,7 +182,7 @@ func Changes(ctx context.Context, changeFn fs.ChangeFunc, upperdir, upperdirView
 		} else if redirect {
 			// Return error when redirect_dir is enabled which can result to a wrong diff.
 			// TODO: support redirect_dir
-			return fmt.Errorf("redirect_dir is used but it's not supported in overlayfs differ")
+			return errors.New("redirect_dir is used but it's not supported in overlayfs differ")
 		}
 
 		// Check if this is a deleted entry

--- a/util/resolver/authorizer.go
+++ b/util/resolver/authorizer.go
@@ -279,7 +279,7 @@ func (ah *authHandler) doBasicAuth(ctx context.Context) (string, error) {
 	username, secret := ah.common.Username, ah.common.Secret
 
 	if username == "" || secret == "" {
-		return "", fmt.Errorf("failed to handle basic auth because missing username or secret")
+		return "", errors.New("failed to handle basic auth because missing username or secret")
 	}
 
 	auth := base64.StdEncoding.EncodeToString([]byte(username + ":" + secret))

--- a/util/sshutil/keyscan.go
+++ b/util/sshutil/keyscan.go
@@ -1,6 +1,7 @@
 package sshutil
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -11,7 +12,7 @@ import (
 
 const defaultPort = 22
 
-var errCallbackDone = fmt.Errorf("callback failed on purpose")
+var errCallbackDone = errors.New("callback failed on purpose")
 
 // addDefaultPort appends a default port if hostport doesn't contain one
 func addDefaultPort(hostport string, defaultPort int) string {

--- a/util/system/path_windows.go
+++ b/util/system/path_windows.go
@@ -4,9 +4,10 @@
 package system
 
 import (
-	"fmt"
 	"path/filepath"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 // CheckSystemDriveAndRemoveDriveLetter verifies and manipulates a Windows path.
@@ -22,13 +23,13 @@ import (
 // d:\			--> Fail
 func CheckSystemDriveAndRemoveDriveLetter(path string) (string, error) {
 	if len(path) == 2 && string(path[1]) == ":" {
-		return "", fmt.Errorf("No relative path specified in %q", path)
+		return "", errors.Errorf("No relative path specified in %q", path)
 	}
 	if !filepath.IsAbs(path) || len(path) < 2 {
 		return filepath.FromSlash(path), nil
 	}
 	if string(path[1]) == ":" && !strings.EqualFold(string(path[0]), "c") {
-		return "", fmt.Errorf("The specified path is not on the system drive (C:)")
+		return "", errors.New("The specified path is not on the system drive (C:)")
 	}
 	return filepath.FromSlash(path[2:]), nil
 }

--- a/util/tracing/otlptracegrpc/client.go
+++ b/util/tracing/otlptracegrpc/client.go
@@ -16,17 +16,14 @@ package otlptracegrpc
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"sync"
 	"time"
 
+	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
-
-	"google.golang.org/grpc"
-
 	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/grpc"
 )
 
 type client struct {
@@ -37,10 +34,6 @@ type client struct {
 }
 
 var _ otlptrace.Client = (*client)(nil)
-
-var (
-	errNoClient = errors.New("no client")
-)
 
 // NewClient creates a new gRPC trace client.
 func NewClient(cc *grpc.ClientConn) otlptrace.Client {
@@ -73,7 +66,7 @@ func (c *client) Stop(ctx context.Context) error {
 // UploadTraces sends a batch of spans to the collector.
 func (c *client) UploadTraces(ctx context.Context, protoSpans []*tracepb.ResourceSpans) error {
 	if !c.connection.Connected() {
-		return fmt.Errorf("traces exporter is disconnected from the server: %w", c.connection.LastConnectError())
+		return errors.Wrap(c.connection.LastConnectError(), "traces exporter is disconnected from the server")
 	}
 
 	ctx, cancel := c.connection.ContextWithStop(ctx)

--- a/util/tracing/otlptracegrpc/errors.go
+++ b/util/tracing/otlptracegrpc/errors.go
@@ -1,0 +1,7 @@
+package otlptracegrpc
+
+import "errors"
+
+var (
+	errNoClient = errors.New("no client")
+)


### PR DESCRIPTION
In general, we prefer to use `github.com/pkg/errors` wherever possible, since it provides stacktraces, and we try and enforce this in code-review. However, this is easy to forget (especially for me :smile:) - so we should provide a linting rule to ban using `fmt.Errorf`. This should stop these leaking through in future PRs.

This PR adds a linter rule to `forbidigo`, to ban this function, requesting that users switch to using the `errors` package. As part of this, we also need to update all the instances of `fmt.Errorf`, which was useful to cleanup some cases of code-rot.