### PR TITLE
attestation: update default SBOM generator image

### DIFF
--- a/frontend/attestations/parse.go
+++ b/frontend/attestations/parse.go
@@ -13,8 +13,7 @@ const (
 )
 
 const (
-	// TODO: update this before next buildkit release
-	defaultSBOMGenerator = "jedevc/buildkit-syft-scanner:master@sha256:de630f621eb0ab1bb1245cea76d01c5bddfe78af4f5b9adecde424cb7ec5605e"
+	defaultSBOMGenerator = "docker/buildkit-syft-scanner:stable-1"
 )
 
 func Filter(v map[string]string) map[string]string {


### PR DESCRIPTION
Set default SBOM generator image to stable one: https://hub.docker.com/r/docker/buildkit-syft-scanner/tags

Like the BuildKit image for Buildx we use a mutable tag named `stable-1` that can be updated manually through this workflow: https://github.com/docker/buildkit-syft-scanner/blob/master/.github/workflows/buildkit-image.yml

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>