### PR TITLE
executor: stubs cleaner should remove empty directory mounts

### DIFF
--- a/executor/stubs.go
+++ b/executor/stubs.go
@@ -42,9 +42,18 @@ func MountStubsCleaner(dir string, mounts []Mount) func() {
 			if err != nil {
 				continue
 			}
-			if st.Size() != 0 {
+			if st.IsDir() {
+				entries, err := os.ReadDir(p)
+				if err != nil {
+					continue
+				}
+				if len(entries) != 0 {
+					continue
+				}
+			} else if st.Size() != 0 {
 				continue
 			}
+
 			// Back up the timestamps of the dir for reproducible builds
 			// https://github.com/moby/buildkit/issues/3148
 			dir := filepath.Dir(p)

--- a/util/system/atime_unix.go
+++ b/util/system/atime_unix.go
@@ -4,18 +4,18 @@
 package system
 
 import (
-	"fmt"
 	iofs "io/fs"
 	"syscall"
 	"time"
 
 	"github.com/containerd/continuity/fs"
+	"github.com/pkg/errors"
 )
 
 func Atime(st iofs.FileInfo) (time.Time, error) {
 	stSys, ok := st.Sys().(*syscall.Stat_t)
 	if !ok {
-		return time.Time{}, fmt.Errorf("expected st.Sys() to be *syscall.Stat_t, got %T", st.Sys())
+		return time.Time{}, errors.Errorf("expected st.Sys() to be *syscall.Stat_t, got %T", st.Sys())
 	}
 	return fs.StatATimeAsTime(stSys), nil
 }


### PR DESCRIPTION
On Linux, an empty directory is usually 4096 bytes, not 0, so we need an additional explicit check here.

Signed-off-by: Justin Chadwell <me@jedevc.com>