### PR TITLE
exporter: validate attestations on unbundle

### DIFF
--- a/exporter/attestation/unbundle.go
+++ b/exporter/attestation/unbundle.go
@@ -69,6 +69,11 @@ func Unbundle(ctx context.Context, s session.Group, refs map[string]cache.Immuta
 	for _, atts := range unbundled {
 		joined = append(joined, atts...)
 	}
+	for _, att := range joined {
+		if err := validate(att); err != nil {
+			return nil, err
+		}
+	}
 	return joined, nil
 }
 
@@ -125,4 +130,14 @@ func unbundle(ctx context.Context, root string, bundle result.Attestation) ([]re
 		})
 	}
 	return unbundled, nil
+}
+
+func validate(att result.Attestation) error {
+	if att.Path == "" {
+		return errors.New("attestation does not have set path")
+	}
+	if att.Ref == "" && att.ContentFunc == nil {
+		return errors.New("attestation does not have available content")
+	}
+	return nil
 }

--- a/exporter/local/fs.go
+++ b/exporter/local/fs.go
@@ -132,9 +132,6 @@ func CreateFS(ctx context.Context, sessionID string, k string, ref cache.Immutab
 				return nil, nil, errors.Wrap(err, "failed to marshal attestation")
 			}
 
-			if attestations[i].Path == "" {
-				return nil, nil, errors.New("attestation does not have set path")
-			}
 			name := opt.AttestationPrefix + path.Base(attestations[i].Path)
 			if _, ok := names[name]; ok {
 				return nil, nil, errors.Errorf("duplicate attestation path name %s", name)


### PR DESCRIPTION
:arrow_up: Follow-up https://github.com/moby/buildkit/pull/3197#discussion_r1025902880

Consistently validate all attestations when unbundling, to prevent inconsistent attestations error behavior across different exporters.