### PR TITLE
Fixup attestation platforms for the local exporter

### DIFF
--- a/client/build.go
+++ b/client/build.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/moby/buildkit/client/buildid"
-	"github.com/moby/buildkit/frontend/attestations"
 	gateway "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/frontend/gateway/grpcclient"
 	gatewayapi "github.com/moby/buildkit/frontend/gateway/pb"
@@ -24,7 +23,6 @@ func (c *Client) Build(ctx context.Context, opt SolveOpt, product string, buildF
 	feOpts := opt.FrontendAttrs
 
 	opt.Frontend = ""
-	opt.FrontendAttrs = attestations.Filter(opt.FrontendAttrs)
 
 	if product == "" {
 		product = apicaps.ExportedProduct

--- a/client/solve.go
+++ b/client/solve.go
@@ -210,11 +210,12 @@ func (c *Client) solve(ctx context.Context, def *llb.Definition, runGateway runG
 		})
 	}
 
+	frontendAttrs := map[string]string{}
+	for k, v := range opt.FrontendAttrs {
+		frontendAttrs[k] = v
+	}
 	for k, v := range cacheOpt.frontendAttrs {
-		if opt.FrontendAttrs == nil {
-			opt.FrontendAttrs = map[string]string{}
-		}
-		opt.FrontendAttrs[k] = v
+		frontendAttrs[k] = v
 	}
 
 	solveCtx, cancelSolve := context.WithCancel(ctx)
@@ -254,7 +255,7 @@ func (c *Client) solve(ctx context.Context, def *llb.Definition, runGateway runG
 			ExporterAttrs:  ex.Attrs,
 			Session:        s.ID(),
 			Frontend:       opt.Frontend,
-			FrontendAttrs:  opt.FrontendAttrs,
+			FrontendAttrs:  frontendAttrs,
 			FrontendInputs: frontendInputs,
 			Cache:          cacheOpt.options,
 			Entitlements:   opt.AllowedEntitlements,
@@ -270,7 +271,7 @@ func (c *Client) solve(ctx context.Context, def *llb.Definition, runGateway runG
 
 	if runGateway != nil {
 		eg.Go(func() error {
-			err := runGateway(ref, s, opt.FrontendAttrs)
+			err := runGateway(ref, s, frontendAttrs)
 			if err == nil {
 				return nil
 			}

--- a/control/control.go
+++ b/control/control.go
@@ -17,6 +17,7 @@ import (
 	controlgateway "github.com/moby/buildkit/control/gateway"
 	"github.com/moby/buildkit/exporter"
 	"github.com/moby/buildkit/exporter/util/epoch"
+	"github.com/moby/buildkit/exporter/util/multiplatform"
 	"github.com/moby/buildkit/frontend"
 	"github.com/moby/buildkit/frontend/attestations"
 	"github.com/moby/buildkit/session"
@@ -301,6 +302,16 @@ func (c *Controller) Solve(ctx context.Context, req *controlapi.SolveRequest) (*
 				req.ExporterAttrs = make(map[string]string)
 			}
 			req.ExporterAttrs[epoch.KeySourceDateEpoch] = v
+		}
+	}
+
+	// if multi-platform is set, enable it for the exporter
+	if v, ok := multiplatform.ParseBuildArgs(req.FrontendAttrs); ok {
+		if _, ok := req.ExporterAttrs[multiplatform.KeyMultiPlatform]; !ok {
+			if req.ExporterAttrs == nil {
+				req.ExporterAttrs = make(map[string]string)
+			}
+			req.ExporterAttrs[multiplatform.KeyMultiPlatform] = v
 		}
 	}
 

--- a/control/control.go
+++ b/control/control.go
@@ -295,12 +295,12 @@ func (c *Controller) Solve(ctx context.Context, req *controlapi.SolveRequest) (*
 	}
 
 	// if SOURCE_DATE_EPOCH is set, enable it for the exporter
-	if epochVal, ok := req.FrontendAttrs["build-arg:SOURCE_DATE_EPOCH"]; ok {
+	if v, ok := epoch.ParseBuildArgs(req.FrontendAttrs); ok {
 		if _, ok := req.ExporterAttrs[epoch.KeySourceDateEpoch]; !ok {
 			if req.ExporterAttrs == nil {
 				req.ExporterAttrs = make(map[string]string)
 			}
-			req.ExporterAttrs[epoch.KeySourceDateEpoch] = epochVal
+			req.ExporterAttrs[epoch.KeySourceDateEpoch] = v
 		}
 	}
 

--- a/exporter/containerimage/opts.go
+++ b/exporter/containerimage/opts.go
@@ -45,7 +45,7 @@ func (c *ImageCommitOpts) Load(opt map[string]string) (map[string]string, error)
 	}
 	opt = toStringMap(optb)
 
-	c.Epoch, opt, err = epoch.ParseAttr(opt)
+	c.Epoch, opt, err = epoch.ParseExporterAttrs(opt)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/containerimage/opts.go
+++ b/exporter/containerimage/opts.go
@@ -6,6 +6,7 @@ import (
 
 	cacheconfig "github.com/moby/buildkit/cache/config"
 	"github.com/moby/buildkit/exporter/util/epoch"
+	"github.com/moby/buildkit/exporter/util/multiplatform"
 	"github.com/moby/buildkit/util/compression"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -34,6 +35,7 @@ type ImageCommitOpts struct {
 	BuildInfoAttrs bool
 	Annotations    AnnotationsGroup
 	Epoch          *time.Time
+	MultiPlatform  *bool
 }
 
 func (c *ImageCommitOpts) Load(opt map[string]string) (map[string]string, error) {
@@ -46,6 +48,11 @@ func (c *ImageCommitOpts) Load(opt map[string]string) (map[string]string, error)
 	opt = toStringMap(optb)
 
 	c.Epoch, opt, err = epoch.ParseExporterAttrs(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	c.MultiPlatform, opt, err = multiplatform.ParseExporterAttrs(opt)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/local/export.go
+++ b/exporter/local/export.go
@@ -41,7 +41,7 @@ func New(opt Opt) (exporter.Exporter, error) {
 }
 
 func (e *localExporter) Resolve(ctx context.Context, opt map[string]string) (exporter.ExporterInstance, error) {
-	tm, _, err := epoch.ParseAttr(opt)
+	tm, _, err := epoch.ParseExporterAttrs(opt)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/local/fs.go
+++ b/exporter/local/fs.go
@@ -27,6 +27,7 @@ import (
 type CreateFSOpts struct {
 	Epoch             *time.Time
 	AttestationPrefix string
+	MultiPlatform     *bool
 }
 
 func CreateFS(ctx context.Context, sessionID string, k string, ref cache.ImmutableRef, refs map[string]cache.ImmutableRef, attestations []result.Attestation, defaultTime time.Time, opt CreateFSOpts) (fsutil.FS, func() error, error) {

--- a/exporter/tar/export.go
+++ b/exporter/tar/export.go
@@ -13,6 +13,7 @@ import (
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/exporter/local"
 	"github.com/moby/buildkit/exporter/util/epoch"
+	"github.com/moby/buildkit/exporter/util/multiplatform"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/filesync"
 	"github.com/moby/buildkit/solver/result"
@@ -48,11 +49,17 @@ func New(opt Opt) (exporter.Exporter, error) {
 func (e *localExporter) Resolve(ctx context.Context, opt map[string]string) (exporter.ExporterInstance, error) {
 	li := &localExporterInstance{localExporter: e}
 
-	tm, _, err := epoch.ParseExporterAttrs(opt)
+	tm, opt, err := epoch.ParseExporterAttrs(opt)
 	if err != nil {
 		return nil, err
 	}
 	li.opts.Epoch = tm
+
+	multiPlatform, opt, err := multiplatform.ParseExporterAttrs(opt)
+	if err != nil {
+		return nil, err
+	}
+	li.opts.MultiPlatform = multiPlatform
 
 	for k, v := range opt {
 		switch k {
@@ -126,6 +133,8 @@ func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source
 		}, nil
 	}
 
+	isMap := len(inp.Refs) > 0
+
 	platformsBytes, ok := inp.Metadata[exptypes.ExporterPlatformsKey]
 	if len(inp.Refs) > 0 && !ok {
 		return nil, errors.Errorf("unable to export multiple refs, missing platforms mapping")
@@ -136,8 +145,17 @@ func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source
 		if err := json.Unmarshal(platformsBytes, &p); err != nil {
 			return nil, errors.Wrapf(err, "failed to parse platforms passed to exporter")
 		}
+		if len(p.Platforms) > 1 {
+			isMap = true
+		}
 	}
-	isMap := len(p.Platforms) > 1
+
+	if e.opts.MultiPlatform != nil {
+		isMap = *e.opts.MultiPlatform
+	}
+	if !isMap && len(p.Platforms) > 1 {
+		return nil, errors.Errorf("unable to export multiple platforms without map")
+	}
 
 	var fs fsutil.FS
 

--- a/exporter/tar/export.go
+++ b/exporter/tar/export.go
@@ -48,7 +48,7 @@ func New(opt Opt) (exporter.Exporter, error) {
 func (e *localExporter) Resolve(ctx context.Context, opt map[string]string) (exporter.ExporterInstance, error) {
 	li := &localExporterInstance{localExporter: e}
 
-	tm, _, err := epoch.ParseAttr(opt)
+	tm, _, err := epoch.ParseExporterAttrs(opt)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/util/epoch/parse.go
+++ b/exporter/util/epoch/parse.go
@@ -10,10 +10,17 @@ import (
 )
 
 const (
+	frontendSourceDateEpochArg = "build-arg:SOURCE_DATE_EPOCH"
+
 	KeySourceDateEpoch = "source-date-epoch"
 )
 
-func ParseAttr(opt map[string]string) (*time.Time, map[string]string, error) {
+func ParseBuildArgs(opt map[string]string) (string, bool) {
+	v, ok := opt[frontendSourceDateEpochArg]
+	return v, ok
+}
+
+func ParseExporterAttrs(opt map[string]string) (*time.Time, map[string]string, error) {
 	rest := make(map[string]string, len(opt))
 
 	var tm *time.Time

--- a/exporter/util/multiplatform/parse.go
+++ b/exporter/util/multiplatform/parse.go
@@ -1,0 +1,45 @@
+package multiplatform
+
+import (
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	frontendMultiPlatform    = "multi-platform"
+	frontendMultiPlatformArg = "build-arg:BUILDKIT_MULTI_PLATFORM"
+
+	KeyMultiPlatform = "multi-platform"
+)
+
+func ParseBuildArgs(opt map[string]string) (string, bool) {
+	if v, ok := opt[frontendMultiPlatform]; ok {
+		return v, true
+	}
+	if v, ok := opt[frontendMultiPlatformArg]; ok {
+		return v, true
+	}
+	return "", false
+}
+
+func ParseExporterAttrs(opt map[string]string) (*bool, map[string]string, error) {
+	rest := make(map[string]string, len(opt))
+
+	var multiPlatform *bool
+
+	for k, v := range opt {
+		switch k {
+		case KeyMultiPlatform:
+			b, err := strconv.ParseBool(v)
+			if err != nil {
+				return nil, nil, errors.Errorf("invalid boolean value %s", v)
+			}
+			multiPlatform = &b
+		default:
+			rest[k] = v
+		}
+	}
+
+	return multiPlatform, rest, nil
+}

--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -414,7 +414,7 @@ func Build(ctx context.Context, c client.Client) (_ *client.Result, err error) {
 			return nil, errors.Errorf("invalid boolean value %s", v)
 		}
 		if !b && exportMap {
-			return nil, errors.Errorf("returning multiple target plaforms is not allowed")
+			return nil, errors.Errorf("returning multiple target platforms is not allowed")
 		}
 		exportMap = b
 	}


### PR DESCRIPTION
:arrow_up: Follow-up to #3197.

This PR corrects the behaviour of the local exporter with the `multi-platform` argument. Essentially, the problem boils down to the fact that we can't distinguish at the exporter level between the results produced by the following:

```
$ buildctl build --opt platform=linux/amd64 --opt attest:sbom
$ buildctl build --opt platform=linux/amd64 --opt attest:sbom --opt build-arg:BUILDKIT_MULTI_PLATFORM=true
```

We'd like the former to produce a flat file structure through the local exporter, and the latter to produce an explicitly nested file structure through the same exporter. However, both of these produce Refs instead of a singular Ref, so we can't just look at the Result to know which one.

To solve this, we can handle this case like `SOURCE_DATE_EPOCH`, and detect in the control API boundary if the multi-platform option is set and directly forward it to the exporter, which we can use to make the right call about what format of output to produce. As part of this, we fixup the client to send *all* frontend attributes to the main solve request for Solves inside Builds - since we would now be having to filter through all attestation arguments, `SOURCE_DATE_EPOCH` and `BUILDKIT_MULTI_PLATFORM`/`multi-platform` - which is frustrating and limits upgrade paths. This behavior was previously broken on master, the fallback for `SOURCE_DATE_EPOCH` in the control API boundary would never be activated by buildctl or buildx, since they use Solves inside Builds exclusively.

We should probably pick this into the release, since without it, `BUILDKIT_MULTI_PLATFORM` won't work as intended for the local exporter. Additionally, the fallback for `SOURCE_DATE_EPOCH` won't work correctly.