### PR TITLE
[Windows] Define defaults on Windows

### DIFF
--- a/cmd/buildkitd/constants_unix.go
+++ b/cmd/buildkitd/constants_unix.go
@@ -5,6 +5,4 @@ package main
 
 const (
 	defaultContainerdAddress = "/run/containerd/containerd.sock"
-	defaultCNIBinDir         = "/opt/cni/bin"
-	defaultCNIConfigPath     = "/etc/buildkit/cni.json"
 )

--- a/cmd/buildkitd/constants_unix.go
+++ b/cmd/buildkitd/constants_unix.go
@@ -1,0 +1,10 @@
+//go:build !windows
+// +build !windows
+
+package main
+
+const (
+	defaultContainerdAddress = "/run/containerd/containerd.sock"
+	defaultCNIBinDir         = "/opt/cni/bin"
+	defaultCNIConfigPath     = "/etc/buildkit/cni.json"
+)

--- a/cmd/buildkitd/constants_windows.go
+++ b/cmd/buildkitd/constants_windows.go
@@ -2,6 +2,4 @@ package main
 
 const (
 	defaultContainerdAddress = "//./pipe/containerd-containerd"
-	defaultCNIBinDir         = "C:/ProgramData/buildkitd/bin"
-	defaultCNIConfigPath     = "C:/ProgramData/buildkitd/cni.json"
 )

--- a/cmd/buildkitd/constants_windows.go
+++ b/cmd/buildkitd/constants_windows.go
@@ -1,0 +1,7 @@
+package main
+
+const (
+	defaultContainerdAddress = "//./pipe/containerd-containerd"
+	defaultCNIBinDir         = "C:/ProgramData/buildkitd/bin"
+	defaultCNIConfigPath     = "C:/ProgramData/buildkitd/cni.json"
+)

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -386,10 +386,10 @@ func setDefaultNetworkConfig(nc config.NetworkConfig) config.NetworkConfig {
 		nc.Mode = "auto"
 	}
 	if nc.CNIConfigPath == "" {
-		nc.CNIConfigPath = defaultCNIConfigPath
+		nc.CNIConfigPath = appdefaults.DefaultCNIConfigPath
 	}
 	if nc.CNIBinaryPath == "" {
-		nc.CNIBinaryPath = defaultCNIBinDir
+		nc.CNIBinaryPath = appdefaults.DefaultCNIBinDir
 	}
 	return nc
 }

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -386,10 +386,10 @@ func setDefaultNetworkConfig(nc config.NetworkConfig) config.NetworkConfig {
 		nc.Mode = "auto"
 	}
 	if nc.CNIConfigPath == "" {
-		nc.CNIConfigPath = "/etc/buildkit/cni.json"
+		nc.CNIConfigPath = defaultCNIConfigPath
 	}
 	if nc.CNIBinaryPath == "" {
-		nc.CNIBinaryPath = "/opt/cni/bin"
+		nc.CNIBinaryPath = defaultCNIBinDir
 	}
 	return nc
 }

--- a/cmd/buildkitd/main_containerd_worker.go
+++ b/cmd/buildkitd/main_containerd_worker.go
@@ -25,7 +25,6 @@ import (
 )
 
 const (
-	defaultContainerdAddress   = "/run/containerd/containerd.sock"
 	defaultContainerdNamespace = "buildkit"
 )
 

--- a/util/appdefaults/appdefaults_unix.go
+++ b/util/appdefaults/appdefaults_unix.go
@@ -10,9 +10,11 @@ import (
 )
 
 const (
-	Address   = "unix:///run/buildkit/buildkitd.sock"
-	Root      = "/var/lib/buildkit"
-	ConfigDir = "/etc/buildkit"
+	Address              = "unix:///run/buildkit/buildkitd.sock"
+	Root                 = "/var/lib/buildkit"
+	ConfigDir            = "/etc/buildkit"
+	DefaultCNIBinDir     = "/opt/cni/bin"
+	DefaultCNIConfigPath = "/etc/buildkit/cni.json"
 )
 
 // UserAddress typically returns /run/user/$UID/buildkit/buildkitd.sock

--- a/util/appdefaults/appdefaults_windows.go
+++ b/util/appdefaults/appdefaults_windows.go
@@ -10,8 +10,10 @@ const (
 )
 
 var (
-	Root      = filepath.Join(os.Getenv("ProgramData"), "buildkitd", ".buildstate")
-	ConfigDir = filepath.Join(os.Getenv("ProgramData"), "buildkitd")
+	Root                 = filepath.Join(os.Getenv("ProgramData"), "buildkitd", ".buildstate")
+	ConfigDir            = filepath.Join(os.Getenv("ProgramData"), "buildkitd")
+	DefaultCNIBinDir     = filepath.Join(ConfigDir, "bin")
+	DefaultCNIConfigPath = filepath.Join(ConfigDir, "cni.json")
 )
 
 func UserAddress() string {


### PR DESCRIPTION
This change adds Windows specific default settings. I don't think there is a generic default path for CNI binaries and config files. For example, containerd uses ```C:\Program Files\containerd\cni\conf``` and ```C:\Program Files\containerd\cni\bin``` as defaults.

Signed-off-by: Gabriel Adrian Samfira <gsamfira@cloudbasesolutions.com>