### PR TITLE
Introduce attestation metadata

### DIFF
--- a/exporter/attestation/filter.go
+++ b/exporter/attestation/filter.go
@@ -1,0 +1,45 @@
+package attestation
+
+import (
+	"bytes"
+
+	"github.com/moby/buildkit/solver/result"
+)
+
+func Filter(attestations []result.Attestation, include map[string][]byte, exclude map[string][]byte) []result.Attestation {
+	if len(include) == 0 && len(exclude) == 0 {
+		return attestations
+	}
+
+	result := []result.Attestation{}
+	for _, att := range attestations {
+		meta := att.Metadata
+		if meta == nil {
+			meta = map[string][]byte{}
+		}
+
+		match := true
+		for k, v := range include {
+			if !bytes.Equal(meta[k], v) {
+				match = false
+				break
+			}
+		}
+		if !match {
+			continue
+		}
+
+		for k, v := range exclude {
+			if bytes.Equal(meta[k], v) {
+				match = false
+				break
+			}
+		}
+		if !match {
+			continue
+		}
+
+		result = append(result, att)
+	}
+	return result
+}

--- a/exporter/local/fs.go
+++ b/exporter/local/fs.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path"
+	"strconv"
 	"time"
 
 	"github.com/docker/docker/pkg/idtools"
@@ -87,6 +88,9 @@ func CreateFS(ctx context.Context, sessionID string, k string, ref cache.Immutab
 	}
 
 	outputFS := fsutil.NewFS(src, walkOpt)
+	attestations = attestation.Filter(attestations, nil, map[string][]byte{
+		result.AttestationInlineOnlyKey: []byte(strconv.FormatBool(true)),
+	})
 	attestations, err = attestation.Unbundle(ctx, session.NewGroup(sessionID), refs, attestations)
 	if err != nil {
 		return nil, nil, err

--- a/frontend/attestations/sbom/sbom.go
+++ b/frontend/attestations/sbom/sbom.go
@@ -80,6 +80,9 @@ func CreateSBOMScanner(ctx context.Context, resolver llb.ImageMetaResolver, scan
 		stsbom := runscan.AddMount(outDir, llb.Scratch())
 		return result.Attestation{
 			Kind: gatewaypb.AttestationKindBundle,
+			Metadata: map[string][]byte{
+				result.AttestationReasonKey: result.AttestationReasonSBOM,
+			},
 			InToto: result.InTotoAttestation{
 				PredicateType: intoto.PredicateSPDX,
 			},

--- a/solver/llbsolver/proc/provenance.go
+++ b/solver/llbsolver/proc/provenance.go
@@ -66,6 +66,11 @@ func ProvenanceProcessor(attrs map[string]string) llbsolver.Processor {
 			}
 		}
 
+		var inlineOnly bool
+		if v, err := strconv.ParseBool(attrs["inline-only"]); v && err == nil {
+			inlineOnly = true
+		}
+
 		for _, p := range ps.Platforms {
 			cp, ok := res.Provenance.Refs[p.ID]
 			if !ok {
@@ -145,6 +150,7 @@ func ProvenanceProcessor(attrs map[string]string) llbsolver.Processor {
 				Kind: gatewaypb.AttestationKindInToto,
 				Metadata: map[string][]byte{
 					result.AttestationReasonKey:     result.AttestationReasonProvenance,
+					result.AttestationInlineOnlyKey: []byte(strconv.FormatBool(inlineOnly)),
 				},
 				InToto: result.InTotoAttestation{
 					PredicateType: slsa.PredicateSLSAProvenance,

--- a/solver/llbsolver/proc/provenance.go
+++ b/solver/llbsolver/proc/provenance.go
@@ -145,6 +145,9 @@ func ProvenanceProcessor(attrs map[string]string) llbsolver.Processor {
 
 			res.AddAttestation(p.ID, result.Attestation{
 				Kind: gatewaypb.AttestationKindInToto,
+				Metadata: map[string][]byte{
+					result.AttestationReasonKey:     result.AttestationReasonProvenance,
+				},
 				InToto: result.InTotoAttestation{
 					PredicateType: slsa.PredicateSLSAProvenance,
 				},

--- a/solver/llbsolver/proc/provenance.go
+++ b/solver/llbsolver/proc/provenance.go
@@ -57,8 +57,6 @@ func ProvenanceProcessor(attrs map[string]string) llbsolver.Processor {
 		var mode string
 		if v, ok := attrs["mode"]; ok {
 			switch v {
-			case "disabled", "none":
-				return res, nil
 			case "full":
 				mode = "max"
 			case "max", "min":

--- a/solver/result/attestation.go
+++ b/solver/result/attestation.go
@@ -5,8 +5,19 @@ import (
 	digest "github.com/opencontainers/go-digest"
 )
 
+const (
+	AttestationReasonKey     = "reason"
+)
+
+var (
+	AttestationReasonSBOM       = []byte("sbom")
+	AttestationReasonProvenance = []byte("provenance")
+)
+
 type Attestation struct {
 	Kind pb.AttestationKind
+
+	Metadata map[string][]byte
 
 	Ref         string
 	Path        string

--- a/solver/result/attestation.go
+++ b/solver/result/attestation.go
@@ -7,6 +7,7 @@ import (
 
 const (
 	AttestationReasonKey     = "reason"
+	AttestationInlineOnlyKey = "inline-only"
 )
 
 var (


### PR DESCRIPTION
This will be useful to help with default values for https://github.com/docker/buildx/pull/1412.

With this PR, buildx can attach the option `--opt attest:provenance=mode=min,inline-only=true`. This `inline-only` option is propagated through attestation metadata to the exporter, where it can be filtered out for the local/tar exporters, while being included for the image/oci/docker exporters. We could achieve similar functionality if we attempted to explicitly modify the exporter properties in buildx, but this would be overly complex logic to put into the client.

Additionally, I've added a `reason` field to the metadata, which can be optionally added to the metadata on attestation creation indicating the purpose of the attestation - in the future, this could be used by the exporter to filter out specific attestations for exporters (will be useful when we support multiple exporters, if different attestation output is desired). We could also (maybe) use the metadata in the SBOM scanner component to detect if the scanner has already run instead of relying on checking the predicate types.