### PR TITLE
Dockerfile: remove containerd-runtime stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -199,14 +199,6 @@ FROM binaries AS buildkit-windows
 # this is not in binaries-windows because it is not intended for release yet, just CI
 COPY --link --from=buildkitd /usr/bin/buildkitd /buildkitd.exe
 
-FROM alpine:${ALPINE_VERSION} AS containerd-runtime
-COPY --link --from=runc /usr/bin/runc /usr/bin/
-COPY --link --from=containerd /out/containerd* /usr/bin/
-COPY --link --from=containerd /out/ctr /usr/bin/
-VOLUME /var/lib/containerd
-VOLUME /run/containerd
-ENTRYPOINT ["containerd"]
-
 FROM --platform=$BUILDPLATFORM alpine:${ALPINE_VERSION} AS cni-plugins
 RUN apk add --no-cache curl
 ARG CNI_VERSION


### PR DESCRIPTION
Remove orphan `containerd-runtime` stage.

Was added in https://github.com/moby/buildkit/pull/666/files#diff-d4df02cc7c752c203625dc3d58ba3dcbda82247290de3554493a2ef1d50a25c0R181-R187 but doesn't look necessary anymore.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>