### PR TITLE
[0.10] Dockerfile: enforce Alpine version for Go image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apk add --no-cache git
 # xx is a helper for cross-compilation
 FROM --platform=$BUILDPLATFORM tonistiigi/xx@sha256:1e96844fadaa2f9aea021b2b05299bc02fe4c39a92d8e735b93e8e2b15610128 AS xx
 
-FROM --platform=$BUILDPLATFORM golang:1.18-alpine AS golatest
+FROM --platform=$BUILDPLATFORM golang:1.18-alpine${ALPINE_VERSION} AS golatest
 
 # gobuild is base stage for compiling go/cgo
 FROM golatest AS gobuild-base

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -845,7 +845,12 @@ func testSecurityModeSysfs(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 	defer c.Close()
 
-	command := `mkdir /sys/fs/cgroup/cpuset/securitytest`
+	cg := "/sys/fs/cgroup/cpuset/securitytest" // cgroup v1
+	if _, err := os.Stat("/sys/fs/cgroup/cpuset"); errors.Is(err, os.ErrNotExist) {
+		cg = "/sys/fs/cgroup/securitytest" // cgroup v2
+	}
+
+	command := "mkdir " + cg
 	st := llb.Image("busybox:latest").
 		Run(llb.Shlex(command),
 			llb.Security(mode))
@@ -860,7 +865,7 @@ func testSecurityModeSysfs(t *testing.T, sb integration.Sandbox) {
 	if secMode == securitySandbox {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "did not complete successfully")
-		require.Contains(t, err.Error(), "mkdir /sys/fs/cgroup/cpuset/securitytest")
+		require.Contains(t, err.Error(), "mkdir "+cg)
 	} else {
 		require.NoError(t, err)
 	}


### PR DESCRIPTION
follow-up #3350

Align Alpine version for the Go image to fix https://github.com/moby/moby/issues/44570.

Needs to backport
* https://github.com/moby/buildkit/pull/3269

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>