### PR TITLE
vendor: github.com/containerd/containerd v1.6.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.26.9
 	github.com/aws/smithy-go v1.11.2
 	github.com/containerd/console v1.0.3
-	github.com/containerd/containerd v1.6.10
+	github.com/containerd/containerd v1.6.11
 	github.com/containerd/continuity v0.3.0
 	github.com/containerd/fuse-overlayfs-snapshotter v1.0.2
 	github.com/containerd/go-cni v1.1.6

--- a/go.sum
+++ b/go.sum
@@ -370,8 +370,8 @@ github.com/containerd/containerd v1.5.7/go.mod h1:gyvv6+ugqY25TiXxcZC3L5yOeYgEw0
 github.com/containerd/containerd v1.5.8/go.mod h1:YdFSv5bTFLpG2HIYmfqDpSYYTDX+mc5qtSuYx1YUb/s=
 github.com/containerd/containerd v1.6.1/go.mod h1:1nJz5xCZPusx6jJU8Frfct988y0NpumIq9ODB0kLtoE=
 github.com/containerd/containerd v1.6.9/go.mod h1:XVicUvkxOrftE2Q1YWUXgZwkkAxwQYNOFzYWvfVfEfQ=
-github.com/containerd/containerd v1.6.10 h1:8aiav7I2ZyQLbTlNMcBXyAU1FtFvp6VuyuW13qSd6Hk=
-github.com/containerd/containerd v1.6.10/go.mod h1:CVqfxdJ95PDgORwA219AwwLrREZgrTFybXu2HfMKRG0=
+github.com/containerd/containerd v1.6.11 h1:uIn0uKrRhETIPyAb0lz6WY2xhYBObUOF1bBi5rqZ5x4=
+github.com/containerd/containerd v1.6.11/go.mod h1:K4Bw7gjgh4TnkmQY+py/PYQGp4e7xgnHAeg87VeWb3A=
 github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20190815185530-f2a389ac0a02/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20191127005431-f65d91d395eb/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=

--- a/vendor/github.com/containerd/containerd/leases/lease.go
+++ b/vendor/github.com/containerd/containerd/leases/lease.go
@@ -65,10 +65,15 @@ func SynchronousDelete(ctx context.Context, o *DeleteOptions) error {
 	return nil
 }
 
-// WithLabels sets labels on a lease
+// WithLabels merges labels on a lease
 func WithLabels(labels map[string]string) Opt {
 	return func(l *Lease) error {
-		l.Labels = labels
+		if l.Labels == nil {
+			l.Labels = map[string]string{}
+		}
+		for k, v := range labels {
+			l.Labels[k] = v
+		}
 		return nil
 	}
 }

--- a/vendor/github.com/containerd/containerd/rootfs/diff.go
+++ b/vendor/github.com/containerd/containerd/rootfs/diff.go
@@ -44,7 +44,7 @@ func CreateDiff(ctx context.Context, snapshotID string, sn snapshots.Snapshotter
 		return ocispec.Descriptor{}, err
 	}
 
-	lowerKey := fmt.Sprintf("%s-parent-view", info.Parent)
+	lowerKey := fmt.Sprintf("%s-parent-view-%s", info.Parent, uniquePart())
 	lower, err := sn.View(ctx, lowerKey, info.Parent)
 	if err != nil {
 		return ocispec.Descriptor{}, err
@@ -58,7 +58,7 @@ func CreateDiff(ctx context.Context, snapshotID string, sn snapshots.Snapshotter
 			return ocispec.Descriptor{}, err
 		}
 	} else {
-		upperKey := fmt.Sprintf("%s-view", snapshotID)
+		upperKey := fmt.Sprintf("%s-view-%s", snapshotID, uniquePart())
 		upper, err = sn.View(ctx, upperKey, snapshotID)
 		if err != nil {
 			return ocispec.Descriptor{}, err

--- a/vendor/github.com/containerd/containerd/version/version.go
+++ b/vendor/github.com/containerd/containerd/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.10+unknown"
+	Version = "1.6.11+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -215,7 +215,7 @@ github.com/containerd/cgroups/stats/v1
 # github.com/containerd/console v1.0.3
 ## explicit; go 1.13
 github.com/containerd/console
-# github.com/containerd/containerd v1.6.10
+# github.com/containerd/containerd v1.6.11
 ## explicit; go 1.17
 github.com/containerd/containerd
 github.com/containerd/containerd/api/services/containers/v1


### PR DESCRIPTION
- Fix nil pointer deference for Windows containers in CRI plugin
- Fix lease labels unexpectedly overwriting expiration
- Fix for simultaneous diff creation using the same parent snapshot

full diff: https://github.com/containerd/containerd/v1.6.10...v1.6.11
