### PR TITLE
exporter: filter out inline attestations for docker exporter

### DIFF
--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -111,10 +112,15 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 			ref = inp.Ref
 		} else if len(p.Platforms) > 0 {
 			p := p.Platforms[0]
-			if _, ok := inp.Attestations[p.ID]; ok {
-				return nil, errors.Errorf("cannot export attestations without multi-platform enabled")
-			}
 			ref = inp.Refs[p.ID]
+			if atts, ok := inp.Attestations[p.ID]; ok {
+				atts = attestation.Filter(atts, nil, map[string][]byte{
+					result.AttestationInlineOnlyKey: []byte(strconv.FormatBool(true)),
+				})
+				if len(atts) > 0 {
+					return nil, errors.Errorf("cannot export attestations without multi-platform enabled")
+				}
+			}
 		} else if len(inp.Refs) == 1 {
 			for _, ref = range inp.Refs {
 			}

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -77,6 +77,14 @@ func (e *imageExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 		return nil, err
 	}
 
+	if e.opt.Variant == VariantDocker {
+		if i.opts.MultiPlatform != nil && *i.opts.MultiPlatform {
+			return nil, errors.Errorf("docker exporter does not currently support exporting manifest lists")
+		}
+		b := false
+		i.opts.MultiPlatform = &b
+	}
+
 	for k, v := range opt {
 		switch k {
 		case keyTar:
@@ -115,10 +123,6 @@ func (e *imageExporterInstance) Config() *exporter.Config {
 }
 
 func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source, sessionID string) (map[string]string, error) {
-	if e.opt.Variant == VariantDocker && len(src.Refs) > 0 {
-		return nil, errors.Errorf("docker exporter does not currently support exporting manifest lists")
-	}
-
 	if src.Metadata == nil {
 		src.Metadata = make(map[string][]byte)
 	}


### PR DESCRIPTION
:cherries: Cherry-pick from https://github.com/moby/buildkit/pull/3379 since it should be an easy merge.

The docker exporter should filter out inline attestations, since it doesn't support them. Any remaining attestations should cause an error, since they have been requested but cannot actually be output.

Signed-off-by: Justin Chadwell <me@jedevc.com>