### PR TITLE
Fix configuration on `GCKeepStorage` when reading it from file

### DIFF
--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -413,7 +413,9 @@ func setDefaultConfig(cfg *config.Config) {
 	}
 
 	cfg.Workers.OCI.NetworkConfig = setDefaultNetworkConfig(cfg.Workers.OCI.NetworkConfig)
+	cfg.Workers.OCI.GCKeepStorage = cfg.Workers.OCI.GCKeepStorage * 1e6
 	cfg.Workers.Containerd.NetworkConfig = setDefaultNetworkConfig(cfg.Workers.Containerd.NetworkConfig)
+	cfg.Workers.Containerd.GCKeepStorage = cfg.Workers.Containerd.GCKeepStorage * 1e6
 
 	if userns.RunningInUserNS() {
 		// if buildkitd is being executed as the mapped-root (not only EUID==0 but also $USER==root)


### PR DESCRIPTION
Fix configuration on `GCKeepStorage` when reading it from file
Hi.
Currently [documentation for buildkitd.toml](https://github.com/moby/buildkit/blob/ca8dadffd6ea65a8d9627b70f8216f51b5663419/docs/buildkitd.toml.md) say that `oci.(worker|containerd).gckeepstorage` can be specified in MB.
However, when I set `gckeepstorage = 50000` (intend to 50GB), `buildkitd` caches almost nothing and seems to interpret `gckeepstorage` setting as in bytes.

Current implementation seems to forget to multiply `1e6` after loading config files(although this is handled correctly for command line flags ([oci](https://github.com/moby/buildkit/blob/01c0d6748e84eec86f8a61efd8cedf1f4ac345f3/cmd/buildkitd/main_oci_worker.go#L223)/[containerd](https://github.com/moby/buildkit/blob/01c0d6748e84eec86f8a61efd8cedf1f4ac345f3/cmd/buildkitd/main_containerd_worker.go#L210))).

Signed-off-by: Yuna Tomida <ytomida.mmm@gmail.com>