### PR TITLE
containerimage: fix removeinternalannotations

### DIFF
--- a/solver/llbsolver/provenance.go
+++ b/solver/llbsolver/provenance.go
@@ -548,7 +548,7 @@ func (c *cacheRecord) AddResult(dgst digest.Digest, idx int, createdAt time.Time
 	descs := make([]ocispecs.Descriptor, len(result.Descriptors))
 	for i, desc := range result.Descriptors {
 		d := desc
-		containerimage.RemoveInternalLayerAnnotations(&d, true)
+		d.Annotations = containerimage.RemoveInternalLayerAnnotations(d.Annotations, true)
 		descs[i] = d
 	}
 	c.ce.layers[e] = append(c.ce.layers[e], descs)


### PR DESCRIPTION
It is unsafe to map direct modifications in the
Annotations make of the Remote descriptor. The same map inside the Descriptor could be used in other
components.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>