### PR TITLE
Pass platform constraint for oci layout

### DIFF
--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -993,11 +993,17 @@ func contextByName(ctx context.Context, c client.Client, sessionID, name string,
 			return nil, nil, errors.Wrap(err, "could not parse oci-layout image config")
 		}
 
+		ociOpt := []llb.OCILayoutOption{
+			llb.WithCustomName("[context " + name + "] OCI load from client"),
+			llb.OCISessionID(c.BuildOpts().SessionID),
+		}
+		if platform != nil {
+			ociOpt = append(ociOpt, llb.Platform(*platform))
+		}
 		st := llb.OCILayout(
 			named.Name(),
 			digested.Digest(),
-			llb.WithCustomName("[context "+name+"] OCI load from client"),
-			llb.OCISessionID(c.BuildOpts().SessionID),
+			ociOpt...,
 		)
 		st, err = st.WithImageConfig(data)
 		if err != nil {


### PR DESCRIPTION
In case of oci layout `FROM --platform=` notation does not pass platform
 constraint. In case of pointing onto digest of multi-platform index we
 try to resolve target platform, which is wrong.

fixes https://github.com/moby/buildkit/issues/3396

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>