### PR TITLE
Introduce new `attestation` exporter options

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -7469,8 +7469,9 @@ func testExportAttestations(t *testing.T, sb integration.Sandbox) {
 
 		for _, p := range ps {
 			var attest intoto.Statement
-			dt := m[path.Join(strings.ReplaceAll(platforms.Format(p), "/", "_"), "test.attestation.json")].Data
-			require.NoError(t, json.Unmarshal(dt, &attest))
+			item := m[path.Join(strings.ReplaceAll(platforms.Format(p), "/", "_"), "test.attestation.json")]
+			require.NotNil(t, item)
+			require.NoError(t, json.Unmarshal(item.Data, &attest))
 
 			require.Equal(t, "https://in-toto.io/Statement/v0.1", attest.Type)
 			require.Equal(t, "https://example.com/attestations/v1.0", attest.PredicateType)
@@ -7482,8 +7483,9 @@ func testExportAttestations(t *testing.T, sb integration.Sandbox) {
 			}}, attest.Subject)
 
 			var attest2 intoto.Statement
-			dt = m[path.Join(strings.ReplaceAll(platforms.Format(p), "/", "_"), "test.attestation2.json")].Data
-			require.NoError(t, json.Unmarshal(dt, &attest2))
+			item = m[path.Join(strings.ReplaceAll(platforms.Format(p), "/", "_"), "test.attestation2.json")]
+			require.NotNil(t, item)
+			require.NoError(t, json.Unmarshal(item.Data, &attest2))
 
 			require.Equal(t, "https://in-toto.io/Statement/v0.1", attest2.Type)
 			require.Equal(t, "https://example.com/attestations2/v1.0", attest2.PredicateType)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -7402,7 +7402,7 @@ func testExportAttestations(t *testing.T, sb integration.Sandbox) {
 					Type:      ExporterLocal,
 					OutputDir: dir,
 					Attrs: map[string]string{
-						"attestation-prefix": "test.",
+						"attestations-prefix": "test.",
 					},
 				},
 			},
@@ -7454,7 +7454,7 @@ func testExportAttestations(t *testing.T, sb integration.Sandbox) {
 					Type:   ExporterTar,
 					Output: fixedWriteCloser(outW),
 					Attrs: map[string]string{
-						"attestation-prefix": "test.",
+						"attestations-prefix": "test.",
 					},
 				},
 			},

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -78,7 +78,8 @@ func (e *imageExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 			RefCfg: cacheconfig.RefConfig{
 				Compression: compression.New(compression.Default),
 			},
-			BuildInfo: true,
+			BuildInfo:    true,
+			Attestations: true,
 		},
 		store: true,
 	}

--- a/exporter/containerimage/opts.go
+++ b/exporter/containerimage/opts.go
@@ -19,6 +19,7 @@ const (
 	keyOCITypes         = "oci-mediatypes"
 	keyBuildInfo        = "buildinfo"
 	keyBuildInfoAttrs   = "buildinfo-attrs"
+	keyAttestations     = "attestations"
 
 	// preferNondistLayersKey is an exporter option which can be used to mark a layer as non-distributable if the layer reference was
 	// already found to use a non-distributable media type.
@@ -34,6 +35,7 @@ type ImageCommitOpts struct {
 	BuildInfoAttrs bool
 	Annotations    AnnotationsGroup
 	Epoch          *time.Time
+	Attestations   bool
 }
 
 func (c *ImageCommitOpts) Load(opt map[string]string) (map[string]string, error) {
@@ -73,6 +75,8 @@ func (c *ImageCommitOpts) Load(opt map[string]string) (map[string]string, error)
 			err = parseBoolWithDefault(&c.BuildInfo, k, v, true)
 		case keyBuildInfoAttrs:
 			err = parseBoolWithDefault(&c.BuildInfoAttrs, k, v, false)
+		case keyAttestations:
+			err = parseBool(&c.Attestations, k, v)
 		case keyPreferNondistLayers:
 			err = parseBool(&c.RefCfg.PreferNonDistributable, k, v)
 		default:

--- a/exporter/containerimage/opts.go
+++ b/exporter/containerimage/opts.go
@@ -2,6 +2,7 @@ package containerimage
 
 import (
 	"strconv"
+	"strings"
 	"time"
 
 	cacheconfig "github.com/moby/buildkit/cache/config"
@@ -28,14 +29,15 @@ const (
 )
 
 type ImageCommitOpts struct {
-	ImageName      string
-	RefCfg         cacheconfig.RefConfig
-	OCITypes       bool
-	BuildInfo      bool
-	BuildInfoAttrs bool
-	Annotations    AnnotationsGroup
-	Epoch          *time.Time
-	Attestations   bool
+	ImageName          string
+	RefCfg             cacheconfig.RefConfig
+	OCITypes           bool
+	BuildInfo          bool
+	BuildInfoAttrs     bool
+	Annotations        AnnotationsGroup
+	Epoch              *time.Time
+	Attestations       bool
+	AttestationsFilter []string
 }
 
 func (c *ImageCommitOpts) Load(opt map[string]string) (map[string]string, error) {
@@ -76,7 +78,10 @@ func (c *ImageCommitOpts) Load(opt map[string]string) (map[string]string, error)
 		case keyBuildInfoAttrs:
 			err = parseBoolWithDefault(&c.BuildInfoAttrs, k, v, false)
 		case keyAttestations:
-			err = parseBool(&c.Attestations, k, v)
+			if parseBool(&c.Attestations, k, v) != nil {
+				c.Attestations = true
+				c.AttestationsFilter = strings.Split(v, ",")
+			}
 		case keyPreferNondistLayers:
 			err = parseBool(&c.RefCfg.PreferNonDistributable, k, v)
 		default:

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -69,19 +69,20 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 		return nil, err
 	}
 
-	requiredAttestations := false
+	hasAttestations := false
 	for _, p := range ps.Platforms {
 		if atts, ok := inp.Attestations[p.ID]; ok {
 			atts = attestation.Filter(atts, nil, map[string][]byte{
 				result.AttestationInlineOnlyKey: []byte(strconv.FormatBool(true)),
 			})
 			if len(atts) > 0 {
-				requiredAttestations = true
+				hasAttestations = true
 				break
 			}
 		}
 	}
-	if requiredAttestations {
+	hasAttestations = opts.Attestations && hasAttestations
+	if hasAttestations {
 		isMap = true
 	}
 
@@ -108,7 +109,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 		if len(ps.Platforms) > 1 {
 			return nil, errors.Errorf("cannot export multiple platforms without multi-platform enabled")
 		}
-		if requiredAttestations {
+		if hasAttestations {
 			return nil, errors.Errorf("cannot export attestations without multi-platform enabled")
 		}
 
@@ -159,7 +160,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 		return mfstDesc, nil
 	}
 
-	if len(inp.Attestations) > 0 {
+	if hasAttestations {
 		opts.EnableOCITypes("attestations")
 	}
 

--- a/exporter/local/export.go
+++ b/exporter/local/export.go
@@ -20,10 +20,6 @@ import (
 	"golang.org/x/time/rate"
 )
 
-const (
-	keyAttestationPrefix = "attestation-prefix"
-)
-
 type Opt struct {
 	SessionManager *session.Manager
 }
@@ -39,24 +35,14 @@ func New(opt Opt) (exporter.Exporter, error) {
 }
 
 func (e *localExporter) Resolve(ctx context.Context, opt map[string]string) (exporter.ExporterInstance, error) {
-	tm, _, err := epoch.ParseExporterAttrs(opt)
+	i := &localExporterInstance{
+		localExporter: e,
+	}
+	opt, err := i.opts.Load(opt)
 	if err != nil {
 		return nil, err
 	}
-
-	i := &localExporterInstance{
-		localExporter: e,
-		opts: CreateFSOpts{
-			Epoch: tm,
-		},
-	}
-
-	for k, v := range opt {
-		switch k {
-		case keyAttestationPrefix:
-			i.opts.AttestationPrefix = v
-		}
-	}
+	_ = opt
 
 	return i, nil
 }

--- a/exporter/local/export.go
+++ b/exporter/local/export.go
@@ -37,6 +37,9 @@ func New(opt Opt) (exporter.Exporter, error) {
 func (e *localExporter) Resolve(ctx context.Context, opt map[string]string) (exporter.ExporterInstance, error) {
 	i := &localExporterInstance{
 		localExporter: e,
+		opts: CreateFSOpts{
+			Attestations: true,
+		},
 	}
 	opt, err := i.opts.Load(opt)
 	if err != nil {

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -67,8 +67,9 @@ func (e *imageExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 			RefCfg: cacheconfig.RefConfig{
 				Compression: compression.New(compression.Default),
 			},
-			BuildInfo: true,
-			OCITypes:  e.opt.Variant == VariantOCI,
+			BuildInfo:    true,
+			OCITypes:     e.opt.Variant == VariantOCI,
+			Attestations: true,
 		},
 	}
 

--- a/exporter/tar/export.go
+++ b/exporter/tar/export.go
@@ -34,7 +34,12 @@ func New(opt Opt) (exporter.Exporter, error) {
 }
 
 func (e *localExporter) Resolve(ctx context.Context, opt map[string]string) (exporter.ExporterInstance, error) {
-	li := &localExporterInstance{localExporter: e}
+	li := &localExporterInstance{
+		localExporter: e,
+		opts: local.CreateFSOpts{
+			Attestations: true,
+		},
+	}
 	opt, err := li.opts.Load(opt)
 	if err != nil {
 		return nil, err

--- a/exporter/tar/export.go
+++ b/exporter/tar/export.go
@@ -21,8 +21,6 @@ import (
 )
 
 const (
-	attestationPrefixKey = "attestation-prefix"
-
 	// preferNondistLayersKey is an exporter option which can be used to mark a layer as non-distributable if the layer reference was
 	// already found to use a non-distributable media type.
 	// When this option is not set, the exporter will change the media type of the layer to a distributable one.
@@ -45,12 +43,10 @@ func New(opt Opt) (exporter.Exporter, error) {
 
 func (e *localExporter) Resolve(ctx context.Context, opt map[string]string) (exporter.ExporterInstance, error) {
 	li := &localExporterInstance{localExporter: e}
-
-	tm, opt, err := epoch.ParseExporterAttrs(opt)
+	opt, err := li.opts.Load(opt)
 	if err != nil {
 		return nil, err
 	}
-	li.opts.Epoch = tm
 
 	for k, v := range opt {
 		switch k {
@@ -60,8 +56,6 @@ func (e *localExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 				return nil, errors.Wrapf(err, "non-bool value for %s: %s", preferNondistLayersKey, v)
 			}
 			li.preferNonDist = b
-		case attestationPrefixKey:
-			li.opts.AttestationPrefix = v
 		}
 	}
 

--- a/exporter/tar/export.go
+++ b/exporter/tar/export.go
@@ -3,7 +3,6 @@ package local
 import (
 	"context"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -18,13 +17,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/tonistiigi/fsutil"
 	fstypes "github.com/tonistiigi/fsutil/types"
-)
-
-const (
-	// preferNondistLayersKey is an exporter option which can be used to mark a layer as non-distributable if the layer reference was
-	// already found to use a non-distributable media type.
-	// When this option is not set, the exporter will change the media type of the layer to a distributable one.
-	preferNondistLayersKey = "prefer-nondist-layers"
 )
 
 type Opt struct {
@@ -47,25 +39,14 @@ func (e *localExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 	if err != nil {
 		return nil, err
 	}
-
-	for k, v := range opt {
-		switch k {
-		case preferNondistLayersKey:
-			b, err := strconv.ParseBool(v)
-			if err != nil {
-				return nil, errors.Wrapf(err, "non-bool value for %s: %s", preferNondistLayersKey, v)
-			}
-			li.preferNonDist = b
-		}
-	}
+	_ = opt
 
 	return li, nil
 }
 
 type localExporterInstance struct {
 	*localExporter
-	opts          local.CreateFSOpts
-	preferNonDist bool
+	opts local.CreateFSOpts
 }
 
 func (e *localExporterInstance) Name() string {


### PR DESCRIPTION
These replace the `inline-only` attestation fields introduce in #3342.

Instead, we can now specify `attestations=<true/false/filter-list>` per exporter, to enable specific attestation per exporter - the default in buildkit is set to `true`. The possible values are:

- `true`: output all provided attestations from the solver
- `false`: output none of the provided attestations from the solver
- `reason,[reasons]`: a csv list of reasons, outputs only the attestations that were generated for one of those specified reasons, using the metadata field. e.g. `--output type=...,attestations=provenance` will only include provenance attestations in the output for that exporter, even if other attestations (like SBOMs) were generated in the solver.

We also update the `attestation-prefix` option to be `attestation[s]-prefix` - to be more aligned with the new `attestations` flag.

Additionally, we have a few smaller minor refactoring commits around the exporter:
- Propogate metadata through unbundling (wasn't causing any issues now, but could in the future, since logically we should inherit metadata through the process)
- Moves fs opt parsing into shared logic between the local+tar exporters, so we don't need to duplicate all of that.
- Removes non-dist options from the tar exporter (introduced in #2561) - these aren't ever used, so we can silently drop them. If clients were using this, no error will occur, it will just silently do nothing.