### PR TITLE
chore: fixup dockerfile DetectSyntax doc comment

### DIFF
--- a/frontend/dockerfile/parser/directives.go
+++ b/frontend/dockerfile/parser/directives.go
@@ -100,7 +100,7 @@ func (d *DirectiveParser) ParseAll(data []byte) ([]*Directive, error) {
 	return directives, nil
 }
 
-// DetectSyntaxFromDockerfile returns the syntax of provided input.
+// DetectSyntax returns the syntax of provided input.
 //
 // The traditional dockerfile directives '# syntax = ...' are used by default,
 // however, the function will also fallback to c-style directives '// syntax = ...'


### PR DESCRIPTION
:hammer_and_wrench: Fixes https://github.com/moby/buildkit/pull/2937/files/9b73e88f26f5efd148d4e09350fc963f6af61b97#r1047904770 (from @tianon):

> This probably should've just been DetectSyntax, right? 
>
> (The function itself doesn't have the FromDockerfile suffix on the name )