### PR TITLE
Improved SBOM filenames

### DIFF
--- a/frontend/attestations/sbom/sbom.go
+++ b/frontend/attestations/sbom/sbom.go
@@ -16,6 +16,9 @@ import (
 )
 
 const (
+	CoreSBOMName    = "sbom"
+	ExtraSBOMPrefix = CoreSBOMName + "-"
+
 	srcDir = "/run/src/"
 	outDir = "/run/out/"
 )
@@ -56,7 +59,7 @@ func CreateSBOMScanner(ctx context.Context, resolver llb.ImageMetaResolver, scan
 		var env []string
 		env = append(env, cfg.Config.Env...)
 		env = append(env, "BUILDKIT_SCAN_DESTINATION="+outDir)
-		env = append(env, "BUILDKIT_SCAN_SOURCE="+path.Join(srcDir, "core"))
+		env = append(env, "BUILDKIT_SCAN_SOURCE="+path.Join(srcDir, "core", CoreSBOMName))
 		if len(extras) > 0 {
 			env = append(env, "BUILDKIT_SCAN_SOURCE_EXTRAS="+path.Join(srcDir, "extras/"))
 		}
@@ -72,9 +75,9 @@ func CreateSBOMScanner(ctx context.Context, resolver llb.ImageMetaResolver, scan
 		}
 
 		runscan := llb.Image(scanner).Run(opts...)
-		runscan.AddMount(path.Join(srcDir, "core"), ref, llb.Readonly)
+		runscan.AddMount(path.Join(srcDir, "core", CoreSBOMName), ref, llb.Readonly)
 		for k, extra := range extras {
-			runscan.AddMount(path.Join(srcDir, "extras", k), extra, llb.Readonly)
+			runscan.AddMount(path.Join(srcDir, "extras", ExtraSBOMPrefix+k), extra, llb.Readonly)
 		}
 
 		stsbom := runscan.AddMount(outDir, llb.Scratch())

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -105,11 +105,11 @@ func Dockerfile2LLB(ctx context.Context, dt []byte, opt ConvertOpt) (*llb.State,
 	}
 	for dsi := ds; dsi != nil; dsi = dsi.base {
 		if ds != dsi && dsi.scanStage {
-			sbom.Extras["stage:"+dsi.stageName] = dsi.state
+			sbom.Extras[dsi.stageName] = dsi.state
 		}
 		for dsi2 := range dsi.deps {
 			if dsi2.scanStage {
-				sbom.Extras["stage:"+dsi2.stageName] = dsi2.state
+				sbom.Extras[dsi2.stageName] = dsi2.state
 			}
 		}
 	}


### PR DESCRIPTION
From the following Dockerfile:

```dockerfile
ARG BUILDKIT_SBOM_SCAN_STAGE=true

FROM alpine:latest AS base
RUN echo test > /test

FROM scratch
COPY --from=base /test /
```

we get:

```
$ docker buildx build --builder=dev . --sbom=true --provenance=true -o ./dir
$ ls ./dir
provenance.json  sbom-base.spdx.json  sbom.spdx.json  foo
```