### PR TITLE
vendor: replace spdx/tools-golang with jedevc/spdx-tools-golang

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -152,3 +152,5 @@ require (
 	golang.org/x/text v0.5.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/spdx/tools-golang => github.com/jedevc/spdx-tools-golang v0.0.0-20221205121515-6fe9d226281a

--- a/go.sum
+++ b/go.sum
@@ -912,6 +912,8 @@ github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6t
 github.com/j-keck/arping v1.0.2/go.mod h1:aJbELhR92bSk7tp79AWM/ftfc90EfEi2bQJrbBFOsPw=
 github.com/jaguilar/vt100 v0.0.0-20150826170717-2703a27b14ea/go.mod h1:QMdK4dGB3YhEW2BmA1wgGpPYI3HZy/5gD705PXKUVSg=
 github.com/jarcoal/httpmock v1.0.5/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
+github.com/jedevc/spdx-tools-golang v0.0.0-20221205121515-6fe9d226281a h1:oEb/YxUfXfGhRJVEg4yBfSnB6ZgS9aBu4RAM0fB9XsA=
+github.com/jedevc/spdx-tools-golang v0.0.0-20221205121515-6fe9d226281a/go.mod h1:VHzvNsKAfAGqs4ZvwRL+7a0dNsL20s7lGui4K9C0xQM=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
 github.com/jingyugao/rowserrcheck v0.0.0-20191204022205-72ab7603b68a/go.mod h1:xRskid8CManxVta/ALEhJha/pweKBaVG6fWgc0yH25s=
 github.com/jirfag/go-printf-func-name v0.0.0-20191110105641-45db9963cdd3/go.mod h1:HEWGJkRDzjJY2sqdDwxccsGicWEf9BQOZsq2tV+xzM0=
@@ -1316,8 +1318,6 @@ github.com/sourcegraph/go-diff v0.5.1/go.mod h1:j2dHj3m8aZgQO8lMTcTnBcXkRRRqi34c
 github.com/sourcegraph/go-diff v0.5.3/go.mod h1:v9JDtjCE4HHHCZGId75rg8gkKKa98RVjBcBGsVmMmak=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spdx/gordf v0.0.0-20201111095634-7098f93598fb/go.mod h1:uKWaldnbMnjsSAXRurWqqrdyZen1R7kxl8TkmWk2OyM=
-github.com/spdx/tools-golang v0.3.1-0.20221108182156-8a01147e6342 h1:6uvaOTv4GeRqQV6O1/znbpziqhctMRLTy3OGeZrNMic=
-github.com/spdx/tools-golang v0.3.1-0.20221108182156-8a01147e6342/go.mod h1:VHzvNsKAfAGqs4ZvwRL+7a0dNsL20s7lGui4K9C0xQM=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=

--- a/vendor/github.com/spdx/tools-golang/spdx/v2_2/creation_info.go
+++ b/vendor/github.com/spdx/tools-golang/spdx/v2_2/creation_info.go
@@ -22,5 +22,5 @@ type CreationInfo struct {
 
 	// 6.10: Creator Comment
 	// Cardinality: optional, one
-	CreatorComment string `json:"comment"`
+	CreatorComment string `json:"comment,omitempty"`
 }

--- a/vendor/github.com/spdx/tools-golang/spdx/v2_2/document.go
+++ b/vendor/github.com/spdx/tools-golang/spdx/v2_2/document.go
@@ -53,13 +53,13 @@ type Document struct {
 	DocumentComment string `json:"comment,omitempty"`
 
 	CreationInfo  *CreationInfo   `json:"creationInfo"`
-	Packages      []*Package      `json:"packages"`
-	Files         []*File         `json:"files"`
-	OtherLicenses []*OtherLicense `json:"hasExtractedLicensingInfos"`
-	Relationships []*Relationship `json:"relationships"`
-	Annotations   []*Annotation   `json:"annotations"`
-	Snippets      []Snippet       `json:"snippets"`
+	Packages      []*Package      `json:"packages,omitempty"`
+	Files         []*File         `json:"files,omitempty"`
+	OtherLicenses []*OtherLicense `json:"hasExtractedLicensingInfos,omitempty"`
+	Relationships []*Relationship `json:"relationships,omitempty"`
+	Annotations   []*Annotation   `json:"annotations,omitempty"`
+	Snippets      []Snippet       `json:"snippets,omitempty"`
 
 	// DEPRECATED in version 2.0 of spec
-	Reviews []*Review
+	Reviews []*Review `json:"-"`
 }

--- a/vendor/github.com/spdx/tools-golang/spdx/v2_2/package.go
+++ b/vendor/github.com/spdx/tools-golang/spdx/v2_2/package.go
@@ -9,7 +9,7 @@ type Package struct {
 	// NOT PART OF SPEC
 	// flag: does this "package" contain files that were in fact "unpackaged",
 	// e.g. included directly in the Document without being in a Package?
-	IsUnpackaged bool
+	IsUnpackaged bool `json:"-"`
 
 	// 7.1: Package Name
 	// Cardinality: mandatory, one
@@ -45,14 +45,14 @@ type Package struct {
 	// Cardinality: optional, one; default value is "true" if omitted
 	FilesAnalyzed bool `json:"filesAnalyzed,omitempty"`
 	// NOT PART OF SPEC: did FilesAnalyzed tag appear?
-	IsFilesAnalyzedTagPresent bool
+	IsFilesAnalyzedTagPresent bool `json:"-"`
 
 	// 7.9: Package Verification Code
 	PackageVerificationCode common.PackageVerificationCode `json:"packageVerificationCode"`
 
 	// 7.10: Package Checksum: may have keys for SHA1, SHA256 and/or MD5
 	// Cardinality: optional, one or many
-	PackageChecksums []common.Checksum `json:"checksums"`
+	PackageChecksums []common.Checksum `json:"checksums,omitempty"`
 
 	// 7.11: Package Home Page
 	// Cardinality: optional, one
@@ -108,9 +108,9 @@ type Package struct {
 	PackageAttributionTexts []string `json:"attributionTexts,omitempty"`
 
 	// Files contained in this Package
-	Files []*File
+	Files []*File `json:"files,omitempty"`
 
-	Annotations []Annotation `json:"annotations"`
+	Annotations []Annotation `json:"annotations,omitempty"`
 }
 
 // PackageExternalReference is an External Reference to additional info
@@ -129,5 +129,5 @@ type PackageExternalReference struct {
 
 	// 7.22: Package External Reference Comment
 	// Cardinality: conditional (optional, one) for each External Reference
-	ExternalRefComment string `json:"comment"`
+	ExternalRefComment string `json:"comment,omitempty"`
 }

--- a/vendor/github.com/spdx/tools-golang/spdx/v2_3/creation_info.go
+++ b/vendor/github.com/spdx/tools-golang/spdx/v2_3/creation_info.go
@@ -22,5 +22,5 @@ type CreationInfo struct {
 
 	// 6.10: Creator Comment
 	// Cardinality: optional, one
-	CreatorComment string `json:"comment"`
+	CreatorComment string `json:"comment,omitempty"`
 }

--- a/vendor/github.com/spdx/tools-golang/spdx/v2_3/package.go
+++ b/vendor/github.com/spdx/tools-golang/spdx/v2_3/package.go
@@ -147,5 +147,5 @@ type PackageExternalReference struct {
 
 	// 7.22: Package External Reference Comment
 	// Cardinality: conditional (optional, one) for each External Reference
-	ExternalRefComment string `json:"comment"`
+	ExternalRefComment string `json:"comment,omitempty"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -664,7 +664,7 @@ github.com/shibumi/go-pathspec
 # github.com/sirupsen/logrus v1.9.0
 ## explicit; go 1.13
 github.com/sirupsen/logrus
-# github.com/spdx/tools-golang v0.3.1-0.20221108182156-8a01147e6342
+# github.com/spdx/tools-golang v0.3.1-0.20221108182156-8a01147e6342 => github.com/jedevc/spdx-tools-golang v0.0.0-20221205121515-6fe9d226281a
 ## explicit; go 1.13
 github.com/spdx/tools-golang/json
 github.com/spdx/tools-golang/spdx/common
@@ -926,3 +926,4 @@ google.golang.org/protobuf/types/pluginpb
 # gopkg.in/yaml.v3 v3.0.1
 ## explicit
 gopkg.in/yaml.v3
+# github.com/spdx/tools-golang => github.com/jedevc/spdx-tools-golang v0.0.0-20221205121515-6fe9d226281a


### PR DESCRIPTION
The relevant commits including refactoring to the struct tags, preventing unneccessary output from the resulting sbom as we import and re-export it.

This should help reduce the size of the resulting SBOMs (minimally).

For example, before:

```json
        "externalRefs": [
          {
            "referenceCategory": "SECURITY",
            "referenceType": "cpe23Type",
            "referenceLocator": "cpe:2.3:a:musl:musl:1.2.3-r4:*:*:*:*:*:*:*",
            "comment": ""
          },
```

Then, after:

```json
        "externalRefs": [
          {
            "referenceCategory": "SECURITY",
            "referenceType": "cpe23Type",
            "referenceLocator": "cpe:2.3:a:musl:musl:1.2.3-r4:*:*:*:*:*:*:*"
          },
```

See https://github.com/spdx/tools-golang/pull/174 - when this is merged, we can remove the `replace` directive.