### PR TITLE
Update CI to output annotations for failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,8 @@ jobs:
           - pkg: ./...
             skip-integration-tests: 1
             typ: integration gateway
+    env:
+      GOTESTSUM_JSONFILE: ${{github.workspace}}/test.json
     steps:
       -
         name: Checkout
@@ -128,6 +130,10 @@ jobs:
           SKIP_INTEGRATION_TESTS: ${{ matrix.skip-integration-tests }}
           CACHE_FROM: type=gha,scope=${{ env.CACHE_GHA_SCOPE_IT }} type=gha,scope=${{ env.CACHE_GHA_SCOPE_BINARIES }}
       -
+        run: |
+          [ ! -f "${GOTESTSUM_JSONFILE}" ] || jq -s -r -f hack/test2annotation.jq ${GOTESTSUM_JSONFILE}
+        if: always()
+      -
         name: Upload coverage file
         uses: actions/upload-artifact@v3
         with:
@@ -154,6 +160,8 @@ jobs:
           - pkg: ./...
             skip-integration-tests: 1
             typ: integration
+    env:
+      GOTESTSUM_JSONFILE: ${{github.workspace}}/test.json
     steps:
       -
         name: Checkout
@@ -183,6 +191,10 @@ jobs:
           TESTPKGS: ${{ matrix.pkg }}
           SKIP_INTEGRATION_TESTS: ${{ matrix.skip-integration-tests }}
           CACHE_FROM: type=gha,scope=${{ env.CACHE_GHA_SCOPE_IT }} type=gha,scope=${{ env.CACHE_GHA_SCOPE_BINARIES }}
+      -
+        run: |
+          [ ! -f "${GOTESTSUM_JSONFILE}" ] || jq -s -r -f hack/test2annotation.jq ${GOTESTSUM_JSONFILE}
+        if: always()
 
   test-s3:
     runs-on: ubuntu-20.04

--- a/Dockerfile
+++ b/Dockerfile
@@ -145,6 +145,11 @@ ARG TARGETPLATFORM
 ENV CGO_ENABLED=1 BUILDTAGS=no_btrfs GO111MODULE=off
 RUN xx-apk add musl-dev gcc && xx-go --wrap
 
+FROM gobuild-base AS gotestsum
+RUN --mount=target=/root/.cache,type=cache \
+  --mount=target=/go/pkg/mod,type=cache \
+  go install gotest.tools/gotestsum@latest
+
 FROM containerd-base AS containerd
 ARG CONTAINERD_VERSION
 RUN --mount=from=containerd-src,src=/usr/src/containerd,readwrite --mount=target=/root/.cache,type=cache \
@@ -245,6 +250,7 @@ COPY --link --from=registry /bin/registry /usr/bin/
 COPY --link --from=runc /usr/bin/runc /usr/bin/
 COPY --link --from=containerd /out/containerd* /usr/bin/
 COPY --link --from=cni-plugins /opt/cni/bin/bridge /opt/cni/bin/host-local /opt/cni/bin/loopback /opt/cni/bin/firewall /opt/cni/bin/dnsname /opt/cni/bin/
+COPY --link --from=gotestsum /go/bin/gotestsum /usr/bin/
 COPY --link hack/fixtures/cni.json /etc/buildkit/cni.json
 COPY --link hack/fixtures/dns-cni.conflist /etc/buildkit/dns-cni.conflist
 COPY --link --from=binaries / /usr/bin/

--- a/hack/test
+++ b/hack/test
@@ -71,8 +71,19 @@ if ! docker container inspect "$cacheVolume" >/dev/null 2>/dev/null; then
   docker create -v /root/.cache -v /root/.cache/registry -v /go/pkg/mod --name "$cacheVolume" alpine
 fi
 
+if [ -n "${GOTESTSUM_JSONFILE:-}" ]; then
+  f="$(readlink -f "$GOTESTSUM_JSONFILE")" # get absolute path
+  dir="$(dirname ${f})"
+  inContainerPath="/tmp/test/gotestsum/json/$(basename ${f})"
+  gotestsumFlags+="-e GOTESTSUM_JSONFILE=${inContainerPath} -v ${dir}:$(dirname ${inContainerPath}) "
+fi
+
+if [ -n "${GOTESTSUM_FORMAT:="standard-verbose"}" ]; then
+  gotestsumFlags+="-e GOTESTSUM_FORMAT=${GOTESTSUM_FORMAT}"
+fi
+
 if [ "$TEST_INTEGRATION" == 1 ]; then
-  cid=$(docker create --rm -v /tmp $coverageVol --volumes-from=$cacheVolume -e TEST_DOCKERD -e SKIP_INTEGRATION_TESTS ${BUILDKIT_INTEGRATION_SNAPSHOTTER:+"-eBUILDKIT_INTEGRATION_SNAPSHOTTER"} -e BUILDKIT_REGISTRY_MIRROR_DIR=/root/.cache/registry --privileged $iid go test $coverageFlags ${TESTFLAGS:--v} ${TESTPKGS:-./...})
+  cid=$(docker create --rm -v /tmp $coverageVol --volumes-from=$cacheVolume ${gotestsumFlags:=} -e TEST_DOCKERD -e SKIP_INTEGRATION_TESTS ${BUILDKIT_INTEGRATION_SNAPSHOTTER:+"-eBUILDKIT_INTEGRATION_SNAPSHOTTER"} -e BUILDKIT_REGISTRY_MIRROR_DIR=/root/.cache/registry --privileged $iid gotestsum -- $coverageFlags ${TESTFLAGS:-} ${TESTPKGS:-./...})
   if [ "$TEST_DOCKERD" = "1" ]; then
     docker cp "$TEST_DOCKERD_BINARY" $cid:/usr/bin/dockerd
   fi
@@ -112,7 +123,7 @@ if [ "$TEST_DOCKERFILE" == 1 ]; then
 
     if [ -s $tarout ]; then
       if [ "$release" = "mainline" ] || [ "$release" = "labs" ] || [ -n "$DOCKERFILE_RELEASES_CUSTOM" ] || [ "$GITHUB_ACTIONS" = "true" ]; then
-        cid=$(docker create -v /tmp $coverageVol --rm --privileged --volumes-from=$cacheVolume -e TEST_DOCKERD -e BUILDKIT_REGISTRY_MIRROR_DIR=/root/.cache/registry -e BUILDKIT_WORKER_RANDOM -e FRONTEND_GATEWAY_ONLY=local:/$release.tar -e EXTERNAL_DF_FRONTEND=/dockerfile-frontend $iid go test $coverageFlags --count=1 -tags "$buildtags" ${TESTFLAGS:--v} ./frontend/dockerfile)
+        cid=$(docker create -v /tmp $coverageVol --rm --privileged --volumes-from=$cacheVolume -e TEST_DOCKERD -e BUILDKIT_REGISTRY_MIRROR_DIR=/root/.cache/registry -e BUILDKIT_WORKER_RANDOM -e FRONTEND_GATEWAY_ONLY=local:/$release.tar -e EXTERNAL_DF_FRONTEND=/dockerfile-frontend $iid go test $coverageFlags --count=1 -tags "$buildtags" ./frontend/dockerfile)
         docker cp $tarout $cid:/$release.tar
         if [ "$TEST_DOCKERD" = "1" ]; then
           docker cp "$TEST_DOCKERD_BINARY" $cid:/usr/bin/dockerd

--- a/hack/test2annotation.jq
+++ b/hack/test2annotation.jq
@@ -1,0 +1,97 @@
+#!/usr/bin/env -S jq -s -r -f
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# Takes the raw test2json as input and groups each item by package name + test name
+#
+# Example
+# Input:
+#   {...}
+#   {...}
+#   {...}
+# Output:
+#  [[{...},{...},{...}]]
+def group_tests: reduce (.[] | select(.Test != null)) as $item (
+    {}; .["\($item.Package).\($item.Test)"] += [$item]
+);
+
+# Filter a group of tests by action.
+# The way this works is for a group of tests,
+# if none of the tests have an action matching the provided value, the group is
+# dropped.
+def filter_group_action(a): map(select(.[].Action == a));
+
+# Filter a group of tests to just the tests that failed
+def only_failed: filter_group_action("fail");
+
+def merge_strings(s1; s2): if s1 == null then s2 else "\(s1)\(s2)" end;
+
+# Matches an output string to find the test file and line number.
+# The actual string looks something like:
+#  "test_foo.go:12: some failure message\n"
+# There may be arbitrary whitespace at the beginning of the string.
+def capture_fail_details: capture("^\\s*(?<file>\\w+_test\\.go):(?<line>\\d+): "; "x");
+
+# Filter out all the undesirable test line outputs
+def filter_test_item:
+    select(.Output != null)
+    | select(.Output | test("^\\s*=== RUN")| not)
+    | select(.Output | test("^\\s*=== PAUSE")| not)
+    | select(.Output | test("^\\s*=== CONT")| not)
+    | select(.Output | test("^\\s*--- FAIL:")| not)
+;
+
+# Take a list of test groups and make a map of tests keyed on the package name +
+# test name with all the output concatenated.
+#
+# This uses the last test log message to get the the file/line number for the test (as .Details)
+def merge_output: reduce (.[][] | filter_test_item) as $item (
+    {};  (
+        "\($item.Package).\($item.Test)" as $key
+        | merge_strings(.[$key].Output; $item.Output) as $merged
+        | .[$key] += {
+            Output: $merged | sub("^\\s*"; ""; "x"),
+            Test: $item.Test,
+            Package: $item.Package,
+            Details: (($item.Output | capture_fail_details) // .[$key].Details),  # "//" is an operator that returns the first true/non-null value
+        }
+    ) // .
+);
+
+# Used as the "title" field for error annotations
+def err_title: "Failed: \(.Package).\(.Test)";
+
+# Split the containerd root package path to get the directory name that a test belongs to.
+def file_dir: .Package | split("github.com/moby/buildkit/")[-1];
+
+def err_file: if .Details != null and .Details.file != null then "\(file_dir)/\(.Details.file)" else "" end;
+
+# Some cases there may not be any extra details because they got filtered out.
+# This can happen, for instance, if the failure log was create from a file that is not a `_test.go` file.
+# In this case we'd still want the annotation but we just can't get the file/line number (without allowing non-test files to be the source of the failure).
+def details_to_string: if .Details != null  and .Details.file != null then ",file=\(err_file),line=\(.Details.line)" else "" end;
+
+# Replace all occurrences of "\n" with the url-encoded version
+# This allows multi-line strings to work with github annotations.
+# https://github.com/actions/toolkit/issues/193#issuecomment-605394935
+def encode_output: gsub("\n"; "%0A");
+
+# Creates github actions error annotations for each input
+# It is expected that the input is the output of merge_output.
+def to_error: reduce .[] as $item (
+    ""; . += "::error title=\($item | err_title)\($item | details_to_string)::\($item.Output | encode_output)\n"
+);
+
+group_tests | only_failed | merge_output | to_error


### PR DESCRIPTION
It is extremely difficult to determine what error occurred in CI. With this change we'll get an annotation with the test log for failed tests.
