### PR TITLE
Fixes for provenance attestations

### DIFF
--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -16,6 +16,7 @@ import (
 	"github.com/moby/buildkit/util/tracing"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -688,7 +689,7 @@ func (s *sharedOp) LoadCache(ctx context.Context, rec *CacheRecord) (Result, err
 		ctx = trace.ContextWithSpan(ctx, s.st.mspan)
 	}
 	// no cache hit. start evaluating the node
-	span, ctx := tracing.StartSpan(ctx, "load cache: "+s.st.vtx.Name())
+	span, ctx := tracing.StartSpan(ctx, "load cache: "+s.st.vtx.Name(), trace.WithAttributes(attribute.String("vertex", s.st.vtx.Digest().String())))
 	notifyCompleted := notifyStarted(ctx, &s.st.clientVertex, true)
 	res, err := s.Cache().Load(withAncestorCacheOpts(ctx, s.st), rec)
 	tracing.FinishWithError(span, err)
@@ -800,7 +801,7 @@ func (s *sharedOp) CacheMap(ctx context.Context, index int) (resp *cacheMapResp,
 		ctx = withAncestorCacheOpts(ctx, s.st)
 		if len(s.st.vtx.Inputs()) == 0 {
 			// no cache hit. start evaluating the node
-			span, ctx := tracing.StartSpan(ctx, "cache request: "+s.st.vtx.Name())
+			span, ctx := tracing.StartSpan(ctx, "cache request: "+s.st.vtx.Name(), trace.WithAttributes(attribute.String("vertex", s.st.vtx.Digest().String())))
 			notifyCompleted := notifyStarted(ctx, &s.st.clientVertex, false)
 			defer func() {
 				tracing.FinishWithError(span, retErr)
@@ -879,7 +880,7 @@ func (s *sharedOp) Exec(ctx context.Context, inputs []Result) (outputs []Result,
 		ctx = withAncestorCacheOpts(ctx, s.st)
 
 		// no cache hit. start evaluating the node
-		span, ctx := tracing.StartSpan(ctx, s.st.vtx.Name())
+		span, ctx := tracing.StartSpan(ctx, s.st.vtx.Name(), trace.WithAttributes(attribute.String("vertex", s.st.vtx.Digest().String())))
 		notifyCompleted := notifyStarted(ctx, &s.st.clientVertex, false)
 		defer func() {
 			tracing.FinishWithError(span, retErr)

--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -241,6 +241,7 @@ type Job struct {
 
 	progressCloser func()
 	SessionID      string
+	uniqueID       string // unique ID is used for provenance. We use a different field that client can't control
 }
 
 type SolverOpt struct {
@@ -451,6 +452,7 @@ func (jl *Solver) NewJob(id string) (*Job, error) {
 		span:           span,
 		id:             id,
 		startedTime:    time.Now(),
+		uniqueID:       identity.NewID(),
 	}
 	jl.jobs[id] = j
 
@@ -598,6 +600,10 @@ func (j *Job) RegisterCompleteTime() time.Time {
 		j.completedTime = time.Now()
 	}
 	return j.completedTime
+}
+
+func (j *Job) UniqueID() string {
+	return j.uniqueID
 }
 
 func (j *Job) InContext(ctx context.Context, f func(context.Context, session.Group) error) error {

--- a/solver/llbsolver/provenance.go
+++ b/solver/llbsolver/provenance.go
@@ -15,7 +15,6 @@ import (
 	"github.com/moby/buildkit/exporter/containerimage"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/frontend"
-	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/solver"
 	"github.com/moby/buildkit/solver/llbsolver/ops"
 	"github.com/moby/buildkit/solver/llbsolver/provenance"
@@ -402,11 +401,9 @@ func NewProvenanceCreator(ctx context.Context, cp *provenance.Capture, res solve
 
 	st := j.StartedTime()
 
-	buildID := identity.NewID()
-
 	pr.Metadata.BuildStartedOn = &st
 	pr.Metadata.Reproducible = reproducible
-	pr.Metadata.BuildInvocationID = buildID
+	pr.Metadata.BuildInvocationID = j.UniqueID()
 
 	pr.Builder.ID = attrs["builder-id"]
 

--- a/solver/llbsolver/provenance/buildconfig.go
+++ b/solver/llbsolver/provenance/buildconfig.go
@@ -96,6 +96,13 @@ func toBuildSteps(def *pb.Definition) ([]BuildStep, map[digest.Digest]int, error
 		if err := (&op).Unmarshal(dt); err != nil {
 			return nil, nil, errors.Wrap(err, "failed to parse llb proto op")
 		}
+		if src := op.GetSource(); src != nil {
+			for k := range src.Attrs {
+				if k == "local.session" || k == "local.unique" {
+					delete(src.Attrs, k)
+				}
+			}
+		}
 		dgst = digest.FromBytes(dt)
 		ops[dgst] = &op
 		defs[dgst] = dt

--- a/solver/llbsolver/provenance/buildconfig.go
+++ b/solver/llbsolver/provenance/buildconfig.go
@@ -11,7 +11,8 @@ import (
 )
 
 type BuildConfig struct {
-	Definition []BuildStep `json:"llbDefinition,omitempty"`
+	Definition    []BuildStep              `json:"llbDefinition,omitempty"`
+	DigestMapping map[digest.Digest]string `json:"digestMapping,omitempty"`
 }
 
 type BuildStep struct {
@@ -26,9 +27,18 @@ type Source struct {
 }
 
 type SourceInfo struct {
-	Filename   string      `json:"filename,omitempty"`
-	Data       []byte      `json:"data,omitempty"`
-	Definition []BuildStep `json:"llbDefinition,omitempty"`
+	Filename      string                   `json:"filename,omitempty"`
+	Data          []byte                   `json:"data,omitempty"`
+	Definition    []BuildStep              `json:"llbDefinition,omitempty"`
+	DigestMapping map[digest.Digest]string `json:"digestMapping,omitempty"`
+}
+
+func digestMap(idx map[digest.Digest]int) map[digest.Digest]string {
+	m := map[digest.Digest]string{}
+	for k, v := range idx {
+		m[k] = fmt.Sprintf("step%d", v)
+	}
+	return m
 }
 
 func AddBuildConfig(ctx context.Context, p *ProvenancePredicate, rp solver.ResultProxy) (map[digest.Digest]int, error) {
@@ -39,7 +49,8 @@ func AddBuildConfig(ctx context.Context, p *ProvenancePredicate, rp solver.Resul
 	}
 
 	bc := &BuildConfig{
-		Definition: steps,
+		Definition:    steps,
+		DigestMapping: digestMap(indexes),
 	}
 
 	p.BuildConfig = bc
@@ -47,14 +58,15 @@ func AddBuildConfig(ctx context.Context, p *ProvenancePredicate, rp solver.Resul
 	if def.Source != nil {
 		sis := make([]SourceInfo, len(def.Source.Infos))
 		for i, si := range def.Source.Infos {
-			steps, _, err := toBuildSteps(si.Definition)
+			steps, indexes, err := toBuildSteps(si.Definition)
 			if err != nil {
 				return nil, err
 			}
 			s := SourceInfo{
-				Filename:   si.Filename,
-				Data:       si.Data,
-				Definition: steps,
+				Filename:      si.Filename,
+				Data:          si.Data,
+				Definition:    steps,
+				DigestMapping: digestMap(indexes),
 			}
 			sis[i] = s
 		}

--- a/solver/llbsolver/provenance/predicate.go
+++ b/solver/llbsolver/provenance/predicate.go
@@ -233,6 +233,7 @@ func FilterArgs(m map[string]string) map[string]string {
 		"cgroup-parent":      {},
 		"image-resolve-mode": {},
 		"platform":           {},
+		"cache-imports":      {},
 	}
 	out := make(map[string]string)
 	for k, v := range m {

--- a/util/tracing/detect/recorder.go
+++ b/util/tracing/detect/recorder.go
@@ -43,10 +43,6 @@ func NewTraceRecorder() *TraceRecorder {
 }
 
 func (r *TraceRecorder) Record(traceID trace.TraceID) func() []tracetest.SpanStub {
-	if r.flush != nil {
-		r.flush(context.TODO())
-	}
-
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -55,6 +51,10 @@ func (r *TraceRecorder) Record(traceID trace.TraceID) func() []tracetest.SpanStu
 	var spans []tracetest.SpanStub
 	return func() []tracetest.SpanStub {
 		once.Do(func() {
+			if r.flush != nil {
+				r.flush(context.TODO())
+			}
+
 			r.mu.Lock()
 			defer r.mu.Unlock()
 


### PR DESCRIPTION
- Make sure same invocation ID is used for all platforms part of same build
- Cut session identifiers from the provenance
- Add Digestmapping to the provenance attestation. Instead of digests provenance uses more readable `stepN` names. But this means that build step can't be combined with the same step in the status logs or opentelemetry. To fix that I added a map that contains mapping from original LLB digests for each step.
- Filter out cache imports. This may be improved in the future, but for now we want to make sure there is no leakage of cache backends that require authentication or `type=local` cache that is not reproducible.