### PR TITLE
Filter frontend provenance attestations

### DIFF
--- a/exporter/attestation/unbundle.go
+++ b/exporter/attestation/unbundle.go
@@ -65,11 +65,10 @@ func Unbundle(ctx context.Context, s session.Group, bundled []exporter.Attestati
 	for _, atts := range unbundled {
 		joined = append(joined, atts...)
 	}
-	for _, att := range joined {
-		if err := validate(att); err != nil {
+
+	if err := Validate(joined); err != nil {
 			return nil, err
 		}
-	}
 	return joined, nil
 }
 
@@ -127,6 +126,15 @@ func unbundle(ctx context.Context, root string, bundle exporter.Attestation) ([]
 		})
 	}
 	return unbundled, nil
+}
+
+func Validate(atts []exporter.Attestation) error {
+	for _, att := range atts {
+		if err := validate(att); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func validate(att exporter.Attestation) error {

--- a/exporter/attestation/unbundle.go
+++ b/exporter/attestation/unbundle.go
@@ -117,6 +117,7 @@ func unbundle(ctx context.Context, root string, bundle exporter.Attestation) ([]
 		}
 		unbundled = append(unbundled, exporter.Attestation{
 			Kind:        gatewaypb.AttestationKindInToto,
+			Metadata:    bundle.Metadata,
 			Path:        path.Join(bundle.Path, entry.Name()),
 			ContentFunc: func() ([]byte, error) { return predicate, nil },
 			InToto: result.InTotoAttestation{

--- a/exporter/attestation/unbundle.go
+++ b/exporter/attestation/unbundle.go
@@ -20,6 +20,10 @@ import (
 // Unbundle iterates over all provided result attestations and un-bundles any
 // bundled attestations by loading them from the provided refs map.
 func Unbundle(ctx context.Context, s session.Group, bundled []exporter.Attestation) ([]exporter.Attestation, error) {
+	if err := Validate(bundled); err != nil {
+		return nil, err
+	}
+
 	eg, ctx := errgroup.WithContext(ctx)
 	unbundled := make([][]exporter.Attestation, len(bundled))
 
@@ -138,7 +142,7 @@ func Validate(atts []exporter.Attestation) error {
 }
 
 func validate(att exporter.Attestation) error {
-	if att.Path == "" {
+	if att.Kind != gatewaypb.AttestationKindBundle && att.Path == "" {
 		return errors.New("attestation does not have set path")
 	}
 	if att.Ref == nil && att.ContentFunc == nil {

--- a/exporter/containerimage/attestations.go
+++ b/exporter/containerimage/attestations.go
@@ -43,7 +43,8 @@ func supplementSBOM(ctx context.Context, s session.Group, target cache.Immutable
 
 	doc, err := decodeSPDX(content)
 	if err != nil {
-		return att, err
+		// ignore decoding error
+		return att, nil
 	}
 
 	layers, err := newFileLayerFinder(target, targetRemote)

--- a/frontend/attestations/sbom/sbom.go
+++ b/frontend/attestations/sbom/sbom.go
@@ -88,7 +88,7 @@ func CreateSBOMScanner(ctx context.Context, resolver llb.ImageMetaResolver, scan
 			Kind: gatewaypb.AttestationKindBundle,
 			Ref:  stsbom,
 			Metadata: map[string][]byte{
-				result.AttestationReasonKey: result.AttestationReasonSBOM,
+				result.AttestationReasonKey: []byte(result.AttestationReasonSBOM),
 			},
 			InToto: result.InTotoAttestation{
 				PredicateType: intoto.PredicateSPDX,

--- a/frontend/gateway/forwarder/forward.go
+++ b/frontend/gateway/forwarder/forward.go
@@ -67,6 +67,13 @@ func (c *bridgeClient) Solve(ctx context.Context, req client.SolveRequest) (*cli
 	if err != nil {
 		return nil, c.wrapSolveError(err)
 	}
+	for _, atts := range res.Attestations {
+		for _, att := range atts {
+			if att.ContentFunc != nil {
+				return nil, errors.Errorf("attestation callback cannot be sent through gateway")
+			}
+		}
+	}
 
 	c.mu.Lock()
 	cRes, err := result.ConvertResult(res, func(r solver.ResultProxy) (client.Reference, error) {
@@ -178,6 +185,13 @@ func (c *bridgeClient) toFrontendResult(r *client.Result) (*frontend.Result, err
 	if r == nil {
 		return nil, nil
 	}
+	for _, atts := range r.Attestations {
+		for _, att := range atts {
+			if att.ContentFunc != nil {
+				return nil, errors.Errorf("attestation callback cannot be sent through gateway")
+			}
+		}
+	}
 
 	res, err := result.ConvertResult(r, func(r client.Reference) (solver.ResultProxy, error) {
 		rr, ok := r.(*ref)
@@ -186,13 +200,6 @@ func (c *bridgeClient) toFrontendResult(r *client.Result) (*frontend.Result, err
 		}
 		return rr.acquireResultProxy(), nil
 	})
-	for _, atts := range res.Attestations {
-		for _, att := range atts {
-			if att.ContentFunc != nil {
-				return nil, errors.Errorf("attestation callback cannot be sent through gateway")
-			}
-		}
-	}
 	if err != nil {
 		return nil, err
 	}

--- a/solver/llbsolver/proc/provenance.go
+++ b/solver/llbsolver/proc/provenance.go
@@ -45,7 +45,7 @@ func ProvenanceProcessor(attrs map[string]string) llbsolver.Processor {
 			res.AddAttestation(p.ID, llbsolver.Attestation{
 				Kind: gatewaypb.AttestationKindInToto,
 				Metadata: map[string][]byte{
-					result.AttestationReasonKey:     result.AttestationReasonProvenance,
+					result.AttestationReasonKey:     []byte(result.AttestationReasonProvenance),
 					result.AttestationInlineOnlyKey: []byte(strconv.FormatBool(inlineOnly)),
 				},
 				InToto: result.InTotoAttestation{

--- a/solver/result/attestation.go
+++ b/solver/result/attestation.go
@@ -12,9 +12,9 @@ const (
 	AttestationInlineOnlyKey = "inline-only"
 )
 
-var (
-	AttestationReasonSBOM       = []byte("sbom")
-	AttestationReasonProvenance = []byte("provenance")
+const (
+	AttestationReasonSBOM       = "sbom"
+	AttestationReasonProvenance = "provenance"
 )
 
 type Attestation[T any] struct {


### PR DESCRIPTION
The frontend isn't allowed to create provenance attestations - only buildkit is allowed to do this.

We do the check in two stages:
- Verify in the solver that the frontend set a reason for generating the attestation, and then that reason **wasn't** for provenance
- Validate in the exporter (after unbundling) that the attestation predicate was valid for the specified reason. For now, we allow any SLSA provenance attestation for provenance and only allow SPDX for SBOMs.