### PR TITLE
Remove inline-only exporter option

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -7321,8 +7321,9 @@ func testExportAttestations(t *testing.T, sb integration.Sandbox) {
 
 		for _, p := range ps {
 			var attest intoto.Statement
-			dt := m[path.Join(strings.ReplaceAll(platforms.Format(p), "/", "_"), "test.attestation.json")].Data
-			require.NoError(t, json.Unmarshal(dt, &attest))
+			item := m[path.Join(strings.ReplaceAll(platforms.Format(p), "/", "_"), "test.attestation.json")]
+			require.NotNil(t, item)
+			require.NoError(t, json.Unmarshal(item.Data, &attest))
 
 			require.Equal(t, "https://in-toto.io/Statement/v0.1", attest.Type)
 			require.Equal(t, "https://example.com/attestations/v1.0", attest.PredicateType)
@@ -7334,8 +7335,9 @@ func testExportAttestations(t *testing.T, sb integration.Sandbox) {
 			}}, attest.Subject)
 
 			var attest2 intoto.Statement
-			dt = m[path.Join(strings.ReplaceAll(platforms.Format(p), "/", "_"), "test.attestation2.json")].Data
-			require.NoError(t, json.Unmarshal(dt, &attest2))
+			item = m[path.Join(strings.ReplaceAll(platforms.Format(p), "/", "_"), "test.attestation2.json")]
+			require.NotNil(t, item)
+			require.NoError(t, json.Unmarshal(item.Data, &attest2))
 
 			require.Equal(t, "https://in-toto.io/Statement/v0.1", attest2.Type)
 			require.Equal(t, "https://example.com/attestations2/v1.0", attest2.PredicateType)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -7254,7 +7254,7 @@ func testExportAttestations(t *testing.T, sb integration.Sandbox) {
 					Type:      ExporterLocal,
 					OutputDir: dir,
 					Attrs: map[string]string{
-						"attestation-prefix": "test.",
+						"attestations-prefix": "test.",
 					},
 				},
 			},
@@ -7306,7 +7306,7 @@ func testExportAttestations(t *testing.T, sb integration.Sandbox) {
 					Type:   ExporterTar,
 					Output: fixedWriteCloser(outW),
 					Attrs: map[string]string{
-						"attestation-prefix": "test.",
+						"attestations-prefix": "test.",
 					},
 				},
 			},

--- a/exporter/attestation/filter.go
+++ b/exporter/attestation/filter.go
@@ -1,26 +1,9 @@
 package attestation
 
 import (
-	"strconv"
-
 	"github.com/moby/buildkit/exporter"
 	"github.com/moby/buildkit/solver/result"
 )
-
-func FilterInline(attestations []exporter.Attestation) (matching []exporter.Attestation, nonMatching []exporter.Attestation) {
-	for _, att := range attestations {
-		v, ok := att.Metadata[result.AttestationInlineOnlyKey]
-		if ok {
-			b, err := strconv.ParseBool(string(v))
-			if b && err == nil {
-				matching = append(matching, att)
-				continue
-			}
-		}
-		nonMatching = append(nonMatching, att)
-	}
-	return matching, nonMatching
-}
 
 func FilterReasons(attestations []exporter.Attestation, reasons []string) (matching []exporter.Attestation, nonMatching []exporter.Attestation) {
 	if reasons == nil {

--- a/exporter/attestation/unbundle.go
+++ b/exporter/attestation/unbundle.go
@@ -117,6 +117,7 @@ func unbundle(ctx context.Context, root string, bundle exporter.Attestation) ([]
 		}
 		unbundled = append(unbundled, exporter.Attestation{
 			Kind:        gatewaypb.AttestationKindInToto,
+			Metadata:    bundle.Metadata,
 			Path:        path.Join(bundle.Path, entry.Name()),
 			ContentFunc: func() ([]byte, error) { return predicate, nil },
 			InToto: result.InTotoAttestation{

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -78,7 +78,8 @@ func (e *imageExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 			RefCfg: cacheconfig.RefConfig{
 				Compression: compression.New(compression.Default),
 			},
-			BuildInfo: true,
+			BuildInfo:    true,
+			Attestations: true,
 		},
 		store: true,
 	}

--- a/exporter/containerimage/opts.go
+++ b/exporter/containerimage/opts.go
@@ -19,6 +19,7 @@ const (
 	keyOCITypes         = "oci-mediatypes"
 	keyBuildInfo        = "buildinfo"
 	keyBuildInfoAttrs   = "buildinfo-attrs"
+	keyAttestations     = "attestations"
 
 	// preferNondistLayersKey is an exporter option which can be used to mark a layer as non-distributable if the layer reference was
 	// already found to use a non-distributable media type.
@@ -34,6 +35,7 @@ type ImageCommitOpts struct {
 	BuildInfoAttrs bool
 	Annotations    AnnotationsGroup
 	Epoch          *time.Time
+	Attestations   bool
 }
 
 func (c *ImageCommitOpts) Load(opt map[string]string) (map[string]string, error) {
@@ -73,6 +75,8 @@ func (c *ImageCommitOpts) Load(opt map[string]string) (map[string]string, error)
 			err = parseBoolWithDefault(&c.BuildInfo, k, v, true)
 		case keyBuildInfoAttrs:
 			err = parseBoolWithDefault(&c.BuildInfoAttrs, k, v, false)
+		case keyAttestations:
+			err = parseBool(&c.Attestations, k, v)
 		case keyPreferNondistLayers:
 			err = parseBool(&c.RefCfg.PreferNonDistributable, k, v)
 		default:

--- a/exporter/containerimage/opts.go
+++ b/exporter/containerimage/opts.go
@@ -2,6 +2,7 @@ package containerimage
 
 import (
 	"strconv"
+	"strings"
 	"time"
 
 	cacheconfig "github.com/moby/buildkit/cache/config"
@@ -28,14 +29,15 @@ const (
 )
 
 type ImageCommitOpts struct {
-	ImageName      string
-	RefCfg         cacheconfig.RefConfig
-	OCITypes       bool
-	BuildInfo      bool
-	BuildInfoAttrs bool
-	Annotations    AnnotationsGroup
-	Epoch          *time.Time
-	Attestations   bool
+	ImageName          string
+	RefCfg             cacheconfig.RefConfig
+	OCITypes           bool
+	BuildInfo          bool
+	BuildInfoAttrs     bool
+	Annotations        AnnotationsGroup
+	Epoch              *time.Time
+	Attestations       bool
+	AttestationsFilter []string
 }
 
 func (c *ImageCommitOpts) Load(opt map[string]string) (map[string]string, error) {
@@ -76,7 +78,10 @@ func (c *ImageCommitOpts) Load(opt map[string]string) (map[string]string, error)
 		case keyBuildInfoAttrs:
 			err = parseBoolWithDefault(&c.BuildInfoAttrs, k, v, false)
 		case keyAttestations:
-			err = parseBool(&c.Attestations, k, v)
+			if parseBool(&c.Attestations, k, v) != nil {
+				c.Attestations = true
+				c.AttestationsFilter = strings.Split(v, ",")
+			}
 		case keyPreferNondistLayers:
 			err = parseBool(&c.RefCfg.PreferNonDistributable, k, v)
 		default:

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -69,19 +69,20 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 		return nil, err
 	}
 
-	requiredAttestations := false
+	hasAttestations := false
 	for _, p := range ps.Platforms {
 		if atts, ok := inp.Attestations[p.ID]; ok {
 			atts = attestation.Filter(atts, nil, map[string][]byte{
 				result.AttestationInlineOnlyKey: []byte(strconv.FormatBool(true)),
 			})
 			if len(atts) > 0 {
-				requiredAttestations = true
+				hasAttestations = true
 				break
 			}
 		}
 	}
-	if requiredAttestations {
+	hasAttestations = opts.Attestations && hasAttestations
+	if hasAttestations {
 		isMap = true
 	}
 
@@ -108,7 +109,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 		if len(ps.Platforms) > 1 {
 			return nil, errors.Errorf("cannot export multiple platforms without multi-platform enabled")
 		}
-		if requiredAttestations {
+		if hasAttestations {
 			return nil, errors.Errorf("cannot export attestations without multi-platform enabled")
 		}
 
@@ -159,7 +160,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 		return mfstDesc, nil
 	}
 
-	if len(inp.Attestations) > 0 {
+	if hasAttestations {
 		opts.EnableOCITypes("attestations")
 	}
 

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -71,7 +71,6 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 	hasAttestations := false
 	for _, p := range ps.Platforms {
 		if atts, ok := inp.Attestations[p.ID]; ok {
-			_, atts = attestation.FilterInline(atts)
 			atts, _ = attestation.FilterReasons(atts, opts.AttestationsFilter)
 			if len(atts) > 0 {
 				hasAttestations = true

--- a/exporter/local/export.go
+++ b/exporter/local/export.go
@@ -20,10 +20,6 @@ import (
 	"golang.org/x/time/rate"
 )
 
-const (
-	keyAttestationPrefix = "attestation-prefix"
-)
-
 type Opt struct {
 	SessionManager *session.Manager
 }
@@ -39,24 +35,14 @@ func New(opt Opt) (exporter.Exporter, error) {
 }
 
 func (e *localExporter) Resolve(ctx context.Context, opt map[string]string) (exporter.ExporterInstance, error) {
-	tm, _, err := epoch.ParseExporterAttrs(opt)
+	i := &localExporterInstance{
+		localExporter: e,
+	}
+	opt, err := i.opts.Load(opt)
 	if err != nil {
 		return nil, err
 	}
-
-	i := &localExporterInstance{
-		localExporter: e,
-		opts: CreateFSOpts{
-			Epoch: tm,
-		},
-	}
-
-	for k, v := range opt {
-		switch k {
-		case keyAttestationPrefix:
-			i.opts.AttestationPrefix = v
-		}
-	}
+	_ = opt
 
 	return i, nil
 }

--- a/exporter/local/export.go
+++ b/exporter/local/export.go
@@ -37,6 +37,9 @@ func New(opt Opt) (exporter.Exporter, error) {
 func (e *localExporter) Resolve(ctx context.Context, opt map[string]string) (exporter.ExporterInstance, error) {
 	i := &localExporterInstance{
 		localExporter: e,
+		opts: CreateFSOpts{
+			Attestations: true,
+		},
 	}
 	opt, err := i.opts.Load(opt)
 	if err != nil {

--- a/exporter/local/fs.go
+++ b/exporter/local/fs.go
@@ -127,7 +127,6 @@ func CreateFS(ctx context.Context, sessionID string, k string, ref cache.Immutab
 	}
 
 	outputFS := fsutil.NewFS(src, walkOpt)
-	_, attestations = attestation.FilterInline(attestations)
 	attestations, _ = attestation.FilterReasons(attestations, opt.AttestationsFilter)
 	if opt.Attestations && len(attestations) > 0 {
 		attestations, err = attestation.Unbundle(ctx, session.NewGroup(sessionID), attestations)

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -67,8 +67,9 @@ func (e *imageExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 			RefCfg: cacheconfig.RefConfig{
 				Compression: compression.New(compression.Default),
 			},
-			BuildInfo: true,
-			OCITypes:  e.opt.Variant == VariantOCI,
+			BuildInfo:    true,
+			OCITypes:     e.opt.Variant == VariantOCI,
+			Attestations: true,
 		},
 	}
 

--- a/exporter/tar/export.go
+++ b/exporter/tar/export.go
@@ -34,7 +34,12 @@ func New(opt Opt) (exporter.Exporter, error) {
 }
 
 func (e *localExporter) Resolve(ctx context.Context, opt map[string]string) (exporter.ExporterInstance, error) {
-	li := &localExporterInstance{localExporter: e}
+	li := &localExporterInstance{
+		localExporter: e,
+		opts: local.CreateFSOpts{
+			Attestations: true,
+		},
+	}
 	opt, err := li.opts.Load(opt)
 	if err != nil {
 		return nil, err

--- a/exporter/tar/export.go
+++ b/exporter/tar/export.go
@@ -21,8 +21,6 @@ import (
 )
 
 const (
-	attestationPrefixKey = "attestation-prefix"
-
 	// preferNondistLayersKey is an exporter option which can be used to mark a layer as non-distributable if the layer reference was
 	// already found to use a non-distributable media type.
 	// When this option is not set, the exporter will change the media type of the layer to a distributable one.
@@ -45,12 +43,10 @@ func New(opt Opt) (exporter.Exporter, error) {
 
 func (e *localExporter) Resolve(ctx context.Context, opt map[string]string) (exporter.ExporterInstance, error) {
 	li := &localExporterInstance{localExporter: e}
-
-	tm, opt, err := epoch.ParseExporterAttrs(opt)
+	opt, err := li.opts.Load(opt)
 	if err != nil {
 		return nil, err
 	}
-	li.opts.Epoch = tm
 
 	for k, v := range opt {
 		switch k {
@@ -60,8 +56,6 @@ func (e *localExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 				return nil, errors.Wrapf(err, "non-bool value for %s: %s", preferNondistLayersKey, v)
 			}
 			li.preferNonDist = b
-		case attestationPrefixKey:
-			li.opts.AttestationPrefix = v
 		}
 	}
 

--- a/exporter/tar/export.go
+++ b/exporter/tar/export.go
@@ -3,7 +3,6 @@ package local
 import (
 	"context"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -18,13 +17,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/tonistiigi/fsutil"
 	fstypes "github.com/tonistiigi/fsutil/types"
-)
-
-const (
-	// preferNondistLayersKey is an exporter option which can be used to mark a layer as non-distributable if the layer reference was
-	// already found to use a non-distributable media type.
-	// When this option is not set, the exporter will change the media type of the layer to a distributable one.
-	preferNondistLayersKey = "prefer-nondist-layers"
 )
 
 type Opt struct {
@@ -47,25 +39,14 @@ func (e *localExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 	if err != nil {
 		return nil, err
 	}
-
-	for k, v := range opt {
-		switch k {
-		case preferNondistLayersKey:
-			b, err := strconv.ParseBool(v)
-			if err != nil {
-				return nil, errors.Wrapf(err, "non-bool value for %s: %s", preferNondistLayersKey, v)
-			}
-			li.preferNonDist = b
-		}
-	}
+	_ = opt
 
 	return li, nil
 }
 
 type localExporterInstance struct {
 	*localExporter
-	opts          local.CreateFSOpts
-	preferNonDist bool
+	opts local.CreateFSOpts
 }
 
 func (e *localExporterInstance) Name() string {

--- a/solver/llbsolver/proc/provenance.go
+++ b/solver/llbsolver/proc/provenance.go
@@ -3,7 +3,6 @@ package proc
 import (
 	"context"
 	"encoding/json"
-	"strconv"
 
 	slsa02 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
@@ -19,11 +18,6 @@ func ProvenanceProcessor(attrs map[string]string) llbsolver.Processor {
 		ps, err := exptypes.ParsePlatforms(res.Metadata)
 		if err != nil {
 			return nil, err
-		}
-
-		var inlineOnly bool
-		if v, err := strconv.ParseBool(attrs["inline-only"]); v && err == nil {
-			inlineOnly = true
 		}
 
 		for _, p := range ps.Platforms {
@@ -45,8 +39,7 @@ func ProvenanceProcessor(attrs map[string]string) llbsolver.Processor {
 			res.AddAttestation(p.ID, llbsolver.Attestation{
 				Kind: gatewaypb.AttestationKindInToto,
 				Metadata: map[string][]byte{
-					result.AttestationReasonKey:     result.AttestationReasonProvenance,
-					result.AttestationInlineOnlyKey: []byte(strconv.FormatBool(inlineOnly)),
+					result.AttestationReasonKey: result.AttestationReasonProvenance,
 				},
 				InToto: result.InTotoAttestation{
 					PredicateType: slsa02.PredicateSLSAProvenance,

--- a/solver/result/attestation.go
+++ b/solver/result/attestation.go
@@ -8,8 +8,7 @@ import (
 )
 
 const (
-	AttestationReasonKey     = "reason"
-	AttestationInlineOnlyKey = "inline-only"
+	AttestationReasonKey = "reason"
 )
 
 var (


### PR DESCRIPTION
:warning: Requires #3403 - marked as do-not-merge until #3404 is.

Split out from #3403 as an additional commit, so that we can more easily pull in the improvements in that branch since the main objection seemed to be the removal of `inline-only`.