### PR TITLE
Only supplement SBOMs with file-layer info for specified SBOMs

### DIFF
--- a/docs/attestations/sbom-protocol.md
+++ b/docs/attestations/sbom-protocol.md
@@ -48,9 +48,8 @@ by BuildKit:
   This variable specifies the main target, passing the path to the root
   filesystem of the final build result.
 
-  The scanner should scan this filesystem, and write its SBOM scans to
-  `$BUILDKIT_SCAN_DESTINATION/<scan>.spdx.json`. If the scan name is not
-  significant the scan can be named `$(basename $BUILDKIT_SCAN_SOURCE)`.
+  The scanner should scan this filesystem, and write its SBOM result to
+  `$BUILDKIT_SCAN_DESTINATION/$(basename $BUILDKIT_SCAN_SOURCE).spdx.json`.
 
 - `BUILDKIT_SCAN_SOURCE_EXTRAS` (optional)
 

--- a/exporter/containerimage/attestations.go
+++ b/exporter/containerimage/attestations.go
@@ -14,6 +14,7 @@ import (
 	gatewaypb "github.com/moby/buildkit/frontend/gateway/pb"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/solver/result"
 	"github.com/moby/buildkit/version"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -33,6 +34,13 @@ func supplementSBOM(ctx context.Context, s session.Group, target cache.Immutable
 		return att, nil
 	}
 	if att.InToto.PredicateType != intoto.PredicateSPDX {
+		return att, nil
+	}
+	name, ok := att.Metadata[result.AttestationSBOMCore]
+	if !ok {
+		return att, nil
+	}
+	if n, _, _ := strings.Cut(att.Path, "."); n != string(name) {
 		return att, nil
 	}
 

--- a/frontend/attestations/sbom/sbom.go
+++ b/frontend/attestations/sbom/sbom.go
@@ -89,6 +89,7 @@ func CreateSBOMScanner(ctx context.Context, resolver llb.ImageMetaResolver, scan
 			Ref:  stsbom,
 			Metadata: map[string][]byte{
 				result.AttestationReasonKey: []byte(result.AttestationReasonSBOM),
+				result.AttestationSBOMCore:  []byte(CoreSBOMName),
 			},
 			InToto: result.InTotoAttestation{
 				PredicateType: intoto.PredicateSPDX,

--- a/solver/result/attestation.go
+++ b/solver/result/attestation.go
@@ -9,6 +9,7 @@ import (
 
 const (
 	AttestationReasonKey     = "reason"
+	AttestationSBOMCore      = "sbom-core"
 	AttestationInlineOnlyKey = "inline-only"
 )
 


### PR DESCRIPTION
:arrow_up: Follow-up to #3258.

Previously, we would attempt to add file data for every single SBOM - however, if these SBOMs were taken of layers that were not exported, then these could be wrong.
    
To workaround this, for the file layer details to be added to the resulting SBOM, we require that the scanner add a metadata property to indicate the default value. This is configurable, since in the future we may want behavior that allows the frontend to specify no file layers, or wants an SBOM with layers other than the default.

There are some other possible solutions in the future: the "proper" way to do this would be to attach a second ref to every single attestation, so that we could track exactly what part of the build the attestation was about, so that we could then correctly identify which part of the layer chain we should extract file-layer info from. However, this would be a major refactor, and is something we can add later without loss of backwards compatibility in the future :tada: