### PR TITLE
Fix typo in 'soruce.http.uidgid'

### DIFF
--- a/solver/pb/caps.go
+++ b/solver/pb/caps.go
@@ -33,7 +33,7 @@ const (
 	CapSourceHTTP         apicaps.CapID = "source.http"
 	CapSourceHTTPChecksum apicaps.CapID = "source.http.checksum"
 	CapSourceHTTPPerm     apicaps.CapID = "source.http.perm"
-	CapSourceHTTPUIDGID   apicaps.CapID = "soruce.http.uidgid"
+	CapSourceHTTPUIDGID   apicaps.CapID = "source.http.uidgid"
 
 	CapSourceOCILayout           apicaps.CapID = "source.ocilayout"
 	CapSourceOCILayoutSessionID  apicaps.CapID = "source.ocilayout.sessionid"


### PR DESCRIPTION
I doubt it is possible to directly change this because it's a public API, but I'm unsure how that should be done. This PR is here mostly just to bring attention to the issue and discuss possible resolutions. 