### PR TITLE
Fix typo in CapExecMountBindReadWriteNoOutput

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert_runmount.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_runmount.go
@@ -96,7 +96,7 @@ func dispatchRunMounts(d *dispatchState, c *instructions.RunCommand, sources []*
 		}
 		if mount.ReadOnly {
 			mountOpts = append(mountOpts, llb.Readonly)
-		} else if mount.Type == instructions.MountTypeBind && opt.llbCaps.Supports(pb.CapExecMountBindReadWriteNoOuput) == nil {
+		} else if mount.Type == instructions.MountTypeBind && opt.llbCaps.Supports(pb.CapExecMountBindReadWriteNoOutput) == nil {
 			mountOpts = append(mountOpts, llb.ForceNoOutput)
 		}
 		if mount.Type == instructions.MountTypeCache {

--- a/solver/pb/caps.go
+++ b/solver/pb/caps.go
@@ -51,7 +51,7 @@ const (
 	CapExecMetaUlimit                    apicaps.CapID = "exec.meta.ulimit"
 	CapExecMetaRemoveMountStubsRecursive apicaps.CapID = "exec.meta.removemountstubs.recursive"
 	CapExecMountBind                     apicaps.CapID = "exec.mount.bind"
-	CapExecMountBindReadWriteNoOuput     apicaps.CapID = "exec.mount.bind.readwrite-nooutput"
+	CapExecMountBindReadWriteNoOutput    apicaps.CapID = "exec.mount.bind.readwrite-nooutput"
 	CapExecMountCache                    apicaps.CapID = "exec.mount.cache"
 	CapExecMountCacheSharing             apicaps.CapID = "exec.mount.cache.sharing"
 	CapExecMountSelector                 apicaps.CapID = "exec.mount.selector"
@@ -300,7 +300,7 @@ func init() {
 	})
 
 	Caps.Init(apicaps.Cap{
-		ID:      CapExecMountBindReadWriteNoOuput,
+		ID:      CapExecMountBindReadWriteNoOutput,
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})


### PR DESCRIPTION
I'm unsure if this is exposed via public API