### PR TITLE
feat: handle mirror url with path

### DIFF
--- a/docs/buildkitd.toml.md
+++ b/docs/buildkitd.toml.md
@@ -95,7 +95,8 @@ insecure-entitlements = [ "network.host", "security.insecure" ]
 
 # registry configures a new Docker register used for cache import or output.
 [registry."docker.io"]
-  mirrors = ["yourmirror.local:5000"]
+  # mirror configuration to handle path in case a mirror registry requires a /project path rather than just a host:port
+  mirrors = ["yourmirror.local:5000", "core.harbor.domain/proxy.docker.io"]
   http = true
   insecure = true
   ca=["/etc/config/myca.pem"]

--- a/util/resolver/resolver_test.go
+++ b/util/resolver/resolver_test.go
@@ -1,0 +1,68 @@
+package resolver
+
+import (
+	"bytes"
+	"path"
+	"testing"
+
+	"github.com/moby/buildkit/cmd/buildkitd/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMirrorRegistryHost(t *testing.T) {
+	const testConfig = `
+[registry."docker.io"]
+mirrors = ["hub.docker.io", "yourmirror.local:5000/proxy.docker.io"]
+[registry."quay.io"]
+mirrors = ["yourmirror.local:5000/proxy.quay.io"]
+[registry."fake.io"]
+mirrors = ["https://url/", "https://url/path/"]
+`
+
+	tests := map[string]struct {
+		description string
+		host        string
+		path        string
+	}{
+		"hub.docker.io": {
+			description: "docker_io_mirror_without_path",
+			host:        "hub.docker.io",
+			path:        defaultPath,
+		},
+		"yourmirror.local:5000/proxy.docker.io": {
+			description: "docker_io_mirror_with_path",
+			host:        "yourmirror.local:5000",
+			path:        path.Join(defaultPath, "proxy.docker.io"),
+		},
+		"yourmirror.local:5000/proxy.quay.io": {
+			description: "docker_quay_mirror_with_path",
+			host:        "yourmirror.local:5000",
+			path:        path.Join(defaultPath, "proxy.quay.io"),
+		},
+		"https://url/": {
+			description: "docker_fake_mirror_scheme_without_path",
+			host:        "url",
+			path:        defaultPath,
+		},
+		"https://url/path/": {
+			description: "docker_fake_mirror_scheme_with_path",
+			host:        "url",
+			path:        path.Join(defaultPath, "path"),
+		},
+	}
+
+	cfg, err := config.Load(bytes.NewBuffer([]byte(testConfig)))
+	require.NoError(t, err)
+
+	require.NotEqual(t, len(cfg.Registries), 0)
+	for _, registry := range cfg.Registries {
+		require.NotEqual(t, len(registry.Mirrors), 0)
+		for _, m := range registry.Mirrors {
+			test := tests[m]
+			h := newMirrorRegistryHost(m)
+			require.NotEqual(t, h, nil)
+			require.Equal(t, h.Host, test.host)
+			require.Equal(t, h.Path, test.path)
+		}
+	}
+}

--- a/util/resolver/utils.go
+++ b/util/resolver/utils.go
@@ -1,0 +1,22 @@
+package resolver
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+func extractMirrorHostAndPath(mirror string) (string, string) {
+	var path string
+	host := mirror
+
+	u, err := url.Parse(mirror)
+	if err != nil || u.Host == "" {
+		u, err = url.Parse(fmt.Sprintf("//%s", mirror))
+	}
+	if err != nil || u.Host == "" {
+		return host, path
+	}
+
+	return u.Host, strings.TrimRight(u.Path, "/")
+}


### PR DESCRIPTION
Allow the use of mirror registry such as Harbor in buildkit with the possibility to have one registry host and multiple proxy_cache projects inside

example:
buildkit side:
```
[registry."docker.io"]
mirrors = ["core.harbor.domain/proxy.docker.io"]
[registry."quay.io"]
mirrors = ["core.harbor.domain/proxy.quay.io"]
```
harbor side:
```
proxy_cache projects named:
- proxy.docker.io (configured for hub.docker.io endpoint)
- proxy.quay.io (configured for quay.io endpoint)
```

Let's take this Dockerfile to be built by buildkit:
```
FROM ubuntu:22.04

RUN echo test
```

With the mirror configuration above, buildkit will pull ubuntu:22.04 from  `core.harbor.domain/proxy.docker.io/library/ubuntu:22.04`