### PR TITLE
Provenance attestation fixes

### DIFF
--- a/frontend/dockerfile/dockerfile_provenance_test.go
+++ b/frontend/dockerfile/dockerfile_provenance_test.go
@@ -198,7 +198,7 @@ RUN echo "ok" > /foo
 
 			require.False(t, pred.Metadata.Completeness.Materials)
 			require.False(t, pred.Metadata.Reproducible)
-			require.False(t, pred.Metadata.Completeness.Hermetic)
+			require.False(t, pred.Metadata.Hermetic)
 
 			if mode == "max" || mode == "" {
 				require.Equal(t, 2, len(pred.Metadata.BuildKitMetadata.Layers))
@@ -347,8 +347,8 @@ COPY myapp.Dockerfile /
 	require.Equal(t, 0, len(pred.Invocation.Parameters.Locals))
 
 	require.True(t, pred.Metadata.Completeness.Materials)
-	require.True(t, pred.Metadata.Completeness.Hermetic)
 	require.True(t, pred.Metadata.Completeness.Environment)
+	require.True(t, pred.Metadata.Hermetic)
 
 	if isClient {
 		require.False(t, pred.Metadata.Completeness.Parameters)

--- a/solver/llbsolver/proc/provenance.go
+++ b/solver/llbsolver/proc/provenance.go
@@ -42,6 +42,11 @@ func ProvenanceProcessor(attrs map[string]string) llbsolver.Processor {
 				return nil, err
 			}
 
+			filename := "provenance.json"
+			if v, ok := attrs["filename"]; ok {
+				filename = v
+			}
+
 			res.AddAttestation(p.ID, llbsolver.Attestation{
 				Kind: gatewaypb.AttestationKindInToto,
 				Metadata: map[string][]byte{
@@ -51,7 +56,7 @@ func ProvenanceProcessor(attrs map[string]string) llbsolver.Processor {
 				InToto: result.InTotoAttestation{
 					PredicateType: slsa02.PredicateSLSAProvenance,
 				},
-				Path: "provenance.json",
+				Path: filename,
 				ContentFunc: func() ([]byte, error) {
 					pr, err := pc.Predicate()
 					if err != nil {

--- a/solver/llbsolver/provenance/buildconfig.go
+++ b/solver/llbsolver/provenance/buildconfig.go
@@ -141,11 +141,6 @@ func toBuildSteps(def *pb.Definition) ([]BuildStep, map[digest.Digest]int, error
 	if err != nil {
 		return nil, nil, err
 	}
-	for i := 0; i < len(dgsts)/2; i++ {
-		j := len(dgsts) - 1 - i
-		dgsts[i], dgsts[j] = dgsts[j], dgsts[i]
-	}
-
 	indexes := map[digest.Digest]int{}
 	for i, dgst := range dgsts {
 		indexes[dgst] = i
@@ -179,7 +174,6 @@ func walkDigests(dgsts []digest.Digest, ops map[digest.Digest]*pb.Op, dgst diges
 	if op == nil {
 		return nil, errors.Errorf("invalid nil input %v", dgst)
 	}
-	dgsts = append(dgsts, dgst)
 	visited[dgst] = struct{}{}
 	for _, inp := range op.Inputs {
 		var err error
@@ -188,5 +182,6 @@ func walkDigests(dgsts []digest.Digest, ops map[digest.Digest]*pb.Op, dgst diges
 			return nil, err
 		}
 	}
+	dgsts = append(dgsts, dgst)
 	return dgsts, nil
 }

--- a/solver/llbsolver/provenance/predicate.go
+++ b/solver/llbsolver/provenance/predicate.go
@@ -44,13 +44,8 @@ type Environment struct {
 
 type ProvenanceMetadata struct {
 	slsa02.ProvenanceMetadata
-	Completeness     ProvenanceComplete `json:"completeness"`
-	BuildKitMetadata BuildKitMetadata   `json:"https://mobyproject.org/buildkit@v1#metadata,omitempty"`
-}
-
-type ProvenanceComplete struct {
-	slsa02.ProvenanceComplete
-	Hermetic bool `json:"https://mobyproject.org/buildkit@v1#hermetic,omitempty"`
+	BuildKitMetadata BuildKitMetadata `json:"https://mobyproject.org/buildkit@v1#metadata,omitempty"`
+	Hermetic         bool             `json:"https://mobyproject.org/buildkit@v1#hermetic,omitempty"`
 }
 
 type BuildKitMetadata struct {
@@ -211,14 +206,14 @@ func NewPredicate(c *Capture) (*ProvenancePredicate, error) {
 			Materials: materials,
 		},
 		Metadata: &ProvenanceMetadata{
-			Completeness: ProvenanceComplete{
-				ProvenanceComplete: slsa02.ProvenanceComplete{
+			ProvenanceMetadata: slsa02.ProvenanceMetadata{
+				Completeness: slsa02.ProvenanceComplete{
 					Parameters:  c.Frontend != "",
 					Environment: true,
 					Materials:   !incompleteMaterials,
 				},
-				Hermetic: !incompleteMaterials && !c.NetworkAccess,
 			},
+			Hermetic: !incompleteMaterials && !c.NetworkAccess,
 		},
 	}
 


### PR DESCRIPTION
- add possibility to override filename for provenance
- provenance: move hermetic field into a correct struct. I think putting the field under "completeness" field isn't really correct as it doesn't signify the completeness of another field. It is now in the same level as "reproducible" field.
- provenance: fix the order of the build steps. Previous sorting was not correct in complex graphs.