### PR TITLE
[v0.11 backport] frontend: fix testMultiStageImplicitFrom to account for busybox changes

### DIFF
--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -3598,7 +3598,7 @@ COPY --from=busybox /etc/passwd test
 
 	dockerfile = []byte(`
 FROM busybox AS golang
-RUN mkdir /usr/bin && echo -n foo > /usr/bin/go
+RUN mkdir -p /usr/bin && echo -n foo > /usr/bin/go
 
 FROM scratch
 COPY --from=golang /usr/bin/go go


### PR DESCRIPTION
- backport of https://github.com/moby/buildkit/pull/3436

It looks like there's some changes between `busybox:1.34.0` and up; version 1.34.0 of the image did not have a `/usr/bin` directory (only `/usr/sbin`);

    docker run --rm -it busybox:1.34.0 ls -al /usr/
    total 12
    drwxr-xr-x    3 root     root          4096 Sep 13  2021 .
    drwxr-xr-x    1 root     root          4096 Dec 27 14:45 ..
    drwxr-xr-x    2 daemon   daemon        4096 Sep 13  2021 sbin

But 1.34.1 and up do;

    docker run --rm -it busybox:1.34.1 ls -al usr/
    total 16
    drwxr-xr-x    4 root     root          4096 Dec 21 18:28 .
    drwxr-xr-x    1 root     root          4096 Dec 27 14:44 ..
    drwxr-xr-x    2 root     root          4096 Dec 21 18:28 bin
    drwxr-xr-x    2 daemon   daemon        4096 Dec 21 18:28 sbin

It's not immediately apparent what caused this change, or if it's in busybox itself, or in the official image only;
https://github.com/mirror/busybox/compare/1_34_0...1_34_1

But either way, this change caused a test to fail:

    sandbox.go:238: time="2022-12-27T13:45:25.294022820Z" level=debug msg="> creating 4gr5bno8rj7l3k7h9jxe3jhal [/bin/sh -c mkdir /usr/bin && echo -n foo > /usr/bin/go]" span="[golang 2/2] RUN mkdir /usr/bin && echo -n foo > /usr/bin/go"
    sandbox.go:238: time="2022-12-27T13:45:25.433886983Z" level=debug msg="sandbox set key processing took 70.062631ms for container 5b4o358g2ryquk4s6ami38gqo"
    sandbox.go:238: mkdir: can't create directory '/usr/bin': File exists

(cherry picked from commit 34f9898f3112cac7c899e41d45ecdeb1502c3131)
