### PR TITLE
client: add extra debug to tests

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -6718,6 +6718,18 @@ loop0:
 			break
 		}
 		if retries >= 50 {
+			for _, info := range infos {
+				t.Logf("content: %v %v %+v", info.Digest, info.Size, info.Labels)
+				ra, err := client.ContentStore().ReaderAt(ctx, ocispecs.Descriptor{
+					Digest: info.Digest,
+					Size:   info.Size,
+				})
+				if err == nil {
+					dt := make([]byte, 1024)
+					n, err := ra.ReadAt(dt, 0)
+					t.Logf("data: %+v %q", err, string(dt[:n]))
+				}
+			}
 			require.FailNowf(t, "content still exists", "%+v", infos)
 		}
 		retries++


### PR DESCRIPTION
I was trying to debug #3401 but couldn't repro or understand how the race is possible as long as tests do not have inner parallelization. Adding more debug so if it happens again we have some extra data.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>