### PR TITLE
progress: fix clean context cancelling

### DIFF
--- a/util/pull/pullprogress/progress.go
+++ b/util/pull/pullprogress/progress.go
@@ -106,6 +106,8 @@ func trackProgress(ctx context.Context, desc ocispecs.Descriptor, manager PullMa
 		select {
 		case <-ctx.Done():
 			onFinalStatus = true
+			// we need a context for the manager.Status() calls to pass once. after that this function will exit
+			ctx = context.TODO()
 		case <-ticker.C:
 		}
 


### PR DESCRIPTION
@sipsma I'm not sure if this is best solution so feel free to open an alternative but discovered that the current state is not quite correct.

When `case <-ctx.Done():` gets called it doesn't return out of the function but sets `onFinalStatus` to return after iteration. But then it calls `manager.Status(ctx` that is guaranteed to error because we already know that the context is closed. Because the error handling is relaxed it doesn't error the function but still logs error message every time.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>