### PR TITLE
[remotecache/s3] fix: "updated_at" in http header can't pass some http gateway, "_" -> "-"

### DIFF
--- a/cache/remotecache/s3/s3.go
+++ b/cache/remotecache/s3/s3.go
@@ -446,7 +446,7 @@ func (s3Client *s3Client) touch(ctx context.Context, key string) error {
 		Bucket:            &s3Client.bucket,
 		CopySource:        &copySource,
 		Key:               &key,
-		Metadata:          map[string]string{"updated_at": time.Now().String()},
+		Metadata:          map[string]string{"updated-at": time.Now().String()},
 		MetadataDirective: "REPLACE",
 	}
 


### PR DESCRIPTION
the word `updated_at` in s3 Metadata will be converted to `x-amz-meta-updated_at` in the http header, but the http headers which contain `_` can't pass some http gateway, such as tencent cloud object storage gateway.