### PR TITLE
Fix error: content digest sha256: ***: not found

### DIFF
--- a/cache/refs.go
+++ b/cache/refs.go
@@ -277,19 +277,21 @@ func (cr *cacheRecord) walkUniqueAncestors(f func(*cacheRecord) error) error {
 }
 
 func (cr *cacheRecord) isLazy(ctx context.Context) (bool, error) {
-	if !cr.getBlobOnly() {
-		return false, nil
-	}
 	dgst := cr.getBlob()
 	// special case for moby where there is no compressed blob (empty digest)
 	if dgst == "" {
 		return false, nil
 	}
+
 	_, err := cr.cm.ContentStore.Info(ctx, dgst)
 	if errors.Is(err, errdefs.ErrNotFound) {
 		return true, nil
 	} else if err != nil {
 		return false, err
+	}
+
+	if !cr.getBlobOnly() {
+		return false, nil
 	}
 
 	// If the snapshot is a remote snapshot, this layer is lazy.


### PR DESCRIPTION
PR created from patch by @imeoer posted on https://github.com/moby/buildkit/issues/2631#issuecomment-1291462675

Prioritize checking that the layer content does not exist to make sure the cache is lazy.

All credits to: Yan Song <imeoer@linux.alibaba.com>