### PR TITLE
test: add proxy build args when existed

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -97,6 +97,10 @@ DOCKERFILE_RELEASES=labs TESTFLAGS="--run /TestRunGlobalNetwork/worker=oci$/ -v"
 Set `TEST_KEEP_CACHE=1` for the test framework to keep external dependant images in a docker volume
 if you are repeatedly calling `./hack/test` script. This helps to avoid rate limiting on the remote registry side.
 
+If you are working behind a proxy, you can set some of or all
+`HTTP_PROXY=http://ip:port`, `HTTPS_PROXY=http://ip:port`, `NO_PROXY=http://ip:port` for the test framework
+to specify the proxy build args.
+
 Updating vendored dependencies:
 
 ```bash

--- a/hack/test
+++ b/hack/test
@@ -3,6 +3,9 @@
 . $(dirname $0)/util
 set -eu -o pipefail
 
+: ${HTTP_PROXY=}
+: ${HTTPS_PROXY=}
+: ${NO_PROXY=}
 : ${TEST_INTEGRATION=}
 : ${TEST_GATEWAY=}
 : ${TEST_DOCKERFILE=}
@@ -61,7 +64,10 @@ if [ "$TEST_COVERAGE" = "1" ]; then
 fi
 
 buildxCmd build $cacheFromFlags \
-  --build-arg "BUILDKITD_TAGS=$BUILDKITD_TAGS" \
+  --build-arg BUILDKITD_TAGS \
+  --build-arg HTTP_PROXY \
+  --build-arg HTTPS_PROXY \
+  --build-arg NO_PROXY \
   --target "integration-tests" \
   --output "type=docker,name=$iid" \
   $currentcontext


### PR DESCRIPTION
Signed-off-by: Wei Zhang <kweizh@gmail.com>

when working behind a proxy, the build command has to specify the `--build-arg HTTP_PROXY` etc...

this PR checks the `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` env and set it to build arg when it exists.
