### PR TITLE
llbsolver: fix panic when requesting provenance on nil result

### DIFF
--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -154,6 +154,7 @@ var allTests = integration.TestFuncs(
 	testClientFrontendProvenance,
 	testClientLLBProvenance,
 	testSecretSSHProvenance,
+	testNilProvenance,
 	testSBOMScannerArgs,
 )
 

--- a/solver/llbsolver/proc/provenance.go
+++ b/solver/llbsolver/proc/provenance.go
@@ -32,6 +32,10 @@ func ProvenanceProcessor(attrs map[string]string) llbsolver.Processor {
 				return nil, errors.Errorf("no build info found for provenance %s", p.ID)
 			}
 
+			if cp == nil {
+				continue
+			}
+
 			ref, ok := res.FindRef(p.ID)
 			if !ok {
 				return nil, errors.Errorf("could not find ref %s", p.ID)


### PR DESCRIPTION
Requesting provenance on build that returned `nil` resulted in daemon panic.

Theoretically, one could argue that even nil ref could have a provenance with frontend and build-arg names but trying to keep it turned out to be very complicated with a lot of functions needing exceptions as provenance is tracked per ref, not per result. If this becomes an issue somehow (are there any legit nil result builds?) then it can be revisited later. For now provenance is skipped for such builds, even if requested.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>