### PR TITLE
Various exporter refactoring fixes

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -7692,8 +7692,9 @@ func testExportAttestations(t *testing.T, sb integration.Sandbox) {
 
 		for _, p := range ps {
 			var attest intoto.Statement
-			dt := m[path.Join(strings.ReplaceAll(platforms.Format(p), "/", "_"), "test.attestation.json")].Data
-			require.NoError(t, json.Unmarshal(dt, &attest))
+			item := m[path.Join(strings.ReplaceAll(platforms.Format(p), "/", "_"), "test.attestation.json")]
+			require.NotNil(t, item)
+			require.NoError(t, json.Unmarshal(item.Data, &attest))
 
 			require.Equal(t, "https://in-toto.io/Statement/v0.1", attest.Type)
 			require.Equal(t, "https://example.com/attestations/v1.0", attest.PredicateType)
@@ -7705,8 +7706,9 @@ func testExportAttestations(t *testing.T, sb integration.Sandbox) {
 			}}, attest.Subject)
 
 			var attest2 intoto.Statement
-			dt = m[path.Join(strings.ReplaceAll(platforms.Format(p), "/", "_"), "test.attestation2.json")].Data
-			require.NoError(t, json.Unmarshal(dt, &attest2))
+			item = m[path.Join(strings.ReplaceAll(platforms.Format(p), "/", "_"), "test.attestation2.json")]
+			require.NotNil(t, item)
+			require.NoError(t, json.Unmarshal(item.Data, &attest2))
 
 			require.Equal(t, "https://in-toto.io/Statement/v0.1", attest2.Type)
 			require.Equal(t, "https://example.com/attestations2/v1.0", attest2.PredicateType)

--- a/exporter/local/export.go
+++ b/exporter/local/export.go
@@ -20,10 +20,6 @@ import (
 	"golang.org/x/time/rate"
 )
 
-const (
-	keyAttestationPrefix = "attestation-prefix"
-)
-
 type Opt struct {
 	SessionManager *session.Manager
 }
@@ -39,23 +35,12 @@ func New(opt Opt) (exporter.Exporter, error) {
 }
 
 func (e *localExporter) Resolve(ctx context.Context, opt map[string]string) (exporter.ExporterInstance, error) {
-	tm, _, err := epoch.ParseExporterAttrs(opt)
-	if err != nil {
-		return nil, err
-	}
-
 	i := &localExporterInstance{
 		localExporter: e,
-		opts: CreateFSOpts{
-			Epoch: tm,
-		},
 	}
-
-	for k, v := range opt {
-		switch k {
-		case keyAttestationPrefix:
-			i.opts.AttestationPrefix = v
-		}
+	_, err := i.opts.Load(opt)
+	if err != nil {
+		return nil, err
 	}
 
 	return i, nil

--- a/exporter/local/fs.go
+++ b/exporter/local/fs.go
@@ -15,6 +15,7 @@ import (
 	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/exporter"
 	"github.com/moby/buildkit/exporter/attestation"
+	"github.com/moby/buildkit/exporter/util/epoch"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/snapshot"
 	"github.com/moby/buildkit/solver/result"
@@ -25,9 +26,34 @@ import (
 	fstypes "github.com/tonistiigi/fsutil/types"
 )
 
+const (
+	keyAttestationPrefix = "attestation-prefix"
+)
+
 type CreateFSOpts struct {
 	Epoch             *time.Time
 	AttestationPrefix string
+}
+
+func (c *CreateFSOpts) Load(opt map[string]string) (map[string]string, error) {
+	rest := make(map[string]string)
+
+	var err error
+	c.Epoch, opt, err = epoch.ParseExporterAttrs(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range opt {
+		switch k {
+		case keyAttestationPrefix:
+			c.AttestationPrefix = v
+		default:
+			rest[k] = v
+		}
+	}
+
+	return rest, nil
 }
 
 func CreateFS(ctx context.Context, sessionID string, k string, ref cache.ImmutableRef, attestations []exporter.Attestation, defaultTime time.Time, opt CreateFSOpts) (fsutil.FS, func() error, error) {

--- a/exporter/tar/export.go
+++ b/exporter/tar/export.go
@@ -3,7 +3,6 @@ package local
 import (
 	"context"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -18,13 +17,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/tonistiigi/fsutil"
 	fstypes "github.com/tonistiigi/fsutil/types"
-)
-
-const (
-	// preferNondistLayersKey is an exporter option which can be used to mark a layer as non-distributable if the layer reference was
-	// already found to use a non-distributable media type.
-	// When this option is not set, the exporter will change the media type of the layer to a distributable one.
-	preferNondistLayersKey = "prefer-nondist-layers"
 )
 
 type Opt struct {
@@ -47,25 +39,14 @@ func (e *localExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 	if err != nil {
 		return nil, err
 	}
-
-	for k, v := range opt {
-		switch k {
-		case preferNondistLayersKey:
-			b, err := strconv.ParseBool(v)
-			if err != nil {
-				return nil, errors.Wrapf(err, "non-bool value for %s: %s", preferNondistLayersKey, v)
-			}
-			li.preferNonDist = b
-		}
-	}
+	_ = opt
 
 	return li, nil
 }
 
 type localExporterInstance struct {
 	*localExporter
-	opts          local.CreateFSOpts
-	preferNonDist bool
+	opts local.CreateFSOpts
 }
 
 func (e *localExporterInstance) Name() string {

--- a/exporter/tar/export.go
+++ b/exporter/tar/export.go
@@ -21,8 +21,6 @@ import (
 )
 
 const (
-	attestationPrefixKey = "attestation-prefix"
-
 	// preferNondistLayersKey is an exporter option which can be used to mark a layer as non-distributable if the layer reference was
 	// already found to use a non-distributable media type.
 	// When this option is not set, the exporter will change the media type of the layer to a distributable one.
@@ -45,12 +43,10 @@ func New(opt Opt) (exporter.Exporter, error) {
 
 func (e *localExporter) Resolve(ctx context.Context, opt map[string]string) (exporter.ExporterInstance, error) {
 	li := &localExporterInstance{localExporter: e}
-
-	tm, opt, err := epoch.ParseExporterAttrs(opt)
+	_, err := li.opts.Load(opt)
 	if err != nil {
 		return nil, err
 	}
-	li.opts.Epoch = tm
 
 	for k, v := range opt {
 		switch k {
@@ -60,8 +56,6 @@ func (e *localExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 				return nil, errors.Wrapf(err, "non-bool value for %s: %s", preferNondistLayersKey, v)
 			}
 			li.preferNonDist = b
-		case attestationPrefixKey:
-			li.opts.AttestationPrefix = v
 		}
 	}
 


### PR DESCRIPTION
Pulled out the various exporter fixups from https://github.com/moby/buildkit/pull/3403, since we won't merge new attestation options for now.