### PR TITLE
exporter: force enabling inline attestations for image export

### DIFF
--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -78,7 +78,8 @@ func (e *imageExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 			RefCfg: cacheconfig.RefConfig{
 				Compression: compression.New(compression.Default),
 			},
-			BuildInfo: true,
+			BuildInfo:               true,
+			ForceInlineAttestations: true,
 		},
 		store: true,
 	}

--- a/exporter/containerimage/opts.go
+++ b/exporter/containerimage/opts.go
@@ -34,6 +34,8 @@ type ImageCommitOpts struct {
 	BuildInfoAttrs bool
 	Annotations    AnnotationsGroup
 	Epoch          *time.Time
+
+	ForceInlineAttestations bool // force inline attestations to be attached
 }
 
 func (c *ImageCommitOpts) Load(opt map[string]string) (map[string]string, error) {

--- a/exporter/containerimage/opts.go
+++ b/exporter/containerimage/opts.go
@@ -12,13 +12,14 @@ import (
 )
 
 const (
-	keyImageName        = "name"
-	keyLayerCompression = "compression"
-	keyCompressionLevel = "compression-level"
-	keyForceCompression = "force-compression"
-	keyOCITypes         = "oci-mediatypes"
-	keyBuildInfo        = "buildinfo"
-	keyBuildInfoAttrs   = "buildinfo-attrs"
+	keyImageName               = "name"
+	keyLayerCompression        = "compression"
+	keyCompressionLevel        = "compression-level"
+	keyForceCompression        = "force-compression"
+	keyOCITypes                = "oci-mediatypes"
+	keyBuildInfo               = "buildinfo"
+	keyBuildInfoAttrs          = "buildinfo-attrs"
+	keyForceInlineAttestations = "attestation-inline"
 
 	// preferNondistLayersKey is an exporter option which can be used to mark a layer as non-distributable if the layer reference was
 	// already found to use a non-distributable media type.
@@ -75,6 +76,8 @@ func (c *ImageCommitOpts) Load(opt map[string]string) (map[string]string, error)
 			err = parseBoolWithDefault(&c.BuildInfo, k, v, true)
 		case keyBuildInfoAttrs:
 			err = parseBoolWithDefault(&c.BuildInfoAttrs, k, v, false)
+		case keyForceInlineAttestations:
+			err = parseBool(&c.ForceInlineAttestations, k, v)
 		case keyPreferNondistLayers:
 			err = parseBool(&c.RefCfg.PreferNonDistributable, k, v)
 		default:


### PR DESCRIPTION
As discussed with @tonistiigi, we don't need the complexity of https://github.com/moby/buildkit/pull/3403, we just need to rework the behavior of inline attestations slightly.

- For the `local` and `tar` exporters, never export inline attestations
- For the `oci` and `docker` exporters, only export inline attestations if we are already exporting an image index (e.g. in the case of a multi-platform image, or if we have other attestations to export as well)
- For the `image` exporter, always export inline attestations, forcing generation of an index even if we otherwise wouldn't.

No corresponding buildx changes are necessary.