### PR TITLE
docs: change semicolons to double ampersands

### DIFF
--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -529,14 +529,14 @@ In the *shell* form you can use a `\` (backslash) to continue a single
 RUN instruction onto the next line. For example, consider these two lines:
 
 ```dockerfile
-RUN /bin/bash -c 'source $HOME/.bashrc; \
+RUN /bin/bash -c 'source $HOME/.bashrc && \
 echo $HOME'
 ```
 
 Together they are equivalent to this single line:
 
 ```dockerfile
-RUN /bin/bash -c 'source $HOME/.bashrc; echo $HOME'
+RUN /bin/bash -c 'source $HOME/.bashrc && echo $HOME'
 ```
 
 To use a different shell, other than '/bin/sh', use the *exec* form passing in


### PR DESCRIPTION
If semicolons are used, `docker build` will complete and return 0 even when some commands between semicolons fail

Signed-off-by: Andy Alt <andy5995@users.noreply.github.com>