### PR TITLE
ci: add ci to check README toc

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Join `#buildkit` channel on [Docker Community Slack](https://dockr.ly/comm-slack
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Used by](#used-by)
 - [Quick start](#quick-start)
   - [Starting the `buildkitd` daemon](#starting-the-buildkitd-daemon)

--- a/hack/validate-generated-files
+++ b/hack/validate-generated-files
@@ -8,3 +8,9 @@ buildxCmd build \
   --output "type=cacheonly" \
   --file "./hack/dockerfiles/generated-files.Dockerfile" \
   .
+
+buildxCmd build \
+  --target "validate-toc" \
+  --output "type=cacheonly" \
+  --file "./hack/dockerfiles/generated-files.Dockerfile" \
+  .


### PR DESCRIPTION
Signed-off-by: Wei Zhang <kweizh@gmail.com>

add node:19-alpine image to install doctoc, and generate the validated README.md,
then use to base image to check the git difference.

it will fail when README toc does not match the generated one.

so that we do not have to check it manually https://github.com/moby/buildkit/pull/3468#discussion_r1063945863