### PR TITLE
feat: add namespace support for nerdctl container

### DIFF
--- a/cmd/buildctl/main.go
+++ b/cmd/buildctl/main.go
@@ -6,6 +6,7 @@ import (
 
 	_ "github.com/moby/buildkit/client/connhelper/dockercontainer"
 	_ "github.com/moby/buildkit/client/connhelper/kubepod"
+	_ "github.com/moby/buildkit/client/connhelper/nerdctlcontainer"
 	_ "github.com/moby/buildkit/client/connhelper/podmancontainer"
 	_ "github.com/moby/buildkit/client/connhelper/ssh"
 	bccommon "github.com/moby/buildkit/cmd/buildctl/common"


### PR DESCRIPTION
Signed-off-by: Wei Zhang <kweizh@gmail.com>

1. --addr support nerdctl-container://container?namespace=ns
2. import nerdctlcontainer in the main package to initialize the nerdctl container support