### PR TITLE
azblob_test: pin busybox to avoid "Illegal instruction" error

### DIFF
--- a/hack/azblob_test/test1/Dockerfile
+++ b/hack/azblob_test/test1/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox AS build
+FROM busybox:1.35 AS build
 RUN cat /dev/urandom | head -c 100 | sha256sum > unique_first
 RUN cat /dev/urandom | head -c 100 | sha256sum > unique_second
 

--- a/hack/azblob_test/test2/Dockerfile
+++ b/hack/azblob_test/test2/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox AS build
+FROM busybox:1.35 AS build
 RUN cat /dev/urandom | head -c 100 | sha256sum > unique_first
 RUN cat /dev/urandom | head -c 100 | sha256sum > unique_second
 RUN cat /dev/urandom | head -c 100 | sha256sum > unique_third


### PR DESCRIPTION
Follow-up to https://github.com/moby/buildkit/pull/3469#issuecomment-1374688261
