### PR TITLE
azblob cache: account_name attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,11 @@ There are 2 options supported for Azure Blob Storage authentication:
 * Any system using environment variables supported by the [Azure SDK for Go](https://docs.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication). The configuration must be available for the buildkit daemon, not for the client.
 * Secret Access Key, using the `secret_access_key` attribute to specify the primary or secondary account key for your Azure Blob Storage account. [Azure Blob Storage account keys](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage)
 
+> **Note**
+>
+> Account name can also be specified with `account_name` attribute (or `$BUILDKIT_AZURE_STORAGE_ACCOUNT_NAME`)
+> if it is not part of the account URL host.
+
 `--export-cache` options:
 * `type=azblob`
 * `mode=<min|max>`: specify cache layers to export (default: `min`)

--- a/cache/remotecache/azblob/utils.go
+++ b/cache/remotecache/azblob/utils.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	attrSecretAccessKey = "secret_access_key"
+	attrAccountName     = "account_name"
 	attrAccountURL      = "account_url"
 	attrPrefix          = "prefix"
 	attrManifestsPrefix = "manifests_prefix"
@@ -50,7 +51,16 @@ func getConfig(attrs map[string]string) (*Config, error) {
 		return &Config{}, errors.Wrap(err, "azure storage account url provided is not a valid url")
 	}
 
-	accountName := strings.Split(accountURL.Hostname(), ".")[0]
+	accountName, ok := attrs[attrAccountName]
+	if !ok {
+		accountName, ok = os.LookupEnv("BUILDKIT_AZURE_STORAGE_ACCOUNT_NAME")
+		if !ok {
+			accountName = strings.Split(accountURL.Hostname(), ".")[0]
+		}
+	}
+	if accountName == "" {
+		return &Config{}, errors.New("unable to retrieve account name from account url or ${BUILDKIT_AZURE_STORAGE_ACCOUNT_NAME} or account_name attribute for azblob cache")
+	}
 
 	container, ok := attrs[attrContainer]
 	if !ok {


### PR DESCRIPTION
By default account name is parsed from request uri host (account url) but when product style url is disabled, account name is not part of the host. This new attribute allows to specify the account name in such case.

cc @vangarp

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>