### PR TITLE
[v0.10 backport] integration: set mirrors and entitlements with dockerd worker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   base:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       -
         name: Checkout
@@ -62,7 +62,7 @@ jobs:
           CACHE_TO: type=gha,scope=${{ env.CACHE_GHA_SCOPE_IT }}
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [base]
     strategy:
       fail-fast: false
@@ -132,9 +132,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          # - ubuntu-latest
-          # - macOS-latest
-          - windows-latest
+          # - ubuntu-20.04
+          # - macOS-11
+          - windows-2022
     steps:
       -
         name: Checkout
@@ -166,7 +166,7 @@ jobs:
           path: ./coverage
 
   upload-coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [test, test-os]
     steps:
       -
@@ -196,7 +196,7 @@ jobs:
           files: ${{ steps.files.outputs.result }}
 
   cross:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       -
         name: Checkout
@@ -225,7 +225,7 @@ jobs:
           CACHE_TO: type=gha,scope=${{ env.CACHE_GHA_SCOPE_CROSS }}
 
   release-base:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       tag: ${{ steps.prep.outputs.tag }}
       push: ${{ steps.prep.outputs.push }}
@@ -249,7 +249,7 @@ jobs:
           echo ::set-output name=push::${PUSH}
 
   image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [release-base, test, cross]
     strategy:
       fail-fast: false
@@ -291,7 +291,7 @@ jobs:
           CACHE_TO: type=gha,scope=image${{ matrix.target-stage }}
 
   binaries:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [release-base, test, cross]
     steps:
       -
@@ -340,7 +340,7 @@ jobs:
           name: ${{ needs.release-base.outputs.tag }}
 
   frontend-base:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.event_name != 'schedule'
     outputs:
       typ: ${{ steps.prep.outputs.typ }}
@@ -366,7 +366,7 @@ jobs:
           echo ::set-output name=push::${PUSH}
 
   frontend-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.event_name != 'schedule'
     needs: [frontend-base, test]
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,16 +32,16 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Expose GitHub Runtime
-        uses: crazy-max/ghaction-github-runtime@v1
+        uses: crazy-max/ghaction-github-runtime@v2
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         with:
           version: ${{ env.BUILDX_VERSION }}
           driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
@@ -92,16 +92,16 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Expose GitHub Runtime
-        uses: crazy-max/ghaction-github-runtime@v1
+        uses: crazy-max/ghaction-github-runtime@v2
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         with:
           version: ${{ env.BUILDX_VERSION }}
           driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
@@ -121,7 +121,7 @@ jobs:
           CACHE_FROM: type=gha,scope=${{ env.CACHE_GHA_SCOPE_IT }} type=gha,scope=${{ env.CACHE_GHA_SCOPE_BINARIES }}
       -
         name: Upload coverage file
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: coverage
           path: ./coverage
@@ -138,20 +138,13 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18
-      -
-        name: Cache Go modules
-        uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache: true
       -
         name: Go mod
         run: |
@@ -167,7 +160,7 @@ jobs:
         shell: bash
       -
         name: Upload coverage file
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: coverage
           path: ./coverage
@@ -178,16 +171,16 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Download coverage files
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: coverage
           path: ./coverage
       -
         name: List coverage files
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         id: files
         with:
           result-encoding: string
@@ -207,16 +200,16 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Expose GitHub Runtime
-        uses: crazy-max/ghaction-github-runtime@v1
+        uses: crazy-max/ghaction-github-runtime@v2
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         with:
           version: ${{ env.BUILDX_VERSION }}
           driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
@@ -267,16 +260,16 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Expose GitHub Runtime
-        uses: crazy-max/ghaction-github-runtime@v1
+        uses: crazy-max/ghaction-github-runtime@v2
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         with:
           version: ${{ env.BUILDX_VERSION }}
           driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
@@ -284,7 +277,7 @@ jobs:
       -
         name: Login to DockerHub
         if: needs.release-base.outputs.push == 'push'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -303,16 +296,16 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Expose GitHub Runtime
-        uses: crazy-max/ghaction-github-runtime@v1
+        uses: crazy-max/ghaction-github-runtime@v2
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         with:
           version: ${{ env.BUILDX_VERSION }}
           driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
@@ -330,7 +323,7 @@ jobs:
           mv ./release-out/**/* ./release-out/
       -
         name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: buildkit
           path: ./release-out/*
@@ -338,7 +331,7 @@ jobs:
       -
         name: GitHub Release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -379,23 +372,23 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Expose GitHub Runtime
-        uses: crazy-max/ghaction-github-runtime@v1
+        uses: crazy-max/ghaction-github-runtime@v2
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         with:
           version: ${{ env.BUILDX_VERSION }}
           driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
           buildkitd-flags: --debug
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         if: needs.frontend-base.outputs.push == 'push'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/buildx-image.yml
+++ b/.github/workflows/buildx-image.yml
@@ -31,7 +31,7 @@ env:
 
 jobs:
   create:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/buildx-image.yml
+++ b/.github/workflows/buildx-image.yml
@@ -41,13 +41,13 @@ jobs:
     steps:
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         with:
           version: ${{ env.BUILDX_VERSION }}
       -
         name: Login to DockerHub
         if: github.event.inputs.dry-run != 'true'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/dockerd.yml
+++ b/.github/workflows/dockerd.yml
@@ -43,7 +43,7 @@ jobs:
             return true;
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         with:
           version: ${{ env.BUILDX_VERSION }}
           driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
@@ -51,7 +51,7 @@ jobs:
       -
         name: Build
         if: steps.build.outputs.result == 'true'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ${{ env.DOCKER_VERSION }}
           target: binary
@@ -72,7 +72,7 @@ jobs:
           wget -qO- "https://download.docker.com/linux/static/stable/x86_64/docker-${{ env.DOCKER_VERSION }}.tgz" | tar xvz --strip 1
       -
         name: Upload dockerd
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: dockerd
           path: /tmp/moby/dockerd
@@ -99,23 +99,23 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Expose GitHub Runtime
-        uses: crazy-max/ghaction-github-runtime@v1
+        uses: crazy-max/ghaction-github-runtime@v2
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         with:
           version: ${{ env.BUILDX_VERSION }}
           driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
           buildkitd-flags: --debug
       -
         name: Download dockerd
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: dockerd
           path: ./build/

--- a/.github/workflows/dockerd.yml
+++ b/.github/workflows/dockerd.yml
@@ -61,21 +61,21 @@ jobs:
         if: steps.build.outputs.result == 'true'
         run: |
           if [ -L "/tmp/moby/binary-daemon/dockerd" ]; then
-            mv -f $(readlink /tmp/moby/binary-daemon/dockerd) /tmp/moby/binary-daemon/dockerd
+            mv -f $(readlink /tmp/moby/binary-daemon/dockerd) /tmp/moby/dockerd
           fi
       -
         name: Download
         if: steps.build.outputs.result != 'true'
         run: |
-          mkdir -p /tmp/moby/binary-daemon
-          cd /tmp/moby/binary-daemon
+          mkdir -p /tmp/moby
+          cd /tmp/moby
           wget -qO- "https://download.docker.com/linux/static/stable/x86_64/docker-${{ env.DOCKER_VERSION }}.tgz" | tar xvz --strip 1
       -
         name: Upload dockerd
         uses: actions/upload-artifact@v2
         with:
           name: dockerd
-          path: /tmp/moby/binary-daemon/dockerd
+          path: /tmp/moby/dockerd
           if-no-files-found: error
 
   test:

--- a/.github/workflows/dockerd.yml
+++ b/.github/workflows/dockerd.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       -
         name: Check version
@@ -79,7 +79,7 @@ jobs:
           if-no-files-found: error
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - prepare
     strategy:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -31,10 +31,10 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         with:
           version: ${{ env.BUILDX_VERSION }}
           driver-opts: image=${{ env.REPO_SLUG_ORIGIN }}
@@ -42,7 +42,3 @@ jobs:
         name: Run
         run: |
           ${{ matrix.script }}
-      -
-        name: Dump context
-        if: always()
-        uses: crazy-max/ghaction-dump-context@v1

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/util/testutil/dockerd/config.go
+++ b/util/testutil/dockerd/config.go
@@ -1,0 +1,16 @@
+package dockerd
+
+type Config struct {
+	Features map[string]bool `json:"features,omitempty"`
+	Mirrors  []string        `json:"registry-mirrors,omitempty"`
+	Builder  BuilderConfig   `json:"builder,omitempty"`
+}
+
+type BuilderEntitlements struct {
+	NetworkHost      bool `json:"network-host,omitempty"`
+	SecurityInsecure bool `json:"security-insecure,omitempty"`
+}
+
+type BuilderConfig struct {
+	Entitlements BuilderEntitlements `json:",omitempty"`
+}


### PR DESCRIPTION
* backport of https://github.com/moby/buildkit/pull/3482

Wasn't a clean cherry-pick due lack of https://github.com/moby/buildkit/pull/3176

Also encounter an issue on CI when building on `ubuntu-latest` (22.04): https://github.com/crazy-max/buildkit/actions/runs/3878639330/jobs/6615033505#step:9:26

```
+ docker buildx build --cache-from=type=gha,scope=integration-tests --cache-from=type=gha,scope=binaries --target integration-tests --output type=docker,name=buildkit-tests --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 https://github.com/crazy-max/buildkit.git#refs/heads/0.10_backport_integration-dockerd-mirror --progress=plain
#1 [internal] booting buildkit
#1 starting container buildx_buildkit_builder-70cdfac4-26c1-4d4d-b0d3-0dc9af310a5e0 done
#1 ERROR: Error response from daemon: cgroup-parent for systemd cgroup should be a valid slice named as "xxx.slice"
------
 > [internal] booting buildkit:
------
ERROR: Error response from daemon: cgroup-parent for systemd cgroup should be a valid slice named as "xxx.slice"
Error: Process completed with exit code 1.
```

Builder config: https://github.com/crazy-max/buildkit/actions/runs/3878639330/jobs/6615033505#step:5:132

```
  /usr/bin/docker buildx inspect --bootstrap --builder builder-70cdfac4-26c1-4d4d-b0d3-0dc9af310a5e
  #1 [internal] booting buildkit
  #1 pulling image moby/buildkit:latest
  #1 pulling image moby/buildkit:latest 0.5s done
  #1 creating container buildx_buildkit_builder-70cdfac4-26c1-4d4d-b0d3-0dc9af310a5e0
  #1 creating container buildx_buildkit_builder-70cdfac4-26c1-4d4d-b0d3-0dc9af310a5e0 3.1s done
  #1 DONE 3.5s
  Name:   builder-70cdfac4-26c1-4d4d-b0d3-0dc9af310a5e
  Driver: docker-container
  
  Nodes:
  Name:           builder-70cdfac4-26c1-4d4d-b0d3-0dc9af310a5e0
  Endpoint:       unix:///var/run/docker.sock
  Driver Options: image="moby/buildkit:latest"
  Status:         running
  Flags:          --debug
  Buildkit:       v0.10.6
  Platforms:      linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/amd64/v4, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/mips64le, linux/mips64, linux/arm/v7, linux/arm/v6
```

Looks like a cgroupv2 issue. Looking at the GH runner environment, the daemon config is: https://github.com/docker/build-push-action/actions/runs/3872692680/jobs/6601841667#step:7:5

```
{ "exec-opts": ["native.cgroupdriver=cgroupfs"], "cgroup-parent": "/actions_job" }
```

As discussed with @tonistiigi, we already have a cond for `cgroupfs` in buildx: https://github.com/docker/buildx/blob/5c56e947fe17fd3290eefdc29a49270fa2b626df/driver/docker-container/driver.go#L126-L133

We could set the [`cgroup-parent` driver-opt](https://docs.docker.com/build/drivers/docker-container/) or just take the default one if already set (`/actions_job` in this case). WDYT @djs55?

In the meantime, backport 2 commits from:
* https://github.com/moby/buildkit/pull/3032
  * https://github.com/moby/buildkit/pull/3032/commits/35ae9d151314b5e56a6fea6e450572c570ed5772
  * https://github.com/moby/buildkit/pull/3032/commits/43e9b91980e106fb2d8f024707bbb63cb96ee216

Verified in https://github.com/crazy-max/buildkit/actions/runs/3878708568