### PR TITLE
buildctl: add `buildctl debug histories, buildctl prune-histories`

### DIFF
--- a/cmd/buildctl/debug.go
+++ b/cmd/buildctl/debug.go
@@ -17,5 +17,6 @@ var debugCommand = cli.Command{
 		debug.LogsCommand,
 		debug.CtlCommand,
 		debug.GetCommand,
+		debug.HistoriesCommand,
 	},
 }

--- a/cmd/buildctl/debug/histories.go
+++ b/cmd/buildctl/debug/histories.go
@@ -1,0 +1,100 @@
+package debug
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"time"
+
+	controlapi "github.com/moby/buildkit/api/services/control"
+	bccommon "github.com/moby/buildkit/cmd/buildctl/common"
+	"github.com/moby/buildkit/util/appcontext"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
+)
+
+var HistoriesCommand = cli.Command{
+	Name:   "histories",
+	Usage:  "list build records",
+	Action: histories,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "format",
+			Usage: "Format the output using the given Go template, e.g, '{{json .}}'",
+		},
+	},
+}
+
+func histories(clicontext *cli.Context) error {
+	c, err := bccommon.ResolveClient(clicontext)
+	if err != nil {
+		return err
+	}
+
+	ctx := appcontext.Context()
+	resp, err := c.ControlClient().ListenBuildHistory(ctx, &controlapi.BuildHistoryRequest{
+		EarlyExit: true,
+	})
+	if err != nil {
+		return err
+	}
+
+	if format := clicontext.String("format"); format != "" {
+		tmpl, err := bccommon.ParseTemplate(format)
+		if err != nil {
+			return err
+		}
+		for {
+			ev, err := resp.Recv()
+			if errors.Is(err, io.EOF) {
+				break
+			} else if err != nil {
+				return err
+			}
+			if err := tmpl.Execute(clicontext.App.Writer, ev); err != nil {
+				return err
+			}
+			if _, err = fmt.Fprintf(clicontext.App.Writer, "\n"); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return printRecordsTable(clicontext.App.Writer, resp)
+}
+
+func printRecordsTable(w io.Writer, eventReceiver controlapi.Control_ListenBuildHistoryClient) error {
+	tw := tabwriter.NewWriter(w, 1, 8, 1, '\t', 0)
+	fmt.Fprintln(tw, "TYPE\tREF\tCREATED\tCOMPLETED\tGENERATION\tPINNED")
+	for {
+		ev, err := eventReceiver.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		} else if err != nil {
+			return err
+		}
+		var (
+			ref         string
+			createdAt   string
+			completedAt string
+			generation  int32
+			pinned      string
+		)
+		if r := ev.Record; r != nil {
+			ref = r.Ref
+			if r.CreatedAt != nil {
+				createdAt = r.CreatedAt.Local().Format(time.RFC3339)
+			}
+			if r.CompletedAt != nil {
+				completedAt = r.CompletedAt.Local().Format(time.RFC3339)
+			}
+			generation = r.Generation
+			if r.Pinned {
+				pinned = "*"
+			}
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\t%s\n", ev.Type, ref, createdAt, completedAt, generation, pinned)
+		tw.Flush()
+	}
+	return tw.Flush()
+}

--- a/cmd/buildctl/main.go
+++ b/cmd/buildctl/main.go
@@ -92,6 +92,7 @@ func main() {
 	app.Commands = []cli.Command{
 		diskUsageCommand,
 		pruneCommand,
+		pruneHistoriesCommand,
 		buildCommand,
 		debugCommand,
 		dialStdioCommand,

--- a/cmd/buildctl/prunehistories.go
+++ b/cmd/buildctl/prunehistories.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	controlapi "github.com/moby/buildkit/api/services/control"
+	bccommon "github.com/moby/buildkit/cmd/buildctl/common"
+	"github.com/moby/buildkit/util/appcontext"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
+)
+
+var pruneHistoriesCommand = cli.Command{
+	Name:   "prune-histories",
+	Usage:  "clean up build histories",
+	Action: pruneHistories,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "format",
+			Usage: "Format the output using the given Go template, e.g, '{{json .}}'",
+		},
+	},
+}
+
+func pruneHistories(clicontext *cli.Context) error {
+	c, err := bccommon.ResolveClient(clicontext)
+	if err != nil {
+		return err
+	}
+
+	ctx := appcontext.Context()
+	controlClient := c.ControlClient()
+	resp, err := controlClient.ListenBuildHistory(ctx, &controlapi.BuildHistoryRequest{
+		EarlyExit: true,
+	})
+	if err != nil {
+		return err
+	}
+
+	var rerr error
+	if format := clicontext.String("format"); format != "" {
+		tmpl, err := bccommon.ParseTemplate(format)
+		if err != nil {
+			return err
+		}
+		for {
+			ev, err := resp.Recv()
+			if errors.Is(err, io.EOF) {
+				break
+			} else if err != nil {
+				return err
+			}
+			if ev.Record == nil || ev.Record.Pinned {
+				continue
+			}
+			if _, err := controlClient.UpdateBuildHistory(ctx, &controlapi.UpdateBuildHistoryRequest{
+				Ref:    ev.Record.Ref,
+				Delete: true,
+			}); err != nil {
+				rerr = multierror.Append(rerr, err).ErrorOrNil()
+				continue
+			}
+			if err := tmpl.Execute(clicontext.App.Writer, ev); err != nil {
+				return err
+			}
+			if _, err = fmt.Fprintf(clicontext.App.Writer, "\n"); err != nil {
+				return err
+			}
+		}
+		return rerr
+	}
+	return pruneHistoriesWithTableOutput(ctx, clicontext.App.Writer, controlClient, resp)
+}
+
+func pruneHistoriesWithTableOutput(ctx context.Context, w io.Writer, controlClient controlapi.ControlClient,
+	eventReceiver controlapi.Control_ListenBuildHistoryClient) error {
+	tw := tabwriter.NewWriter(w, 1, 8, 1, '\t', 0)
+	fmt.Fprintln(tw, "TYPE\tREF\tCREATED\tCOMPLETED\tGENERATION")
+	var rerr error
+	for {
+		ev, err := eventReceiver.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		} else if err != nil {
+			return err
+		}
+		r := ev.Record
+		if r == nil || r.Pinned {
+			continue
+		}
+		if _, err := controlClient.UpdateBuildHistory(ctx, &controlapi.UpdateBuildHistoryRequest{
+			Ref:    ev.Record.Ref,
+			Delete: true,
+		}); err != nil {
+			rerr = multierror.Append(rerr, err).ErrorOrNil()
+			continue
+		}
+		var (
+			createdAt   string
+			completedAt string
+		)
+		if r.CreatedAt != nil {
+			createdAt = r.CreatedAt.Local().Format(time.RFC3339)
+		}
+		if r.CompletedAt != nil {
+			completedAt = r.CompletedAt.Local().Format(time.RFC3339)
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\n", ev.Type, r.Ref, createdAt, completedAt, r.Generation)
+		tw.Flush()
+	}
+	tw.Flush()
+	return rerr
+}


### PR DESCRIPTION
```console
$ buildctl debug histories
TYPE            REF                             CREATED                         COMPLETED                       GENERATION      PINNED
COMPLETE        40d2kg3dqh8dflruacpyd7bdz       2023-01-13T18:35:33+09:00       2023-01-13T18:35:35+09:00       2               *
COMPLETE        ks37bedzwtb7446srrlnb28li       2023-01-13T18:38:06+09:00       2023-01-13T18:38:08+09:00       0
COMPLETE        mmsit25ck1w6qzcja5cdcstfx       2023-01-13T18:38:00+09:00       2023-01-13T18:38:05+09:00       1

$ buildctl prune-histories
TYPE            REF                             CREATED                         COMPLETED                       GENERATION
COMPLETE        ks37bedzwtb7446srrlnb28li       2023-01-13T18:38:06+09:00       2023-01-13T18:38:08+09:00       1
COMPLETE        mmsit25ck1w6qzcja5cdcstfx       2023-01-13T18:38:00+09:00       2023-01-13T18:38:05+09:00       1
```