### PR TITLE
Add registry.insecure option to registry exporter

### DIFF
--- a/cache/remotecache/registry/registry.go
+++ b/cache/remotecache/registry/registry.go
@@ -15,21 +15,23 @@ import (
 	"github.com/moby/buildkit/util/estargz"
 	"github.com/moby/buildkit/util/push"
 	"github.com/moby/buildkit/util/resolver"
+	resolverconfig "github.com/moby/buildkit/util/resolver/config"
 	"github.com/moby/buildkit/util/resolver/limited"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
-func canonicalizeRef(rawRef string) (string, error) {
+func canonicalizeRef(rawRef string) (reference.Named, error) {
 	if rawRef == "" {
-		return "", errors.New("missing ref")
+		return nil, errors.New("missing ref")
 	}
 	parsed, err := reference.ParseNormalizedNamed(rawRef)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return reference.TagNameOnly(parsed).String(), nil
+	parsed = reference.TagNameOnly(parsed)
+	return parsed, nil
 }
 
 const (
@@ -38,6 +40,7 @@ const (
 	attrLayerCompression = "compression"
 	attrForceCompression = "force-compression"
 	attrCompressionLevel = "compression-level"
+	attrInsecure         = "registry.insecure"
 )
 
 func ResolveCacheExporterFunc(sm *session.Manager, hosts docker.RegistryHosts) remotecache.ResolveCacheExporterFunc {
@@ -50,6 +53,7 @@ func ResolveCacheExporterFunc(sm *session.Manager, hosts docker.RegistryHosts) r
 		if err != nil {
 			return nil, err
 		}
+		refString := ref.String()
 		ociMediatypes := true
 		if v, ok := attrs[attrOCIMediatypes]; ok {
 			b, err := strconv.ParseBool(v)
@@ -58,12 +62,22 @@ func ResolveCacheExporterFunc(sm *session.Manager, hosts docker.RegistryHosts) r
 			}
 			ociMediatypes = b
 		}
-		remote := resolver.DefaultPool.GetResolver(hosts, ref, "push", sm, g)
-		pusher, err := push.Pusher(ctx, remote, ref)
+		insecure := false
+		if v, ok := attrs[attrInsecure]; ok {
+			b, err := strconv.ParseBool(v)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to parse %s", attrInsecure)
+			}
+			insecure = b
+		}
+
+		scope, hosts := registryConfig(hosts, ref, "push", insecure)
+		remote := resolver.DefaultPool.GetResolver(hosts, refString, scope, sm, g)
+		pusher, err := push.Pusher(ctx, remote, refString)
 		if err != nil {
 			return nil, err
 		}
-		return remotecache.NewExporter(contentutil.FromPusher(pusher), ref, ociMediatypes, *compressionConfig), nil
+		return remotecache.NewExporter(contentutil.FromPusher(pusher), refString, ociMediatypes, *compressionConfig), nil
 	}
 }
 
@@ -73,8 +87,19 @@ func ResolveCacheImporterFunc(sm *session.Manager, cs content.Store, hosts docke
 		if err != nil {
 			return nil, ocispecs.Descriptor{}, err
 		}
-		remote := resolver.DefaultPool.GetResolver(hosts, ref, "pull", sm, g)
-		xref, desc, err := remote.Resolve(ctx, ref)
+		refString := ref.String()
+		insecure := false
+		if v, ok := attrs[attrInsecure]; ok {
+			b, err := strconv.ParseBool(v)
+			if err != nil {
+				return nil, ocispecs.Descriptor{}, errors.Wrapf(err, "failed to parse %s", attrInsecure)
+			}
+			insecure = b
+		}
+
+		scope, hosts := registryConfig(hosts, ref, "pull", insecure)
+		remote := resolver.DefaultPool.GetResolver(hosts, refString, scope, sm, g)
+		xref, desc, err := remote.Resolve(ctx, refString)
 		if err != nil {
 			return nil, ocispecs.Descriptor{}, err
 		}
@@ -83,8 +108,8 @@ func ResolveCacheImporterFunc(sm *session.Manager, cs content.Store, hosts docke
 			return nil, ocispecs.Descriptor{}, err
 		}
 		src := &withDistributionSourceLabel{
-			Provider: contentutil.FromFetcher(limited.Default.WrapFetcher(fetcher, ref)),
-			ref:      ref,
+			Provider: contentutil.FromFetcher(limited.Default.WrapFetcher(fetcher, refString)),
+			ref:      refString,
 			source:   cs,
 		}
 		return remotecache.NewImporter(src), desc, nil
@@ -163,4 +188,19 @@ func attrsToCompression(attrs map[string]string) (*compression.Config, error) {
 		compressionConfig = compressionConfig.SetLevel(int(ii))
 	}
 	return &compressionConfig, nil
+}
+
+func registryConfig(hosts docker.RegistryHosts, ref reference.Named, scope string, insecure bool) (string, docker.RegistryHosts) {
+	if insecure {
+		insecureTrue := true
+		httpTrue := true
+		hosts = resolver.NewRegistryConfig(map[string]resolverconfig.RegistryConfig{
+			reference.Domain(ref): {
+				Insecure:  &insecureTrue,
+				PlainHTTP: &httpTrue,
+			},
+		})
+		scope += ":insecure"
+	}
+	return scope, hosts
 }


### PR DESCRIPTION
:hammer_and_wrench: Fixes https://github.com/moby/buildkit/issues/3266.

Users attempt to use `registry.insecure` in the `registry` cache exporter (which makes sense, since many other options are shared, such as `oci-mediatypes`) - as in https://github.com/docker/buildx/issues/1370.

We should support `registry.insecure` in the registry supporter, using similar a similar code pattern to the corresponding exporter code.