### PR TITLE
dockerfile: fix panic on warnings with multi-platform

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -183,6 +183,10 @@ func toDispatchState(ctx context.Context, dt []byte, opt ConvertOpt) (*dispatchS
 		opt.ContextLocalName = defaultContextLocalName
 	}
 
+	if opt.Warn == nil {
+		opt.Warn = func(string, string, [][]byte, *parser.Range) {}
+	}
+
 	platformOpt := buildPlatformOpt(&opt)
 
 	optMetaArgs := getPlatformArgs(platformOpt)


### PR DESCRIPTION
fixes #3495

On multi-platform builds warning as disabled for secondary platforms to avoid duplicates, but nil value can cause a panic.

Regression from https://github.com/moby/buildkit/commit/ec9a3ac14119da55d18b26fec68137b845aa30a4#diff-c876ea8bd639239ba60cde8cc40c2c2dd761f361564d4465b139b7b628e815bbR481

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>