### PR TITLE
Propagate sshforward send side connection close

### DIFF
--- a/session/sshforward/copy.go
+++ b/session/sshforward/copy.go
@@ -23,7 +23,12 @@ func Copy(ctx context.Context, conn io.ReadWriteCloser, stream Stream, closeStre
 			if err := stream.RecvMsg(p); err != nil {
 				if err == io.EOF {
 					// indicates client performed CloseSend, but they may still be
-					// reading data, so don't close conn yet
+					// reading data
+					if conn, ok := conn.(interface {
+						CloseWrite() error
+					}); ok {
+						conn.CloseWrite()
+					}
 					return nil
 				}
 				conn.Close()


### PR DESCRIPTION
PR #3431 caused connections closed on the remote side of a sshforward session to not always result in the local side reading an EOF from the connection. This change restores that behavior by closing the write side of the forwarded connection after reading an EOF from the stream. Since only the write side is being closed, it doesn't prevent the remote side from continuing to read from the connection.