### PR TITLE
examples: optimize --dry-run flag

### DIFF
--- a/examples/kubernetes/create-certs.sh
+++ b/examples/kubernetes/create-certs.sh
@@ -37,6 +37,6 @@ mkdir -p $DIR ${DIR}/daemon ${DIR}/client
 	cp -f rootCA.pem client/ca.pem
 	rm -f rootCA.pem rootCA-key.pem
 
-	kubectl create secret generic ${PRODUCT}-daemon-certs --dry-run -o yaml --from-file=./daemon >${PRODUCT}-daemon-certs.yaml
-	kubectl create secret generic ${PRODUCT}-client-certs --dry-run -o yaml --from-file=./client >${PRODUCT}-client-certs.yaml
+	kubectl create secret generic ${PRODUCT}-daemon-certs --dry-run=client -o yaml --from-file=./daemon >${PRODUCT}-daemon-certs.yaml
+	kubectl create secret generic ${PRODUCT}-client-certs --dry-run=client -o yaml --from-file=./client >${PRODUCT}-client-certs.yaml
 )


### PR DESCRIPTION
Add client value for --dry-run flag

```bash
$ ./create-certs.sh 127.0.0.1
W0118 15:45:11.833516   92593 helpers.go:663] --dry-run is deprecated and can be replaced with --dry-run=client.
W0118 15:45:11.869140   92594 helpers.go:663] --dry-run is deprecated and can be replaced with --dry-run=client.
```

Signed-off-by: George <george@betterde.com>