### PR TITLE
[Windows] Add get-user-info utility

### DIFF
--- a/cmd/buildkitd/main_windows.go
+++ b/cmd/buildkitd/main_windows.go
@@ -8,6 +8,7 @@ import (
 	"net"
 
 	_ "github.com/moby/buildkit/solver/llbsolver/ops"
+	_ "github.com/moby/buildkit/util/system/getuserinfo"
 	"github.com/pkg/errors"
 )
 

--- a/util/system/getuserinfo/userinfo_windows.go
+++ b/util/system/getuserinfo/userinfo_windows.go
@@ -4,7 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"syscall"
+
+	"golang.org/x/sys/windows"
 
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/reexec"
@@ -24,20 +25,16 @@ func userInfoMain() {
 		os.Exit(1)
 	}
 	username := os.Args[1]
-	sid, _, _, err := syscall.LookupSID("", username)
+	sid, _, _, err := windows.LookupSID("", username)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(3)
 	}
 
-	sidAsString, err := sid.String()
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(4)
-	}
 	ident := idtools.Identity{
-		SID: sidAsString,
+		SID: sid.String(),
 	}
+
 	asJson, err := json.Marshal(ident)
 	if err != nil {
 		fmt.Println(err)

--- a/util/system/getuserinfo/userinfo_windows.go
+++ b/util/system/getuserinfo/userinfo_windows.go
@@ -1,0 +1,47 @@
+package getuserinfo
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/docker/docker/pkg/idtools"
+	"github.com/docker/docker/pkg/reexec"
+)
+
+const (
+	getUserInfoCmd = "get-user-info"
+)
+
+func init() {
+	reexec.Register(getUserInfoCmd, userInfoMain)
+}
+
+func userInfoMain() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: get-user-info usernameOrGroup")
+		os.Exit(1)
+	}
+	username := os.Args[1]
+	sid, _, _, err := syscall.LookupSID("", username)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(3)
+	}
+
+	sidAsString, err := sid.String()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(4)
+	}
+	ident := idtools.Identity{
+		SID: sidAsString,
+	}
+	asJson, err := json.Marshal(ident)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(5)
+	}
+	fmt.Fprintf(os.Stdout, "%s", string(asJson))
+}


### PR DESCRIPTION
This utility allows us to mount the ```buildkitd``` executable inside a Windows container and fetch the SID of any existing user. This is to work around the fact that the SAM hive data structures are undocumented and there is no API to inspect an offline SAM hive to fetch the security info of an existing user.

We will use this utility when determining the SID of the user when we conduct ```FileOps``` and is part of a replacement for: https://github.com/moby/buildkit/pull/3248

Depends on: https://github.com/moby/moby/pull/44847

Signed-off-by: Gabriel Adrian Samfira <gsamfira@cloudbasesolutions.com>