### PR TITLE
ci: use moby/buildkit:latest in build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ on:
       - 'frontend/dockerfile/docs/**'
 
 env:
-  REPO_SLUG_ORIGIN: "moby/buildkit:v0.11.0-rc4"
+  REPO_SLUG_ORIGIN: "moby/buildkit:latest"
   REPO_SLUG_TARGET: "moby/buildkit"
   DF_REPO_SLUG_TARGET: "docker/dockerfile-upstream"
   PLATFORMS: "linux/amd64,linux/arm/v7,linux/arm64,linux/s390x,linux/ppc64le,linux/riscv64"


### PR DESCRIPTION
In https://github.com/moby/buildkit/pull/3345, we modified the buildkit repo to point to a specific experimental version of buildkit, so we could test attestation support.

Now that moby/buildkit:latest points to v0.11 which contains attestations, we can revert back to using the old tag.