### PR TITLE
Revert "chore: use double spaces when marshalling manifests/indexes"

### DIFF
--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -291,7 +291,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 		labels[fmt.Sprintf("containerd.io/gc.ref.content.%d", len(ps.Platforms)+i)] = mfst.Digest.String()
 	}
 
-	idxBytes, err := json.MarshalIndent(idx, "", "  ")
+	idxBytes, err := json.MarshalIndent(idx, "", "   ")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to marshal index")
 	}
@@ -416,7 +416,7 @@ func (ic *ImageWriter) commitDistributionManifest(ctx context.Context, opts *Ima
 		mfst.Layers = append(mfst.Layers, desc)
 	}
 
-	mfstJSON, err := json.MarshalIndent(mfst, "", "  ")
+	mfstJSON, err := json.MarshalIndent(mfst, "", "   ")
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to marshal manifest")
 	}
@@ -528,7 +528,7 @@ func (ic *ImageWriter) commitAttestationsManifest(ctx context.Context, opts *Ima
 		labels[fmt.Sprintf("containerd.io/gc.ref.content.%d", i+1)] = desc.Digest.String()
 	}
 
-	mfstJSON, err := json.MarshalIndent(mfst, "", "  ")
+	mfstJSON, err := json.MarshalIndent(mfst, "", "   ")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to marshal manifest")
 	}

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -6518,7 +6518,7 @@ FROM scratch
 COPY --from=0 / /
 `)
 
-	const expectedDigest = "sha256:9e36395384d073e711102b13bd0ba4b779ef6afbaf5cadeb77fe77dba8967d1f"
+	const expectedDigest = "sha256:a8e4b7d24b1777ba9dd258db7a6571c27e6883fc5b5f7b325a2d7786ef361365"
 
 	dir, err := integration.Tmpdir(
 		t,

--- a/util/imageutil/schema1.go
+++ b/util/imageutil/schema1.go
@@ -69,7 +69,7 @@ func convertSchema1ConfigMeta(in []byte) ([]byte, error) {
 		}
 	}
 
-	dt, err := json.MarshalIndent(img, "", "  ")
+	dt, err := json.MarshalIndent(img, "", "   ")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to marshal schema1 config")
 	}


### PR DESCRIPTION
This reverts commit b5f427aa077d84ab13879832a18e79ac9d99703d.

Ideally, we wouldn't need this - but apparently, docker manifest relies on a very specific indentation level: see https://github.com/docker/cli/pull/3990, for the docker manifest fix that would correct this.

However, because of release timings, we could probably attempt to revert the buildkit change, at least for 0.11 - by our next major release, users should be able to get the new docker manifest command.