### PR TITLE
cache/manager: make sure mutex is released on error

### DIFF
--- a/cache/manager.go
+++ b/cache/manager.go
@@ -1169,6 +1169,7 @@ func (cm *cacheManager) prune(ctx context.Context, ch chan client.UsageInfo, opt
 			cr.mu.Unlock()
 		}
 		if err != nil {
+			cm.mu.Unlock()
 			return err
 		}
 		toDelete = toDelete[:1]


### PR DESCRIPTION
This is something I ran into while reading the code for a different issue (I'm working on the bug report right now).

I'm gonna submit this as a draft PR and then work to add a test or something like that.