### PR TITLE
hack: do not cache some stages on release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -344,6 +344,7 @@ jobs:
         run: |
           ./hack/images "${{ needs.release-base.outputs.tag }}" "$REPO_SLUG_TARGET" "${{ needs.release-base.outputs.push }}"
         env:
+          RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
           TARGET: ${{ matrix.target-stage }}
           CACHE_FROM: type=gha,scope=${{ env.CACHE_GHA_SCOPE_CROSS }} type=gha,scope=image${{ matrix.target-stage }}
           CACHE_TO: type=gha,scope=image${{ matrix.target-stage }}
@@ -373,6 +374,7 @@ jobs:
         run: |
           ./hack/release-tar "${{ needs.release-base.outputs.tag }}" release-out
         env:
+          RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
           PLATFORMS: ${{ env.PLATFORMS }},darwin/amd64,darwin/arm64,windows/amd64,windows/arm64
           CACHE_FROM: type=gha,scope=${{ env.CACHE_GHA_SCOPE_BINARIES }} type=gha,scope=${{ env.CACHE_GHA_SCOPE_CROSS }}
       -
@@ -468,6 +470,7 @@ jobs:
         run: |
           ./frontend/dockerfile/cmd/dockerfile-frontend/hack/release "${{ needs.frontend-base.outputs.typ }}" "${{ matrix.tag }}" "$DF_REPO_SLUG_TARGET" "${{ needs.frontend-base.outputs.push }}"
         env:
+          RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
           PLATFORMS: ${{ env.PLATFORMS }},linux/386,linux/mips,linux/mipsle,linux/mips64,linux/mips64le
           CACHE_FROM: type=gha,scope=${{ env.CACHE_SCOPE }}
           CACHE_TO: type=gha,scope=${{ env.CACHE_SCOPE }}

--- a/frontend/dockerfile/cmd/dockerfile-frontend/hack/release
+++ b/frontend/dockerfile/cmd/dockerfile-frontend/hack/release
@@ -3,6 +3,7 @@
 . $(dirname $0)/../../../../../hack/util
 set -eu
 
+: "${RELEASE=false}"
 : "${PLATFORMS=}"
 : "${DAILY_TARGETS=}"
 
@@ -70,6 +71,11 @@ if [ "$PUSH" = "push" ]; then
   pushFlag="push=true"
 fi
 
+nocacheFilterFlag=""
+if [[ "$RELEASE" = "true" ]] && [[ "$GITHUB_ACTIONS" = "true" ]]; then
+  nocacheFilterFlag="--no-cache-filter=base"
+fi
+
 case $TYP in
 "master")
   tagf=./frontend/dockerfile/release/$TAG/tags
@@ -84,7 +90,7 @@ case $TYP in
     pushTag=${pushTag}-$TAG
   fi
 
-  buildxCmd build $platformFlag $cacheFromFlags $cacheToFlags $(buildAttestFlags) \
+  buildxCmd build $platformFlag $cacheFromFlags $cacheToFlags $nocacheFilterFlag $(buildAttestFlags) \
     --build-arg "CHANNEL=$TAG" \
     --build-arg "BUILDTAGS=$buildTags" \
     --output "type=image,name=$REPO:$pushTag,buildinfo-attrs=true,$pushFlag" \
@@ -101,7 +107,7 @@ case $TYP in
   fi
   buildTags=$(cat $tagf)
 
-  buildxCmd build $platformFlag $cacheFromFlags $cacheToFlags $(buildAttestFlags) \
+  buildxCmd build $platformFlag $cacheFromFlags $cacheToFlags $nocacheFilterFlag $(buildAttestFlags) \
     --build-arg "CHANNEL=$TAG" \
     --build-arg "BUILDTAGS=$buildTags" \
     --output "type=image,\"name=$publishedNames\",buildinfo-attrs=true,$pushFlag" \
@@ -127,7 +133,7 @@ case $TYP in
 
     tmp=$(mktemp -d -t buildid.XXXXXXXXXX)
     dt=$(date +%Y%m%d)
-    buildxCmd build $platformFlag $cacheFromFlags $cacheToFlags \
+    buildxCmd build $platformFlag $cacheFromFlags $cacheToFlags $nocacheFilterFlag \
       --target "buildid" \
       --build-arg "CHANNEL=$TAG" \
       --build-arg "BUILDTAGS=$buildTags" \
@@ -141,7 +147,7 @@ case $TYP in
       buildid=$(cat $tmp/buildid)
       echo "buildid: $buildid"
 
-      buildxCmd build $platformFlag $cacheFromFlags $cacheToFlags $(buildAttestFlags) \
+      buildxCmd build $platformFlag $cacheFromFlags $cacheToFlags $nocacheFilterFlag $(buildAttestFlags) \
         --build-arg "CHANNEL=$TAG" \
         --build-arg "BUILDTAGS=$buildTags" \
         --output "type=image,name=$REPO:$dt-$TAG,buildinfo-attrs=true,$pushFlag" \

--- a/hack/images
+++ b/hack/images
@@ -7,6 +7,7 @@ PUSH=$3
 . $(dirname $0)/util
 set -eu -o pipefail
 
+: ${RELEASE=false}
 : ${PLATFORMS=}
 : ${TARGET=}
 
@@ -91,5 +92,10 @@ for tagName in $tagNames; do
   tagFlags="$tagFlags--tag=$tagName "
 done
 
-buildxCmd build $platformFlag $targetFlag $importCacheFlags $exportCacheFlags $tagFlags $outputFlag $attestFlags \
+nocacheFilterFlag=""
+if [[ "$RELEASE" = "true" ]] && [[ "$GITHUB_ACTIONS" = "true" ]]; then
+  nocacheFilterFlag="--no-cache-filter=git,buildkit-export,gobuild-base"
+fi
+
+buildxCmd build $platformFlag $targetFlag $importCacheFlags $exportCacheFlags $tagFlags $outputFlag $nocacheFilterFlag $attestFlags \
   $currentcontext

--- a/hack/release-tar
+++ b/hack/release-tar
@@ -6,6 +6,7 @@ OUT=$2
 . $(dirname $0)/util
 set -eu -o pipefail
 
+: ${RELEASE=false}
 : ${PLATFORMS=}
 
 usage() {
@@ -22,9 +23,14 @@ if [ -n "$PLATFORMS" ]; then
   platformFlag="--platform=$PLATFORMS"
 fi
 
+nocacheFilterFlag=""
+if [[ "$RELEASE" = "true" ]] && [[ "$GITHUB_ACTIONS" = "true" ]]; then
+  nocacheFilterFlag="--no-cache-filter=git,gobuild-base"
+fi
+
 output=$(mktemp -d -t buildkit-output.XXXXXXXXXX)
 
-buildxCmd build $platformFlag $cacheFromFlags $(buildAttestFlags) \
+buildxCmd build $platformFlag $cacheFromFlags $nocacheFilterFlag $(buildAttestFlags) \
   --build-arg "BUILDKIT_MULTI_PLATFORM=true" \
   --target release \
   --output "type=local,dest=$output" \


### PR DESCRIPTION
fixes #3542 

Disables cache on release for some stages so packages are always installed and up to date.