### PR TITLE
[Windows] Fix tracing listener

### DIFF
--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -630,7 +630,7 @@ func newController(c *cli.Context, cfg *config.Config) (*control.Controller, err
 
 	var traceSocket string
 	if tc != nil {
-		traceSocket = filepath.Join(cfg.Root, "otel-grpc.sock")
+		traceSocket = traceSocketPath(cfg.Root)
 		if err := runTraceController(traceSocket, tc); err != nil {
 			return nil, err
 		}
@@ -813,14 +813,9 @@ func parseBoolOrAuto(s string) (*bool, error) {
 func runTraceController(p string, exp sdktrace.SpanExporter) error {
 	server := grpc.NewServer()
 	tracev1.RegisterTraceServiceServer(server, &traceCollector{exporter: exp})
-	uid := os.Getuid()
-	l, err := sys.GetLocalListener(p, uid, uid)
+	l, err := getLocalListener(p)
 	if err != nil {
-		return err
-	}
-	if err := os.Chmod(p, 0666); err != nil {
-		l.Close()
-		return err
+		return errors.Wrap(err, "creating trace controller listener")
 	}
 	go server.Serve(l)
 	return nil

--- a/cmd/buildkitd/main_windows.go
+++ b/cmd/buildkitd/main_windows.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	defaultTraceSocketPath = `\\.\pipe\otel-grpc`
+	defaultTraceSocketPath = `\\.\pipe\buildkit-otel-grpc`
 )
 
 func listenFD(addr string, tlsConfig *tls.Config) (net.Listener, error) {

--- a/cmd/buildkitd/main_windows.go
+++ b/cmd/buildkitd/main_windows.go
@@ -7,10 +7,36 @@ import (
 	"crypto/tls"
 	"net"
 
+	"github.com/Microsoft/go-winio"
 	_ "github.com/moby/buildkit/solver/llbsolver/ops"
 	"github.com/pkg/errors"
 )
 
+const (
+	defaultTraceSocketPath = `\\.\pipe\otel-grpc`
+)
+
 func listenFD(addr string, tlsConfig *tls.Config) (net.Listener, error) {
 	return nil, errors.New("listening server on fd not supported on windows")
+}
+
+func traceSocketPath(root string) string {
+	return defaultTraceSocketPath
+}
+
+func getLocalListener(listenerPath string) (net.Listener, error) {
+	pc := &winio.PipeConfig{
+		// Allow generic read and generic write access to authenticated users
+		// and system users. On Linux, this pipe seems to be given rw access to
+		// user, group and others (666).
+		// TODO(gabriel-samfira): should we restrict access to this pipe to just
+		// authenticated users? Or Administrators group?
+		SecurityDescriptor: "D:P(A;;GRGW;;;AU)(A;;GRGW;;;SY)",
+	}
+
+	listener, err := winio.ListenPipe(listenerPath, pc)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating listener")
+	}
+	return listener, nil
 }

--- a/executor/oci/spec.go
+++ b/executor/oci/spec.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -112,7 +113,7 @@ func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mou
 
 	if tracingSocket != "" {
 		// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md
-		meta.Env = append(meta.Env, "OTEL_TRACES_EXPORTER=otlp", "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=unix:///dev/otel-grpc.sock", "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc")
+		meta.Env = append(meta.Env, tracingEnvVars...)
 		meta.Env = append(meta.Env, traceexec.Environ(ctx)...)
 	}
 
@@ -183,12 +184,20 @@ func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mou
 	}
 
 	if tracingSocket != "" {
-		s.Mounts = append(s.Mounts, specs.Mount{
-			Destination: "/dev/otel-grpc.sock",
-			Type:        "bind",
-			Source:      tracingSocket,
-			Options:     []string{"ro", "rbind"},
-		})
+		if runtime.GOOS == "windows" {
+			s.Mounts = append(s.Mounts, specs.Mount{
+				Destination: `\\.\pipe\otel-grpc`,
+				Source:      tracingSocket,
+				Options:     []string{"ro"},
+			})
+		} else {
+			s.Mounts = append(s.Mounts, specs.Mount{
+				Destination: "/dev/otel-grpc.sock",
+				Type:        "bind",
+				Source:      tracingSocket,
+				Options:     []string{"ro", "rbind"},
+			})
+		}
 	}
 
 	s.Mounts = dedupMounts(s.Mounts)

--- a/executor/oci/spec_unix.go
+++ b/executor/oci/spec_unix.go
@@ -21,6 +21,12 @@ import (
 	"github.com/pkg/errors"
 )
 
+var tracingEnvVars = []string{
+	"OTEL_TRACES_EXPORTER=otlp",
+	"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=unix:///dev/otel-grpc.sock",
+	"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc",
+}
+
 func generateMountOpts(resolvConf, hostsFile string) ([]oci.SpecOpts, error) {
 	return []oci.SpecOpts{
 		// https://github.com/moby/buildkit/issues/429

--- a/executor/oci/spec_unix.go
+++ b/executor/oci/spec_unix.go
@@ -21,11 +21,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-var tracingEnvVars = []string{
-	"OTEL_TRACES_EXPORTER=otlp",
-	"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=unix:///dev/otel-grpc.sock",
-	"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc",
-}
+const (
+	tracingSocketPath = "/dev/otel-grpc.sock"
+)
 
 func generateMountOpts(resolvConf, hostsFile string) ([]oci.SpecOpts, error) {
 	return []oci.SpecOpts{
@@ -127,4 +125,17 @@ func withDefaultProfile() oci.SpecOpts {
 		s.Linux.Seccomp, err = seccomp.GetDefaultProfile(s)
 		return err
 	}
+}
+
+func getTracingSocketMount(socket string) specs.Mount {
+	return specs.Mount{
+		Destination: tracingSocketPath,
+		Type:        "bind",
+		Source:      socket,
+		Options:     []string{"ro", "rbind"},
+	}
+}
+
+func getTracingSocket() string {
+	return fmt.Sprintf("unix://%s", tracingSocketPath)
 }

--- a/executor/oci/spec_windows.go
+++ b/executor/oci/spec_windows.go
@@ -4,17 +4,19 @@
 package oci
 
 import (
+	"fmt"
+	"path/filepath"
+
 	"github.com/containerd/containerd/oci"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/moby/buildkit/solver/pb"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 )
 
-var tracingEnvVars = []string{
-	"OTEL_TRACES_EXPORTER=otlp",
-	"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=npipe:////./pipe/otel-grpc",
-	"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc",
-}
+const (
+	tracingSocketPath = "//./pipe/otel-grpc"
+)
 
 func generateMountOpts(resolvConf, hostsFile string) ([]oci.SpecOpts, error) {
 	return nil, nil
@@ -48,4 +50,16 @@ func generateRlimitOpts(ulimits []*pb.Ulimit) ([]oci.SpecOpts, error) {
 		return nil, nil
 	}
 	return nil, errors.New("no support for POSIXRlimit on Windows")
+}
+
+func getTracingSocketMount(socket string) specs.Mount {
+	return specs.Mount{
+		Destination: filepath.FromSlash(tracingSocketPath),
+		Source:      socket,
+		Options:     []string{"ro"},
+	}
+}
+
+func getTracingSocket() string {
+	return fmt.Sprintf("npipe://%s", filepath.ToSlash(tracingSocketPath))
 }

--- a/executor/oci/spec_windows.go
+++ b/executor/oci/spec_windows.go
@@ -10,6 +10,12 @@ import (
 	"github.com/pkg/errors"
 )
 
+var tracingEnvVars = []string{
+	"OTEL_TRACES_EXPORTER=otlp",
+	"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=npipe:////./pipe/otel-grpc",
+	"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc",
+}
+
 func generateMountOpts(resolvConf, hostsFile string) ([]oci.SpecOpts, error) {
 	return nil, nil
 }


### PR DESCRIPTION
  * The tracing socket is a named pipe on Windows
  * Sets proper permissions on the named pipe
  * Sets proper environment variables inside the executor
  * Defines proper mount for the tracing socket

Signed-off-by: Gabriel Adrian Samfira <gsamfira@cloudbasesolutions.com>