### PR TITLE
Allow ARGs in COPY --from and RUN --mount=from

### DIFF
--- a/frontend/dockerfile/instructions/commands_runmount.go
+++ b/frontend/dockerfile/instructions/commands_runmount.go
@@ -2,7 +2,6 @@ package instructions
 
 import (
 	"encoding/csv"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -169,17 +168,17 @@ func parseMount(val string, expander SingleWordExpander) (*Mount, error) {
 			}
 		}
 
+		// never expand from now - defer evaluation to when we create the dispatchState
+		if key == "from" {
+			m.From = value
+			continue
+		}
+
 		// check for potential variable
 		if expander != nil {
 			value, err = expander(value)
 			if err != nil {
 				return nil, err
-			}
-		} else if key == "from" {
-			if matched, err := regexp.MatchString(`\$.`, value); err != nil { //nolint
-				return nil, err
-			} else if matched {
-				return nil, errors.Errorf("'%s' doesn't support variable expansion, define alias stage instead", key)
 			}
 		} else {
 			// if we don't have an expander, defer evaluation to later
@@ -193,8 +192,6 @@ func parseMount(val string, expander SingleWordExpander) (*Mount, error) {
 				return nil, suggest.WrapError(errors.Errorf("unsupported mount type %q", value), value, allMountTypes(), true)
 			}
 			m.Type = v
-		case "from":
-			m.From = value
 		case "source", "src":
 			m.Source = value
 		case "target", "dst", "destination":


### PR DESCRIPTION
:hammer_and_wrench: Fixes #2717 (https://github.com/moby/buildkit/issues/2412 is also relevant)

Previously, using ARGs in COPY --from or RUN --mounts from was not supported, requiring using an extra intermediate stage.  This patch allows global args to be used directly in these locations.

To do this, we need to resolve a dependency issue:
- We need to construct all the dispatchStates before evaluating.
- To construct the dispatchStates, we need to determine the fully-evaluated base LLB source.
- However, to fully-evaluate the base name using the Expand interface, we need to have constructed all the dispatchStates.

It is theoretically possible to refactor to not have this restriction, however, this is not required to implement the base functionality for global args.

To resolve this, we can use just the global args to evaluate the FROM fields using the toCommand helper, where the stage resolution occurs today.

At some point, it should be possible to implement local arg resolution as well here - however, this requires a change from the current approach of creating an intermediate dispatchState for those components.

@tonistiigi does this seem like a reasonable approach for a first pass?