### PR TITLE
progress: keep color enabled with NO_COLOR empty

### DIFF
--- a/util/progress/progressui/init.go
+++ b/util/progress/progressui/init.go
@@ -14,7 +14,7 @@ var colorError aec.ANSI
 
 func init() {
 	// As recommended on https://no-color.org/
-	if _, ok := os.LookupEnv("NO_COLOR"); ok {
+	if v := os.Getenv("NO_COLOR"); v != "" {
 		// nil values will result in no ANSI color codes being emitted.
 		return
 	} else if runtime.GOOS == "windows" {


### PR DESCRIPTION
:bug: Fixes https://github.com/moby/buildkit/issues/3537

The NO_COLOR specification says that color should be disabled if NO_COLOR is set *and not empty*.

cc @spkane (author of the original NO_COLOR PR in https://github.com/moby/buildkit/pull/2954)