### PR TITLE
SOURCE_DATE_EPOCH: drop timezone

### DIFF
--- a/exporter/util/epoch/parse.go
+++ b/exporter/util/epoch/parse.go
@@ -60,6 +60,6 @@ func parseTime(key, value string) (*time.Time, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "invalid %s: %s", key, err)
 	}
-	tm := time.Unix(sde, 0)
+	tm := time.Unix(sde, 0).UTC()
 	return &tm, nil
 }

--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -1131,6 +1131,6 @@ func parseSourceDateEpoch(v string) (*time.Time, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "invalid SOURCE_DATE_EPOCH: %s", v)
 	}
-	tm := time.Unix(sde, 0)
+	tm := time.Unix(sde, 0).UTC()
 	return &tm, nil
 }


### PR DESCRIPTION
The timezone information is not exposed to the uint64 representation, but exposed to RFC3339 representation.

This was making the image config non-reproducible depending on the host timezone
