### PR TITLE
cache: don’t link blobonly based on chainid

### DIFF
--- a/cache/manager.go
+++ b/cache/manager.go
@@ -222,10 +222,8 @@ func (cm *cacheManager) GetByBlob(ctx context.Context, desc ocispecs.Descriptor,
 
 	id := identity.NewID()
 	snapshotID := chainID.String()
-	blobOnly := true
 	if link != nil {
 		snapshotID = link.getSnapshotID()
-		blobOnly = link.getBlobOnly()
 		go link.Release(context.TODO())
 	}
 
@@ -289,7 +287,7 @@ func (cm *cacheManager) GetByBlob(ctx context.Context, desc ocispecs.Descriptor,
 	rec.queueChainID(chainID)
 	rec.queueBlobChainID(blobChainID)
 	rec.queueSnapshotID(snapshotID)
-	rec.queueBlobOnly(blobOnly)
+	rec.queueBlobOnly(true)
 	rec.queueMediaType(desc.MediaType)
 	rec.queueBlobSize(desc.Size)
 	rec.appendURLs(desc.URLs)


### PR DESCRIPTION
Debugging https://github.com/moby/buildkit/issues/2631 and trying to understand how #3447 might fix this I found this case where we link to another snapshot that has the same chainID(uncompressed digest) but different blobID(compressed digest). In that case, we can mark the blob as `!blobOnly` while the ref is actually lazy. That does not look correct.

This case should be quite hard to hit, but maybe there are some layers with very common files that could make it more likely. @ohmer is testing if this is enough to fix the issue they are seeing.

Looking at @imeoer patch https://github.com/moby/buildkit/pull/3447 again it doesn't look very scary, so if this patch doesn't fully fix this, we could pick that as well, but I'm worried that we don't understand the actual issue, then and it will return in some other form.

PTAL @imeoer @sipsma 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>