### PR TITLE
[0.11 backport] integration: fix compat check for CNI DNS test 

### DIFF
--- a/client/build_test.go
+++ b/client/build_test.go
@@ -1991,7 +1991,6 @@ func testClientGatewayContainerSignal(t *testing.T, sb integration.Sandbox) {
 }
 
 func testClientGatewayNilResult(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, "hangs: https://github.com/moby/buildkit/pull/3176#issuecomment-1323954327")
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -309,7 +309,7 @@ func testBridgeNetworking(t *testing.T, sb integration.Sandbox) {
 }
 
 func testBridgeNetworkingDNSNoRootless(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, "hangs: https://github.com/moby/buildkit/issues/3171")
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCNINetwork)
 	if os.Getenv("BUILDKIT_RUN_NETWORK_INTEGRATION_TESTS") == "" {
 		t.SkipNow()
 	}

--- a/util/testutil/integration/dockerd.go
+++ b/util/testutil/integration/dockerd.go
@@ -33,6 +33,7 @@ func InitDockerdWorker() {
 			FeatureProvenance,
 			FeatureSBOM,
 			FeatureSecurityMode,
+			FeatureCNINetwork,
 		},
 	})
 	Register(&moby{
@@ -40,6 +41,7 @@ func InitDockerdWorker() {
 		rootless: false,
 		unsupported: []string{
 			FeatureSecurityMode,
+			FeatureCNINetwork,
 		},
 	})
 }

--- a/util/testutil/integration/sandbox.go
+++ b/util/testutil/integration/sandbox.go
@@ -281,6 +281,7 @@ const (
 	FeatureSBOM             = "sbom"
 	FeatureSecurityMode     = "security mode"
 	FeatureSourceDateEpoch  = "source date epoch"
+	FeatureCNINetwork       = "cni network"
 )
 
 var features = map[string]struct{}{
@@ -299,6 +300,7 @@ var features = map[string]struct{}{
 	FeatureSBOM:             {},
 	FeatureSecurityMode:     {},
 	FeatureSourceDateEpoch:  {},
+	FeatureCNINetwork:       {},
 }
 
 func CheckFeatureCompat(t *testing.T, sb Sandbox, reason ...string) {


### PR DESCRIPTION
- backports https://github.com/moby/buildkit/pull/3567
- relates to https://github.com/moby/moby/pull/44686#discussion_r1094414342