### PR TITLE
Skip configuring cache exporter if it is nil.

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -368,6 +368,10 @@ func (c *Controller) Solve(ctx context.Context, req *controlapi.SolveRequest) (*
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to configure %v cache exporter", e.Type)
 		}
+		if exp.Exporter == nil {
+			bklog.G(ctx).Debugf("cache exporter resolver for %v returned nil, skipping exporter", e.Type)
+			continue
+		}
 		if exportMode, supported := parseCacheExportMode(e.Attrs["mode"]); !supported {
 			bklog.G(ctx).Debugf("skipping invalid cache export mode: %s", e.Attrs["mode"])
 		} else {


### PR DESCRIPTION
Signed-off-by: Erik Sipsma <erik@sipsma.dev>

Context: in Dagger we're experimenting w/ a custom cache exporter/importer implementation that would be configured entirely server-side (as opposed to remote cache configuration today which is specified by clients).

To start with, the idea is to just have clients always specify this custom cache exporter in their solve requests and then the implementation server-side can decide whether+how to actually do the caching.

We thankfully can do this w/out forking buildkit by just creating our own main func to replace buildkitd's and plug in our custom implementation [here](https://github.com/sipsma/buildkit/blob/6ca5ee16821881fd6267ee95a0c4f5b88c664f1d/cmd/buildkitd/main.go#L668-L668).

The only problem is that we sometimes want to skip cache export entirely. I started w/ returning a no-op implementation of the exporter, which works except for the fact that all the layers are still prepared for export, which can be an expensive operation that is wasted in this case.

The fix here allows the cache exporter resolver to return nil, in which case it's just skipped entirely. That lets our exporter implementation decide to disable cache export and layer preparation based on its settings.

Obviously we're gonna need a lot more upstream changes to get all this working but this change seems harmless by itself and will save us from having to hard fork the buildkit code for a while as we flesh out the rest of it.