### PR TITLE
[0.11 backport] integration: set mirrors and entitlements with dockerd worker 

### DIFF
--- a/.github/workflows/dockerd.yml
+++ b/.github/workflows/dockerd.yml
@@ -61,21 +61,21 @@ jobs:
         if: steps.build.outputs.result == 'true'
         run: |
           if [ -L "/tmp/moby/binary-daemon/dockerd" ]; then
-            mv -f $(readlink /tmp/moby/binary-daemon/dockerd) /tmp/moby/binary-daemon/dockerd
+            mv -f $(readlink /tmp/moby/binary-daemon/dockerd) /tmp/moby/dockerd
           fi
       -
         name: Download
         if: steps.build.outputs.result != 'true'
         run: |
-          mkdir -p /tmp/moby/binary-daemon
-          cd /tmp/moby/binary-daemon
+          mkdir -p /tmp/moby
+          cd /tmp/moby
           wget -qO- "https://download.docker.com/linux/static/stable/x86_64/docker-${{ env.DOCKER_VERSION }}.tgz" | tar xvz --strip 1
       -
         name: Upload dockerd
         uses: actions/upload-artifact@v3
         with:
           name: dockerd
-          path: /tmp/moby/binary-daemon/dockerd
+          path: /tmp/moby/dockerd
           if-no-files-found: error
 
   test:

--- a/util/testutil/dockerd/config.go
+++ b/util/testutil/dockerd/config.go
@@ -1,0 +1,16 @@
+package dockerd
+
+type Config struct {
+	Features map[string]bool `json:"features,omitempty"`
+	Mirrors  []string        `json:"registry-mirrors,omitempty"`
+	Builder  BuilderConfig   `json:"builder,omitempty"`
+}
+
+type BuilderEntitlements struct {
+	NetworkHost      bool `json:"network-host,omitempty"`
+	SecurityInsecure bool `json:"security-insecure,omitempty"`
+}
+
+type BuilderConfig struct {
+	Entitlements BuilderEntitlements `json:",omitempty"`
+}

--- a/util/testutil/integration/dockerd.go
+++ b/util/testutil/integration/dockerd.go
@@ -3,7 +3,7 @@ package integration
 import (
 	"bytes"
 	"context"
-	"fmt"
+	"encoding/json"
 	"io"
 	"net"
 	"os"
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/client"
+	"github.com/moby/buildkit/cmd/buildkitd/config"
 	"github.com/moby/buildkit/util/testutil/dockerd"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
@@ -65,6 +66,37 @@ func (c moby) New(ctx context.Context, cfg *BackendConfig) (b Backend, cl func()
 		return nil, nil, err
 	}
 
+	bkcfg, err := config.LoadFile(cfg.ConfigFile)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "failed to load buildkit config file %s", cfg.ConfigFile)
+	}
+
+	dcfg := dockerd.Config{
+		Features: map[string]bool{
+			"containerd-snapshotter": c.name == "dockerd-containerd",
+		},
+	}
+	if reg, ok := bkcfg.Registries["docker.io"]; ok && len(reg.Mirrors) > 0 {
+		for _, m := range reg.Mirrors {
+			dcfg.Mirrors = append(dcfg.Mirrors, "http://"+m)
+		}
+	}
+	if bkcfg.Entitlements != nil {
+		for _, e := range bkcfg.Entitlements {
+			switch e {
+			case "network.host":
+				dcfg.Builder.Entitlements.NetworkHost = true
+			case "security.insecure":
+				dcfg.Builder.Entitlements.SecurityInsecure = true
+			}
+		}
+	}
+
+	dcfgdt, err := json.Marshal(dcfg)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "failed to marshal dockerd config")
+	}
+
 	deferF := &multiCloser{}
 	cl = deferF.F()
 
@@ -88,14 +120,8 @@ func (c moby) New(ctx context.Context, cfg *BackendConfig) (b Backend, cl func()
 		return nil, nil, errors.Errorf("new daemon error: %q, %s", err, formatLogs(cfg.Logs))
 	}
 
-	dockerdConfig := fmt.Sprintf(`{
-  "features": {
-    "containerd-snapshotter": %v
-  }
-}`, c.name == "dockerd-containerd")
-
 	dockerdConfigFile := filepath.Join(workDir, "daemon.json")
-	if err := os.WriteFile(dockerdConfigFile, []byte(dockerdConfig), 0644); err != nil {
+	if err := os.WriteFile(dockerdConfigFile, dcfgdt, 0644); err != nil {
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
- backport of https://github.com/moby/buildkit/pull/3482
- relates to https://github.com/moby/moby/pull/44916#issuecomment-1416646298
- follow-up https://github.com/moby/moby/pull/44772#issuecomment-1376216194
- Also update dockerd workflow following changes on moby: https://github.com/moby/moby/pull/44546
