### PR TITLE
buildctl: Provide --wait option

### DIFF
--- a/cmd/buildctl/main.go
+++ b/cmd/buildctl/main.go
@@ -87,6 +87,10 @@ func main() {
 			Usage: "timeout backend connection after value seconds",
 			Value: 5,
 		},
+		cli.BoolFlag{
+			Name:  "wait",
+			Usage: "block RPCs until the connection becomes available",
+		},
 	}
 
 	app.Commands = []cli.Command{

--- a/docs/reference/buildctl.md
+++ b/docs/reference/buildctl.md
@@ -30,6 +30,7 @@ GLOBAL OPTIONS:
    --tlskey value         client key
    --tlsdir value         directory containing CA certificate, client certificate, and client key
    --timeout value        timeout backend connection after value seconds (default: 5)
+   --wait                 block RPCs until the connection becomes available
    --help, -h             show help
    --version, -v          print the version
 ```


### PR DESCRIPTION
Provide a `WaitForReady` client method that performs a preflight request and specifies `grpc.WaitForReady(true)` to ensure that the `grpc.ClientConn` has established the underlying connection and that it can be considered available.

Performing this request prior to solves makes the client more robust in environments where the server is behind a proxy or part of a service mesh (e.g. Istio/Envoy). In these environments, connections may be prematurely closed prior to any client requests due to circuit breaking on max connections.

For the moment, this incurs a redundant request to `ListWorkers` which seemed to be the more backwards compatible request to make as a preflight; `Info` is not available in older versions. If buildkitd ever implements the `grpc.health.v1.Health` directly on its server endpoint, a `grpc.health.v1.Health/Check` may make more sense.

Signed-off-by: Dan Duvall <dduvall@wikimedia.org>