### PR TITLE
resolver: Isolate auth token cache per session

### DIFF
--- a/util/resolver/pool.go
+++ b/util/resolver/pool.go
@@ -15,9 +15,11 @@ import (
 	distreference "github.com/distribution/reference"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver/pb"
+	log "github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/version"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // DefaultPool is the default shared resolver pool instance
@@ -82,15 +84,27 @@ func (p *Pool) GetResolver(hosts docker.RegistryHosts, ref, scope string, sm *se
 		name = named.Name()
 	}
 
-	key := fmt.Sprintf("%s::%s", name, scope)
+	// Index the authHandlerNS cache by session id(s) as well to prevent tokens
+	// from leaking between client sessions. The key will end up looking
+	// something like 'wujskoey891qc5cv1edd3yj3p::repository:foo/bar::pull,push'
+	key := fmt.Sprintf("%s::%s::%s", strings.Join(session.AllSessionIDs(g), ":"), name, scope)
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	h, ok := p.m[key]
+
 	if !ok {
 		h = newAuthHandlerNS(sm)
 		p.m[key] = h
 	}
+
+	log.G(context.TODO()).WithFields(logrus.Fields{
+		"name":   name,
+		"scope":  scope,
+		"key":    key,
+		"cached": ok,
+	}).Debugf("checked for cached auth handler namespace")
+
 	return newResolver(hosts, h, sm, g)
 }
 


### PR DESCRIPTION
Prior to this change, entries in the resolver's auth token cache was keyed only by remote name and action (push/pull). This resulted in remote authenticated sessions being leaked between distinct client sessions with the potential for one client's token to be used in authentication for another client's registry access.

While this may not have had a substantial impact for pull requests as the solver vertices are shared for all clients as is the local cache namespace—i.e. one client can always receive a cache entry that was the result of another client's cached pull request—the shared auth cache also allowed one client to push to a remote registry for a ref it may not have otherwise had rights to. This behavior is particularly problematic in shared CI environments where auth token scopes are used to limit push access by registry namespace.

Key each entry in the auth token cache by `<session id>:<ref>:<action>` to avoid cross use between distinct client sessions.

Signed-off-by: Dan Duvall <dduvall@wikimedia.org>