### PR TITLE
[v0.10] cache: add fallback for snapshotID

### DIFF
--- a/cache/metadata.go
+++ b/cache/metadata.go
@@ -251,7 +251,11 @@ func (md *cacheMetadata) queueMediaType(str string) error {
 }
 
 func (md *cacheMetadata) getSnapshotID() string {
-	return md.GetString(keySnapshot)
+	sid := md.GetString(keySnapshot)
+	if sid == "" {
+		return md.ID()
+	}
+	return sid
 }
 
 func (md *cacheMetadata) queueSnapshotID(str string) error {


### PR DESCRIPTION
fix for moby/moby#44943

In older BuildKit versions, snapshotID was not always set if the record was not created with GetByBlob method. Old code defaulted to cache record ID in that case, but that broke with the metadata interface refactor.

Regression for this fallback is in:
before: https://github.com/moby/buildkit/commit/a9f1980ebbe85053232f8c512e9a906e5d568aa9#diff-e4a99c1c50054f36891bbe03da3784b5d2d4ca6b279ff32c7999d3ac5db48dc7L81

<img width="614" alt="image" src="https://user-images.githubusercontent.com/585223/217408865-14928771-b7ec-4e0c-aeb2-f6f222c5007b.png">


after: https://github.com/moby/buildkit/commit/a9f1980ebbe85053232f8c512e9a906e5d568aa9#diff-e4a99c1c50054f36891bbe03da3784b5d2d4ca6b279ff32c7999d3ac5db48dc7R250

<img width="513" alt="image" src="https://user-images.githubusercontent.com/585223/217408974-8df9699a-ba71-45f1-81d9-2ce708b97e9e.png">


It doesn't appear in current versions (at least) because `snapshotID` is explicitly set in `finalize/commit` https://github.com/moby/buildkit/commit/a9f1980ebbe85053232f8c512e9a906e5d568aa9#diff-94cb4012b7ea73b110c7ac219d52793e11b96d9141c3ad631603f34a7fc9289aR917

finalize:
<img width="754" alt="image" src="https://user-images.githubusercontent.com/585223/217409835-f9cd5e80-4b69-40fa-8bfa-59d76e218b3d.png">


commit:
<img width="879" alt="image" src="https://user-images.githubusercontent.com/585223/217409148-c3d1f012-3a09-4435-835d-7968ca3e97be.png">


@neersighted @thaJeztah @sipsma 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>