### PR TITLE
git context: fix support for empty git ref with subdir

### DIFF
--- a/source/gitidentifier_test.go
+++ b/source/gitidentifier_test.go
@@ -7,27 +7,43 @@ import (
 )
 
 func TestNewGitIdentifier(t *testing.T) {
-	gi, err := NewGitIdentifier("ssh://root@subdomain.example.hostname:2222/root/my/really/weird/path/foo.git")
-	require.Nil(t, err)
-	require.Equal(t, "ssh://root@subdomain.example.hostname:2222/root/my/really/weird/path/foo.git", gi.Remote)
-	require.Equal(t, "", gi.Ref)
-	require.Equal(t, "", gi.Subdir)
-
-	gi, err = NewGitIdentifier("ssh://root@subdomain.example.hostname:2222/root/my/really/weird/path/foo.git#main")
-	require.Nil(t, err)
-	require.Equal(t, "ssh://root@subdomain.example.hostname:2222/root/my/really/weird/path/foo.git", gi.Remote)
-	require.Equal(t, "main", gi.Ref)
-	require.Equal(t, "", gi.Subdir)
-
-	gi, err = NewGitIdentifier("git@github.com:moby/buildkit.git")
-	require.Nil(t, err)
-	require.Equal(t, "git@github.com:moby/buildkit.git", gi.Remote)
-	require.Equal(t, "", gi.Ref)
-	require.Equal(t, "", gi.Subdir)
-
-	gi, err = NewGitIdentifier("github.com/moby/buildkit.git#main")
-	require.Nil(t, err)
-	require.Equal(t, "https://github.com/moby/buildkit.git", gi.Remote)
-	require.Equal(t, "main", gi.Ref)
-	require.Equal(t, "", gi.Subdir)
+	tests := []struct {
+		url      string
+		expected GitIdentifier
+	}{
+		{
+			url: "ssh://root@subdomain.example.hostname:2222/root/my/really/weird/path/foo.git",
+			expected: GitIdentifier{
+				Remote: "ssh://root@subdomain.example.hostname:2222/root/my/really/weird/path/foo.git",
+			},
+		},
+		{
+			url: "ssh://root@subdomain.example.hostname:2222/root/my/really/weird/path/foo.git#main",
+			expected: GitIdentifier{
+				Remote: "ssh://root@subdomain.example.hostname:2222/root/my/really/weird/path/foo.git",
+				Ref:    "main",
+			},
+		},
+		{
+			url: "git@github.com:moby/buildkit.git",
+			expected: GitIdentifier{
+				Remote: "git@github.com:moby/buildkit.git",
+			},
+		},
+		{
+			url: "github.com/moby/buildkit.git#main",
+			expected: GitIdentifier{
+				Remote: "https://github.com/moby/buildkit.git",
+				Ref:    "main",
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.url, func(t *testing.T) {
+			gi, err := NewGitIdentifier(tt.url)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, *gi)
+		})
+	}
 }

--- a/source/gitidentifier_test.go
+++ b/source/gitidentifier_test.go
@@ -37,6 +37,77 @@ func TestNewGitIdentifier(t *testing.T) {
 				Ref:    "main",
 			},
 		},
+		{
+			url: "git://github.com/user/repo.git",
+			expected: GitIdentifier{
+				Remote: "git://github.com/user/repo.git",
+			},
+		},
+		{
+			url: "git://github.com/user/repo.git#mybranch:mydir/mysubdir/",
+			expected: GitIdentifier{
+				Remote: "git://github.com/user/repo.git",
+				Ref:    "mybranch",
+				Subdir: "mydir/mysubdir/",
+			},
+		},
+		{
+			url: "git://github.com/user/repo.git#:mydir/mysubdir/",
+			expected: GitIdentifier{
+				Remote: "git://github.com/user/repo.git",
+				Subdir: "mydir/mysubdir/",
+			},
+		},
+		{
+			url: "https://github.com/user/repo.git",
+			expected: GitIdentifier{
+				Remote: "https://github.com/user/repo.git",
+			},
+		},
+		{
+			url: "https://github.com/user/repo.git#mybranch:mydir/mysubdir/",
+			expected: GitIdentifier{
+				Remote: "https://github.com/user/repo.git",
+				Ref:    "mybranch",
+				Subdir: "mydir/mysubdir/",
+			},
+		},
+		{
+			url: "git@github.com:user/repo.git",
+			expected: GitIdentifier{
+				Remote: "git@github.com:user/repo.git",
+			},
+		},
+		{
+			url: "git@github.com:user/repo.git#mybranch:mydir/mysubdir/",
+			expected: GitIdentifier{
+				Remote: "git@github.com:user/repo.git",
+				Ref:    "mybranch",
+				Subdir: "mydir/mysubdir/",
+			},
+		},
+		{
+			url: "ssh://github.com/user/repo.git",
+			expected: GitIdentifier{
+				Remote: "ssh://github.com/user/repo.git",
+			},
+		},
+		{
+			url: "ssh://github.com/user/repo.git#mybranch:mydir/mysubdir/",
+			expected: GitIdentifier{
+				Remote: "ssh://github.com/user/repo.git",
+				Ref:    "mybranch",
+				Subdir: "mydir/mysubdir/",
+			},
+		},
+		{
+			url: "ssh://foo%40barcorp.com@github.com/user/repo.git#mybranch:mydir/mysubdir/",
+			expected: GitIdentifier{
+				Remote: "ssh://foo%40barcorp.com@github.com/user/repo.git",
+				Ref:    "mybranch",
+				Subdir: "mydir/mysubdir/",
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/util/gitutil/git_ref.go
+++ b/util/gitutil/git_ref.go
@@ -73,22 +73,12 @@ func ParseGitRef(ref string) (*GitRef, error) {
 		}
 	}
 
-	refSplitBySharp := strings.SplitN(ref, "#", 2)
-	res.Remote = refSplitBySharp[0]
+	var fragment string
+	res.Remote, fragment, _ = strings.Cut(ref, "#")
 	if len(res.Remote) == 0 {
 		return res, errdefs.ErrInvalidArgument
 	}
-
-	if len(refSplitBySharp) > 1 {
-		refSplitBySharpSplitByColon := strings.SplitN(refSplitBySharp[1], ":", 2)
-		res.Commit = refSplitBySharpSplitByColon[0]
-		if len(res.Commit) == 0 {
-			return res, errdefs.ErrInvalidArgument
-		}
-		if len(refSplitBySharpSplitByColon) > 1 {
-			res.SubDir = refSplitBySharpSplitByColon[1]
-		}
-	}
+	res.Commit, res.SubDir, _ = strings.Cut(fragment, ":")
 	repoSplitBySlash := strings.Split(res.Remote, "/")
 	res.ShortName = strings.TrimSuffix(repoSplitBySlash[len(repoSplitBySlash)-1], ".git")
 	return res, nil

--- a/util/gitutil/git_ref_test.go
+++ b/util/gitutil/git_ref_test.go
@@ -6,72 +6,127 @@ import (
 )
 
 func TestParseGitRef(t *testing.T) {
-	cases := map[string]*GitRef{
-		"https://example.com/":    nil,
-		"https://example.com/foo": nil,
-		"https://example.com/foo.git": {
-			Remote:    "https://example.com/foo.git",
-			ShortName: "foo",
+	cases := []struct {
+		ref      string
+		expected *GitRef
+	}{
+		{
+			ref:      "https://example.com/",
+			expected: nil,
 		},
-		"https://example.com/foo.git#deadbeef": {
-			Remote:    "https://example.com/foo.git",
-			ShortName: "foo",
-			Commit:    "deadbeef",
+		{
+			ref:      "https://example.com/foo",
+			expected: nil,
 		},
-		"https://example.com/foo.git#release/1.2": {
-			Remote:    "https://example.com/foo.git",
-			ShortName: "foo",
-			Commit:    "release/1.2",
+		{
+			ref: "https://example.com/foo.git",
+			expected: &GitRef{
+				Remote:    "https://example.com/foo.git",
+				ShortName: "foo",
+			},
 		},
-		"https://example.com/foo.git/":    nil,
-		"https://example.com/foo.git.bar": nil,
-		"git://example.com/foo": {
-			Remote:         "git://example.com/foo",
-			ShortName:      "foo",
-			UnencryptedTCP: true,
+		{
+			ref: "https://example.com/foo.git#deadbeef",
+			expected: &GitRef{
+				Remote:    "https://example.com/foo.git",
+				ShortName: "foo",
+				Commit:    "deadbeef",
+			},
 		},
-		"github.com/moby/buildkit": {
-			Remote: "github.com/moby/buildkit", ShortName: "buildkit",
-			IndistinguishableFromLocal: true,
+		{
+			ref: "https://example.com/foo.git#release/1.2",
+			expected: &GitRef{
+				Remote:    "https://example.com/foo.git",
+				ShortName: "foo",
+				Commit:    "release/1.2",
+			},
 		},
-		"https://github.com/moby/buildkit": nil,
-		"https://github.com/moby/buildkit.git": {
-			Remote:    "https://github.com/moby/buildkit.git",
-			ShortName: "buildkit",
+		{
+			ref:      "https://example.com/foo.git/",
+			expected: nil,
 		},
-		"git@github.com:moby/buildkit": {
-			Remote:    "git@github.com:moby/buildkit",
-			ShortName: "buildkit",
+		{
+			ref:      "https://example.com/foo.git.bar",
+			expected: nil,
 		},
-		"git@github.com:moby/buildkit.git": {
-			Remote:    "git@github.com:moby/buildkit.git",
-			ShortName: "buildkit",
+		{
+			ref: "git://example.com/foo",
+			expected: &GitRef{
+				Remote:         "git://example.com/foo",
+				ShortName:      "foo",
+				UnencryptedTCP: true,
+			},
 		},
-		"git@bitbucket.org:atlassianlabs/atlassian-docker.git": {
-			Remote:    "git@bitbucket.org:atlassianlabs/atlassian-docker.git",
-			ShortName: "atlassian-docker",
+		{
+			ref: "github.com/moby/buildkit",
+			expected: &GitRef{
+				Remote:                     "github.com/moby/buildkit",
+				ShortName:                  "buildkit",
+				IndistinguishableFromLocal: true,
+			},
 		},
-		"https://github.com/foo/bar.git#baz/qux:quux/quuz": {
-			Remote:    "https://github.com/foo/bar.git",
-			ShortName: "bar",
-			Commit:    "baz/qux",
-			SubDir:    "quux/quuz",
+		{
+			ref:      "https://github.com/moby/buildkit",
+			expected: nil,
 		},
-		"http://github.com/docker/docker.git:#branch": nil,
+		{
+			ref: "https://github.com/moby/buildkit.git",
+			expected: &GitRef{
+				Remote:    "https://github.com/moby/buildkit.git",
+				ShortName: "buildkit",
+			},
+		},
+		{
+			ref: "git@github.com:moby/buildkit",
+			expected: &GitRef{
+				Remote:    "git@github.com:moby/buildkit",
+				ShortName: "buildkit",
+			},
+		},
+		{
+			ref: "git@github.com:moby/buildkit.git",
+			expected: &GitRef{
+				Remote:    "git@github.com:moby/buildkit.git",
+				ShortName: "buildkit",
+			},
+		},
+		{
+			ref: "git@bitbucket.org:atlassianlabs/atlassian-docker.git",
+			expected: &GitRef{
+				Remote:    "git@bitbucket.org:atlassianlabs/atlassian-docker.git",
+				ShortName: "atlassian-docker",
+			},
+		},
+		{
+			ref: "https://github.com/foo/bar.git#baz/qux:quux/quuz",
+			expected: &GitRef{
+				Remote:    "https://github.com/foo/bar.git",
+				ShortName: "bar",
+				Commit:    "baz/qux",
+				SubDir:    "quux/quuz",
+			},
+		},
+		{
+			ref:      "http://github.com/docker/docker.git:#branch",
+			expected: nil,
+		},
 	}
-	for ref, expected := range cases {
-		got, err := ParseGitRef(ref)
-		if expected == nil {
-			if err == nil {
-				t.Errorf("expected an error for ParseGitRef(%q)", ref)
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.ref, func(t *testing.T) {
+			got, err := ParseGitRef(tt.ref)
+			if tt.expected == nil {
+				if err == nil {
+					t.Errorf("expected an error for ParseGitRef(%q)", tt.ref)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("got an unexpected error: ParseGitRef(%q): %v", tt.ref, err)
+				}
+				if !reflect.DeepEqual(got, tt.expected) {
+					t.Errorf("expected ParseGitRef(%q) to return %#v, got %#v", tt.ref, tt.expected, got)
+				}
 			}
-		} else {
-			if err != nil {
-				t.Errorf("got an unexpected error: ParseGitRef(%q): %v", ref, err)
-			}
-			if !reflect.DeepEqual(got, expected) {
-				t.Errorf("expected ParseGitRef(%q) to return %#v, got %#v", ref, expected, got)
-			}
-		}
+		})
 	}
 }

--- a/util/gitutil/git_ref_test.go
+++ b/util/gitutil/git_ref_test.go
@@ -110,6 +110,14 @@ func TestParseGitRef(t *testing.T) {
 			ref:      "http://github.com/docker/docker.git:#branch",
 			expected: nil,
 		},
+		{
+			ref: "https://github.com/docker/docker.git#:myfolder",
+			expected: &GitRef{
+				Remote:    "https://github.com/docker/docker.git",
+				ShortName: "docker",
+				SubDir:    "myfolder",
+			},
+		},
 	}
 	for _, tt := range cases {
 		tt := tt


### PR DESCRIPTION
fixes https://github.com/docker/buildx/issues/1604

Git context detection in the frontend https://github.com/moby/buildkit/blob/ecc5937ca6d3e20b402331e2520df25c9b73e3ed/frontend/dockerfile/builder/build.go#L700-L703

does not match `myrepo.git#:myfolder` but should be supported.

Also adds more test cases to be sure we don't miss anything else.

Looking at our docs in https://docs.docker.com/build/building/context/#git-repositories 

![image](https://user-images.githubusercontent.com/1951866/217518189-29d6a9c8-99fe-4e74-b6ba-1d831991dd8e.png)

@dvdksn "Commit Used" for `myrepo.git` and `myrepo.git#:myfolder` should be instead `default branch` imo.

I also wonder if we should mutualize the logic from https://github.com/moby/buildkit/blob/ecc5937ca6d3e20b402331e2520df25c9b73e3ed/source/gitidentifier.go#L23-L54 with https://github.com/moby/buildkit/blob/ecc5937ca6d3e20b402331e2520df25c9b73e3ed/util/gitutil/git_ref.go#L51-L95