### PR TITLE
hack: do not set attest flags when exporting to docker

### DIFF
--- a/hack/images
+++ b/hack/images
@@ -39,12 +39,15 @@ if [[ "$TAG" == "local" ]]; then
   fi
 fi
 
+attestFlags="$(buildAttestFlags)"
+
 outputFlag="--output=type=image,push=false"
 if [ "$PUSH" = "push" ]; then
   outputFlag="--output=type=image,buildinfo-attrs=true,push=true"
 fi
 if [ -n "$localmode" ]; then
   outputFlag="--output=type=docker,buildinfo-attrs=true"
+  attestFlags=""
 fi
 
 targetFlag=""
@@ -88,5 +91,5 @@ for tagName in $tagNames; do
   tagFlags="$tagFlags--tag=$tagName "
 done
 
-buildxCmd build $platformFlag $targetFlag $importCacheFlags $exportCacheFlags $tagFlags $outputFlag $(buildAttestFlags) \
+buildxCmd build $platformFlag $targetFlag $importCacheFlags $exportCacheFlags $tagFlags $outputFlag $attestFlags \
   $currentcontext


### PR DESCRIPTION
Attestation flags should not be set when loading image to docker otherwise:

```
$ ./hack/images local moby/buildkit
+ BUILDX_NO_DEFAULT_LOAD=true
+ BUILDX_BUILDER=
+ docker buildx build --tag=moby/buildkit:local --output=type=docker,buildinfo-attrs=true --attest=type=sbom --attest=type=provenance,mode=max .
ERROR: docker exporter does not currently support exporting manifest lists
```

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>