### PR TITLE
cache: add fallback for snapshotID

### DIFF
--- a/cache/metadata.go
+++ b/cache/metadata.go
@@ -251,7 +251,13 @@ func (md *cacheMetadata) queueMediaType(str string) error {
 }
 
 func (md *cacheMetadata) getSnapshotID() string {
-	return md.GetString(keySnapshot)
+	sid := md.GetString(keySnapshot)
+	// Note that historic buildkit releases did not always set the snapshot ID.
+	// Fallback to record ID is needed for old build cache compatibility.
+	if sid == "" {
+		return md.ID()
+	}
+	return sid
 }
 
 func (md *cacheMetadata) queueSnapshotID(str string) error {


### PR DESCRIPTION
same as #3595

In older BuildKit versions snapshotID was not always set if record was not created with GetByBlob method. Old code defaulted to cache record ID in that case but that broke with the metadata interface refactor.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>