### PR TITLE
remotecache: small enhancements

### DIFF
--- a/cache/remotecache/azblob/exporter.go
+++ b/cache/remotecache/azblob/exporter.go
@@ -54,7 +54,7 @@ type exporter struct {
 }
 
 func (ce *exporter) Name() string {
-	return "exporting cache to azure blob store"
+	return "exporting cache to Azure Blob Storage"
 }
 
 func (ce *exporter) Finalize(ctx context.Context) (map[string]string, error) {

--- a/cache/remotecache/gha/gha.go
+++ b/cache/remotecache/gha/gha.go
@@ -91,7 +91,7 @@ func NewExporter(c *Config) (remotecache.Exporter, error) {
 }
 
 func (*exporter) Name() string {
-	return "exporting to GitHub cache"
+	return "exporting to GitHub Actions Cache"
 }
 
 func (ce *exporter) Config() remotecache.Config {

--- a/cache/remotecache/local/local.go
+++ b/cache/remotecache/local/local.go
@@ -23,6 +23,14 @@ const (
 	contentStoreIDPrefix = "local:"
 )
 
+type exporter struct {
+	remotecache.Exporter
+}
+
+func (*exporter) Name() string {
+	return "exporting cache to client directory"
+}
+
 // ResolveCacheExporterFunc for "local" cache exporter.
 func ResolveCacheExporterFunc(sm *session.Manager) remotecache.ResolveCacheExporterFunc {
 	return func(ctx context.Context, g session.Group, attrs map[string]string) (remotecache.Exporter, error) {
@@ -47,7 +55,7 @@ func ResolveCacheExporterFunc(sm *session.Manager) remotecache.ResolveCacheExpor
 		if err != nil {
 			return nil, err
 		}
-		return remotecache.NewExporter(cs, "", ociMediatypes, compressionConfig), nil
+		return &exporter{remotecache.NewExporter(cs, "", ociMediatypes, compressionConfig)}, nil
 	}
 }
 

--- a/cache/remotecache/local/local.go
+++ b/cache/remotecache/local/local.go
@@ -21,9 +21,6 @@ const (
 	attrDest             = "dest"
 	attrOCIMediatypes    = "oci-mediatypes"
 	contentStoreIDPrefix = "local:"
-	attrLayerCompression = "compression"
-	attrForceCompression = "force-compression"
-	attrCompressionLevel = "compression-level"
 )
 
 // ResolveCacheExporterFunc for "local" cache exporter.
@@ -33,7 +30,7 @@ func ResolveCacheExporterFunc(sm *session.Manager) remotecache.ResolveCacheExpor
 		if store == "" {
 			return nil, errors.New("local cache exporter requires dest")
 		}
-		compressionConfig, err := attrsToCompression(attrs)
+		compressionConfig, err := compression.ParseAttributes(attrs)
 		if err != nil {
 			return nil, err
 		}
@@ -50,7 +47,7 @@ func ResolveCacheExporterFunc(sm *session.Manager) remotecache.ResolveCacheExpor
 		if err != nil {
 			return nil, err
 		}
-		return remotecache.NewExporter(cs, "", ociMediatypes, *compressionConfig), nil
+		return remotecache.NewExporter(cs, "", ociMediatypes, compressionConfig), nil
 	}
 }
 
@@ -108,39 +105,4 @@ type unlazyProvider struct {
 
 func (p *unlazyProvider) UnlazySession(desc ocispecs.Descriptor) session.Group {
 	return p.s
-}
-
-func attrsToCompression(attrs map[string]string) (*compression.Config, error) {
-	var compressionType compression.Type
-	if v, ok := attrs[attrLayerCompression]; ok {
-		c, err := compression.Parse(v)
-		if err != nil {
-			return nil, err
-		}
-		compressionType = c
-	} else {
-		compressionType = compression.Default
-	}
-	compressionConfig := compression.New(compressionType)
-	if v, ok := attrs[attrForceCompression]; ok {
-		var force bool
-		if v == "" {
-			force = true
-		} else {
-			b, err := strconv.ParseBool(v)
-			if err != nil {
-				return nil, errors.Wrapf(err, "non-bool value %s specified for %s", v, attrForceCompression)
-			}
-			force = b
-		}
-		compressionConfig = compressionConfig.SetForce(force)
-	}
-	if v, ok := attrs[attrCompressionLevel]; ok {
-		ii, err := strconv.ParseInt(v, 10, 64)
-		if err != nil {
-			return nil, errors.Wrapf(err, "non-integer value %s specified for %s", v, attrCompressionLevel)
-		}
-		compressionConfig = compressionConfig.SetLevel(int(ii))
-	}
-	return &compressionConfig, nil
 }

--- a/cache/remotecache/registry/registry.go
+++ b/cache/remotecache/registry/registry.go
@@ -40,6 +40,14 @@ const (
 	attrInsecure      = "registry.insecure"
 )
 
+type exporter struct {
+	remotecache.Exporter
+}
+
+func (*exporter) Name() string {
+	return "exporting cache to registry"
+}
+
 func ResolveCacheExporterFunc(sm *session.Manager, hosts docker.RegistryHosts) remotecache.ResolveCacheExporterFunc {
 	return func(ctx context.Context, g session.Group, attrs map[string]string) (remotecache.Exporter, error) {
 		compressionConfig, err := compression.ParseAttributes(attrs)
@@ -74,7 +82,7 @@ func ResolveCacheExporterFunc(sm *session.Manager, hosts docker.RegistryHosts) r
 		if err != nil {
 			return nil, err
 		}
-		return remotecache.NewExporter(contentutil.FromPusher(pusher), refString, ociMediatypes, compressionConfig), nil
+		return &exporter{remotecache.NewExporter(contentutil.FromPusher(pusher), refString, ociMediatypes, compressionConfig)}, nil
 	}
 }
 

--- a/cache/remotecache/registry/registry.go
+++ b/cache/remotecache/registry/registry.go
@@ -35,17 +35,14 @@ func canonicalizeRef(rawRef string) (reference.Named, error) {
 }
 
 const (
-	attrRef              = "ref"
-	attrOCIMediatypes    = "oci-mediatypes"
-	attrLayerCompression = "compression"
-	attrForceCompression = "force-compression"
-	attrCompressionLevel = "compression-level"
-	attrInsecure         = "registry.insecure"
+	attrRef           = "ref"
+	attrOCIMediatypes = "oci-mediatypes"
+	attrInsecure      = "registry.insecure"
 )
 
 func ResolveCacheExporterFunc(sm *session.Manager, hosts docker.RegistryHosts) remotecache.ResolveCacheExporterFunc {
 	return func(ctx context.Context, g session.Group, attrs map[string]string) (remotecache.Exporter, error) {
-		compressionConfig, err := attrsToCompression(attrs)
+		compressionConfig, err := compression.ParseAttributes(attrs)
 		if err != nil {
 			return nil, err
 		}
@@ -77,7 +74,7 @@ func ResolveCacheExporterFunc(sm *session.Manager, hosts docker.RegistryHosts) r
 		if err != nil {
 			return nil, err
 		}
-		return remotecache.NewExporter(contentutil.FromPusher(pusher), refString, ociMediatypes, *compressionConfig), nil
+		return remotecache.NewExporter(contentutil.FromPusher(pusher), refString, ociMediatypes, compressionConfig), nil
 	}
 }
 
@@ -153,41 +150,6 @@ func (dsl *withDistributionSourceLabel) SnapshotLabels(descs []ocispecs.Descript
 		labels[k] = v
 	}
 	return labels
-}
-
-func attrsToCompression(attrs map[string]string) (*compression.Config, error) {
-	var compressionType compression.Type
-	if v, ok := attrs[attrLayerCompression]; ok {
-		c, err := compression.Parse(v)
-		if err != nil {
-			return nil, err
-		}
-		compressionType = c
-	} else {
-		compressionType = compression.Default
-	}
-	compressionConfig := compression.New(compressionType)
-	if v, ok := attrs[attrForceCompression]; ok {
-		var force bool
-		if v == "" {
-			force = true
-		} else {
-			b, err := strconv.ParseBool(v)
-			if err != nil {
-				return nil, errors.Wrapf(err, "non-bool value %s specified for %s", v, attrForceCompression)
-			}
-			force = b
-		}
-		compressionConfig = compressionConfig.SetForce(force)
-	}
-	if v, ok := attrs[attrCompressionLevel]; ok {
-		ii, err := strconv.ParseInt(v, 10, 64)
-		if err != nil {
-			return nil, errors.Wrapf(err, "non-integer value %s specified for %s", v, attrCompressionLevel)
-		}
-		compressionConfig = compressionConfig.SetLevel(int(ii))
-	}
-	return &compressionConfig, nil
 }
 
 func registryConfig(hosts docker.RegistryHosts, ref reference.Named, scope string, insecure bool) (string, docker.RegistryHosts) {

--- a/cache/remotecache/s3/s3.go
+++ b/cache/remotecache/s3/s3.go
@@ -162,7 +162,7 @@ type exporter struct {
 }
 
 func (*exporter) Name() string {
-	return "exporting cache to s3"
+	return "exporting cache to Amazon S3"
 }
 
 func (e *exporter) Config() remotecache.Config {

--- a/exporter/containerimage/opts.go
+++ b/exporter/containerimage/opts.go
@@ -13,9 +13,6 @@ import (
 
 const (
 	keyImageName               = "name"
-	keyLayerCompression        = "compression"
-	keyCompressionLevel        = "compression-level"
-	keyForceCompression        = "force-compression"
 	keyOCITypes                = "oci-mediatypes"
 	keyBuildInfo               = "buildinfo"
 	keyBuildInfoAttrs          = "buildinfo-attrs"
@@ -53,23 +50,15 @@ func (c *ImageCommitOpts) Load(opt map[string]string) (map[string]string, error)
 		return nil, err
 	}
 
+	if c.RefCfg.Compression, err = compression.ParseAttributes(opt); err != nil {
+		return nil, err
+	}
+
 	for k, v := range opt {
 		var err error
 		switch k {
 		case keyImageName:
 			c.ImageName = v
-		case keyLayerCompression:
-			c.RefCfg.Compression.Type, err = compression.Parse(v)
-		case keyCompressionLevel:
-			ii, err2 := strconv.ParseInt(v, 10, 64)
-			if err != nil {
-				err = errors.Wrapf(err2, "non-int value %s specified for %s", v, k)
-				break
-			}
-			v := int(ii)
-			c.RefCfg.Compression.Level = &v
-		case keyForceCompression:
-			err = parseBoolWithDefault(&c.RefCfg.Compression.Force, k, v, true)
 		case keyOCITypes:
 			err = parseBoolWithDefault(&c.OCITypes, k, v, true)
 		case keyBuildInfo:

--- a/util/compression/attrs.go
+++ b/util/compression/attrs.go
@@ -1,0 +1,48 @@
+package compression
+
+import (
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	attrLayerCompression = "compression"
+	attrForceCompression = "force-compression"
+	attrCompressionLevel = "compression-level"
+)
+
+func ParseAttributes(attrs map[string]string) (Config, error) {
+	var compressionType Type
+	if v, ok := attrs[attrLayerCompression]; ok {
+		c, err := Parse(v)
+		if err != nil {
+			return Config{}, err
+		}
+		compressionType = c
+	} else {
+		compressionType = Default
+	}
+	compressionConfig := New(compressionType)
+	if v, ok := attrs[attrForceCompression]; ok {
+		var force bool
+		if v == "" {
+			force = true
+		} else {
+			b, err := strconv.ParseBool(v)
+			if err != nil {
+				return Config{}, errors.Wrapf(err, "non-bool value %s specified for %s", v, attrForceCompression)
+			}
+			force = b
+		}
+		compressionConfig = compressionConfig.SetForce(force)
+	}
+	if v, ok := attrs[attrCompressionLevel]; ok {
+		ii, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return Config{}, errors.Wrapf(err, "non-integer value %s specified for %s", v, attrCompressionLevel)
+		}
+		compressionConfig = compressionConfig.SetLevel(int(ii))
+	}
+	return compressionConfig, nil
+}


### PR DESCRIPTION
First two commits move attributes parsing for compression in its own package so we can remove dedup ones in remotecache and exporter packages. This could then be used for other remote caches if we want to implement compression (cc @bpaquet).

Also set explicit names for registry and local cache exporters as well.

Last commit sets more appropriate names for gha, s3 and azblob remote caches (cc @bpaquet @vangarp).