### PR TITLE
Proposal: set custom config media type on attestation manifests

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -7501,13 +7501,11 @@ func testExportAttestations(t *testing.T, sb integration.Sandbox) {
 		require.Equal(t, len(ps), len(atts.Images))
 		for i, att := range atts.Images {
 			require.Equal(t, ocispecs.MediaTypeImageManifest, att.Desc.MediaType)
+			require.Empty(t, att.Img)
 			require.Equal(t, "unknown/unknown", platforms.Format(*att.Desc.Platform))
-			require.Equal(t, "unknown/unknown", att.Img.OS+"/"+att.Img.Architecture)
 			require.Equal(t, attestation.DockerAnnotationReferenceTypeDefault, att.Desc.Annotations[attestation.DockerAnnotationReferenceType])
 			require.Equal(t, bases[i].Desc.Digest.String(), att.Desc.Annotations[attestation.DockerAnnotationReferenceDigest])
 			require.Equal(t, 2, len(att.Layers))
-			require.Equal(t, len(att.Layers), len(att.Img.RootFS.DiffIDs))
-			require.Equal(t, len(att.Img.History), 0)
 
 			var attest intoto.Statement
 			require.NoError(t, json.Unmarshal(att.LayersRaw[0], &attest))

--- a/docs/attestations/attestation-storage.md
+++ b/docs/attestations/attestation-storage.md
@@ -19,17 +19,19 @@ style to OCI artifacts.
 Attestation manifests are attached to the root image index object, under a
 separate [OCI image manifest](https://github.com/opencontainers/image-spec/blob/main/manifest.md).
 Each attestation manifest can contain multiple [attestation blobs](#attestation-blob),
-with all the of the attestations in a manifest applying to a single platform
+with all of the attestations in a manifest applying to a single platform
 manifest. All properties of standard OCI and Docker manifests continue to
 apply.
 
-The image `config` descriptor will point to a valid [image config](https://github.com/opencontainers/image-spec/blob/main/config.md),
-however, it will not contain attestation-specific details, and should be
-ignored as it is only included for compatibility purposes.
+The image `config` descriptor should point to a config object with a media type
+of `application/vnd.docker.attestation.config.v1+json`. For now, only an empty
+JSON object is included, however, in the future, additional content may be
+allowed - implementations should ignore fields that they do not recognize if
+they choose to parse the config.
 
 Each image layer in `layers` will contain a descriptor for a single
 [attestation blob](#attestation-blob). The `mediaType` of each layer will be
-set in accordance to its contents, one of:
+set in accordance with its contents, one of:
 
 - `application/vnd.in-toto+json` (currently, the only supported option)
 

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -212,7 +212,7 @@ func (s *Solver) recordBuildHistory(ctx context.Context, id string, req frontend
 			if err != nil {
 				return nil, nil, err
 			}
-			w, err := s.history.OpenBlobWriter(ctx, attestation.MediaTypeDockerSchema2AttestationType)
+			w, err := s.history.OpenBlobWriter(ctx, attestation.MediaTypeAttestationLayer)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/util/attestation/types.go
+++ b/util/attestation/types.go
@@ -1,7 +1,8 @@
 package attestation
 
 const (
-	MediaTypeDockerSchema2AttestationType = "application/vnd.in-toto+json"
+	MediaTypeAttestationLayer     = "application/vnd.in-toto+json"
+	MediaTypeOCIAttestationConfig = "application/vnd.docker.attestation.config.v1+json"
 
 	DockerAnnotationReferenceType        = "vnd.docker.reference.type"
 	DockerAnnotationReferenceDigest      = "vnd.docker.reference.digest"

--- a/util/imageutil/config.go
+++ b/util/imageutil/config.go
@@ -174,7 +174,7 @@ func childrenConfigHandler(provider content.Provider, platform platforms.MatchCo
 				descs = append(descs, index.Manifests...)
 			}
 		case images.MediaTypeDockerSchema2Config, ocispecs.MediaTypeImageConfig, docker.LegacyConfigMediaType,
-			attestation.MediaTypeDockerSchema2AttestationType:
+			attestation.MediaTypeAttestationLayer, attestation.MediaTypeOCIAttestationConfig:
 			// childless data types.
 			return nil, nil
 		default:

--- a/util/push/push.go
+++ b/util/push/push.go
@@ -250,7 +250,7 @@ func childrenHandler(provider content.Provider) images.HandlerFunc {
 		case images.MediaTypeDockerSchema2Layer, images.MediaTypeDockerSchema2LayerGzip,
 			images.MediaTypeDockerSchema2Config, ocispecs.MediaTypeImageConfig,
 			ocispecs.MediaTypeImageLayer, ocispecs.MediaTypeImageLayerGzip,
-			attestation.MediaTypeDockerSchema2AttestationType:
+			attestation.MediaTypeAttestationLayer, attestation.MediaTypeOCIAttestationConfig:
 			// childless data types.
 			return nil, nil
 		default:


### PR DESCRIPTION
This patch sets the media type for attestation manifests to `application/vnd.docker.attestation.config.v1+json` instead of faking a `application/vnd.oci.image.config.v1+json` type.

This updates the attestation manifests inline with the OCI artifact type defined at https://github.com/opencontainers/artifacts. Aside from just making us inline with the spec here, we would hopefully be able to see better integrations in registries that just handle config media types and don't inspect the custom buildkit attestations.

Additionally, this makes it *firmly* impossible for runtimes to accidentally download and run the attestation manifest, treating it as an image manifest.