### PR TITLE
gha: avoid range requests with too big offset

### DIFF
--- a/cache/remotecache/gha/gha.go
+++ b/cache/remotecache/gha/gha.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"sync"
 	"time"
@@ -369,6 +370,13 @@ func (p *ciProvider) ReaderAt(ctx context.Context, desc ocispecs.Descriptor) (co
 type readerAt struct {
 	actionscache.ReaderAtCloser
 	desc ocispecs.Descriptor
+}
+
+func (r *readerAt) ReadAt(p []byte, off int64) (int, error) {
+	if off >= r.desc.Size {
+		return 0, io.EOF
+	}
+	return r.ReaderAtCloser.ReadAt(p, off)
 }
 
 func (r *readerAt) Size() int64 {


### PR DESCRIPTION
Saw this error in CI

```
ERROR: failed to solve: failed to compute cache key: failed to copy: invalid status response 416 The range specified is invalid for the current size of the resource. for https://ki6cacprodeus1file5.blob.core.windows.net/2ff2ce0399e5464697755b110c91788d/d7eb6ee20e7bed11ac20501ac56bd055?sv=2019-07-07&sr=b&sig=9HSdAre3Gb4Ze9oOBRtnlFxRSkqAWnf5dueVJ3DPwhY%3D&se=2023-02-11T01%3A34%3A32Z&sp=r&rscl=x-e2eid-19509829-00204bd7-8d7f39b2-ab93df7f, range: bytes=20588289-
```

This has been reported before as well but can't find a tracking issue atm. This is the same issue https://github.com/tonistiigi/go-actions-cache/pull/14 debug was added.

I confirmed that it was coming because of the `offset == size`. There might be some containerd bug that causes this read and that usually goes unnoticed because it just results in one extra query and not an error. I haven't figured out what condition triggers this but it might have something to do with parallel pulls of the same blob.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>