### PR TITLE
set osversion in index descriptor from base image

### DIFF
--- a/frontend/dockerui/build.go
+++ b/frontend/dockerui/build.go
@@ -50,6 +50,17 @@ func (bc *Client) Build(ctx context.Context, fn BuildFunc) (*ResultBuilder, erro
 			if tp != nil {
 				p = *tp
 			}
+
+			// in certain conditions we allow input platform to be extended from base image
+			if p.OS == "windows" && img.OS == p.OS {
+				if p.OSVersion == "" && img.OSVersion != "" {
+					p.OSVersion = img.OSVersion
+				}
+				if p.OSFeatures == nil && len(img.OSFeatures) > 0 {
+					p.OSFeatures = img.OSFeatures
+				}
+			}
+
 			p = platforms.Normalize(p)
 			k := platforms.Format(p)
 


### PR DESCRIPTION
As pointed out by @cpuguy83 , when cross-compiling windows images, the manifest descriptors do not contain `OSVersion` that is used on windows. There is currently no way to pass `OSVersion` as containerd has not defined the `os/arch/variant` serialization for that field, but if base image used by the build has `OSVersion` defined we can just use that one. In image config `OSVersion` was already set before by the base image.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>