### PR TITLE
integration: make sure registry directory exists

### DIFF
--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -320,6 +320,9 @@ func runMirror(t *testing.T, mirroredImages map[string]string) (host string, _ f
 
 	var lock *flock.Flock
 	if mirrorDir != "" {
+		if err := os.MkdirAll(mirrorDir, 0700); err != nil {
+			return "", nil, err
+		}
 		lock = flock.New(filepath.Join(mirrorDir, "lock"))
 		if err := lock.Lock(); err != nil {
 			return "", nil, err


### PR DESCRIPTION
When running tests with `hack/shell` currently registry mirror directory needs to be created manually each time as it is inside a newly created volume.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>