### PR TITLE
dockerfile: fix reproducible digest test for non-amd64

### DIFF
--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -230,7 +230,10 @@ func TestIntegration(t *testing.T) {
 
 	integration.Run(t, reproTests, append(opts,
 		// Only use the amd64 digest,  regardless to the host platform
-		integration.WithMirroredImages(integration.OfficialImages("debian:bullseye-20230109-slim@sha256:1acb06a0c31fb467eb8327ad361f1091ab265e0bf26d452dea45dcb0c0ea5e75")))...)
+		integration.WithMirroredImages(map[string]string{
+			"amd64/bullseye-20230109-slim": "docker.io/amd64/debian:bullseye-20230109-slim@sha256:1acb06a0c31fb467eb8327ad361f1091ab265e0bf26d452dea45dcb0c0ea5e75",
+		}),
+	)...)
 }
 
 func testDefaultEnvWithArgs(t *testing.T, sb integration.Sandbox) {
@@ -6526,17 +6529,13 @@ func testReproSourceDateEpoch(t *testing.T, sb integration.Sandbox) {
 	if sb.Snapshotter() == "native" {
 		t.Skip("the digest is not reproducible with the \"native\" snapshotter because hardlinks are processed in a different way: https://github.com/moby/buildkit/pull/3456#discussion_r1062650263")
 	}
-	if runtime.GOARCH != "amd64" {
-		t.Skip("FIXME: the image cannot be pulled on non-amd64 (`docker.io/arm64v8/debian:bullseye-20230109-slim@...: not found`): https://github.com/moby/buildkit/pull/3456#discussion_r1068989918")
-	}
-
 	f := getFrontend(t, sb)
 
 	tm := time.Date(2023, time.January, 10, 12, 34, 56, 0, time.UTC)
 	t.Logf("SOURCE_DATE_EPOCH=%d", tm.Unix())
 
 	dockerfile := []byte(`# The base image cannot be busybox, due to https://github.com/moby/buildkit/issues/3455
-FROM --platform=linux/amd64 debian:bullseye-20230109-slim@sha256:1acb06a0c31fb467eb8327ad361f1091ab265e0bf26d452dea45dcb0c0ea5e75
+FROM amd64/debian:bullseye-20230109-slim
 RUN touch /foo
 RUN touch /foo.1
 RUN touch -d '2010-01-01 12:34:56' /foo-2010

--- a/util/testutil/integration/pins.go
+++ b/util/testutil/integration/pins.go
@@ -12,9 +12,4 @@ var pins = map[string]map[string]string{
 		"arm64v8": "sha256:af06af3514c44a964d3b905b498cf6493db8f1cde7c10e078213a89c87308ba0",
 		"library": "sha256:8914eb54f968791faf6a8638949e480fef81e697984fba772b3976835194c6d4",
 	},
-	"debian:bullseye-20230109-slim": {
-		"amd64":   "sha256:1acb06a0c31fb467eb8327ad361f1091ab265e0bf26d452dea45dcb0c0ea5e75",
-		"arm64v8": "sha256:7816383f71131e55256c17d42fd77bd80f3c1c98948ebf449fe56eb6580f4c4c",
-		"library": "sha256:98d3b4b0cee264301eb1354e0b549323af2d0633e1c43375d0b25c01826b6790",
-	},
 }


### PR DESCRIPTION
Fix the test so it works on non-amd64. Currently, the test cases failure even though there is a skip as the mirroring code already failed because it tries to mirror amd64 image from `arm64v8` namespace.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>