### PR TITLE
ci: split cross job

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -146,7 +146,7 @@ jobs:
       -
         name: GitHub Release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844  # v0.1.15
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -126,34 +126,6 @@ jobs:
           path: ./release-out/*
           if-no-files-found: error
 
-  binaries:
-    runs-on: ubuntu-20.04
-    needs:
-      - prepare
-      - cross
-      - test
-    steps:
-      -
-        name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: buildkit
-          path: ./release-out/*
-      -
-        name: List artifacts
-        run: |
-          tree -nh ./release-out/
-      -
-        name: GitHub Release
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844  # v0.1.15
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          draft: true
-          files: ./release-out/*
-          name: ${{ needs.prepare.outputs.tag }}
-
   image:
     runs-on: ubuntu-20.04
     needs:
@@ -198,3 +170,32 @@ jobs:
           TARGET: ${{ matrix.target-stage }}
           CACHE_FROM: type=gha,scope=image${{ matrix.target-stage }}
           CACHE_TO: type=gha,scope=image${{ matrix.target-stage }}
+
+  release:
+    runs-on: ubuntu-20.04
+    needs:
+      - prepare
+      - test
+      - cross
+      - image
+    steps:
+      -
+        name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: buildkit
+          path: ./release-out/*
+      -
+        name: List artifacts
+        run: |
+          tree -nh ./release-out/
+      -
+        name: GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844  # v0.1.15
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          draft: true
+          files: ./release-out/*
+          name: ${{ needs.prepare.outputs.tag }}

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -25,37 +25,8 @@ env:
   SETUP_BUILDKIT_IMAGE: "moby/buildkit:latest"
   IMAGE_NAME: "moby/buildkit"
   PLATFORMS: "linux/amd64,linux/arm/v7,linux/arm64,linux/s390x,linux/ppc64le,linux/riscv64"
-  CACHE_GHA_SCOPE_BINARIES: "binaries"
-  CACHE_GHA_SCOPE_CROSS: "cross"
 
 jobs:
-  base:
-    runs-on: ubuntu-20.04
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v3
-      -
-        name: Expose GitHub Runtime
-        uses: crazy-max/ghaction-github-runtime@v2
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          version: ${{ env.SETUP_BUILDX_VERSION }}
-          driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
-          buildkitd-flags: --debug
-      -
-        name: Build ${{ env.CACHE_GHA_SCOPE_BINARIES }}
-        run: |
-          ./hack/build_ci_first_pass binaries
-        env:
-          CACHE_FROM: type=gha,scope=${{ env.CACHE_GHA_SCOPE_BINARIES }}
-          CACHE_TO: type=gha,scope=${{ env.CACHE_GHA_SCOPE_BINARIES }}
-
   test:
     uses: ./.github/workflows/.test.yml
     with:
@@ -80,9 +51,48 @@ jobs:
           skip-integration-tests: 1
           typ: integration
 
+  prepare:
+    runs-on: ubuntu-20.04
+    outputs:
+      tag: ${{ steps.prep.outputs.tag }}
+      push: ${{ steps.prep.outputs.push }}
+      platforms: ${{ steps.prep.outputs.platforms }}
+    steps:
+      -
+        name: Prepare
+        id: prep
+        run: |
+          TAG=pr
+          PUSH=false
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            TAG=nightly
+            PUSH=push
+          elif [[ $GITHUB_REF == refs/tags/v* ]]; then
+            TAG=${GITHUB_REF#refs/tags/}
+            PUSH=push
+          elif [[ $GITHUB_REF == refs/heads/* ]]; then
+            TAG=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
+            PUSH=push
+          fi
+          echo "tag=${TAG}" >>${GITHUB_OUTPUT}
+          echo "push=${PUSH}" >>${GITHUB_OUTPUT}
+          platforms=$(jq -c -n --argjson str '"${{ env.PLATFORMS }},darwin/amd64,darwin/arm64,windows/amd64,windows/arm64"' '$str|split(",")')
+          echo "platforms=$platforms" >>${GITHUB_OUTPUT}
+
   cross:
     runs-on: ubuntu-20.04
+    needs:
+      - prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ${{ fromJson(needs.prepare.outputs.platforms) }}
     steps:
+      -
+        name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
       -
         name: Checkout
         uses: actions/checkout@v3
@@ -100,44 +110,55 @@ jobs:
           driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
           buildkitd-flags: --debug
       -
-        name: Cross
+        name: Build
         run: |
-          ./hack/cross
+          ./hack/release-tar "${{ needs.prepare.outputs.tag }}" release-out
         env:
-          PLATFORMS: ${{ env.PLATFORMS }},darwin/amd64,darwin/arm64,windows/amd64,windows/arm64
-          CACHE_FROM: type=gha,scope=${{ env.CACHE_GHA_SCOPE_CROSS }}
-          CACHE_TO: type=gha,scope=${{ env.CACHE_GHA_SCOPE_CROSS }}
+          RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
+          PLATFORMS: ${{ matrix.platform }}
+          CACHE_FROM: type=gha,scope=cross-${{ env.PLATFORM_PAIR }}
+          CACHE_TO: type=gha,scope=cross-${{ env.PLATFORM_PAIR }}
+      -
+        name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: buildkit
+          path: ./release-out/*
+          if-no-files-found: error
 
-  release-base:
+  binaries:
     runs-on: ubuntu-20.04
-    outputs:
-      tag: ${{ steps.prep.outputs.tag }}
-      push: ${{ steps.prep.outputs.push }}
+    needs:
+      - prepare
+      - cross
+      - test
     steps:
-      - name: Prepare
-        id: prep
+      -
+        name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: buildkit
+          path: ./release-out/*
+      -
+        name: List artifacts
         run: |
-          TAG=pr
-          PUSH=false
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            TAG=nightly
-            PUSH=push
-          elif [[ $GITHUB_REF == refs/tags/v* ]]; then
-            TAG=${GITHUB_REF#refs/tags/}
-            PUSH=push
-          elif [[ $GITHUB_REF == refs/heads/* ]]; then
-            TAG=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
-            PUSH=push
-          fi
-          echo "tag=${TAG}" >>${GITHUB_OUTPUT}
-          echo "push=${PUSH}" >>${GITHUB_OUTPUT}
+          tree -nh ./release-out/
+      -
+        name: GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          draft: true
+          files: ./release-out/*
+          name: ${{ needs.prepare.outputs.tag }}
 
   image:
     runs-on: ubuntu-20.04
     needs:
-      - release-base
+      - prepare
       - test
-      - cross
     strategy:
       fail-fast: false
       matrix:
@@ -163,66 +184,17 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Login to DockerHub
-        if: needs.release-base.outputs.push == 'push'
+        if: needs.prepare.outputs.push == 'push'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
-        name: Build ${{ needs.release-base.outputs.tag }}
+        name: Build ${{ needs.prepare.outputs.tag }}
         run: |
-          ./hack/images "${{ needs.release-base.outputs.tag }}" "$IMAGE_NAME" "${{ needs.release-base.outputs.push }}"
+          ./hack/images "${{ needs.prepare.outputs.tag }}" "$IMAGE_NAME" "${{ needs.prepare.outputs.push }}"
         env:
           RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
           TARGET: ${{ matrix.target-stage }}
-          CACHE_FROM: type=gha,scope=${{ env.CACHE_GHA_SCOPE_CROSS }} type=gha,scope=image${{ matrix.target-stage }}
+          CACHE_FROM: type=gha,scope=image${{ matrix.target-stage }}
           CACHE_TO: type=gha,scope=image${{ matrix.target-stage }}
-
-  binaries:
-    runs-on: ubuntu-20.04
-    needs:
-      - release-base
-      - test
-      - cross
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v3
-      -
-        name: Expose GitHub Runtime
-        uses: crazy-max/ghaction-github-runtime@v2
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          version: ${{ env.SETUP_BUILDX_VERSION }}
-          driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
-          buildkitd-flags: --debug
-      -
-        name: Build ${{ needs.release-base.outputs.tag }}
-        run: |
-          ./hack/release-tar "${{ needs.release-base.outputs.tag }}" release-out
-        env:
-          RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
-          PLATFORMS: ${{ env.PLATFORMS }},darwin/amd64,darwin/arm64,windows/amd64,windows/arm64
-          CACHE_FROM: type=gha,scope=${{ env.CACHE_GHA_SCOPE_BINARIES }} type=gha,scope=${{ env.CACHE_GHA_SCOPE_CROSS }}
-      -
-        name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: buildkit
-          path: ./release-out/*
-          if-no-files-found: error
-      -
-        name: GitHub Release
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          draft: true
-          files: ./release-out/*
-          name: ${{ needs.release-base.outputs.tag }}

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -105,7 +105,6 @@ jobs:
           ./hack/cross
         env:
           PLATFORMS: ${{ env.PLATFORMS }},darwin/amd64,darwin/arm64,windows/amd64,windows/arm64
-          RUNC_PLATFORMS: ${{ env.PLATFORMS }}
           CACHE_FROM: type=gha,scope=${{ env.CACHE_GHA_SCOPE_CROSS }}
           CACHE_TO: type=gha,scope=${{ env.CACHE_GHA_SCOPE_CROSS }}
 

--- a/.github/workflows/dockerd.yml
+++ b/.github/workflows/dockerd.yml
@@ -12,8 +12,6 @@ on:
 env:
   SETUP_BUILDX_VERSION: "latest"
   SETUP_BUILDKIT_IMAGE: "moby/buildkit:latest"
-  CACHE_GHA_SCOPE_IT: "integration-tests"
-  CACHE_GHA_SCOPE_BINARIES: "binaries"
   TESTFLAGS: "-v --parallel=1 --timeout=30m"
 
 jobs:
@@ -129,7 +127,7 @@ jobs:
           TESTPKGS: "${{ matrix.pkg }}"
           TESTFLAGS: "${{ env.TESTFLAGS }} --run=//worker=${{ matrix.worker }}$"
           SKIP_INTEGRATION_TESTS: "${{ matrix.skip-integration-tests }}"
-          CACHE_FROM: "type=gha,scope=${{ env.CACHE_GHA_SCOPE_IT }} type=gha,scope=${{ env.CACHE_GHA_SCOPE_BINARIES }}"
+          CACHE_FROM: "type=gha,scope=build-integration-tests"
           BUILDKIT_INTEGRATION_DOCKERD_FLAGS: |
             --bip=10.66.66.1/24
             --default-address-pool=base=10.66.66.0/16,size=24

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -41,6 +41,7 @@ jobs:
     outputs:
       typ: ${{ steps.prep.outputs.typ }}
       push: ${{ steps.prep.outputs.push }}
+      tag: ${{ steps.prep.outputs.tag }}
       tags: ${{ steps.prep.outputs.tags }}
     steps:
       -
@@ -59,6 +60,7 @@ jobs:
           fi
           echo "typ=${TYP}" >>${GITHUB_OUTPUT}
           echo "push=${PUSH}" >>${GITHUB_OUTPUT}
+          echo "tag=${TAG}" >>${GITHUB_OUTPUT}
           if [ "${TYP}" = "master" ]; then
             echo "tags=$(jq -cn --arg tag "$TAG" '[$tag, "labs"]')" >>${GITHUB_OUTPUT}
           else
@@ -114,3 +116,20 @@ jobs:
           RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
           CACHE_FROM: type=gha,scope=${{ env.CACHE_SCOPE }}
           CACHE_TO: type=gha,scope=${{ env.CACHE_SCOPE }}
+
+  release:
+    runs-on: ubuntu-20.04
+    if: startsWith(github.ref, 'refs/tags/dockerfile')
+    needs:
+      - prepare
+      - test
+      - image
+    steps:
+      -
+        name: GitHub Release
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844  # v0.1.15
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          draft: true
+          name: ${{ needs.prepare.outputs.tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,12 +107,10 @@ RUN --mount=target=. --mount=target=/root/.cache,type=cache \
   CGO_ENABLED=0 xx-go build -ldflags "$(cat /tmp/.ldflags) -extldflags '-static'" -tags "osusergo netgo static_build seccomp ${BUILDKITD_TAGS}" -o /usr/bin/buildkitd ./cmd/buildkitd && \
   xx-verify --static /usr/bin/buildkitd
 
-FROM scratch AS binaries-linux-helper
+FROM scratch AS binaries-linux
 COPY --link --from=runc /usr/bin/runc /buildkit-runc
 # built from https://github.com/tonistiigi/binfmt/releases/tag/buildkit%2Fv7.1.0-30
 COPY --link --from=tonistiigi/binfmt:buildkit-v7.1.0-30@sha256:45dd57b4ba2f24e2354f71f1e4e51f073cb7a28fd848ce6f5f2a7701142a6bf0 / /
-
-FROM binaries-linux-helper AS binaries-linux
 COPY --link --from=buildctl /usr/bin/buildctl /
 COPY --link --from=buildkitd /usr/bin/buildkitd /
 

--- a/hack/build_ci_first_pass
+++ b/hack/build_ci_first_pass
@@ -6,7 +6,7 @@ TYP=$1
 set -e
 
 usage() {
-  echo "usage: ./hack/build_ci_first_pass <binaries|integration-tests>"
+  echo "usage: ./hack/build_ci_first_pass <integration-tests>"
   exit 1
 }
 
@@ -15,11 +15,6 @@ if [ -z "$TYP" ]; then
 fi
 
 case $TYP in
-  "binaries")
-    buildxCmd build $cacheFromFlags $cacheToFlags \
-      --target "binaries" \
-      $currentcontext
-    ;;
   "integration-tests")
     buildxCmd build $cacheFromFlags $cacheToFlags \
       --target "integration-tests-base" \

--- a/hack/cross
+++ b/hack/cross
@@ -10,12 +10,5 @@ if [ -n "$PLATFORMS" ]; then
   platformFlag="--platform=$PLATFORMS"
 fi
 
-if [ -n "$RUNC_PLATFORMS" ]; then
-  buildxCmd build $cacheFromFlags $cacheToFlags \
-    --target "binaries-linux-helper" \
-    --platform "$RUNC_PLATFORMS" \
-    $currentcontext
-fi
-
 buildxCmd build $platformFlag $cacheFromFlags \
   $currentcontext


### PR DESCRIPTION
follow-up https://github.com/moby/buildkit/pull/3237 and carry some changes from https://github.com/moby/buildkit/pull/3204

`cross` job is pretty slow atm as it needs to build every platforms in the same runner. It was also used only for cache without any other purpose. This PR splits the cross job per platform to build binaries and merge them together in the `binaries` job for release. This should reduce build time to create binaries by about 20min.