### PR TITLE
ci: fix missing TESTFLAGS env var in test-os workflow

### DIFF
--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -19,6 +19,7 @@ on:
 
 env:
   GO_VERSION: "1.19"
+  TESTFLAGS: "-v --parallel=6 --timeout=30m"
 
 jobs:
   test:


### PR DESCRIPTION
regression from https://github.com/moby/buildkit/pull/3237