### PR TITLE
[WIP] hack/dockerfile: add dockerignore for vendor.dockerfile

### DIFF
--- a/hack/dockerfiles/vendor.Dockerfile.dockerignore
+++ b/hack/dockerfiles/vendor.Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+.git
+.github
+bin
+.certs
+.tmp
+vendor


### PR DESCRIPTION
Some of the Dockerfiles in this repository may needed the git source to do their work, but vendoring likely doesn't, and I noticed that sending over the build-context was considerably slowing down the process.

This patch adds a dockerignoe specific for this Dockerfile. It's based on the `.dockerignore` at the root of the repository, but adds the `.git`, `.github`, and `vendor` directories. Possibly other non-code paths could be excluded as well, but would probably likely only bring minor improvements.

before:

    make vendor
    ...
    [+] Building 100.6s (14/14) FINISHED
    ...
        => [internal] load build context                                23.5s
        => => transferring context: 99.02MB                             23.3s

After removing `.git`:

    => [internal] load build context                                    15.2s
    => => transferring context: 43.10MB                                 15.1s

After removing both `.git` and `vendor`:

    make vendor
    ...
    [+] Building 13.6s (13/13) FINISHED
    ...
        => [internal] load build context                                1.2s
        => => transferring context: 5.24MB                              1.0s