### PR TITLE
update to Go 1.20

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -27,7 +27,7 @@ on:
         type: string
 
 env:
-  GO_VERSION: "1.19"
+  GO_VERSION: "1.20"
   SETUP_BUILDX_VERSION: "latest"
   SETUP_BUILDKIT_IMAGE: "moby/buildkit:latest"
   TESTFLAGS: "-v --parallel=6 --timeout=30m"

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -20,7 +20,7 @@ on:
       - 'frontend/dockerfile/docs/**'
 
 env:
-  GO_VERSION: "1.19"
+  GO_VERSION: "1.20"
   SETUP_BUILDX_VERSION: "latest"
   SETUP_BUILDKIT_IMAGE: "moby/buildkit:latest"
   IMAGE_NAME: "moby/buildkit"

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -18,7 +18,7 @@ on:
       - 'frontend/dockerfile/docs/**'
 
 env:
-  GO_VERSION: "1.19"
+  GO_VERSION: "1.20"
   SETUP_BUILDX_VERSION: "latest"
   SETUP_BUILDKIT_TAG: "moby/buildkit:latest"
   IMAGE_NAME: "docker/dockerfile-upstream"

--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -18,7 +18,7 @@ on:
       - 'frontend/dockerfile/docs/**'
 
 env:
-  GO_VERSION: "1.19"
+  GO_VERSION: "1.20"
   TESTFLAGS: "-v --parallel=6 --timeout=30m"
 
 jobs:
@@ -39,7 +39,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: "${{ env.GO_VERSION }}"
           cache: true
       -
         name: Go mod

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,6 @@ run:
 
 linters:
   enable:
-    - deadcode
     - depguard
     - gofmt
     - goimports
@@ -25,7 +24,6 @@ linters:
     - staticcheck
     - typecheck
     - unused
-    - varcheck
     - bodyclose
     - errname
     - makezero

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ ARG MINIO_VERSION=RELEASE.2022-05-03T20-36-08Z
 ARG MINIO_MC_VERSION=RELEASE.2022-05-04T06-07-55Z
 ARG AZURITE_VERSION=3.18.0
 
+ARG GO_VERSION=1.20
 ARG ALPINE_VERSION=3.17
 
 # minio for s3 integration tests
@@ -35,7 +36,7 @@ FROM alpine-$TARGETARCH AS alpinebase
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.2.1 AS xx
 
 # go base image
-FROM --platform=$BUILDPLATFORM golang:1.19-alpine${ALPINE_VERSION} AS golatest
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS golatest
 
 # git stage is used for checking out remote repository sources
 FROM --platform=$BUILDPLATFORM alpine:${ALPINE_VERSION} AS git

--- a/cmd/buildkitd/debug.go
+++ b/cmd/buildkitd/debug.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"runtime"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/trace"
@@ -36,7 +37,12 @@ func setupDebugHandlers(addr string) error {
 	if err != nil {
 		return err
 	}
+	server := &http.Server{
+		Addr:              l.Addr().String(),
+		Handler:           m,
+		ReadHeaderTimeout: time.Minute,
+	}
 	logrus.Debugf("debug handlers listening at %s", addr)
-	go http.Serve(l, m)
+	go server.ListenAndServe()
 	return nil
 }

--- a/examples/buildkit0/buildkit.go
+++ b/examples/buildkit0/buildkit.go
@@ -33,7 +33,7 @@ func main() {
 }
 
 func goBuildBase() llb.State {
-	goAlpine := llb.Image("docker.io/library/golang:1.19-alpine")
+	goAlpine := llb.Image("docker.io/library/golang:1.20-alpine")
 	return goAlpine.
 		AddEnv("PATH", "/usr/local/go/bin:"+system.DefaultPathEnvUnix).
 		AddEnv("GOPATH", "/go").

--- a/examples/buildkit1/buildkit.go
+++ b/examples/buildkit1/buildkit.go
@@ -33,7 +33,7 @@ func main() {
 }
 
 func goBuildBase() llb.State {
-	goAlpine := llb.Image("docker.io/library/golang:1.19-alpine")
+	goAlpine := llb.Image("docker.io/library/golang:1.20-alpine")
 	return goAlpine.
 		AddEnv("PATH", "/usr/local/go/bin:"+system.DefaultPathEnvUnix).
 		AddEnv("GOPATH", "/go").

--- a/examples/buildkit2/buildkit.go
+++ b/examples/buildkit2/buildkit.go
@@ -33,7 +33,7 @@ func main() {
 }
 
 func goBuildBase() llb.State {
-	goAlpine := llb.Image("docker.io/library/golang:1.19-alpine")
+	goAlpine := llb.Image("docker.io/library/golang:1.20-alpine")
 	return goAlpine.
 		AddEnv("PATH", "/usr/local/go/bin:"+system.DefaultPathEnvUnix).
 		AddEnv("GOPATH", "/go").

--- a/examples/buildkit3/buildkit.go
+++ b/examples/buildkit3/buildkit.go
@@ -34,7 +34,7 @@ func main() {
 }
 
 func goBuildBase() llb.State {
-	goAlpine := llb.Image("docker.io/library/golang:1.19-alpine")
+	goAlpine := llb.Image("docker.io/library/golang:1.20-alpine")
 	return goAlpine.
 		AddEnv("PATH", "/usr/local/go/bin:"+system.DefaultPathEnvUnix).
 		AddEnv("GOPATH", "/go").

--- a/examples/buildkit4/buildkit.go
+++ b/examples/buildkit4/buildkit.go
@@ -37,7 +37,7 @@ func main() {
 }
 
 func goBuildBase() llb.State {
-	goAlpine := llb.Image("docker.io/library/golang:1.19-alpine")
+	goAlpine := llb.Image("docker.io/library/golang:1.20-alpine")
 	return goAlpine.
 		AddEnv("PATH", "/usr/local/go/bin:"+system.DefaultPathEnvUnix).
 		AddEnv("GOPATH", "/go").

--- a/examples/nested-llb/main.go
+++ b/examples/nested-llb/main.go
@@ -32,7 +32,7 @@ func main() {
 }
 
 func goBuildBase() llb.State {
-	goAlpine := llb.Image("docker.io/library/golang:1.19-alpine")
+	goAlpine := llb.Image("docker.io/library/golang:1.20-alpine")
 	return goAlpine.
 		AddEnv("PATH", "/usr/local/go/bin:"+system.DefaultPathEnvUnix).
 		AddEnv("GOPATH", "/go").

--- a/frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile
+++ b/frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile
@@ -1,9 +1,11 @@
 # syntax=docker/dockerfile-upstream:master
 
+ARG GO_VERSION=1.20
+
 # xx is a helper for cross-compilation
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:master@sha256:d4254d9739ce2de9fb88e09bdc716aa0c65f0446a2a2143399f991d71136a3d4 AS xx
 
-FROM --platform=$BUILDPLATFORM golang:1.19-alpine AS base
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS base
 RUN apk add git bash
 COPY --from=xx / /
 WORKDIR /src

--- a/frontend/gateway/container.go
+++ b/frontend/gateway/container.go
@@ -293,7 +293,7 @@ type gatewayContainer struct {
 	cancel     func()
 }
 
-func (gwCtr *gatewayContainer) Start(ctx context.Context, req client.StartRequest) (client.ContainerProcess, error) {
+func (gwCtr *gatewayContainer) Start(_ context.Context, req client.StartRequest) (client.ContainerProcess, error) {
 	resize := make(chan executor.WinSize)
 	signal := make(chan syscall.Signal)
 	procInfo := executor.ProcessInfo{

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/moby/buildkit
 
-go 1.18
+go 1.19
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.1.0

--- a/hack/dockerfiles/generated-files.Dockerfile
+++ b/hack/dockerfiles/generated-files.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:master
 
-ARG GO_VERSION="1.19"
+ARG GO_VERSION="1.20"
 ARG NODE_VERSION="19"
 ARG PROTOC_VERSION="3.11.4"
 

--- a/hack/dockerfiles/lint.Dockerfile
+++ b/hack/dockerfiles/lint.Dockerfile
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile-upstream:master
 
-FROM golang:1.19-alpine
+ARG GO_VERSION=1.20
+
+FROM golang:${GO_VERSION}-alpine
 ENV GOFLAGS="-buildvcs=false"
 RUN apk add --no-cache gcc musl-dev yamllint
 RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.48.0

--- a/hack/dockerfiles/lint.Dockerfile
+++ b/hack/dockerfiles/lint.Dockerfile
@@ -5,7 +5,7 @@ ARG GO_VERSION=1.20
 FROM golang:${GO_VERSION}-alpine
 ENV GOFLAGS="-buildvcs=false"
 RUN apk add --no-cache gcc musl-dev yamllint
-RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.48.0
+RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.51.1
 WORKDIR /go/src/github.com/moby/buildkit
 RUN --mount=target=/go/src/github.com/moby/buildkit --mount=target=/root/.cache,type=cache \
   GOARCH=amd64 golangci-lint run && \

--- a/hack/dockerfiles/vendor.Dockerfile
+++ b/hack/dockerfiles/vendor.Dockerfile
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile-upstream:master
 
-FROM golang:1.19-alpine AS vendored
+ARG GO_VERSION=1.20
+
+FROM golang:${GO_VERSION}-alpine AS vendored
 RUN  apk add --no-cache git
 WORKDIR /src
 RUN --mount=target=/src,rw \

--- a/solver/scheduler_test.go
+++ b/solver/scheduler_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func init() {
+	rand.Seed(time.Now().UnixNano()) //nolint:staticcheck // Ignore SA1019. No way to get the automatically generated seed since Go 1.20.
 	if debugScheduler {
 		logrus.SetOutput(os.Stdout)
 		logrus.SetLevel(logrus.DebugLevel)
@@ -716,8 +717,6 @@ func TestHugeGraph(t *testing.T) {
 	t.Parallel()
 	ctx := context.TODO()
 
-	rand.Seed(time.Now().UnixNano())
-
 	cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
 	l := NewSolver(SolverOpt{
@@ -1036,8 +1035,6 @@ func TestSlowCache(t *testing.T) {
 	t.Parallel()
 	ctx := context.TODO()
 
-	rand.Seed(time.Now().UnixNano())
-
 	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 	})
@@ -1117,8 +1114,6 @@ func TestParallelInputs(t *testing.T) {
 	t.Parallel()
 	ctx := context.TODO()
 
-	rand.Seed(time.Now().UnixNano())
-
 	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
 	})
@@ -1174,8 +1169,6 @@ func TestParallelInputs(t *testing.T) {
 func TestErrorReturns(t *testing.T) {
 	t.Parallel()
 	ctx := context.TODO()
-
-	rand.Seed(time.Now().UnixNano())
 
 	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
@@ -3047,8 +3040,6 @@ func TestCacheExportingMergedKey(t *testing.T) {
 func TestMergedEdgesLookup(t *testing.T) {
 	t.Parallel()
 
-	rand.Seed(time.Now().UnixNano())
-
 	// this test requires multiple runs to trigger the race
 	for i := 0; i < 20; i++ {
 		func() {
@@ -3101,8 +3092,6 @@ func TestMergedEdgesLookup(t *testing.T) {
 
 func TestCacheLoadError(t *testing.T) {
 	t.Parallel()
-
-	rand.Seed(time.Now().UnixNano())
 
 	ctx := context.TODO()
 

--- a/source/http/httpsource.go
+++ b/source/http/httpsource.go
@@ -392,6 +392,9 @@ func (hs *httpSourceHandler) Snapshot(ctx context.Context, g session.Group) (cac
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	ref, dgst, err := hs.save(ctx, resp, g)
 	if err != nil {

--- a/util/archutil/Dockerfile
+++ b/util/archutil/Dockerfile
@@ -52,7 +52,7 @@ FROM base AS exit-mips64
 COPY fixtures/exit.mips64.s .
 RUN mips64-linux-gnuabi64-as --noexecstack -o exit.o exit.mips64.s && mips64-linux-gnuabi64-ld -o exit -s exit.o
 
-FROM golang:1.19-alpine AS generate
+FROM golang:1.20-alpine AS generate
 WORKDIR /src
 COPY --from=exit-amd64 /src/exit amd64
 COPY --from=exit-386 /src/exit 386

--- a/util/compression/compression.go
+++ b/util/compression/compression.go
@@ -81,7 +81,7 @@ const (
 	mediaTypeImageLayerZstd         = ocispecs.MediaTypeImageLayer + "+zstd" // unreleased image-spec#790
 )
 
-var Default gzipType = Gzip
+var Default = Gzip
 
 func parse(t string) (Type, error) {
 	switch t {

--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -164,8 +164,8 @@ func Run(t *testing.T, testCases []Test, opt ...TestOpt) {
 
 	list := List()
 	if os.Getenv("BUILDKIT_WORKER_RANDOM") == "1" && len(list) > 0 {
-		rand.Seed(time.Now().UnixNano())
-		list = []Worker{list[rand.Intn(len(list))]} //nolint:gosec // using math/rand is fine in a test utility
+		rng := rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec // using math/rand is fine in a test utility
+		list = []Worker{list[rng.Intn(len(list))]}
 	}
 
 	for _, br := range list {


### PR DESCRIPTION
Update to Go 1.20 and golangci-lint to 1.51.1 as well.

Also needs to fix lint and gosec issues following this update:

```
#11 22.12 cmd/buildkitd/debug.go:40:5: G114: Use of net/http serve function that has no support for setting timeouts (gosec)
#11 22.12       go http.Serve(l, m)
#11 22.12          ^
#11 22.12 util/compression/compression.go:84:13: var-declaration: should omit type gzipType from declaration of var Default; it will be inferred from the right-hand side (revive)
#11 22.12 var Default gzipType = Gzip
#11 22.12             ^
#11 22.12 source/http/httpsource.go:391:24: response body must be closed (bodyclose)
#11 22.12       resp, err := client.Do(req)
#11 22.12                             ^
#11 22.12 util/testutil/integration/run.go:167:3: SA1019: rand.Seed has been deprecated since Go 1.20 and an alternative has been available since Go 1.0: Programs that call Seed and then expect a specific sequence of results from the global random source (using functions such as Int) can be broken when a dependency changes how much it consumes from the global random source. To avoid such breakages, programs that need a specific result sequence should use NewRand(NewSource(seed)) to obtain a random generator that other packages cannot access. (staticcheck)
#11 22.12               rand.Seed(time.Now().UnixNano())
#11 22.12               ^
#11 22.12 solver/scheduler_test.go:719:2: SA1019: rand.Seed has been deprecated since Go 1.20 and an alternative has been available since Go 1.0: Programs that call Seed and then expect a specific sequence of results from the global random source (using functions such as Int) can be broken when a dependency changes how much it consumes from the global random source. To avoid such breakages, programs that need a specific result sequence should use NewRand(NewSource(seed)) to obtain a random generator that other packages cannot access. (staticcheck)
#11 22.12       rand.Seed(time.Now().UnixNano())
#11 22.12       ^
#11 22.12 solver/scheduler_test.go:1039:2: SA1019: rand.Seed has been deprecated since Go 1.20 and an alternative has been available since Go 1.0: Programs that call Seed and then expect a specific sequence of results from the global random source (using functions such as Int) can be broken when a dependency changes how much it consumes from the global random source. To avoid such breakages, programs that need a specific result sequence should use NewRand(NewSource(seed)) to obtain a random generator that other packages cannot access. (staticcheck)
#11 22.12       rand.Seed(time.Now().UnixNano())
#11 22.12       ^
#11 22.12 frontend/gateway/container.go:296:38: SA4009: argument ctx is overwritten before first use (staticcheck)
#11 22.12 func (gwCtr *gatewayContainer) Start(ctx context.Context, req client.StartRequest) (client.ContainerProcess, error) {
#11 22.12                                      ^
#11 22.12 frontend/gateway/container.go:332:2: SA4009(related information): assignment to ctx (staticcheck)
#11 22.12       eg, ctx := errgroup.WithContext(gwCtr.ctx)
#11 22.12       ^
#11 ERROR: process "/bin/sh -c GOARCH=amd64 golangci-lint run &&   GOARCH=arm64 golangci-lint run" did not complete successfully: exit code: 1
```

> SA1019: rand.Seed has been deprecated since Go 1.20 and an alternative has been available since Go 1.0: Programs that call Seed and then expect a specific sequence of results from the global random source (using functions such as Int) can be broken when a dependency changes how much it consumes from the global random source. To avoid such breakages, programs that need a specific result sequence should use `NewRand(NewSource(seed))` to obtain a random generator that other packages cannot access. (staticcheck)

> G114: Use of net/http serve function that has no support for setting timeouts (gosec)
> https://deepsource.io/directory/analyzers/go/issues/GO-S2114