### PR TITLE
specify a `ResponseHeaderTimeout` value

### DIFF
--- a/util/resolver/resolver.go
+++ b/util/resolver/resolver.go
@@ -206,6 +206,7 @@ func newDefaultTransport() *http.Transport {
 		MaxIdleConnsPerHost:   4,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 5 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
 		TLSNextProto:          make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
 	}
 }


### PR DESCRIPTION
This guards against the case where an existing http connection is reused; however the server fails to respond to the second request.