### PR TITLE
ci: trigger workflows on push to release branches

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'v[0-9]+.[0-9]+'
     tags:
       - 'v*'
   pull_request:
@@ -72,7 +73,9 @@ jobs:
             PUSH=push
           elif [[ $GITHUB_REF == refs/heads/* ]]; then
             TAG=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
-            PUSH=push
+            if [ $GITHUB_REF = "refs/heads/${{ github.event.repository.default_branch }}" ]; then
+              PUSH=push
+            fi
           fi
           echo "tag=${TAG}" >>${GITHUB_OUTPUT}
           echo "push=${PUSH}" >>${GITHUB_OUTPUT}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'v[0-9]+.[0-9]+'
     tags:
       - 'dockerfile/*'
   pull_request:
@@ -56,7 +57,9 @@ jobs:
             TAG=${GITHUB_REF#refs/tags/}
             PUSH=push
           elif [[ $GITHUB_REF == refs/heads/* ]]; then
-            PUSH=push
+            if [ $GITHUB_REF = "refs/heads/${{ github.event.repository.default_branch }}" ]; then
+              PUSH=push
+            fi
           fi
           echo "typ=${TYP}" >>${GITHUB_OUTPUT}
           echo "push=${PUSH}" >>${GITHUB_OUTPUT}

--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'v[0-9]+.[0-9]+'
   pull_request:
     paths-ignore:
       - 'README.md'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'v[0-9]+.[0-9]+'
     tags:
       - 'v*'
       - 'dockerfile/*'


### PR DESCRIPTION
We don't do any build when changes are pushed/merged to release branches. Following changes will trigger workflows but not push images.

I guess we could also push images but current tag would be the branch name (e.g., `v0.11`) which might be confusing and taken as a release tag. Maybe we could append `-dev`? Thoughts?