### PR TITLE
fix gateway exec tty cleanup on context.Canceled

### DIFF
--- a/frontend/gateway/grpcclient/client.go
+++ b/frontend/gateway/grpcclient/client.go
@@ -928,11 +928,11 @@ func (ctr *container) Start(ctx context.Context, req client.StartRequest) (clien
 
 			if msg == nil {
 				// empty message from ctx cancel, so just start shutting down
-				// input, but continue processing more exit/done messages
+				// input
 				closeDoneOnce.Do(func() {
 					close(done)
 				})
-				continue
+				return ctx.Err()
 			}
 
 			if file := msg.GetFile(); file != nil {


### PR DESCRIPTION
This fixes an issue where the tty message handling loop will go into a tight loop and never exit upon context.Canceled.  There is select statement in `(*procMessageForwarder).Recv` that [returns nil on ctx.Done](https://github.com/moby/buildkit/blob/5e08ad3a8a91e7b73ac0f0047edbadd866afa59c/frontend/gateway/grpcclient/client.go#L590-L591), but [the control loop in `(*container).Start` did not exit](https://github.com/moby/buildkit/blob/5e08ad3a8a91e7b73ac0f0047edbadd866afa59c/frontend/gateway/grpcclient/client.go#L921-L934) on this condition.  I think the intent was to flush out any inflight messages on cancel, but this is already done in `(*procMessageForwarder) Close`.