### PR TITLE
Fix buildkitd panic when frontend input is nil.

### DIFF
--- a/client/llb/definition.go
+++ b/client/llb/definition.go
@@ -29,6 +29,10 @@ type DefinitionOp struct {
 
 // NewDefinitionOp returns a new operation from a marshalled definition.
 func NewDefinitionOp(def *pb.Definition) (*DefinitionOp, error) {
+	if def == nil {
+		return nil, errors.New("invalid nil input definition to definition op")
+	}
+
 	ops := make(map[digest.Digest]*pb.Op)
 	defs := make(map[digest.Digest][]byte)
 	platforms := make(map[digest.Digest]*ocispecs.Platform)

--- a/client/llb/definition_test.go
+++ b/client/llb/definition_test.go
@@ -118,3 +118,9 @@ func TestDefinitionInputCache(t *testing.T) {
 	// 1 exec + 2x2 mounts from stA and stB + 1 src = 6 vertexes
 	require.Equal(t, 6, len(vertexCache))
 }
+
+func TestDefinitionNil(t *testing.T) {
+	// should be an error, not a panic
+	_, err := NewDefinitionOp(nil)
+	require.Error(t, err)
+}

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -160,6 +160,7 @@ var allTests = integration.TestFuncs(
 	testNilProvenance,
 	testSBOMScannerArgs,
 	testMultiPlatformWarnings,
+	testNilContextInSolveGateway,
 )
 
 // Tests that depend on the `security.*` entitlements
@@ -6561,6 +6562,29 @@ COPY --from=0 / /
 	t.Logf("OCI archive digest=%q", outDigest)
 	t.Log("The digest may change depending on the BuildKit version, the snapshotter configuration, etc.")
 	require.Equal(t, expectedDigest, outDigest)
+}
+
+func testNilContextInSolveGateway(t *testing.T, sb integration.Sandbox) {
+	f := getFrontend(t, sb)
+	c, err := client.New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = c.Build(sb.Context(), client.SolveOpt{}, "", func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
+		res, err := f.SolveGateway(ctx, c, gateway.SolveRequest{
+			Frontend: "dockerfile.v0",
+			FrontendInputs: map[string]*pb.Definition{
+				dockerui.DefaultLocalNameContext:    nil,
+				dockerui.DefaultLocalNameDockerfile: nil,
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		return res, nil
+	}, nil)
+	// should not cause buildkitd to panic
+	require.ErrorContains(t, err, "invalid nil input definition to definition op")
 }
 
 func runShell(dir string, cmds ...string) error {


### PR DESCRIPTION
See integ test case for repro, it causes a server-side panic.

Probably a bunch of possible fixes on different levels but opted for the "lowest-level" one by handling this case in `NewDefinitionOp` for now; reduces what was a panic to an `err` return there. Let me know if it's preferable to handle this elsewhere and make `NewDefinitionOp` return `nil, nil` in this case or something like that @tonistiigi 