### PR TITLE
[v0.11 backport] test/client: Close buildkit client

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -7160,11 +7160,13 @@ func testExportAttestations(t *testing.T, sb integration.Sandbox) {
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
+	defer c.Close()
 
 	registry, err := sb.NewRegistry()
 	if errors.Is(err, integration.ErrRequirements) {
 		t.Skip(err.Error())
 	}
+	require.NoError(t, err)
 
 	ps := []ocispecs.Platform{
 		platforms.MustParse("linux/amd64"),
@@ -7480,11 +7482,13 @@ func testAttestationDefaultSubject(t *testing.T, sb integration.Sandbox) {
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
+	defer c.Close()
 
 	registry, err := sb.NewRegistry()
 	if errors.Is(err, integration.ErrRequirements) {
 		t.Skip(err.Error())
 	}
+	require.NoError(t, err)
 
 	ps := []ocispecs.Platform{
 		platforms.MustParse("linux/amd64"),
@@ -7617,11 +7621,13 @@ func testAttestationBundle(t *testing.T, sb integration.Sandbox) {
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
+	defer c.Close()
 
 	registry, err := sb.NewRegistry()
 	if errors.Is(err, integration.ErrRequirements) {
 		t.Skip(err.Error())
 	}
+	require.NoError(t, err)
 
 	ps := []ocispecs.Platform{
 		platforms.MustParse("linux/amd64"),
@@ -7766,11 +7772,13 @@ func testSBOMScan(t *testing.T, sb integration.Sandbox) {
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
+	defer c.Close()
 
 	registry, err := sb.NewRegistry()
 	if errors.Is(err, integration.ErrRequirements) {
 		t.Skip(err.Error())
 	}
+	require.NoError(t, err)
 
 	p := platforms.MustParse("linux/amd64")
 	pk := platforms.Format(p)
@@ -8042,11 +8050,13 @@ func testSBOMScanSingleRef(t *testing.T, sb integration.Sandbox) {
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
+	defer c.Close()
 
 	registry, err := sb.NewRegistry()
 	if errors.Is(err, integration.ErrRequirements) {
 		t.Skip(err.Error())
 	}
+	require.NoError(t, err)
 
 	p := platforms.DefaultSpec()
 	pk := platforms.Format(p)
@@ -8206,11 +8216,13 @@ func testSBOMSupplements(t *testing.T, sb integration.Sandbox) {
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
+	defer c.Close()
 
 	registry, err := sb.NewRegistry()
 	if errors.Is(err, integration.ErrRequirements) {
 		t.Skip(err.Error())
 	}
+	require.NoError(t, err)
 
 	p := platforms.MustParse("linux/amd64")
 	pk := platforms.Format(p)


### PR DESCRIPTION
- Cherry-pick: https://github.com/moby/buildkit/pull/3675

This fixes hang in these tests which caused a timeout.

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>
(cherry picked from commit 3b0aa6949de9857e4209844ee0bc3fd31cebe490)