### PR TITLE
llb: Allow DefinitionOp to track sources

### DIFF
--- a/client/llb/definition.go
+++ b/client/llb/definition.go
@@ -205,6 +205,7 @@ func (d *DefinitionOp) Inputs() []Output {
 				dgst:       input.Digest,
 				index:      input.Index,
 				inputCache: d.inputCache,
+				sources:    d.sources,
 			}
 			existingIndexes := d.inputCache[input.Digest]
 			indexDiff := int(input.Index) - len(existingIndexes)


### PR DESCRIPTION
Currently source information stored in DefinitionOp isn't propagated to the vertices available from `DefinitionOp.Inputs()`. This commit changes this and makes the source information available in the input vertices as well. This would be useful for inspecting/debugging each vertex in the LLB with keeping track the source location.