### PR TITLE
[0.11 backport] Allow DefinitionOp to track sources

### DIFF
--- a/client/llb/definition.go
+++ b/client/llb/definition.go
@@ -209,6 +209,7 @@ func (d *DefinitionOp) Inputs() []Output {
 				dgst:       input.Digest,
 				index:      input.Index,
 				inputCache: d.inputCache,
+				sources:    d.sources,
 			}
 			existingIndexes := d.inputCache[input.Digest]
 			indexDiff := int(input.Index) - len(existingIndexes)


### PR DESCRIPTION
- cherry-picked from https://github.com/moby/buildkit/pull/3678