### PR TITLE
remove context name validation from kubepod connhelper

### DIFF
--- a/client/connhelper/kubepod/kubepod.go
+++ b/client/connhelper/kubepod/kubepod.go
@@ -51,9 +51,6 @@ func SpecFromURL(u *url.URL) (*Spec, error) {
 		Pod:       u.Hostname(),
 		Container: q.Get("container"),
 	}
-	if sp.Context != "" && !validKubeIdentifier(sp.Context) {
-		return nil, errors.Errorf("unsupported context name: %q", sp.Context)
-	}
 	if sp.Namespace != "" && !validKubeIdentifier(sp.Namespace) {
 		return nil, errors.Errorf("unsupported namespace name: %q", sp.Namespace)
 	}

--- a/client/connhelper/kubepod/kubepod_test.go
+++ b/client/connhelper/kubepod/kubepod_test.go
@@ -15,8 +15,13 @@ func TestSpecFromURL(t *testing.T) {
 		"kube-pod://podname?container=containername&namespace=nsname&context=ctxname": {
 			Context: "ctxname", Namespace: "nsname", Pod: "podname", Container: "containername",
 		},
+		"kube-pod://podname?container=containername&namespace=nsname&context=user@cluster": {
+			Context: "user@cluster", Namespace: "nsname", Pod: "podname", Container: "containername",
+		},
 		"kube-pod://":                     nil,
 		"kube-pod://unsupported_pod_name": nil,
+		"kube-pod://podname?container=unsupported_container_name&namespace=nsname&context=ctxname": nil,
+		"kube-pod://podname?container=containername&namespace=unsupported_ns_name&context=ctxname": nil,
 	}
 	for s, expected := range cases {
 		u, err := url.Parse(s)


### PR DESCRIPTION
When specifying multiple contexts in kubeconfig, we sometimes set the context name to something like "user@cluster" for convenience.

However, current kubepod connhelper considers this kind of context name to be invalid.

```bash
$ buildctl --addr "kube-pod://bk?context=user@cluster" build --frontend=dockerfile.v0 --local context=. --local dockerfile=.
error: unsupported context name: "user@cluster"
```

kubepod connhelper should not validate context name for the following reasons:
- While [this K8s documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names) mentions name constraints for K8s resources, context is not applicable because it is not a resource.
- `kubectl` also does not validate its name except empty check.
   - https://github.com/kubernetes/client-go/blob/06ad6b391d35497951c73aad9bbdd4c94571d31d/tools/clientcmd/validation.go#L345-L371