### PR TITLE
buildctl: Add configured --registry-auth-tlscacert certificate to trust store when making calls to registry auth

### DIFF
--- a/cmd/buildctl/build.go
+++ b/cmd/buildctl/build.go
@@ -158,7 +158,7 @@ func buildAction(clicontext *cli.Context) error {
 	}
 
 	dockerConfig := config.LoadDefaultConfigFile(os.Stderr)
-	attachable := []session.Attachable{authprovider.NewDockerAuthProvider(dockerConfig)}
+	attachable := []session.Attachable{authprovider.NewDockerAuthProvider(dockerConfig, clicontext.String("tlscacert"))}
 
 	if ssh := clicontext.StringSlice("ssh"); len(ssh) > 0 {
 		configs, err := build.ParseSSH(ssh)

--- a/cmd/buildctl/build.go
+++ b/cmd/buildctl/build.go
@@ -105,6 +105,10 @@ var buildCommand = cli.Command{
 			Name:  "ref-file",
 			Usage: "Write build ref to a file",
 		},
+		cli.StringFlag{
+			Name:  "registry-auth-tlscacert",
+			Usage: "CA certificate to validate TLS when authenticating with registries",
+		},
 	},
 }
 
@@ -158,7 +162,7 @@ func buildAction(clicontext *cli.Context) error {
 	}
 
 	dockerConfig := config.LoadDefaultConfigFile(os.Stderr)
-	attachable := []session.Attachable{authprovider.NewDockerAuthProvider(dockerConfig, clicontext.String("tlscacert"))}
+	attachable := []session.Attachable{authprovider.NewDockerAuthProvider(dockerConfig, clicontext.String("registry-auth-tlscacert"))}
 
 	if ssh := clicontext.StringSlice("ssh"); len(ssh) > 0 {
 		configs, err := build.ParseSSH(ssh)

--- a/session/auth/authprovider/authprovider.go
+++ b/session/auth/authprovider/authprovider.go
@@ -98,12 +98,15 @@ func (ap *authProvider) FetchToken(ctx context.Context, req *auth.FetchTokenRequ
 		if err != nil {
 			return nil, err
 		}
-		caCertPool := x509.NewCertPool()
-		caCertPool.AppendCertsFromPEM(caCert)
+		rootCAs, _ := x509.SystemCertPool()
+		if rootCAs == nil {
+			rootCAs = x509.NewCertPool()
+		}
+		rootCAs.AppendCertsFromPEM(caCert)
 		httpClient = &http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{
-					RootCAs: caCertPool,
+					RootCAs: rootCAs,
 				},
 			},
 		}

--- a/session/auth/authprovider/authprovider.go
+++ b/session/auth/authprovider/authprovider.go
@@ -103,13 +103,8 @@ func (ap *authProvider) FetchToken(ctx context.Context, req *auth.FetchTokenRequ
 			rootCAs = x509.NewCertPool()
 		}
 		rootCAs.AppendCertsFromPEM(caCert)
-		httpClient = &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{
-					RootCAs: rootCAs,
-				},
-			},
-		}
+		httpClient.Transport = http.DefaultTransport
+		httpClient.Transport.(*http.Transport).TLSClientConfig = &tls.Config{RootCAs: rootCAs}
 	}
 
 	if creds.Secret != "" {

--- a/session/auth/authprovider/authprovider.go
+++ b/session/auth/authprovider/authprovider.go
@@ -8,7 +8,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strconv"
@@ -94,7 +93,7 @@ func (ap *authProvider) FetchToken(ctx context.Context, req *auth.FetchTokenRequ
 
 	var httpClient = http.DefaultClient
 	if ap.tlscacert != "" {
-		caCert, err := ioutil.ReadFile(ap.tlscacert)
+		caCert, err := os.ReadFile(ap.tlscacert)
 		if err != nil {
 			return nil, err
 		}

--- a/session/auth/authprovider/authprovider.go
+++ b/session/auth/authprovider/authprovider.go
@@ -5,7 +5,10 @@ import (
 	"crypto/ed25519"
 	"crypto/hmac"
 	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"strconv"
@@ -30,12 +33,13 @@ import (
 
 const defaultExpiration = 60
 
-func NewDockerAuthProvider(cfg *configfile.ConfigFile) session.Attachable {
+func NewDockerAuthProvider(cfg *configfile.ConfigFile, tlscacert string) session.Attachable {
 	return &authProvider{
 		authConfigCache: map[string]*types.AuthConfig{},
 		config:          cfg,
 		seeds:           &tokenSeeds{dir: config.Dir()},
 		loggerCache:     map[string]struct{}{},
+		tlscacert:       tlscacert,
 	}
 }
 
@@ -45,6 +49,7 @@ type authProvider struct {
 	seeds           *tokenSeeds
 	logger          progresswriter.Logger
 	loggerCache     map[string]struct{}
+	tlscacert       string
 
 	// The need for this mutex is not well understood.
 	// Without it, the docker cli on OS X hangs when
@@ -87,6 +92,23 @@ func (ap *authProvider) FetchToken(ctx context.Context, req *auth.FetchTokenRequ
 		Secret:   creds.Secret,
 	}
 
+	var httpClient = http.DefaultClient
+	if ap.tlscacert != "" {
+		caCert, err := ioutil.ReadFile(ap.tlscacert)
+		if err != nil {
+			return nil, err
+		}
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(caCert)
+		httpClient = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					RootCAs: caCertPool,
+				},
+			},
+		}
+	}
+
 	if creds.Secret != "" {
 		done := func(progresswriter.SubLogger) error {
 			return err
@@ -101,7 +123,7 @@ func (ap *authProvider) FetchToken(ctx context.Context, req *auth.FetchTokenRequ
 		}
 		ap.mu.Unlock()
 		// credential information is provided, use oauth POST endpoint
-		resp, err := authutil.FetchTokenWithOAuth(ctx, http.DefaultClient, nil, "buildkit-client", to)
+		resp, err := authutil.FetchTokenWithOAuth(ctx, httpClient, nil, "buildkit-client", to)
 		if err != nil {
 			var errStatus remoteserrors.ErrUnexpectedStatus
 			if errors.As(err, &errStatus) {
@@ -109,7 +131,7 @@ func (ap *authProvider) FetchToken(ctx context.Context, req *auth.FetchTokenRequ
 				// As of September 2017, GCR is known to return 404.
 				// As of February 2018, JFrog Artifactory is known to return 401.
 				if (errStatus.StatusCode == 405 && to.Username != "") || errStatus.StatusCode == 404 || errStatus.StatusCode == 401 {
-					resp, err := authutil.FetchToken(ctx, http.DefaultClient, nil, to)
+					resp, err := authutil.FetchToken(ctx, httpClient, nil, to)
 					if err != nil {
 						return nil, err
 					}
@@ -121,7 +143,7 @@ func (ap *authProvider) FetchToken(ctx context.Context, req *auth.FetchTokenRequ
 		return toTokenResponse(resp.AccessToken, resp.IssuedAt, resp.ExpiresIn), nil
 	}
 	// do request anonymously
-	resp, err := authutil.FetchToken(ctx, http.DefaultClient, nil, to)
+	resp, err := authutil.FetchToken(ctx, httpClient, nil, to)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to fetch anonymous token")
 	}


### PR DESCRIPTION
Alternative approach to #3278 to resolve #3218.

~Though I'm unsure if its a good idea to take this from the global config options as that assumes that the `buildkitd` instance and registry auth providers share a CA, or add a new flag under build.~

Extends the Certificate Authority trust pool to include certificates provided when making calls to the authenticate with registires.

Usage: 

```shell
buildctl build --registry-auth-tlscacert /path/to/my/ca.crt
```