### PR TITLE
Problem: can't use anonymous S3 credentials

### DIFF
--- a/cache/remotecache/s3/s3.go
+++ b/cache/remotecache/s3/s3.go
@@ -360,6 +360,10 @@ func newS3Client(ctx context.Context, config Config) (*s3Client, error) {
 	client := s3.NewFromConfig(cfg, func(options *s3.Options) {
 		if config.AccessKeyID != "" && config.SecretAccessKey != "" {
 			options.Credentials = credentials.NewStaticCredentialsProvider(config.AccessKeyID, config.SecretAccessKey, config.SessionToken)
+		} else {
+			// Setting `nil` for anonymous credentials as per
+			// https://pkg.go.dev/github.com/aws/aws-sdk-go-v2@v1.17.6/aws#AnonymousCredentials
+			options.Credentials = nil
 		}
 		if config.EndpointURL != "" {
 			options.UsePathStyle = config.UsePathStyle


### PR DESCRIPTION
When trying to use S3 cache with anonymous credentials (for example, for importing publicly available layers), the cache is not used.

Solution: enable anonymous credentials

According to the API documentation:

"If using the `NewFromConfig` constructor you'll need to explicitly set
the `Credentials` member to nil, if the external config resolved a
credential provider."

This change allows setting these empty credentials so that the client can be used anonymously.

--- 

This would solve my issues described in https://github.com/docker/buildx/issues/1666 and would generally allow users to share cache publicly (for example, in fork PRs)