### PR TITLE
version: add "v" prefix to version for tagging convention consistency

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	defaultVersion = "0.0.0+unknown"
+	defaultVersion = "v0.0.0+unknown"
 )
 
 var (


### PR DESCRIPTION
:arrow_up: Follow-up to https://github.com/docker/buildx/pull/1637#discussion_r1108625166.
:link: Similar to https://github.com/docker/buildx/pull/1670.

Ensures that the BuildKit version always begins with a `v` (as in the version tagging convention we use). This will only apply in cases when users build buildkit from scratch *without* using the provided build scripts (and just using `go build` directly).