### PR TITLE
[0.11 backport] rootless: support Bottlerocket OS

### DIFF
--- a/docs/rootless.md
+++ b/docs/rootless.md
@@ -24,6 +24,12 @@ spec:
 
 See also the [example manifests](#Kubernetes).
 
+### Bottlerocket OS
+
+Needs to run `sysctl -w user.max_user_namespaces=N` (N=positive integer, like 63359) on the host nodes.
+
+See [`../examples/kubernetes/sysctl-userns.privileged.yaml`](../examples/kubernetes/sysctl-userns.privileged.yaml).
+
 <details>
 <summary>Old distributions</summary>
 
@@ -103,6 +109,11 @@ See https://rootlesscontaine.rs/getting-started/common/subuid/
 
 ### Error `Options:[rbind ro]}]: operation not permitted`
 Make sure to mount an `emptyDir` volume on `/home/user/.local/share/buildkit` .
+
+### Error `fork/exec /proc/self/exe: no space left on device` with `level=warning msg="/proc/sys/user/max_user_namespaces needs to be set to non-zero."`
+Run `sysctl -w user.max_user_namespaces=N` (N=positive integer, like 63359) on the host nodes.
+
+See [`../examples/kubernetes/sysctl-userns.privileged.yaml`](../examples/kubernetes/sysctl-userns.privileged.yaml).
 
 ## Containerized deployment
 

--- a/examples/kubernetes/sysctl-userns.privileged.yaml
+++ b/examples/kubernetes/sysctl-userns.privileged.yaml
@@ -1,0 +1,26 @@
+# Run `sysctl -w user.max_user_namespaces=63359` on all the nodes,
+# for errors like "/proc/sys/user/max_user_namespaces needs to be set to non-zero"
+# on running rootless buildkitd pods.
+#
+# This workaround is known to be needed on Bottlerocket OS.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: sysctl-userns
+  name: sysctl-userns
+spec:
+  selector:
+    matchLabels:
+      app: sysctl-userns
+  template:
+    metadata:
+      labels:
+        app: sysctl-userns
+    spec:
+      containers:
+        - name: sysctl-userns
+          image: busybox
+          command: ["sh", "-euxc", "sysctl -w user.max_user_namespaces=63359 && sleep infinity"]
+          securityContext:
+            privileged: true

--- a/util/rootless/mountopts/mountopts_linux.go
+++ b/util/rootless/mountopts/mountopts_linux.go
@@ -1,0 +1,88 @@
+package mountopts
+
+import (
+	"github.com/containerd/containerd/mount"
+	"github.com/moby/buildkit/util/strutil"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+// UnprivilegedMountFlags gets the set of mount flags that are set on the mount that contains the given
+// path and are locked by CL_UNPRIVILEGED. This is necessary to ensure that
+// bind-mounting "with options" will not fail with user namespaces, due to
+// kernel restrictions that require user namespace mounts to preserve
+// CL_UNPRIVILEGED locked flags.
+//
+// From https://github.com/moby/moby/blob/v23.0.1/daemon/oci_linux.go#L430-L460
+func UnprivilegedMountFlags(path string) ([]string, error) {
+	var statfs unix.Statfs_t
+	if err := unix.Statfs(path, &statfs); err != nil {
+		return nil, err
+	}
+
+	// The set of keys come from https://github.com/torvalds/linux/blob/v4.13/fs/namespace.c#L1034-L1048.
+	unprivilegedFlags := map[uint64]string{
+		unix.MS_RDONLY:     "ro",
+		unix.MS_NODEV:      "nodev",
+		unix.MS_NOEXEC:     "noexec",
+		unix.MS_NOSUID:     "nosuid",
+		unix.MS_NOATIME:    "noatime",
+		unix.MS_RELATIME:   "relatime",
+		unix.MS_NODIRATIME: "nodiratime",
+	}
+
+	var flags []string
+	for mask, flag := range unprivilegedFlags {
+		if uint64(statfs.Flags)&mask == mask {
+			flags = append(flags, flag)
+		}
+	}
+
+	return flags, nil
+}
+
+// FixUp is for https://github.com/moby/buildkit/issues/3098
+func FixUp(mounts []mount.Mount) ([]mount.Mount, error) {
+	for i, m := range mounts {
+		var isBind bool
+		for _, o := range m.Options {
+			switch o {
+			case "bind", "rbind":
+				isBind = true
+			}
+		}
+		if !isBind {
+			continue
+		}
+		unpriv, err := UnprivilegedMountFlags(m.Source)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get unprivileged mount flags for %+v", m)
+		}
+		m.Options = strutil.DedupeSlice(append(m.Options, unpriv...))
+		mounts[i] = m
+	}
+	return mounts, nil
+}
+
+func FixUpOCI(mounts []specs.Mount) ([]specs.Mount, error) {
+	for i, m := range mounts {
+		var isBind bool
+		for _, o := range m.Options {
+			switch o {
+			case "bind", "rbind":
+				isBind = true
+			}
+		}
+		if !isBind {
+			continue
+		}
+		unpriv, err := UnprivilegedMountFlags(m.Source)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get unprivileged mount flags for %+v", m)
+		}
+		m.Options = strutil.DedupeSlice(append(m.Options, unpriv...))
+		mounts[i] = m
+	}
+	return mounts, nil
+}

--- a/util/rootless/mountopts/mountopts_others.go
+++ b/util/rootless/mountopts/mountopts_others.go
@@ -1,0 +1,21 @@
+//go:build !linux
+// +build !linux
+
+package mountopts
+
+import (
+	"github.com/containerd/containerd/mount"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func UnprivilegedMountFlags(path string) ([]string, error) {
+	return []string{}, nil
+}
+
+func FixUp(mounts []mount.Mount) ([]mount.Mount, error) {
+	return mounts, nil
+}
+
+func FixUpOCI(mounts []specs.Mount) ([]specs.Mount, error) {
+	return mounts, nil
+}

--- a/util/strutil/strutil.go
+++ b/util/strutil/strutil.go
@@ -1,0 +1,30 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package strutil
+
+// DedupeSlice is from https://github.com/containerd/nerdctl/blob/v1.2.1/pkg/strutil/strutil.go#L72-L82
+func DedupeSlice(in []string) []string {
+	m := make(map[string]struct{})
+	var res []string
+	for _, s := range in {
+		if _, ok := m[s]; !ok {
+			res = append(res, s)
+			m[s] = struct{}{}
+		}
+	}
+	return res
+}


### PR DESCRIPTION
Cherry-pick (clean):
- https://github.com/moby/buildkit/pull/3697