### PR TITLE
use bklog.G(ctx) instead of logrus directly

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,6 +44,7 @@ linters-settings:
   forbidigo:
     forbid:
       - '^fmt\.Errorf(# use errors\.Errorf instead)?$'
+      - 'logrus\.(Trace|Debug|Info|Warn|Warning|Error|Fatal)(f|ln)?\((# use bklog\.G\(ctx\) instead of logrus directly)?'
   importas:
     alias:
       - pkg: "github.com/opencontainers/image-spec/specs-go/v1"

--- a/cache/blobs.go
+++ b/cache/blobs.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/mount"
 	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/compression"
 	"github.com/moby/buildkit/util/flightcontrol"
 	"github.com/moby/buildkit/util/winlayers"
@@ -18,7 +19,6 @@ import (
 	imagespecidentity "github.com/opencontainers/image-spec/identity"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -180,7 +180,7 @@ func computeBlobChain(ctx context.Context, sr *immutableRef, createIfNeeded bool
 							}
 						}
 						if logWarnOnErr {
-							logrus.Warnf("failed to compute blob by overlay differ (ok=%v): %v", ok, err)
+							bklog.G(ctx).Warnf("failed to compute blob by overlay differ (ok=%v): %v", ok, err)
 						}
 					}
 					if ok {
@@ -198,7 +198,7 @@ func computeBlobChain(ctx context.Context, sr *immutableRef, createIfNeeded bool
 						diff.WithCompressor(compressorFunc),
 					)
 					if err != nil {
-						logrus.WithError(err).Warnf("failed to compute blob by buildkit differ")
+						bklog.G(ctx).WithError(err).Warnf("failed to compute blob by buildkit differ")
 					}
 				}
 

--- a/cache/manager.go
+++ b/cache/manager.go
@@ -27,7 +27,6 @@ import (
 	imagespecidentity "github.com/opencontainers/image-spec/identity"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -243,7 +242,7 @@ func (cm *cacheManager) GetByBlob(ctx context.Context, desc ocispecs.Descriptor,
 			if err := cm.LeaseManager.Delete(context.TODO(), leases.Lease{
 				ID: l.ID,
 			}); err != nil {
-				logrus.Errorf("failed to remove lease: %+v", err)
+				bklog.G(ctx).Errorf("failed to remove lease: %+v", err)
 			}
 		}
 	}()
@@ -319,7 +318,7 @@ func (cm *cacheManager) init(ctx context.Context) error {
 
 	for _, si := range items {
 		if _, err := cm.getRecord(ctx, si.ID()); err != nil {
-			logrus.Debugf("could not load snapshot %s: %+v", si.ID(), err)
+			bklog.G(ctx).Debugf("could not load snapshot %s: %+v", si.ID(), err)
 			cm.MetadataStore.Clear(si.ID())
 			cm.LeaseManager.Delete(ctx, leases.Lease{ID: si.ID()})
 		}
@@ -597,7 +596,7 @@ func (cm *cacheManager) New(ctx context.Context, s ImmutableRef, sess session.Gr
 			if err := cm.LeaseManager.Delete(context.TODO(), leases.Lease{
 				ID: l.ID,
 			}); err != nil {
-				logrus.Errorf("failed to remove lease: %+v", err)
+				bklog.G(ctx).Errorf("failed to remove lease: %+v", err)
 			}
 		}
 	}()

--- a/cache/metadata.go
+++ b/cache/metadata.go
@@ -87,7 +87,7 @@ func (cm *cacheManager) Search(ctx context.Context, idx string) ([]RefMetadata, 
 
 // callers must hold cm.mu lock
 func (cm *cacheManager) search(ctx context.Context, idx string) ([]RefMetadata, error) {
-	sis, err := cm.MetadataStore.Search(idx)
+	sis, err := cm.MetadataStore.Search(ctx, idx)
 	if err != nil {
 		return nil, err
 	}

--- a/cache/metadata/metadata.go
+++ b/cache/metadata/metadata.go
@@ -2,12 +2,13 @@ package metadata
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"strings"
 	"sync"
 
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -80,7 +81,7 @@ func (s *Store) Probe(index string) (bool, error) {
 	return exists, errors.WithStack(err)
 }
 
-func (s *Store) Search(index string) ([]*StorageItem, error) {
+func (s *Store) Search(ctx context.Context, index string) ([]*StorageItem, error) {
 	var out []*StorageItem
 	err := s.db.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(indexBucket))
@@ -100,7 +101,7 @@ func (s *Store) Search(index string) ([]*StorageItem, error) {
 				k, _ = c.Next()
 				b := main.Bucket([]byte(itemID))
 				if b == nil {
-					logrus.Errorf("index pointing to missing record %s", itemID)
+					bklog.G(ctx).Errorf("index pointing to missing record %s", itemID)
 					continue
 				}
 				si, err := newStorageItem(itemID, b, s)

--- a/cache/metadata/metadata_test.go
+++ b/cache/metadata/metadata_test.go
@@ -1,6 +1,7 @@
 package metadata
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -140,14 +141,15 @@ func TestIndexes(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	sis, err := s.Search("tag:baz")
+	ctx := context.Background()
+	sis, err := s.Search(ctx, "tag:baz")
 	require.NoError(t, err)
 	require.Equal(t, 2, len(sis))
 
 	require.Equal(t, sis[0].ID(), "foo1")
 	require.Equal(t, sis[1].ID(), "foo3")
 
-	sis, err = s.Search("tag:bax")
+	sis, err = s.Search(ctx, "tag:bax")
 	require.NoError(t, err)
 	require.Equal(t, 1, len(sis))
 
@@ -156,7 +158,7 @@ func TestIndexes(t *testing.T) {
 	err = s.Clear("foo1")
 	require.NoError(t, err)
 
-	sis, err = s.Search("tag:baz")
+	sis, err = s.Search(ctx, "tag:baz")
 	require.NoError(t, err)
 	require.Equal(t, 1, len(sis))
 

--- a/cache/refs.go
+++ b/cache/refs.go
@@ -34,7 +34,6 @@ import (
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -993,7 +992,7 @@ func (sr *immutableRef) withRemoteSnapshotLabelsStargzMode(ctx context.Context, 
 				info.Labels[k] = "" // Remove labels appended in this call
 			}
 			if _, err := r.cm.Snapshotter.Update(ctx, info, flds...); err != nil {
-				logrus.Warn(errors.Wrapf(err, "failed to remove tmp remote labels"))
+				bklog.G(ctx).Warn(errors.Wrapf(err, "failed to remove tmp remote labels"))
 			}
 		}()
 
@@ -1055,7 +1054,7 @@ func (sr *immutableRef) prepareRemoteSnapshotsStargzMode(ctx context.Context, s 
 								info.Labels[k] = ""
 							}
 							if _, err := r.cm.Snapshotter.Update(ctx, info, tmpFields...); err != nil {
-								logrus.Warn(errors.Wrapf(err,
+								bklog.G(ctx).Warn(errors.Wrapf(err,
 									"failed to remove tmp remote labels after prepare"))
 							}
 						}()
@@ -1363,7 +1362,7 @@ func (cr *cacheRecord) finalize(ctx context.Context) error {
 		cr.cm.mu.Lock()
 		defer cr.cm.mu.Unlock()
 		if err := mutable.remove(context.TODO(), true); err != nil {
-			logrus.Error(err)
+			bklog.G(ctx).Error(err)
 		}
 	}()
 

--- a/cache/remotecache/azblob/exporter.go
+++ b/cache/remotecache/azblob/exporter.go
@@ -14,11 +14,11 @@ import (
 	v1 "github.com/moby/buildkit/cache/remotecache/v1"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/compression"
 	"github.com/moby/buildkit/util/progress"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 // ResolveCacheExporterFunc for "azblob" cache exporter.
@@ -89,7 +89,7 @@ func (ce *exporter) Finalize(ctx context.Context) (map[string]string, error) {
 			return nil, err
 		}
 
-		logrus.Debugf("layers %s exists = %t", key, exists)
+		bklog.G(ctx).Debugf("layers %s exists = %t", key, exists)
 
 		if !exists {
 			layerDone := progress.OneOff(ctx, fmt.Sprintf("writing layer %s", l.Blob))

--- a/cache/remotecache/azblob/importer.go
+++ b/cache/remotecache/azblob/importer.go
@@ -13,12 +13,12 @@ import (
 	v1 "github.com/moby/buildkit/cache/remotecache/v1"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/contentutil"
 	"github.com/moby/buildkit/util/progress"
 	"github.com/moby/buildkit/worker"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -92,7 +92,7 @@ func (ci *importer) loadManifest(ctx context.Context, name string) (*v1.CacheCha
 		return nil, err
 	}
 
-	logrus.Debugf("name %s cache with key %s exists = %v", name, key, exists)
+	bklog.G(ctx).Debugf("name %s cache with key %s exists = %v", name, key, exists)
 
 	if !exists {
 		return v1.NewCacheChains(), nil
@@ -113,7 +113,7 @@ func (ci *importer) loadManifest(ctx context.Context, name string) (*v1.CacheCha
 		return nil, errors.WithStack(err)
 	}
 
-	logrus.Debugf("imported config: %s", string(bytes))
+	bklog.G(ctx).Debugf("imported config: %s", string(bytes))
 
 	var config v1.CacheConfig
 	if err := json.Unmarshal(bytes, &config); err != nil {
@@ -188,7 +188,7 @@ func (f *fetcher) Fetch(ctx context.Context, desc ocispecs.Descriptor) (io.ReadC
 		return nil, errors.Errorf("blob %s not found", desc.Digest)
 	}
 
-	logrus.Debugf("reading layer from cache: %s", key)
+	bklog.G(ctx).Debugf("reading layer from cache: %s", key)
 
 	blobClient, err := f.containerClient.NewBlockBlobClient(key)
 	if err != nil {

--- a/cache/remotecache/export.go
+++ b/cache/remotecache/export.go
@@ -104,7 +104,7 @@ func (ce *contentCacheExporter) Finalize(ctx context.Context) (map[string]string
 		mfst.Manifests = append(mfst.Manifests, dgstPair.Descriptor)
 	}
 
-	mfst.Manifests = compression.ConvertAllLayerMediaTypes(ce.oci, mfst.Manifests...)
+	mfst.Manifests = compression.ConvertAllLayerMediaTypes(ctx, ce.oci, mfst.Manifests...)
 
 	dt, err := json.Marshal(config)
 	if err != nil {

--- a/cache/remotecache/gha/gha.go
+++ b/cache/remotecache/gha/gha.go
@@ -15,6 +15,7 @@ import (
 	v1 "github.com/moby/buildkit/cache/remotecache/v1"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/compression"
 	"github.com/moby/buildkit/util/progress"
 	"github.com/moby/buildkit/util/tracing"
@@ -22,13 +23,12 @@ import (
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	actionscache "github.com/tonistiigi/go-actions-cache"
 	"golang.org/x/sync/errgroup"
 )
 
 func init() {
-	actionscache.Log = logrus.Debugf
+	actionscache.Log = bklog.L.Debugf
 }
 
 const (

--- a/cache/remotecache/import.go
+++ b/cache/remotecache/import.go
@@ -12,12 +12,12 @@ import (
 	v1 "github.com/moby/buildkit/cache/remotecache/v1"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/imageutil"
 	"github.com/moby/buildkit/worker"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -162,7 +162,7 @@ func (ci *contentCacheImporter) importInlineCache(ctx context.Context, dt []byte
 				}
 
 				if len(img.Rootfs.DiffIDs) != len(m.Layers) {
-					logrus.Warnf("invalid image with mismatching manifest and config")
+					bklog.G(ctx).Warnf("invalid image with mismatching manifest and config")
 					return nil
 				}
 

--- a/cache/remotecache/inline/inline.go
+++ b/cache/remotecache/inline/inline.go
@@ -8,10 +8,10 @@ import (
 	v1 "github.com/moby/buildkit/cache/remotecache/v1"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/compression"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 func ResolveCacheExporterFunc() remotecache.ResolveCacheExporterFunc {
@@ -85,7 +85,7 @@ func (ce *exporter) ExportForLayers(ctx context.Context, layers []digest.Digest)
 	}
 
 	if len(cfg.Layers) == 0 {
-		logrus.Warn("failed to match any cache with layers")
+		bklog.G(ctx).Warn("failed to match any cache with layers")
 		return nil, nil
 	}
 

--- a/cache/remotecache/v1/chains.go
+++ b/cache/remotecache/v1/chains.go
@@ -39,7 +39,7 @@ func (c *CacheChains) Visited(v interface{}) bool {
 	return ok
 }
 
-func (c *CacheChains) normalize() error {
+func (c *CacheChains) normalize(ctx context.Context) error {
 	st := &normalizeState{
 		added: map[*item]*item{},
 		links: map[*item]map[nlink]map[digest.Digest]struct{}{},
@@ -66,7 +66,7 @@ func (c *CacheChains) normalize() error {
 		}
 	}
 
-	st.removeLoops()
+	st.removeLoops(ctx)
 
 	items := make([]*item, 0, len(st.byKey))
 	for _, it := range st.byKey {
@@ -77,7 +77,7 @@ func (c *CacheChains) normalize() error {
 }
 
 func (c *CacheChains) Marshal(ctx context.Context) (*CacheConfig, DescriptorProvider, error) {
-	if err := c.normalize(); err != nil {
+	if err := c.normalize(ctx); err != nil {
 		return nil, nil, err
 	}
 

--- a/cache/remotecache/v1/utils.go
+++ b/cache/remotecache/v1/utils.go
@@ -6,10 +6,10 @@ import (
 	"sort"
 
 	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/util/bklog"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 // sortConfig sorts the config structure to make sure it is deterministic
@@ -128,7 +128,7 @@ type normalizeState struct {
 	next  int
 }
 
-func (s *normalizeState) removeLoops() {
+func (s *normalizeState) removeLoops(ctx context.Context) {
 	roots := []digest.Digest{}
 	for dgst, it := range s.byKey {
 		if len(it.links) == 0 {
@@ -139,11 +139,11 @@ func (s *normalizeState) removeLoops() {
 	visited := map[digest.Digest]struct{}{}
 
 	for _, d := range roots {
-		s.checkLoops(d, visited)
+		s.checkLoops(ctx, d, visited)
 	}
 }
 
-func (s *normalizeState) checkLoops(d digest.Digest, visited map[digest.Digest]struct{}) {
+func (s *normalizeState) checkLoops(ctx context.Context, d digest.Digest, visited map[digest.Digest]struct{}) {
 	it, ok := s.byKey[d]
 	if !ok {
 		return
@@ -165,11 +165,11 @@ func (s *normalizeState) checkLoops(d digest.Digest, visited map[digest.Digest]s
 					continue
 				}
 				if !it2.removeLink(it) {
-					logrus.Warnf("failed to remove looping cache key %s %s", d, id)
+					bklog.G(ctx).Warnf("failed to remove looping cache key %s %s", d, id)
 				}
 				delete(links[l], id)
 			} else {
-				s.checkLoops(id, visited)
+				s.checkLoops(ctx, id, visited)
 			}
 		}
 	}

--- a/cmd/buildctl/build.go
+++ b/cmd/buildctl/build.go
@@ -22,10 +22,10 @@ import (
 	"github.com/moby/buildkit/session/sshforward/sshprovider"
 	"github.com/moby/buildkit/solver/pb"
 	spb "github.com/moby/buildkit/sourcepolicy/pb"
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/progress/progresswriter"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	"golang.org/x/sync/errgroup"
 )
@@ -154,7 +154,7 @@ func buildAction(clicontext *cli.Context) error {
 		defer traceFile.Close()
 		traceEnc = json.NewEncoder(traceFile)
 
-		logrus.Infof("tracing logs to %s", traceFile.Name())
+		bklog.L.Infof("tracing logs to %s", traceFile.Name())
 	}
 
 	dockerConfig := config.LoadDefaultConfigFile(os.Stderr)
@@ -339,7 +339,7 @@ func buildAction(clicontext *cli.Context) error {
 			return err
 		}
 		for k, v := range resp.ExporterResponse {
-			logrus.Debugf("exporter response: %s=%s", k, v)
+			bklog.G(ctx).Debugf("exporter response: %s=%s", k, v)
 		}
 
 		metadataFile := clicontext.String("metadata-file")

--- a/cmd/buildctl/build/exportcache.go
+++ b/cmd/buildctl/build/exportcache.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 
 	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 func parseExportCacheCSV(s string) (client.CacheOptionsEntry, error) {
@@ -51,7 +51,7 @@ func ParseExportCache(exportCaches []string) ([]client.CacheOptionsEntry, error)
 		legacy := !strings.Contains(exportCache, "type=")
 		if legacy {
 			// Deprecated since BuildKit v0.4.0, but no plan to remove: https://github.com/moby/buildkit/pull/2783#issuecomment-1093449772
-			logrus.Warnf("--export-cache <ref> is deprecated. Please use --export-cache type=registry,ref=<ref>,<opt>=<optval>[,<opt>=<optval>] instead")
+			bklog.L.Warnf("--export-cache <ref> is deprecated. Please use --export-cache type=registry,ref=<ref>,<opt>=<optval>[,<opt>=<optval>] instead")
 			exports = append(exports, client.CacheOptionsEntry{
 				Type: "registry",
 				Attrs: map[string]string{

--- a/cmd/buildctl/build/importcache.go
+++ b/cmd/buildctl/build/importcache.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 
 	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 func parseImportCacheCSV(s string) (client.CacheOptionsEntry, error) {
@@ -48,7 +48,7 @@ func ParseImportCache(importCaches []string) ([]client.CacheOptionsEntry, error)
 		legacy := !strings.Contains(importCache, "type=")
 		if legacy {
 			// Deprecated since BuildKit v0.4.0, but no plan to remove: https://github.com/moby/buildkit/pull/2783#issuecomment-1093449772
-			logrus.Warn("--import-cache <ref> is deprecated. Please use --import-cache type=registry,ref=<ref>,<opt>=<optval>[,<opt>=<optval>] instead.")
+			bklog.L.Warn("--import-cache <ref> is deprecated. Please use --import-cache type=registry,ref=<ref>,<opt>=<optval>[,<opt>=<optval>] instead.")
 			imports = append(imports, client.CacheOptionsEntry{
 				Type:  "registry",
 				Attrs: map[string]string{"ref": importCache},

--- a/cmd/buildctl/debug/workers.go
+++ b/cmd/buildctl/debug/workers.go
@@ -11,8 +11,8 @@ import (
 	"github.com/containerd/containerd/platforms"
 	"github.com/moby/buildkit/client"
 	bccommon "github.com/moby/buildkit/cmd/buildctl/common"
+	"github.com/moby/buildkit/util/bklog"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 	"github.com/tonistiigi/units"
 	"github.com/urfave/cli"
 )
@@ -49,7 +49,7 @@ func listWorkers(clicontext *cli.Context) error {
 	}
 	if format := clicontext.String("format"); format != "" {
 		if clicontext.Bool("verbose") {
-			logrus.Debug("Ignoring --verbose")
+			bklog.L.Debug("Ignoring --verbose")
 		}
 		tmpl, err := bccommon.ParseTemplate(format)
 		if err != nil {

--- a/cmd/buildctl/dialstdio.go
+++ b/cmd/buildctl/dialstdio.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -74,10 +74,10 @@ func dialer(address string, timeout time.Duration) (net.Conn, error) {
 func copier(to halfWriteCloser, from halfReadCloser, debugDescription string) error {
 	defer func() {
 		if err := from.CloseRead(); err != nil {
-			logrus.Errorf("error while CloseRead (%s): %v", debugDescription, err)
+			bklog.L.Errorf("error while CloseRead (%s): %v", debugDescription, err)
 		}
 		if err := to.CloseWrite(); err != nil {
-			logrus.Errorf("error while CloseWrite (%s): %v", debugDescription, err)
+			bklog.L.Errorf("error while CloseWrite (%s): %v", debugDescription, err)
 		}
 	}()
 	if _, err := io.Copy(to, from); err != nil {

--- a/cmd/buildctl/diskusage.go
+++ b/cmd/buildctl/diskusage.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/moby/buildkit/client"
 	bccommon "github.com/moby/buildkit/cmd/buildctl/common"
-	"github.com/sirupsen/logrus"
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/tonistiigi/units"
 	"github.com/urfave/cli"
 )
@@ -47,7 +47,7 @@ func diskUsage(clicontext *cli.Context) error {
 
 	if format := clicontext.String("format"); format != "" {
 		if clicontext.Bool("verbose") {
-			logrus.Debug("Ignoring --verbose")
+			bklog.L.Debug("Ignoring --verbose")
 		}
 		tmpl, err := bccommon.ParseTemplate(format)
 		if err != nil {

--- a/cmd/buildctl/prune.go
+++ b/cmd/buildctl/prune.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/moby/buildkit/client"
 	bccommon "github.com/moby/buildkit/cmd/buildctl/common"
-	"github.com/sirupsen/logrus"
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/tonistiigi/units"
 	"github.com/urfave/cli"
 )
@@ -65,7 +65,7 @@ func prune(clicontext *cli.Context) error {
 
 	if format := clicontext.String("format"); format != "" {
 		if clicontext.Bool("verbose") {
-			logrus.Debug("Ignoring --verbose")
+			bklog.L.Debug("Ignoring --verbose")
 		}
 		tmpl, err := bccommon.ParseTemplate(format)
 		if err != nil {

--- a/cmd/buildkitd/debug.go
+++ b/cmd/buildkitd/debug.go
@@ -8,7 +8,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	"github.com/moby/buildkit/util/bklog"
 	"golang.org/x/net/trace"
 )
 
@@ -25,7 +25,7 @@ func setupDebugHandlers(addr string) error {
 
 	m.Handle("/debug/gc", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		runtime.GC()
-		logrus.Debugf("triggered GC from debug endpoint")
+		bklog.G(req.Context()).Debugf("triggered GC from debug endpoint")
 	}))
 
 	// setting debugaddr is opt-in. permission is defined by listener address
@@ -42,7 +42,7 @@ func setupDebugHandlers(addr string) error {
 		Handler:           m,
 		ReadHeaderTimeout: time.Minute,
 	}
-	logrus.Debugf("debug handlers listening at %s", addr)
+	bklog.L.Debugf("debug handlers listening at %s", addr)
 	go server.ListenAndServe()
 	return nil
 }

--- a/cmd/buildkitd/main_containerd_worker.go
+++ b/cmd/buildkitd/main_containerd_worker.go
@@ -13,13 +13,13 @@ import (
 	ctd "github.com/containerd/containerd"
 	"github.com/containerd/containerd/pkg/userns"
 	"github.com/moby/buildkit/cmd/buildkitd/config"
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/network/cniprovider"
 	"github.com/moby/buildkit/util/network/netproviders"
 	"github.com/moby/buildkit/worker"
 	"github.com/moby/buildkit/worker/base"
 	"github.com/moby/buildkit/worker/containerd"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	"golang.org/x/sync/semaphore"
 )
@@ -247,7 +247,7 @@ func containerdWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([
 	}
 
 	if cfg.Rootless {
-		logrus.Debugf("running in rootless mode")
+		bklog.L.Debugf("running in rootless mode")
 		if common.config.Workers.Containerd.NetworkConfig.Mode == "auto" {
 			common.config.Workers.Containerd.NetworkConfig.Mode = "host"
 		}
@@ -305,16 +305,16 @@ func validContainerdSocket(cfg config.ContainerdConfig) bool {
 	socketPath := strings.TrimPrefix(socket, "unix://")
 	if _, err := os.Stat(socketPath); errors.Is(err, os.ErrNotExist) {
 		// FIXME(AkihiroSuda): add more conditions
-		logrus.Warnf("skipping containerd worker, as %q does not exist", socketPath)
+		bklog.L.Warnf("skipping containerd worker, as %q does not exist", socketPath)
 		return false
 	}
 	c, err := ctd.New(socketPath, ctd.WithDefaultNamespace(cfg.Namespace))
 	if err != nil {
-		logrus.Warnf("skipping containerd worker, as failed to connect client to %q: %v", socketPath, err)
+		bklog.L.Warnf("skipping containerd worker, as failed to connect client to %q: %v", socketPath, err)
 		return false
 	}
 	if _, err := c.Server(context.Background()); err != nil {
-		logrus.Warnf("skipping containerd worker, as failed to call introspection API on %q: %v", socketPath, err)
+		bklog.L.Warnf("skipping containerd worker, as failed to call introspection API on %q: %v", socketPath, err)
 		return false
 	}
 	return true

--- a/cmd/buildkitd/main_oci_worker.go
+++ b/cmd/buildkitd/main_oci_worker.go
@@ -33,6 +33,7 @@ import (
 	"github.com/moby/buildkit/cmd/buildkitd/config"
 	"github.com/moby/buildkit/executor/oci"
 	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/network/cniprovider"
 	"github.com/moby/buildkit/util/network/netproviders"
 	"github.com/moby/buildkit/util/resolver"
@@ -275,7 +276,7 @@ func ociWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([]worker
 	}
 
 	if cfg.Rootless {
-		logrus.Debugf("running in rootless mode")
+		bklog.L.Debugf("running in rootless mode")
 		if common.config.Workers.OCI.NetworkConfig.Mode == "auto" {
 			common.config.Workers.OCI.NetworkConfig.Mode = "host"
 		}
@@ -283,7 +284,7 @@ func ociWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([]worker
 
 	processMode := oci.ProcessSandbox
 	if cfg.NoProcessSandbox {
-		logrus.Warn("NoProcessSandbox is enabled. Note that NoProcessSandbox allows build containers to kill (and potentially ptrace) an arbitrary process in the BuildKit host namespace. NoProcessSandbox should be enabled only when the BuildKit is running in a container as an unprivileged user.")
+		bklog.L.Warn("NoProcessSandbox is enabled. Note that NoProcessSandbox allows build containers to kill (and potentially ptrace) an arbitrary process in the BuildKit host namespace. NoProcessSandbox should be enabled only when the BuildKit is running in a container as an unprivileged user.")
 		if !cfg.Rootless {
 			return nil, errors.New("can't enable NoProcessSandbox without Rootless")
 		}
@@ -367,15 +368,15 @@ func snapshotterFactory(commonRoot string, cfg config.OCIConfig, sm *session.Man
 		if err := overlayutils.Supported(commonRoot); err == nil {
 			name = "overlayfs"
 		} else {
-			logrus.Debugf("auto snapshotter: overlayfs is not available for %s, trying fuse-overlayfs: %v", commonRoot, err)
+			bklog.L.Debugf("auto snapshotter: overlayfs is not available for %s, trying fuse-overlayfs: %v", commonRoot, err)
 			if err2 := fuseoverlayfs.Supported(commonRoot); err2 == nil {
 				name = "fuse-overlayfs"
 			} else {
-				logrus.Debugf("auto snapshotter: fuse-overlayfs is not available for %s, falling back to native: %v", commonRoot, err2)
+				bklog.L.Debugf("auto snapshotter: fuse-overlayfs is not available for %s, falling back to native: %v", commonRoot, err2)
 				name = "native"
 			}
 		}
-		logrus.Infof("auto snapshotter: using %s", name)
+		bklog.L.Infof("auto snapshotter: using %s", name)
 	}
 
 	snFactory := runc.SnapshotterFactory{
@@ -412,7 +413,7 @@ func snapshotterFactory(commonRoot string, cfg config.OCIConfig, sm *session.Man
 		snFactory.New = func(root string) (ctdsnapshot.Snapshotter, error) {
 			userxattr, err := overlayutils.NeedsUserXAttr(root)
 			if err != nil {
-				logrus.WithError(err).Warnf("cannot detect whether \"userxattr\" option needs to be used, assuming to be %v", userxattr)
+				bklog.L.WithError(err).Warnf("cannot detect whether \"userxattr\" option needs to be used, assuming to be %v", userxattr)
 			}
 			opq := sgzlayer.OverlayOpaqueTrusted
 			if userxattr {
@@ -442,7 +443,7 @@ func validOCIBinary() bool {
 	_, err := exec.LookPath("runc")
 	_, err1 := exec.LookPath("buildkit-runc")
 	if err != nil && err1 != nil {
-		logrus.Warnf("skipping oci worker, as runc does not exist")
+		bklog.L.Warnf("skipping oci worker, as runc does not exist")
 		return false
 	}
 	return true

--- a/cmd/buildkitd/util_linux.go
+++ b/cmd/buildkitd/util_linux.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 
 	"github.com/docker/docker/pkg/idtools"
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 func parseIdentityMapping(str string) (*idtools.IdentityMapping, error) {
@@ -20,7 +20,7 @@ func parseIdentityMapping(str string) (*idtools.IdentityMapping, error) {
 
 	username := idparts[0]
 
-	logrus.Debugf("user namespaces: ID ranges will be mapped to subuid ranges of: %s", username)
+	bklog.L.Debugf("user namespaces: ID ranges will be mapped to subuid ranges of: %s", username)
 
 	mappings, err := idtools.LoadIdentityMapping(username)
 	if err != nil {

--- a/executor/containerdexecutor/executor.go
+++ b/executor/containerdexecutor/executor.go
@@ -135,7 +135,7 @@ func (w *containerdExecutor) Run(ctx context.Context, id string, root executor.M
 		return err
 	}
 	defer lm.Unmount()
-	defer executor.MountStubsCleaner(rootfsPath, mounts, meta.RemoveMountStubsRecursive)()
+	defer executor.MountStubsCleaner(ctx, rootfsPath, mounts, meta.RemoveMountStubsRecursive)()
 
 	uid, gid, sgids, err := oci.GetUser(rootfsPath, meta.User)
 	if err != nil {

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -224,7 +224,7 @@ func (w *runcExecutor) Run(ctx context.Context, id string, root executor.Mount, 
 	}
 	defer mount.Unmount(rootFSPath, 0)
 
-	defer executor.MountStubsCleaner(rootFSPath, mounts, meta.RemoveMountStubsRecursive)()
+	defer executor.MountStubsCleaner(ctx, rootFSPath, mounts, meta.RemoveMountStubsRecursive)()
 
 	uid, gid, sgids, err := oci.GetUser(rootFSPath, meta.User)
 	if err != nil {

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -83,7 +83,7 @@ func (e *imageExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 		store: true,
 	}
 
-	opt, err := i.opts.Load(opt)
+	opt, err := i.opts.Load(ctx, opt)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -100,7 +100,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 			}
 		}
 		if len(a.Index)+len(a.IndexDescriptor)+len(a.ManifestDescriptor) > 0 {
-			opts.EnableOCITypes("annotations")
+			opts.EnableOCITypes(ctx, "annotations")
 		}
 	}
 
@@ -148,7 +148,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 	}
 
 	if len(inp.Attestations) > 0 {
-		opts.EnableOCITypes("attestations")
+		opts.EnableOCITypes(ctx, "attestations")
 	}
 
 	refs := make([]cache.ImmutableRef, 0, len(inp.Refs))
@@ -722,7 +722,7 @@ func normalizeLayersAndHistory(ctx context.Context, remote *solver.Remote, histo
 	}
 
 	// convert between oci and docker media types (or vice versa) if needed
-	remote.Descriptors = compression.ConvertAllLayerMediaTypes(oci, remote.Descriptors...)
+	remote.Descriptors = compression.ConvertAllLayerMediaTypes(ctx, oci, remote.Descriptors...)
 
 	return remote, history
 }

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -71,7 +71,7 @@ func (e *imageExporter) Resolve(ctx context.Context, opt map[string]string) (exp
 		},
 	}
 
-	opt, err := i.opts.Load(opt)
+	opt, err := i.opts.Load(ctx, opt)
 	if err != nil {
 		return nil, err
 	}

--- a/frontend/dockerfile/cmd/dockerfile-frontend/main.go
+++ b/frontend/dockerfile/cmd/dockerfile-frontend/main.go
@@ -8,8 +8,8 @@ import (
 	dockerfile "github.com/moby/buildkit/frontend/dockerfile/builder"
 	"github.com/moby/buildkit/frontend/gateway/grpcclient"
 	"github.com/moby/buildkit/util/appcontext"
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/stack"
-	"github.com/sirupsen/logrus"
 )
 
 func init() {
@@ -27,7 +27,7 @@ func main() {
 	}
 
 	if err := grpcclient.RunFromEnvironment(appcontext.Context(), dockerfile.Build); err != nil {
-		logrus.Errorf("fatal error: %+v", err)
+		bklog.L.Errorf("fatal error: %+v", err)
 		panic(err)
 	}
 }

--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -1324,7 +1324,7 @@ func (lbf *llbBridgeForwarder) ExecProcess(srv pb.LLBBridge_ExecProcessServer) e
 					var statusError *rpc.Status
 					if err != nil {
 						statusCode = pb.UnknownExitStatus
-						st, _ := status.FromError(grpcerrors.ToGRPC(err))
+						st, _ := status.FromError(grpcerrors.ToGRPC(ctx, err))
 						stp := st.Proto()
 						statusError = &rpc.Status{
 							Code:    stp.Code,

--- a/frontend/gateway/grpcclient/client.go
+++ b/frontend/gateway/grpcclient/client.go
@@ -190,7 +190,7 @@ func (c *grpcClient) Run(ctx context.Context, f client.BuildFunc) (retError erro
 				}
 			}
 			if retError != nil {
-				st, _ := status.FromError(grpcerrors.ToGRPC(retError))
+				st, _ := status.FromError(grpcerrors.ToGRPC(ctx, retError))
 				stp := st.Proto()
 				req.Error = &rpc.Status{
 					Code:    stp.Code,

--- a/util/appcontext/appcontext.go
+++ b/util/appcontext/appcontext.go
@@ -6,7 +6,7 @@ import (
 	"os/signal"
 	"sync"
 
-	"github.com/sirupsen/logrus"
+	"github.com/moby/buildkit/util/bklog"
 )
 
 var appContextCache context.Context
@@ -36,7 +36,7 @@ func Context() context.Context {
 				cancel()
 				retries++
 				if retries >= exitLimit {
-					logrus.Errorf("got %d SIGTERM/SIGINTs, forcing shutdown", retries)
+					bklog.G(ctx).Errorf("got %d SIGTERM/SIGINTs, forcing shutdown", retries)
 					os.Exit(1)
 				}
 			}

--- a/util/archutil/detect.go
+++ b/util/archutil/detect.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 
 	"github.com/containerd/containerd/platforms"
+	"github.com/moby/buildkit/util/bklog"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 )
 
 var mu sync.Mutex
@@ -181,10 +181,10 @@ func amd64vector(v string) (out []string) {
 
 func printPlatformWarning(p ocispecs.Platform, err error) {
 	if strings.Contains(err.Error(), "exec format error") {
-		logrus.Warnf("platform %s cannot pass the validation, kernel support for miscellaneous binary may have not enabled.", platforms.Format(p))
+		bklog.L.Warnf("platform %s cannot pass the validation, kernel support for miscellaneous binary may have not enabled.", platforms.Format(p))
 	} else if strings.Contains(err.Error(), "no such file or directory") {
-		logrus.Warnf("platforms %s cannot pass the validation, '-F' flag might have not set for 'archutil'.", platforms.Format(p))
+		bklog.L.Warnf("platforms %s cannot pass the validation, '-F' flag might have not set for 'archutil'.", platforms.Format(p))
 	} else {
-		logrus.Warnf("platforms %s cannot pass the validation: %s", platforms.Format(p), err.Error())
+		bklog.L.Warnf("platforms %s cannot pass the validation: %s", platforms.Format(p), err.Error())
 	}
 }

--- a/util/compression/compression.go
+++ b/util/compression/compression.go
@@ -9,11 +9,11 @@ import (
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/stargz-snapshotter/estargz"
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/iohelper"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 type Compressor func(dest io.Writer, mediaType string) (io.WriteCloser, error)
@@ -211,7 +211,7 @@ var toOCILayerType = map[string]string{
 	mediaTypeDockerSchema2LayerZstd:                  mediaTypeImageLayerZstd,
 }
 
-func convertLayerMediaType(mediaType string, oci bool) string {
+func convertLayerMediaType(ctx context.Context, mediaType string, oci bool) string {
 	var converted string
 	if oci {
 		converted = toOCILayerType[mediaType]
@@ -219,16 +219,16 @@ func convertLayerMediaType(mediaType string, oci bool) string {
 		converted = toDockerLayerType[mediaType]
 	}
 	if converted == "" {
-		logrus.Warnf("unhandled conversion for mediatype %q", mediaType)
+		bklog.G(ctx).Warnf("unhandled conversion for mediatype %q", mediaType)
 		return mediaType
 	}
 	return converted
 }
 
-func ConvertAllLayerMediaTypes(oci bool, descs ...ocispecs.Descriptor) []ocispecs.Descriptor {
+func ConvertAllLayerMediaTypes(ctx context.Context, oci bool, descs ...ocispecs.Descriptor) []ocispecs.Descriptor {
 	var converted []ocispecs.Descriptor
 	for _, desc := range descs {
-		desc.MediaType = convertLayerMediaType(desc.MediaType, oci)
+		desc.MediaType = convertLayerMediaType(ctx, desc.MediaType, oci)
 		converted = append(converted, desc)
 	}
 	return converted

--- a/util/grpcerrors/grpcerrors.go
+++ b/util/grpcerrors/grpcerrors.go
@@ -1,6 +1,7 @@
 package grpcerrors
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 
@@ -9,8 +10,8 @@ import (
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/golang/protobuf/proto" //nolint:staticcheck
 	"github.com/golang/protobuf/ptypes/any"
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/stack"
-	"github.com/sirupsen/logrus"
 	spb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -25,7 +26,7 @@ type TypedErrorProto interface {
 	WrapError(error) error
 }
 
-func ToGRPC(err error) error {
+func ToGRPC(ctx context.Context, err error) error {
 	if err == nil {
 		return nil
 	}
@@ -64,7 +65,7 @@ func ToGRPC(err error) error {
 	})
 
 	if len(details) > 0 {
-		if st2, err := withDetails(st, details...); err == nil {
+		if st2, err := withDetails(ctx, st, details...); err == nil {
 			st = st2
 		}
 	}
@@ -72,7 +73,7 @@ func ToGRPC(err error) error {
 	return st.Err()
 }
 
-func withDetails(s *status.Status, details ...proto.Message) (*status.Status, error) {
+func withDetails(ctx context.Context, s *status.Status, details ...proto.Message) (*status.Status, error) {
 	if s.Code() == codes.OK {
 		return nil, errors.New("no error details for status with code OK")
 	}
@@ -80,7 +81,7 @@ func withDetails(s *status.Status, details ...proto.Message) (*status.Status, er
 	for _, detail := range details {
 		url, err := typeurl.TypeURL(detail)
 		if err != nil {
-			logrus.Warnf("ignoring typed error %T: not registered", detail)
+			bklog.G(ctx).Warnf("ignoring typed error %T: not registered", detail)
 			continue
 		}
 		dt, err := json.Marshal(detail)

--- a/util/grpcerrors/intercept.go
+++ b/util/grpcerrors/intercept.go
@@ -15,7 +15,7 @@ func UnaryServerInterceptor(ctx context.Context, req interface{}, info *grpc.Una
 	oldErr := err
 	if err != nil {
 		stack.Helper()
-		err = ToGRPC(err)
+		err = ToGRPC(ctx, err)
 	}
 	if oldErr != nil && err == nil {
 		logErr := errors.Wrap(err, "invalid grpc error conversion")
@@ -30,7 +30,7 @@ func UnaryServerInterceptor(ctx context.Context, req interface{}, info *grpc.Una
 }
 
 func StreamServerInterceptor(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-	err := ToGRPC(handler(srv, ss))
+	err := ToGRPC(ss.Context(), handler(srv, ss))
 	if err != nil {
 		stack.Helper()
 	}
@@ -50,5 +50,5 @@ func StreamClientInterceptor(ctx context.Context, desc *grpc.StreamDesc, cc *grp
 	if err != nil {
 		stack.Helper()
 	}
-	return s, ToGRPC(err)
+	return s, ToGRPC(ctx, err)
 }

--- a/util/network/netproviders/network_unix.go
+++ b/util/network/netproviders/network_unix.go
@@ -4,8 +4,8 @@
 package netproviders
 
 import (
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/network"
-	"github.com/sirupsen/logrus"
 )
 
 func getHostProvider() (network.Provider, bool) {
@@ -13,6 +13,6 @@ func getHostProvider() (network.Provider, bool) {
 }
 
 func getFallback() (network.Provider, string) {
-	logrus.Warn("using host network as the default")
+	bklog.L.Warn("using host network as the default")
 	return network.NewHostProvider(), "host"
 }

--- a/util/network/netproviders/network_windows.go
+++ b/util/network/netproviders/network_windows.go
@@ -4,8 +4,8 @@
 package netproviders
 
 import (
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/network"
-	"github.com/sirupsen/logrus"
 )
 
 func getHostProvider() (network.Provider, bool) {
@@ -13,6 +13,6 @@ func getHostProvider() (network.Provider, bool) {
 }
 
 func getFallback() (network.Provider, string) {
-	logrus.Warn("using null network as the default")
+	bklog.L.Warn("using null network as the default")
 	return network.NewNoneProvider(), ""
 }

--- a/util/pull/pullprogress/progress.go
+++ b/util/pull/pullprogress/progress.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/remotes"
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/progress"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -33,13 +34,14 @@ func (p *ProviderWithProgress) ReaderAt(ctx context.Context, desc ocispecs.Descr
 	ctx, cancel := context.WithCancel(ctx)
 	doneCh := make(chan struct{})
 	go trackProgress(ctx, desc, p.Manager, doneCh)
-	return readerAtWithCancel{ReaderAt: ra, cancel: cancel, doneCh: doneCh}, nil
+	return readerAtWithCancel{ReaderAt: ra, cancel: cancel, doneCh: doneCh, logger: bklog.G(ctx)}, nil
 }
 
 type readerAtWithCancel struct {
 	content.ReaderAt
 	cancel func()
 	doneCh <-chan struct{}
+	logger *logrus.Entry
 }
 
 func (ra readerAtWithCancel) Close() error {
@@ -47,7 +49,7 @@ func (ra readerAtWithCancel) Close() error {
 	select {
 	case <-ra.doneCh:
 	case <-time.After(time.Second):
-		logrus.Warn("timeout waiting for pull progress to complete")
+		ra.logger.Warn("timeout waiting for pull progress to complete")
 	}
 	return ra.ReaderAt.Close()
 }
@@ -66,13 +68,14 @@ func (f *FetcherWithProgress) Fetch(ctx context.Context, desc ocispecs.Descripto
 	ctx, cancel := context.WithCancel(ctx)
 	doneCh := make(chan struct{})
 	go trackProgress(ctx, desc, f.Manager, doneCh)
-	return readerWithCancel{ReadCloser: rc, cancel: cancel, doneCh: doneCh}, nil
+	return readerWithCancel{ReadCloser: rc, cancel: cancel, doneCh: doneCh, logger: bklog.G(ctx)}, nil
 }
 
 type readerWithCancel struct {
 	io.ReadCloser
 	cancel func()
 	doneCh <-chan struct{}
+	logger *logrus.Entry
 }
 
 func (r readerWithCancel) Close() error {
@@ -80,7 +83,7 @@ func (r readerWithCancel) Close() error {
 	select {
 	case <-r.doneCh:
 	case <-time.After(time.Second):
-		logrus.Warn("timeout waiting for pull progress to complete")
+		r.logger.Warn("timeout waiting for pull progress to complete")
 	}
 	return r.ReadCloser.Close()
 }
@@ -120,7 +123,7 @@ func trackProgress(ctx context.Context, desc ocispecs.Descriptor, manager PullMa
 			})
 			continue
 		} else if !errors.Is(err, errdefs.ErrNotFound) {
-			logrus.Errorf("unexpected error getting ingest status of %q: %v", ingestRef, err)
+			bklog.G(ctx).Errorf("unexpected error getting ingest status of %q: %v", ingestRef, err)
 			return
 		}
 

--- a/util/push/push.go
+++ b/util/push/push.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/util/attestation"
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/flightcontrol"
 	"github.com/moby/buildkit/util/imageutil"
 	"github.com/moby/buildkit/util/progress"
@@ -27,7 +28,6 @@ import (
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 type pusher struct {
@@ -254,7 +254,7 @@ func childrenHandler(provider content.Provider) images.HandlerFunc {
 			// childless data types.
 			return nil, nil
 		default:
-			logrus.Warnf("encountered unknown type %v; children may not be fetched", desc.MediaType)
+			bklog.G(ctx).Warnf("encountered unknown type %v; children may not be fetched", desc.MediaType)
 		}
 
 		return descs, nil
@@ -289,7 +289,7 @@ func updateDistributionSourceHandler(manager content.Manager, pushF images.Handl
 		// update distribution source to layer
 		if islayer {
 			if _, err := updateF(ctx, desc); err != nil {
-				logrus.Warnf("failed to update distribution source for layer %v: %v", desc.Digest, err)
+				bklog.G(ctx).Warnf("failed to update distribution source for layer %v: %v", desc.Digest, err)
 			}
 		}
 		return children, nil

--- a/util/resolver/limited/group.go
+++ b/util/resolver/limited/group.go
@@ -11,8 +11,8 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/remotes"
 	"github.com/docker/distribution/reference"
+	"github.com/moby/buildkit/util/bklog"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
 )
 
@@ -119,7 +119,7 @@ func (f *fetcher) Fetch(ctx context.Context, desc ocispecs.Descriptor) (io.ReadC
 	rcw := &readCloser{ReadCloser: rc}
 	closer := func() {
 		if !rcw.closed {
-			logrus.Warnf("fetcher not closed cleanly: %s", desc.Digest)
+			bklog.G(ctx).Warnf("fetcher not closed cleanly: %s", desc.Digest)
 		}
 		release()
 	}

--- a/util/testutil/integration/containerd.go
+++ b/util/testutil/integration/containerd.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 func InitContainerdWorker() {
@@ -45,7 +45,7 @@ func InitContainerdWorker() {
 	if s := os.Getenv("BUILDKIT_INTEGRATION_ROOTLESS_IDPAIR"); s != "" {
 		var uid, gid int
 		if _, err := fmt.Sscanf(s, "%d:%d", &uid, &gid); err != nil {
-			logrus.Fatalf("unexpected BUILDKIT_INTEGRATION_ROOTLESS_IDPAIR: %q", s)
+			bklog.L.Fatalf("unexpected BUILDKIT_INTEGRATION_ROOTLESS_IDPAIR: %q", s)
 		}
 		if rootlessSupported(uid) {
 			Register(&containerd{

--- a/util/testutil/integration/oci.go
+++ b/util/testutil/integration/oci.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 func InitOCIWorker() {
@@ -18,7 +18,7 @@ func InitOCIWorker() {
 	if s := os.Getenv("BUILDKIT_INTEGRATION_ROOTLESS_IDPAIR"); s != "" {
 		var uid, gid int
 		if _, err := fmt.Sscanf(s, "%d:%d", &uid, &gid); err != nil {
-			logrus.Fatalf("unexpected BUILDKIT_INTEGRATION_ROOTLESS_IDPAIR: %q", s)
+			bklog.L.Fatalf("unexpected BUILDKIT_INTEGRATION_ROOTLESS_IDPAIR: %q", s)
 		}
 		if rootlessSupported(uid) {
 			Register(&oci{uid: uid, gid: gid})

--- a/util/testutil/integration/sandbox.go
+++ b/util/testutil/integration/sandbox.go
@@ -14,8 +14,8 @@ import (
 	"time"
 
 	"github.com/google/shlex"
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 const buildkitdConfigFile = "buildkitd.toml"
@@ -267,7 +267,7 @@ func rootlessSupported(uid int) bool {
 	cmd := exec.Command("sudo", "-u", fmt.Sprintf("#%d", uid), "-i", "--", "exec", "unshare", "-U", "true") //nolint:gosec // test utility
 	b, err := cmd.CombinedOutput()
 	if err != nil {
-		logrus.Warnf("rootless mode is not supported on this host: %v (%s)", err, string(b))
+		bklog.L.Warnf("rootless mode is not supported on this host: %v (%s)", err, string(b))
 		return false
 	}
 	return true

--- a/util/winlayers/differ.go
+++ b/util/winlayers/differ.go
@@ -18,8 +18,8 @@ import (
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 
+	"github.com/moby/buildkit/util/bklog"
 	log "github.com/moby/buildkit/util/bklog"
 )
 
@@ -109,7 +109,7 @@ func (s *winDiffer) Compare(ctx context.Context, lower, upper []mount.Mount, opt
 				if err != nil {
 					return errors.Wrap(err, "failed to get compressed stream")
 				}
-				w, discard, done := makeWindowsLayer(io.MultiWriter(compressed, dgstr.Hash()))
+				w, discard, done := makeWindowsLayer(ctx, io.MultiWriter(compressed, dgstr.Hash()))
 				err = archive.WriteDiff(ctx, w, lowerRoot, upperRoot)
 				if err != nil {
 					discard(err)
@@ -125,7 +125,7 @@ func (s *winDiffer) Compare(ctx context.Context, lower, upper []mount.Mount, opt
 				}
 				config.Labels["containerd.io/uncompressed"] = dgstr.Digest().String()
 			} else {
-				w, discard, done := makeWindowsLayer(cw)
+				w, discard, done := makeWindowsLayer(ctx, cw)
 				if err = archive.WriteDiff(ctx, w, lowerRoot, upperRoot); err != nil {
 					discard(err)
 					return errors.Wrap(err, "failed to write diff")
@@ -203,7 +203,7 @@ func addSecurityDescriptor(h *tar.Header) {
 	}
 }
 
-func makeWindowsLayer(w io.Writer) (io.Writer, func(error), chan error) {
+func makeWindowsLayer(ctx context.Context, w io.Writer) (io.Writer, func(error), chan error) {
 	pr, pw := io.Pipe()
 	done := make(chan error)
 
@@ -259,7 +259,7 @@ func makeWindowsLayer(w io.Writer) (io.Writer, func(error), chan error) {
 			return tarWriter.Close()
 		}()
 		if err != nil {
-			logrus.Errorf("makeWindowsLayer %+v", err)
+			bklog.G(ctx).Errorf("makeWindowsLayer %+v", err)
 		}
 		pw.CloseWithError(err)
 		done <- err


### PR DESCRIPTION
This is a continuation of #2236

I noticed there were several lines in our logs that were missing traceID fields and found they were still using logrus directly.  

I have modified a few apis to pass through the context, and in some cases (where a request context was not applicable) I used `bklog.L` although I could change that to use `bklog.G(context.Background())` if that is preferable.

