### PR TITLE
dockerfile(docs): fix liquid syntax

### DIFF
--- a/.github/workflows/docs-upstream.yml
+++ b/.github/workflows/docs-upstream.yml
@@ -1,0 +1,35 @@
+# this workflow runs the remote validate bake target from docker/docker.github.io
+# to check if yaml reference docs and markdown files used in this repo are still
+# valid: https://github.com/docker/docs/blob/98c7c9535063ae4cd2cd0a31478a21d16d2f07a3/docker-bake.hcl#L34-L36
+# path filters reflects the files that are used as remote resource in this
+# repo: https://github.com/docker/docs/blob/d5312d53e255a24e421dfe6c3344359e10271cb8/_config.yml#L202-L217
+name: docs-upstream
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'v[0-9]*'
+    paths:
+      - '.github/workflows/docs-upstream.yml'
+      - 'docs/buildkitd.toml.md'
+      - 'docs/attestations/slsa-definitions.md'
+      - 'docs/attestations/attestation-storage.md'
+      - 'frontend/dockerfile/docs/reference.md'
+  pull_request:
+    paths:
+      - '.github/workflows/docs-upstream.yml'
+      - 'docs/buildkitd.toml.md'
+      - 'docs/attestations/slsa-definitions.md'
+      - 'docs/attestations/attestation-storage.md'
+      - 'frontend/dockerfile/docs/reference.md'
+
+jobs:
+  validate:
+    uses: docker/docs/.github/workflows/validate-upstream.yml@main
+    with:
+      repo: https://github.com/${{ github.repository }}

--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -964,9 +964,11 @@ the most-recently-applied value overrides any previously-set value.
 To view an image's labels, use the `docker image inspect` command. You can use
 the `--format` option to show just the labels;
  
+{% raw %}
 ```console
 $ docker image inspect --format='{{json .Config.Labels}}' myimage
 ```
+{% endraw %}
 
 ```json
 {


### PR DESCRIPTION
closes https://github.com/docker/docs/issues/16875

fix liquid syntax issue and also adds a conformance validation workflow for the upstream docs.