### PR TITLE
integration: enforce features compat through env vars

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -5817,6 +5817,7 @@ func testProxyEnv(t *testing.T, sb integration.Sandbox) {
 }
 
 func testMergeOp(t *testing.T, sb integration.Sandbox) {
+	integration.CheckFeatureCompat(t, sb, integration.FeatureMergeDiff)
 	requiresLinux(t)
 
 	c, err := New(sb.Context(), sb.Address())
@@ -5929,7 +5930,7 @@ func testMergeOpCacheMax(t *testing.T, sb integration.Sandbox) {
 
 func testMergeOpCache(t *testing.T, sb integration.Sandbox, mode string) {
 	t.Helper()
-	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush)
+	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush, integration.FeatureMergeDiff)
 	requiresLinux(t)
 
 	cdAddress := sb.ContainerdAddress()

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -245,7 +245,7 @@ func newContainerd(cdAddress string) (*containerd.Client, error) {
 
 // moby/buildkit#1336
 func testCacheExportCacheKeyLoop(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport, integration.FeatureCacheBackendLocal)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -3747,7 +3747,7 @@ func testBuildPushAndValidate(t *testing.T, sb integration.Sandbox) {
 }
 
 func testStargzLazyRegistryCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport, integration.FeatureCacheImport, integration.FeatureCacheBackendRegistry)
 	requiresLinux(t)
 	cdAddress := sb.ContainerdAddress()
 	if cdAddress == "" || sb.Snapshotter() != "stargz" {
@@ -3945,7 +3945,12 @@ func testStargzLazyRegistryCacheImportExport(t *testing.T, sb integration.Sandbo
 }
 
 func testStargzLazyInlineCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
+	integration.CheckFeatureCompat(t, sb,
+		integration.FeatureCacheExport,
+		integration.FeatureCacheImport,
+		integration.FeatureCacheBackendInline,
+		integration.FeatureCacheBackendRegistry,
+	)
 	requiresLinux(t)
 	cdAddress := sb.ContainerdAddress()
 	if cdAddress == "" || sb.Snapshotter() != "stargz" {
@@ -4392,7 +4397,7 @@ func testLazyImagePush(t *testing.T, sb integration.Sandbox) {
 }
 
 func testZstdLocalCacheExport(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport, integration.FeatureCacheBackendLocal)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -4451,7 +4456,7 @@ func testZstdLocalCacheExport(t *testing.T, sb integration.Sandbox) {
 }
 
 func testCacheExportIgnoreError(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport, integration.FeatureCacheBackendLocal)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -4558,7 +4563,7 @@ func testCacheExportIgnoreError(t *testing.T, sb integration.Sandbox) {
 }
 
 func testUncompressedLocalCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport, integration.FeatureCacheImport, integration.FeatureCacheBackendLocal)
 	dir := t.TempDir()
 	im := CacheOptionsEntry{
 		Type: "local",
@@ -4578,7 +4583,7 @@ func testUncompressedLocalCacheImportExport(t *testing.T, sb integration.Sandbox
 }
 
 func testUncompressedRegistryCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport, integration.FeatureCacheImport, integration.FeatureCacheBackendRegistry)
 	registry, err := sb.NewRegistry()
 	if errors.Is(err, integration.ErrRequirements) {
 		t.Skip(err.Error())
@@ -4603,7 +4608,7 @@ func testUncompressedRegistryCacheImportExport(t *testing.T, sb integration.Sand
 }
 
 func testZstdLocalCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport, integration.FeatureCacheImport, integration.FeatureCacheBackendLocal)
 	dir := t.TempDir()
 	im := CacheOptionsEntry{
 		Type: "local",
@@ -4624,7 +4629,7 @@ func testZstdLocalCacheImportExport(t *testing.T, sb integration.Sandbox) {
 }
 
 func testZstdRegistryCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport, integration.FeatureCacheImport, integration.FeatureCacheBackendRegistry)
 	registry, err := sb.NewRegistry()
 	if errors.Is(err, integration.ErrRequirements) {
 		t.Skip(err.Error())
@@ -4712,7 +4717,7 @@ func testBasicCacheImportExport(t *testing.T, sb integration.Sandbox, cacheOptio
 }
 
 func testBasicRegistryCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport, integration.FeatureCacheImport, integration.FeatureCacheBackendRegistry)
 	registry, err := sb.NewRegistry()
 	if errors.Is(err, integration.ErrRequirements) {
 		t.Skip(err.Error())
@@ -4729,7 +4734,7 @@ func testBasicRegistryCacheImportExport(t *testing.T, sb integration.Sandbox) {
 }
 
 func testMultipleRegistryCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport, integration.FeatureCacheImport, integration.FeatureCacheBackendRegistry)
 	registry, err := sb.NewRegistry()
 	if errors.Is(err, integration.ErrRequirements) {
 		t.Skip(err.Error())
@@ -4752,7 +4757,7 @@ func testMultipleRegistryCacheImportExport(t *testing.T, sb integration.Sandbox)
 }
 
 func testBasicLocalCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport, integration.FeatureCacheImport, integration.FeatureCacheBackendLocal)
 	dir := t.TempDir()
 	im := CacheOptionsEntry{
 		Type: "local",
@@ -4770,7 +4775,7 @@ func testBasicLocalCacheImportExport(t *testing.T, sb integration.Sandbox) {
 }
 
 func testBasicS3CacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport, integration.FeatureCacheImport, integration.FeatureCacheBackendS3)
 
 	opts := integration.MinioOpts{
 		Region:          "us-east-1",
@@ -4808,7 +4813,7 @@ func testBasicS3CacheImportExport(t *testing.T, sb integration.Sandbox) {
 }
 
 func testBasicAzblobCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport, integration.FeatureCacheImport, integration.FeatureCacheBackendAzblob)
 
 	opts := integration.AzuriteOpts{
 		AccountName: "azblobcacheaccount",
@@ -4841,7 +4846,13 @@ func testBasicAzblobCacheImportExport(t *testing.T, sb integration.Sandbox) {
 }
 
 func testBasicInlineCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush, integration.FeatureCacheImport)
+	integration.CheckFeatureCompat(t, sb,
+		integration.FeatureDirectPush,
+		integration.FeatureCacheExport,
+		integration.FeatureCacheImport,
+		integration.FeatureCacheBackendInline,
+		integration.FeatureCacheBackendRegistry,
+	)
 	requiresLinux(t)
 	registry, err := sb.NewRegistry()
 	if errors.Is(err, integration.ErrRequirements) {
@@ -5001,7 +5012,7 @@ func testBasicInlineCacheImportExport(t *testing.T, sb integration.Sandbox) {
 }
 
 func testBasicGhaCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport, integration.FeatureCacheImport, integration.FeatureCacheBackendGha)
 	runtimeToken := os.Getenv("ACTIONS_RUNTIME_TOKEN")
 	cacheURL := os.Getenv("ACTIONS_CACHE_URL")
 	if runtimeToken == "" || cacheURL == "" {

--- a/client/mergediff_test.go
+++ b/client/mergediff_test.go
@@ -1187,6 +1187,7 @@ func (tc verifyContents) Name() string {
 }
 
 func (tc verifyContents) Run(t *testing.T, sb integration.Sandbox) {
+	integration.CheckFeatureCompat(t, sb, integration.FeatureMergeDiff)
 	if tc.skipOnRootless && sb.Rootless() {
 		t.Skip("rootless")
 	}

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -420,7 +420,7 @@ RUN [ "$(cat testfile)" == "contents0" ]
 }
 
 func testExportCacheLoop(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport, integration.FeatureCacheImport, integration.FeatureCacheBackendLocal)
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -3949,7 +3949,12 @@ ONBUILD RUN mkdir -p /out && echo -n 11 >> /out/foo
 }
 
 func testCacheMultiPlatformImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush)
+	integration.CheckFeatureCompat(t, sb,
+		integration.FeatureDirectPush,
+		integration.FeatureCacheExport,
+		integration.FeatureCacheBackendInline,
+		integration.FeatureCacheBackendRegistry,
+	)
 	f := getFrontend(t, sb)
 
 	registry, err := sb.NewRegistry()
@@ -4072,7 +4077,7 @@ COPY --from=base arch /
 }
 
 func testCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
+	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport, integration.FeatureCacheBackendLocal)
 	f := getFrontend(t, sb)
 
 	registry, err := sb.NewRegistry()

--- a/hack/test
+++ b/hack/test
@@ -78,7 +78,7 @@ if ! docker container inspect "$cacheVolume" >/dev/null 2>/dev/null; then
 fi
 
 if [ "$TEST_INTEGRATION" == 1 ]; then
-  cid=$(docker create --rm -v /tmp $coverageVol --volumes-from=$cacheVolume -e GITHUB_REF -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e TEST_DOCKERD -e SKIP_INTEGRATION_TESTS ${BUILDKIT_INTEGRATION_SNAPSHOTTER:+"-eBUILDKIT_INTEGRATION_SNAPSHOTTER"} -e BUILDKIT_REGISTRY_MIRROR_DIR=/root/.cache/registry -e BUILDKIT_INTEGRATION_DOCKERD_FLAGS --privileged $iid go test $coverageFlags ${TESTFLAGS:--v} ${TESTPKGS:-./...})
+  cid=$(docker create --rm -v /tmp $coverageVol --volumes-from=$cacheVolume -e GITHUB_REF -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e TEST_DOCKERD -e SKIP_INTEGRATION_TESTS -e BUILDKIT_TEST_ENABLE_FEATURES -e BUILDKIT_TEST_DISABLE_FEATURES ${BUILDKIT_INTEGRATION_SNAPSHOTTER:+"-eBUILDKIT_INTEGRATION_SNAPSHOTTER"} -e BUILDKIT_REGISTRY_MIRROR_DIR=/root/.cache/registry -e BUILDKIT_INTEGRATION_DOCKERD_FLAGS --privileged $iid go test $coverageFlags ${TESTFLAGS:--v} ${TESTPKGS:-./...})
   if [ "$TEST_DOCKERD" = "1" ]; then
     docker cp "$TEST_DOCKERD_BINARY" $cid:/usr/bin/dockerd
   fi
@@ -118,7 +118,7 @@ if [ "$TEST_DOCKERFILE" == 1 ]; then
 
     if [ -s $tarout ]; then
       if [ "$release" = "mainline" ] || [ "$release" = "labs" ] || [ -n "$DOCKERFILE_RELEASES_CUSTOM" ] || [ "$GITHUB_ACTIONS" = "true" ]; then
-        cid=$(docker create -v /tmp $coverageVol --rm --privileged --volumes-from=$cacheVolume -e GITHUB_REF -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e TEST_DOCKERD -e BUILDKIT_REGISTRY_MIRROR_DIR=/root/.cache/registry -e BUILDKIT_WORKER_RANDOM -e BUILDKIT_INTEGRATION_DOCKERD_FLAGS -e FRONTEND_GATEWAY_ONLY=local:/$release.tar -e EXTERNAL_DF_FRONTEND=/dockerfile-frontend $iid go test $coverageFlags --count=1 -tags "$buildtags" ${TESTFLAGS:--v} ./frontend/dockerfile)
+        cid=$(docker create -v /tmp $coverageVol --rm --privileged --volumes-from=$cacheVolume -e GITHUB_REF -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e TEST_DOCKERD -e BUILDKIT_TEST_ENABLE_FEATURES -e BUILDKIT_TEST_DISABLE_FEATURES -e BUILDKIT_REGISTRY_MIRROR_DIR=/root/.cache/registry -e BUILDKIT_WORKER_RANDOM -e BUILDKIT_INTEGRATION_DOCKERD_FLAGS -e FRONTEND_GATEWAY_ONLY=local:/$release.tar -e EXTERNAL_DF_FRONTEND=/dockerfile-frontend $iid go test $coverageFlags --count=1 -tags "$buildtags" ${TESTFLAGS:--v} ./frontend/dockerfile)
         docker cp $tarout $cid:/$release.tar
         if [ "$TEST_DOCKERD" = "1" ]; then
           docker cp "$TEST_DOCKERD_BINARY" $cid:/usr/bin/dockerd

--- a/util/testutil/integration/dockerd.go
+++ b/util/testutil/integration/dockerd.go
@@ -25,6 +25,11 @@ func InitDockerdWorker() {
 		unsupported: []string{
 			FeatureCacheExport,
 			FeatureCacheImport,
+			FeatureCacheBackendAzblob,
+			FeatureCacheBackendGha,
+			FeatureCacheBackendLocal,
+			FeatureCacheBackendRegistry,
+			FeatureCacheBackendS3,
 			FeatureDirectPush,
 			FeatureImageExporter,
 			FeatureMultiCacheExport,

--- a/util/testutil/integration/sandbox.go
+++ b/util/testutil/integration/sandbox.go
@@ -297,6 +297,7 @@ const (
 	FeatureFrontendTargets      = "frontend_targets"
 	FeatureImageExporter        = "image_exporter"
 	FeatureInfo                 = "info"
+	FeatureMergeDiff            = "merge_diff"
 	FeatureMultiCacheExport     = "multi_cache_export"
 	FeatureMultiPlatform        = "multi_platform"
 	FeatureOCIExporter          = "oci_exporter"
@@ -322,6 +323,7 @@ var features = map[string]struct{}{
 	FeatureFrontendTargets:      {},
 	FeatureImageExporter:        {},
 	FeatureInfo:                 {},
+	FeatureMergeDiff:            {},
 	FeatureMultiCacheExport:     {},
 	FeatureMultiPlatform:        {},
 	FeatureOCIExporter:          {},

--- a/util/testutil/integration/sandbox.go
+++ b/util/testutil/integration/sandbox.go
@@ -46,6 +46,20 @@ func (b backend) Snapshotter() string {
 }
 
 func (b backend) isUnsupportedFeature(feature string) bool {
+	if enabledFeatures := os.Getenv("BUILDKIT_TEST_ENABLE_FEATURES"); enabledFeatures != "" {
+		for _, enabledFeature := range strings.Split(enabledFeatures, ",") {
+			if feature == enabledFeature {
+				return false
+			}
+		}
+	}
+	if disabledFeatures := os.Getenv("BUILDKIT_TEST_DISABLE_FEATURES"); disabledFeatures != "" {
+		for _, disabledFeature := range strings.Split(disabledFeatures, ",") {
+			if feature == disabledFeature {
+				return true
+			}
+		}
+	}
 	for _, unsupportedFeature := range b.unsupportedFeatures {
 		if feature == unsupportedFeature {
 			return true
@@ -270,22 +284,22 @@ func printLogs(logs map[string]*bytes.Buffer, f func(args ...interface{})) {
 }
 
 const (
-	FeatureCacheExport      = "cache export"
-	FeatureCacheImport      = "cache import"
-	FeatureDirectPush       = "direct push"
-	FeatureFrontendOutline  = "frontend outline"
-	FeatureFrontendTargets  = "frontend targets"
-	FeatureImageExporter    = "image exporter"
+	FeatureCacheExport      = "cache_export"
+	FeatureCacheImport      = "cache_import"
+	FeatureDirectPush       = "direct_push"
+	FeatureFrontendOutline  = "frontend_outline"
+	FeatureFrontendTargets  = "frontend_targets"
+	FeatureImageExporter    = "image_exporter"
 	FeatureInfo             = "info"
-	FeatureMultiCacheExport = "multi cache export"
-	FeatureMultiPlatform    = "multi-platform"
-	FeatureOCIExporter      = "oci exporter"
-	FeatureOCILayout        = "oci layout"
+	FeatureMultiCacheExport = "multi_cache_export"
+	FeatureMultiPlatform    = "multi_platform"
+	FeatureOCIExporter      = "oci_exporter"
+	FeatureOCILayout        = "oci_layout"
 	FeatureProvenance       = "provenance"
 	FeatureSBOM             = "sbom"
-	FeatureSecurityMode     = "security mode"
-	FeatureSourceDateEpoch  = "source date epoch"
-	FeatureCNINetwork       = "cni network"
+	FeatureSecurityMode     = "security_mode"
+	FeatureSourceDateEpoch  = "source_date_epoch"
+	FeatureCNINetwork       = "cni_network"
 )
 
 var features = map[string]struct{}{

--- a/util/testutil/integration/sandbox.go
+++ b/util/testutil/integration/sandbox.go
@@ -284,41 +284,53 @@ func printLogs(logs map[string]*bytes.Buffer, f func(args ...interface{})) {
 }
 
 const (
-	FeatureCacheExport      = "cache_export"
-	FeatureCacheImport      = "cache_import"
-	FeatureDirectPush       = "direct_push"
-	FeatureFrontendOutline  = "frontend_outline"
-	FeatureFrontendTargets  = "frontend_targets"
-	FeatureImageExporter    = "image_exporter"
-	FeatureInfo             = "info"
-	FeatureMultiCacheExport = "multi_cache_export"
-	FeatureMultiPlatform    = "multi_platform"
-	FeatureOCIExporter      = "oci_exporter"
-	FeatureOCILayout        = "oci_layout"
-	FeatureProvenance       = "provenance"
-	FeatureSBOM             = "sbom"
-	FeatureSecurityMode     = "security_mode"
-	FeatureSourceDateEpoch  = "source_date_epoch"
-	FeatureCNINetwork       = "cni_network"
+	FeatureCacheExport          = "cache_export"
+	FeatureCacheImport          = "cache_import"
+	FeatureCacheBackendAzblob   = "cache_backend_azblob"
+	FeatureCacheBackendGha      = "cache_backend_gha"
+	FeatureCacheBackendInline   = "cache_backend_inline"
+	FeatureCacheBackendLocal    = "cache_backend_local"
+	FeatureCacheBackendRegistry = "cache_backend_registry"
+	FeatureCacheBackendS3       = "cache_backend_s3"
+	FeatureDirectPush           = "direct_push"
+	FeatureFrontendOutline      = "frontend_outline"
+	FeatureFrontendTargets      = "frontend_targets"
+	FeatureImageExporter        = "image_exporter"
+	FeatureInfo                 = "info"
+	FeatureMultiCacheExport     = "multi_cache_export"
+	FeatureMultiPlatform        = "multi_platform"
+	FeatureOCIExporter          = "oci_exporter"
+	FeatureOCILayout            = "oci_layout"
+	FeatureProvenance           = "provenance"
+	FeatureSBOM                 = "sbom"
+	FeatureSecurityMode         = "security_mode"
+	FeatureSourceDateEpoch      = "source_date_epoch"
+	FeatureCNINetwork           = "cni_network"
 )
 
 var features = map[string]struct{}{
-	FeatureCacheExport:      {},
-	FeatureCacheImport:      {},
-	FeatureDirectPush:       {},
-	FeatureFrontendOutline:  {},
-	FeatureFrontendTargets:  {},
-	FeatureImageExporter:    {},
-	FeatureInfo:             {},
-	FeatureMultiCacheExport: {},
-	FeatureMultiPlatform:    {},
-	FeatureOCIExporter:      {},
-	FeatureOCILayout:        {},
-	FeatureProvenance:       {},
-	FeatureSBOM:             {},
-	FeatureSecurityMode:     {},
-	FeatureSourceDateEpoch:  {},
-	FeatureCNINetwork:       {},
+	FeatureCacheExport:          {},
+	FeatureCacheImport:          {},
+	FeatureCacheBackendAzblob:   {},
+	FeatureCacheBackendGha:      {},
+	FeatureCacheBackendInline:   {},
+	FeatureCacheBackendLocal:    {},
+	FeatureCacheBackendRegistry: {},
+	FeatureCacheBackendS3:       {},
+	FeatureDirectPush:           {},
+	FeatureFrontendOutline:      {},
+	FeatureFrontendTargets:      {},
+	FeatureImageExporter:        {},
+	FeatureInfo:                 {},
+	FeatureMultiCacheExport:     {},
+	FeatureMultiPlatform:        {},
+	FeatureOCIExporter:          {},
+	FeatureOCILayout:            {},
+	FeatureProvenance:           {},
+	FeatureSBOM:                 {},
+	FeatureSecurityMode:         {},
+	FeatureSourceDateEpoch:      {},
+	FeatureCNINetwork:           {},
 }
 
 func CheckFeatureCompat(t *testing.T, sb Sandbox, reason ...string) {


### PR DESCRIPTION
follow-up https://github.com/moby/moby/pull/44079#issuecomment-1456934350

Adds ability to enforce features compatibility check through env vars in integration tests.

For example to disable `integration.FeatureCacheExport` and `integration.FeatureCacheImport` feature you can set `BUILDKIT_TEST_DISABLE_FEATURES=cache_export,cache_import`. Set `BUILDKIT_TEST_ENABLE_FEATURES=cache_export,cache_import` to enable.

Also adds extra features compat for specific cache backends and mergediff.