### PR TITLE
Use initContainer in privileged k8s example to ensure QEMU is registered on node

### DIFF
--- a/examples/kubernetes/deployment+service.privileged.yaml
+++ b/examples/kubernetes/deployment+service.privileged.yaml
@@ -14,6 +14,15 @@ spec:
       labels:
         app: buildkitd
     spec:
+      initContainers:
+      - name: qemu
+        image: 'tonistiigi/binfmt:latest'
+        args:
+          - '--install'
+          - all
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
       containers:
         - name: buildkitd
           image: moby/buildkit:master


### PR DESCRIPTION
The [documentation](https://github.com/moby/buildkit/blob/master/docs/multi-platform.md#error-exec-user-process-caused-exec-format-error) for multi-platform builds instructs users to run `docker run --privileged --rm tonistiigi/binfmt --install all` when a certain error is encountered due to lack of QEMU registration on the node.  The issue is that since k8s 1.25 `docker` may no longer be used as well as `docker.sock` may no longer be present, as was the case described in [this](https://github.com/tonistiigi/binfmt/issues/52) issue and personally encountered.  Were it not for the issue previously linked, I would have been lost as to how to proceed. The recommended course of action is to use an initContainer to run `tonistiigi/binfmt --install all` instead.

This PR adds the initContainer to the kubernetes privileged deployment+service example.  Please let me know if this PR requires anything else. Thank you.  