### PR TITLE
Return cache export errors of dep when mode is max.

### DIFF
--- a/solver/exporter.go
+++ b/solver/exporter.go
@@ -171,6 +171,12 @@ func (e *exporter) ExportTo(ctx context.Context, t CacheExporterTarget, opt Cach
 		for _, dep := range deps {
 			recs, err := dep.CacheKey.Exporter.ExportTo(ctx, t, opt)
 			if err != nil {
+				if opt.Mode == CacheExportModeMax {
+					// we wanted to export everything in this mode, so no toleration
+					// for failures
+					return nil, err
+				}
+				// ignore errors in min or remote-only mode
 				return nil, nil
 			}
 			for _, r := range recs {
@@ -183,6 +189,12 @@ func (e *exporter) ExportTo(ctx context.Context, t CacheExporterTarget, opt Cach
 		for _, de := range e.edge.secondaryExporters {
 			recs, err := de.cacheKey.CacheKey.Exporter.ExportTo(ctx, t, opt)
 			if err != nil {
+				if opt.Mode == CacheExportModeMax {
+					// we wanted to export everything in this mode, so no toleration
+					// for failures
+					return nil, err
+				}
+				// ignore errors in min or remote-only mode
 				return nil, nil
 			}
 			for _, r := range recs {


### PR DESCRIPTION
@tonistiigi I'm 99% sure this isn't correct as is, just sending out for discussion.

My best guess is that the right behavior is that when `mode=max` we are attempting to export every record and should thus fail if anything fails.

When `mode=min` it looks like the code intends to try to include the export if we already have a remote for it, thus these lines: https://github.com/sipsma/buildkit/blob/a33bb54df091a95350ff1a05278eb5f9bfe24a6a/solver/exporter.go#L164-L166

? Not totally sure on that front. If it's true, then I can see why ignoring the error makes sense in that case.

Let me know if that's on the right track, happy to update further with specific error type checks and such too.