### PR TITLE
llbsolver: Fix performance of recomputeDigests

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -194,6 +194,7 @@ func TestIntegration(t *testing.T) {
 		testMountStubsDirectory,
 		testMountStubsTimestamp,
 		testSourcePolicy,
+		testLLBMountPerformance,
 	)
 }
 
@@ -8990,4 +8991,32 @@ func testSourcePolicy(t *testing.T, sb integration.Sandbox) {
 		_, err = c.Build(sb.Context(), SolveOpt{}, "", frontend, nil)
 		require.ErrorContains(t, err, sourcepolicy.ErrSourceDenied.Error())
 	})
+}
+
+func testLLBMountPerformance(t *testing.T, sb integration.Sandbox) {
+	c, err := New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	mntInput := llb.Image("busybox:latest")
+	st := llb.Image("busybox:latest")
+	var mnts []llb.State
+	for i := 0; i < 20; i++ {
+		execSt := st.Run(
+			llb.Args([]string{"true"}),
+		)
+		mnts = append(mnts, mntInput)
+		for j := range mnts {
+			mnts[j] = execSt.AddMount(fmt.Sprintf("/tmp/bin%d", j), mnts[j], llb.SourcePath("/bin"))
+		}
+		st = execSt.Root()
+	}
+
+	def, err := st.Marshal(sb.Context())
+	require.NoError(t, err)
+
+	timeoutCtx, cancel := context.WithTimeout(sb.Context(), time.Minute)
+	defer cancel()
+	_, err = c.Solve(timeoutCtx, def, SolveOpt{}, nil)
+	require.NoError(t, err)
 }

--- a/solver/llbsolver/vertex.go
+++ b/solver/llbsolver/vertex.go
@@ -210,6 +210,7 @@ func recomputeDigests(ctx context.Context, all map[digest.Digest]*pb.Op, visited
 	}
 
 	if !mutated {
+		visited[dgst] = dgst
 		return dgst, nil
 	}
 
@@ -274,7 +275,7 @@ func loadLLB(ctx context.Context, def *pb.Definition, polEngine SourcePolicyEval
 
 	for {
 		newDgst, ok := mutatedDigests[lastDgst]
-		if !ok {
+		if !ok || newDgst == lastDgst {
 			break
 		}
 		lastDgst = newDgst


### PR DESCRIPTION
Before this, in the case where nothing was mutated the visited memo would never be updated, thus causing exponential complexity.

Now the memo is updated even when nothing is mutated, just setting old and new to be the same digest.

---

This was causing real world performance regressions for dagger (due to the fact that dagger tries to by default propagate mount changes across every Exec, you can end up with fairly complicated LLB graphs pretty easily): https://github.com/dagger/dagger/issues/4620