### PR TITLE
llbsolver: fix sorting of history records

### DIFF
--- a/solver/llbsolver/history.go
+++ b/solver/llbsolver/history.go
@@ -102,13 +102,13 @@ func (h *HistoryQueue) gc() error {
 	}
 
 	// in order for record to get deleted by gc it exceed both maxentries and maxage criteria
-
 	if len(records) < int(h.CleanConfig.MaxEntries) {
 		return nil
 	}
 
+	// sort array by newest records first
 	sort.Slice(records, func(i, j int) bool {
-		return records[i].CompletedAt.Before(*records[j].CompletedAt)
+		return records[i].CompletedAt.After(*records[j].CompletedAt)
 	})
 
 	h.mu.Lock()


### PR DESCRIPTION
The sorting in history GC was wrong. We want a reverse sort so we can skip the N newest records, not the N oldest.