### PR TITLE
docs/rootless: use Bottlerocket's API configurations

### DIFF
--- a/docs/rootless.md
+++ b/docs/rootless.md
@@ -26,9 +26,14 @@ See also the [example manifests](#Kubernetes).
 
 ### Bottlerocket OS
 
-Needs to run `sysctl -w user.max_user_namespaces=N` (N=positive integer, like 63359) on the host nodes.
+Needs to set the max user namespaces to a positive integer, through the [API settings](https://github.com/bottlerocket-os/bottlerocket#kernel-settings):
 
-See [`../examples/kubernetes/sysctl-userns.privileged.yaml`](../examples/kubernetes/sysctl-userns.privileged.yaml).
+```toml
+[settings.kernel.sysctl]
+"user.max_user_namespaces" = "16384"
+```
+
+See [`../examples/eksctl/bottlerocket.yaml`](../examples/eskctl/bottlerocket.yaml) for an example to configure a Node Group in EKS.
 
 <details>
 <summary>Old distributions</summary>

--- a/examples/eksctl/bottlerocket.yaml
+++ b/examples/eksctl/bottlerocket.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: bottlerocket
+  region: us-west-2
+  version: '1.27'
+
+nodeGroups:
+  - name: buildkit
+    desiredCapacity: 1
+    amiFamily: Bottlerocket
+    iam:
+      attachPolicyARNs:
+        - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
+        - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+    bottlerocket:
+      settings:
+        kernel:
+          sysctl:
+            # Adjust the value as needed
+            "user.max_user_namespace": "16384"


### PR DESCRIPTION
## Description

Bottlerocket favors API configurations instead of manual calls to configure sysctl knobs