### PR TITLE
v0.11: Revert "fix process termination handling for runc exec"

### DIFF
--- a/client/build_test.go
+++ b/client/build_test.go
@@ -47,7 +47,6 @@ func TestClientGatewayIntegration(t *testing.T) {
 		testClientGatewayContainerPID1Tty,
 		testClientGatewayContainerCancelPID1Tty,
 		testClientGatewayContainerExecTty,
-		testClientGatewayContainerCancelExecTty,
 		testClientSlowCacheRootfsRef,
 		testClientGatewayContainerPlatformPATH,
 		testClientGatewayExecError,
@@ -1137,87 +1136,6 @@ func testClientGatewayContainerExecTty(t *testing.T, sb integration.Sandbox) {
 	require.ErrorAs(t, err, &exitError)
 	require.Equal(t, uint32(99), exitError.ExitCode)
 	require.Regexp(t, "exit code: 99", err.Error())
-
-	inputW.Close()
-	inputR.Close()
-
-	checkAllReleasable(t, c, sb, true)
-}
-
-// testClientGatewayContainerExecTty is testing the tty shuts down cleanly
-// on context.Cancel
-func testClientGatewayContainerCancelExecTty(t *testing.T, sb integration.Sandbox) {
-	requiresLinux(t)
-	ctx := sb.Context()
-
-	c, err := New(ctx, sb.Address())
-	require.NoError(t, err)
-	defer c.Close()
-
-	product := "buildkit_test"
-
-	inputR, inputW := io.Pipe()
-	output := bytes.NewBuffer(nil)
-	b := func(ctx context.Context, c client.Client) (*client.Result, error) {
-		ctx, timeout := context.WithTimeout(ctx, 10*time.Second)
-		defer timeout()
-		st := llb.Image("busybox:latest")
-
-		def, err := st.Marshal(ctx)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to marshal state")
-		}
-
-		r, err := c.Solve(ctx, client.SolveRequest{
-			Definition: def.ToPB(),
-		})
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to solve")
-		}
-
-		ctr, err := c.NewContainer(ctx, client.NewContainerRequest{
-			Mounts: []client.Mount{{
-				Dest:      "/",
-				MountType: pb.MountType_BIND,
-				Ref:       r.Ref,
-			}},
-		})
-		require.NoError(t, err)
-
-		pid1, err := ctr.Start(ctx, client.StartRequest{
-			Args: []string{"sleep", "10"},
-		})
-		require.NoError(t, err)
-
-		defer pid1.Wait()
-		defer ctr.Release(ctx)
-
-		execCtx, cancel := context.WithCancel(ctx)
-		defer cancel()
-
-		prompt := newTestPrompt(execCtx, t, inputW, output)
-		pid2, err := ctr.Start(execCtx, client.StartRequest{
-			Args:   []string{"sh"},
-			Tty:    true,
-			Stdin:  inputR,
-			Stdout: &nopCloser{output},
-			Stderr: &nopCloser{output},
-			Env:    []string{fmt.Sprintf("PS1=%s", prompt.String())},
-		})
-		require.NoError(t, err)
-
-		prompt.SendExpect("echo hi", "hi")
-		cancel()
-
-		err = pid2.Wait()
-		require.ErrorIs(t, err, context.Canceled)
-
-		return &client.Result{}, err
-	}
-
-	_, err = c.Build(ctx, SolveOpt{}, product, b, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), context.Canceled.Error())
 
 	inputW.Close()
 	inputR.Close()


### PR DESCRIPTION
This reverts commit 2f79b149127d8fb34e530f9534b0a73ff58ef62b.
Regression caused #3751

Summary:

This commit ended up masking rather than solving the original problem, which was unreaped zombie processes caused by cancelling the context for `runc exec` processes initiated via the gateway `(*Client).NewContainer` apis.  More discussion for a proper fix in #3754