### PR TITLE
Add client opts to enable system certificates

### DIFF
--- a/cmd/buildctl/common/common.go
+++ b/cmd/buildctl/common/common.go
@@ -82,8 +82,11 @@ func ResolveClient(c *cli.Context) (*client.Client, error) {
 		}
 	}
 
-	if caCert != "" || cert != "" || key != "" {
-		opts = append(opts, client.WithCredentials(serverName, caCert, cert, key))
+	if caCert != "" {
+		opts = append(opts, client.WithServerConfig(serverName, caCert))
+	}
+	if cert != "" || key != "" {
+		opts = append(opts, client.WithCredentials(cert, key))
 	}
 
 	timeout := time.Duration(c.GlobalInt("timeout"))


### PR DESCRIPTION
Additionally, this splits out WithCredentials into separate methods:

- WithCredentials configures the client credentials presented to the server
- WithServerConfig configures the name and ca certificate to check the server's certificate against
- WithServerConfigSystem configures the name to check the server's certificate against - the ca certificate is automatically pulled from the system store.

This essentially splits out the different possible TLS combinations into:
- No TLS - none of the above client options
- TLS verifying the server against a known CA cert - use WithServerConfig
- TLS verifying the server against a system cert - use WithServerConfigSystem
- mTLS verifying the server against a known CA cert - use WithServerConfig + WithCredentials
- mTLS verifying the server against a system cert - use WithServerConfigSystem + WithCredentials