### PR TITLE
Make ClientOpts type safe

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -9036,7 +9036,7 @@ func testClientCustomGRPCOpts(t *testing.T, sb integration.Sandbox) {
 		interceptedMethods = append(interceptedMethods, method)
 		return invoker(ctx, method, req, reply, cc, opts...)
 	}
-	c, err := New(sb.Context(), sb.Address(), grpc.WithChainUnaryInterceptor(intercept))
+	c, err := New(sb.Context(), sb.Address(), WithGRPCDialOption(grpc.WithChainUnaryInterceptor(intercept)))
 	require.NoError(t, err)
 	defer c.Close()
 


### PR DESCRIPTION
This provides some compile-time safety around options passed when creating a buildkit client.
Before this change since a ClientOpt is an empty interface anything and everything could be passed in.

This is a breaking change since before consumers could pass in a raw grpc.DialOption, this now needs to be wrapped with `client.WithGRPCDialOption(grpcOpt)`
Consumers could also pass in something tat was not a client opt at all and it was completely ignored.