### PR TITLE
[v0.10] cherry-pick: Make local cache importer non-lazy

### DIFF
--- a/cache/manager.go
+++ b/cache/manager.go
@@ -301,7 +301,14 @@ func (cm *cacheManager) GetByBlob(ctx context.Context, desc ocispecs.Descriptor,
 
 	cm.records[id] = rec
 
-	return rec.ref(true, descHandlers, nil), nil
+	ref := rec.ref(true, descHandlers, nil)
+	if s := unlazySessionOf(opts...); s != nil {
+		if err := ref.unlazy(ctx, ref.descHandlers, ref.progress, s, true); err != nil {
+			return nil, err
+		}
+	}
+
+	return ref, nil
 }
 
 // init loads all snapshots from metadata state and tries to load the records

--- a/cache/opts.go
+++ b/cache/opts.go
@@ -37,3 +37,14 @@ func (m NeedsRemoteProviderError) Error() string {
 }
 
 type ProgressKey struct{}
+
+type Unlazy session.Group
+
+func unlazySessionOf(opts ...RefOption) session.Group {
+	for _, opt := range opts {
+		if opt, ok := opt.(session.Group); ok {
+			return opt
+		}
+	}
+	return nil
+}

--- a/cache/remotecache/local/local.go
+++ b/cache/remotecache/local/local.go
@@ -98,7 +98,16 @@ func getContentStore(ctx context.Context, sm *session.Manager, g session.Group, 
 	if err != nil {
 		return nil, err
 	}
-	return sessioncontent.NewCallerStore(caller, storeID), nil
+	return &unlazyProvider{sessioncontent.NewCallerStore(caller, storeID), g}, nil
+}
+
+type unlazyProvider struct {
+	content.Store
+	s session.Group
+}
+
+func (p *unlazyProvider) UnlazySession(desc ocispecs.Descriptor) session.Group {
+	return p.s
 }
 
 func attrsToCompression(attrs map[string]string) (*compression.Config, error) {

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -447,6 +447,14 @@ func (w *Worker) FromRemote(ctx context.Context, remote *solver.Remote) (ref cac
 			cache.WithCreationTime(tm),
 			descHandlers,
 		}
+		if ul, ok := remote.Provider.(interface {
+			UnlazySession(ocispecs.Descriptor) session.Group
+		}); ok {
+			s := ul.UnlazySession(desc)
+			if s != nil {
+				opts = append(opts, cache.Unlazy(s))
+			}
+		}
 		if dh, ok := descHandlers[desc.Digest]; ok {
 			if ref, ok := dh.Annotations["containerd.io/distribution.source.ref"]; ok {
 				opts = append(opts, cache.WithImageRef(ref)) // can set by registry cache importer


### PR DESCRIPTION
https://github.com/moby/buildkit/pull/3493
https://github.com/moby/buildkit/issues/3770