### PR TITLE
buildkitd: allow multiple units for gc config

### DIFF
--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -116,7 +116,7 @@ type ContainerdConfig struct {
 type GCPolicy struct {
 	All          bool      `toml:"all"`
 	KeepBytes    DiskSpace `toml:"keepBytes"`
-	KeepDuration int64     `toml:"keepDuration"`
+	KeepDuration Duration  `toml:"keepDuration"`
 	Filters      []string  `toml:"filters"`
 }
 
@@ -127,6 +127,6 @@ type DNSConfig struct {
 }
 
 type HistoryConfig struct {
-	MaxAge     int64 `toml:"maxAge"`
-	MaxEntries int64 `toml:"maxEntries"`
+	MaxAge     Duration `toml:"maxAge"`
+	MaxEntries int64    `toml:"maxEntries"`
 }

--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -47,7 +47,7 @@ type TLSConfig struct {
 
 type GCConfig struct {
 	GC            *bool      `toml:"gc"`
-	GCKeepStorage int64      `toml:"gckeepstorage"`
+	GCKeepStorage DiskSpace  `toml:"gckeepstorage"`
 	GCPolicy      []GCPolicy `toml:"gcpolicy"`
 }
 
@@ -114,10 +114,10 @@ type ContainerdConfig struct {
 }
 
 type GCPolicy struct {
-	All          bool     `toml:"all"`
-	KeepBytes    int64    `toml:"keepBytes"`
-	KeepDuration int64    `toml:"keepDuration"`
-	Filters      []string `toml:"filters"`
+	All          bool      `toml:"all"`
+	KeepBytes    DiskSpace `toml:"keepBytes"`
+	KeepDuration int64     `toml:"keepDuration"`
+	Filters      []string  `toml:"filters"`
 }
 
 type DNSConfig struct {

--- a/cmd/buildkitd/config/gcpolicy.go
+++ b/cmd/buildkitd/config/gcpolicy.go
@@ -1,17 +1,55 @@
 package config
 
+import (
+	"strconv"
+	"strings"
+
+	"github.com/docker/go-units"
+	"github.com/pkg/errors"
+)
+
+type DiskSpace struct {
+	Bytes      int64
+	Percentage int64
+}
+
+var _ encoding.TextUnmarshaler = &DiskSpace{}
+
+func (d *DiskSpace) UnmarshalText(textb []byte) error {
+	text := stripQuotes(string(textb))
+	if len(text) == 0 {
+		return nil
+	}
+
+	if text2 := strings.TrimSuffix(text, "%"); len(text2) < len(text) {
+		i, err := strconv.ParseInt(text2, 10, 64)
+		if err != nil {
+			return err
+		}
+		d.Percentage = i
+		return nil
+	}
+
+	if i, err := units.RAMInBytes(text); err == nil {
+		d.Bytes = i
+		return nil
+	}
+
+	return errors.Errorf("invalid disk space %s", text)
+}
+
 const defaultCap int64 = 2e9 // 2GB
 
-func DefaultGCPolicy(p string, keep int64) []GCPolicy {
-	if keep == 0 {
-		keep = DetectDefaultGCCap(p)
+func DefaultGCPolicy(keep DiskSpace) []GCPolicy {
+	if keep == (DiskSpace{}) {
+		keep = DetectDefaultGCCap()
 	}
 	return []GCPolicy{
 		// if build cache uses more than 512MB delete the most easily reproducible data after it has not been used for 2 days
 		{
 			Filters:      []string{"type==source.local,type==exec.cachemount,type==source.git.checkout"},
-			KeepDuration: 48 * 3600, // 48h
-			KeepBytes:    512 * 1e6, // 512MB
+			KeepDuration: 48 * 3600,                   // 48h
+			KeepBytes:    DiskSpace{Bytes: 512 * 1e6}, // 512MB
 		},
 		// remove any data not used for 60 days
 		{
@@ -28,4 +66,14 @@ func DefaultGCPolicy(p string, keep int64) []GCPolicy {
 			KeepBytes: keep,
 		},
 	}
+}
+
+func stripQuotes(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+	if s[0] == '"' && s[len(s)-1] == '"' {
+		return s[1 : len(s)-1]
+	}
+	return s
 }

--- a/cmd/buildkitd/config/gcpolicy.go
+++ b/cmd/buildkitd/config/gcpolicy.go
@@ -1,12 +1,39 @@
 package config
 
 import (
+	"encoding"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/docker/go-units"
 	"github.com/pkg/errors"
 )
+
+type Duration struct {
+	time.Duration
+}
+
+func (d *Duration) UnmarshalText(textb []byte) error {
+	text := stripQuotes(string(textb))
+	if len(text) == 0 {
+		return nil
+	}
+
+	if duration, err := time.ParseDuration(text); err == nil {
+		d.Duration = duration
+		return nil
+	}
+
+	if i, err := strconv.ParseInt(text, 10, 64); err == nil {
+		d.Duration = time.Duration(i) * time.Second
+		return nil
+	}
+
+	return errors.Errorf("invalid duration %s", text)
+}
+
+var _ encoding.TextUnmarshaler = &Duration{}
 
 type DiskSpace struct {
 	Bytes      int64
@@ -48,12 +75,12 @@ func DefaultGCPolicy(keep DiskSpace) []GCPolicy {
 		// if build cache uses more than 512MB delete the most easily reproducible data after it has not been used for 2 days
 		{
 			Filters:      []string{"type==source.local,type==exec.cachemount,type==source.git.checkout"},
-			KeepDuration: 48 * 3600,                   // 48h
-			KeepBytes:    DiskSpace{Bytes: 512 * 1e6}, // 512MB
+			KeepDuration: Duration{Duration: time.Duration(48) * time.Hour}, // 48h
+			KeepBytes:    DiskSpace{Bytes: 512 * 1e6},                       // 512MB
 		},
 		// remove any data not used for 60 days
 		{
-			KeepDuration: 60 * 24 * 3600, // 60d
+			KeepDuration: Duration{Duration: time.Duration(60) * 24 * time.Hour}, // 60d
 			KeepBytes:    keep,
 		},
 		// keep the unshared build cache under cap

--- a/cmd/buildkitd/config/gcpolicy_unix.go
+++ b/cmd/buildkitd/config/gcpolicy_unix.go
@@ -7,12 +7,23 @@ import (
 	"syscall"
 )
 
-func DetectDefaultGCCap(root string) int64 {
+func DetectDefaultGCCap() DiskSpace {
+	return DiskSpace{Percentage: 10}
+}
+
+func (d DiskSpace) AsBytes(root string) int64 {
+	if d.Bytes != 0 {
+		return d.Bytes
+	}
+	if d.Percentage == 0 {
+		return 0
+	}
+
 	var st syscall.Statfs_t
 	if err := syscall.Statfs(root, &st); err != nil {
 		return defaultCap
 	}
 	diskSize := int64(st.Bsize) * int64(st.Blocks)
-	avail := diskSize / 10
+	avail := diskSize * d.Percentage / 100
 	return (avail/(1<<30) + 1) * 1e9 // round up
 }

--- a/cmd/buildkitd/config/gcpolicy_windows.go
+++ b/cmd/buildkitd/config/gcpolicy_windows.go
@@ -3,6 +3,10 @@
 
 package config
 
-func DetectDefaultGCCap(root string) int64 {
-	return defaultCap
+func DetectDefaultGCCap() DiskSpace {
+	return DiskSpace{Bytes: defaultCap}
+}
+
+func (d DiskSpace) AsBytes(root string) int64 {
+	return d.Bytes
 }

--- a/cmd/buildkitd/config/load_test.go
+++ b/cmd/buildkitd/config/load_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -48,6 +49,7 @@ keepBytes="40MB"
 keepDuration=7200
 [[worker.containerd.gcpolicy]]
 keepBytes="20%"
+keepDuration="24h"
 
 [registry."docker.io"]
 mirrors=["hub.docker.io"]
@@ -104,8 +106,9 @@ searchDomains=["example.com"]
 	require.Equal(t, int64(20), cfg.Workers.Containerd.GCPolicy[0].KeepBytes.Bytes)
 	require.Equal(t, int64(40*1024*1024), cfg.Workers.Containerd.GCPolicy[1].KeepBytes.Bytes)
 	require.Equal(t, int64(20), cfg.Workers.Containerd.GCPolicy[2].KeepBytes.Percentage)
-	require.Equal(t, int64(3600), cfg.Workers.Containerd.GCPolicy[0].KeepDuration)
-	require.Equal(t, int64(7200), cfg.Workers.Containerd.GCPolicy[1].KeepDuration)
+	require.Equal(t, time.Duration(3600), cfg.Workers.Containerd.GCPolicy[0].KeepDuration.Duration/time.Second)
+	require.Equal(t, time.Duration(7200), cfg.Workers.Containerd.GCPolicy[1].KeepDuration.Duration/time.Second)
+	require.Equal(t, time.Duration(86400), cfg.Workers.Containerd.GCPolicy[2].KeepDuration.Duration/time.Second)
 	require.Equal(t, 1, len(cfg.Workers.Containerd.GCPolicy[0].Filters))
 	require.Equal(t, 0, len(cfg.Workers.Containerd.GCPolicy[1].Filters))
 

--- a/cmd/buildkitd/config/load_test.go
+++ b/cmd/buildkitd/config/load_test.go
@@ -44,8 +44,10 @@ filters=["foo==bar"]
 keepBytes=20
 keepDuration=3600
 [[worker.containerd.gcpolicy]]
-keepBytes=40
+keepBytes="40MB"
 keepDuration=7200
+[[worker.containerd.gcpolicy]]
+keepBytes="20%"
 
 [registry."docker.io"]
 mirrors=["hub.docker.io"]
@@ -78,7 +80,7 @@ searchDomains=["example.com"]
 	require.Equal(t, "mycert.pem", cfg.GRPC.TLS.Cert)
 
 	require.NotNil(t, cfg.Workers.OCI.Enabled)
-	require.Equal(t, int64(123456789), cfg.Workers.OCI.GCKeepStorage)
+	require.Equal(t, int64(123456789), cfg.Workers.OCI.GCKeepStorage.Bytes)
 	require.Equal(t, true, *cfg.Workers.OCI.Enabled)
 	require.Equal(t, "overlay", cfg.Workers.OCI.Snapshotter)
 	require.Equal(t, true, cfg.Workers.OCI.Rootless)
@@ -93,13 +95,15 @@ searchDomains=["example.com"]
 
 	require.Equal(t, 0, len(cfg.Workers.OCI.GCPolicy))
 	require.Equal(t, "non-default", cfg.Workers.Containerd.Namespace)
-	require.Equal(t, 2, len(cfg.Workers.Containerd.GCPolicy))
+	require.Equal(t, 3, len(cfg.Workers.Containerd.GCPolicy))
 
 	require.Nil(t, cfg.Workers.Containerd.GC)
 	require.Equal(t, true, cfg.Workers.Containerd.GCPolicy[0].All)
 	require.Equal(t, false, cfg.Workers.Containerd.GCPolicy[1].All)
-	require.Equal(t, int64(20), cfg.Workers.Containerd.GCPolicy[0].KeepBytes)
-	require.Equal(t, int64(40), cfg.Workers.Containerd.GCPolicy[1].KeepBytes)
+	require.Equal(t, false, cfg.Workers.Containerd.GCPolicy[2].All)
+	require.Equal(t, int64(20), cfg.Workers.Containerd.GCPolicy[0].KeepBytes.Bytes)
+	require.Equal(t, int64(40*1024*1024), cfg.Workers.Containerd.GCPolicy[1].KeepBytes.Bytes)
+	require.Equal(t, int64(20), cfg.Workers.Containerd.GCPolicy[2].KeepBytes.Percentage)
 	require.Equal(t, int64(3600), cfg.Workers.Containerd.GCPolicy[0].KeepDuration)
 	require.Equal(t, int64(7200), cfg.Workers.Containerd.GCPolicy[1].KeepDuration)
 	require.Equal(t, 1, len(cfg.Workers.Containerd.GCPolicy[0].Filters))

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -769,14 +769,14 @@ func getGCPolicy(cfg config.GCConfig, root string) []client.PruneInfo {
 		return nil
 	}
 	if len(cfg.GCPolicy) == 0 {
-		cfg.GCPolicy = config.DefaultGCPolicy(root, cfg.GCKeepStorage)
+		cfg.GCPolicy = config.DefaultGCPolicy(cfg.GCKeepStorage)
 	}
 	out := make([]client.PruneInfo, 0, len(cfg.GCPolicy))
 	for _, rule := range cfg.GCPolicy {
 		out = append(out, client.PruneInfo{
 			Filter:       rule.Filters,
 			All:          rule.All,
-			KeepBytes:    rule.KeepBytes,
+			KeepBytes:    rule.KeepBytes.AsBytes(root),
 			KeepDuration: time.Duration(rule.KeepDuration) * time.Second,
 		})
 	}

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -12,7 +12,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/containerd/containerd/pkg/seed" //nolint:staticcheck // SA1019 deprecated
 	"github.com/containerd/containerd/pkg/userns"
@@ -777,7 +776,7 @@ func getGCPolicy(cfg config.GCConfig, root string) []client.PruneInfo {
 			Filter:       rule.Filters,
 			All:          rule.All,
 			KeepBytes:    rule.KeepBytes.AsBytes(root),
-			KeepDuration: time.Duration(rule.KeepDuration) * time.Second,
+			KeepDuration: rule.KeepDuration.Duration,
 		})
 	}
 	return out

--- a/cmd/buildkitd/main_containerd_worker.go
+++ b/cmd/buildkitd/main_containerd_worker.go
@@ -137,10 +137,11 @@ func init() {
 		Name:  "containerd-worker-gc-keepstorage",
 		Usage: "Amount of storage GC keep locally (MB)",
 		Value: func() int64 {
-			if defaultConf.Workers.Containerd.GCKeepStorage != 0 {
-				return defaultConf.Workers.Containerd.GCKeepStorage / 1e6
+			keep := defaultConf.Workers.Containerd.GCKeepStorage.AsBytes(defaultConf.Root)
+			if keep == 0 {
+				keep = config.DetectDefaultGCCap().AsBytes(defaultConf.Root)
 			}
-			return config.DetectDefaultGCCap(defaultConf.Root) / 1e6
+			return keep / 1e6
 		}(),
 		Hidden: len(defaultConf.Workers.Containerd.GCPolicy) != 0,
 	})
@@ -207,7 +208,7 @@ func applyContainerdFlags(c *cli.Context, cfg *config.Config) error {
 	}
 
 	if c.GlobalIsSet("containerd-worker-gc-keepstorage") {
-		cfg.Workers.Containerd.GCKeepStorage = c.GlobalInt64("containerd-worker-gc-keepstorage") * 1e6
+		cfg.Workers.Containerd.GCKeepStorage = config.DiskSpace{Bytes: c.GlobalInt64("containerd-worker-gc-keepstorage") * 1e6}
 	}
 
 	if c.GlobalIsSet("containerd-worker-net") {

--- a/cmd/buildkitd/main_oci_worker.go
+++ b/cmd/buildkitd/main_oci_worker.go
@@ -153,10 +153,11 @@ func init() {
 		Name:  "oci-worker-gc-keepstorage",
 		Usage: "Amount of storage GC keep locally (MB)",
 		Value: func() int64 {
-			if defaultConf.Workers.OCI.GCKeepStorage != 0 {
-				return defaultConf.Workers.OCI.GCKeepStorage / 1e6
+			keep := defaultConf.Workers.OCI.GCKeepStorage.AsBytes(defaultConf.Root)
+			if keep == 0 {
+				keep = config.DetectDefaultGCCap().AsBytes(defaultConf.Root)
 			}
-			return config.DetectDefaultGCCap(defaultConf.Root) / 1e6
+			return keep / 1e6
 		}(),
 		Hidden: len(defaultConf.Workers.OCI.GCPolicy) != 0,
 	})
@@ -221,7 +222,7 @@ func applyOCIFlags(c *cli.Context, cfg *config.Config) error {
 	}
 
 	if c.GlobalIsSet("oci-worker-gc-keepstorage") {
-		cfg.Workers.OCI.GCKeepStorage = c.GlobalInt64("oci-worker-gc-keepstorage") * 1e6
+		cfg.Workers.OCI.GCKeepStorage = config.DiskSpace{Bytes: c.GlobalInt64("oci-worker-gc-keepstorage") * 1e6}
 	}
 
 	if c.GlobalIsSet("oci-worker-net") {

--- a/docs/buildkitd.toml.md
+++ b/docs/buildkitd.toml.md
@@ -63,8 +63,13 @@ insecure-entitlements = [ "network.host", "security.insecure" ]
     "foo" = "bar"
 
   [[worker.oci.gcpolicy]]
-    keepBytes = 512000000
-    keepDuration = 172800
+    # keepBytes can be an integer number of bytes (e.g. 512000000), a string
+    # with a unit (e.g. "512MB"), or a string percentage of available disk
+    # space (e.g. "10%")
+    keepBytes = "512MB"
+    # keepDuration can be an integer number of seconds (e.g. 172800), or a
+    # string duration (e.g. "48h")
+    keepDuration = "48h"
     filters = [ "type==source.local", "type==exec.cachemount", "type==source.git.checkout"]
   [[worker.oci.gcpolicy]]
     all = true
@@ -87,7 +92,7 @@ insecure-entitlements = [ "network.host", "security.insecure" ]
 
   [[worker.containerd.gcpolicy]]
     keepBytes = 512000000
-    keepDuration = 172800 # in seconds
+    keepDuration = 172800
     filters = [ "type==source.local", "type==exec.cachemount", "type==source.git.checkout"]
   [[worker.containerd.gcpolicy]]
     all = true

--- a/solver/llbsolver/history.go
+++ b/solver/llbsolver/history.go
@@ -54,7 +54,7 @@ type StatusImportResult struct {
 func NewHistoryQueue(opt HistoryQueueOpt) *HistoryQueue {
 	if opt.CleanConfig == nil {
 		opt.CleanConfig = &config.HistoryConfig{
-			MaxAge:     int64((48 * time.Hour).Seconds()),
+			MaxAge:     config.Duration{Duration: 48 * time.Hour},
 			MaxEntries: 50,
 		}
 	}
@@ -116,7 +116,7 @@ func (h *HistoryQueue) gc() error {
 
 	now := time.Now()
 	for _, r := range records[h.CleanConfig.MaxEntries:] {
-		if now.Add(time.Duration(h.CleanConfig.MaxAge) * -time.Second).After(*r.CompletedAt) {
+		if now.Add(0 - h.CleanConfig.MaxAge.Duration).After(*r.CompletedAt) {
 			if err := h.delete(r.Ref, false); err != nil {
 				return err
 			}


### PR DESCRIPTION
In addition to parsing the raw number of bytes, we can additionally supporting reading short notations from strings, such as "50MB", or "10GB". We can also support different percentages, such as "20%", which allows for consuming a maximum percentage of the disk easily (previously, only the default was set to 10%, with no ability to change to use an arbitrary percentage).