### PR TITLE
Revert "Problem: can't use anonymous S3 credentials"

### DIFF
--- a/cache/remotecache/s3/s3.go
+++ b/cache/remotecache/s3/s3.go
@@ -360,10 +360,6 @@ func newS3Client(ctx context.Context, config Config) (*s3Client, error) {
 	client := s3.NewFromConfig(cfg, func(options *s3.Options) {
 		if config.AccessKeyID != "" && config.SecretAccessKey != "" {
 			options.Credentials = credentials.NewStaticCredentialsProvider(config.AccessKeyID, config.SecretAccessKey, config.SessionToken)
-		} else {
-			// Setting `nil` for anonymous credentials as per
-			// https://pkg.go.dev/github.com/aws/aws-sdk-go-v2@v1.17.6/aws#AnonymousCredentials
-			options.Credentials = nil
 		}
 		if config.EndpointURL != "" {
 			options.UsePathStyle = config.UsePathStyle


### PR DESCRIPTION
Reverts moby/buildkit#3692

See #3785

We need a better solution for anonymous creds