### PR TITLE
bump up golangci-lint to v1.52.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,3 +66,18 @@ issues:
     - linters:
         - revive
       text: "stutters"
+    - linters:
+        - revive
+      text: "empty-block"
+    - linters:
+        - revive
+      text: "superfluous-else"
+    - linters:
+        - revive
+      text: "unused-parameter"
+    - linters:
+        - revive
+      text: "redefines-builtin-id"
+    - linters:
+        - revive
+      text: "if-return"

--- a/hack/dockerfiles/lint.Dockerfile
+++ b/hack/dockerfiles/lint.Dockerfile
@@ -5,7 +5,7 @@ ARG GO_VERSION=1.20
 FROM golang:${GO_VERSION}-alpine
 ENV GOFLAGS="-buildvcs=false"
 RUN apk add --no-cache gcc musl-dev yamllint
-RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.51.1
+RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.52.2
 WORKDIR /go/src/github.com/moby/buildkit
 RUN --mount=target=/go/src/github.com/moby/buildkit --mount=target=/root/.cache,type=cache \
   GOARCH=amd64 golangci-lint run && \


### PR DESCRIPTION
This PR bumps up golangci-lint to v1.52.2 https://github.com/golangci/golangci-lint/releases/tag/v1.52.2
With this version, the linter fails with a lot of `unused-parameter` failures. Though this PR fixes the code to pass the linter, maybe we can disable it if unnecessary.