### PR TITLE
ci: put worker name first for better UX in actions

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -105,10 +105,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pkg: ${{ fromJson(needs.prepare.outputs.pkgs) }}
-        kind: ${{ fromJson(needs.prepare.outputs.kinds) }}
-        tags: ${{ fromJson(needs.prepare.outputs.tags) }}
-        include: ${{ fromJson(needs.prepare.outputs.includes) }}
         worker:
           - containerd
           - containerd-rootless
@@ -117,6 +113,10 @@ jobs:
           - oci
           - oci-rootless
           - oci-snapshotter-stargz
+        pkg: ${{ fromJson(needs.prepare.outputs.pkgs) }}
+        kind: ${{ fromJson(needs.prepare.outputs.kinds) }}
+        tags: ${{ fromJson(needs.prepare.outputs.tags) }}
+        include: ${{ fromJson(needs.prepare.outputs.includes) }}
     steps:
       -
         name: Environment variables


### PR DESCRIPTION
Previously, github actions were showing only `run (./client ./cmd/buildctl ./wor...` for all worker configurations.
This commit put the worker name first so we can easily see which worker a job is testing.

Before:
![image](https://user-images.githubusercontent.com/5435069/232560007-d2c163bd-29d9-42c7-81e3-952a0885dd97.png)

After (ignore the additional test jobs):
![image](https://user-images.githubusercontent.com/5435069/232560209-c9a48659-52d7-49b9-b862-7184bf9bf4c3.png)

