### PR TITLE
test: don't hang if a process doesn't run

### DIFF
--- a/util/testutil/integration/containerd.go
+++ b/util/testutil/integration/containerd.go
@@ -185,7 +185,7 @@ disabled_plugins = ["cri"]
 	if err != nil {
 		return nil, nil, err
 	}
-	if err := waitUnix(address, 10*time.Second); err != nil {
+	if err := waitUnix(address, 10*time.Second, cmd); err != nil {
 		ctdStop()
 		return nil, nil, errors.Wrapf(err, "containerd did not start up: %s", formatLogs(cfg.Logs))
 	}

--- a/util/testutil/integration/dockerd.go
+++ b/util/testutil/integration/dockerd.go
@@ -145,7 +145,7 @@ func (c moby) New(ctx context.Context, cfg *BackendConfig) (b Backend, cl func()
 	}
 	deferF.append(d.StopWithError)
 
-	if err := waitUnix(d.Sock(), 5*time.Second); err != nil {
+	if err := waitUnix(d.Sock(), 5*time.Second, nil); err != nil {
 		return nil, nil, errors.Errorf("dockerd did not start up: %q, %s", err, formatLogs(cfg.Logs))
 	}
 

--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -448,7 +448,7 @@ func runStargzSnapshotter(cfg *BackendConfig) (address string, cl func() error, 
 	if err != nil {
 		return "", nil, err
 	}
-	if err = waitUnix(address, 10*time.Second); err != nil {
+	if err = waitUnix(address, 10*time.Second, cmd); err != nil {
 		snStop()
 		return "", nil, errors.Wrapf(err, "containerd-stargz-grpc did not start up: %s", formatLogs(cfg.Logs))
 	}

--- a/util/testutil/integration/sandbox.go
+++ b/util/testutil/integration/sandbox.go
@@ -229,7 +229,7 @@ func runBuildkitd(ctx context.Context, conf *BackendConfig, args []string, logs 
 	}
 	deferF.append(stop)
 
-	if err := waitUnix(address, 15*time.Second); err != nil {
+	if err := waitUnix(address, 15*time.Second, cmd); err != nil {
 		return "", nil, err
 	}
 


### PR DESCRIPTION
If a process is started but exits early because of an error, don't hang and instead detect process exit.
This happens when the process doesn't exist (for example, when `registry` binary is missing).
This helps to know what's wrong instead of having to use the debugger.