### PR TITLE
Add checks to avoid provenance and sbom post processing if not results were created

### DIFF
--- a/solver/llbsolver/proc/sbom.go
+++ b/solver/llbsolver/proc/sbom.go
@@ -38,6 +38,10 @@ func SBOMProcessor(scannerRef string, useCache bool) llbsolver.Processor {
 			if !ok {
 				return nil, errors.Errorf("could not find ref %s", p.ID)
 			}
+			if ref == nil {
+				continue
+			}
+
 			defop, err := llb.NewDefinitionOp(ref.Definition())
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
:arrow_up: Follow-up to https://github.com/moby/buildkit/pull/3462.

This fixes the panic that we can trigger in https://github.com/docker/buildx/pull/1640#issuecomment-1513000048.

This scenario would happen if we returned a result containing no refs, but the solve opt specified we should have some platforms, we'd still attempt to access them, and panic.

This is probably a candidate for cherry-picking. 

cc @ktock 