### PR TITLE
solver: Release unused refs in LoadWithParents

### DIFF
--- a/solver/cachemanager.go
+++ b/solver/cachemanager.go
@@ -217,6 +217,11 @@ func (c *cacheManager) LoadWithParents(ctx context.Context, rec *CacheRecord) ([
 			r.Release(context.TODO())
 		}
 	}
+	for _, r := range m {
+		// refs added to results are deleted from m by filterResults
+		// so release any leftovers
+		r.Release(context.TODO())
+	}
 
 	return results, nil
 }


### PR DESCRIPTION
Before this any refs that were loaded but not put into results would be leaked.

---

~~cc @tonistiigi noticed in certain load tests I was running w/ Dagger that cache refs were leaking, this fixes it. I am still trying to understand the exact circumstances it arises in.~~

~~I know for sure it only happens when using a cacheManager constructed from a remote cache import. And I also *think* it might happen when there are multiple results that end up with the same layers (i.e. two image refs resolve to the same set of layers). However, the context in which this was triggered involved cache manifest json constructed by custom code, not by the normal buildkit code, so I don't know if it's possible to trigger this using a cache manifest generated by buildkit upstream.~~

Either way, I think this fix is desirable upstream since we should never leave refs unreleased anyways.

---

EDIT: @tonistiigi  I was able to reproduce this same bug purely with Buildkit, see the newly added integration test, which fails without this change present.

The problem happens when a remote cache import has multiple records with the same layers. In this case the resultID is calculated as a hash of the layer digests, so both records are associated with the same resultID. This causes them both to be loaded in `LoadWithParents` in the remote cache result storage. `filterResults` then only chooses one of them to use for the returned `results` list, but it never releases the refs for the others it didn't end up choosing.