### PR TITLE
chore: tidy up duplicated imports

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -50,7 +50,6 @@ import (
 	"github.com/moby/buildkit/solver/result"
 	"github.com/moby/buildkit/sourcepolicy"
 	sourcepolicypb "github.com/moby/buildkit/sourcepolicy/pb"
-	spb "github.com/moby/buildkit/sourcepolicy/pb"
 	"github.com/moby/buildkit/util/attestation"
 	"github.com/moby/buildkit/util/contentutil"
 	"github.com/moby/buildkit/util/entitlements"
@@ -9087,11 +9086,11 @@ func testSourcePolicy(t *testing.T, sb integration.Sandbox) {
 			}
 			return c.Solve(ctx, gateway.SolveRequest{
 				Definition: def.ToPB(),
-				SourcePolicies: []*spb.Policy{{
-					Rules: []*spb.Rule{
+				SourcePolicies: []*sourcepolicypb.Policy{{
+					Rules: []*sourcepolicypb.Rule{
 						{
-							Action: spb.PolicyAction_DENY,
-							Selector: &spb.Selector{
+							Action: sourcepolicypb.PolicyAction_DENY,
+							Selector: &sourcepolicypb.Selector{
 								Identifier: denied,
 							},
 						},

--- a/util/winlayers/differ.go
+++ b/util/winlayers/differ.go
@@ -15,12 +15,10 @@ import (
 	"github.com/containerd/containerd/diff"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/mount"
+	log "github.com/moby/buildkit/util/bklog"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
-
-	"github.com/moby/buildkit/util/bklog"
-	log "github.com/moby/buildkit/util/bklog"
 )
 
 const (
@@ -259,7 +257,7 @@ func makeWindowsLayer(ctx context.Context, w io.Writer) (io.Writer, func(error),
 			return tarWriter.Close()
 		}()
 		if err != nil {
-			bklog.G(ctx).Errorf("makeWindowsLayer %+v", err)
+			log.G(ctx).Errorf("makeWindowsLayer %+v", err)
 		}
 		pw.CloseWithError(err)
 		done <- err


### PR DESCRIPTION
Looks like we had some duplicated imports.

While there *is* a revive rule for this, it's disabled by default... and enabling it requires manually listing out every single rule we want to enable 1-by-1. So I think it's maybe not worth enabling it, at least until we can resolve #3796.