### PR TITLE
Expose client through interface

### DIFF
--- a/client/build.go
+++ b/client/build.go
@@ -13,7 +13,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-func (c *Client) Build(ctx context.Context, opt SolveOpt, product string, buildFunc gateway.BuildFunc, statusChan chan *SolveStatus) (*SolveResponse, error) {
+func (c *cl) Build(ctx context.Context, opt SolveOpt, product string, buildFunc gateway.BuildFunc, statusChan chan *SolveStatus) (*SolveResponse, error) {
 	defer func() {
 		if statusChan != nil {
 			close(statusChan)
@@ -48,7 +48,7 @@ func (c *Client) Build(ctx context.Context, opt SolveOpt, product string, buildF
 			}
 			feOpts[k] = v
 		}
-		gwClient := c.gatewayClientForBuild(ref)
+		gwClient := c.gatewayClient(ref)
 		g, err := grpcclient.New(ctx, feOpts, s.ID(), product, gwClient, gworkers)
 		if err != nil {
 			return err
@@ -63,14 +63,6 @@ func (c *Client) Build(ctx context.Context, opt SolveOpt, product string, buildF
 	}
 
 	return c.solve(ctx, nil, cb, opt, statusChan)
-}
-
-func (c *Client) gatewayClientForBuild(buildid string) *gatewayClientForBuild {
-	g := gatewayapi.NewLLBBridgeClient(c.conn)
-	return &gatewayClientForBuild{
-		gateway: g,
-		buildID: buildid,
-	}
 }
 
 type gatewayClientForBuild struct {

--- a/client/build_test.go
+++ b/client/build_test.go
@@ -313,7 +313,7 @@ func testNoBuildID(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 	defer c.Close()
 
-	g := gatewayapi.NewLLBBridgeClient(c.conn)
+	g := c.(*cl).gatewayClient("")
 	_, err = g.Ping(ctx, &gatewayapi.PingRequest{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no buildid found in context")
@@ -328,7 +328,7 @@ func testUnknownBuildID(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 	defer c.Close()
 
-	g := c.gatewayClientForBuild(t.Name() + identity.NewID())
+	g := c.(*cl).gatewayClient(t.Name() + identity.NewID())
 	_, err = g.Ping(ctx, &gatewayapi.PingRequest{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no such job")

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -5218,7 +5218,7 @@ func testMultipleRecordsWithSameLayersCacheImportExport(t *testing.T, sb integra
 	ensurePruneAll(t, c, sb)
 }
 
-func readFileInImage(ctx context.Context, t *testing.T, c *Client, ref, path string) ([]byte, error) {
+func readFileInImage(ctx context.Context, t *testing.T, c Client, ref, path string) ([]byte, error) {
 	def, err := llb.Image(ref).Marshal(ctx)
 	if err != nil {
 		return nil, err
@@ -6467,7 +6467,7 @@ func testMergeOpCache(t *testing.T, sb integration.Sandbox, mode string) {
 	}
 }
 
-func requireContents(ctx context.Context, t *testing.T, c *Client, sb integration.Sandbox, state llb.State, cacheImports, cacheExports []CacheOptionsEntry, imageTarget string, files ...fstest.Applier) {
+func requireContents(ctx context.Context, t *testing.T, c Client, sb integration.Sandbox, state llb.State, cacheImports, cacheExports []CacheOptionsEntry, imageTarget string, files ...fstest.Applier) {
 	t.Helper()
 
 	def, err := state.Marshal(ctx)
@@ -6515,7 +6515,7 @@ func requireContents(ctx context.Context, t *testing.T, c *Client, sb integratio
 	}
 }
 
-func requireEqualContents(ctx context.Context, t *testing.T, c *Client, stateA, stateB llb.State) {
+func requireEqualContents(ctx context.Context, t *testing.T, c Client, stateA, stateB llb.State) {
 	t.Helper()
 
 	defA, err := stateA.Marshal(ctx)
@@ -6577,7 +6577,7 @@ func requiresLinux(t *testing.T) {
 // there can be situation where a build has finished but the following prune doesn't
 // cleanup cache because some records still haven't been released.
 // This function tries to ensure prune by retrying it.
-func ensurePruneAll(t *testing.T, c *Client, sb integration.Sandbox) {
+func ensurePruneAll(t *testing.T, c Client, sb integration.Sandbox) {
 	for i := 0; i < 2; i++ {
 		require.NoError(t, c.Prune(sb.Context(), nil, PruneAll))
 		for j := 0; j < 20; j++ {
@@ -6593,7 +6593,7 @@ func ensurePruneAll(t *testing.T, c *Client, sb integration.Sandbox) {
 	t.Fatalf("failed to ensure prune")
 }
 
-func checkAllReleasable(t *testing.T, c *Client, sb integration.Sandbox, checkContent bool) {
+func checkAllReleasable(t *testing.T, c Client, sb integration.Sandbox, checkContent bool) {
 	cl, err := c.ControlClient().ListenBuildHistory(sb.Context(), &controlapi.BuildHistoryRequest{
 		EarlyExit: true,
 	})

--- a/client/diskusage.go
+++ b/client/diskusage.go
@@ -24,7 +24,7 @@ type UsageInfo struct {
 	Shared      bool            `json:"shared"`
 }
 
-func (c *Client) DiskUsage(ctx context.Context, opts ...DiskUsageOption) ([]*UsageInfo, error) {
+func (c *cl) DiskUsage(ctx context.Context, opts ...DiskUsageOption) ([]*UsageInfo, error) {
 	info := &DiskUsageInfo{}
 	for _, o := range opts {
 		o.SetDiskUsageOption(info)

--- a/client/info.go
+++ b/client/info.go
@@ -18,7 +18,7 @@ type BuildkitVersion struct {
 	Revision string `json:"revision"`
 }
 
-func (c *Client) Info(ctx context.Context) (*Info, error) {
+func (c *cl) Info(ctx context.Context) (*Info, error) {
 	res, err := c.ControlClient().Info(ctx, &controlapi.InfoRequest{})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to call info")

--- a/client/mergediff_test.go
+++ b/client/mergediff_test.go
@@ -1408,7 +1408,7 @@ func (tc verifyBlobReuse) Run(t *testing.T, sb integration.Sandbox) {
 	}), img.Target()))
 }
 
-func resetState(t *testing.T, c *Client, sb integration.Sandbox) {
+func resetState(t *testing.T, c Client, sb integration.Sandbox) {
 	ctx := namespaces.WithNamespace(sb.Context(), "buildkit")
 	cdAddress := sb.ContainerdAddress()
 	if cdAddress != "" {

--- a/client/prune.go
+++ b/client/prune.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (c *Client) Prune(ctx context.Context, ch chan UsageInfo, opts ...PruneOption) error {
+func (c *cl) Prune(ctx context.Context, ch chan UsageInfo, opts ...PruneOption) error {
 	info := &PruneInfo{}
 	for _, o := range opts {
 		o.SetPruneOption(info)

--- a/client/solve.go
+++ b/client/solve.go
@@ -66,7 +66,7 @@ type CacheOptionsEntry struct {
 
 // Solve calls Solve on the controller.
 // def must be nil if (and only if) opt.Frontend is set.
-func (c *Client) Solve(ctx context.Context, def *llb.Definition, opt SolveOpt, statusChan chan *SolveStatus) (*SolveResponse, error) {
+func (c *cl) Solve(ctx context.Context, def *llb.Definition, opt SolveOpt, statusChan chan *SolveStatus) (*SolveResponse, error) {
 	defer func() {
 		if statusChan != nil {
 			close(statusChan)
@@ -85,7 +85,7 @@ func (c *Client) Solve(ctx context.Context, def *llb.Definition, opt SolveOpt, s
 
 type runGatewayCB func(ref string, s *session.Session, opts map[string]string) error
 
-func (c *Client) solve(ctx context.Context, def *llb.Definition, runGateway runGatewayCB, opt SolveOpt, statusChan chan *SolveStatus) (*SolveResponse, error) {
+func (c *cl) solve(ctx context.Context, def *llb.Definition, runGateway runGatewayCB, opt SolveOpt, statusChan chan *SolveStatus) (*SolveResponse, error) {
 	if def != nil && runGateway != nil {
 		return nil, errors.New("invalid with def and cb")
 	}

--- a/client/workers.go
+++ b/client/workers.go
@@ -21,7 +21,7 @@ type WorkerInfo struct {
 }
 
 // ListWorkers lists all active workers
-func (c *Client) ListWorkers(ctx context.Context, opts ...ListWorkersOption) ([]*WorkerInfo, error) {
+func (c *cl) ListWorkers(ctx context.Context, opts ...ListWorkersOption) ([]*WorkerInfo, error) {
 	info := &ListWorkersInfo{}
 	for _, o := range opts {
 		o.SetListWorkersOption(info)

--- a/cmd/buildctl/common/common.go
+++ b/cmd/buildctl/common/common.go
@@ -19,7 +19,7 @@ import (
 )
 
 // ResolveClient resolves a client from CLI args
-func ResolveClient(c *cli.Context) (*client.Client, error) {
+func ResolveClient(c *cli.Context) (client.Client, error) {
 	serverName := c.GlobalString("tlsservername")
 	if serverName == "" {
 		// guess servername as hostname of target address

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -182,7 +182,7 @@ var opts []integration.TestOpt
 var securityOpts []integration.TestOpt
 
 type frontend interface {
-	Solve(context.Context, *client.Client, client.SolveOpt, chan *client.SolveStatus) (*client.SolveResponse, error)
+	Solve(context.Context, client.Client, client.SolveOpt, chan *client.SolveStatus) (*client.SolveResponse, error)
 	SolveGateway(context.Context, gateway.Client, gateway.SolveRequest) (*gateway.Result, error)
 	DFCmdArgs(string, string) (string, string)
 	RequiresBuildctl(t *testing.T)
@@ -6646,7 +6646,7 @@ func runShell(dir string, cmds ...string) error {
 // there can be situation where a build has finished but the following prune doesn't
 // cleanup cache because some records still haven't been released.
 // This function tries to ensure prune by retrying it.
-func ensurePruneAll(t *testing.T, c *client.Client, sb integration.Sandbox) {
+func ensurePruneAll(t *testing.T, c client.Client, sb integration.Sandbox) {
 	for i := 0; i < 2; i++ {
 		require.NoError(t, c.Prune(sb.Context(), nil, client.PruneAll))
 		for j := 0; j < 20; j++ {
@@ -6662,7 +6662,7 @@ func ensurePruneAll(t *testing.T, c *client.Client, sb integration.Sandbox) {
 	t.Fatalf("failed to ensure prune")
 }
 
-func checkAllReleasable(t *testing.T, c *client.Client, sb integration.Sandbox, checkContent bool) {
+func checkAllReleasable(t *testing.T, c client.Client, sb integration.Sandbox, checkContent bool) {
 	cl, err := c.ControlClient().ListenBuildHistory(sb.Context(), &controlapi.BuildHistoryRequest{
 		EarlyExit: true,
 	})
@@ -6769,7 +6769,7 @@ type builtinFrontend struct{}
 
 var _ frontend = &builtinFrontend{}
 
-func (f *builtinFrontend) Solve(ctx context.Context, c *client.Client, opt client.SolveOpt, statusChan chan *client.SolveStatus) (*client.SolveResponse, error) {
+func (f *builtinFrontend) Solve(ctx context.Context, c client.Client, opt client.SolveOpt, statusChan chan *client.SolveStatus) (*client.SolveResponse, error) {
 	opt.Frontend = "dockerfile.v0"
 	return c.Solve(ctx, nil, opt, statusChan)
 }
@@ -6789,7 +6789,7 @@ type clientFrontend struct{}
 
 var _ frontend = &clientFrontend{}
 
-func (f *clientFrontend) Solve(ctx context.Context, c *client.Client, opt client.SolveOpt, statusChan chan *client.SolveStatus) (*client.SolveResponse, error) {
+func (f *clientFrontend) Solve(ctx context.Context, c client.Client, opt client.SolveOpt, statusChan chan *client.SolveStatus) (*client.SolveResponse, error) {
 	return c.Build(ctx, opt, "", builder.Build, statusChan)
 }
 
@@ -6813,7 +6813,7 @@ type gatewayFrontend struct {
 
 var _ frontend = &gatewayFrontend{}
 
-func (f *gatewayFrontend) Solve(ctx context.Context, c *client.Client, opt client.SolveOpt, statusChan chan *client.SolveStatus) (*client.SolveResponse, error) {
+func (f *gatewayFrontend) Solve(ctx context.Context, c client.Client, opt client.SolveOpt, statusChan chan *client.SolveStatus) (*client.SolveResponse, error) {
 	opt.Frontend = "gateway.v0"
 	if opt.FrontendAttrs == nil {
 		opt.FrontendAttrs = make(map[string]string)


### PR DESCRIPTION
Create a client interface and expose that instead of the struct directly.

The idea is that all the properties on the client object are private, so no one accesses them - so an interface would be fine for this purpose. Additionally, it may be useful for custom clients to override parts of the client object so that they can implement custom functionality. 

It's also a nice consistency improvement - the gateway client, the llb bridge client, and pretty much every other client type we have is also an interface - it makes sense to change the full buildkit client to be the same.