### PR TITLE
fixes for history events

### DIFF
--- a/solver/llbsolver/history.go
+++ b/solver/llbsolver/history.go
@@ -567,7 +567,7 @@ func (h *HistoryQueue) Listen(ctx context.Context, req *controlapi.BuildHistoryR
 		if _, ok := h.deleted[e.Ref]; ok {
 			continue
 		}
-		sub.ps.Send(&controlapi.BuildHistoryEvent{
+		sub.send(&controlapi.BuildHistoryEvent{
 			Type:   controlapi.BuildHistoryEventType_STARTED,
 			Record: e,
 		})

--- a/solver/llbsolver/history.go
+++ b/solver/llbsolver/history.go
@@ -133,6 +133,10 @@ func (h *HistoryQueue) delete(ref string, sync bool) error {
 		return nil
 	}
 	delete(h.deleted, ref)
+	h.ps.Send(&controlapi.BuildHistoryEvent{
+		Type:   controlapi.BuildHistoryEventType_DELETED,
+		Record: &controlapi.BuildHistoryRecord{Ref: ref},
+	})
 	if err := h.DB.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(recordsBucket))
 		if b == nil {


### PR DESCRIPTION
Make sure if a request is marked deleted (but not deleted yet because it has active reference), it doesn't show up in Listen responses anymore.

While debugging this, I also noticed 2 other small issues. Added in separate commits.

cc @aaronlehmann 