### PR TITLE
test: use appropriate snapshotter service to walk snapshots

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -6648,7 +6648,8 @@ loop0:
 	defer client.Close()
 
 	ctx := namespaces.WithNamespace(sb.Context(), "buildkit")
-	snapshotService := client.SnapshotService("overlayfs")
+	snapshotterName := sb.Snapshotter()
+	snapshotService := client.SnapshotService(snapshotterName)
 
 	retries = 0
 	for {


### PR DESCRIPTION
If a different snapshotter service is used, it will walk on the wrong snapshotter, overlayfs, instead of the actual used one by containerd.