### PR TITLE
overlay: use function to check for overlay-based mounts

### DIFF
--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/moby/buildkit/util/contentutil"
 	"github.com/moby/buildkit/util/iohelper"
 	"github.com/moby/buildkit/util/leaseutil"
+	"github.com/moby/buildkit/util/overlay"
 	"github.com/moby/buildkit/util/winlayers"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -2701,7 +2702,7 @@ func isReadOnly(mnt mount.Mount) bool {
 			hasUpperdir = true
 		}
 	}
-	if mnt.Type == "overlay" {
+	if overlay.IsOverlayMountType(mnt) {
 		return !hasUpperdir
 	}
 	return false

--- a/cache/refs.go
+++ b/cache/refs.go
@@ -27,6 +27,7 @@ import (
 	"github.com/moby/buildkit/util/compression"
 	"github.com/moby/buildkit/util/flightcontrol"
 	"github.com/moby/buildkit/util/leaseutil"
+	"github.com/moby/buildkit/util/overlay"
 	"github.com/moby/buildkit/util/progress"
 	rootlessmountopts "github.com/moby/buildkit/util/rootless/mountopts"
 	"github.com/moby/buildkit/util/winlayers"
@@ -1513,7 +1514,7 @@ func (m *readOnlyMounter) Mount() ([]mount.Mount, func() error, error) {
 		return nil, nil, err
 	}
 	for i, m := range mounts {
-		if m.Type == "overlay" {
+		if overlay.IsOverlayMountType(m) {
 			mounts[i].Options = readonlyOverlay(m.Options)
 			continue
 		}
@@ -1623,7 +1624,7 @@ func (sm *sharableMountable) Mount() (_ []mount.Mount, _ func() error, retErr er
 		}()
 		var isOverlay bool
 		for _, m := range mounts {
-			if m.Type == "overlay" {
+			if overlay.IsOverlayMountType(m) {
 				isOverlay = true
 				break
 			}

--- a/snapshot/snapshotter.go
+++ b/snapshot/snapshotter.go
@@ -167,6 +167,8 @@ func setRedirectDir(mounts []mount.Mount, redirectDirOption string) (ret []mount
 		return mounts
 	}
 	for _, m := range mounts {
+		// Replace redirect_dir options, but only for overlay.
+		// redirect_dir is not supported by fuse-overlayfs.
 		if m.Type == "overlay" {
 			var opts []string
 			for _, o := range m.Options {

--- a/snapshot/snapshotter_test.go
+++ b/snapshot/snapshotter_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/containerd/continuity/fs/fstest"
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/util/leaseutil"
+	overlayutil "github.com/moby/buildkit/util/overlay"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	bolt "go.etcd.io/bbolt"
@@ -602,7 +603,7 @@ func pathCallback[T any](ctx context.Context, t *testing.T, sn *mergeSnapshotter
 	require.Len(t, mounts, 1)
 	mnt := mounts[0]
 
-	if mnt.Type == "overlay" {
+	if overlayutil.IsOverlayMountType(mnt) {
 		var upperdir string
 		var lowerdirs []string
 		for _, opt := range mnt.Options {

--- a/util/overlay/overlay.go
+++ b/util/overlay/overlay.go
@@ -1,0 +1,8 @@
+package overlay
+
+import "github.com/containerd/containerd/mount"
+
+// IsOverlayMountType returns true if the mount type is overlay-based
+func IsOverlayMountType(mnt mount.Mount) bool {
+	return mnt.Type == "overlay"
+}

--- a/util/overlay/overlay_linux.go
+++ b/util/overlay/overlay_linux.go
@@ -38,24 +38,23 @@ func GetUpperdir(lower, upper []mount.Mount) (string, error) {
 		// Get layer directories of lower snapshot
 		var lowerlayers []string
 		lowerM := lower[0]
-		switch lowerM.Type {
-		case "bind":
+		if lowerM.Type == "bind" {
 			// lower snapshot is a bind mount of one layer
 			lowerlayers = []string{lowerM.Source}
-		case "overlay":
+		} else if IsOverlayMountType(lowerM) {
 			// lower snapshot is an overlay mount of multiple layers
 			var err error
 			lowerlayers, err = GetOverlayLayers(lowerM)
 			if err != nil {
 				return "", err
 			}
-		default:
+		} else {
 			return "", errors.Errorf("cannot get layer information from mount option (type = %q)", lowerM.Type)
 		}
 
 		// Get layer directories of upper snapshot
 		upperM := upper[0]
-		if upperM.Type != "overlay" {
+		if !IsOverlayMountType(upperM) {
 			return "", errors.Errorf("upper snapshot isn't overlay mounted (type = %q)", upperM.Type)
 		}
 		upperlayers, err := GetOverlayLayers(upperM)


### PR DESCRIPTION
Factorize code that check for an overlay mount type by using a function instead.

This will allow supporting other overlay-based mount types more easily in the future (for example fuse-overlayfs).