### PR TITLE
docs: fixup build repro doc with updated policy format

### DIFF
--- a/docs/build-repro.md
+++ b/docs/build-repro.md
@@ -15,21 +15,19 @@ An example `policy.json`:
   "rules": [
     {
       "action": "CONVERT",
-      "source": {
-        "type": "docker-image",
-        "identifier": "docker.io/library/alpine:latest"
+      "selector": {
+        "identifier": "docker-image://docker.io/library/alpine:latest"
       },
-      "destination": {
+      "updates": {
         "identifier": "docker-image://docker.io/library/alpine:latest@sha256:4edbd2beb5f78b1014028f4fbb99f3237d9561100b6881aabbf5acce2c4f9454"
       }
     },
     {
       "action": "CONVERT",
-      "source": {
-        "type": "http",
+      "selector": {
         "identifier": "https://raw.githubusercontent.com/moby/buildkit/v0.10.1/README.md"
       },
-      "destination": {
+      "updates": {
         "attrs": {"http.checksum": "sha256:6e4b94fc270e708e1068be28bd3551dc6917a4fc5a61293d51bb36e6b75c4b53"}
       }
     }


### PR DESCRIPTION
https://github.com/moby/buildkit/commit/6d061b9a3a92501961687085d296e88dae28c9f8 updated the policy format, but the corresponding build repro docs still use the old format.

This patch fixes the example to use the newer policy format.