### PR TITLE
progressui: fix possible zero prefix numbers in logs

### DIFF
--- a/util/progress/progressui/display.go
+++ b/util/progress/progressui/display.go
@@ -582,7 +582,7 @@ func (t *trace) update(s *client.SolveStatus, termWidth int) {
 				} else if sec < 100 {
 					prec = 2
 				}
-				v.logs = append(v.logs, []byte(fmt.Sprintf("#%d %s %s", v.index, fmt.Sprintf("%.[2]*[1]f", sec, prec), dt)))
+				v.logs = append(v.logs, []byte(fmt.Sprintf("%s %s", fmt.Sprintf("%.[2]*[1]f", sec, prec), dt)))
 			}
 			i++
 		})

--- a/util/progress/progressui/printer.go
+++ b/util/progress/progressui/printer.go
@@ -146,7 +146,7 @@ func (p *textMux) printVtx(t *trace, dgst digest.Digest) {
 		if i == 0 {
 			l = l[v.logsOffset:]
 		}
-		fmt.Fprintf(p.w, "%s", []byte(l))
+		fmt.Fprintf(p.w, "#%d %s", v.index, []byte(l))
 		if i != len(v.logs)-1 || !v.logsPartial {
 			fmt.Fprintln(p.w, "")
 		}


### PR DESCRIPTION
Prefix numbers should only be assigned before printing, not when receiving data.

fixes #3834