### PR TITLE
solver: drop unneeded variable

### DIFF
--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -34,7 +34,7 @@ import (
 	"github.com/moby/buildkit/util/progress"
 	"github.com/moby/buildkit/util/tracing/detect"
 	"github.com/moby/buildkit/worker"
-	"github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -920,7 +920,6 @@ func notifyStarted(ctx context.Context, v *client.Vertex) func(err error) {
 	start := time.Now()
 	v.Started = &start
 	v.Completed = nil
-	v.Cached = false
 	id := identity.NewID()
 	pw.Write(id, *v)
 	return func(err error) {

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -34,7 +34,7 @@ import (
 	"github.com/moby/buildkit/util/progress"
 	"github.com/moby/buildkit/util/tracing/detect"
 	"github.com/moby/buildkit/worker"
-	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
@@ -907,27 +907,27 @@ func inBuilderContext(ctx context.Context, b solver.Builder, name, id string, f 
 	}
 	return b.InContext(ctx, func(ctx context.Context, g session.Group) error {
 		pw, _, ctx := progress.NewFromContext(ctx, progress.WithMetadata("vertex", v.Digest))
-		notifyCompleted := notifyStarted(ctx, &v, false)
+		notifyCompleted := notifyStarted(ctx, &v)
 		defer pw.Close()
 		err := f(ctx, g)
-		notifyCompleted(err, false)
+		notifyCompleted(err)
 		return err
 	})
 }
 
-func notifyStarted(ctx context.Context, v *client.Vertex, cached bool) func(err error, cached bool) {
+func notifyStarted(ctx context.Context, v *client.Vertex) func(err error) {
 	pw, _, _ := progress.NewFromContext(ctx)
 	start := time.Now()
 	v.Started = &start
 	v.Completed = nil
-	v.Cached = cached
+	v.Cached = false
 	id := identity.NewID()
 	pw.Write(id, *v)
-	return func(err error, cached bool) {
+	return func(err error) {
 		defer pw.Close()
 		stop := time.Now()
 		v.Completed = &stop
-		v.Cached = cached
+		v.Cached = false
 		if err != nil {
 			v.Error = err.Error()
 		}


### PR DESCRIPTION
`func notifyStarted(ctx context.Context, v *client.Vertex, cached bool) func(err error, cached bool)` of `solver/llbsolver/solver.go` is not referenced elsewhere and the value of `cached` is always `false`.

So I thought it would be better to write the value of `cached` directly in the function and modify it this way.