### PR TITLE
cache: always release ref when getting size in usage.

### DIFF
--- a/cache/manager.go
+++ b/cache/manager.go
@@ -1425,12 +1425,13 @@ func (cm *cacheManager) DiskUsage(ctx context.Context, opt client.DiskUsageInfo)
 						d.Size = 0
 						return nil
 					}
+					defer ref.Release(context.TODO())
 					s, err := ref.size(ctx)
 					if err != nil {
 						return err
 					}
 					d.Size = s
-					return ref.Release(context.TODO())
+					return nil
 				})
 			}(d)
 		}


### PR DESCRIPTION
Noticed a few cache refs leaked occasionally during long running tests. Debugged by changing `immutableRef` and `mutableRef` to store the stack trace of the caller when they are created, saw that it leaked on the lines fixed here.

I considered whether we should leave the stack traces in those data structures but I saw it was taking up a ton of memory, so probably best for local debugging only for now cc @tonistiigi 