### PR TITLE
llb: don't include platform in fileop proto

### DIFF
--- a/client/llb/diff.go
+++ b/client/llb/diff.go
@@ -104,5 +104,5 @@ func Diff(lower, upper State, opts ...ConstraintsOpt) State {
 	for _, o := range opts {
 		o.SetConstraintsOption(&c)
 	}
-	return NewState(NewDiff(lower, upper, c).Output())
+	return lower.WithOutput(NewDiff(lower, upper, c).Output())
 }

--- a/client/llb/fileop.go
+++ b/client/llb/fileop.go
@@ -691,6 +691,7 @@ func (f *FileOp) Marshal(ctx context.Context, c *Constraints) (digest.Digest, []
 	}
 
 	pop, md := MarshalConstraints(c, &f.constraints)
+	pop.Platform = nil // file op is not platform specific
 	pop.Op = &pb.Op_File{
 		File: pfo,
 	}

--- a/client/llb/merge.go
+++ b/client/llb/merge.go
@@ -92,5 +92,5 @@ func Merge(inputs []State, opts ...ConstraintsOpt) State {
 		o.SetConstraintsOption(&c)
 	}
 	addCap(&c, pb.CapMergeOp)
-	return NewState(NewMerge(filteredInputs, c).Output())
+	return filteredInputs[0].WithOutput(NewMerge(filteredInputs, c).Output())
 }

--- a/client/llb/state_test.go
+++ b/client/llb/state_test.go
@@ -213,6 +213,29 @@ func TestPlatformFromImage(t *testing.T) {
 	require.Equal(t, "docker-image://docker.io/library/srcimage:latest", src.Source.Identifier)
 	require.Equal(t, "s390x", vtx.Platform.Architecture)
 }
+
+func TestPlatformFromImageWithMerge(t *testing.T) {
+	t.Parallel()
+
+	s := Image("srcimage", LinuxS390x)
+
+	s2 := Scratch().File(Mkdir("/foo", 0700).Mkfile("/bar", 0600, []byte("bar")))
+
+	dest := Merge([]State{s, s2}).Run(Args([]string{"aftermerge"}))
+
+	def, err := dest.Marshal(context.TODO(), LinuxPpc64le)
+	require.NoError(t, err)
+
+	m, arr := parseDef(t, def.Def)
+	_ = m
+	require.Equal(t, 5, len(arr))
+
+	dgst, idx := last(t, arr)
+	require.Equal(t, 0, idx)
+
+	vtx, ok := m[dgst]
+	require.Equal(t, true, ok)
+
 	_, ok = vtx.Op.(*pb.Op_Exec)
 	require.Equal(t, true, ok)
 	require.Equal(t, "s390x", vtx.Platform.Architecture)
@@ -220,10 +243,26 @@ func TestPlatformFromImage(t *testing.T) {
 	vtx, ok = m[vtx.Inputs[0].Digest]
 	require.Equal(t, true, ok)
 
-	src, ok = vtx.Op.(*pb.Op_Source)
+	_, ok = vtx.Op.(*pb.Op_Merge)
+	require.Equal(t, true, ok)
+	require.Nil(t, vtx.Platform)
+
+	mainVtx := vtx
+	vtx, ok = m[vtx.Inputs[0].Digest]
+	require.Equal(t, true, ok)
+
+	src, ok := vtx.Op.(*pb.Op_Source)
 	require.Equal(t, true, ok)
 	require.Equal(t, "docker-image://docker.io/library/srcimage:latest", src.Source.Identifier)
 	require.Equal(t, "s390x", vtx.Platform.Architecture)
+
+	vtx, ok = m[mainVtx.Inputs[1].Digest]
+	require.Equal(t, true, ok)
+
+	f, ok := vtx.Op.(*pb.Op_File)
+	require.Equal(t, true, ok)
+	require.Equal(t, 2, len(f.File.Actions))
+	require.Nil(t, vtx.Platform)
 }
 
 func getEnvHelper(t *testing.T, s State, k string) (string, bool) {


### PR DESCRIPTION
Afaics FileOp has the same behavior independently from the target platform, so don't include the platform value in the LLB digest. The same already happens for MergeOp/DiffOp.

Atm. when doing multi-platform builds, copying the same files in both architectures can create different LLB. BuildKit solver will discover that the vertexes are the same after doing the cache key computation but this means that it goes to the "merging edges" code path and some vertexes will be canceled. This means inefficient and more complicated codepath as well as weird output to the user.

I also discovered https://github.com/moby/buildkit/pull/1889 but have no memory of the full intentions behind it.

 While modifying the tests to make sure that platform is still carried over correctly if run steps happen after fileop I discovered that this was not working correctly (imho) for merge and diff op. The second commit is for that. If needed I could also separate it into another PR.

@sipsma 