### PR TITLE
fix: prevent data race in some occasions

### DIFF
--- a/cache/blobs_nolinux.go
+++ b/cache/blobs_nolinux.go
@@ -6,8 +6,8 @@ package cache
 import (
 	"context"
 
-	"github.com/moby/buildkit/util/compression"
 	"github.com/containerd/containerd/mount"
+	"github.com/moby/buildkit/util/compression"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )

--- a/cache/contenthash/checksum.go
+++ b/cache/contenthash/checksum.go
@@ -110,7 +110,9 @@ func (cm *cacheManager) GetCacheContext(ctx context.Context, md cache.RefMetadat
 	cm.lruMu.Unlock()
 	if ok {
 		cm.locker.Unlock(md.ID())
+		v.(*cacheContext).mu.Lock()
 		v.(*cacheContext).linkMap = map[string][][]byte{}
+		v.(*cacheContext).mu.Unlock()
 		return v.(*cacheContext), nil
 	}
 	cc, err := newCacheContext(md)

--- a/solver/cachekey.go
+++ b/solver/cachekey.go
@@ -62,8 +62,10 @@ func (ck *CacheKey) clone() *CacheKey {
 		output: ck.output,
 		ids:    map[*cacheManager]string{},
 	}
+	ck.mu.RLock()
 	for cm, id := range ck.ids {
 		nk.ids[cm] = id
 	}
+	ck.mu.RUnlock()
 	return nk
 }

--- a/solver/llbsolver/provenance.go
+++ b/solver/llbsolver/provenance.go
@@ -136,11 +136,13 @@ func (b *provenanceBridge) ResolveImageConfig(ctx context.Context, ref string, o
 		return "", nil, err
 	}
 
+	b.mu.Lock()
 	b.images = append(b.images, provenance.ImageSource{
 		Ref:      ref,
 		Platform: opt.Platform,
 		Digest:   dgst,
 	})
+	b.mu.Unlock()
 	return dgst, config, nil
 }
 

--- a/util/progress/multiwriter.go
+++ b/util/progress/multiwriter.go
@@ -69,9 +69,9 @@ func (ps *MultiWriter) Write(id string, v interface{}) error {
 }
 
 func (ps *MultiWriter) WriteRawProgress(p *Progress) error {
-	meta := p.meta
 	if len(ps.meta) > 0 {
-		meta = map[string]interface{}{}
+		meta := map[string]interface{}{}
+		p.metaMu.Lock()
 		for k, v := range p.meta {
 			meta[k] = v
 		}
@@ -80,8 +80,9 @@ func (ps *MultiWriter) WriteRawProgress(p *Progress) error {
 				meta[k] = v
 			}
 		}
+		p.meta = meta
+		p.metaMu.Unlock()
 	}
-	p.meta = meta
 	return ps.writeRawProgress(p)
 }
 


### PR DESCRIPTION
All fixed data races have been observed by using the `-race`  go utility.

Originally my buildkit deamon was crashing due to a very similar error as reported on https://github.com/moby/buildkit/issues/2041, so I started debugging and found some other race conditions and now my log is clean, no more `WARNING: DATA RACE` message.

I am not sure if the approach I used is correct, just let me know if I need to change something.