### PR TITLE
Move containerd media type warnings for attestations

### DIFF
--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -14,10 +14,8 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/platforms"
-	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/containerd/containerd/rootfs"
-	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/moby/buildkit/cache"
 	cacheconfig "github.com/moby/buildkit/cache/config"
 	"github.com/moby/buildkit/exporter"
@@ -355,8 +353,6 @@ func (e *imageExporterInstance) pushImage(ctx context.Context, src *exporter.Sou
 			}
 		}
 	}
-
-	ctx = remotes.WithMediaTypeKeyPrefix(ctx, intoto.PayloadType, "intoto")
 	return push.Push(ctx, e.opt.SessionManager, sessionID, mprovider, e.opt.ImageWriter.ContentStore(), dgst, targetName, e.insecure, e.opt.RegistryHosts, e.pushByDigest, annotations)
 }
 

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -437,7 +437,7 @@ func (ic *ImageWriter) commitAttestationsManifest(ctx context.Context, opts *Ima
 		}
 		digest := digest.FromBytes(data)
 		desc := ocispecs.Descriptor{
-			MediaType: attestationTypes.MediaTypeDockerSchema2AttestationType,
+			MediaType: intoto.PayloadType,
 			Digest:    digest,
 			Size:      int64(len(data)),
 			Annotations: map[string]string{

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -11,9 +11,7 @@ import (
 
 	archiveexporter "github.com/containerd/containerd/images/archive"
 	"github.com/containerd/containerd/leases"
-	"github.com/containerd/containerd/remotes"
 	"github.com/docker/distribution/reference"
-	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/moby/buildkit/cache"
 	cacheconfig "github.com/moby/buildkit/cache/config"
 	"github.com/moby/buildkit/exporter"
@@ -266,7 +264,6 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 		}
 		report(nil)
 	} else {
-		ctx = remotes.WithMediaTypeKeyPrefix(ctx, intoto.PayloadType, "intoto")
 		store := sessioncontent.NewCallerStore(caller, "export")
 		if err != nil {
 			return nil, nil, err

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	slsa02 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 	controlapi "github.com/moby/buildkit/api/services/control"
 	"github.com/moby/buildkit/cache"
@@ -26,7 +27,6 @@ import (
 	"github.com/moby/buildkit/solver/llbsolver/provenance"
 	"github.com/moby/buildkit/solver/result"
 	spb "github.com/moby/buildkit/sourcepolicy/pb"
-	"github.com/moby/buildkit/util/attestation"
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/compression"
 	"github.com/moby/buildkit/util/entitlements"
@@ -210,7 +210,7 @@ func (s *Solver) recordBuildHistory(ctx context.Context, id string, req frontend
 			if err != nil {
 				return nil, nil, err
 			}
-			w, err := s.history.OpenBlobWriter(ctx, attestation.MediaTypeDockerSchema2AttestationType)
+			w, err := s.history.OpenBlobWriter(ctx, intoto.PayloadType)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/util/attestation/types.go
+++ b/util/attestation/types.go
@@ -1,8 +1,6 @@
 package attestation
 
 const (
-	MediaTypeDockerSchema2AttestationType = "application/vnd.in-toto+json"
-
 	DockerAnnotationReferenceType        = "vnd.docker.reference.type"
 	DockerAnnotationReferenceDigest      = "vnd.docker.reference.digest"
 	DockerAnnotationReferenceDescription = "vnd.docker.reference.description"

--- a/util/contentutil/copy.go
+++ b/util/contentutil/copy.go
@@ -15,6 +15,7 @@ import (
 )
 
 func Copy(ctx context.Context, ingester content.Ingester, provider content.Provider, desc ocispecs.Descriptor, ref string, logger func([]byte)) error {
+	ctx = RegisterContentPayloadTypes(ctx)
 	if _, err := retryhandler.New(limited.FetchHandler(ingester, &localFetcher{provider}, ref), logger)(ctx, desc); err != nil {
 		return err
 	}
@@ -60,6 +61,7 @@ func (r *rc) Seek(offset int64, whence int) (int64, error) {
 }
 
 func CopyChain(ctx context.Context, ingester content.Ingester, provider content.Provider, desc ocispecs.Descriptor) error {
+	ctx = RegisterContentPayloadTypes(ctx)
 	var m sync.Mutex
 	manifestStack := []ocispecs.Descriptor{}
 

--- a/util/contentutil/types.go
+++ b/util/contentutil/types.go
@@ -1,0 +1,15 @@
+package contentutil
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/remotes"
+	intoto "github.com/in-toto/in-toto-golang/in_toto"
+)
+
+// RegisterContentPayloadTypes registers content types that are not defined by
+// default but that we expect to find in registry images.
+func RegisterContentPayloadTypes(ctx context.Context) context.Context {
+	ctx = remotes.WithMediaTypeKeyPrefix(ctx, intoto.PayloadType, "intoto")
+	return ctx
+}

--- a/util/imageutil/config.go
+++ b/util/imageutil/config.go
@@ -13,7 +13,7 @@ import (
 	"github.com/containerd/containerd/reference"
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
-	"github.com/moby/buildkit/util/attestation"
+	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/moby/buildkit/util/contentutil"
 	"github.com/moby/buildkit/util/leaseutil"
 	"github.com/moby/buildkit/util/resolver/limited"
@@ -174,7 +174,7 @@ func childrenConfigHandler(provider content.Provider, platform platforms.MatchCo
 				descs = append(descs, index.Manifests...)
 			}
 		case images.MediaTypeDockerSchema2Config, ocispecs.MediaTypeImageConfig, docker.LegacyConfigMediaType,
-			attestation.MediaTypeDockerSchema2AttestationType:
+			intoto.PayloadType:
 			// childless data types.
 			return nil, nil
 		default:

--- a/util/push/push.go
+++ b/util/push/push.go
@@ -15,7 +15,6 @@ import (
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/docker/distribution/reference"
 	"github.com/moby/buildkit/session"
-	"github.com/moby/buildkit/util/attestation"
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/flightcontrol"
 	"github.com/moby/buildkit/util/imageutil"
@@ -250,7 +249,7 @@ func childrenHandler(provider content.Provider) images.HandlerFunc {
 		case images.MediaTypeDockerSchema2Layer, images.MediaTypeDockerSchema2LayerGzip,
 			images.MediaTypeDockerSchema2Config, ocispecs.MediaTypeImageConfig,
 			ocispecs.MediaTypeImageLayer, ocispecs.MediaTypeImageLayerGzip,
-			attestation.MediaTypeDockerSchema2AttestationType:
+			intoto.PayloadType:
 			// childless data types.
 			return nil, nil
 		default:

--- a/util/push/push.go
+++ b/util/push/push.go
@@ -14,8 +14,10 @@ import (
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/docker/distribution/reference"
+	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/util/bklog"
+	"github.com/moby/buildkit/util/contentutil"
 	"github.com/moby/buildkit/util/flightcontrol"
 	"github.com/moby/buildkit/util/imageutil"
 	"github.com/moby/buildkit/util/progress"
@@ -45,6 +47,7 @@ func Pusher(ctx context.Context, resolver remotes.Resolver, ref string) (remotes
 }
 
 func Push(ctx context.Context, sm *session.Manager, sid string, provider content.Provider, manager content.Manager, dgst digest.Digest, ref string, insecure bool, hosts docker.RegistryHosts, byDigest bool, annotations map[digest.Digest]map[string]string) error {
+	ctx = contentutil.RegisterContentPayloadTypes(ctx)
 	desc := ocispecs.Descriptor{
 		Digest: dgst,
 	}


### PR DESCRIPTION
:arrow_up: Follow-up to #3063

This moves the containerd suppressions for media type warnings from the
exporter package into the push and copy packages which allow them to be
used by all lower-level buildkit utilities, e.g. tests: https://github.com/moby/buildkit/blob/81d19ad945cdbf921d182c50fc91169b1375b44d/util/testutil/integration/run.go#L256-L258.

Previously, this would cause containerd media type warnings to be printed in test logs if an image with attestations was copied into the local image cache.

While working on this, I also noticed that we can remove our custom definition of the `application/vnd.in-toto+json` media type and replace it with `intoto.PayloadType` (which we were already using in some places, but inconsistently).