### PR TITLE
Expose testutil integration workers as public

### DIFF
--- a/util/testutil/integration/dockerd.go
+++ b/util/testutil/integration/dockerd.go
@@ -212,6 +212,7 @@ func (c Moby) New(ctx context.Context, cfg *BackendConfig) (b Backend, cl func()
 
 	return backend{
 		address:             "unix://" + listener.Addr().String(),
+		dockerAddress:       d.Sock(),
 		rootless:            c.IsRootless,
 		isDockerd:           true,
 		unsupportedFeatures: c.Unsupported,

--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -35,6 +35,7 @@ func init() {
 // Backend is the minimal interface that describes a testing backend.
 type Backend interface {
 	Address() string
+	DockerAddress() string
 	ContainerdAddress() string
 	Rootless() bool
 	Snapshotter() string

--- a/util/testutil/integration/sandbox.go
+++ b/util/testutil/integration/sandbox.go
@@ -22,6 +22,7 @@ const buildkitdConfigFile = "buildkitd.toml"
 
 type backend struct {
 	address             string
+	dockerAddress       string
 	containerdAddress   string
 	rootless            bool
 	snapshotter         string
@@ -31,6 +32,10 @@ type backend struct {
 
 func (b backend) Address() string {
 	return b.address
+}
+
+func (b backend) DockerAddress() string {
+	return b.dockerAddress
 }
 
 func (b backend) ContainerdAddress() string {


### PR DESCRIPTION
This PR exposes the integration test workers as public, performing a few small refactors to make them more flexible (so that the caller can always enforce a custom name).

This is designed to be used in the context of https://github.com/docker/buildx/pull/1770, where we [wrap the `moby` worker to create the `docker` driver worker](https://github.com/docker/buildx/pull/1770/files#diff-592a8568a609f6623b5465a4a56ba7a9041a37f2394ed5d39385f78ec887694eR32-R38), and [wrap the `oci` worker to create the `remote` driver worker](https://github.com/docker/buildx/pull/1770/files#diff-247f899685dd94607c2a773712563962bb322403652cb4932771b9c56440c7d4R32-R36).

This allows us to avoid copying all the logic to spin up buildkit sandboxes inside of buildx, and to share that logic, so that we can automatically consume changes from the upstream test framework.

Additionally, we also add a new `DockerAddress` method to the `Backend` interface which returns the address of the UNIX socket for worker backends that support it (currently only moby).

```diff
type Backend interface {
	Address() string
+	DockerAddress() string
	ContainerdAddress() string
   ...
```

This is designed to be consumed by the buildx `docker` driver worker wrapper, so that we can connect directly to the docker instance using the `docker` driver.