### PR TITLE
test: run tests with fuse-overlayfs snapshotter

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -108,10 +108,14 @@ jobs:
         worker:
           - containerd
           - containerd-rootless
+          - containerd-rootless-snapshotter-fuse-overlayfs
+          - containerd-rootless-snapshotter-fuse-overlayfs-disable-ovl-whiteout
           - containerd-1.6
           - containerd-snapshotter-stargz
           - oci
           - oci-rootless
+          - oci-rootless-snapshotter-fuse-overlayfs
+          - oci-rootless-snapshotter-fuse-overlayfs-disable-ovl-whiteout
           - oci-snapshotter-stargz
         pkg: ${{ fromJson(needs.prepare.outputs.pkgs) }}
         kind: ${{ fromJson(needs.prepare.outputs.kinds) }}

--- a/hack/test
+++ b/hack/test
@@ -75,7 +75,8 @@ if ! docker container inspect "$cacheVolume" >/dev/null 2>/dev/null; then
 fi
 
 if [ "$TEST_INTEGRATION" == 1 ]; then
-  cid=$(docker create --rm -v /tmp $testReportsVol --volumes-from=$cacheVolume -e GITHUB_REF -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e TEST_DOCKERD -e SKIP_INTEGRATION_TESTS -e BUILDKIT_TEST_ENABLE_FEATURES -e GOTESTSUM_FORMAT ${BUILDKIT_INTEGRATION_SNAPSHOTTER:+"-eBUILDKIT_INTEGRATION_SNAPSHOTTER"} -e BUILDKIT_REGISTRY_MIRROR_DIR=/root/.cache/registry -e BUILDKIT_INTEGRATION_DOCKERD_FLAGS --privileged $iid gotestsum $gotestsumArgs --packages="${TESTPKGS:-./...}" -- $gotestArgs ${TESTFLAGS:--v})
+  modprobe fuse || true
+  cid=$(docker create --rm -v /tmp $testReportsVol --volumes-from=$cacheVolume -e GITHUB_REF -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e TEST_DOCKERD -e SKIP_INTEGRATION_TESTS -e BUILDKIT_TEST_ENABLE_FEATURES -e GOTESTSUM_FORMAT ${BUILDKIT_INTEGRATION_SNAPSHOTTER:+"-eBUILDKIT_INTEGRATION_SNAPSHOTTER"} -e BUILDKIT_REGISTRY_MIRROR_DIR=/root/.cache/registry -e BUILDKIT_INTEGRATION_DOCKERD_FLAGS --device /dev/fuse --privileged $iid gotestsum $gotestsumArgs --packages="${TESTPKGS:-./...}" -- $gotestArgs ${TESTFLAGS:--v})
   if [ "$TEST_DOCKERD" = "1" ]; then
     docker cp "$TEST_DOCKERD_BINARY" $cid:/usr/bin/dockerd
   fi

--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -21,7 +21,6 @@ import (
 	"github.com/moby/buildkit/util/appcontext"
 	"github.com/moby/buildkit/util/contentutil"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/semaphore"
 )
@@ -415,45 +414,4 @@ func prepareValueMatrix(tc testConf) []matrixValue {
 		m = append(m, matrixValue{})
 	}
 	return m
-}
-
-func runStargzSnapshotter(cfg *BackendConfig) (address string, cl func() error, err error) {
-	binary := "containerd-stargz-grpc"
-	if err := lookupBinary(binary); err != nil {
-		return "", nil, err
-	}
-
-	deferF := &multiCloser{}
-	cl = deferF.F()
-
-	defer func() {
-		if err != nil {
-			deferF.F()()
-			cl = nil
-		}
-	}()
-
-	tmpStargzDir, err := os.MkdirTemp("", "bktest_containerd_stargz_grpc")
-	if err != nil {
-		return "", nil, err
-	}
-	deferF.append(func() error { return os.RemoveAll(tmpStargzDir) })
-
-	address = filepath.Join(tmpStargzDir, "containerd-stargz-grpc.sock")
-	stargzRootDir := filepath.Join(tmpStargzDir, "root")
-	cmd := exec.Command(binary,
-		"--log-level", "debug",
-		"--address", address,
-		"--root", stargzRootDir)
-	snStop, err := startCmd(cmd, cfg.Logs)
-	if err != nil {
-		return "", nil, err
-	}
-	if err = waitUnix(address, 10*time.Second, cmd); err != nil {
-		snStop()
-		return "", nil, errors.Wrapf(err, "containerd-stargz-grpc did not start up: %s", formatLogs(cfg.Logs))
-	}
-	deferF.append(snStop)
-
-	return
 }


### PR DESCRIPTION
With containerd, this requires running a snapshotter plugin in the same rootless namespace as containerd and buildkitd. To do this, we need to run rootlesskit with a dummy `sleep` process and then run all needed processes in the appropriate order using nsenter:

- fuse-overlayfs snapshotter plugin
- containerd
- buildkitd

This commit prepare the use of overlayfs optimizations for fuse-overlayfs related to #3718.