### PR TITLE
fuse-overlayfs: use temporary mount wrapper

### DIFF
--- a/cache/refs.go
+++ b/cache/refs.go
@@ -1690,7 +1690,8 @@ func (sm *sharableMountable) Mount() (_ []mount.Mount, _ func() error, retErr er
 		}()
 		var isOverlay bool
 		for _, m := range mounts {
-			if overlay.IsOverlayMountType(m) {
+			// fuse-overlayfs also need the bind mount for the same reason as overlayfs.
+			if overlay.IsOverlayMountType(m) || m.Type == "fuse3.fuse-overlayfs" {
 				isOverlay = true
 				break
 			}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -194,6 +194,7 @@ func TestIntegration(t *testing.T) {
 		testSBOMSupplements,
 		testMultipleCacheExports,
 		testMountStubsDirectory,
+		testImmutableMountFromOtherImageCheckOCISpec,
 		testMountStubsTimestamp,
 		testSourcePolicy,
 		testImageManifestRegistryCacheImportExport,
@@ -8790,6 +8791,41 @@ func testMountStubsDirectory(t *testing.T, sb integration.Sandbox) {
 		"baz/keep",
 		"qux/",
 	}, keys)
+}
+
+func testImmutableMountFromOtherImageCheckOCISpec(t *testing.T, sb integration.Sandbox) {
+	// This test ensure fuse mounts are correctly handled when passed to runc via an OCI spec.
+
+	c, err := New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	stage1 := llb.Image("busybox:latest").
+		Run(llb.Args([]string{"mkdir", "/test/"})).
+		Root()
+
+	stage2 := llb.Image("busybox:latest").
+		Run(llb.Args([]string{"mkdir", "/test2/"})).
+		Run(llb.Args([]string{"mkdir", "/bin/test_bin/"})).
+		Root()
+
+	st := llb.Image("busybox:latest").
+		Run(
+			llb.Args([]string{"sh", "-c", "[ -d /test/test ] && [ -d /test_mirror_use_same_bind_mount/test ] && [ -d /test2/test2 ] && [ -d /test2_subpath/test_bin ]"}),
+			// Check we can mount immutable overlayfs directory from another image
+			llb.AddMount("/test", stage1, llb.SourcePath("/"), llb.Readonly),
+			// This duplicate mount to a different directory will trigger mount cache in submounts.m
+			llb.AddMount("/test_mirror_use_same_bind_mount", stage1, llb.SourcePath("/"), llb.Readonly),
+			// Try another different mutable mount
+			llb.AddMount("/test2", stage2, llb.SourcePath("/")),
+			// Try mount a subdirectory instead of the root directory
+			llb.AddMount("/test2_subpath", stage2, llb.SourcePath("/bin"), llb.Readonly),
+		).Root()
+	def, err := st.Marshal(sb.Context())
+	require.NoError(t, err)
+
+	_, err = c.Solve(sb.Context(), def, SolveOpt{}, nil)
+	require.NoError(t, err)
 }
 
 // https://github.com/moby/buildkit/issues/3148


### PR DESCRIPTION
runc (and containerd as it also uses runc it seems) will fail to mount mounts using fuse-overlayfs.

This makes tests to fail when using fuse-overlayfs snapshotter with this error:
```
failed to create shim task:
OCI runtime create failed:
runc create failed:
unable to start container process:
error during container init:
error mounting \"overlay\" to rootfs at \"/rw\":
    mount overlay:/rw (via /proc/self/fd/7),
    data:
        workdir=/tmp/bktest_containerd-fuse-overlayfs-grpc312066418/root/snapshots/12/work,
        upperdir=/tmp/bktest_containerd-fuse-overlayfs-grpc312066418/root/snapshots/12/fs,
        lowerdir=/tmp/bktest_containerd-fuse-overlayfs-grpc312066418/root/snapshots/10/fs:/tmp/bktest_containerd-fuse-overlayfs-grpc312066418/root/snapshots/8/fs
    : no such device: unknown
```
---
The failing fuse-overlayfs test was discovered on PR #3876 that adds fuse-overlayfs tests.
The error can be seen here: https://github.com/moby/buildkit/actions/runs/4996865039/jobs/8950612470#step:7:1002

With this commit, fuse-overlayfs tests enabled by PR #3876 should run successfully (at least for buildkitd workflow, see https://github.com/amurzeau/buildkit/actions/runs/5009224692/jobs/8977964559)

I'm not sure why this is required as fuse-overlayfs is working outside tests.
To ensure this is not a regression from my previous PRs, I've tried to cherry-pick fuse-overlayfs test PR #3876 on top of a old commit before any of my previous merged PR and tests fails too with the same error.
Maybe the code path is not always triggered ?