### PR TITLE
bump nydus-snapshotter dependence to v0.8.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/containerd/fuse-overlayfs-snapshotter v1.0.2
 	github.com/containerd/go-cni v1.1.9
 	github.com/containerd/go-runc v1.0.1-0.20230316182144-f5d58d02d6c8
-	github.com/containerd/nydus-snapshotter v0.8.0
+	github.com/containerd/nydus-snapshotter v0.8.2
 	github.com/containerd/stargz-snapshotter v0.14.3
 	github.com/containerd/stargz-snapshotter/estargz v0.14.3
 	github.com/containerd/typeurl/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -349,8 +349,8 @@ github.com/containerd/imgcrypt v1.0.4-0.20210301171431-0ae5c75f59ba/go.mod h1:6T
 github.com/containerd/imgcrypt v1.1.1-0.20210312161619-7ed62a527887/go.mod h1:5AZJNI6sLHJljKuI9IHnw1pWqo/F0nGDOuR9zgTs7ow=
 github.com/containerd/nri v0.0.0-20201007170849-eb1350a75164/go.mod h1:+2wGSDGFYfE5+So4M5syatU0N0f0LbWpuqyMi4/BE8c=
 github.com/containerd/nri v0.0.0-20210316161719-dbaa18c31c14/go.mod h1:lmxnXF6oMkbqs39FiCt1s0R2HSMhcLel9vNL3m4AaeY=
-github.com/containerd/nydus-snapshotter v0.8.0 h1:3Hlz/oZBUlOmM0Tf6Y1SrYc3+OOvfZ0q/CFKoGXGtxQ=
-github.com/containerd/nydus-snapshotter v0.8.0/go.mod h1:UJILTN5LVBRY+dt8BGJbp72Xy729hUZsOugObEI3/O8=
+github.com/containerd/nydus-snapshotter v0.8.2 h1:7SOrMU2YmLzfbsr5J7liMZJlNi5WT6vtIOxLGv+iz7E=
+github.com/containerd/nydus-snapshotter v0.8.2/go.mod h1:UJILTN5LVBRY+dt8BGJbp72Xy729hUZsOugObEI3/O8=
 github.com/containerd/stargz-snapshotter v0.0.0-20201027054423-3a04e4c2c116/go.mod h1:o59b3PCKVAf9jjiKtCc/9hLAd+5p/rfhBfm6aBcTEr4=
 github.com/containerd/stargz-snapshotter v0.14.3 h1:OTUVZoPSPs8mGgmQUE1dqw3WX/3nrsmsurW7UPLWl1U=
 github.com/containerd/stargz-snapshotter v0.14.3/go.mod h1:j2Ya4JeA5gMZJr8BchSkPjlcCEh++auAxp4nidPI6N0=

--- a/vendor/github.com/containerd/nydus-snapshotter/pkg/converter/convert_unix.go
+++ b/vendor/github.com/containerd/nydus-snapshotter/pkg/converter/convert_unix.go
@@ -140,6 +140,11 @@ func unpackNydusBlob(bootDst, blobDst string, ra content.ReaderAt, unpackBlob bo
 		defer blob.Close()
 
 		if _, err = UnpackEntry(ra, EntryBlob, blob); err != nil {
+			if errors.Is(err, ErrNotFound) {
+				// The nydus layer may contain only bootstrap and no blob
+				// data, which should be ignored.
+				return nil
+			}
 			return errors.Wrap(err, "unpack blob from nydus")
 		}
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -355,7 +355,7 @@ github.com/containerd/go-cni
 # github.com/containerd/go-runc v1.0.1-0.20230316182144-f5d58d02d6c8
 ## explicit; go 1.18
 github.com/containerd/go-runc
-# github.com/containerd/nydus-snapshotter v0.8.0
+# github.com/containerd/nydus-snapshotter v0.8.2
 ## explicit; go 1.19
 github.com/containerd/nydus-snapshotter/pkg/converter
 github.com/containerd/nydus-snapshotter/pkg/converter/tool


### PR DESCRIPTION
In order to fix a bug when converting nydus image with an empty blob layer.

It fixes https://github.com/moby/buildkit/pull/3814#issuecomment-1554245344