### PR TITLE
provenance: fix possible empty digest access

### DIFF
--- a/solver/llbsolver/provenance/predicate.go
+++ b/solver/llbsolver/provenance/predicate.go
@@ -64,12 +64,15 @@ func slsaMaterials(srcs Sources) ([]slsa.ProvenanceMaterial, error) {
 		if err != nil {
 			return nil, err
 		}
-		out = append(out, slsa.ProvenanceMaterial{
+		material := slsa.ProvenanceMaterial{
 			URI: uri,
-			Digest: slsa.DigestSet{
+		}
+		if s.Digest != "" {
+			material.Digest = slsa.DigestSet{
 				s.Digest.Algorithm().String(): s.Digest.Hex(),
-			},
-		})
+			}
+		}
+		out = append(out, material)
 	}
 
 	for _, s := range srcs.Git {
@@ -99,12 +102,16 @@ func slsaMaterials(srcs Sources) ([]slsa.ProvenanceMaterial, error) {
 			})
 		}
 		packageurl.NewPackageURL(packageurl.TypeOCI, "", s.Ref, "", q, "")
-		out = append(out, slsa.ProvenanceMaterial{
+
+		material := slsa.ProvenanceMaterial{
 			URI: s.Ref,
-			Digest: slsa.DigestSet{
+		}
+		if s.Digest != "" {
+			material.Digest = slsa.DigestSet{
 				s.Digest.Algorithm().String(): s.Digest.Hex(),
-			},
-		})
+			}
+		}
+		out = append(out, material)
 	}
 	return out, nil
 }


### PR DESCRIPTION
:hammer_and_wrench: Fixes https://github.com/docker/buildx/issues/1836.

> ```
> panic: no ':' separator in digest ""
> goroutine 4749 [running]:
> github.com/docker/docker/vendor/github.com/opencontainers/go-digest.Digest.sepIndex({0x0, 0x0})
>         /go/src/github.com/docker/docker/vendor/github.com/opencontainers/go-digest/digest.go:153 +0x9a
> github.com/docker/docker/vendor/github.com/opencontainers/go-digest.Digest.Algorithm(...)
>         /go/src/github.com/docker/docker/vendor/github.com/opencontainers/go-digest/digest.go:122
> github.com/docker/docker/vendor/github.com/moby/buildkit/solver/llbsolver/provenance.slsaMaterials({{0xc001df0500, 0x3, 0x3}, {0x0, 0x0, 0x0}, {0x0, 0x0, 0x0}, {0x0, ...}, ...})
>         /go/src/github.com/docker/docker/vendor/github.com/moby/buildkit/solver/llbsolver/provenance/predicate.go:70 +0x16b
> github.com/docker/docker/vendor/github.com/moby/buildkit/solver/llbsolver/provenance.NewPredicate(0xc001280c30)
>         /go/src/github.com/docker/docker/vendor/github.com/moby/buildkit/solver/llbsolver/provenance/predicate.go:137 +0xa5
> github.com/docker/docker/vendor/github.com/moby/buildkit/solver/llbsolver.NewProvenanceCreator({0x55ebdba328f8, 0xc0009b42d0}, 0x0?, {0x55ebdba36600, 0xc000ff5820}, 0x55ebda1d45dc?, 0xc00065a000)
>         /go/src/github.com/docker/docker/vendor/github.com/moby/buildkit/solver/llbsolver/provenance.go:397 +0x3d0
> github.com/docker/docker/vendor/github.com/moby/buildkit/solver/llbsolver.(*Solver).recordBuildHistory.func1.1({0x55ebdba36600?, 0xc000ff5820?}, 0x0?)
>         /go/src/github.com/docker/docker/vendor/github.com/moby/buildkit/solver/llbsolver/solver.go:203 +0xb1
> github.com/docker/docker/vendor/github.com/moby/buildkit/solver/llbsolver.(*Solver).recordBuildHistory.func1.2()
>         /go/src/github.com/docker/docker/vendor/github.com/moby/buildkit/solver/llbsolver/solver.go:245 +0x54
> github.com/docker/docker/vendor/golang.org/x/sync/errgroup.(*Group).Go.func1()
>         /go/src/github.com/docker/docker/vendor/golang.org/x/sync/errgroup/errgroup.go:75 +0x64
> created by github.com/docker/docker/vendor/golang.org/x/sync/errgroup.(*Group).Go
>         /go/src/github.com/docker/docker/vendor/golang.org/x/sync/errgroup/errgroup.go:72 +0xa5
> ```

If the digest for an ImageSource is the empty string, then calling `Digest.Algorithm` will panic at runtime.

This scenario *can* happen if `ResolveImageConfig` returns an empty digest, but correctly returns a config object. This doesn't occur in buildkit directly, however, [buildkit-in-moby implements a custom worker which also performs image lookups on local images](https://github.com/moby/moby/blob/1d68544fbfadc9807d1ddef74bb74726ae5ae63d/builder/builder-next/adapters/containerimage/pull.go#L147-L157), in which case the digest for the index may not be available (though this may be possible with the containerd image store?).

Therefore, we shouldn't assume that the digest is always available in buildkit, and should instead check that is valid before inserting it into the digest set (which is already an optional map).