### PR TITLE
[0.11 backport] session: avoid logging healthcheck error on canceled connection

### DIFF
--- a/session/grpc.go
+++ b/session/grpc.go
@@ -112,6 +112,11 @@ func monitorHealth(ctx context.Context, cc *grpc.ClientConn, cancelConn func()) 
 			}
 
 			if err != nil {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
 				if failedBefore {
 					bklog.G(ctx).Error("healthcheck failed fatally")
 					return


### PR DESCRIPTION
- backports https://github.com/moby/buildkit/pull/3882
- relates to https://github.com/moby/buildkit/issues/3871#issuecomment-1555406539

(cherry picked from commit de53eb0072e4a8feed27e670e045445f7289eabf)