### PR TITLE
vendor: github.com/containerd/go-runc v1.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/containerd/continuity v0.3.0
 	github.com/containerd/fuse-overlayfs-snapshotter v1.0.2
 	github.com/containerd/go-cni v1.1.9
-	github.com/containerd/go-runc v1.0.1-0.20230316182144-f5d58d02d6c8
+	github.com/containerd/go-runc v1.1.0
 	github.com/containerd/nydus-snapshotter v0.8.2
 	github.com/containerd/stargz-snapshotter v0.14.3
 	github.com/containerd/stargz-snapshotter/estargz v0.14.3

--- a/go.sum
+++ b/go.sum
@@ -344,8 +344,8 @@ github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3/go.mod h1:IV7qH
 github.com/containerd/go-runc v0.0.0-20190911050354-e029b79d8cda/go.mod h1:IV7qH3hrUgRmyYrtgEeGWJfWbgcHL9CSRruz2Vqcph0=
 github.com/containerd/go-runc v0.0.0-20200220073739-7016d3ce2328/go.mod h1:PpyHrqVs8FTi9vpyHwPwiNEGaACDxT/N/pLcvMSRA9g=
 github.com/containerd/go-runc v0.0.0-20201020171139-16b287bc67d0/go.mod h1:cNU0ZbCgCQVZK4lgG3P+9tn9/PaJNmoDXPpoJhDR+Ok=
-github.com/containerd/go-runc v1.0.1-0.20230316182144-f5d58d02d6c8 h1:PCkiJcIQIOyhwsVjN2AGZaItt+mKpw3sWsJB3eKmyyI=
-github.com/containerd/go-runc v1.0.1-0.20230316182144-f5d58d02d6c8/go.mod h1:3nyIw00YvKyqQHpVTwj21SepIlzVs2cYLEwJZdqQjwY=
+github.com/containerd/go-runc v1.1.0 h1:OX4f+/i2y5sUT7LhmcJH7GYrjjhHa1QI4e8yO0gGleA=
+github.com/containerd/go-runc v1.1.0/go.mod h1:xJv2hFF7GvHtTJd9JqTS2UVxMkULUYw4JN5XAUZqH5U=
 github.com/containerd/imgcrypt v1.0.1/go.mod h1:mdd8cEPW7TPgNG4FpuP3sGBiQ7Yi/zak9TYCG3juvb0=
 github.com/containerd/imgcrypt v1.0.4-0.20210301171431-0ae5c75f59ba/go.mod h1:6TNsg0ctmizkrOgXRNQjAPFWpMYRWuiB6dSF4Pfa5SA=
 github.com/containerd/imgcrypt v1.1.1-0.20210312161619-7ed62a527887/go.mod h1:5AZJNI6sLHJljKuI9IHnw1pWqo/F0nGDOuR9zgTs7ow=

--- a/vendor/github.com/containerd/go-runc/runc.go
+++ b/vendor/github.com/containerd/go-runc/runc.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-spec/specs-go/features"
 )
 
 // Format is the type of log formatting options available
@@ -742,6 +743,26 @@ func parseVersion(data []byte) (Version, error) {
 	}
 
 	return v, nil
+}
+
+// Features shows the features implemented by the runtime.
+//
+// Availability:
+//
+//   - runc:  supported since runc v1.1.0
+//   - crun:  https://github.com/containers/crun/issues/1177
+//   - youki: https://github.com/containers/youki/issues/815
+func (r *Runc) Features(context context.Context) (*features.Features, error) {
+	data, err := r.cmdOutput(r.command(context, "features"), false, nil)
+	defer putBuf(data)
+	if err != nil {
+		return nil, err
+	}
+	var feat features.Features
+	if err := json.Unmarshal(data.Bytes(), &feat); err != nil {
+		return nil, err
+	}
+	return &feat, nil
 }
 
 func (r *Runc) args() (out []string) {

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/features/features.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/features/features.go
@@ -1,0 +1,125 @@
+// Package features provides the Features struct.
+package features
+
+// Features represents the supported features of the runtime.
+type Features struct {
+	// OCIVersionMin is the minimum OCI Runtime Spec version recognized by the runtime, e.g., "1.0.0".
+	OCIVersionMin string `json:"ociVersionMin,omitempty"`
+
+	// OCIVersionMax is the maximum OCI Runtime Spec version recognized by the runtime, e.g., "1.0.2-dev".
+	OCIVersionMax string `json:"ociVersionMax,omitempty"`
+
+	// Hooks is the list of the recognized hook names, e.g., "createRuntime".
+	// Nil value means "unknown", not "no support for any hook".
+	Hooks []string `json:"hooks,omitempty"`
+
+	// MountOptions is the list of the recognized mount options, e.g., "ro".
+	// Nil value means "unknown", not "no support for any mount option".
+	// This list does not contain filesystem-specific options passed to mount(2) syscall as (const void *).
+	MountOptions []string `json:"mountOptions,omitempty"`
+
+	// Linux is specific to Linux.
+	Linux *Linux `json:"linux,omitempty"`
+
+	// Annotations contains implementation-specific annotation strings,
+	// such as the implementation version, and third-party extensions.
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+// Linux is specific to Linux.
+type Linux struct {
+	// Namespaces is the list of the recognized namespaces, e.g., "mount".
+	// Nil value means "unknown", not "no support for any namespace".
+	Namespaces []string `json:"namespaces,omitempty"`
+
+	// Capabilities is the list of the recognized capabilities , e.g., "CAP_SYS_ADMIN".
+	// Nil value means "unknown", not "no support for any capability".
+	Capabilities []string `json:"capabilities,omitempty"`
+
+	Cgroup   *Cgroup   `json:"cgroup,omitempty"`
+	Seccomp  *Seccomp  `json:"seccomp,omitempty"`
+	Apparmor *Apparmor `json:"apparmor,omitempty"`
+	Selinux  *Selinux  `json:"selinux,omitempty"`
+	IntelRdt *IntelRdt `json:"intelRdt,omitempty"`
+}
+
+// Cgroup represents the "cgroup" field.
+type Cgroup struct {
+	// V1 represents whether Cgroup v1 support is compiled in.
+	// Unrelated to whether the host uses cgroup v1 or not.
+	// Nil value means "unknown", not "false".
+	V1 *bool `json:"v1,omitempty"`
+
+	// V2 represents whether Cgroup v2 support is compiled in.
+	// Unrelated to whether the host uses cgroup v2 or not.
+	// Nil value means "unknown", not "false".
+	V2 *bool `json:"v2,omitempty"`
+
+	// Systemd represents whether systemd-cgroup support is compiled in.
+	// Unrelated to whether the host uses systemd or not.
+	// Nil value means "unknown", not "false".
+	Systemd *bool `json:"systemd,omitempty"`
+
+	// SystemdUser represents whether user-scoped systemd-cgroup support is compiled in.
+	// Unrelated to whether the host uses systemd or not.
+	// Nil value means "unknown", not "false".
+	SystemdUser *bool `json:"systemdUser,omitempty"`
+
+	// Rdma represents whether RDMA cgroup support is compiled in.
+	// Unrelated to whether the host supports RDMA or not.
+	// Nil value means "unknown", not "false".
+	Rdma *bool `json:"rdma,omitempty"`
+}
+
+// Seccomp represents the "seccomp" field.
+type Seccomp struct {
+	// Enabled is true if seccomp support is compiled in.
+	// Nil value means "unknown", not "false".
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// Actions is the list of the recognized actions, e.g., "SCMP_ACT_NOTIFY".
+	// Nil value means "unknown", not "no support for any action".
+	Actions []string `json:"actions,omitempty"`
+
+	// Operators is the list of the recognized operators, e.g., "SCMP_CMP_NE".
+	// Nil value means "unknown", not "no support for any operator".
+	Operators []string `json:"operators,omitempty"`
+
+	// Archs is the list of the recognized archs, e.g., "SCMP_ARCH_X86_64".
+	// Nil value means "unknown", not "no support for any arch".
+	Archs []string `json:"archs,omitempty"`
+
+	// KnownFlags is the list of the recognized filter flags, e.g., "SECCOMP_FILTER_FLAG_LOG".
+	// Nil value means "unknown", not "no flags are recognized".
+	KnownFlags []string `json:"knownFlags,omitempty"`
+
+	// SupportedFlags is the list of the supported filter flags, e.g., "SECCOMP_FILTER_FLAG_LOG".
+	// This list may be a subset of KnownFlags due to some flags
+	// not supported by the current kernel and/or libseccomp.
+	// Nil value means "unknown", not "no flags are supported".
+	SupportedFlags []string `json:"supportedFlags,omitempty"`
+}
+
+// Apparmor represents the "apparmor" field.
+type Apparmor struct {
+	// Enabled is true if AppArmor support is compiled in.
+	// Unrelated to whether the host supports AppArmor or not.
+	// Nil value means "unknown", not "false".
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+// Selinux represents the "selinux" field.
+type Selinux struct {
+	// Enabled is true if SELinux support is compiled in.
+	// Unrelated to whether the host supports SELinux or not.
+	// Nil value means "unknown", not "false".
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+// IntelRdt represents the "intelRdt" field.
+type IntelRdt struct {
+	// Enabled is true if Intel RDT support is compiled in.
+	// Unrelated to whether the host supports Intel RDT or not.
+	// Nil value means "unknown", not "false".
+	Enabled *bool `json:"enabled,omitempty"`
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -357,7 +357,7 @@ github.com/containerd/fuse-overlayfs-snapshotter
 # github.com/containerd/go-cni v1.1.9
 ## explicit; go 1.19
 github.com/containerd/go-cni
-# github.com/containerd/go-runc v1.0.1-0.20230316182144-f5d58d02d6c8
+# github.com/containerd/go-runc v1.1.0
 ## explicit; go 1.18
 github.com/containerd/go-runc
 # github.com/containerd/nydus-snapshotter v0.8.2
@@ -661,6 +661,7 @@ github.com/opencontainers/runc/libcontainer/user
 # github.com/opencontainers/runtime-spec v1.1.0-rc.2
 ## explicit
 github.com/opencontainers/runtime-spec/specs-go
+github.com/opencontainers/runtime-spec/specs-go/features
 # github.com/opencontainers/selinux v1.11.0
 ## explicit; go 1.19
 github.com/opencontainers/selinux/go-selinux


### PR DESCRIPTION
full diff: https://github.com/containerd/go-runc/compare/f5d58d02d6c8...v1.1.0