### PR TITLE
[v0.11 backport] Prevent overflow of runc exit code.

### DIFF
--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -341,7 +341,7 @@ func exitError(ctx context.Context, err error) error {
 			Err:      err,
 		}
 		var runcExitError *runc.ExitError
-		if errors.As(err, &runcExitError) {
+		if errors.As(err, &runcExitError) && runcExitError.Status >= 0 {
 			exitErr = &gatewayapi.ExitError{
 				ExitCode: uint32(runcExitError.Status),
 			}


### PR DESCRIPTION
- ⚠️ this is only a partial backport of https://github.com/moby/buildkit/pull/3765. Only one of 2 commits, as the other commit (updating go-runc) may be more contentious. This patch seemed to be "safe" to backport.


It's possible for the Status field of runc.ExitError to be set to -1, in which case conversion to uint32 results in the error message to say that the container exited with code 4294967295 (2^32-1).


(cherry picked from commit 9b0bdb600641f3dd1d96f54ac2d86581ab6433b2)