### PR TITLE
cache: add a few more fields to ref trace logs.

### DIFF
--- a/util/bklog/log.go
+++ b/util/bklog/log.go
@@ -70,3 +70,7 @@ type LazyStackTrace struct{}
 func (LazyStackTrace) String() string {
 	return string(debug.Stack())
 }
+
+func (LazyStackTrace) MarshalText() ([]byte, error) {
+	return debug.Stack(), nil
+}


### PR DESCRIPTION
The trace logs now also include the pointer value of the ref, which serves as its "ID" amongst all the refs for the underlying record.

They also now include equal{Mutable,Immutable} IDs, which are otherwise hard to determine with the Usage API.

Finally, LazyStackTrace now has a MarshalText method which returns the same value as the existing String method. This allows it to work with custom logrus hooks that rely on marshaling the fields.