### PR TITLE
Handle file paths base on target platform

### DIFF
--- a/client/llb/fileop.go
+++ b/client/llb/fileop.go
@@ -56,7 +56,7 @@ type CopyInput interface {
 }
 
 type subAction interface {
-	toProtoAction(ctx context.Context, parent string, base pb.InputIndex, platform string) (pb.IsFileAction, error)
+	toProtoAction(ctx context.Context, parent string, base pb.InputIndex, platformOS string) (pb.IsFileAction, error)
 }
 
 type capAdder interface {
@@ -162,8 +162,8 @@ type fileActionMkdir struct {
 	info MkdirInfo
 }
 
-func (a *fileActionMkdir) toProtoAction(ctx context.Context, parent string, base pb.InputIndex, platform string) (pb.IsFileAction, error) {
-	normalizedPath, err := system.NormalizePath(parent, a.file, platform, false)
+func (a *fileActionMkdir) toProtoAction(ctx context.Context, parent string, base pb.InputIndex, platformOS string) (pb.IsFileAction, error) {
+	normalizedPath, err := system.NormalizePath(parent, a.file, platformOS, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "normalizing path")
 	}
@@ -340,8 +340,8 @@ type fileActionMkfile struct {
 	info MkfileInfo
 }
 
-func (a *fileActionMkfile) toProtoAction(ctx context.Context, parent string, base pb.InputIndex, platform string) (pb.IsFileAction, error) {
-	normalizedPath, err := system.NormalizePath(parent, a.file, platform, false)
+func (a *fileActionMkfile) toProtoAction(ctx context.Context, parent string, base pb.InputIndex, platformOS string) (pb.IsFileAction, error) {
+	normalizedPath, err := system.NormalizePath(parent, a.file, platformOS, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "normalizing path")
 	}
@@ -412,8 +412,8 @@ type fileActionRm struct {
 	info RmInfo
 }
 
-func (a *fileActionRm) toProtoAction(ctx context.Context, parent string, base pb.InputIndex, platform string) (pb.IsFileAction, error) {
-	normalizedPath, err := system.NormalizePath(parent, a.file, platform, false)
+func (a *fileActionRm) toProtoAction(ctx context.Context, parent string, base pb.InputIndex, platformOS string) (pb.IsFileAction, error) {
+	normalizedPath, err := system.NormalizePath(parent, a.file, platformOS, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "normalizing path")
 	}
@@ -506,12 +506,12 @@ type fileActionCopy struct {
 	info  CopyInfo
 }
 
-func (a *fileActionCopy) toProtoAction(ctx context.Context, parent string, base pb.InputIndex, platform string) (pb.IsFileAction, error) {
-	src, err := a.sourcePath(ctx, platform)
+func (a *fileActionCopy) toProtoAction(ctx context.Context, parent string, base pb.InputIndex, platformOS string) (pb.IsFileAction, error) {
+	src, err := a.sourcePath(ctx, platformOS)
 	if err != nil {
 		return nil, err
 	}
-	normalizedPath, err := system.NormalizePath(parent, a.dest, platform, false)
+	normalizedPath, err := system.NormalizePath(parent, a.dest, platformOS, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "normalizing path")
 	}
@@ -773,11 +773,11 @@ func (f *FileOp) Marshal(ctx context.Context, c *Constraints) (digest.Digest, []
 		}
 
 		// Assume that we're building an image for the same OS we're running on.
-		platform := runtime.GOOS
+		platformOS := runtime.GOOS
 		if f.constraints.Platform != nil {
-			platform = f.constraints.Platform.OS
+			platformOS = f.constraints.Platform.OS
 		}
-		action, err := st.action.toProtoAction(ctx, parent, st.base, platform)
+		action, err := st.action.toProtoAction(ctx, parent, st.base, platformOS)
 		if err != nil {
 			return "", nil, nil, nil, err
 		}

--- a/client/llb/fileop.go
+++ b/client/llb/fileop.go
@@ -5,7 +5,6 @@ import (
 	_ "crypto/sha256" // for opencontainers/go-digest
 	"os"
 	"path"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -523,9 +522,7 @@ func (a *fileActionCopy) toProtoAction(ctx context.Context, parent string, base 
 }
 
 func (a *fileActionCopy) sourcePath(ctx context.Context) (string, error) {
-	// filepath.Clean() also does a filepath.FromSlash(). Explicitly convert back to UNIX path
-	// separators.
-	p := filepath.ToSlash(filepath.Clean(a.src))
+	p := path.Clean(a.src)
 	dir := "/"
 	var err error
 	if !path.IsAbs(p) {

--- a/client/llb/fileop.go
+++ b/client/llb/fileop.go
@@ -5,7 +5,6 @@ import (
 	_ "crypto/sha256" // for opencontainers/go-digest
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -772,12 +771,7 @@ func (f *FileOp) Marshal(ctx context.Context, c *Constraints) (digest.Digest, []
 			}
 		}
 
-		// Assume that we're building an image for the same OS we're running on.
-		platformOS := runtime.GOOS
-		if f.constraints.Platform != nil {
-			platformOS = f.constraints.Platform.OS
-		}
-		action, err := st.action.toProtoAction(ctx, parent, st.base, platformOS)
+		action, err := st.action.toProtoAction(ctx, parent, st.base, f.constraints.Platform.OS)
 		if err != nil {
 			return "", nil, nil, nil, err
 		}

--- a/client/llb/fileop.go
+++ b/client/llb/fileop.go
@@ -5,6 +5,7 @@ import (
 	_ "crypto/sha256" // for opencontainers/go-digest
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -771,7 +772,8 @@ func (f *FileOp) Marshal(ctx context.Context, c *Constraints) (digest.Digest, []
 			}
 		}
 
-		var platform string
+		// Assume that we're building an image for the same OS we're running on.
+		platform := runtime.GOOS
 		if f.constraints.Platform != nil {
 			platform = f.constraints.Platform.OS
 		}

--- a/client/llb/meta.go
+++ b/client/llb/meta.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"runtime"
 
 	"github.com/containerd/containerd/platforms"
 	"github.com/google/shlex"
@@ -77,7 +76,7 @@ func dirf(value string, replace bool, v ...interface{}) StateOption {
 	}
 	return func(s State) State {
 		return s.withValue(keyDir, func(ctx context.Context, c *Constraints) (interface{}, error) {
-			platform := runtime.GOOS
+			platform := "linux"
 			if c != nil && c.Platform != nil {
 				platform = c.Platform.OS
 			}

--- a/client/llb/meta.go
+++ b/client/llb/meta.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"runtime"
 
 	"github.com/containerd/containerd/platforms"
 	"github.com/google/shlex"
@@ -76,7 +77,7 @@ func dirf(value string, replace bool, v ...interface{}) StateOption {
 	}
 	return func(s State) State {
 		return s.withValue(keyDir, func(ctx context.Context, c *Constraints) (interface{}, error) {
-			var platform string
+			platform := runtime.GOOS
 			if c != nil && c.Platform != nil {
 				platform = c.Platform.OS
 			}

--- a/client/llb/meta_test.go
+++ b/client/llb/meta_test.go
@@ -4,24 +4,25 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestRelativeWd(t *testing.T) {
 	st := Scratch().Dir("foo")
-	require.Equal(t, getDirHelper(t, st), "/foo")
+	assert.Equal(t, getDirHelper(t, st), "/foo")
 
 	st = st.Dir("bar")
-	require.Equal(t, getDirHelper(t, st), "/foo/bar")
+	assert.Equal(t, getDirHelper(t, st), "/foo/bar")
 
 	st = st.Dir("..")
-	require.Equal(t, getDirHelper(t, st), "/foo")
+	assert.Equal(t, getDirHelper(t, st), "/foo")
 
 	st = st.Dir("/baz")
-	require.Equal(t, getDirHelper(t, st), "/baz")
+	assert.Equal(t, getDirHelper(t, st), "/baz")
 
 	st = st.Dir("../../..")
-	require.Equal(t, getDirHelper(t, st), "/")
+	assert.Equal(t, getDirHelper(t, st), "/")
 }
 
 func getDirHelper(t *testing.T, s State) string {

--- a/client/llb/state.go
+++ b/client/llb/state.go
@@ -302,8 +302,7 @@ func (s State) File(a *FileAction, opts ...ConstraintsOpt) State {
 	// No platform was set by constraint options. Set the current OS and arch.
 	if c.Platform == nil {
 		c.Platform = &ocispecs.Platform{
-			OS:           "linux",
-			Architecture: "amd64",
+			OS: "linux",
 		}
 	}
 	return s.WithOutput(NewFileOp(s, a, c).Output())

--- a/client/llb/state.go
+++ b/client/llb/state.go
@@ -299,6 +299,11 @@ func (s State) File(a *FileAction, opts ...ConstraintsOpt) State {
 		o.SetConstraintsOption(&c)
 	}
 
+	// No platform was set by constraint options. Set the current OS and arch.
+	if c.Platform == nil {
+		platform := platforms.DefaultSpec()
+		c.Platform = &platform
+	}
 	return s.WithOutput(NewFileOp(s, a, c).Output())
 }
 

--- a/client/llb/state.go
+++ b/client/llb/state.go
@@ -301,8 +301,10 @@ func (s State) File(a *FileAction, opts ...ConstraintsOpt) State {
 
 	// No platform was set by constraint options. Set the current OS and arch.
 	if c.Platform == nil {
-		platform := platforms.DefaultSpec()
-		c.Platform = &platform
+		c.Platform = &ocispecs.Platform{
+			OS:           "linux",
+			Architecture: "amd64",
+		}
 	}
 	return s.WithOutput(NewFileOp(s, a, c).Output())
 }

--- a/client/llb/state.go
+++ b/client/llb/state.go
@@ -299,12 +299,6 @@ func (s State) File(a *FileAction, opts ...ConstraintsOpt) State {
 		o.SetConstraintsOption(&c)
 	}
 
-	// No platform was set by constraint options. Set the current OS and arch.
-	if c.Platform == nil {
-		c.Platform = &ocispecs.Platform{
-			OS: "linux",
-		}
-	}
 	return s.WithOutput(NewFileOp(s, a, c).Output())
 }
 

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -996,7 +996,7 @@ func dispatchRun(d *dispatchState, c *instructions.RunCommand, proxy *llb.ProxyE
 
 func dispatchWorkdir(d *dispatchState, c *instructions.WorkdirCommand, commit bool, opt *dispatchOpt) error {
 	platformOS := runtime.GOOS
-	if d != nil && d.platform != nil {
+	if d.platform != nil {
 		platformOS = d.platform.OS
 	}
 	wd, err := system.NormalizeWorkdir(d.image.Config.WorkingDir, c.Path, platformOS)

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -995,11 +995,7 @@ func dispatchRun(d *dispatchState, c *instructions.RunCommand, proxy *llb.ProxyE
 }
 
 func dispatchWorkdir(d *dispatchState, c *instructions.WorkdirCommand, commit bool, opt *dispatchOpt) error {
-	platformOS := runtime.GOOS
-	if d.platform != nil {
-		platformOS = d.platform.OS
-	}
-	wd, err := system.NormalizeWorkdir(d.image.Config.WorkingDir, c.Path, platformOS)
+	wd, err := system.NormalizeWorkdir(d.image.Config.WorkingDir, c.Path, d.platform.OS)
 	if err != nil {
 		return errors.Wrap(err, "normalizing workdir")
 	}

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -1003,7 +1003,7 @@ func dispatchWorkdir(d *dispatchState, c *instructions.WorkdirCommand, commit bo
 	d.image.Config.WorkingDir = wd
 
 	// From this point forward, we can use UNIX style paths.
-	wd = filepath.ToSlash(wd)
+	wd = system.ToSlash(wd, d.platform.OS)
 	d.state = d.state.Dir(wd)
 
 	if commit {
@@ -1421,7 +1421,6 @@ func pathRelativeToWorkingDir(s llb.State, p string, platform ocispecs.Platform)
 	if len(p) == 0 {
 		return dir, nil
 	}
-
 	p, err = system.CheckSystemDriveAndRemoveDriveLetter(p, platform.OS)
 	if err != nil {
 		return "", errors.Wrap(err, "remving drive letter")

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -994,7 +995,7 @@ func dispatchRun(d *dispatchState, c *instructions.RunCommand, proxy *llb.ProxyE
 }
 
 func dispatchWorkdir(d *dispatchState, c *instructions.WorkdirCommand, commit bool, opt *dispatchOpt) error {
-	var platformOS string
+	platformOS := runtime.GOOS
 	if d != nil && d.platform != nil {
 		platformOS = d.platform.OS
 	}
@@ -1032,7 +1033,7 @@ func dispatchWorkdir(d *dispatchState, c *instructions.WorkdirCommand, commit bo
 }
 
 func dispatchCopy(d *dispatchState, cfg copyConfig) error {
-	var platformOS string
+	platformOS := runtime.GOOS
 	if d.platform != nil {
 		platformOS = d.platform.OS
 	}

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -995,7 +995,11 @@ func dispatchRun(d *dispatchState, c *instructions.RunCommand, proxy *llb.ProxyE
 }
 
 func dispatchWorkdir(d *dispatchState, c *instructions.WorkdirCommand, commit bool, opt *dispatchOpt) error {
-	wd, err := system.NormalizeWorkdir(d.image.Config.WorkingDir, c.Path, d.platform.OS)
+	platformOS := runtime.GOOS
+	if d.platform != nil {
+		platformOS = d.platform.OS
+	}
+	wd, err := system.NormalizeWorkdir(d.image.Config.WorkingDir, c.Path, platformOS)
 	if err != nil {
 		return errors.Wrap(err, "normalizing workdir")
 	}

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -1185,7 +1185,7 @@ func dispatchCopy(d *dispatchState, cfg copyConfig) error {
 		}}, copyOpt...)
 
 		if a == nil {
-			a = llb.Copy(st, filepath.ToSlash(f), dest, opts...)
+			a = llb.Copy(st, system.ToSlash(f, d.platform.OS), dest, opts...)
 		} else {
 			a = a.Copy(st, filepath.ToSlash(f), dest, opts...)
 		}
@@ -1423,11 +1423,11 @@ func pathRelativeToWorkingDir(s llb.State, p string, platform ocispecs.Platform)
 	}
 	p, err = system.CheckSystemDriveAndRemoveDriveLetter(p, platform.OS)
 	if err != nil {
-		return "", errors.Wrap(err, "remving drive letter")
+		return "", errors.Wrap(err, "removing drive letter")
 	}
 
 	if system.IsAbs(p, platform.OS) {
-		return p, nil
+		return system.NormalizePath("/", p, platform.OS, false)
 	}
 	return system.NormalizePath(dir, p, platform.OS, false)
 }

--- a/solver/llbsolver/file/backend.go
+++ b/solver/llbsolver/file/backend.go
@@ -352,13 +352,14 @@ func cleanPath(s string) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "removing drive letter")
 	}
+	s = filepath.FromSlash(s)
 	s2 := filepath.Join("/", s)
-	if strings.HasSuffix(filepath.FromSlash(s), string(filepath.Separator)+".") {
+	if strings.HasSuffix(s, string(filepath.Separator)+".") {
 		if s2 != string(filepath.Separator) {
 			s2 += string(filepath.Separator)
 		}
 		s2 += "."
-	} else if strings.HasSuffix(filepath.FromSlash(s), string(filepath.Separator)) && s2 != string(filepath.Separator) {
+	} else if strings.HasSuffix(s, string(filepath.Separator)) && s2 != string(filepath.Separator) {
 		s2 += string(filepath.Separator)
 	}
 	return s2, nil

--- a/solver/llbsolver/file/backend.go
+++ b/solver/llbsolver/file/backend.go
@@ -68,11 +68,7 @@ func mapUserToChowner(user *copy.User, idmap *idtools.IdentityMapping) (copy.Cho
 }
 
 func mkdir(ctx context.Context, d string, action pb.FileActionMkDir, user *copy.User, idmap *idtools.IdentityMapping) error {
-	actionPath, err := system.NormalizePath("/", action.Path, runtime.GOOS, false)
-	if err != nil {
-		return errors.Wrap(err, "removing drive letter")
-	}
-	p, err := fs.RootPath(d, filepath.FromSlash(actionPath))
+	p, err := fs.RootPath(d, action.Path)
 	if err != nil {
 		return err
 	}

--- a/solver/llbsolver/file/backend.go
+++ b/solver/llbsolver/file/backend.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/moby/buildkit/snapshot"
 	"github.com/moby/buildkit/solver/llbsolver/ops/fileoptypes"
 	"github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/util/system"
 	"github.com/pkg/errors"
 	copy "github.com/tonistiigi/fsutil/copy"
 )
@@ -66,7 +68,11 @@ func mapUserToChowner(user *copy.User, idmap *idtools.IdentityMapping) (copy.Cho
 }
 
 func mkdir(ctx context.Context, d string, action pb.FileActionMkDir, user *copy.User, idmap *idtools.IdentityMapping) error {
-	p, err := fs.RootPath(d, filepath.Join("/", action.Path))
+	actionPath, err := system.NormalizePath("/", action.Path, runtime.GOOS, false)
+	if err != nil {
+		return errors.Wrap(err, "removing drive letter")
+	}
+	p, err := fs.RootPath(d, filepath.FromSlash(actionPath))
 	if err != nil {
 		return err
 	}
@@ -126,7 +132,10 @@ func mkfile(ctx context.Context, d string, action pb.FileActionMkFile, user *cop
 
 func rm(ctx context.Context, d string, action pb.FileActionRm) error {
 	if action.AllowWildcard {
-		src := cleanPath(action.Path)
+		src, err := cleanPath(action.Path)
+		if err != nil {
+			return errors.Wrap(err, "cleaning path")
+		}
 		m, err := copy.ResolveWildcards(d, src, false)
 		if err != nil {
 			return err
@@ -167,9 +176,14 @@ func rmPath(root, src string, allowNotFound bool) error {
 }
 
 func docopy(ctx context.Context, src, dest string, action pb.FileActionCopy, u *copy.User, idmap *idtools.IdentityMapping) error {
-	srcPath := cleanPath(action.Src)
-	destPath := cleanPath(action.Dest)
-
+	srcPath, err := cleanPath(action.Src)
+	if err != nil {
+		return errors.Wrap(err, "cleaning source path")
+	}
+	destPath, err := cleanPath(action.Dest)
+	if err != nil {
+		return errors.Wrap(err, "cleaning path")
+	}
 	if !action.CreateDestPath {
 		p, err := fs.RootPath(dest, filepath.Join("/", action.Dest))
 		if err != nil {
@@ -242,19 +256,6 @@ func docopy(ctx context.Context, src, dest string, action pb.FileActionCopy, u *
 	}
 
 	return nil
-}
-
-func cleanPath(s string) string {
-	s2 := filepath.Join("/", s)
-	if strings.HasSuffix(s, "/.") {
-		if s2 != "/" {
-			s2 += "/"
-		}
-		s2 += "."
-	} else if strings.HasSuffix(s, "/") && s2 != "/" {
-		s2 += "/"
-	}
-	return s2
 }
 
 type Backend struct {
@@ -348,4 +349,21 @@ func (fb *Backend) Copy(ctx context.Context, m1, m2, user, group fileoptypes.Mou
 	}
 
 	return docopy(ctx, src, dest, action, u, mnt2.m.IdentityMapping())
+}
+
+func cleanPath(s string) (string, error) {
+	s, err := system.CheckSystemDriveAndRemoveDriveLetter(s, runtime.GOOS)
+	if err != nil {
+		return "", errors.Wrap(err, "removing drive letter")
+	}
+	s2 := filepath.Join("/", s)
+	if strings.HasSuffix(filepath.FromSlash(s), string(filepath.Separator)+".") {
+		if s2 != string(filepath.Separator) {
+			s2 += string(filepath.Separator)
+		}
+		s2 += "."
+	} else if strings.HasSuffix(filepath.FromSlash(s), string(filepath.Separator)) && s2 != string(filepath.Separator) {
+		s2 += string(filepath.Separator)
+	}
+	return s2, nil
 }

--- a/solver/llbsolver/ops/exec.go
+++ b/solver/llbsolver/ops/exec.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -260,7 +261,7 @@ func (e *ExecOp) Exec(ctx context.Context, g session.Group, inputs []solver.Resu
 		}
 	}
 
-	var platformOS string
+	platformOS := runtime.GOOS
 	if e.platform != nil {
 		platformOS = e.platform.OS
 	}

--- a/solver/llbsolver/ops/exec.go
+++ b/solver/llbsolver/ops/exec.go
@@ -260,10 +260,14 @@ func (e *ExecOp) Exec(ctx context.Context, g session.Group, inputs []solver.Resu
 		}
 	}
 
+	var platformOS string
+	if e.platform != nil {
+		platformOS = e.platform.OS
+	}
 	p, err := container.PrepareMounts(ctx, e.mm, e.cm, g, e.op.Meta.Cwd, e.op.Mounts, refs, func(m *pb.Mount, ref cache.ImmutableRef) (cache.MutableRef, error) {
 		desc := fmt.Sprintf("mount %s from exec %s", m.Dest, strings.Join(e.op.Meta.Args, " "))
 		return e.cm.New(ctx, ref, g, cache.WithDescription(desc))
-	})
+	}, platformOS)
 	defer func() {
 		if err != nil {
 			execInputs := make([]solver.Result, len(e.op.Mounts))

--- a/util/system/path.go
+++ b/util/system/path.go
@@ -86,11 +86,10 @@ func NormalizePath(parent, newPath, inputOS string, keepSlash bool) (string, err
 }
 
 func ToSlash(inputPath, inputOS string) string {
-	separator := "/"
-	if inputOS == "windows" {
-		separator = "\\"
+	if inputOS != "windows" {
+		return inputPath
 	}
-	return strings.Replace(inputPath, separator, "/", -1)
+	return strings.Replace(inputPath, "\\", "/", -1)
 }
 
 func FromSlash(inputPath, inputOS string) string {

--- a/util/system/path.go
+++ b/util/system/path.go
@@ -37,8 +37,8 @@ func NormalizePath(parent, newPath, inputOS string, keepSlash bool) (string, err
 		inputOS = "linux"
 	}
 
-	newPath = toSlash(newPath, inputOS)
-	parent = toSlash(parent, inputOS)
+	newPath = ToSlash(newPath, inputOS)
+	parent = ToSlash(parent, inputOS)
 	origPath := newPath
 
 	if parent == "" {
@@ -82,10 +82,10 @@ func NormalizePath(parent, newPath, inputOS string, keepSlash bool) (string, err
 		}
 	}
 
-	return toSlash(newPath, inputOS), nil
+	return ToSlash(newPath, inputOS), nil
 }
 
-func toSlash(inputPath, inputOS string) string {
+func ToSlash(inputPath, inputOS string) string {
 	separator := "/"
 	if inputOS == "windows" {
 		separator = "\\"
@@ -93,7 +93,7 @@ func toSlash(inputPath, inputOS string) string {
 	return strings.Replace(inputPath, separator, "/", -1)
 }
 
-func fromSlash(inputPath, inputOS string) string {
+func FromSlash(inputPath, inputOS string) string {
 	separator := "/"
 	if inputOS == "windows" {
 		separator = "\\"
@@ -119,7 +119,7 @@ func NormalizeWorkdir(current, wd string, inputOS string) (string, error) {
 
 	// Make sure we use the platform specific path separator. HCS does not like forward
 	// slashes in CWD.
-	return fromSlash(wd, inputOS), nil
+	return FromSlash(wd, inputOS), nil
 }
 
 // IsAbs returns a boolean value indicating whether or not the path
@@ -142,7 +142,7 @@ func IsAbs(pth, inputOS string) bool {
 	if err != nil {
 		return false
 	}
-	cleanedPath = toSlash(cleanedPath, inputOS)
+	cleanedPath = ToSlash(cleanedPath, inputOS)
 	// We stripped any potential drive letter and converted any backslashes to
 	// forward slashes. We can safely use path.IsAbs() for both Windows and Linux.
 	return path.IsAbs(cleanedPath)
@@ -189,14 +189,14 @@ func CheckSystemDriveAndRemoveDriveLetter(path string, inputOS string) (string, 
 	}
 
 	// UNC paths should error out
-	if len(path) >= 2 && toSlash(path[:2], inputOS) == "//" {
+	if len(path) >= 2 && ToSlash(path[:2], inputOS) == "//" {
 		return "", errors.Errorf("UNC paths are not supported")
 	}
 
 	parts := strings.SplitN(path, ":", 2)
 	// Path does not have a drive letter. Just return it.
 	if len(parts) < 2 {
-		return toSlash(filepath.Clean(path), inputOS), nil
+		return ToSlash(filepath.Clean(path), inputOS), nil
 	}
 
 	// We expect all paths to be in C:
@@ -221,5 +221,5 @@ func CheckSystemDriveAndRemoveDriveLetter(path string, inputOS string) (string, 
 	//
 	// We must return the second element of the split path, as is, without attempting to convert
 	// it to an absolute path. We have no knowledge of the CWD; that is treated elsewhere.
-	return toSlash(filepath.Clean(parts[1]), inputOS), nil
+	return ToSlash(filepath.Clean(parts[1]), inputOS), nil
 }


### PR DESCRIPTION
This change properly handles paths on different platforms. In short, this change checks the target platform we're building an image for and applies normalization steps to make sure the file paths are valid. This makes buildkit properly handle paths on both *nix systems and on Windows.

Depends on:

  * https://github.com/moby/buildkit/pull/3906
  * https://github.com/moby/buildkit/pull/3907

Replaces:

  * https://github.com/moby/buildkit/pull/3322 (see https://github.com/moby/buildkit/pull/3322#issuecomment-1560864125)

Note: This branch will fail to build until dependencies are merged. Leaving the old branch up, as it contains a longer discussion related to the changes in these 3 PRs.

Here is a test run with all 3 branches merged: https://github.com/gabriel-samfira/buildkit/actions/runs/5091195907

CC: @crazy-max @jedevc 