### PR TITLE
authprovider: fix a bug where registry-1.docker.io auth was always a cache miss

### DIFF
--- a/session/auth/authprovider/authprovider.go
+++ b/session/auth/authprovider/authprovider.go
@@ -29,8 +29,8 @@ import (
 )
 
 const defaultExpiration = 60
-const dockerIndexConfigfileKey = "https://index.docker.io/v1/"
-const dockerRegistryHost = "registry-1.docker.io"
+const dockerHubConfigfileKey = "https://index.docker.io/v1/"
+const dockerHubRegistryHost = "registry-1.docker.io"
 
 func NewDockerAuthProvider(cfg *configfile.ConfigFile) session.Attachable {
 	return &authProvider{
@@ -186,8 +186,8 @@ func (ap *authProvider) getAuthConfig(host string) (*types.AuthConfig, error) {
 	ap.mu.Lock()
 	defer ap.mu.Unlock()
 
-	if host == dockerRegistryHost {
-		host = dockerIndexConfigfileKey
+	if host == dockerHubRegistryHost {
+		host = dockerHubConfigfileKey
 	}
 
 	if _, exists := ap.authConfigCache[host]; !exists {

--- a/session/auth/authprovider/authprovider.go
+++ b/session/auth/authprovider/authprovider.go
@@ -29,6 +29,8 @@ import (
 )
 
 const defaultExpiration = 60
+const dockerIndexConfigfileKey = "https://index.docker.io/v1/"
+const dockerRegistryHost = "registry-1.docker.io"
 
 func NewDockerAuthProvider(cfg *configfile.ConfigFile) session.Attachable {
 	return &authProvider{
@@ -183,10 +185,12 @@ func (ap *authProvider) VerifyTokenAuthority(ctx context.Context, req *auth.Veri
 func (ap *authProvider) getAuthConfig(host string) (*types.AuthConfig, error) {
 	ap.mu.Lock()
 	defer ap.mu.Unlock()
+
+	if host == dockerRegistryHost {
+		host = dockerIndexConfigfileKey
+	}
+
 	if _, exists := ap.authConfigCache[host]; !exists {
-		if host == "registry-1.docker.io" {
-			host = "https://index.docker.io/v1/"
-		}
 		ac, err := ap.config.GetAuthConfig(host)
 		if err != nil {
 			return nil, err

--- a/session/auth/authprovider/authprovider_test.go
+++ b/session/auth/authprovider/authprovider_test.go
@@ -14,16 +14,16 @@ import (
 func TestFetchTokenCaching(t *testing.T) {
 	cfg := &configfile.ConfigFile{
 		AuthConfigs: map[string]types.AuthConfig{
-			dockerIndexConfigfileKey: {Username: "user", RegistryToken: "hunter2"},
+			dockerHubConfigfileKey: {Username: "user", RegistryToken: "hunter2"},
 		},
 	}
 	p := NewDockerAuthProvider(cfg).(*authProvider)
-	res, err := p.FetchToken(context.Background(), &auth.FetchTokenRequest{Host: dockerRegistryHost})
+	res, err := p.FetchToken(context.Background(), &auth.FetchTokenRequest{Host: dockerHubRegistryHost})
 	require.NoError(t, err)
 	assert.Equal(t, "hunter2", res.Token)
 
-	cfg.AuthConfigs[dockerIndexConfigfileKey] = types.AuthConfig{Username: "user", RegistryToken: "hunter3"}
-	res, err = p.FetchToken(context.Background(), &auth.FetchTokenRequest{Host: dockerRegistryHost})
+	cfg.AuthConfigs[dockerHubConfigfileKey] = types.AuthConfig{Username: "user", RegistryToken: "hunter3"}
+	res, err = p.FetchToken(context.Background(), &auth.FetchTokenRequest{Host: dockerHubRegistryHost})
 	require.NoError(t, err)
 
 	// Verify that we cached the result instead of returning hunter3.

--- a/session/auth/authprovider/authprovider_test.go
+++ b/session/auth/authprovider/authprovider_test.go
@@ -1,0 +1,31 @@
+package authprovider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/docker/cli/cli/config/configfile"
+	"github.com/docker/cli/cli/config/types"
+	"github.com/moby/buildkit/session/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchTokenCaching(t *testing.T) {
+	cfg := &configfile.ConfigFile{
+		AuthConfigs: map[string]types.AuthConfig{
+			dockerIndexConfigfileKey: {Username: "user", RegistryToken: "hunter2"},
+		},
+	}
+	p := NewDockerAuthProvider(cfg).(*authProvider)
+	res, err := p.FetchToken(context.Background(), &auth.FetchTokenRequest{Host: dockerRegistryHost})
+	require.NoError(t, err)
+	assert.Equal(t, "hunter2", res.Token)
+
+	cfg.AuthConfigs[dockerIndexConfigfileKey] = types.AuthConfig{Username: "user", RegistryToken: "hunter3"}
+	res, err = p.FetchToken(context.Background(), &auth.FetchTokenRequest{Host: dockerRegistryHost})
+	require.NoError(t, err)
+
+	// Verify that we cached the result instead of returning hunter3.
+	assert.Equal(t, "hunter2", res.Token)
+}


### PR DESCRIPTION
this looks like it was an accidental logic error during refactoring...but maybe there's some reason it's intended that i don't understand?