### PR TITLE
Ensure Provenance Material URIs for OCI sources are configured to use `pkg:oci` PURLs 

### DIFF
--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -34,6 +34,7 @@ import (
 	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/package-url/packageurl-go"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -235,7 +236,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 				if name == "" {
 					continue
 				}
-				pl, err := purl.RefToPURL(name, &p.Platform)
+				pl, err := purl.RefToPURL(packageurl.TypeDocker, name, &p.Platform)
 				if err != nil {
 					return nil, err
 				}

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -161,6 +161,7 @@ var allTests = integration.TestFuncs(
 	testClientFrontendProvenance,
 	testClientLLBProvenance,
 	testSecretSSHProvenance,
+	testOCILayoutProvenance,
 	testNilProvenance,
 	testSBOMScannerArgs,
 	testMultiPlatformWarnings,

--- a/solver/llbsolver/provenance.go
+++ b/solver/llbsolver/provenance.go
@@ -140,6 +140,7 @@ func (b *provenanceBridge) ResolveImageConfig(ctx context.Context, ref string, o
 		Ref:      ref,
 		Platform: opt.Platform,
 		Digest:   dgst,
+		Local:    opt.ResolverType == llb.ResolverTypeOCILayout,
 	})
 	return dgst, config, nil
 }
@@ -322,10 +323,11 @@ func captureProvenance(ctx context.Context, res solver.CachedResultWithProvenanc
 				if err != nil {
 					return errors.Wrapf(err, "failed to parse OCI digest %s", pin)
 				}
-				c.AddLocalImage(provenance.ImageSource{
+				c.AddImage(provenance.ImageSource{
 					Ref:      s.Reference.String(),
 					Platform: s.Platform,
 					Digest:   dgst,
+					Local:    true,
 				})
 			default:
 				return errors.Errorf("unknown source identifier %T", id)

--- a/solver/llbsolver/provenance/capture.go
+++ b/solver/llbsolver/provenance/capture.go
@@ -16,6 +16,7 @@ type ImageSource struct {
 	Ref      string
 	Platform *ocispecs.Platform
 	Digest   digest.Digest
+	Local    bool
 }
 
 type GitSource struct {
@@ -43,11 +44,10 @@ type SSH struct {
 }
 
 type Sources struct {
-	Images      []ImageSource
-	LocalImages []ImageSource
-	Git         []GitSource
-	HTTP        []HTTPSource
-	Local       []LocalSource
+	Images []ImageSource
+	Git    []GitSource
+	HTTP   []HTTPSource
+	Local  []LocalSource
 }
 
 type Capture struct {
@@ -66,9 +66,6 @@ func (c *Capture) Merge(c2 *Capture) error {
 	}
 	for _, i := range c2.Sources.Images {
 		c.AddImage(i)
-	}
-	for _, i := range c2.Sources.LocalImages {
-		c.AddLocalImage(i)
 	}
 	for _, l := range c2.Sources.Local {
 		c.AddLocal(l)
@@ -97,9 +94,6 @@ func (c *Capture) Merge(c2 *Capture) error {
 func (c *Capture) Sort() {
 	sort.Slice(c.Sources.Images, func(i, j int) bool {
 		return c.Sources.Images[i].Ref < c.Sources.Images[j].Ref
-	})
-	sort.Slice(c.Sources.LocalImages, func(i, j int) bool {
-		return c.Sources.LocalImages[i].Ref < c.Sources.LocalImages[j].Ref
 	})
 	sort.Slice(c.Sources.Local, func(i, j int) bool {
 		return c.Sources.Local[i].Name < c.Sources.Local[j].Name
@@ -151,7 +145,7 @@ func (c *Capture) OptimizeImageSources() error {
 
 func (c *Capture) AddImage(i ImageSource) {
 	for _, v := range c.Sources.Images {
-		if v.Ref == i.Ref {
+		if v.Ref == i.Ref && v.Local == i.Local {
 			if v.Platform == i.Platform {
 				return
 			}
@@ -163,22 +157,6 @@ func (c *Capture) AddImage(i ImageSource) {
 		}
 	}
 	c.Sources.Images = append(c.Sources.Images, i)
-}
-
-func (c *Capture) AddLocalImage(i ImageSource) {
-	for _, v := range c.Sources.LocalImages {
-		if v.Ref == i.Ref {
-			if v.Platform == i.Platform {
-				return
-			}
-			if v.Platform != nil && i.Platform != nil {
-				if v.Platform.Architecture == i.Platform.Architecture && v.Platform.OS == i.Platform.OS && v.Platform.Variant == i.Platform.Variant {
-					return
-				}
-			}
-		}
-	}
-	c.Sources.LocalImages = append(c.Sources.LocalImages, i)
 }
 
 func (c *Capture) AddLocal(l LocalSource) {

--- a/solver/llbsolver/provenance/predicate.go
+++ b/solver/llbsolver/provenance/predicate.go
@@ -60,7 +60,7 @@ func slsaMaterials(srcs Sources) ([]slsa.ProvenanceMaterial, error) {
 	out := make([]slsa.ProvenanceMaterial, 0, count)
 
 	for _, s := range srcs.Images {
-		uri, err := purl.RefToPURL(s.Ref, s.Platform)
+		uri, err := purl.RefToPURL(packageurl.TypeDocker, s.Ref, s.Platform)
 		if err != nil {
 			return nil, err
 		}

--- a/util/purl/image.go
+++ b/util/purl/image.go
@@ -14,7 +14,7 @@ import (
 // RefToPURL converts an image reference with optional platform constraint to a package URL.
 // Image references are defined in https://github.com/distribution/distribution/blob/v2.8.1/reference/reference.go#L1
 // Package URLs are defined in https://github.com/package-url/purl-spec
-func RefToPURL(ref string, platform *ocispecs.Platform) (string, error) {
+func RefToPURL(purlType string, ref string, platform *ocispecs.Platform) (string, error) {
 	named, err := reference.ParseNormalizedNamed(ref)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to parse ref %q", ref)
@@ -52,7 +52,7 @@ func RefToPURL(ref string, platform *ocispecs.Platform) (string, error) {
 		})
 	}
 
-	p := packageurl.NewPackageURL("docker", ns, name, version, qualifiers, "")
+	p := packageurl.NewPackageURL(purlType, ns, name, version, qualifiers, "")
 	return p.ToString(), nil
 }
 

--- a/util/purl/image_test.go
+++ b/util/purl/image_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/containerd/containerd/platforms"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	packageurl "github.com/package-url/packageurl-go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -74,7 +75,7 @@ func TestRefToPURL(t *testing.T) {
 	for _, tc := range tcases {
 		tc := tc
 		t.Run(tc.ref, func(t *testing.T) {
-			purl, err := RefToPURL(tc.ref, tc.platform)
+			purl, err := RefToPURL(packageurl.TypeDocker, tc.ref, tc.platform)
 			if tc.err {
 				require.Error(t, err)
 				return


### PR DESCRIPTION
Previously, OCI layout sources were being incorrectly recorded in the materials.

There were two main issues:
- The URI was the docker reference, not a PURL. [The line to do a PURL translation was being used as a no-op](https://github.com/moby/buildkit/blob/36917a9b5e943b48fa67cf173f086e69ca7a477f/solver/llbsolver/provenance/predicate.go#L104).
- The image was being duplicated in the materials list. This was because we were not distinguishing between remote and local images in calls to `ResolveImageConfig` (which can take a `ResolverType` parameter to read from local oci stores).

Now locally loaded images are more reasonably recorded in the materials. See the added test.