### PR TITLE
solver: lock before using actives

### DIFF
--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -533,6 +533,8 @@ func (wp *withProvenance) WalkProvenance(ctx context.Context, f func(ProvenanceP
 	if wp.j == nil {
 		return nil
 	}
+	wp.j.list.mu.RLock()
+	defer wp.j.list.mu.RUnlock()
 	m := map[digest.Digest]struct{}{}
 	return wp.j.walkProvenance(ctx, wp.e, f, m)
 }


### PR DESCRIPTION
This fixes:

    fatal error: concurrent map read and map write

```
goroutine 151083 [running]:
github.com/moby/buildkit/solver.(*Job).walkProvenance(0xc0005663c0, {0x1cf5008, 0xc00b1270e0}, {0x47?, {0x1cf7e60?, 0xc006e4a680?}}, 0xc00a1fc690, 0xc0200a7d28?)
        /src/solver/jobs.go:545 +0x105
github.com/moby/buildkit/solver.(*Job).walkProvenance(0xc0005663c0, {0x1cf5008, 0xc00b1270e0}, {0x47?, {0x1cf7e60?, 0xc006e4a880?}}, 0xc00a1fc690, 0x163d22c9738c10eb?)
        /src/solver/jobs.go:556 +0x273
github.com/moby/buildkit/solver.(*Job).walkProvenance(0xc0005663c0, {0x1cf5008, 0xc00b1270e0}, {0x47?, {0x1cf7e60?, 0xc006e4a900?}}, 0xc00a1fc690, 0x0?)
        /src/solver/jobs.go:556 +0x273
github.com/moby/buildkit/solver.(*Job).walkProvenance(0xc0005663c0, {0x1cf5008, 0xc00b1270e0}, {0x47?, {0x1cf7e60?, 0xc006e4aac0?}}, 0xc00a1fc690, 0x416190?)
        /src/solver/jobs.go:556 +0x273
github.com/moby/buildkit/solver.(*Job).walkProvenance(0xc0005663c0, {0x1cf5008, 0xc00b1270e0}, {0x47?, {0x1cf7e60?, 0xc006e4acc0?}}, 0xc00a1fc690, 0x80?)
        /src/solver/jobs.go:556 +0x273
github.com/moby/buildkit/solver.(*Job).walkProvenance(0xc0005663c0, {0x1cf5008, 0xc00b1270e0}, {0xc0200a7d60?, {0x1cf7e60?, 0xc006e4ad40?}}, 0xc00a1fc690, 0xc001754d98?)
        /src/solver/jobs.go:556 +0x273
github.com/moby/buildkit/solver.(*withProvenance).WalkProvenance(0xc0135f0cf0, {0x1cf5008, 0xc00b1270e0}, 0x18cf520?)
        /src/solver/jobs.go:537 +0xe5
github.com/moby/buildkit/solver/llbsolver.captureProvenance({0x1cf5008, 0xc00b1270e0}, {0x1cf9a30, 0xc0135f0cf0})
        /src/solver/llbsolver/provenance.go:266 +0xaf
github.com/moby/buildkit/solver/llbsolver.(*resultProxy).Result.func2({0x1cf5008, 0xc00b1270e0})
        /src/solver/llbsolver/bridge.go:347 +0x3bb
github.com/moby/buildkit/util/flightcontrol.(*call).run(0xc01fded440)
        /src/util/flightcontrol/flightcontrol.go:121 +0x5e
sync.(*Once).doSlow(0x1cf5008?, 0xc00d7cfea0?)
        /usr/local/go/src/sync/once.go:74 +0xc2
sync.(*Once).Do(0xc01a9fc790?, 0xc00152cae0?)
        /usr/local/go/src/sync/once.go:65 +0x1f
created by github.com/moby/buildkit/util/flightcontrol.(*call).wait
        /src/util/flightcontrol/flightcontrol.go:164 +0x44f

```