### PR TITLE
progressui: fix index printing on partial rows

### DIFF
--- a/util/progress/progressui/printer.go
+++ b/util/progress/progressui/printer.go
@@ -143,10 +143,13 @@ func (p *textMux) printVtx(t *trace, dgst digest.Digest) {
 	}
 
 	for i, l := range v.logs {
-		if i == 0 {
+		if i == 0 && v.logsOffset != 0 { // index has already been printed
 			l = l[v.logsOffset:]
+			fmt.Fprintf(p.w, "%s", l)
+		} else {
+			fmt.Fprintf(p.w, "#%d %s", v.index, []byte(l))
 		}
-		fmt.Fprintf(p.w, "#%d %s", v.index, []byte(l))
+
 		if i != len(v.logs)-1 || !v.logsPartial {
 			fmt.Fprintln(p.w, "")
 		}


### PR DESCRIPTION
fixes https://github.com/moby/buildkit/pull/3838#issuecomment-1581619566

@tianon 

@jedevc This is a client side fix, so should go to buildx.