### PR TITLE
handle missing provenance for non-evaluated result 

### DIFF
--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -163,6 +163,7 @@ var allTests = integration.TestFuncs(
 	testSecretSSHProvenance,
 	testOCILayoutProvenance,
 	testNilProvenance,
+	testDockerIgnoreMissingProvenance,
 	testSBOMScannerArgs,
 	testMultiPlatformWarnings,
 	testNilContextInSolveGateway,

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -163,6 +163,7 @@ var allTests = integration.TestFuncs(
 	testSecretSSHProvenance,
 	testOCILayoutProvenance,
 	testNilProvenance,
+	testDuplicatePlatformProvenance,
 	testDockerIgnoreMissingProvenance,
 	testSBOMScannerArgs,
 	testMultiPlatformWarnings,

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -749,9 +749,6 @@ func getRefProvenance(ref solver.ResultProxy, br *provenanceBridge) (*provenance
 	}
 	p := ref.Provenance()
 	if p == nil {
-		if br.req != nil {
-			return nil, errors.Errorf("missing provenance for %s", ref.ID())
-		}
 		return nil, nil
 	}
 


### PR DESCRIPTION
fixes #3928
fixes #3562
depends on #3860

If resultProxy has been created but the result has not been
evaluated then it shouldn't show missing provenance error
for that result.

This patch works together with the previous one that fixes
error reporting on provenance creation.

https://github.com/moby/buildkit/compare/master...tonistiigi:buildkit:fix-missing-provenance?expand=1#diff-2fc2e99eea0899fac8a14da1878d67aa8520bed09be4de598226d4d29450d6c8R279