### PR TITLE
remove uses of deprecated ResolverOptions.Client

### DIFF
--- a/client/llb/imagemetaresolver/resolver.go
+++ b/client/llb/imagemetaresolver/resolver.go
@@ -45,7 +45,6 @@ func New(with ...ImageMetaResolverOpt) llb.ImageMetaResolver {
 	headers.Set("User-Agent", version.UserAgent())
 	return &imageMetaResolver{
 		resolver: docker.NewResolver(docker.ResolverOptions{
-			Client:  http.DefaultClient,
 			Headers: headers,
 		}),
 		platform: opts.platform,

--- a/util/contentutil/refs.go
+++ b/util/contentutil/refs.go
@@ -20,7 +20,6 @@ func ProviderFromRef(ref string) (ocispecs.Descriptor, content.Provider, error) 
 	headers := http.Header{}
 	headers.Set("User-Agent", version.UserAgent())
 	remote := docker.NewResolver(docker.ResolverOptions{
-		Client:  http.DefaultClient,
 		Headers: headers,
 	})
 
@@ -40,7 +39,6 @@ func IngesterFromRef(ref string) (content.Ingester, error) {
 	headers := http.Header{}
 	headers.Set("User-Agent", version.UserAgent())
 	remote := docker.NewResolver(docker.ResolverOptions{
-		Client:  http.DefaultClient,
 		Headers: headers,
 	})
 


### PR DESCRIPTION
`NewResolver` calls `NewDockerAuthorizer` and `ConfigureDefaultRegistries`, both of which set the client if none is set;

https://github.com/containerd/containerd/blob/dd5e9f653813b3177c3b70ea03e20aaed397e1f9/remotes/docker/authorizer.go#L91-L99

```go
func NewDockerAuthorizer(opts ...AuthorizerOpt) Authorizer {
	var ao authorizerConfig
	for _, opt := range opts {
		opt(&ao)
	}

	if ao.client == nil {
		ao.client = http.DefaultClient
	}
	...
```

https://github.com/containerd/containerd/blob/dd5e9f653813b3177c3b70ea03e20aaed397e1f9/remotes/docker/registry.go#L156-L174

```go
func ConfigureDefaultRegistries(ropts ...RegistryOpt) RegistryHosts {
	var opts registryOpts
	for _, opt := range ropts {
		opt(&opts)
	}

	return func(host string) ([]RegistryHost, error) {
		config := RegistryHost{
			Client:       opts.client,
			Authorizer:   opts.authorizer,
			Host:         host,
			Scheme:       "https",
			Path:         "/v2",
			Capabilities: HostCapabilityPull | HostCapabilityResolve | HostCapabilityPush,
		}

		if config.Client == nil {
			config.Client = http.DefaultClient
		}
		...
```
