### PR TITLE
move flightcontrol to use generics

### DIFF
--- a/cache/blobs.go
+++ b/cache/blobs.go
@@ -22,7 +22,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var g flightcontrol.Group
+var g flightcontrol.Group[struct{}]
+var gFileList flightcontrol.Group[[]string]
 
 const containerdUncompressed = "containerd.io/uncompressed"
 
@@ -86,12 +87,12 @@ func computeBlobChain(ctx context.Context, sr *immutableRef, createIfNeeded bool
 
 	if _, ok := filter[sr.ID()]; ok {
 		eg.Go(func() error {
-			_, err := g.Do(ctx, fmt.Sprintf("%s-%t", sr.ID(), createIfNeeded), func(ctx context.Context) (interface{}, error) {
+			_, err := g.Do(ctx, fmt.Sprintf("%s-%t", sr.ID(), createIfNeeded), func(ctx context.Context) (struct{}, error) {
 				if sr.getBlob() != "" {
-					return nil, nil
+					return struct{}{}, nil
 				}
 				if !createIfNeeded {
-					return nil, errors.WithStack(ErrNoBlobs)
+					return struct{}{}, errors.WithStack(ErrNoBlobs)
 				}
 
 				compressorFunc, finalize := comp.Type.Compress(ctx, comp)
@@ -108,12 +109,12 @@ func computeBlobChain(ctx context.Context, sr *immutableRef, createIfNeeded bool
 				if lowerRef != nil {
 					m, err := lowerRef.Mount(ctx, true, s)
 					if err != nil {
-						return nil, err
+						return struct{}{}, err
 					}
 					var release func() error
 					lower, release, err = m.Mount()
 					if err != nil {
-						return nil, err
+						return struct{}{}, err
 					}
 					if release != nil {
 						defer release()
@@ -131,12 +132,12 @@ func computeBlobChain(ctx context.Context, sr *immutableRef, createIfNeeded bool
 				if upperRef != nil {
 					m, err := upperRef.Mount(ctx, true, s)
 					if err != nil {
-						return nil, err
+						return struct{}{}, err
 					}
 					var release func() error
 					upper, release, err = m.Mount()
 					if err != nil {
-						return nil, err
+						return struct{}{}, err
 					}
 					if release != nil {
 						defer release()
@@ -151,7 +152,7 @@ func computeBlobChain(ctx context.Context, sr *immutableRef, createIfNeeded bool
 				if forceOvlStr := os.Getenv("BUILDKIT_DEBUG_FORCE_OVERLAY_DIFF"); forceOvlStr != "" && sr.kind() != Diff {
 					enableOverlay, err = strconv.ParseBool(forceOvlStr)
 					if err != nil {
-						return nil, errors.Wrapf(err, "invalid boolean in BUILDKIT_DEBUG_FORCE_OVERLAY_DIFF")
+						return struct{}{}, errors.Wrapf(err, "invalid boolean in BUILDKIT_DEBUG_FORCE_OVERLAY_DIFF")
 					}
 					fallback = false // prohibit fallback on debug
 				} else if !isTypeWindows(sr) {
@@ -173,10 +174,10 @@ func computeBlobChain(ctx context.Context, sr *immutableRef, createIfNeeded bool
 					if !ok || err != nil {
 						if !fallback {
 							if !ok {
-								return nil, errors.Errorf("overlay mounts not detected (lower=%+v,upper=%+v)", lower, upper)
+								return struct{}{}, errors.Errorf("overlay mounts not detected (lower=%+v,upper=%+v)", lower, upper)
 							}
 							if err != nil {
-								return nil, errors.Wrapf(err, "failed to compute overlay diff")
+								return struct{}{}, errors.Wrapf(err, "failed to compute overlay diff")
 							}
 						}
 						if logWarnOnErr {
@@ -209,7 +210,7 @@ func computeBlobChain(ctx context.Context, sr *immutableRef, createIfNeeded bool
 						diff.WithCompressor(compressorFunc),
 					)
 					if err != nil {
-						return nil, err
+						return struct{}{}, err
 					}
 				}
 
@@ -219,7 +220,7 @@ func computeBlobChain(ctx context.Context, sr *immutableRef, createIfNeeded bool
 				if finalize != nil {
 					a, err := finalize(ctx, sr.cm.ContentStore)
 					if err != nil {
-						return nil, errors.Wrapf(err, "failed to finalize compression")
+						return struct{}{}, errors.Wrapf(err, "failed to finalize compression")
 					}
 					for k, v := range a {
 						desc.Annotations[k] = v
@@ -227,7 +228,7 @@ func computeBlobChain(ctx context.Context, sr *immutableRef, createIfNeeded bool
 				}
 				info, err := sr.cm.ContentStore.Info(ctx, desc.Digest)
 				if err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 
 				if diffID, ok := info.Labels[containerdUncompressed]; ok {
@@ -235,13 +236,13 @@ func computeBlobChain(ctx context.Context, sr *immutableRef, createIfNeeded bool
 				} else if mediaType == ocispecs.MediaTypeImageLayer {
 					desc.Annotations[containerdUncompressed] = desc.Digest.String()
 				} else {
-					return nil, errors.Errorf("unknown layer compression type")
+					return struct{}{}, errors.Errorf("unknown layer compression type")
 				}
 
 				if err := sr.setBlob(ctx, desc); err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
-				return nil, nil
+				return struct{}{}, nil
 			})
 			if err != nil {
 				return err
@@ -415,29 +416,29 @@ func isTypeWindows(sr *immutableRef) bool {
 
 // ensureCompression ensures the specified ref has the blob of the specified compression Type.
 func ensureCompression(ctx context.Context, ref *immutableRef, comp compression.Config, s session.Group) error {
-	_, err := g.Do(ctx, fmt.Sprintf("%s-%s", ref.ID(), comp.Type), func(ctx context.Context) (interface{}, error) {
+	_, err := g.Do(ctx, fmt.Sprintf("ensureComp-%s-%s", ref.ID(), comp.Type), func(ctx context.Context) (struct{}, error) {
 		desc, err := ref.ociDesc(ctx, ref.descHandlers, true)
 		if err != nil {
-			return nil, err
+			return struct{}{}, err
 		}
 
 		// Resolve converters
 		layerConvertFunc, err := getConverter(ctx, ref.cm.ContentStore, desc, comp)
 		if err != nil {
-			return nil, err
+			return struct{}{}, err
 		} else if layerConvertFunc == nil {
 			if isLazy, err := ref.isLazy(ctx); err != nil {
-				return nil, err
+				return struct{}{}, err
 			} else if isLazy {
 				// This ref can be used as the specified compressionType. Keep it lazy.
-				return nil, nil
+				return struct{}{}, nil
 			}
-			return nil, ref.linkBlob(ctx, desc)
+			return struct{}{}, ref.linkBlob(ctx, desc)
 		}
 
 		// First, lookup local content store
 		if _, err := ref.getBlobWithCompression(ctx, comp.Type); err == nil {
-			return nil, nil // found the compression variant. no need to convert.
+			return struct{}{}, nil // found the compression variant. no need to convert.
 		}
 
 		// Convert layer compression type
@@ -447,18 +448,18 @@ func ensureCompression(ctx context.Context, ref *immutableRef, comp compression.
 			dh:      ref.descHandlers[desc.Digest],
 			session: s,
 		}).Unlazy(ctx); err != nil {
-			return nil, err
+			return struct{}{}, err
 		}
 		newDesc, err := layerConvertFunc(ctx, ref.cm.ContentStore, desc)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to convert")
+			return struct{}{}, errors.Wrapf(err, "failed to convert")
 		}
 
 		// Start to track converted layer
 		if err := ref.linkBlob(ctx, *newDesc); err != nil {
-			return nil, errors.Wrapf(err, "failed to add compression blob")
+			return struct{}{}, errors.Wrapf(err, "failed to add compression blob")
 		}
-		return nil, nil
+		return struct{}{}, nil
 	})
 	return err
 }

--- a/cache/filelist.go
+++ b/cache/filelist.go
@@ -20,7 +20,7 @@ const keyFileList = "filelist"
 // are in the tar stream (AUFS whiteout format). If the reference does not have a
 // a blob associated with it, the list is empty.
 func (sr *immutableRef) FileList(ctx context.Context, s session.Group) ([]string, error) {
-	res, err := g.Do(ctx, fmt.Sprintf("filelist-%s", sr.ID()), func(ctx context.Context) (interface{}, error) {
+	return gFileList.Do(ctx, fmt.Sprintf("filelist-%s", sr.ID()), func(ctx context.Context) ([]string, error) {
 		dt, err := sr.GetExternal(keyFileList)
 		if err == nil && dt != nil {
 			var files []string
@@ -80,11 +80,4 @@ func (sr *immutableRef) FileList(ctx context.Context, s session.Group) ([]string
 		}
 		return files, nil
 	})
-	if err != nil {
-		return nil, err
-	}
-	if res == nil {
-		return nil, nil
-	}
-	return res.([]string), nil
 }

--- a/cache/manager.go
+++ b/cache/manager.go
@@ -93,7 +93,7 @@ type cacheManager struct {
 	mountPool sharableMountPool
 
 	muPrune sync.Mutex // make sure parallel prune is not allowed so there will not be inconsistent results
-	unlazyG flightcontrol.Group
+	unlazyG flightcontrol.Group[struct{}]
 }
 
 func NewManager(opt ManagerOpt) (Manager, error) {

--- a/cache/remote.go
+++ b/cache/remote.go
@@ -305,11 +305,11 @@ func (p lazyRefProvider) ReaderAt(ctx context.Context, desc ocispecs.Descriptor)
 }
 
 func (p lazyRefProvider) Unlazy(ctx context.Context) error {
-	_, err := p.ref.cm.unlazyG.Do(ctx, string(p.desc.Digest), func(ctx context.Context) (_ interface{}, rerr error) {
+	_, err := p.ref.cm.unlazyG.Do(ctx, string(p.desc.Digest), func(ctx context.Context) (_ struct{}, rerr error) {
 		if isLazy, err := p.ref.isLazy(ctx); err != nil {
-			return nil, err
+			return struct{}{}, err
 		} else if !isLazy {
-			return nil, nil
+			return struct{}{}, nil
 		}
 		defer func() {
 			if rerr == nil {
@@ -320,7 +320,7 @@ func (p lazyRefProvider) Unlazy(ctx context.Context) error {
 		if p.dh == nil {
 			// shouldn't happen, if you have a lazy immutable ref it already should be validated
 			// that descriptor handlers exist for it
-			return nil, errors.New("unexpected nil descriptor handler")
+			return struct{}{}, errors.New("unexpected nil descriptor handler")
 		}
 
 		if p.dh.Progress != nil {
@@ -337,7 +337,7 @@ func (p lazyRefProvider) Unlazy(ctx context.Context) error {
 			Manager:  p.ref.cm.ContentStore,
 		}, p.desc, p.dh.Ref, logs.LoggerFromContext(ctx))
 		if err != nil {
-			return nil, err
+			return struct{}{}, err
 		}
 
 		if imageRefs := p.ref.getImageRefs(); len(imageRefs) > 0 {
@@ -345,12 +345,12 @@ func (p lazyRefProvider) Unlazy(ctx context.Context) error {
 			imageRef := imageRefs[0]
 			if p.ref.GetDescription() == "" {
 				if err := p.ref.SetDescription("pulled from " + imageRef); err != nil {
-					return nil, err
+					return struct{}{}, err
 				}
 			}
 		}
 
-		return nil, nil
+		return struct{}{}, nil
 	})
 	return err
 }

--- a/client/llb/async.go
+++ b/client/llb/async.go
@@ -15,7 +15,7 @@ type asyncState struct {
 	target State
 	set    bool
 	err    error
-	g      flightcontrol.Group
+	g      flightcontrol.Group[State]
 }
 
 func (as *asyncState) Output() Output {
@@ -53,7 +53,7 @@ func (as *asyncState) ToInput(ctx context.Context, c *Constraints) (*pb.Input, e
 }
 
 func (as *asyncState) Do(ctx context.Context, c *Constraints) error {
-	_, err := as.g.Do(ctx, "", func(ctx context.Context) (interface{}, error) {
+	_, err := as.g.Do(ctx, "", func(ctx context.Context) (State, error) {
 		if as.set {
 			return as.target, as.err
 		}

--- a/executor/oci/hosts.go
+++ b/executor/oci/hosts.go
@@ -20,9 +20,9 @@ func GetHostsFile(ctx context.Context, stateDir string, extraHosts []executor.Ho
 		return makeHostsFile(stateDir, extraHosts, idmap, hostname)
 	}
 
-	_, err := g.Do(ctx, stateDir, func(ctx context.Context) (interface{}, error) {
+	_, err := g.Do(ctx, stateDir, func(ctx context.Context) (struct{}, error) {
 		_, _, err := makeHostsFile(stateDir, nil, idmap, hostname)
-		return nil, err
+		return struct{}{}, err
 	})
 	if err != nil {
 		return "", nil, err

--- a/frontend/dockerui/config.go
+++ b/frontend/dockerui/config.go
@@ -77,7 +77,7 @@ type Client struct {
 	client      client.Client
 	ignoreCache []string
 	bctx        *buildContext
-	g           flightcontrol.Group
+	g           flightcontrol.Group[*buildContext]
 	bopts       client.BuildOpts
 
 	dockerignore []byte
@@ -280,7 +280,7 @@ func (bc *Client) init() error {
 }
 
 func (bc *Client) buildContext(ctx context.Context) (*buildContext, error) {
-	bctx, err := bc.g.Do(ctx, "initcontext", func(ctx context.Context) (interface{}, error) {
+	return bc.g.Do(ctx, "initcontext", func(ctx context.Context) (*buildContext, error) {
 		if bc.bctx != nil {
 			return bc.bctx, nil
 		}
@@ -290,10 +290,6 @@ func (bc *Client) buildContext(ctx context.Context) (*buildContext, error) {
 		}
 		return bctx, err
 	})
-	if err != nil {
-		return nil, err
-	}
-	return bctx.(*buildContext), nil
 }
 
 func (bc *Client) ReadEntrypoint(ctx context.Context, lang string, opts ...llb.LocalOption) (*Source, error) {

--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -661,9 +661,11 @@ type execRes struct {
 }
 
 type sharedOp struct {
-	resolver ResolveOpFunc
-	st       *state
-	g        flightcontrol.Group
+	resolver  ResolveOpFunc
+	st        *state
+	gDigest   flightcontrol.Group[digest.Digest]
+	gCacheRes flightcontrol.Group[[]*CacheMap]
+	gExecRes  flightcontrol.Group[*execRes]
 
 	opOnce     sync.Once
 	op         Op
@@ -725,7 +727,7 @@ func (s *sharedOp) CalcSlowCache(ctx context.Context, index Index, p PreprocessF
 		err = errdefs.WrapVertex(err, s.st.origDigest)
 	}()
 	flightControlKey := fmt.Sprintf("slow-compute-%d", index)
-	key, err := s.g.Do(ctx, flightControlKey, func(ctx context.Context) (interface{}, error) {
+	key, err := s.gDigest.Do(ctx, flightControlKey, func(ctx context.Context) (digest.Digest, error) {
 		s.slowMu.Lock()
 		// TODO: add helpers for these stored values
 		if res, ok := s.slowCacheRes[index]; ok {
@@ -734,7 +736,7 @@ func (s *sharedOp) CalcSlowCache(ctx context.Context, index Index, p PreprocessF
 		}
 		if err := s.slowCacheErr[index]; err != nil {
 			s.slowMu.Unlock()
-			return nil, err
+			return "", err
 		}
 		s.slowMu.Unlock()
 
@@ -742,7 +744,7 @@ func (s *sharedOp) CalcSlowCache(ctx context.Context, index Index, p PreprocessF
 		if p != nil {
 			st := s.st.solver.getState(s.st.vtx.Inputs()[index])
 			if st == nil {
-				return nil, errors.Errorf("failed to get state for index %d on %v", index, s.st.vtx.Name())
+				return "", errors.Errorf("failed to get state for index %d on %v", index, s.st.vtx.Name())
 			}
 			ctx2 := progress.WithProgress(ctx, st.mpw)
 			if st.mspan.Span != nil {
@@ -793,7 +795,7 @@ func (s *sharedOp) CalcSlowCache(ctx context.Context, index Index, p PreprocessF
 		notifyCompleted(err, false)
 		return "", err
 	}
-	return key.(digest.Digest), nil
+	return key, nil
 }
 
 func (s *sharedOp) CacheMap(ctx context.Context, index int) (resp *cacheMapResp, err error) {
@@ -806,7 +808,7 @@ func (s *sharedOp) CacheMap(ctx context.Context, index int) (resp *cacheMapResp,
 		return nil, err
 	}
 	flightControlKey := fmt.Sprintf("cachemap-%d", index)
-	res, err := s.g.Do(ctx, flightControlKey, func(ctx context.Context) (ret interface{}, retErr error) {
+	res, err := s.gCacheRes.Do(ctx, flightControlKey, func(ctx context.Context) (ret []*CacheMap, retErr error) {
 		if s.cacheRes != nil && s.cacheDone || index < len(s.cacheRes) {
 			return s.cacheRes, nil
 		}
@@ -862,11 +864,11 @@ func (s *sharedOp) CacheMap(ctx context.Context, index int) (resp *cacheMapResp,
 		return nil, err
 	}
 
-	if len(res.([]*CacheMap)) <= index {
+	if len(res) <= index {
 		return s.CacheMap(ctx, index)
 	}
 
-	return &cacheMapResp{CacheMap: res.([]*CacheMap)[index], complete: s.cacheDone}, nil
+	return &cacheMapResp{CacheMap: res[index], complete: s.cacheDone}, nil
 }
 
 func (s *sharedOp) Exec(ctx context.Context, inputs []Result) (outputs []Result, exporters []ExportableCacheKey, err error) {
@@ -879,7 +881,7 @@ func (s *sharedOp) Exec(ctx context.Context, inputs []Result) (outputs []Result,
 		return nil, nil, err
 	}
 	flightControlKey := "exec"
-	res, err := s.g.Do(ctx, flightControlKey, func(ctx context.Context) (ret interface{}, retErr error) {
+	res, err := s.gExecRes.Do(ctx, flightControlKey, func(ctx context.Context) (ret *execRes, retErr error) {
 		if s.execDone {
 			if s.execErr != nil {
 				return nil, s.execErr
@@ -941,8 +943,7 @@ func (s *sharedOp) Exec(ctx context.Context, inputs []Result) (outputs []Result,
 	if res == nil || err != nil {
 		return nil, nil, err
 	}
-	r := res.(*execRes)
-	return unwrapShared(r.execRes), r.execExporters, nil
+	return unwrapShared(res.execRes), res.execExporters, nil
 }
 
 func (s *sharedOp) getOp() (Op, error) {

--- a/solver/llbsolver/bridge.go
+++ b/solver/llbsolver/bridge.go
@@ -155,7 +155,7 @@ type resultProxy struct {
 	id         string
 	b          *provenanceBridge
 	req        frontend.SolveRequest
-	g          flightcontrol.Group
+	g          flightcontrol.Group[solver.CachedResult]
 	mu         sync.Mutex
 	released   bool
 	v          solver.CachedResult
@@ -244,7 +244,7 @@ func (rp *resultProxy) Result(ctx context.Context) (res solver.CachedResult, err
 	defer func() {
 		err = rp.wrapError(err)
 	}()
-	r, err := rp.g.Do(ctx, "result", func(ctx context.Context) (interface{}, error) {
+	return rp.g.Do(ctx, "result", func(ctx context.Context) (solver.CachedResult, error) {
 		rp.mu.Lock()
 		if rp.released {
 			rp.mu.Unlock()
@@ -288,10 +288,6 @@ func (rp *resultProxy) Result(ctx context.Context) (res solver.CachedResult, err
 		rp.mu.Unlock()
 		return v, err
 	})
-	if r != nil {
-		return r.(solver.CachedResult), nil
-	}
-	return nil, err
 }
 
 func (b *llbBridge) ResolveImageConfig(ctx context.Context, ref string, opt llb.ResolveImageConfigOpt) (dgst digest.Digest, config []byte, err error) {

--- a/source/containerimage/pull.go
+++ b/source/containerimage/pull.go
@@ -60,9 +60,14 @@ type SourceOpt struct {
 	LeaseManager leases.Manager
 }
 
+type resolveImageResult struct {
+	dgst digest.Digest
+	dt   []byte
+}
+
 type Source struct {
 	SourceOpt
-	g flightcontrol.Group
+	g flightcontrol.Group[*resolveImageResult]
 }
 
 var _ source.Source = &Source{}
@@ -83,11 +88,6 @@ func (is *Source) ID() string {
 }
 
 func (is *Source) ResolveImageConfig(ctx context.Context, ref string, opt llb.ResolveImageConfigOpt, sm *session.Manager, g session.Group) (digest.Digest, []byte, error) {
-	type t struct {
-		dgst digest.Digest
-		dt   []byte
-	}
-	var typed *t
 	key := ref
 	if platform := opt.Platform; platform != nil {
 		key += platforms.Format(*platform)
@@ -110,18 +110,17 @@ func (is *Source) ResolveImageConfig(ctx context.Context, ref string, opt llb.Re
 		rslvr = getOCILayoutResolver(opt.Store, sm, g)
 	}
 	key += rm.String()
-	res, err := is.g.Do(ctx, key, func(ctx context.Context) (interface{}, error) {
+	res, err := is.g.Do(ctx, key, func(ctx context.Context) (*resolveImageResult, error) {
 		dgst, dt, err := imageutil.Config(ctx, ref, rslvr, is.ContentStore, is.LeaseManager, opt.Platform)
 		if err != nil {
 			return nil, err
 		}
-		return &t{dgst: dgst, dt: dt}, nil
+		return &resolveImageResult{dgst: dgst, dt: dt}, nil
 	})
 	if err != nil {
 		return "", nil, err
 	}
-	typed = res.(*t)
-	return typed.dgst, typed.dt, nil
+	return res.dgst, res.dt, nil
 }
 
 func (is *Source) Resolve(ctx context.Context, id source.Identifier, sm *session.Manager, vtx solver.Vertex) (source.SourceInstance, error) {
@@ -205,7 +204,7 @@ type puller struct {
 	ResolverType
 	store llb.ResolveImageConfigOptStore
 
-	g                flightcontrol.Group
+	g                flightcontrol.Group[struct{}]
 	cacheKeyErr      error
 	cacheKeyDone     bool
 	releaseTmpLeases func(context.Context) error
@@ -255,9 +254,9 @@ func (p *puller) CacheKey(ctx context.Context, g session.Group, index int) (cach
 	// be canceled before the progress output is complete
 	progressFactory := progress.FromContext(ctx)
 
-	_, err = p.g.Do(ctx, "", func(ctx context.Context) (_ interface{}, err error) {
+	_, err = p.g.Do(ctx, "", func(ctx context.Context) (_ struct{}, err error) {
 		if p.cacheKeyErr != nil || p.cacheKeyDone {
-			return nil, p.cacheKeyErr
+			return struct{}{}, p.cacheKeyErr
 		}
 		defer func() {
 			if !errdefs.IsCanceled(ctx, err) {
@@ -266,7 +265,7 @@ func (p *puller) CacheKey(ctx context.Context, g session.Group, index int) (cach
 		}()
 		ctx, done, err := leaseutil.WithLease(ctx, p.LeaseManager, leases.WithExpiration(5*time.Minute), leaseutil.MakeTemporary)
 		if err != nil {
-			return nil, err
+			return struct{}{}, err
 		}
 		p.releaseTmpLeases = done
 		defer imageutil.AddLease(done)
@@ -278,12 +277,12 @@ func (p *puller) CacheKey(ctx context.Context, g session.Group, index int) (cach
 
 		p.manifest, err = p.PullManifests(ctx, getResolver)
 		if err != nil {
-			return nil, err
+			return struct{}{}, err
 		}
 
 		if ll := p.layerLimit; ll != nil {
 			if *ll > len(p.manifest.Descriptors) {
-				return nil, errors.Errorf("layer limit %d is greater than the number of layers in the image %d", *ll, len(p.manifest.Descriptors))
+				return struct{}{}, errors.Errorf("layer limit %d is greater than the number of layers in the image %d", *ll, len(p.manifest.Descriptors))
 			}
 			p.manifest.Descriptors = p.manifest.Descriptors[:*ll]
 		}
@@ -320,21 +319,21 @@ func (p *puller) CacheKey(ctx context.Context, g session.Group, index int) (cach
 		desc := p.manifest.MainManifestDesc
 		k, err := mainManifestKey(ctx, desc, p.Platform, p.layerLimit)
 		if err != nil {
-			return nil, err
+			return struct{}{}, err
 		}
 		p.manifestKey = k.String()
 
 		dt, err := content.ReadBlob(ctx, p.ContentStore, p.manifest.ConfigDesc)
 		if err != nil {
-			return nil, err
+			return struct{}{}, err
 		}
 		ck, err := cacheKeyFromConfig(dt, p.layerLimit)
 		if err != nil {
-			return nil, err
+			return struct{}{}, err
 		}
 		p.configKey = ck.String()
 		p.cacheKeyDone = true
-		return nil, nil
+		return struct{}{}, nil
 	})
 	if err != nil {
 		return "", "", nil, false, err

--- a/util/pull/pull.go
+++ b/util/pull/pull.go
@@ -32,7 +32,7 @@ type Puller struct {
 	Src          reference.Spec
 	Platform     ocispecs.Platform
 
-	g           flightcontrol.Group
+	g           flightcontrol.Group[struct{}]
 	resolveErr  error
 	resolveDone bool
 	desc        ocispecs.Descriptor
@@ -54,9 +54,9 @@ type PulledManifests struct {
 }
 
 func (p *Puller) resolve(ctx context.Context, resolver remotes.Resolver) error {
-	_, err := p.g.Do(ctx, "", func(ctx context.Context) (_ interface{}, err error) {
+	_, err := p.g.Do(ctx, "", func(ctx context.Context) (_ struct{}, err error) {
 		if p.resolveErr != nil || p.resolveDone {
-			return nil, p.resolveErr
+			return struct{}{}, p.resolveErr
 		}
 		defer func() {
 			if !errors.Is(err, context.Canceled) {
@@ -68,12 +68,12 @@ func (p *Puller) resolve(ctx context.Context, resolver remotes.Resolver) error {
 		}
 		ref, desc, err := resolver.Resolve(ctx, p.Src.String())
 		if err != nil {
-			return nil, err
+			return struct{}{}, err
 		}
 		p.desc = desc
 		p.ref = ref
 		p.resolveDone = true
-		return nil, nil
+		return struct{}{}, nil
 	})
 	return err
 }

--- a/util/resolver/pool.go
+++ b/util/resolver/pool.go
@@ -131,7 +131,7 @@ type Resolver struct {
 // HostsFunc implements registry configuration of this Resolver
 func (r *Resolver) HostsFunc(host string) ([]docker.RegistryHost, error) {
 	return func(domain string) ([]docker.RegistryHost, error) {
-		v, err := r.handler.g.Do(context.TODO(), domain, func(ctx context.Context) (interface{}, error) {
+		v, err := r.handler.g.Do(context.TODO(), domain, func(ctx context.Context) ([]docker.RegistryHost, error) {
 			// long lock not needed because flightcontrol.Do
 			r.handler.muHosts.Lock()
 			v, ok := r.handler.hosts[domain]
@@ -151,13 +151,12 @@ func (r *Resolver) HostsFunc(host string) ([]docker.RegistryHost, error) {
 		if err != nil || v == nil {
 			return nil, err
 		}
-		vv := v.([]docker.RegistryHost)
-		if len(vv) == 0 {
+		if len(v) == 0 {
 			return nil, nil
 		}
 		// make a copy so authorizer is set on unique instance
-		res := make([]docker.RegistryHost, len(vv))
-		copy(res, vv)
+		res := make([]docker.RegistryHost, len(v))
+		copy(res, v)
 		auth := newDockerAuthorizer(res[0].Client, r.handler, r.sm, r.g)
 		for i := range res {
 			res[i].Authorizer = auth


### PR DESCRIPTION
This should be much safer than the `interface{}` casts.