### PR TITLE
Fix issue with digest merge (inconsistent graph state)

### DIFF
--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -343,11 +343,10 @@ func (jl *Solver) loadUnlocked(v, parent Vertex, j *Job, cache map[Vertex]Vertex
 	st, ok := jl.actives[dgstWithoutCache]
 
 	if ok {
-		v = &vertexWithCacheOptions{
-			Vertex: v,
-			dgst:   dgstWithoutCache,
-			inputs: inputs,
-		}
+		// When matching an existing active vertext by dgstWithoutCache, set v to the
+		// existing active vertex, as otherwise the original vertex will use an
+		// incorrect digest and can incorrectly delete it while it is still in use.
+		v = st.vtx
 	}
 
 	if !ok {

--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -342,6 +342,14 @@ func (jl *Solver) loadUnlocked(v, parent Vertex, j *Job, cache map[Vertex]Vertex
 	// if same vertex is already loaded without cache just use that
 	st, ok := jl.actives[dgstWithoutCache]
 
+	if ok {
+		v = &vertexWithCacheOptions{
+			Vertex: v,
+			dgst:   dgstWithoutCache,
+			inputs: inputs,
+		}
+	}
+
 	if !ok {
 		st, ok = jl.actives[dgst]
 


### PR DESCRIPTION
Related to #2303 

---

This PR attempts to fix the `panic: failed to get edge` error using the reproduction posted by @coryb here: https://github.com/moby/buildkit/issues/2303#issuecomment-1593711074.

It appears that it's possible for the digest merging logic in `loadUnlocked` to fail to accurately track which digest a vertex is using when it applies the `IgnoreCache` / `!IgnoreCache` merging logic. Specifically, a digest can get removed from the `actives` list too early if a vertex isn't tracking the correct digest.

It seems to be possible to get into this state with the following steps in order:

1. `loadUnlocked` is called with a vertex where `IgnoreCache` is false - this will add to actives using `v.Digest()`.
2. While that digest is active, another job calls `loadUnlocked` with the same vertex, but where `IgnoreCache` is true - this will add to the actives using the `%s-ignorecache` digest.
3. The job owning the first vertex is discarded and the digest is removed from `actives`.
4. A third job calls `loadUnlocked` with the same vertex - this will match against the `%s-ignorecache` digest in actives and not add any digests.
5. That third job will eventually call `solver.getEdge`, which tries to look up `actives[e.Vertex.Digest()]`, _however_ that digest will be the original one, not the `%s-ignorecache` digest. This errors with the `inconsistent graph state` error.

This PR attempts to solve the issue by returning a new `vertexWithCacheOptions` when matching the `dgstWithoutCache`, so that the vertex properly references that digest.

This appears to solve the reproduction from #2303.