### PR TITLE
tests: add worker cleanup method to interface

### DIFF
--- a/util/testutil/integration/containerd.go
+++ b/util/testutil/integration/containerd.go
@@ -230,6 +230,10 @@ disabled_plugins = ["cri"]
 	}, cl, nil
 }
 
+func (c *Containerd) Close() error {
+	return nil
+}
+
 func formatLogs(m map[string]*bytes.Buffer) string {
 	var ss []string
 	for k, b := range m {

--- a/util/testutil/integration/dockerd.go
+++ b/util/testutil/integration/dockerd.go
@@ -123,9 +123,6 @@ func (c Moby) New(ctx context.Context, cfg *BackendConfig) (b Backend, cl func()
 	if err != nil {
 		return nil, nil, err
 	}
-	deferF.append(func() error {
-		return os.RemoveAll(workDir)
-	})
 
 	d, err := dockerd.NewDaemon(workDir)
 	if err != nil {
@@ -220,6 +217,10 @@ func (c Moby) New(ctx context.Context, cfg *BackendConfig) (b Backend, cl func()
 		isDockerd:           true,
 		unsupportedFeatures: c.Unsupported,
 	}, cl, nil
+}
+
+func (c Moby) Close() error {
+	return nil
 }
 
 func waitForAPI(ctx context.Context, apiClient *client.Client, d time.Duration) error {

--- a/util/testutil/integration/oci.go
+++ b/util/testutil/integration/oci.go
@@ -84,3 +84,7 @@ func (s *OCI) New(ctx context.Context, cfg *BackendConfig) (Backend, func() erro
 		snapshotter: s.Snapshotter,
 	}, stop, nil
 }
+
+func (s *OCI) Close() error {
+	return nil
+}

--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -62,6 +62,7 @@ type BackendConfig struct {
 
 type Worker interface {
 	New(context.Context, *BackendConfig) (Backend, func() error, error)
+	Close() error
 	Name() string
 	Rootless() bool
 }
@@ -168,6 +169,11 @@ func Run(t *testing.T, testCases []Test, opt ...TestOpt) {
 		rng := rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec // using math/rand is fine in a test utility
 		list = []Worker{list[rng.Intn(len(list))]}
 	}
+	t.Cleanup(func() {
+		for _, br := range list {
+			_ = br.Close()
+		}
+	})
 
 	for _, br := range list {
 		for _, tc := range testCases {


### PR DESCRIPTION
This is so that we can allow workers to provision and manage resources that have a lifetime greater than a single sandbox.

Although none of our current workers currently implement this method, we want to implement this for buildx downstream to allow reusing docker daemons between docker-container workers.