### PR TITLE
compression: register docker zstd stream processor

### DIFF
--- a/util/compression/compression.go
+++ b/util/compression/compression.go
@@ -78,7 +78,6 @@ func (c Config) SetLevel(l int) Config {
 
 const (
 	mediaTypeDockerSchema2LayerZstd = images.MediaTypeDockerSchema2Layer + ".zstd"
-	mediaTypeImageLayerZstd         = ocispecs.MediaTypeImageLayer + "+zstd" // unreleased image-spec#790
 )
 
 var Default = Gzip
@@ -104,7 +103,7 @@ func fromMediaType(mediaType string) (Type, error) {
 		return Uncompressed, nil
 	case ocispecs.MediaTypeImageLayerGzip, ocispecs.MediaTypeImageLayerNonDistributableGzip: //nolint:staticcheck // ignore SA1019: Non-distributable layers are deprecated, and not recommended for future use.
 		return Gzip, nil
-	case mediaTypeImageLayerZstd, ocispecs.MediaTypeImageLayerNonDistributableZstd: //nolint:staticcheck // ignore SA1019: Non-distributable layers are deprecated, and not recommended for future use.
+	case ocispecs.MediaTypeImageLayerZstd, ocispecs.MediaTypeImageLayerNonDistributableZstd: //nolint:staticcheck // ignore SA1019: Non-distributable layers are deprecated, and not recommended for future use.
 		return Zstd, nil
 	default:
 		return nil, errors.Errorf("unsupported media type %s", mediaType)
@@ -193,7 +192,7 @@ var toDockerLayerType = map[string]string{
 	images.MediaTypeDockerSchema2LayerForeignGzip:    images.MediaTypeDockerSchema2LayerForeignGzip,
 	ocispecs.MediaTypeImageLayerNonDistributable:     images.MediaTypeDockerSchema2LayerForeign,     //nolint:staticcheck // ignore SA1019: Non-distributable layers are deprecated, and not recommended for future use.
 	ocispecs.MediaTypeImageLayerNonDistributableGzip: images.MediaTypeDockerSchema2LayerForeignGzip, //nolint:staticcheck // ignore SA1019: Non-distributable layers are deprecated, and not recommended for future use.
-	mediaTypeImageLayerZstd:                          mediaTypeDockerSchema2LayerZstd,
+	ocispecs.MediaTypeImageLayerZstd:                 mediaTypeDockerSchema2LayerZstd,
 	mediaTypeDockerSchema2LayerZstd:                  mediaTypeDockerSchema2LayerZstd,
 }
 
@@ -207,8 +206,8 @@ var toOCILayerType = map[string]string{
 	images.MediaTypeDockerSchema2LayerGzip:           ocispecs.MediaTypeImageLayerGzip,
 	images.MediaTypeDockerSchema2LayerForeign:        ocispecs.MediaTypeImageLayerNonDistributable,     //nolint:staticcheck // ignore SA1019: Non-distributable layers are deprecated, and not recommended for future use.
 	images.MediaTypeDockerSchema2LayerForeignGzip:    ocispecs.MediaTypeImageLayerNonDistributableGzip, //nolint:staticcheck // ignore SA1019: Non-distributable layers are deprecated, and not recommended for future use.
-	mediaTypeImageLayerZstd:                          mediaTypeImageLayerZstd,
-	mediaTypeDockerSchema2LayerZstd:                  mediaTypeImageLayerZstd,
+	ocispecs.MediaTypeImageLayerZstd:                 ocispecs.MediaTypeImageLayerZstd,
+	mediaTypeDockerSchema2LayerZstd:                  ocispecs.MediaTypeImageLayerZstd,
 }
 
 func convertLayerMediaType(ctx context.Context, mediaType string, oci bool) string {

--- a/util/compression/zstd.go
+++ b/util/compression/zstd.go
@@ -47,7 +47,7 @@ func (c zstdType) NeedsForceCompression() bool {
 }
 
 func (c zstdType) MediaType() string {
-	return mediaTypeImageLayerZstd
+	return ocispecs.MediaTypeImageLayerZstd
 }
 
 func (c zstdType) String() string {

--- a/util/winlayers/applier.go
+++ b/util/winlayers/applier.go
@@ -37,6 +37,12 @@ type winApplier struct {
 }
 
 func (s *winApplier) Apply(ctx context.Context, desc ocispecs.Descriptor, mounts []mount.Mount, opts ...diff.ApplyOpt) (d ocispecs.Descriptor, err error) {
+	// HACK:, containerd doesn't know about vnd.docker.image.rootfs.diff.tar.zstd, but that
+	// media type is compatible w/ the oci type, so just lie and say it's the oci type
+	if desc.MediaType == images.MediaTypeDockerSchema2Layer+".zstd" {
+		desc.MediaType = ocispecs.MediaTypeImageLayerZstd
+	}
+
 	if !hasWindowsLayerMode(ctx) {
 		return s.apply(ctx, desc, mounts, opts...)
 	}


### PR DESCRIPTION
Before this, buildkit was able to create and push layers of type `vnd.docker.image.rootfs.diff.tar.zstd` but if you tried to then pull and unpack those layers in buildkit, you'd get an error from containerd: `failed to get stream processor for application/vnd.docker.image.rootfs.diff.tar.zstd: no processor for media-type`

While that media type is not official, [support for exporting it was added to buildkit in the past anyways since it works in practice and is accepted by many registries](https://github.com/moby/buildkit/pull/2344#discussion_r703068189). It thus seems logical that buildkit should also support pulling and unpacking those layers too.

~~The fix works by just registering a custom stream processor w/ containerd.~~

There is support for registering stream processors in containerd, but
those only work when using the OCI worker since it relies on the apply
implementation being in the same process as buildkitd.

As a fallback, we instead just implement a hack that swaps out the
docker zstd media type for the oci one before sending it to containerd.
This works in practice because the two types are compatible.

---

Ran into problems with this [in the real world with dagger here](https://github.com/dagger/dagger/pull/5359)