### PR TITLE
shell: start shell from cmd, not entrypoint

### DIFF
--- a/hack/shell
+++ b/hack/shell
@@ -21,4 +21,4 @@ if [ -n "$MOUNT_BUILDKIT_SOURCE" ]; then
 fi
 
 set -x
-docker run $SSH $volumes -it --privileged -v /tmp --net=host --entrypoint ash -e BUILDKIT_REGISTRY_MIRROR_DIR=/root/.cache/registry --rm $(cat $iidfile)
+docker run $SSH $volumes -it --privileged -v /tmp --net=host -e BUILDKIT_REGISTRY_MIRROR_DIR=/root/.cache/registry --rm $(cat $iidfile) ash


### PR DESCRIPTION
Dev stage now requires custom entrypoint for containerd tests so setting entrypoint would override that and make the tests fail.