### PR TITLE
containerimage: keep layer labels for exported images

### DIFF
--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -376,9 +376,10 @@ func (ic *ImageWriter) commitDistributionManifest(ctx context.Context, opts *Ima
 		"containerd.io/gc.ref.content.0": configDigest.String(),
 	}
 
-	for _, desc := range remote.Descriptors {
+	for i, desc := range remote.Descriptors {
 		desc.Annotations = RemoveInternalLayerAnnotations(desc.Annotations, opts.OCITypes)
 		mfst.Layers = append(mfst.Layers, desc)
+		labels[fmt.Sprintf("containerd.io/gc.ref.content.%d", i+1)] = desc.Digest.String()
 	}
 
 	mfstJSON, err := json.MarshalIndent(mfst, "", "  ")


### PR DESCRIPTION
When moving blobs to history namespace also move the blobs the labels point to, but don't move actual image layers.

fixes #3893

@vvoland 

This was removed in https://github.com/moby/buildkit/commit/2be7e546e9502ded67f2c59be362dbed39fb9219 because I didn't want history objects to keep layers from getting deleted. But I didn't think about the case where image store using the same blob might still need the layers. Now when we move the blobs to separate history namespace, we can leave the layers in labels because if there is no image, then the main manifest will be released.