### PR TITLE
tests: add sandbox ID and Home methods

### DIFF
--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -45,14 +45,16 @@ type Backend interface {
 type Sandbox interface {
 	Backend
 
+	ID() string
+	Name() string
 	Context() context.Context
+	Home() string
 	Cmd(...string) *exec.Cmd
 	Logs() map[string]*bytes.Buffer
 	PrintLogs(*testing.T)
 	ClearLogs()
 	NewRegistry() (string, error)
 	Value(string) interface{} // chosen matrix value
-	Name() string
 }
 
 // BackendConfig is used to configure backends created by a worker.


### PR DESCRIPTION
follow-up https://github.com/docker/buildx/pull/1919/files#diff-12855e5a65cd0dc084324f4808d159cf2ebd514a77c6eee4dba653e1a4e94470R206

Jailing `HOME` and setting the env for each test in our sandbox can be useful to avoid concurrent access. The `ID()` method creates an unique ID for each test. Not used atm but can also be useful.