### PR TITLE
dockerfile: mod-outdated target to check modules updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,3 +92,7 @@ doctoc:
 .PHONY: docs
 docs:
 	$(BUILDX_CMD) bake docs
+
+.PHONY: mod-outdated
+mod-outdated:
+	$(BUILDX_CMD) bake mod-outdated

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -167,3 +167,11 @@ target "docs" {
   target = "update"
   output = ["./docs"]
 }
+
+target "mod-outdated" {
+  inherits = ["_common"]
+  dockerfile = "./hack/dockerfiles/vendor.Dockerfile"
+  target = "outdated"
+  no-cache-filter = ["outdated"]
+  output = ["type=cacheonly"]
+}


### PR DESCRIPTION
same as https://github.com/docker/buildx/pull/758

```shell
$ make mod-outdated
...
#12 145.6 +------------------------------------------------------------------------------+--------------------------------------+------------------------------------+--------+------------------+
#12 145.6 |                                    MODULE                                    |               VERSION                |            NEW VERSION             | DIRECT | VALID TIMESTAMPS |
#12 145.6 +------------------------------------------------------------------------------+--------------------------------------+------------------------------------+--------+------------------+
#12 145.6 | github.com/Azure/azure-sdk-for-go/sdk/azidentity                             | v1.1.0                               | v1.3.0                             | true   | true             |
#12 145.6 | github.com/Azure/azure-sdk-for-go/sdk/storage/azblob                         | v0.4.1                               | v1.0.0                             | true   | true             |
#12 145.6 | github.com/Masterminds/semver/v3                                             | v3.1.0                               | v3.2.1                             | true   | true             |
#12 145.6 | github.com/aws/aws-sdk-go-v2/config                                          | v1.18.16                             | v1.18.27                           | true   | true             |
#12 145.6 | github.com/aws/aws-sdk-go-v2/credentials                                     | v1.13.16                             | v1.13.26                           | true   | true             |
#12 145.6 | github.com/aws/aws-sdk-go-v2/feature/s3/manager                              | v1.11.56                             | v1.11.71                           | true   | true             |
#12 145.6 | github.com/aws/aws-sdk-go-v2/service/s3                                      | v1.30.6                              | v1.36.0                            | true   | true             |
#12 145.6 | github.com/containerd/fuse-overlayfs-snapshotter                             | v1.0.2                               | v1.0.6                             | true   | true             |
#12 145.6 | github.com/containerd/nydus-snapshotter                                      | v0.8.2                               | v0.11.3                            | true   | false            |
#12 145.6 | github.com/grpc-ecosystem/go-grpc-middleware                                 | v1.3.0                               | v1.4.0                             | true   | true             |
#12 145.6 | github.com/hashicorp/golang-lru                                              | v0.5.4                               | v1.0.1                             | true   | true             |
#12 145.6 | github.com/in-toto/in-toto-golang                                            | v0.5.0                               | v0.9.0                             | true   | true             |
#12 145.6 | github.com/klauspost/compress                                                | v1.16.3                              | v1.16.6                            | true   | true             |
#12 145.6 | github.com/opencontainers/runtime-spec                                       | v1.1.0-rc.2                          | v1.1.0-rc.3                        | true   | true             |
#12 145.6 | github.com/package-url/packageurl-go                                         | v0.1.1-0.20220428063043-89078438f170 | v0.1.1                             | true   | true             |
#12 145.6 | github.com/pkg/profile                                                       | v1.5.0                               | v1.7.0                             | true   | true             |
#12 145.6 | github.com/prometheus/procfs                                                 | v0.9.0                               | v0.11.0                            | true   | true             |
#12 145.6 | github.com/serialx/hashring                                                  | v0.0.0-20190422032157-8b2912629002   | v0.0.0-20200727003509-22c0c7ab6b1b | true   | true             |
#12 145.6 | github.com/sirupsen/logrus                                                   | v1.9.0                               | v1.9.3                             | true   | true             |
#12 145.6 | github.com/spdx/tools-golang                                                 | v0.5.1                               | v0.5.2                             | true   | true             |
#12 145.6 | github.com/stretchr/testify                                                  | v1.8.3                               | v1.8.4                             | true   | true             |
#12 145.6 | github.com/tonistiigi/fsutil                                                 | v0.0.0-20230407161946-9e7a6df48576   | v0.0.0-20230629203738-36ef4d8c0dbb | true   | true             |
#12 145.6 | github.com/urfave/cli                                                        | v1.22.12                             | v1.22.14                           | true   | true             |
#12 145.6 | go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc  | v0.40.0                              | v0.42.0                            | true   | true             |
#12 145.6 | go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace | v0.40.0                              | v0.42.0                            | true   | true             |
#12 145.6 | go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp                | v0.40.0                              | v0.42.0                            | true   | true             |
#12 145.6 | go.opentelemetry.io/otel                                                     | v1.14.0                              | v1.16.0                            | true   | true             |
#12 145.6 | go.opentelemetry.io/otel/exporters/jaeger                                    | v1.14.0                              | v1.16.0                            | true   | true             |
#12 145.6 | go.opentelemetry.io/otel/exporters/otlp/otlptrace                            | v1.14.0                              | v1.16.0                            | true   | true             |
#12 145.6 | go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc              | v1.14.0                              | v1.16.0                            | true   | true             |
#12 145.6 | go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp              | v1.14.0                              | v1.16.0                            | true   | true             |
#12 145.6 | go.opentelemetry.io/otel/sdk                                                 | v1.14.0                              | v1.16.0                            | true   | true             |
#12 145.6 | go.opentelemetry.io/otel/trace                                               | v1.14.0                              | v1.16.0                            | true   | true             |
#12 145.6 | go.opentelemetry.io/proto/otlp                                               | v0.19.0                              | v0.20.0                            | true   | true             |
#12 145.6 | golang.org/x/crypto                                                          | v0.2.0                               | v0.10.0                            | true   | true             |
#12 145.6 | golang.org/x/net                                                             | v0.8.0                               | v0.11.0                            | true   | true             |
#12 145.6 | golang.org/x/sync                                                            | v0.1.0                               | v0.3.0                             | true   | true             |
#12 145.6 | golang.org/x/sys                                                             | v0.7.0                               | v0.9.0                             | true   | true             |
#12 145.6 | google.golang.org/genproto                                                   | v0.0.0-20230306155012-7f2fa6fef1f4   | v0.0.0-20230629202037-9506855d4529 | true   | true             |
#12 145.6 | google.golang.org/grpc                                                       | v1.53.0                              | v1.56.1                            | true   | true             |
#12 145.6 | google.golang.org/protobuf                                                   | v1.30.0                              | v1.31.0                            | true   | true             |
#12 145.6 | kernel.org/pub/linux/libs/security/libcap/cap                                | v1.2.67                              | v1.2.69                            | true   | true             |
#12 145.6 +------------------------------------------------------------------------------+--------------------------------------+------------------------------------+--------+------------------+
#12 DONE 145.6s
```