### PR TITLE
dockerfile: graduate `ADD <git ref>` and `ADD --checksum=<checksum>` from labs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,6 @@ run:
 
   build-tags:
     - dfrunsecurity
-    - dfaddgit
     - dfaddchecksum
 
 linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,6 @@ run:
 
   build-tags:
     - dfrunsecurity
-    - dfaddchecksum
 
 linters:
   enable:

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -1082,9 +1082,6 @@ func dispatchCopy(d *dispatchState, cfg copyConfig) error {
 			if !cfg.isAddCommand {
 				return errors.New("source can't be a git ref for COPY")
 			}
-			if !addGitEnabled {
-				return errors.New("instruction ADD <git ref> requires the labs channel")
-			}
 			// TODO: print a warning (not an error) if gitRef.UnencryptedTCP is true
 			commit := gitRef.Commit
 			if gitRef.SubDir != "" {

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -1055,9 +1055,6 @@ func dispatchCopy(d *dispatchState, cfg copyConfig) error {
 		if !cfg.isAddCommand {
 			return errors.New("checksum can't be specified for COPY")
 		}
-		if !addChecksumEnabled {
-			return errors.New("instruction 'ADD --checksum=<CHECKSUM>' requires the labs channel")
-		}
 		if len(cfg.params.SourcePaths) != 1 {
 			return errors.New("checksum can't be specified for multiple sources")
 		}

--- a/frontend/dockerfile/dockerfile2llb/convert_addchecksum.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_addchecksum.go
@@ -1,6 +1,0 @@
-//go:build dfaddchecksum
-// +build dfaddchecksum
-
-package dockerfile2llb
-
-const addChecksumEnabled = true

--- a/frontend/dockerfile/dockerfile2llb/convert_addgit.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_addgit.go
@@ -1,6 +1,0 @@
-//go:build dfaddgit
-// +build dfaddgit
-
-package dockerfile2llb
-
-const addGitEnabled = true

--- a/frontend/dockerfile/dockerfile2llb/convert_noaddchecksum.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_noaddchecksum.go
@@ -1,6 +1,0 @@
-//go:build !dfaddchecksum
-// +build !dfaddchecksum
-
-package dockerfile2llb
-
-const addChecksumEnabled = false

--- a/frontend/dockerfile/dockerfile2llb/convert_noaddgit.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_noaddgit.go
@@ -1,6 +1,0 @@
-//go:build !dfaddgit
-// +build !dfaddgit
-
-package dockerfile2llb
-
-const addGitEnabled = false

--- a/frontend/dockerfile/dockerfile_addchecksum_test.go
+++ b/frontend/dockerfile/dockerfile_addchecksum_test.go
@@ -1,6 +1,3 @@
-//go:build dfaddchecksum
-// +build dfaddchecksum
-
 package dockerfile
 
 import (

--- a/frontend/dockerfile/dockerfile_addgit_test.go
+++ b/frontend/dockerfile/dockerfile_addgit_test.go
@@ -1,6 +1,3 @@
-//go:build dfaddgit
-// +build dfaddgit
-
 package dockerfile
 
 import (

--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -1298,6 +1298,7 @@ guide – Leverage build cache](https://docs.docker.com/develop/develop-images/d
 > **Note**
 >
 > Not yet available in stable syntax, use [`docker/dockerfile:1-labs`](#syntax) version (`1.5-labs` or newer).
+> Planned to be included in `docker/dockerfile:1.6`.
 
 The checksum of a remote file can be verified with the `--checksum` flag:
 

--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -1312,6 +1312,7 @@ The `--checksum` flag only supports HTTP sources currently.
 > **Note**
 >
 > Not yet available in stable syntax, use [`docker/dockerfile:1-labs`](#syntax) version (`1.5-labs` or newer).
+> Planned to be included in `docker/dockerfile:1.6`.
 
 This form allows adding a git repository to an image directly, without using the `git` command inside the image:
 ```

--- a/frontend/dockerfile/release/labs/tags
+++ b/frontend/dockerfile/release/labs/tags
@@ -1,1 +1,1 @@
-dfrunsecurity dfaddgit dfaddchecksum
+dfrunsecurity dfaddchecksum

--- a/frontend/dockerfile/release/labs/tags
+++ b/frontend/dockerfile/release/labs/tags
@@ -1,1 +1,1 @@
-dfrunsecurity dfaddchecksum
+dfrunsecurity


### PR DESCRIPTION
Graduate the following syntaxes added in `dockerfile:1.5-labs`:
- #2799 
- #3093 
