### PR TITLE
overlay: set whiteout timestamps to 1970-01-01 (not to SOURCE_DATE_EPOCH)

### DIFF
--- a/util/overlay/overlay_linux.go
+++ b/util/overlay/overlay_linux.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/containerd/containerd/archive"
 	"github.com/containerd/containerd/mount"
@@ -126,7 +127,8 @@ func WriteUpperdir(ctx context.Context, w io.Writer, upperdir string, lower []mo
 	}
 	return mount.WithTempMount(ctx, lower, func(lowerRoot string) error {
 		return mount.WithTempMount(ctx, upperView, func(upperViewRoot string) error {
-			cw := archive.NewChangeWriter(&cancellableWriter{ctx, w}, upperViewRoot)
+			// WithWhiteoutTime(0) will no longer need to be specified when https://github.com/containerd/containerd/pull/8764 gets merged
+			cw := archive.NewChangeWriter(&cancellableWriter{ctx, w}, upperViewRoot, archive.WithWhiteoutTime(time.Unix(0, 0).UTC()))
 			if err := Changes(ctx, cw.HandleChange, upperdir, upperViewRoot, lowerRoot); err != nil {
 				if err2 := cw.Close(); err2 != nil {
 					return errors.Wrapf(err, "failed to record upperdir changes (close error: %v)", err2)


### PR DESCRIPTION
Even with this commit, the `COPY --from=0 / /` workaround mentioned in `docs/build-repro.md` is *still* needed for most Dockerfiles. (See PR #3980 for the reason)

Partially closes #3168 (for overlayfs and stargz)

Relevant: 
- containerd/containerd#8764