### PR TITLE
Fix containerimage multi-platform unpack

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2108,6 +2108,7 @@ func testBuildExportScratch(t *testing.T, sb integration.Sandbox) {
 				Attrs: map[string]string{
 					"name":        target,
 					"push":        "true",
+					"unpack":      "true",
 					"compression": "uncompressed",
 				},
 			},

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -258,7 +258,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 				}
 				tagDone(nil)
 
-				if src.Ref != nil && e.unpack {
+				if e.unpack {
 					if err := e.unpackImage(ctx, img, src, session.NewGroup(sessionID)); err != nil {
 						return nil, nil, err
 					}
@@ -366,16 +366,16 @@ func (e *imageExporterInstance) unpackImage(ctx context.Context, img images.Imag
 		return err
 	}
 
-	topLayerRef := src.Ref
-	if len(src.Refs) > 0 {
-		if r, ok := src.Refs[defaultPlatform()]; ok {
-			topLayerRef = r
-		} else {
-			return errors.Errorf("no reference for default platform %s", defaultPlatform())
-		}
+	ref, ok := src.FindRef(defaultPlatform())
+	if !ok {
+		return errors.Errorf("no reference for default platform %s", defaultPlatform())
+	}
+	if ref == nil {
+		// ref has no layers, so nothing to unpack
+		return nil
 	}
 
-	remotes, err := topLayerRef.GetRemotes(ctx, true, e.opts.RefCfg, false, s)
+	remotes, err := ref.GetRemotes(ctx, true, e.opts.RefCfg, false, s)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
:hammer_and_wrench: Fix https://github.com/docker/buildx/pull/1813#issuecomment-1564619467 (see point 2 in https://github.com/moby/buildkit/issues/3891#issuecomment-1614641533)
:arrow_up: Fixes up https://github.com/moby/buildkit/pull/3251

cc @vvoland @rumpl

In https://github.com/moby/buildkit/pull/3251, we added an overly restrictive check for `unpackImage` which, while preventing it from unpacking images with no layers, also prevented it from unpacking multi-platform images.

This PR pushes the check further down into `unpackImage`, so that we can still unpack multi-platform images.

(Maybe also worth a cherry-pick back to the v0.11 branch?)