### PR TITLE
exporter: unlazy references in parallel

### DIFF
--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -27,6 +27,7 @@ import (
 	"github.com/moby/buildkit/util/progress"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 )
 
@@ -212,21 +213,29 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 	for _, ref := range src.Refs {
 		refs = append(refs, ref)
 	}
+	eg, egCtx := errgroup.WithContext(ctx)
 	mprovider := contentutil.NewMultiProvider(e.opt.ImageWriter.ContentStore())
 	for _, ref := range refs {
-		remotes, err := ref.GetRemotes(ctx, false, e.opts.RefCfg, false, session.NewGroup(sessionID))
-		if err != nil {
-			return nil, nil, err
-		}
-		remote := remotes[0]
-		if unlazier, ok := remote.Provider.(cache.Unlazier); ok {
-			if err := unlazier.Unlazy(ctx); err != nil {
-				return nil, nil, err
+		ref := ref
+		eg.Go(func() error {
+			remotes, err := ref.GetRemotes(egCtx, false, e.opts.RefCfg, false, session.NewGroup(sessionID))
+			if err != nil {
+				return err
 			}
-		}
-		for _, desc := range remote.Descriptors {
-			mprovider.Add(desc.Digest, remote.Provider)
-		}
+			remote := remotes[0]
+			if unlazier, ok := remote.Provider.(cache.Unlazier); ok {
+				if err := unlazier.Unlazy(egCtx); err != nil {
+					return err
+				}
+			}
+			for _, desc := range remote.Descriptors {
+				mprovider.Add(desc.Digest, remote.Provider)
+			}
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, nil, err
 	}
 
 	if e.tar {


### PR DESCRIPTION
From slack:
> **jed**: for the unlazying stuff we do in the exporter - should we perform this in parallel over all the refs? I notice when it's pulling images, we actually pull two different architectures in sequence, instead of in parallel.
It's a pretty quick fix with an errgroup, but maybe it's intentional as is?
>
> **tonistiigi**: No reason this could be intentional

We can unlazy all the references in parallel, since these perform network operations, we should attempt to pull them all together, instead of one-after-each-other.

~~We can also use the `EachRef` helper to simplify the iteration over all the references - I think this now would include the attestation references? I don't think this affects anything since attestation references weren't lazily computed, and it just makes sure that they are included in the multi-provider.~~