### PR TITLE
dockerfile: heredoc should use 0644 permissions

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -1159,7 +1159,7 @@ func dispatchCopy(d *dispatchState, cfg copyConfig) error {
 		data := src.Data
 		f := src.Path
 		st := llb.Scratch().File(
-			llb.Mkfile(f, 0664, []byte(data)),
+			llb.Mkfile(f, 0644, []byte(data)),
 			dockerui.WithInternalName("preparing inline document"),
 		)
 


### PR DESCRIPTION
:hammer_and_wrench: Fixes https://github.com/moby/buildkit/issues/3889

Previously, it appears the permissions were 0664, which seems to be a typo of the above - there's no real reason for these permissions to be higher, so we can bring them down to be consistent with everywhere else we create files.