### PR TITLE
dockerfile: arg for controlling go build flags

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -156,6 +156,9 @@ TESTPKGS=./client TESTFLAGS="--run //worker=containerd -v" ./hack/test integrati
 
 # run a specific dockerfile test only on labs channel
 DOCKERFILE_RELEASES=labs TESTFLAGS="--run /TestRunGlobalNetwork/worker=oci$/ -v" ./hack/test dockerfile
+
+# enabling go data race detector
+GO_RACE_ENABLED=1 ./hack/test integration
 ```
 
 Set `TEST_KEEP_CACHE=1` for the test framework to keep external dependant images in a docker volume

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -158,7 +158,7 @@ TESTPKGS=./client TESTFLAGS="--run //worker=containerd -v" ./hack/test integrati
 DOCKERFILE_RELEASES=labs TESTFLAGS="--run /TestRunGlobalNetwork/worker=oci$/ -v" ./hack/test dockerfile
 
 # enabling go data race detector
-GO_RACE_ENABLED=1 ./hack/test integration
+CGO_ENABLED=1 BUILDFLAGS="-race" ./hack/test integration
 ```
 
 Set `TEST_KEEP_CACHE=1` for the test framework to keep external dependant images in a docker volume

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -158,7 +158,7 @@ TESTPKGS=./client TESTFLAGS="--run //worker=containerd -v" ./hack/test integrati
 DOCKERFILE_RELEASES=labs TESTFLAGS="--run /TestRunGlobalNetwork/worker=oci$/ -v" ./hack/test dockerfile
 
 # enabling go data race detector
-CGO_ENABLED=1 BUILDFLAGS="-race" ./hack/test integration
+CGO_ENABLED=1 GOBUILDFLAGS="-race" ./hack/test integration
 ```
 
 Set `TEST_KEEP_CACHE=1` for the test framework to keep external dependant images in a docker volume

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ ARG MINIO_VERSION=RELEASE.2022-05-03T20-36-08Z
 ARG MINIO_MC_VERSION=RELEASE.2022-05-04T06-07-55Z
 ARG AZURITE_VERSION=3.18.0
 ARG GOTESTSUM_VERSION=v1.9.0
+ARG GO_RACE_ENABLED=0
 
 ARG GO_VERSION=1.20
 ARG ALPINE_VERSION=3.18
@@ -94,11 +95,12 @@ FROM buildkit-base AS buildkitd
 # BUILDKITD_TAGS defines additional Go build tags for compiling buildkitd
 ARG BUILDKITD_TAGS
 ARG TARGETPLATFORM
+ARG GO_RACE_ENABLED
 RUN --mount=target=. --mount=target=/root/.cache,type=cache \
   --mount=target=/go/pkg/mod,type=cache \
   --mount=source=/tmp/.ldflags,target=/tmp/.ldflags,from=buildkit-version \
-  CGO_ENABLED=0 xx-go build -ldflags "$(cat /tmp/.ldflags) -extldflags '-static'" -tags "osusergo netgo static_build seccomp ${BUILDKITD_TAGS}" -o /usr/bin/buildkitd ./cmd/buildkitd && \
-  xx-verify --static /usr/bin/buildkitd
+  CGO_ENABLED="$GO_RACE_ENABLED" xx-go build $(if [ "$GO_RACE_ENABLED" != "0" ]; then echo -race; fi) -ldflags "$(cat /tmp/.ldflags) -extldflags '-static'" -tags "osusergo netgo static_build seccomp ${BUILDKITD_TAGS}" -o /usr/bin/buildkitd ./cmd/buildkitd && \
+  if [ "$GO_RACE_ENABLED" = "0" ]; then xx-verify --static /usr/bin/buildkitd; fi
 
 FROM scratch AS binaries-linux
 COPY --link --from=runc /usr/bin/runc /buildkit-runc

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,13 +94,13 @@ FROM buildkit-base AS buildkitd
 # BUILDKITD_TAGS defines additional Go build tags for compiling buildkitd
 ARG BUILDKITD_TAGS
 ARG TARGETPLATFORM
-ARG BUILDFLAGS
+ARG GOBUILDFLAGS
 ARG VERIFYFLAGS="--static"
 ARG CGO_ENABLED=0
 RUN --mount=target=. --mount=target=/root/.cache,type=cache \
   --mount=target=/go/pkg/mod,type=cache \
   --mount=source=/tmp/.ldflags,target=/tmp/.ldflags,from=buildkit-version \
-  xx-go build ${BUILDFLAGS} -ldflags "$(cat /tmp/.ldflags) -extldflags '-static'" -tags "osusergo netgo static_build seccomp ${BUILDKITD_TAGS}" -o /usr/bin/buildkitd ./cmd/buildkitd && \
+  xx-go build ${GOBUILDFLAGS} -ldflags "$(cat /tmp/.ldflags) -extldflags '-static'" -tags "osusergo netgo static_build seccomp ${BUILDKITD_TAGS}" -o /usr/bin/buildkitd ./cmd/buildkitd && \
   xx-verify ${VERIFYFLAGS} /usr/bin/buildkitd
 
 FROM scratch AS binaries-linux

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ clean:
 test:
 	./hack/test integration gateway dockerfile
 
+.PHONY: test-race
+test-race:
+	GO_RACE_ENABLED=1 ./hack/test integration gateway dockerfile
+
 .PHONY: lint
 lint:
 	$(BUILDX_CMD) bake lint

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ test:
 
 .PHONY: test-race
 test-race:
-	CGO_ENABLED=1 BUILDFLAGS="-race" ./hack/test integration gateway dockerfile
+	CGO_ENABLED=1 GOBUILDFLAGS="-race" ./hack/test integration gateway dockerfile
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ test:
 
 .PHONY: test-race
 test-race:
-	GO_RACE_ENABLED=1 ./hack/test integration gateway dockerfile
+	CGO_ENABLED=1 BUILDFLAGS="-race" ./hack/test integration gateway dockerfile
 
 .PHONY: lint
 lint:

--- a/hack/test
+++ b/hack/test
@@ -65,7 +65,7 @@ gotestArgs="-mod=vendor -coverprofile=/testreports/coverage-report$TEST_REPORT_S
 
 if [[ "$GOBUILDFLAGS" == *"-race"* ]]; then
   if [ "$CGO_ENABLED" != "1" ]; then
-    echo>&2 "go race detector requires CGO_ENABLED=1"
+    echo >&2 "go race detector requires CGO_ENABLED=1"
     exit 1
   fi
   # force buildkitd to halt on detected race conditions, which will cause the tests to fail

--- a/hack/test
+++ b/hack/test
@@ -13,7 +13,9 @@ set -eu -o pipefail
 : ${TEST_DOCKERD_BINARY=$(which dockerd)}
 : ${TEST_REPORT_SUFFIX=}
 : ${TEST_KEEP_CACHE=}
-: ${GO_RACE_ENABLED=}
+: ${BUILDFLAGS=}
+: ${VERIFYFLAGS=}
+: ${CGO_ENABLED=}
 : ${DOCKERFILE_RELEASES=}
 : ${BUILDKIT_WORKER_RANDOM=}
 : ${BUILDKITD_TAGS=}
@@ -61,12 +63,24 @@ testReportsVol="-v $testReportsDir:/testreports"
 gotestsumArgs="--format=standard-verbose --jsonfile=/testreports/go-test-report$TEST_REPORT_SUFFIX.json --junitfile=/testreports/junit-report$TEST_REPORT_SUFFIX.xml"
 gotestArgs="-mod=vendor -coverprofile=/testreports/coverage-report$TEST_REPORT_SUFFIX.txt -covermode=atomic"
 
+if [[ "$BUILDFLAGS" == *"-race"* ]]; then
+  if [ "$CGO_ENABLED" != "1" ]; then
+    echo>&2 "go race detector requires CGO_ENABLED=1"
+    exit 1
+  fi
+  # force buildkitd to halt on detected race conditions, which will cause the tests to fail
+  export GORACE="halt_on_error=1"
+  export VERIFYFLAGS="" # prevent -static verification
+fi
+
 buildxCmd build $cacheFromFlags \
   --build-arg BUILDKITD_TAGS \
   --build-arg HTTP_PROXY \
   --build-arg HTTPS_PROXY \
   --build-arg NO_PROXY \
-  --build-arg GO_RACE_ENABLED \
+  --build-arg BUILDFLAGS \
+  --build-arg VERIFYFLAGS \
+  --build-arg CGO_ENABLED \
   --target "integration-tests" \
   --output "type=docker,name=$iid" \
   $currentcontext
@@ -74,11 +88,6 @@ buildxCmd build $cacheFromFlags \
 cacheVolume="buildkit-test-cache"
 if ! docker container inspect "$cacheVolume" >/dev/null 2>/dev/null; then
   docker create -v /root/.cache -v /root/.cache/registry -v /go/pkg/mod --name "$cacheVolume" alpine
-fi
-
-if [ "$GO_RACE_ENABLED" = "1" ]; then
-  # force buildkitd to half on detected race conditions, which will cause the tests to fail
-  export GORACE="halt_on_error=1"
 fi
 
 if [ "$TEST_INTEGRATION" == 1 ]; then

--- a/hack/test
+++ b/hack/test
@@ -13,6 +13,7 @@ set -eu -o pipefail
 : ${TEST_DOCKERD_BINARY=$(which dockerd)}
 : ${TEST_REPORT_SUFFIX=}
 : ${TEST_KEEP_CACHE=}
+: ${GO_RACE_ENABLED=}
 : ${DOCKERFILE_RELEASES=}
 : ${BUILDKIT_WORKER_RANDOM=}
 : ${BUILDKITD_TAGS=}
@@ -65,6 +66,7 @@ buildxCmd build $cacheFromFlags \
   --build-arg HTTP_PROXY \
   --build-arg HTTPS_PROXY \
   --build-arg NO_PROXY \
+  --build-arg GO_RACE_ENABLED \
   --target "integration-tests" \
   --output "type=docker,name=$iid" \
   $currentcontext
@@ -74,8 +76,13 @@ if ! docker container inspect "$cacheVolume" >/dev/null 2>/dev/null; then
   docker create -v /root/.cache -v /root/.cache/registry -v /go/pkg/mod --name "$cacheVolume" alpine
 fi
 
+if [ "$GO_RACE_ENABLED" = "1" ]; then
+  # force buildkitd to half on detected race conditions, which will cause the tests to fail
+  export GORACE="halt_on_error=1"
+fi
+
 if [ "$TEST_INTEGRATION" == 1 ]; then
-  cid=$(docker create --rm -v /tmp $testReportsVol --volumes-from=$cacheVolume -e GITHUB_REF -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e TEST_DOCKERD -e SKIP_INTEGRATION_TESTS -e BUILDKIT_TEST_ENABLE_FEATURES -e GOTESTSUM_FORMAT ${BUILDKIT_INTEGRATION_SNAPSHOTTER:+"-eBUILDKIT_INTEGRATION_SNAPSHOTTER"} -e BUILDKIT_REGISTRY_MIRROR_DIR=/root/.cache/registry -e BUILDKIT_INTEGRATION_DOCKERD_FLAGS --privileged $iid gotestsum $gotestsumArgs --packages="${TESTPKGS:-./...}" -- $gotestArgs ${TESTFLAGS:--v})
+  cid=$(docker create --rm -v /tmp $testReportsVol --volumes-from=$cacheVolume -e GITHUB_REF -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e TEST_DOCKERD -e SKIP_INTEGRATION_TESTS -e BUILDKIT_TEST_ENABLE_FEATURES -e GOTESTSUM_FORMAT ${BUILDKIT_INTEGRATION_SNAPSHOTTER:+"-eBUILDKIT_INTEGRATION_SNAPSHOTTER"} -e BUILDKIT_REGISTRY_MIRROR_DIR=/root/.cache/registry -e BUILDKIT_INTEGRATION_DOCKERD_FLAGS -e GORACE --privileged $iid gotestsum $gotestsumArgs --packages="${TESTPKGS:-./...}" -- $gotestArgs ${TESTFLAGS:--v})
   if [ "$TEST_DOCKERD" = "1" ]; then
     docker cp "$TEST_DOCKERD_BINARY" $cid:/usr/bin/dockerd
   fi
@@ -115,7 +122,7 @@ if [ "$TEST_DOCKERFILE" == 1 ]; then
 
     if [ -s $tarout ]; then
       if [ "$release" = "mainline" ] || [ "$release" = "labs" ] || [ -n "$DOCKERFILE_RELEASES_CUSTOM" ] || [ "$GITHUB_ACTIONS" = "true" ]; then
-        cid=$(docker create -v /tmp $testReportsVol --rm --privileged --volumes-from=$cacheVolume -e GITHUB_REF -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e TEST_DOCKERD -e BUILDKIT_TEST_ENABLE_FEATURES -e GOTESTSUM_FORMAT -e BUILDKIT_REGISTRY_MIRROR_DIR=/root/.cache/registry -e BUILDKIT_WORKER_RANDOM -e BUILDKIT_INTEGRATION_DOCKERD_FLAGS -e FRONTEND_GATEWAY_ONLY=local:/$release.tar -e EXTERNAL_DF_FRONTEND=/dockerfile-frontend $iid gotestsum $gotestsumArgs --packages=./frontend/dockerfile -- $gotestArgs --count=1 -tags "$buildtags" ${TESTFLAGS:--v})
+        cid=$(docker create -v /tmp $testReportsVol --rm --privileged --volumes-from=$cacheVolume -e GITHUB_REF -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e TEST_DOCKERD -e BUILDKIT_TEST_ENABLE_FEATURES -e GOTESTSUM_FORMAT -e BUILDKIT_REGISTRY_MIRROR_DIR=/root/.cache/registry -e BUILDKIT_WORKER_RANDOM -e BUILDKIT_INTEGRATION_DOCKERD_FLAGS -e FRONTEND_GATEWAY_ONLY=local:/$release.tar -e EXTERNAL_DF_FRONTEND=/dockerfile-frontend -e GORACE $iid gotestsum $gotestsumArgs --packages=./frontend/dockerfile -- $gotestArgs --count=1 -tags "$buildtags" ${TESTFLAGS:--v})
         docker cp $tarout $cid:/$release.tar
         if [ "$TEST_DOCKERD" = "1" ]; then
           docker cp "$TEST_DOCKERD_BINARY" $cid:/usr/bin/dockerd

--- a/hack/test
+++ b/hack/test
@@ -13,7 +13,7 @@ set -eu -o pipefail
 : ${TEST_DOCKERD_BINARY=$(which dockerd)}
 : ${TEST_REPORT_SUFFIX=}
 : ${TEST_KEEP_CACHE=}
-: ${BUILDFLAGS=}
+: ${GOBUILDFLAGS=}
 : ${VERIFYFLAGS=}
 : ${CGO_ENABLED=}
 : ${DOCKERFILE_RELEASES=}
@@ -63,7 +63,7 @@ testReportsVol="-v $testReportsDir:/testreports"
 gotestsumArgs="--format=standard-verbose --jsonfile=/testreports/go-test-report$TEST_REPORT_SUFFIX.json --junitfile=/testreports/junit-report$TEST_REPORT_SUFFIX.xml"
 gotestArgs="-mod=vendor -coverprofile=/testreports/coverage-report$TEST_REPORT_SUFFIX.txt -covermode=atomic"
 
-if [[ "$BUILDFLAGS" == *"-race"* ]]; then
+if [[ "$GOBUILDFLAGS" == *"-race"* ]]; then
   if [ "$CGO_ENABLED" != "1" ]; then
     echo>&2 "go race detector requires CGO_ENABLED=1"
     exit 1
@@ -78,7 +78,7 @@ buildxCmd build $cacheFromFlags \
   --build-arg HTTP_PROXY \
   --build-arg HTTPS_PROXY \
   --build-arg NO_PROXY \
-  --build-arg BUILDFLAGS \
+  --build-arg GOBUILDFLAGS \
   --build-arg VERIFYFLAGS \
   --build-arg CGO_ENABLED \
   --target "integration-tests" \


### PR DESCRIPTION
This introduces new `BUILDFLAGS`, `VERIFYFLAGS`, and `CGO_ENABLED` build-args,
which can be used to change how buildkitd is compiled.

This, for example, can be used to enable the go data race detector during
integration testing:

    CGO_ENABLED=1 BUILDFLAGS="-race" TESTFLAGS="-v -test.run=TestClientGatewayIntegration/TestClientGatewaySolve" TESTPKGS=./client ./hack/test integration

This additionally introduces a new `make test-race` target, which
simplifies how to run all tests with the race detector.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>