### PR TITLE
fix: 30s is too short for monolightc upload

### DIFF
--- a/util/resolver/resolver.go
+++ b/util/resolver/resolver.go
@@ -206,7 +206,7 @@ func newDefaultTransport() *http.Transport {
 		MaxIdleConnsPerHost:   4,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 5 * time.Second,
-		ResponseHeaderTimeout: 30 * time.Second,
+		ResponseHeaderTimeout: 600 * time.Second,
 		TLSNextProto:          make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
 	}
 }


### PR DESCRIPTION
buildkitd use `Monolithic Upload` to push a single layer file to registry, when the layer file is too large, the http put request for `monolightc upload` will timeout (get `net/http: timeout awaiting response headers` error).  set the default `ResponseHeaderTimeout` from 30s to
 600s solved my problem.

<img width="837" alt="image" src="https://github.com/moby/buildkit/assets/16211479/fc657a05-ee4d-4a65-ac76-8be1821e0a96">


> Monolithic Upload
A monolithic upload is simply a chunked upload with a single chunk and may be favored by clients that would like to avoided the complexity of chunking. To carry out a “monolithic” upload, one can simply put the entire content blob to the provided URL:
>```
>PUT /v2/<name>/blobs/uploads/<uuid>?digest=<digest>
>Content-Length: <size of layer>
>Content-Type: application/octet-stream
>
><Layer Binary Data>
>```
https://docs.docker.com/registry/spec/api/

when set  `ResponseHeaderTimeout` to 600s, the image can be pushed successfully 

<img width="820" alt="image" src="https://github.com/moby/buildkit/assets/16211479/d8e72617-b81c-4ad0-bd55-126055f71c9f">
