### PR TITLE
oci: make sure cgroupns is enabled if supported

### DIFF
--- a/executor/oci/spec.go
+++ b/executor/oci/spec.go
@@ -137,6 +137,12 @@ func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mou
 		return nil, nil, err
 	}
 
+	if cgroupNamespaceSupported() {
+		s.Linux.Namespaces = append(s.Linux.Namespaces, specs.LinuxNamespace{
+			Type: specs.CgroupNamespace,
+		})
+	}
+
 	if len(meta.Ulimit) == 0 {
 		// reset open files limit
 		s.Process.Rlimits = nil

--- a/executor/oci/spec_windows.go
+++ b/executor/oci/spec_windows.go
@@ -63,3 +63,7 @@ func getTracingSocketMount(socket string) specs.Mount {
 func getTracingSocket() string {
 	return fmt.Sprintf("npipe://%s", filepath.ToSlash(tracingSocketPath))
 }
+
+func cgroupNamespaceSupported() bool {
+	return false
+}


### PR DESCRIPTION
This is not set by default by containerd default spec but needed for the cgroup mounts to be scoped to the ID by runc.

closes #3985