### PR TITLE
Revert "specify a `ResponseHeaderTimeout` value"

### DIFF
--- a/util/resolver/resolver.go
+++ b/util/resolver/resolver.go
@@ -206,7 +206,6 @@ func newDefaultTransport() *http.Transport {
 		MaxIdleConnsPerHost:   4,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 5 * time.Second,
-		ResponseHeaderTimeout: 30 * time.Second,
 		TLSNextProto:          make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
 	}
 }


### PR DESCRIPTION
Ref #3995

This reverts commit 73ef9e2e2c2199903cf3f21f1c8de026bdf629b5.

Setting timeout here may cause timeouts on uploading big layer blob.

@alexcb 