### PR TITLE
tests: refactor integration test package

### DIFF
--- a/client/build_test.go
+++ b/client/build_test.go
@@ -26,6 +26,7 @@ import (
 	utilsystem "github.com/moby/buildkit/util/system"
 	"github.com/moby/buildkit/util/testutil/echoserver"
 	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/moby/buildkit/util/testutil/workers"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
@@ -1839,7 +1840,7 @@ func testClientGatewayExecFileActionError(t *testing.T, sb integration.Sandbox) 
 // testClientGatewayContainerSecurityMode ensures that the correct security mode
 // is propagated to the gateway container
 func testClientGatewayContainerSecurityMode(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureSecurityMode)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureSecurityMode)
 	requiresLinux(t)
 
 	ctx := sb.Context()
@@ -2215,7 +2216,7 @@ func testClientGatewayContainerSignal(t *testing.T, sb integration.Sandbox) {
 }
 
 func testClientGatewayNilResult(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureMergeDiff)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureMergeDiff)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -2250,7 +2251,7 @@ func testClientGatewayNilResult(t *testing.T, sb integration.Sandbox) {
 }
 
 func testClientGatewayEmptyImageExec(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureDirectPush)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()

--- a/client/client_nydus_test.go
+++ b/client/client_nydus_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/util/compression"
 	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/moby/buildkit/util/testutil/workers"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
@@ -28,7 +29,7 @@ func TestNydusIntegration(t *testing.T) {
 }
 
 func testBuildExportNydusWithHybrid(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureDirectPush)
 	requiresLinux(t)
 
 	cdAddress := sb.ContainerdAddress()

--- a/client/mergediff_test.go
+++ b/client/mergediff_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containerd/continuity/fs/fstest"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/moby/buildkit/util/testutil/workers"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -1187,14 +1188,14 @@ func (tc verifyContents) Name() string {
 }
 
 func (tc verifyContents) Run(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureMergeDiff)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureMergeDiff)
 	if tc.skipOnRootless && sb.Rootless() {
 		t.Skip("rootless")
 	}
 
 	switch tc.name {
 	case "TestDiffUpperScratch":
-		if integration.IsTestDockerdMoby(sb) {
+		if workers.IsTestDockerdMoby(sb) {
 			t.Skip("failed to handle changes: lstat ... no such file or directory: https://github.com/moby/buildkit/pull/2726#issuecomment-1070978499")
 		}
 	}
@@ -1225,7 +1226,7 @@ func (tc verifyContents) Run(t *testing.T, sb integration.Sandbox) {
 	var exportInlineCacheOpts []CacheOptionsEntry
 	var importRegistryCacheOpts []CacheOptionsEntry
 	var exportRegistryCacheOpts []CacheOptionsEntry
-	if !integration.IsTestDockerd() {
+	if !workers.IsTestDockerd() {
 		importInlineCacheOpts = []CacheOptionsEntry{{
 			Type: "registry",
 			Attrs: map[string]string{
@@ -1252,7 +1253,7 @@ func (tc verifyContents) Run(t *testing.T, sb integration.Sandbox) {
 	resetState(t, c, sb)
 	requireContents(ctx, t, c, sb, tc.state, nil, exportInlineCacheOpts, imageTarget, tc.contents(sb))
 
-	if integration.IsTestDockerd() {
+	if workers.IsTestDockerd() {
 		return
 	}
 

--- a/cmd/buildctl/build_test.go
+++ b/cmd/buildctl/build_test.go
@@ -23,11 +23,10 @@ import (
 )
 
 func testBuildWithLocalFiles(t *testing.T, sb integration.Sandbox) {
-	dir, err := tmpdir(
+	dir := integration.Tmpdir(
 		t,
 		fstest.CreateFile("foo", []byte("bar"), 0600),
 	)
-	require.NoError(t, err)
 
 	st := llb.Image("busybox").
 		Run(llb.Shlex("sh -c 'echo -n bar > foo2'")).
@@ -184,12 +183,4 @@ func marshal(ctx context.Context, st llb.State) (io.Reader, error) {
 		return nil, err
 	}
 	return bytes.NewBuffer(dt), nil
-}
-
-func tmpdir(t *testing.T, appliers ...fstest.Applier) (string, error) {
-	tmpdir := t.TempDir()
-	if err := fstest.Apply(appliers...).Apply(tmpdir); err != nil {
-		return "", err
-	}
-	return tmpdir, nil
 }

--- a/cmd/buildctl/buildctl_test.go
+++ b/cmd/buildctl/buildctl_test.go
@@ -7,12 +7,13 @@ import (
 	"testing"
 
 	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/moby/buildkit/util/testutil/workers"
 	"github.com/stretchr/testify/require"
 )
 
 func init() {
-	integration.InitOCIWorker()
-	integration.InitContainerdWorker()
+	workers.InitOCIWorker()
+	workers.InitContainerdWorker()
 }
 
 func TestCLIIntegration(t *testing.T) {

--- a/frontend/dockerfile/dockerfile_heredoc_test.go
+++ b/frontend/dockerfile/dockerfile_heredoc_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/frontend/dockerui"
 	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/moby/buildkit/util/testutil/workers"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -592,7 +593,7 @@ COPY --from=build /dest /
 }
 
 func testOnBuildHeredoc(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureDirectPush)
 	f := getFrontend(t, sb)
 
 	registry, err := sb.NewRegistry()

--- a/frontend/dockerfile/dockerfile_outline_test.go
+++ b/frontend/dockerfile/dockerfile_outline_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/moby/buildkit/frontend/subrequests"
 	"github.com/moby/buildkit/frontend/subrequests/outline"
 	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/moby/buildkit/util/testutil/workers"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -24,7 +25,7 @@ var outlineTests = integration.TestFuncs(
 )
 
 func testOutlineArgs(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureFrontendOutline)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureFrontendOutline)
 	f := getFrontend(t, sb)
 	if _, ok := f.(*clientFrontend); !ok {
 		t.Skip("only test with client frontend")
@@ -137,7 +138,7 @@ FROM second
 }
 
 func testOutlineSecrets(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureFrontendOutline)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureFrontendOutline)
 	f := getFrontend(t, sb)
 	if _, ok := f.(*clientFrontend); !ok {
 		t.Skip("only test with client frontend")
@@ -236,7 +237,7 @@ FROM second
 }
 
 func testOutlineDescribeDefinition(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureFrontendOutline)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureFrontendOutline)
 	f := getFrontend(t, sb)
 	if _, ok := f.(*clientFrontend); !ok {
 		t.Skip("only test with client frontend")

--- a/frontend/dockerfile/dockerfile_provenance_test.go
+++ b/frontend/dockerfile/dockerfile_provenance_test.go
@@ -29,13 +29,14 @@ import (
 	"github.com/moby/buildkit/util/contentutil"
 	"github.com/moby/buildkit/util/testutil"
 	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/moby/buildkit/util/testutil/workers"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
 func testProvenanceAttestation(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush, integration.FeatureProvenance)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureDirectPush, workers.FeatureProvenance)
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())
@@ -225,7 +226,7 @@ RUN echo "ok" > /foo
 }
 
 func testGitProvenanceAttestation(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush, integration.FeatureProvenance)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureDirectPush, workers.FeatureProvenance)
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())
@@ -372,7 +373,7 @@ COPY myapp.Dockerfile /
 }
 
 func testMultiPlatformProvenance(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush, integration.FeatureMultiPlatform, integration.FeatureProvenance)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureDirectPush, workers.FeatureMultiPlatform, workers.FeatureProvenance)
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())
@@ -487,7 +488,7 @@ RUN echo "ok-$TARGETARCH" > /foo
 }
 
 func testClientFrontendProvenance(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush, integration.FeatureProvenance)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureDirectPush, workers.FeatureProvenance)
 	// Building with client frontend does not capture frontend provenance
 	// because frontend runs in client, not in BuildKit.
 	// This test builds Dockerfile inside a client frontend ensuring that
@@ -681,7 +682,7 @@ func testClientFrontendProvenance(t *testing.T, sb integration.Sandbox) {
 }
 
 func testClientLLBProvenance(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush, integration.FeatureProvenance)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureDirectPush, workers.FeatureProvenance)
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())
@@ -795,7 +796,7 @@ func testClientLLBProvenance(t *testing.T, sb integration.Sandbox) {
 }
 
 func testSecretSSHProvenance(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush, integration.FeatureProvenance)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureDirectPush, workers.FeatureProvenance)
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())
@@ -872,7 +873,7 @@ RUN --mount=type=secret,id=mysecret --mount=type=secret,id=othersecret --mount=t
 }
 
 func testOCILayoutProvenance(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureProvenance)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureProvenance)
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())
@@ -1005,7 +1006,7 @@ EOF
 }
 
 func testNilProvenance(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureProvenance)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureProvenance)
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())
@@ -1042,7 +1043,7 @@ ENV FOO=bar
 
 // https://github.com/moby/buildkit/issues/3562
 func testDuplicatePlatformProvenance(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureProvenance)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureProvenance)
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())
@@ -1072,7 +1073,7 @@ func testDuplicatePlatformProvenance(t *testing.T, sb integration.Sandbox) {
 
 // https://github.com/moby/buildkit/issues/3928
 func testDockerIgnoreMissingProvenance(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureProvenance)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureProvenance)
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()

--- a/frontend/dockerfile/dockerfile_runnetwork_test.go
+++ b/frontend/dockerfile/dockerfile_runnetwork_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/moby/buildkit/util/entitlements"
 	"github.com/moby/buildkit/util/testutil/echoserver"
 	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/moby/buildkit/util/testutil/workers"
 	"github.com/stretchr/testify/require"
 )
 
@@ -138,7 +139,7 @@ RUN --network=host nc 127.0.0.1 %s | grep foo
 	case networkHostGranted:
 		require.NoError(t, err)
 	case networkHostDenied:
-		if !integration.IsTestDockerd() {
+		if !workers.IsTestDockerd() {
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "entitlement network.host is not allowed")
 		} else {
@@ -188,7 +189,7 @@ RUN --network=none ! nc -z 127.0.0.1 %s
 	case networkHostGranted:
 		require.NoError(t, err)
 	case networkHostDenied:
-		if !integration.IsTestDockerd() {
+		if !workers.IsTestDockerd() {
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "entitlement network.host is not allowed")
 		} else {

--- a/frontend/dockerfile/dockerfile_targets_test.go
+++ b/frontend/dockerfile/dockerfile_targets_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/moby/buildkit/frontend/subrequests"
 	"github.com/moby/buildkit/frontend/subrequests/targets"
 	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/moby/buildkit/util/testutil/workers"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -23,7 +24,7 @@ var targetsTests = integration.TestFuncs(
 )
 
 func testTargetsList(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureFrontendTargets)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureFrontendTargets)
 	f := getFrontend(t, sb)
 	if _, ok := f.(*clientFrontend); !ok {
 		t.Skip("only test with client frontend")
@@ -122,7 +123,7 @@ FROM second AS binary
 }
 
 func testTargetsDescribeDefinition(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureFrontendTargets)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureFrontendTargets)
 	f := getFrontend(t, sb)
 	if _, ok := f.(*clientFrontend); !ok {
 		t.Skip("only test with client frontend")

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/moby/buildkit/util/testutil"
 	"github.com/moby/buildkit/util/testutil/httpserver"
 	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/moby/buildkit/util/testutil/workers"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -54,11 +55,11 @@ import (
 )
 
 func init() {
-	if integration.IsTestDockerd() {
-		integration.InitDockerdWorker()
+	if workers.IsTestDockerd() {
+		workers.InitDockerdWorker()
 	} else {
-		integration.InitOCIWorker()
-		integration.InitContainerdWorker()
+		workers.InitOCIWorker()
+		workers.InitContainerdWorker()
 	}
 }
 
@@ -426,7 +427,7 @@ RUN [ "$(cat testfile)" == "contents0" ]
 }
 
 func testExportCacheLoop(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport, integration.FeatureCacheImport, integration.FeatureCacheBackendLocal)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureCacheExport, workers.FeatureCacheImport, workers.FeatureCacheBackendLocal)
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -1263,7 +1264,7 @@ COPY --from=build /out .
 }
 
 func testDefaultShellAndPath(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureOCIExporter)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureOCIExporter)
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -1350,7 +1351,7 @@ COPY Dockerfile .
 }
 
 func testExportMultiPlatform(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureOCIExporter, integration.FeatureMultiPlatform)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureOCIExporter, workers.FeatureMultiPlatform)
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -2531,7 +2532,7 @@ ENV foo=bar
 }
 
 func testExposeExpansion(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureImageExporter)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureImageExporter)
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -2764,7 +2765,7 @@ RUN ["ls"]
 	args, trace := f.DFCmdArgs(dir, dir)
 	defer os.RemoveAll(trace)
 
-	integration.CheckFeatureCompat(t, sb, integration.FeatureImageExporter)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureImageExporter)
 
 	target := "example.com/moby/dockerfilescratch:test"
 	cmd := sb.Cmd(args + " --output type=image,name=" + target)
@@ -2818,7 +2819,7 @@ RUN ["ls"]
 }
 
 func testUser(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureImageExporter)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureImageExporter)
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -3671,7 +3672,7 @@ COPY --from=stage1 baz bax
 }
 
 func testLabels(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureImageExporter)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureImageExporter)
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -3781,7 +3782,7 @@ RUN ls /files/file1
 }
 
 func testOnBuildCleared(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureDirectPush)
 	f := getFrontend(t, sb)
 
 	registry, err := sb.NewRegistry()
@@ -3883,11 +3884,11 @@ ONBUILD RUN mkdir -p /out && echo -n 11 >> /out/foo
 }
 
 func testCacheMultiPlatformImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb,
-		integration.FeatureDirectPush,
-		integration.FeatureCacheExport,
-		integration.FeatureCacheBackendInline,
-		integration.FeatureCacheBackendRegistry,
+	workers.CheckFeatureCompat(t, sb,
+		workers.FeatureDirectPush,
+		workers.FeatureCacheExport,
+		workers.FeatureCacheBackendInline,
+		workers.FeatureCacheBackendRegistry,
 	)
 	f := getFrontend(t, sb)
 
@@ -4010,7 +4011,7 @@ COPY --from=base arch /
 }
 
 func testImageManifestCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport, integration.FeatureCacheBackendLocal)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureCacheExport, workers.FeatureCacheBackendLocal)
 	f := getFrontend(t, sb)
 
 	registry, err := sb.NewRegistry()
@@ -4112,7 +4113,7 @@ COPY --from=base unique /
 	require.Equal(t, string(dt), string(dt2))
 }
 func testCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport, integration.FeatureCacheBackendLocal)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureCacheExport, workers.FeatureCacheBackendLocal)
 	f := getFrontend(t, sb)
 
 	registry, err := sb.NewRegistry()
@@ -4203,7 +4204,7 @@ COPY --from=base unique /
 }
 
 func testReproducibleIDs(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureImageExporter)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureImageExporter)
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -5210,7 +5211,7 @@ COPY --from=base /out /
 	require.NoError(t, err)
 	require.True(t, len(dt) > 0)
 
-	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureDirectPush)
 
 	// Now test with an image with custom envs
 	dockerfile = []byte(`
@@ -5299,7 +5300,7 @@ COPY --from=base /env_foobar /
 }
 
 func testNamedImageContextPlatform(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureDirectPush)
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())
@@ -5371,7 +5372,7 @@ RUN echo hello
 }
 
 func testNamedImageContextTimestamps(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureDirectPush)
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())
@@ -5565,7 +5566,7 @@ COPY --from=base /o* /
 }
 
 func testNamedOCILayoutContext(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureOCIExporter, integration.FeatureOCILayout)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureOCIExporter, workers.FeatureOCILayout)
 	// how this test works:
 	// 1- we use a regular builder with a dockerfile to create an image two files: "out" with content "first", "out2" with content "second"
 	// 2- we save the output to an OCI layout dir
@@ -5701,7 +5702,7 @@ COPY --from=imported /test/outfoo /
 }
 
 func testNamedOCILayoutContextExport(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureOCIExporter, integration.FeatureOCILayout)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureOCIExporter, workers.FeatureOCILayout)
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())
@@ -5918,7 +5919,7 @@ COPY --from=build /foo /out /
 }
 
 func testNamedMultiplatformInputContext(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureMultiPlatform)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureMultiPlatform)
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())
@@ -6064,7 +6065,7 @@ COPY --from=build /foo /out /
 }
 
 func testSourceDateEpochWithoutExporter(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureOCIExporter, integration.FeatureSourceDateEpoch)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureOCIExporter, workers.FeatureSourceDateEpoch)
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`
@@ -6138,7 +6139,7 @@ COPY Dockerfile .
 }
 
 func testSBOMScannerImage(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush, integration.FeatureSBOM)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureDirectPush, workers.FeatureSBOM)
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())
@@ -6242,7 +6243,7 @@ EOF
 }
 
 func testSBOMScannerArgs(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureDirectPush, integration.FeatureSBOM)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureDirectPush, workers.FeatureSBOM)
 	ctx := sb.Context()
 
 	c, err := client.New(ctx, sb.Address())
@@ -6543,7 +6544,7 @@ COPY Dockerfile \
 }
 
 func testReproSourceDateEpoch(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureOCIExporter, integration.FeatureSourceDateEpoch)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureOCIExporter, workers.FeatureSourceDateEpoch)
 	if sb.Snapshotter() == "native" {
 		t.Skip("the digest is not reproducible with the \"native\" snapshotter because hardlinks are processed in a different way: https://github.com/moby/buildkit/pull/3456#discussion_r1062650263")
 	}

--- a/frontend/frontend_test.go
+++ b/frontend/frontend_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/moby/buildkit/client/llb"
 	gateway "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/moby/buildkit/util/testutil/workers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tonistiigi/fsutil"
@@ -18,11 +19,11 @@ import (
 )
 
 func init() {
-	if integration.IsTestDockerd() {
-		integration.InitDockerdWorker()
+	if workers.IsTestDockerd() {
+		workers.InitDockerdWorker()
 	} else {
-		integration.InitOCIWorker()
-		integration.InitContainerdWorker()
+		workers.InitOCIWorker()
+		workers.InitContainerdWorker()
 	}
 }
 

--- a/frontend/frontend_test.go
+++ b/frontend/frontend_test.go
@@ -67,11 +67,10 @@ func testRefReadFile(t *testing.T, sb integration.Sandbox) {
 
 	testcontent := []byte(`foobar`)
 
-	dir, err := tmpdir(
+	dir := integration.Tmpdir(
 		t,
 		fstest.CreateFile("test", testcontent, 0666),
 	)
-	require.NoError(t, err)
 
 	frontend := func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
 		def, err := llb.Local("mylocal").Marshal(ctx)
@@ -130,7 +129,7 @@ func testRefReadDir(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 	defer c.Close()
 
-	dir, err := tmpdir(
+	dir := integration.Tmpdir(
 		t,
 		fstest.CreateDir("somedir", 0777),
 		fstest.CreateFile("somedir/foo1.txt", []byte(`foo1`), 0666),
@@ -139,7 +138,6 @@ func testRefReadDir(t *testing.T, sb integration.Sandbox) {
 		fstest.Symlink("bar.log", "somedir/link.log"),
 		fstest.CreateDir("somedir/baz.dir", 0777),
 	)
-	require.NoError(t, err)
 
 	expMap := make(map[string]*fstypes.Stat)
 
@@ -248,11 +246,10 @@ func testRefStatFile(t *testing.T, sb integration.Sandbox) {
 
 	testcontent := []byte(`foobar`)
 
-	dir, err := tmpdir(
+	dir := integration.Tmpdir(
 		t,
 		fstest.CreateFile("test", testcontent, 0666),
 	)
-	require.NoError(t, err)
 
 	exp, err := fsutil.Stat(filepath.Join(dir, "test"))
 	require.NoError(t, err)
@@ -339,12 +336,4 @@ func testRefEvaluate(t *testing.T, sb integration.Sandbox) {
 
 	_, err = c.Build(ctx, client.SolveOpt{}, "", frontend, nil)
 	require.NoError(t, err)
-}
-
-func tmpdir(t *testing.T, appliers ...fstest.Applier) (string, error) {
-	tmpdir := t.TempDir()
-	if err := fstest.Apply(appliers...).Apply(tmpdir); err != nil {
-		return "", err
-	}
-	return tmpdir, nil
 }

--- a/solver/jobs_test.go
+++ b/solver/jobs_test.go
@@ -7,13 +7,14 @@ import (
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/moby/buildkit/util/testutil/workers"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
 
 func init() {
-	integration.InitOCIWorker()
-	integration.InitContainerdWorker()
+	workers.InitOCIWorker()
+	workers.InitContainerdWorker()
 }
 
 func TestJobsIntegration(t *testing.T) {

--- a/util/testutil/integration/registry.go
+++ b/util/testutil/integration/registry.go
@@ -15,11 +15,11 @@ import (
 )
 
 func NewRegistry(dir string) (url string, cl func() error, err error) {
-	if err := lookupBinary("registry"); err != nil {
+	if err := LookupBinary("registry"); err != nil {
 		return "", nil, err
 	}
 
-	deferF := &multiCloser{}
+	deferF := &MultiCloser{}
 	cl = deferF.F()
 
 	defer func() {
@@ -34,7 +34,7 @@ func NewRegistry(dir string) (url string, cl func() error, err error) {
 		if err != nil {
 			return "", nil, err
 		}
-		deferF.append(func() error { return os.RemoveAll(tmpdir) })
+		deferF.Append(func() error { return os.RemoveAll(tmpdir) })
 		dir = tmpdir
 	}
 
@@ -61,11 +61,11 @@ http:
 	if err != nil {
 		return "", nil, err
 	}
-	stop, err := startCmd(cmd, nil)
+	stop, err := StartCmd(cmd, nil)
 	if err != nil {
 		return "", nil, err
 	}
-	deferF.append(stop)
+	deferF.Append(stop)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/util/testutil/workers/backend.go
+++ b/util/testutil/workers/backend.go
@@ -1,0 +1,59 @@
+package workers
+
+import (
+	"os"
+	"strings"
+)
+
+type backend struct {
+	address             string
+	dockerAddress       string
+	containerdAddress   string
+	rootless            bool
+	snapshotter         string
+	unsupportedFeatures []string
+	isDockerd           bool
+}
+
+func (b backend) Address() string {
+	return b.address
+}
+
+func (b backend) DockerAddress() string {
+	return b.dockerAddress
+}
+
+func (b backend) ContainerdAddress() string {
+	return b.containerdAddress
+}
+
+func (b backend) Rootless() bool {
+	return b.rootless
+}
+
+func (b backend) Snapshotter() string {
+	return b.snapshotter
+}
+
+func (b backend) Supports(feature string) bool {
+	if enabledFeatures := os.Getenv("BUILDKIT_TEST_ENABLE_FEATURES"); enabledFeatures != "" {
+		for _, enabledFeature := range strings.Split(enabledFeatures, ",") {
+			if feature == enabledFeature {
+				return true
+			}
+		}
+	}
+	if disabledFeatures := os.Getenv("BUILDKIT_TEST_DISABLE_FEATURES"); disabledFeatures != "" {
+		for _, disabledFeature := range strings.Split(disabledFeatures, ",") {
+			if feature == disabledFeature {
+				return false
+			}
+		}
+	}
+	for _, unsupportedFeature := range b.unsupportedFeatures {
+		if feature == unsupportedFeature {
+			return false
+		}
+	}
+	return true
+}

--- a/util/testutil/workers/features.go
+++ b/util/testutil/workers/features.go
@@ -1,0 +1,63 @@
+package workers
+
+import (
+	"testing"
+
+	"github.com/moby/buildkit/util/testutil/integration"
+)
+
+const (
+	FeatureCacheExport          = "cache_export"
+	FeatureCacheImport          = "cache_import"
+	FeatureCacheBackendAzblob   = "cache_backend_azblob"
+	FeatureCacheBackendGha      = "cache_backend_gha"
+	FeatureCacheBackendInline   = "cache_backend_inline"
+	FeatureCacheBackendLocal    = "cache_backend_local"
+	FeatureCacheBackendRegistry = "cache_backend_registry"
+	FeatureCacheBackendS3       = "cache_backend_s3"
+	FeatureDirectPush           = "direct_push"
+	FeatureFrontendOutline      = "frontend_outline"
+	FeatureFrontendTargets      = "frontend_targets"
+	FeatureImageExporter        = "image_exporter"
+	FeatureInfo                 = "info"
+	FeatureMergeDiff            = "merge_diff"
+	FeatureMultiCacheExport     = "multi_cache_export"
+	FeatureMultiPlatform        = "multi_platform"
+	FeatureOCIExporter          = "oci_exporter"
+	FeatureOCILayout            = "oci_layout"
+	FeatureProvenance           = "provenance"
+	FeatureSBOM                 = "sbom"
+	FeatureSecurityMode         = "security_mode"
+	FeatureSourceDateEpoch      = "source_date_epoch"
+	FeatureCNINetwork           = "cni_network"
+)
+
+var features = map[string]struct{}{
+	FeatureCacheExport:          {},
+	FeatureCacheImport:          {},
+	FeatureCacheBackendAzblob:   {},
+	FeatureCacheBackendGha:      {},
+	FeatureCacheBackendInline:   {},
+	FeatureCacheBackendLocal:    {},
+	FeatureCacheBackendRegistry: {},
+	FeatureCacheBackendS3:       {},
+	FeatureDirectPush:           {},
+	FeatureFrontendOutline:      {},
+	FeatureFrontendTargets:      {},
+	FeatureImageExporter:        {},
+	FeatureInfo:                 {},
+	FeatureMergeDiff:            {},
+	FeatureMultiCacheExport:     {},
+	FeatureMultiPlatform:        {},
+	FeatureOCIExporter:          {},
+	FeatureOCILayout:            {},
+	FeatureProvenance:           {},
+	FeatureSBOM:                 {},
+	FeatureSecurityMode:         {},
+	FeatureSourceDateEpoch:      {},
+	FeatureCNINetwork:           {},
+}
+
+func CheckFeatureCompat(t *testing.T, sb integration.Sandbox, reason ...string) {
+	integration.CheckFeatureCompat(t, sb, features, reason...)
+}

--- a/util/testutil/workers/oci.go
+++ b/util/testutil/workers/oci.go
@@ -1,4 +1,4 @@
-package integration
+package workers
 
 import (
 	"context"
@@ -8,11 +8,12 @@ import (
 	"runtime"
 
 	"github.com/moby/buildkit/util/bklog"
+	"github.com/moby/buildkit/util/testutil/integration"
 	"github.com/pkg/errors"
 )
 
 func InitOCIWorker() {
-	Register(&OCI{ID: "oci"})
+	integration.Register(&OCI{ID: "oci"})
 
 	// the rootless uid is defined in Dockerfile
 	if s := os.Getenv("BUILDKIT_INTEGRATION_ROOTLESS_IDPAIR"); s != "" {
@@ -20,13 +21,13 @@ func InitOCIWorker() {
 		if _, err := fmt.Sscanf(s, "%d:%d", &uid, &gid); err != nil {
 			bklog.L.Fatalf("unexpected BUILDKIT_INTEGRATION_ROOTLESS_IDPAIR: %q", s)
 		}
-		if rootlessSupported(uid) {
-			Register(&OCI{ID: "oci-rootless", UID: uid, GID: gid})
+		if integration.RootlessSupported(uid) {
+			integration.Register(&OCI{ID: "oci-rootless", UID: uid, GID: gid})
 		}
 	}
 
 	if s := os.Getenv("BUILDKIT_INTEGRATION_SNAPSHOTTER"); s != "" {
-		Register(&OCI{ID: "oci-snapshotter-" + s, Snapshotter: s})
+		integration.Register(&OCI{ID: "oci-snapshotter-" + s, Snapshotter: s})
 	}
 }
 
@@ -45,8 +46,8 @@ func (s *OCI) Rootless() bool {
 	return s.UID != 0
 }
 
-func (s *OCI) New(ctx context.Context, cfg *BackendConfig) (Backend, func() error, error) {
-	if err := lookupBinary("buildkitd"); err != nil {
+func (s *OCI) New(ctx context.Context, cfg *integration.BackendConfig) (integration.Backend, func() error, error) {
+	if err := integration.LookupBinary("buildkitd"); err != nil {
 		return nil, nil, err
 	}
 	if err := requireRoot(); err != nil {
@@ -74,7 +75,7 @@ func (s *OCI) New(ctx context.Context, cfg *BackendConfig) (Backend, func() erro
 	}
 	buildkitdSock, stop, err := runBuildkitd(ctx, cfg, buildkitdArgs, cfg.Logs, s.UID, s.GID, extraEnv)
 	if err != nil {
-		printLogs(cfg.Logs, log.Println)
+		integration.PrintLogs(cfg.Logs, log.Println)
 		return nil, nil, err
 	}
 

--- a/util/testutil/workers/sysprocattr_unix.go
+++ b/util/testutil/workers/sysprocattr_unix.go
@@ -1,7 +1,7 @@
 //go:build !windows
 // +build !windows
 
-package integration
+package workers
 
 import (
 	"path/filepath"

--- a/util/testutil/workers/sysprocattr_windows.go
+++ b/util/testutil/workers/sysprocattr_windows.go
@@ -1,7 +1,7 @@
 //go:build windows
 // +build windows
 
-package integration
+package workers
 
 import (
 	"path/filepath"

--- a/util/testutil/workers/util.go
+++ b/util/testutil/workers/util.go
@@ -1,0 +1,89 @@
+package workers
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/pkg/errors"
+)
+
+func requireRoot() error {
+	if os.Getuid() != 0 {
+		return errors.Wrap(integration.ErrRequirements, "requires root")
+	}
+	return nil
+}
+
+func runBuildkitd(ctx context.Context, conf *integration.BackendConfig, args []string, logs map[string]*bytes.Buffer, uid, gid int, extraEnv []string) (address string, cl func() error, err error) {
+	deferF := &integration.MultiCloser{}
+	cl = deferF.F()
+
+	defer func() {
+		if err != nil {
+			deferF.F()()
+			cl = nil
+		}
+	}()
+
+	if conf.ConfigFile != "" {
+		args = append(args, "--config="+conf.ConfigFile)
+	}
+
+	tmpdir, err := os.MkdirTemp("", "bktest_buildkitd")
+	if err != nil {
+		return "", nil, err
+	}
+	if err := os.Chown(tmpdir, uid, gid); err != nil {
+		return "", nil, err
+	}
+	if err := os.MkdirAll(filepath.Join(tmpdir, "tmp"), 0711); err != nil {
+		return "", nil, err
+	}
+	if err := os.Chown(filepath.Join(tmpdir, "tmp"), uid, gid); err != nil {
+		return "", nil, err
+	}
+
+	deferF.Append(func() error { return os.RemoveAll(tmpdir) })
+
+	address = getBuildkitdAddr(tmpdir)
+
+	args = append(args, "--root", tmpdir, "--addr", address, "--debug")
+	cmd := exec.Command(args[0], args[1:]...) //nolint:gosec // test utility
+	cmd.Env = append(os.Environ(), "BUILDKIT_DEBUG_EXEC_OUTPUT=1", "BUILDKIT_DEBUG_PANIC_ON_ERROR=1", "BUILDKIT_TRACE_SOCKET="+getTraceSocketPath(tmpdir), "TMPDIR="+filepath.Join(tmpdir, "tmp"))
+	cmd.Env = append(cmd.Env, extraEnv...)
+	cmd.SysProcAttr = getSysProcAttr()
+
+	stop, err := integration.StartCmd(cmd, logs)
+	if err != nil {
+		return "", nil, err
+	}
+	deferF.Append(stop)
+
+	if err := integration.WaitUnix(address, 15*time.Second, cmd); err != nil {
+		return "", nil, err
+	}
+
+	deferF.Append(func() error {
+		f, err := os.Open("/proc/self/mountinfo")
+		if err != nil {
+			return errors.Wrap(err, "failed to open mountinfo")
+		}
+		defer f.Close()
+		s := bufio.NewScanner(f)
+		for s.Scan() {
+			if strings.Contains(s.Text(), tmpdir) {
+				return errors.Errorf("leaked mountpoint for %s", tmpdir)
+			}
+		}
+		return s.Err()
+	})
+
+	return address, cl, err
+}

--- a/worker/containerd/containerd_test.go
+++ b/worker/containerd/containerd_test.go
@@ -10,13 +10,14 @@ import (
 
 	"github.com/moby/buildkit/util/network/netproviders"
 	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/moby/buildkit/util/testutil/workers"
 	"github.com/moby/buildkit/worker/base"
 	"github.com/moby/buildkit/worker/tests"
 	"github.com/stretchr/testify/require"
 )
 
 func init() {
-	integration.InitContainerdWorker()
+	workers.InitContainerdWorker()
 }
 
 func TestContainerdWorkerIntegration(t *testing.T) {


### PR DESCRIPTION
This patch splits up the integration test package down into several parts, the core integration helpers, the buildkit test workers and various test helpers.

With this, we can split the worker features off as well, which improves the general reusability of the package, so we can create our own custom features in buildx where we reuse this package.