### PR TITLE
tests: set `--iptables=false` for dockerd tests

### DIFF
--- a/.github/workflows/dockerd.yml
+++ b/.github/workflows/dockerd.yml
@@ -12,7 +12,7 @@ on:
 env:
   SETUP_BUILDX_VERSION: "latest"
   SETUP_BUILDKIT_IMAGE: "moby/buildkit:latest"
-  TESTFLAGS: "-v --parallel=1 --timeout=30m"
+  TESTFLAGS: "-v --parallel=6 --timeout=30m"
 
 jobs:
   prepare:

--- a/util/testutil/workers/dockerd.go
+++ b/util/testutil/workers/dockerd.go
@@ -137,6 +137,7 @@ func (c Moby) New(ctx context.Context, cfg *integration.BackendConfig) (b integr
 
 	dockerdFlags := []string{
 		"--config-file", dockerdConfigFile,
+		"--iptables=false",
 		"--userland-proxy=false",
 		"--tls=false",
 		"--debug",


### PR DESCRIPTION
Similar in style to https://github.com/moby/moby/pull/45891.

When attempting to run dockerd tests in parallel, it's easy to get the following error:

```
failed to start daemon: Error initializing network controller: error obtaining controller instance: failed to create NAT chain DOCKER: iptables failed: iptables --wait -t nat -N DOCKER: iptables: Chain already exists.
(exit status 1)
```

(compare [before](https://github.com/jedevc/buildkit/actions/runs/5520028773/jobs/10066103758) and [after](https://github.com/jedevc/buildkit/actions/runs/5519977833/jobs/10065987362)) 

By disabling iptables for parallel tests, we don't hit this problem. I'm *fairly* sure we shouldn't need this for any of the buildkit tests? We're not exposing any ports on the host, and I don't think we use anything but the default bridge network for our tests, which ticks the requirement for the flag under https://docs.docker.com/engine/reference/commandline/dockerd/#run-multiple-daemons.
