### PR TITLE
pullprogress data race

### DIFF
--- a/util/pull/pullprogress/progress.go
+++ b/util/pull/pullprogress/progress.go
@@ -93,10 +93,10 @@ func trackProgress(ctx context.Context, desc ocispecs.Descriptor, manager PullMa
 
 	ticker := time.NewTicker(150 * time.Millisecond)
 	defer ticker.Stop()
-	go func() {
+	go func(ctx context.Context) {
 		<-ctx.Done()
 		ticker.Stop()
-	}()
+	}(ctx)
 
 	pw, _, _ := progress.NewFromContext(ctx)
 	defer pw.Close()


### PR DESCRIPTION
There's a context which gets recreated via

    ctx = context.TODO()

which races with

    go func() {
        <-ctx.Done()
        ticker.Stop()
    }()

To prevent this, the original context reference should be passed in via an arg.