### PR TITLE
filesync: escape special query characters

### DIFF
--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -6766,12 +6766,16 @@ func testCopyUnicodePath(t *testing.T, sb integration.Sandbox) {
 	dockerfile := []byte(`
 FROM alpine
 COPY test-äöü.txt /
+COPY test-%C3%A4%C3%B6%C3%BC.txt /
+COPY test+aou.txt /
 `)
 
 	dir, err := integration.Tmpdir(
 		t,
 		fstest.CreateFile("Dockerfile", dockerfile, 0600),
-		fstest.CreateFile("test-äöü.txt", []byte("test"), 0644),
+		fstest.CreateFile("test-äöü.txt", []byte("foo"), 0644),
+		fstest.CreateFile("test-%C3%A4%C3%B6%C3%BC.txt", []byte("bar"), 0644),
+		fstest.CreateFile("test+aou.txt", []byte("baz"), 0644),
 	)
 	require.NoError(t, err)
 
@@ -6794,7 +6798,15 @@ COPY test-äöü.txt /
 
 	dt, err := os.ReadFile(filepath.Join(destDir, "test-äöü.txt"))
 	require.NoError(t, err)
-	require.Equal(t, "test", string(dt))
+	require.Equal(t, "foo", string(dt))
+
+	dt, err = os.ReadFile(filepath.Join(destDir, "test-%C3%A4%C3%B6%C3%BC.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "bar", string(dt))
+
+	dt, err = os.ReadFile(filepath.Join(destDir, "test+aou.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "baz", string(dt))
 }
 
 func runShell(dir string, cmds ...string) error {

--- a/session/filesync/filesync.go
+++ b/session/filesync/filesync.go
@@ -387,8 +387,9 @@ func decodeOpts(opts map[string][]string) map[string][]string {
 func encodeStringForHeader(input string) string {
 	var output strings.Builder
 	for _, runeVal := range input {
-		// Only encode non-ASCII characters.
-		if runeVal > unicode.MaxASCII {
+		// Only encode non-ASCII characters, and characters that have special
+		// meaning during decoding.
+		if runeVal > unicode.MaxASCII || runeVal == '%' || runeVal == '+' {
 			// Encode each non-ASCII character individually.
 			output.WriteString(url.QueryEscape(string(runeVal)))
 		} else {

--- a/session/filesync/filesync.go
+++ b/session/filesync/filesync.go
@@ -27,7 +27,6 @@ const (
 	keyFollowPaths        = "followpaths"
 	keyDirName            = "dir-name"
 	keyExporterMetaPrefix = "exporter-md-"
-	keyOptsEncoded        = "opts-encoded"
 )
 
 type fsSyncProvider struct {
@@ -86,17 +85,7 @@ func (sp *fsSyncProvider) handle(method string, stream grpc.ServerStream) (retEr
 	}
 
 	opts, _ := metadata.FromIncomingContext(stream.Context()) // if no metadata continue with empty object
-
-	isDecoded := false
-	if v, ok := opts[keyOptsEncoded]; ok && len(v) > 0 {
-		if b, _ := strconv.ParseBool(v[0]); b {
-			isDecoded = true
-		}
-	}
-
-	if isDecoded {
-		opts = decodeOpts(opts)
-	}
+	opts = decodeOpts(opts)
 
 	dirName := ""
 	name, ok := opts[keyDirName]
@@ -223,9 +212,6 @@ func FSSync(ctx context.Context, c session.Caller, opt FSSendRequestOpt) error {
 	client := NewFileSyncClient(c.Conn())
 
 	var stream grpc.ClientStream
-
-	// mark that we have encoded options so older versions with raw values can be detected on client side
-	opts[keyOptsEncoded] = []string{"1"}
 
 	opts = encodeOpts(opts)
 
@@ -361,11 +347,11 @@ func (e InvalidSessionError) Unwrap() error {
 func encodeOpts(opts map[string][]string) map[string][]string {
 	md := make(map[string][]string, len(opts))
 	for k, v := range opts {
-		out := make([]string, len(v))
-		for i, s := range v {
-			out[i] = encodeStringForHeader(s)
-		}
+		out, encoded := encodeStringForHeader(v)
 		md[k] = out
+		if encoded {
+			md[k+"-encoded"] = []string{"1"}
+		}
 	}
 	return md
 }
@@ -374,8 +360,18 @@ func decodeOpts(opts map[string][]string) map[string][]string {
 	md := make(map[string][]string, len(opts))
 	for k, v := range opts {
 		out := make([]string, len(v))
-		for i, s := range v {
-			out[i], _ = url.QueryUnescape(s)
+		var isDecoded bool
+		if v, ok := opts[k+"-encoded"]; ok && len(v) > 0 {
+			if b, _ := strconv.ParseBool(v[0]); b {
+				isDecoded = true
+			}
+		}
+		if isDecoded {
+			for i, s := range v {
+				out[i], _ = url.QueryUnescape(s)
+			}
+		} else {
+			copy(out, v)
 		}
 		md[k] = out
 	}
@@ -384,18 +380,23 @@ func decodeOpts(opts map[string][]string) map[string][]string {
 
 // encodeStringForHeader encodes a string value so it can be used in grpc header. This encoding
 // is backwards compatible and avoids encoding ASCII characters.
-func encodeStringForHeader(input string) string {
-	var output strings.Builder
-	for _, runeVal := range input {
-		// Only encode non-ASCII characters, and characters that have special
-		// meaning during decoding.
-		if runeVal > unicode.MaxASCII || runeVal == '%' || runeVal == '+' {
-			// Encode each non-ASCII character individually.
-			output.WriteString(url.QueryEscape(string(runeVal)))
-		} else {
-			// Directly append ASCII characters and '*' to the output.
-			output.WriteRune(runeVal)
+func encodeStringForHeader(inputs []string) ([]string, bool) {
+	var encode bool
+	for _, input := range inputs {
+		for _, runeVal := range input {
+			// Only encode non-ASCII characters, and characters that have special
+			// meaning during decoding.
+			if runeVal > unicode.MaxASCII {
+				encode = true
+				break
+			}
 		}
 	}
-	return output.String()
+	if !encode {
+		return inputs, false
+	}
+	for i, input := range inputs {
+		inputs[i] = url.QueryEscape(input)
+	}
+	return inputs, true
 }


### PR DESCRIPTION
:hammer_and_wrench: Fixes https://github.com/moby/buildkit/pull/3946#discussion_r1257971201

This ensures that files with '%' and '+' can still be properly copied.

To prevent regressions, this also adds in a couple of example test cases.