### PR TITLE
Clarify the behavior of wildcards in .dockerignore file

### DIFF
--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -392,7 +392,9 @@ uses this mechanism:
 !README.md
 ```
 
-All markdown files *except* `README.md` are excluded from the context.
+All markdown files right under the context directory *except* `README.md`
+are excluded from the context. Note that markdown files under subdirectories
+are still included.
 
 The placement of `!` exception rules influences the behavior: the last
 line of the `.dockerignore` that matches a particular file determines


### PR DESCRIPTION
Unlike .gitignore, `*.md` in .dockerignore doesn't match `subdir/foo.md`. While the logic is in github.com/moby/patternmatcher, it is worth to note the difference in the reference document.