### PR TITLE
llbsolver: fix policy rule ordering

### DIFF
--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -981,27 +981,21 @@ func loadEntitlements(b solver.Builder) (entitlements.Set, error) {
 }
 
 func loadSourcePolicy(b solver.Builder) (*spb.Policy, error) {
-	set := make(map[spb.Rule]struct{}, 0)
+	var srcPol spb.Policy
 	err := b.EachValue(context.TODO(), keySourcePolicy, func(v interface{}) error {
 		x, ok := v.(spb.Policy)
 		if !ok {
 			return errors.Errorf("invalid source policy %T", v)
 		}
 		for _, f := range x.Rules {
-			set[*f] = struct{}{}
+			r := *f
+			srcPol.Rules = append(srcPol.Rules, &r)
 		}
+		srcPol.Version = x.Version
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
-	var srcPol *spb.Policy
-	if len(set) > 0 {
-		srcPol = &spb.Policy{}
-		for k := range set {
-			k := k
-			srcPol.Rules = append(srcPol.Rules, &k)
-		}
-	}
-	return srcPol, nil
+	return &srcPol, nil
 }


### PR DESCRIPTION
The order of rules in policy matters. Eg. in [DENY *, ALLOW ref] mixing the order would deny all sources so map can't be used to deduplicate the rules.

@cpuguy83 @tianon 