### PR TITLE
buildctl: set max backoff delay to 1 second

### DIFF
--- a/cmd/buildctl/common/common.go
+++ b/cmd/buildctl/common/common.go
@@ -16,6 +16,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
 )
 
 // ResolveClient resolves a client from CLI args
@@ -66,6 +68,12 @@ func ResolveClient(c *cli.Context) (*client.Client, error) {
 	}
 
 	opts := []client.ClientOpt{client.WithFailFast()}
+
+	backoffConfig := backoff.DefaultConfig
+	backoffConfig.MaxDelay = 1 * time.Second
+	opts = append(opts, client.WithGRPCDialOption(
+		grpc.WithConnectParams(grpc.ConnectParams{Backoff: backoffConfig}),
+	))
 
 	ctx := CommandContext(c)
 


### PR DESCRIPTION
:arrow_up: Follow up to #3586 

When combined with `--wait`, this ensures that we get a fast response when the server eventually opens up for connections.