### PR TITLE
hack: allow to set GO_VERSION during tests

### DIFF
--- a/hack/test
+++ b/hack/test
@@ -3,6 +3,7 @@
 . $(dirname $0)/util
 set -eu -o pipefail
 
+: ${GO_VERSION=}
 : ${HTTP_PROXY=}
 : ${HTTPS_PROXY=}
 : ${NO_PROXY=}
@@ -74,6 +75,7 @@ if [[ "$GOBUILDFLAGS" == *"-race"* ]]; then
 fi
 
 buildxCmd build $cacheFromFlags \
+  --build-arg GO_VERSION \
   --build-arg BUILDKITD_TAGS \
   --build-arg HTTP_PROXY \
   --build-arg HTTPS_PROXY \


### PR DESCRIPTION
related to
* https://github.com/moby/moby/pull/45932#issuecomment-1632069512
* https://github.com/moby/moby/issues/45935

Will allow to match go version used in moby during BuildKit tests.