### PR TITLE
[0.11] Dockerfile: missing GO_VERSION arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ ARG NERDCTL_VERSION=v1.0.0
 ARG DNSNAME_VERSION=v1.3.1
 ARG NYDUS_VERSION=v2.1.0
 
+ARG GO_VERSION=1.19
 ARG ALPINE_VERSION=3.17
 
 # alpine base for buildkit image
@@ -28,7 +29,7 @@ FROM alpine-$TARGETARCH AS alpinebase
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.2.1 AS xx
 
 # go base image
-FROM --platform=$BUILDPLATFORM golang:1.19-alpine${ALPINE_VERSION} AS golatest
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS golatest
 
 # git stage is used for checking out remote repository sources
 FROM --platform=$BUILDPLATFORM alpine:${ALPINE_VERSION} AS git


### PR DESCRIPTION
* follow-up https://github.com/moby/buildkit/pull/4018

Didn't catch we didn't have a `GO_VERSION` arg on v0.11 branch.