### PR TITLE
examples: create certs bake definition

### DIFF
--- a/examples/create-certs/Dockerfile
+++ b/examples/create-certs/Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1
+
+FROM alpine:edge AS gen
+RUN echo "@testing https://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+RUN apk --update --no-cache add mkcert@testing ca-certificates
+WORKDIR /certs
+RUN mkdir -p daemon client
+ARG SAN=localhost
+ARG SAN_CLIENT=client
+RUN echo $SAN | tr " " "\n" >SAN
+RUN CAROOT=$(pwd) mkcert -cert-file daemon/cert.pem -key-file daemon/key.pem $SAN
+RUN CAROOT=$(pwd) mkcert -client -cert-file client/cert.pem -key-file client/key.pem $SAN_CLIENT
+RUN cp -f rootCA.pem daemon/ca.pem
+RUN cp -f rootCA.pem client/ca.pem
+RUN rm -f rootCA.pem rootCA-key.pem
+
+FROM scratch
+COPY --from=gen /certs /

--- a/examples/create-certs/README.md
+++ b/examples/create-certs/README.md
@@ -1,0 +1,7 @@
+# Create BuildKit certificates
+
+This [bake definition](docker-bake.hcl) can be used for creating certificates:
+
+```bash
+SAN="127.0.0.1" docker buildx bake https://github.com/moby/buildkit.git#master:examples/create-certs
+```

--- a/examples/create-certs/docker-bake.hcl
+++ b/examples/create-certs/docker-bake.hcl
@@ -1,0 +1,14 @@
+variable "SAN" {
+  default = "127.0.0.1"
+}
+
+group "default" {
+  targets = ["certs"]
+}
+
+target "certs" {
+  args = {
+    SAN = SAN
+  }
+  output = ["./.certs"]
+}


### PR DESCRIPTION
* relates to https://github.com/docker/docs/pull/17745

Adds a bake definition to ease BuildKit certs creation when using the Buildx `remote` driver.

Can be tested with:

```
SAN="localhost 127.0.0.1" docker buildx bake "https://github.com/crazy-max/buildkit.git#contrib-create-certs:examples/create-certs"
```