### PR TITLE
[0.12 backport] testutil: move CheckContainerdVersion to a separate package

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -57,6 +57,7 @@ import (
 	"github.com/moby/buildkit/util/contentutil"
 	"github.com/moby/buildkit/util/entitlements"
 	"github.com/moby/buildkit/util/testutil"
+	containerdutil "github.com/moby/buildkit/util/testutil/containerd"
 	"github.com/moby/buildkit/util/testutil/echoserver"
 	"github.com/moby/buildkit/util/testutil/httpserver"
 	"github.com/moby/buildkit/util/testutil/integration"
@@ -3090,7 +3091,7 @@ func testSourceDateEpochImageExporter(t *testing.T, sb integration.Sandbox) {
 		t.SkipNow()
 	}
 	// https://github.com/containerd/containerd/commit/133ddce7cf18a1db175150e7a69470dea1bb3132
-	integration.CheckContainerdVersion(t, cdAddress, ">= 1.7.0-beta.1")
+	containerdutil.CheckVersion(t, cdAddress, ">= 1.7.0-beta.1")
 
 	integration.CheckFeatureCompat(t, sb, integration.FeatureSourceDateEpoch)
 	requiresLinux(t)
@@ -6260,7 +6261,7 @@ func testSourceMapFromRef(t *testing.T, sb integration.Sandbox) {
 
 	frontend := func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
 		st := llb.Scratch().File(
-			llb.Mkdir("foo/bar", 0600), //fails because /foo doesn't exist
+			llb.Mkdir("foo/bar", 0600), // fails because /foo doesn't exist
 			sm.Location([]*pb.Range{{Start: pb.Position{Line: 3, Character: 1}}}),
 		)
 

--- a/util/testutil/containerd/containerd.go
+++ b/util/testutil/containerd/containerd.go
@@ -1,0 +1,38 @@
+package containerd
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	containerdpkg "github.com/containerd/containerd"
+)
+
+func CheckVersion(t *testing.T, cdAddress, constraint string) {
+	t.Helper()
+	constraintSemVer, err := semver.NewConstraint(constraint)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cdClient, err := containerdpkg.New(cdAddress, containerdpkg.WithTimeout(60*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cdClient.Close()
+	ctx := context.TODO()
+	cdVersion, err := cdClient.Version(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cdVersionSemVer, err := semver.NewVersion(cdVersion.Version)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !constraintSemVer.Check(cdVersionSemVer) {
+		t.Skipf("containerd version %q does not satisfy the constraint %q", cdVersion.Version, constraint)
+	}
+}

--- a/util/testutil/integration/sandbox.go
+++ b/util/testutil/integration/sandbox.go
@@ -13,8 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
-	containerdpkg "github.com/containerd/containerd"
 	"github.com/google/shlex"
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/pkg/errors"
@@ -367,33 +365,5 @@ func CheckFeatureCompat(t *testing.T, sb Sandbox, reason ...string) {
 	}
 	if len(ereasons) > 0 {
 		t.Skipf("%s worker can not currently run this test due to missing features (%s)", sb.Name(), strings.Join(ereasons, ", "))
-	}
-}
-
-func CheckContainerdVersion(t *testing.T, cdAddress, constraint string) {
-	t.Helper()
-	constraintSemVer, err := semver.NewConstraint(constraint)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	cdClient, err := containerdpkg.New(cdAddress, containerdpkg.WithTimeout(60*time.Second))
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cdClient.Close()
-	ctx := context.TODO()
-	cdVersion, err := cdClient.Version(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	cdVersionSemVer, err := semver.NewVersion(cdVersion.Version)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !constraintSemVer.Check(cdVersionSemVer) {
-		t.Skipf("containerd version %q does not satisfy the constraint %q", cdVersion.Version, constraint)
 	}
 }


### PR DESCRIPTION
- backport of https://github.com/moby/buildkit/pull/4027
- relates to https://github.com/moby/buildkit/pull/3263
- relates to https://github.com/docker/buildx/pull/1948


This function was introduced in 601dd5ba9b58cb309455f5ac1f905cb74b23e611, but brings in "containerd" as a dependency for testutil/integration, which results in many (indirect) dependencies.


(cherry picked from commit 619a20df406b345e5ae319aa25d626dbde60c091)