### PR TITLE
vendor: github.com/docker/docker 8e51b8b59cb8 (master, v25.0.0-dev)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/docker/cli v24.0.2+incompatible
 	github.com/docker/distribution v2.8.2+incompatible
-	github.com/docker/docker v24.0.0-rc.2.0.20230706181717-98d3da79ef9c+incompatible
+	github.com/docker/docker v24.0.0-rc.2.0.20230718135204-8e51b8b59cb8+incompatible // master (v25.0.0-dev)
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.5.0
 	github.com/gofrs/flock v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -445,8 +445,8 @@ github.com/docker/docker v1.4.2-0.20180531152204-71cd53e4a197/go.mod h1:eEKB0N0r
 github.com/docker/docker v1.4.2-0.20190924003213-a8608b5b67c7/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200730172259-9f28837c1d93+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v20.10.0-beta1.0.20201110211921-af34b94a78a1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
-github.com/docker/docker v24.0.0-rc.2.0.20230706181717-98d3da79ef9c+incompatible h1:XccikgvtGCEZE9ZQoaEApdx9ZvruGYakfi2tw4d/vUg=
-github.com/docker/docker v24.0.0-rc.2.0.20230706181717-98d3da79ef9c+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v24.0.0-rc.2.0.20230718135204-8e51b8b59cb8+incompatible h1:qMc+sk+l2GSLokgRA1uuKgkUVQ/vhAm4LYHC5rtSMq0=
+github.com/docker/docker v24.0.0-rc.2.0.20230718135204-8e51b8b59cb8+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
 github.com/docker/docker-credential-helpers v0.7.0 h1:xtCHsjxogADNZcdv1pKUHXryefjlVRqWqIhk/uXJp0A=
 github.com/docker/docker-credential-helpers v0.7.0/go.mod h1:rETQfLdHNT3foU5kuNkFR1R1V12OJRRO5lzt2D1b5X0=

--- a/vendor/github.com/docker/docker/api/swagger.yaml
+++ b/vendor/github.com/docker/docker/api/swagger.yaml
@@ -9900,7 +9900,9 @@ paths:
               Id: "22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30"
               Warning: ""
         403:
-          description: "operation not supported for pre-defined networks"
+          description: |
+            Forbidden operation. This happens when trying to create a network named after a pre-defined network,
+            or when trying to create an overlay network on a daemon which is not part of a Swarm cluster.
           schema:
             $ref: "#/definitions/ErrorResponse"
         404:

--- a/vendor/github.com/docker/docker/api/types/system/info.go
+++ b/vendor/github.com/docker/docker/api/types/system/info.go
@@ -1,0 +1,115 @@
+package system
+
+import (
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/api/types/swarm"
+)
+
+// Info contains response of Engine API:
+// GET "/info"
+type Info struct {
+	ID                 string
+	Containers         int
+	ContainersRunning  int
+	ContainersPaused   int
+	ContainersStopped  int
+	Images             int
+	Driver             string
+	DriverStatus       [][2]string
+	SystemStatus       [][2]string `json:",omitempty"` // SystemStatus is only propagated by the Swarm standalone API
+	Plugins            PluginsInfo
+	MemoryLimit        bool
+	SwapLimit          bool
+	KernelMemory       bool `json:",omitempty"` // Deprecated: kernel 5.4 deprecated kmem.limit_in_bytes
+	KernelMemoryTCP    bool `json:",omitempty"` // KernelMemoryTCP is not supported on cgroups v2.
+	CPUCfsPeriod       bool `json:"CpuCfsPeriod"`
+	CPUCfsQuota        bool `json:"CpuCfsQuota"`
+	CPUShares          bool
+	CPUSet             bool
+	PidsLimit          bool
+	IPv4Forwarding     bool
+	BridgeNfIptables   bool
+	BridgeNfIP6tables  bool `json:"BridgeNfIp6tables"`
+	Debug              bool
+	NFd                int
+	OomKillDisable     bool
+	NGoroutines        int
+	SystemTime         string
+	LoggingDriver      string
+	CgroupDriver       string
+	CgroupVersion      string `json:",omitempty"`
+	NEventsListener    int
+	KernelVersion      string
+	OperatingSystem    string
+	OSVersion          string
+	OSType             string
+	Architecture       string
+	IndexServerAddress string
+	RegistryConfig     *registry.ServiceConfig
+	NCPU               int
+	MemTotal           int64
+	GenericResources   []swarm.GenericResource
+	DockerRootDir      string
+	HTTPProxy          string `json:"HttpProxy"`
+	HTTPSProxy         string `json:"HttpsProxy"`
+	NoProxy            string
+	Name               string
+	Labels             []string
+	ExperimentalBuild  bool
+	ServerVersion      string
+	Runtimes           map[string]Runtime
+	DefaultRuntime     string
+	Swarm              swarm.Info
+	// LiveRestoreEnabled determines whether containers should be kept
+	// running when the daemon is shutdown or upon daemon start if
+	// running containers are detected
+	LiveRestoreEnabled  bool
+	Isolation           container.Isolation
+	InitBinary          string
+	ContainerdCommit    Commit
+	RuncCommit          Commit
+	InitCommit          Commit
+	SecurityOptions     []string
+	ProductLicense      string               `json:",omitempty"`
+	DefaultAddressPools []NetworkAddressPool `json:",omitempty"`
+
+	// Legacy API fields for older API versions.
+	legacyFields
+
+	// Warnings contains a slice of warnings that occurred  while collecting
+	// system information. These warnings are intended to be informational
+	// messages for the user, and are not intended to be parsed / used for
+	// other purposes, as they do not have a fixed format.
+	Warnings []string
+}
+
+type legacyFields struct {
+	ExecutionDriver string `json:",omitempty"` // Deprecated: deprecated since API v1.25, but returned for older versions.
+}
+
+// PluginsInfo is a temp struct holding Plugins name
+// registered with docker daemon. It is used by [Info] struct
+type PluginsInfo struct {
+	// List of Volume plugins registered
+	Volume []string
+	// List of Network plugins registered
+	Network []string
+	// List of Authorization plugins registered
+	Authorization []string
+	// List of Log plugins registered
+	Log []string
+}
+
+// Commit holds the Git-commit (SHA1) that a binary was built from, as reported
+// in the version-string of external tools, such as containerd, or runC.
+type Commit struct {
+	ID       string // ID is the actual commit ID of external tool.
+	Expected string // Expected is the commit ID of external tool expected by dockerd as set at build time.
+}
+
+// NetworkAddressPool is a temp struct used by [Info] struct.
+type NetworkAddressPool struct {
+	Base string
+	Size int
+}

--- a/vendor/github.com/docker/docker/api/types/system/runtime.go
+++ b/vendor/github.com/docker/docker/api/types/system/runtime.go
@@ -1,0 +1,14 @@
+package system
+
+// Runtime describes an OCI runtime
+type Runtime struct {
+	// "Legacy" runtime configuration for runc-compatible runtimes.
+
+	Path string   `json:"path,omitempty"`
+	Args []string `json:"runtimeArgs,omitempty"`
+
+	// Shimv2 runtime configuration. Mutually exclusive with the legacy config above.
+
+	Type    string                 `json:"runtimeType,omitempty"`
+	Options map[string]interface{} `json:"options,omitempty"`
+}

--- a/vendor/github.com/docker/docker/api/types/system/security_opts.go
+++ b/vendor/github.com/docker/docker/api/types/system/security_opts.go
@@ -1,0 +1,48 @@
+package system
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// SecurityOpt contains the name and options of a security option
+type SecurityOpt struct {
+	Name    string
+	Options []KeyValue
+}
+
+// DecodeSecurityOptions decodes a security options string slice to a
+// type-safe [SecurityOpt].
+func DecodeSecurityOptions(opts []string) ([]SecurityOpt, error) {
+	so := []SecurityOpt{}
+	for _, opt := range opts {
+		// support output from a < 1.13 docker daemon
+		if !strings.Contains(opt, "=") {
+			so = append(so, SecurityOpt{Name: opt})
+			continue
+		}
+		secopt := SecurityOpt{}
+		for _, s := range strings.Split(opt, ",") {
+			k, v, ok := strings.Cut(s, "=")
+			if !ok {
+				return nil, fmt.Errorf("invalid security option %q", s)
+			}
+			if k == "" || v == "" {
+				return nil, errors.New("invalid empty security option")
+			}
+			if k == "name" {
+				secopt.Name = v
+				continue
+			}
+			secopt.Options = append(secopt.Options, KeyValue{Key: k, Value: v})
+		}
+		so = append(so, secopt)
+	}
+	return so, nil
+}
+
+// KeyValue holds a key/value pair.
+type KeyValue struct {
+	Key, Value string
+}

--- a/vendor/github.com/docker/docker/api/types/types.go
+++ b/vendor/github.com/docker/docker/api/types/types.go
@@ -1,18 +1,14 @@
 package types // import "github.com/docker/docker/api/types"
 
 import (
-	"errors"
-	"fmt"
 	"io"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
-	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/go-connections/nat"
@@ -230,155 +226,6 @@ type Version struct {
 	KernelVersion string `json:",omitempty"`
 	Experimental  bool   `json:",omitempty"`
 	BuildTime     string `json:",omitempty"`
-}
-
-// Commit holds the Git-commit (SHA1) that a binary was built from, as reported
-// in the version-string of external tools, such as containerd, or runC.
-type Commit struct {
-	ID       string // ID is the actual commit ID of external tool.
-	Expected string // Expected is the commit ID of external tool expected by dockerd as set at build time.
-}
-
-// Info contains response of Engine API:
-// GET "/info"
-type Info struct {
-	ID                 string
-	Containers         int
-	ContainersRunning  int
-	ContainersPaused   int
-	ContainersStopped  int
-	Images             int
-	Driver             string
-	DriverStatus       [][2]string
-	SystemStatus       [][2]string `json:",omitempty"` // SystemStatus is only propagated by the Swarm standalone API
-	Plugins            PluginsInfo
-	MemoryLimit        bool
-	SwapLimit          bool
-	KernelMemory       bool `json:",omitempty"` // Deprecated: kernel 5.4 deprecated kmem.limit_in_bytes
-	KernelMemoryTCP    bool `json:",omitempty"` // KernelMemoryTCP is not supported on cgroups v2.
-	CPUCfsPeriod       bool `json:"CpuCfsPeriod"`
-	CPUCfsQuota        bool `json:"CpuCfsQuota"`
-	CPUShares          bool
-	CPUSet             bool
-	PidsLimit          bool
-	IPv4Forwarding     bool
-	BridgeNfIptables   bool
-	BridgeNfIP6tables  bool `json:"BridgeNfIp6tables"`
-	Debug              bool
-	NFd                int
-	OomKillDisable     bool
-	NGoroutines        int
-	SystemTime         string
-	LoggingDriver      string
-	CgroupDriver       string
-	CgroupVersion      string `json:",omitempty"`
-	NEventsListener    int
-	KernelVersion      string
-	OperatingSystem    string
-	OSVersion          string
-	OSType             string
-	Architecture       string
-	IndexServerAddress string
-	RegistryConfig     *registry.ServiceConfig
-	NCPU               int
-	MemTotal           int64
-	GenericResources   []swarm.GenericResource
-	DockerRootDir      string
-	HTTPProxy          string `json:"HttpProxy"`
-	HTTPSProxy         string `json:"HttpsProxy"`
-	NoProxy            string
-	Name               string
-	Labels             []string
-	ExperimentalBuild  bool
-	ServerVersion      string
-	Runtimes           map[string]Runtime
-	DefaultRuntime     string
-	Swarm              swarm.Info
-	// LiveRestoreEnabled determines whether containers should be kept
-	// running when the daemon is shutdown or upon daemon start if
-	// running containers are detected
-	LiveRestoreEnabled  bool
-	Isolation           container.Isolation
-	InitBinary          string
-	ContainerdCommit    Commit
-	RuncCommit          Commit
-	InitCommit          Commit
-	SecurityOptions     []string
-	ProductLicense      string               `json:",omitempty"`
-	DefaultAddressPools []NetworkAddressPool `json:",omitempty"`
-
-	// Legacy API fields for older API versions.
-	legacyFields
-
-	// Warnings contains a slice of warnings that occurred  while collecting
-	// system information. These warnings are intended to be informational
-	// messages for the user, and are not intended to be parsed / used for
-	// other purposes, as they do not have a fixed format.
-	Warnings []string
-}
-
-type legacyFields struct {
-	ExecutionDriver string `json:",omitempty"` // Deprecated: deprecated since API v1.25, but returned for older versions.
-}
-
-// KeyValue holds a key/value pair
-type KeyValue struct {
-	Key, Value string
-}
-
-// NetworkAddressPool is a temp struct used by Info struct
-type NetworkAddressPool struct {
-	Base string
-	Size int
-}
-
-// SecurityOpt contains the name and options of a security option
-type SecurityOpt struct {
-	Name    string
-	Options []KeyValue
-}
-
-// DecodeSecurityOptions decodes a security options string slice to a type safe
-// SecurityOpt
-func DecodeSecurityOptions(opts []string) ([]SecurityOpt, error) {
-	so := []SecurityOpt{}
-	for _, opt := range opts {
-		// support output from a < 1.13 docker daemon
-		if !strings.Contains(opt, "=") {
-			so = append(so, SecurityOpt{Name: opt})
-			continue
-		}
-		secopt := SecurityOpt{}
-		for _, s := range strings.Split(opt, ",") {
-			k, v, ok := strings.Cut(s, "=")
-			if !ok {
-				return nil, fmt.Errorf("invalid security option %q", s)
-			}
-			if k == "" || v == "" {
-				return nil, errors.New("invalid empty security option")
-			}
-			if k == "name" {
-				secopt.Name = v
-				continue
-			}
-			secopt.Options = append(secopt.Options, KeyValue{Key: k, Value: v})
-		}
-		so = append(so, secopt)
-	}
-	return so, nil
-}
-
-// PluginsInfo is a temp struct holding Plugins name
-// registered with docker daemon. It is used by Info struct
-type PluginsInfo struct {
-	// List of Volume plugins registered
-	Volume []string
-	// List of Network plugins registered
-	Network []string
-	// List of Authorization plugins registered
-	Authorization []string
-	// List of Log plugins registered
-	Log []string
 }
 
 // ExecStartCheck is a temp struct used by execStart
@@ -650,19 +497,6 @@ type NetworkInspectOptions struct {
 // Checkpoint represents the details of a checkpoint
 type Checkpoint struct {
 	Name string // Name is the name of the checkpoint
-}
-
-// Runtime describes an OCI runtime
-type Runtime struct {
-	// "Legacy" runtime configuration for runc-compatible runtimes.
-
-	Path string   `json:"path,omitempty"`
-	Args []string `json:"runtimeArgs,omitempty"`
-
-	// Shimv2 runtime configuration. Mutually exclusive with the legacy config above.
-
-	Type    string                 `json:"runtimeType,omitempty"`
-	Options map[string]interface{} `json:"options,omitempty"`
 }
 
 // DiskUsageObject represents an object type used for disk usage query filtering.

--- a/vendor/github.com/docker/docker/api/types/types_deprecated.go
+++ b/vendor/github.com/docker/docker/api/types/types_deprecated.go
@@ -1,0 +1,49 @@
+package types
+
+import "github.com/docker/docker/api/types/system"
+
+// Info contains response of Engine API:
+// GET "/info"
+//
+// Deprecated: use [system.Info].
+type Info = system.Info
+
+// Commit holds the Git-commit (SHA1) that a binary was built from, as reported
+// in the version-string of external tools, such as containerd, or runC.
+//
+// Deprecated: use [system.Commit].
+type Commit = system.Commit
+
+// PluginsInfo is a temp struct holding Plugins name
+// registered with docker daemon. It is used by [system.Info] struct
+//
+// Deprecated: use [system.PluginsInfo].
+type PluginsInfo = system.PluginsInfo
+
+// NetworkAddressPool is a temp struct used by [system.Info] struct.
+//
+// Deprecated: use [system.NetworkAddressPool].
+type NetworkAddressPool = system.NetworkAddressPool
+
+// Runtime describes an OCI runtime.
+//
+// Deprecated: use [system.Runtime].
+type Runtime = system.Runtime
+
+// SecurityOpt contains the name and options of a security option.
+//
+// Deprecated: use [system.SecurityOpt].
+type SecurityOpt = system.SecurityOpt
+
+// KeyValue holds a key/value pair.
+//
+// Deprecated: use [system.KeyValue].
+type KeyValue = system.KeyValue
+
+// DecodeSecurityOptions decodes a security options string slice to a type safe
+// [system.SecurityOpt].
+//
+// Deprecated: use [system.DecodeSecurityOptions].
+func DecodeSecurityOptions(opts []string) ([]system.SecurityOpt, error) {
+	return system.DecodeSecurityOptions(opts)
+}

--- a/vendor/github.com/docker/docker/client/client.go
+++ b/vendor/github.com/docker/docker/client/client.go
@@ -56,6 +56,36 @@ import (
 	"github.com/pkg/errors"
 )
 
+// DummyHost is a hostname used for local communication.
+//
+// It acts as a valid formatted hostname for local connections (such as "unix://"
+// or "npipe://") which do not require a hostname. It should never be resolved,
+// but uses the special-purpose ".localhost" TLD (as defined in [RFC 2606, Section 2]
+// and [RFC 6761, Section 6.3]).
+//
+// [RFC 7230, Section 5.4] defines that an empty header must be used for such
+// cases:
+//
+//	If the authority component is missing or undefined for the target URI,
+//	then a client MUST send a Host header field with an empty field-value.
+//
+// However, [Go stdlib] enforces the semantics of HTTP(S) over TCP, does not
+// allow an empty header to be used, and requires req.URL.Scheme to be either
+// "http" or "https".
+//
+// For further details, refer to:
+//
+//   - https://github.com/docker/engine-api/issues/189
+//   - https://github.com/golang/go/issues/13624
+//   - https://github.com/golang/go/issues/61076
+//   - https://github.com/moby/moby/issues/45935
+//
+// [RFC 2606, Section 2]: https://www.rfc-editor.org/rfc/rfc2606.html#section-2
+// [RFC 6761, Section 6.3]: https://www.rfc-editor.org/rfc/rfc6761#section-6.3
+// [RFC 7230, Section 5.4]: https://datatracker.ietf.org/doc/html/rfc7230#section-5.4
+// [Go stdlib]: https://github.com/golang/go/blob/6244b1946bc2101b01955468f1be502dbadd6807/src/net/http/transport.go#L558-L569
+const DummyHost = "api.moby.localhost"
+
 // ErrRedirect is the error returned by checkRedirect when the request is non-GET.
 var ErrRedirect = errors.New("unexpected redirect in response")
 

--- a/vendor/github.com/docker/docker/client/container_attach.go
+++ b/vendor/github.com/docker/docker/client/container_attach.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"context"
+	"net/http"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
@@ -52,8 +53,7 @@ func (cli *Client) ContainerAttach(ctx context.Context, container string, option
 		query.Set("logs", "1")
 	}
 
-	headers := map[string][]string{
+	return cli.postHijacked(ctx, "/containers/"+container+"/attach", query, nil, http.Header{
 		"Content-Type": {"text/plain"},
-	}
-	return cli.postHijacked(ctx, "/containers/"+container+"/attach", query, nil, headers)
+	})
 }

--- a/vendor/github.com/docker/docker/client/container_exec.go
+++ b/vendor/github.com/docker/docker/client/container_exec.go
@@ -3,6 +3,7 @@ package client // import "github.com/docker/docker/client"
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions"
@@ -46,10 +47,9 @@ func (cli *Client) ContainerExecAttach(ctx context.Context, execID string, confi
 	if versions.LessThan(cli.ClientVersion(), "1.42") {
 		config.ConsoleSize = nil
 	}
-	headers := map[string][]string{
+	return cli.postHijacked(ctx, "/exec/"+execID+"/start", nil, config, http.Header{
 		"Content-Type": {"application/json"},
-	}
-	return cli.postHijacked(ctx, "/exec/"+execID+"/start", nil, config, headers)
+	})
 }
 
 // ContainerExecInspect returns information about a specific exec process on the docker host.

--- a/vendor/github.com/docker/docker/client/distribution_inspect.go
+++ b/vendor/github.com/docker/docker/client/distribution_inspect.go
@@ -3,6 +3,7 @@ package client // import "github.com/docker/docker/client"
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"net/url"
 
 	"github.com/docker/docker/api/types/registry"
@@ -19,10 +20,10 @@ func (cli *Client) DistributionInspect(ctx context.Context, image, encodedRegist
 	if err := cli.NewVersionError("1.30", "distribution inspect"); err != nil {
 		return distributionInspect, err
 	}
-	var headers map[string][]string
 
+	var headers http.Header
 	if encodedRegistryAuth != "" {
-		headers = map[string][]string{
+		headers = http.Header{
 			registry.AuthHeader: {encodedRegistryAuth},
 		}
 	}

--- a/vendor/github.com/docker/docker/client/hijack.go
+++ b/vendor/github.com/docker/docker/client/hijack.go
@@ -23,14 +23,10 @@ func (cli *Client) postHijacked(ctx context.Context, path string, query url.Valu
 	if err != nil {
 		return types.HijackedResponse{}, err
 	}
-
-	apiPath := cli.getAPIPath(ctx, path, query)
-	req, err := http.NewRequest(http.MethodPost, apiPath, bodyEncoded)
+	req, err := cli.buildRequest(http.MethodPost, cli.getAPIPath(ctx, path, query), bodyEncoded, headers)
 	if err != nil {
 		return types.HijackedResponse{}, err
 	}
-	req = cli.addHeaders(req, headers)
-
 	conn, mediaType, err := cli.setupHijackConn(ctx, req, "tcp")
 	if err != nil {
 		return types.HijackedResponse{}, err
@@ -64,7 +60,6 @@ func fallbackDial(proto, addr string, tlsConfig *tls.Config) (net.Conn, error) {
 }
 
 func (cli *Client) setupHijackConn(ctx context.Context, req *http.Request, proto string) (net.Conn, string, error) {
-	req.Host = cli.addr
 	req.Header.Set("Connection", "Upgrade")
 	req.Header.Set("Upgrade", proto)
 
@@ -80,8 +75,8 @@ func (cli *Client) setupHijackConn(ctx context.Context, req *http.Request, proto
 	// state. Setting TCP KeepAlive on the socket connection will prohibit
 	// ECONNTIMEOUT unless the socket connection truly is broken
 	if tcpConn, ok := conn.(*net.TCPConn); ok {
-		tcpConn.SetKeepAlive(true)
-		tcpConn.SetKeepAlivePeriod(30 * time.Second)
+		_ = tcpConn.SetKeepAlive(true)
+		_ = tcpConn.SetKeepAlivePeriod(30 * time.Second)
 	}
 
 	clientconn := httputil.NewClientConn(conn, nil)
@@ -96,7 +91,7 @@ func (cli *Client) setupHijackConn(ctx context.Context, req *http.Request, proto
 			return nil, "", err
 		}
 		if resp.StatusCode != http.StatusSwitchingProtocols {
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			return nil, "", fmt.Errorf("unable to upgrade to %s, received %d", proto, resp.StatusCode)
 		}
 	}

--- a/vendor/github.com/docker/docker/client/image_build.go
+++ b/vendor/github.com/docker/docker/client/image_build.go
@@ -23,13 +23,13 @@ func (cli *Client) ImageBuild(ctx context.Context, buildContext io.Reader, optio
 		return types.ImageBuildResponse{}, err
 	}
 
-	headers := http.Header(make(map[string][]string))
 	buf, err := json.Marshal(options.AuthConfigs)
 	if err != nil {
 		return types.ImageBuildResponse{}, err
 	}
-	headers.Add("X-Registry-Config", base64.URLEncoding.EncodeToString(buf))
 
+	headers := http.Header{}
+	headers.Add("X-Registry-Config", base64.URLEncoding.EncodeToString(buf))
 	headers.Set("Content-Type", "application/x-tar")
 
 	serverResp, err := cli.postRaw(ctx, "/build", query, buildContext, headers)
@@ -37,11 +37,9 @@ func (cli *Client) ImageBuild(ctx context.Context, buildContext io.Reader, optio
 		return types.ImageBuildResponse{}, err
 	}
 
-	osType := getDockerOS(serverResp.header.Get("Server"))
-
 	return types.ImageBuildResponse{
 		Body:   serverResp.body,
-		OSType: osType,
+		OSType: getDockerOS(serverResp.header.Get("Server")),
 	}, nil
 }
 

--- a/vendor/github.com/docker/docker/client/image_create.go
+++ b/vendor/github.com/docker/docker/client/image_create.go
@@ -3,6 +3,7 @@ package client // import "github.com/docker/docker/client"
 import (
 	"context"
 	"io"
+	"net/http"
 	"net/url"
 	"strings"
 
@@ -33,6 +34,7 @@ func (cli *Client) ImageCreate(ctx context.Context, parentReference string, opti
 }
 
 func (cli *Client) tryImageCreate(ctx context.Context, query url.Values, registryAuth string) (serverResponse, error) {
-	headers := map[string][]string{registry.AuthHeader: {registryAuth}}
-	return cli.post(ctx, "/images/create", query, nil, headers)
+	return cli.post(ctx, "/images/create", query, nil, http.Header{
+		registry.AuthHeader: {registryAuth},
+	})
 }

--- a/vendor/github.com/docker/docker/client/image_load.go
+++ b/vendor/github.com/docker/docker/client/image_load.go
@@ -3,6 +3,7 @@ package client // import "github.com/docker/docker/client"
 import (
 	"context"
 	"io"
+	"net/http"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
@@ -17,8 +18,9 @@ func (cli *Client) ImageLoad(ctx context.Context, input io.Reader, quiet bool) (
 	if quiet {
 		v.Set("quiet", "1")
 	}
-	headers := map[string][]string{"Content-Type": {"application/x-tar"}}
-	resp, err := cli.postRaw(ctx, "/images/load", v, input, headers)
+	resp, err := cli.postRaw(ctx, "/images/load", v, input, http.Header{
+		"Content-Type": {"application/x-tar"},
+	})
 	if err != nil {
 		return types.ImageLoadResponse{}, err
 	}

--- a/vendor/github.com/docker/docker/client/image_push.go
+++ b/vendor/github.com/docker/docker/client/image_push.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net/http"
 	"net/url"
 
 	"github.com/docker/distribution/reference"
@@ -50,6 +51,7 @@ func (cli *Client) ImagePush(ctx context.Context, image string, options types.Im
 }
 
 func (cli *Client) tryImagePush(ctx context.Context, imageID string, query url.Values, registryAuth string) (serverResponse, error) {
-	headers := map[string][]string{registry.AuthHeader: {registryAuth}}
-	return cli.post(ctx, "/images/"+imageID+"/push", query, nil, headers)
+	return cli.post(ctx, "/images/"+imageID+"/push", query, nil, http.Header{
+		registry.AuthHeader: {registryAuth},
+	})
 }

--- a/vendor/github.com/docker/docker/client/image_search.go
+++ b/vendor/github.com/docker/docker/client/image_search.go
@@ -3,6 +3,7 @@ package client // import "github.com/docker/docker/client"
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"net/url"
 	"strconv"
 
@@ -48,6 +49,7 @@ func (cli *Client) ImageSearch(ctx context.Context, term string, options types.I
 }
 
 func (cli *Client) tryImageSearch(ctx context.Context, query url.Values, registryAuth string) (serverResponse, error) {
-	headers := map[string][]string{registry.AuthHeader: {registryAuth}}
-	return cli.get(ctx, "/images/search", query, headers)
+	return cli.get(ctx, "/images/search", query, http.Header{
+		registry.AuthHeader: {registryAuth},
+	})
 }

--- a/vendor/github.com/docker/docker/client/info.go
+++ b/vendor/github.com/docker/docker/client/info.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/system"
 )
 
 // Info returns information about the docker server.
-func (cli *Client) Info(ctx context.Context) (types.Info, error) {
-	var info types.Info
+func (cli *Client) Info(ctx context.Context) (system.Info, error) {
+	var info system.Info
 	serverResp, err := cli.get(ctx, "/info", url.Values{}, nil)
 	defer ensureReaderClosed(serverResp)
 	if err != nil {

--- a/vendor/github.com/docker/docker/client/interface.go
+++ b/vendor/github.com/docker/docker/client/interface.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/api/types/system"
 	"github.com/docker/docker/api/types/volume"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -165,7 +166,7 @@ type SwarmAPIClient interface {
 // SystemAPIClient defines API client methods for the system
 type SystemAPIClient interface {
 	Events(ctx context.Context, options types.EventsOptions) (<-chan events.Message, <-chan error)
-	Info(ctx context.Context) (types.Info, error)
+	Info(ctx context.Context) (system.Info, error)
 	RegistryLogin(ctx context.Context, auth registry.AuthConfig) (registry.AuthenticateOKBody, error)
 	DiskUsage(ctx context.Context, options types.DiskUsageOptions) (types.DiskUsage, error)
 	Ping(ctx context.Context) (types.Ping, error)

--- a/vendor/github.com/docker/docker/client/plugin_install.go
+++ b/vendor/github.com/docker/docker/client/plugin_install.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"net/http"
 	"net/url"
 
 	"github.com/docker/distribution/reference"
@@ -68,13 +69,15 @@ func (cli *Client) PluginInstall(ctx context.Context, name string, options types
 }
 
 func (cli *Client) tryPluginPrivileges(ctx context.Context, query url.Values, registryAuth string) (serverResponse, error) {
-	headers := map[string][]string{registry.AuthHeader: {registryAuth}}
-	return cli.get(ctx, "/plugins/privileges", query, headers)
+	return cli.get(ctx, "/plugins/privileges", query, http.Header{
+		registry.AuthHeader: {registryAuth},
+	})
 }
 
 func (cli *Client) tryPluginPull(ctx context.Context, query url.Values, privileges types.PluginPrivileges, registryAuth string) (serverResponse, error) {
-	headers := map[string][]string{registry.AuthHeader: {registryAuth}}
-	return cli.post(ctx, "/plugins/pull", query, privileges, headers)
+	return cli.post(ctx, "/plugins/pull", query, privileges, http.Header{
+		registry.AuthHeader: {registryAuth},
+	})
 }
 
 func (cli *Client) checkPluginPermissions(ctx context.Context, query url.Values, options types.PluginInstallOptions) (types.PluginPrivileges, error) {

--- a/vendor/github.com/docker/docker/client/plugin_push.go
+++ b/vendor/github.com/docker/docker/client/plugin_push.go
@@ -3,14 +3,16 @@ package client // import "github.com/docker/docker/client"
 import (
 	"context"
 	"io"
+	"net/http"
 
 	"github.com/docker/docker/api/types/registry"
 )
 
 // PluginPush pushes a plugin to a registry
 func (cli *Client) PluginPush(ctx context.Context, name string, registryAuth string) (io.ReadCloser, error) {
-	headers := map[string][]string{registry.AuthHeader: {registryAuth}}
-	resp, err := cli.post(ctx, "/plugins/"+name+"/push", nil, nil, headers)
+	resp, err := cli.post(ctx, "/plugins/"+name+"/push", nil, nil, http.Header{
+		registry.AuthHeader: {registryAuth},
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/docker/docker/client/plugin_upgrade.go
+++ b/vendor/github.com/docker/docker/client/plugin_upgrade.go
@@ -3,6 +3,7 @@ package client // import "github.com/docker/docker/client"
 import (
 	"context"
 	"io"
+	"net/http"
 	"net/url"
 
 	"github.com/docker/distribution/reference"
@@ -35,6 +36,7 @@ func (cli *Client) PluginUpgrade(ctx context.Context, name string, options types
 }
 
 func (cli *Client) tryPluginUpgrade(ctx context.Context, query url.Values, privileges types.PluginPrivileges, name, registryAuth string) (serverResponse, error) {
-	headers := map[string][]string{registry.AuthHeader: {registryAuth}}
-	return cli.post(ctx, "/plugins/"+name+"/upgrade", query, privileges, headers)
+	return cli.post(ctx, "/plugins/"+name+"/upgrade", query, privileges, http.Header{
+		registry.AuthHeader: {registryAuth},
+	})
 }

--- a/vendor/github.com/docker/docker/client/request.go
+++ b/vendor/github.com/docker/docker/client/request.go
@@ -28,17 +28,17 @@ type serverResponse struct {
 }
 
 // head sends an http request to the docker API using the method HEAD.
-func (cli *Client) head(ctx context.Context, path string, query url.Values, headers map[string][]string) (serverResponse, error) {
+func (cli *Client) head(ctx context.Context, path string, query url.Values, headers http.Header) (serverResponse, error) {
 	return cli.sendRequest(ctx, http.MethodHead, path, query, nil, headers)
 }
 
 // get sends an http request to the docker API using the method GET with a specific Go context.
-func (cli *Client) get(ctx context.Context, path string, query url.Values, headers map[string][]string) (serverResponse, error) {
+func (cli *Client) get(ctx context.Context, path string, query url.Values, headers http.Header) (serverResponse, error) {
 	return cli.sendRequest(ctx, http.MethodGet, path, query, nil, headers)
 }
 
 // post sends an http request to the docker API using the method POST with a specific Go context.
-func (cli *Client) post(ctx context.Context, path string, query url.Values, obj interface{}, headers map[string][]string) (serverResponse, error) {
+func (cli *Client) post(ctx context.Context, path string, query url.Values, obj interface{}, headers http.Header) (serverResponse, error) {
 	body, headers, err := encodeBody(obj, headers)
 	if err != nil {
 		return serverResponse{}, err
@@ -46,11 +46,11 @@ func (cli *Client) post(ctx context.Context, path string, query url.Values, obj 
 	return cli.sendRequest(ctx, http.MethodPost, path, query, body, headers)
 }
 
-func (cli *Client) postRaw(ctx context.Context, path string, query url.Values, body io.Reader, headers map[string][]string) (serverResponse, error) {
+func (cli *Client) postRaw(ctx context.Context, path string, query url.Values, body io.Reader, headers http.Header) (serverResponse, error) {
 	return cli.sendRequest(ctx, http.MethodPost, path, query, body, headers)
 }
 
-func (cli *Client) put(ctx context.Context, path string, query url.Values, obj interface{}, headers map[string][]string) (serverResponse, error) {
+func (cli *Client) put(ctx context.Context, path string, query url.Values, obj interface{}, headers http.Header) (serverResponse, error) {
 	body, headers, err := encodeBody(obj, headers)
 	if err != nil {
 		return serverResponse{}, err
@@ -59,7 +59,7 @@ func (cli *Client) put(ctx context.Context, path string, query url.Values, obj i
 }
 
 // putRaw sends an http request to the docker API using the method PUT.
-func (cli *Client) putRaw(ctx context.Context, path string, query url.Values, body io.Reader, headers map[string][]string) (serverResponse, error) {
+func (cli *Client) putRaw(ctx context.Context, path string, query url.Values, body io.Reader, headers http.Header) (serverResponse, error) {
 	// PUT requests are expected to always have a body (apparently)
 	// so explicitly pass an empty body to sendRequest to signal that
 	// it should set the Content-Type header if not already present.
@@ -70,13 +70,11 @@ func (cli *Client) putRaw(ctx context.Context, path string, query url.Values, bo
 }
 
 // delete sends an http request to the docker API using the method DELETE.
-func (cli *Client) delete(ctx context.Context, path string, query url.Values, headers map[string][]string) (serverResponse, error) {
+func (cli *Client) delete(ctx context.Context, path string, query url.Values, headers http.Header) (serverResponse, error) {
 	return cli.sendRequest(ctx, http.MethodDelete, path, query, nil, headers)
 }
 
-type headers map[string][]string
-
-func encodeBody(obj interface{}, headers headers) (io.Reader, headers, error) {
+func encodeBody(obj interface{}, headers http.Header) (io.Reader, http.Header, error) {
 	if obj == nil {
 		return nil, headers, nil
 	}
@@ -98,24 +96,19 @@ func encodeBody(obj interface{}, headers headers) (io.Reader, headers, error) {
 	return body, headers, nil
 }
 
-func (cli *Client) buildRequest(method, path string, body io.Reader, headers headers) (*http.Request, error) {
+func (cli *Client) buildRequest(method, path string, body io.Reader, headers http.Header) (*http.Request, error) {
 	req, err := http.NewRequest(method, path, body)
 	if err != nil {
 		return nil, err
 	}
 	req = cli.addHeaders(req, headers)
+	req.URL.Scheme = cli.scheme
+	req.URL.Host = cli.addr
 
 	if cli.proto == "unix" || cli.proto == "npipe" {
-		// For local communications, it doesn't matter what the host is. We just
-		// need a valid and meaningful host name. For details, see:
-		//
-		// - https://github.com/docker/engine-api/issues/189
-		// - https://github.com/golang/go/issues/13624
-		req.Host = "docker"
+		// Override host header for non-tcp connections.
+		req.Host = DummyHost
 	}
-
-	req.URL.Host = cli.addr
-	req.URL.Scheme = cli.scheme
 
 	if body != nil && req.Header.Get("Content-Type") == "" {
 		req.Header.Set("Content-Type", "text/plain")
@@ -123,7 +116,7 @@ func (cli *Client) buildRequest(method, path string, body io.Reader, headers hea
 	return req, nil
 }
 
-func (cli *Client) sendRequest(ctx context.Context, method, path string, query url.Values, body io.Reader, headers headers) (serverResponse, error) {
+func (cli *Client) sendRequest(ctx context.Context, method, path string, query url.Values, body io.Reader, headers http.Header) (serverResponse, error) {
 	req, err := cli.buildRequest(method, cli.getAPIPath(ctx, path, query), body, headers)
 	if err != nil {
 		return serverResponse{}, err
@@ -161,19 +154,19 @@ func (cli *Client) doRequest(ctx context.Context, req *http.Request) (serverResp
 			return serverResp, err
 		}
 
-		if nErr, ok := err.(*url.Error); ok {
-			if nErr, ok := nErr.Err.(*net.OpError); ok {
+		if uErr, ok := err.(*url.Error); ok {
+			if nErr, ok := uErr.Err.(*net.OpError); ok {
 				if os.IsPermission(nErr.Err) {
 					return serverResp, errors.Wrapf(err, "permission denied while trying to connect to the Docker daemon socket at %v", cli.host)
 				}
 			}
 		}
 
-		if err, ok := err.(net.Error); ok {
-			if err.Timeout() {
+		if nErr, ok := err.(net.Error); ok {
+			if nErr.Timeout() {
 				return serverResp, ErrorConnectionFailed(cli.host)
 			}
-			if strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "dial unix") {
+			if strings.Contains(nErr.Error(), "connection refused") || strings.Contains(nErr.Error(), "dial unix") {
 				return serverResp, ErrorConnectionFailed(cli.host)
 			}
 		}
@@ -253,7 +246,7 @@ func (cli *Client) checkResponseErr(serverResp serverResponse) error {
 	return errors.Wrap(errors.New(errorMessage), "Error response from daemon")
 }
 
-func (cli *Client) addHeaders(req *http.Request, headers headers) *http.Request {
+func (cli *Client) addHeaders(req *http.Request, headers http.Header) *http.Request {
 	// Add CLI Config's HTTP Headers BEFORE we set the Docker headers
 	// then the user can't change OUR headers
 	for k, v := range cli.customHTTPHeaders {

--- a/vendor/github.com/docker/docker/client/service_create.go
+++ b/vendor/github.com/docker/docker/client/service_create.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/api/types/versions"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
@@ -17,13 +19,6 @@ import (
 // ServiceCreate creates a new service.
 func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec, options types.ServiceCreateOptions) (types.ServiceCreateResponse, error) {
 	var response types.ServiceCreateResponse
-	headers := map[string][]string{
-		"version": {cli.version},
-	}
-
-	if options.EncodedRegistryAuth != "" {
-		headers[registry.AuthHeader] = []string{options.EncodedRegistryAuth}
-	}
 
 	// Make sure containerSpec is not nil when no runtime is set or the runtime is set to container
 	if service.TaskTemplate.ContainerSpec == nil && (service.TaskTemplate.Runtime == "" || service.TaskTemplate.Runtime == swarm.RuntimeContainer) {
@@ -53,6 +48,16 @@ func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec,
 		}
 	}
 
+	headers := http.Header{}
+	if versions.LessThan(cli.version, "1.30") {
+		// the custom "version" header was used by engine API before 20.10
+		// (API 1.30) to switch between client- and server-side lookup of
+		// image digests.
+		headers["version"] = []string{cli.version}
+	}
+	if options.EncodedRegistryAuth != "" {
+		headers[registry.AuthHeader] = []string{options.EncodedRegistryAuth}
+	}
 	resp, err := cli.post(ctx, "/services/create", nil, service, headers)
 	defer ensureReaderClosed(resp)
 	if err != nil {

--- a/vendor/github.com/docker/docker/client/service_update.go
+++ b/vendor/github.com/docker/docker/client/service_update.go
@@ -3,11 +3,13 @@ package client // import "github.com/docker/docker/client"
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/api/types/versions"
 )
 
 // ServiceUpdate updates a Service. The version number is required to avoid conflicting writes.
@@ -18,14 +20,6 @@ func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version 
 		query    = url.Values{}
 		response = types.ServiceUpdateResponse{}
 	)
-
-	headers := map[string][]string{
-		"version": {cli.version},
-	}
-
-	if options.EncodedRegistryAuth != "" {
-		headers[registry.AuthHeader] = []string{options.EncodedRegistryAuth}
-	}
 
 	if options.RegistryAuthFrom != "" {
 		query.Set("registryAuthFrom", options.RegistryAuthFrom)
@@ -60,6 +54,16 @@ func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version 
 		}
 	}
 
+	headers := http.Header{}
+	if versions.LessThan(cli.version, "1.30") {
+		// the custom "version" header was used by engine API before 20.10
+		// (API 1.30) to switch between client- and server-side lookup of
+		// image digests.
+		headers["version"] = []string{cli.version}
+	}
+	if options.EncodedRegistryAuth != "" {
+		headers[registry.AuthHeader] = []string{options.EncodedRegistryAuth}
+	}
 	resp, err := cli.post(ctx, "/services/"+serviceID+"/update", query, service, headers)
 	defer ensureReaderClosed(resp)
 	if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -439,7 +439,7 @@ github.com/docker/cli/cli/connhelper/commandconn
 ## explicit
 github.com/docker/distribution/digestset
 github.com/docker/distribution/reference
-# github.com/docker/docker v24.0.0-rc.2.0.20230706181717-98d3da79ef9c+incompatible
+# github.com/docker/docker v24.0.0-rc.2.0.20230718135204-8e51b8b59cb8+incompatible
 ## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types
@@ -454,6 +454,7 @@ github.com/docker/docker/api/types/registry
 github.com/docker/docker/api/types/strslice
 github.com/docker/docker/api/types/swarm
 github.com/docker/docker/api/types/swarm/runtime
+github.com/docker/docker/api/types/system
 github.com/docker/docker/api/types/time
 github.com/docker/docker/api/types/versions
 github.com/docker/docker/api/types/volume


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/45942
- relates to https://github.com/moby/moby/issues/45935
- relates to https://github.com/moby/buildkit/pull/4021


notable changes:

- client: define a "dummy" hostname to use for local connections fixes "invalid host" errors when compiled with go1.20.6 or go1.19.11

full diff: https://github.com/docker/docker/compare/98d3da79ef9c...8e51b8b59cb81efba9491bb98a80396f2e578fe4