### PR TITLE
[0.12 backport] executor/resource: stub out NewSysSampler on Windows

### DIFF
--- a/executor/resources/sys.go
+++ b/executor/resources/sys.go
@@ -1,95 +1,9 @@
 package resources
 
-import (
-	"os"
-	"time"
-
-	"github.com/moby/buildkit/executor/resources/types"
-	"github.com/prometheus/procfs"
-)
+import "github.com/moby/buildkit/executor/resources/types"
 
 type SysSampler = Sub[*types.SysSample]
 
 func NewSysSampler() (*Sampler[*types.SysSample], error) {
-	procfs, err := procfs.NewDefaultFS()
-	if err != nil {
-		return nil, err
-	}
-
-	return NewSampler(2*time.Second, 20, func(tm time.Time) (*types.SysSample, error) {
-		return sampleSys(procfs, tm)
-	}), nil
-}
-
-func sampleSys(proc procfs.FS, tm time.Time) (*types.SysSample, error) {
-	stat, err := proc.Stat()
-	if err != nil {
-		return nil, err
-	}
-
-	s := &types.SysSample{
-		Timestamp_: tm,
-	}
-
-	s.CPUStat = &types.SysCPUStat{
-		User:      stat.CPUTotal.User,
-		Nice:      stat.CPUTotal.Nice,
-		System:    stat.CPUTotal.System,
-		Idle:      stat.CPUTotal.Idle,
-		Iowait:    stat.CPUTotal.Iowait,
-		IRQ:       stat.CPUTotal.IRQ,
-		SoftIRQ:   stat.CPUTotal.SoftIRQ,
-		Steal:     stat.CPUTotal.Steal,
-		Guest:     stat.CPUTotal.Guest,
-		GuestNice: stat.CPUTotal.GuestNice,
-	}
-
-	s.ProcStat = &types.ProcStat{
-		ContextSwitches:  stat.ContextSwitches,
-		ProcessCreated:   stat.ProcessCreated,
-		ProcessesRunning: stat.ProcessesRunning,
-	}
-
-	mem, err := proc.Meminfo()
-	if err != nil {
-		return nil, err
-	}
-
-	s.MemoryStat = &types.SysMemoryStat{
-		Total:     mem.MemTotal,
-		Free:      mem.MemFree,
-		Buffers:   mem.Buffers,
-		Cached:    mem.Cached,
-		Active:    mem.Active,
-		Inactive:  mem.Inactive,
-		Swap:      mem.SwapTotal,
-		Available: mem.MemAvailable,
-		Dirty:     mem.Dirty,
-		Writeback: mem.Writeback,
-		Slab:      mem.Slab,
-	}
-
-	if _, err := os.Lstat("/proc/pressure"); err != nil {
-		return s, nil
-	}
-
-	cp, err := parsePressureFile("/proc/pressure/cpu")
-	if err != nil {
-		return nil, err
-	}
-	s.CPUPressure = cp
-
-	mp, err := parsePressureFile("/proc/pressure/memory")
-	if err != nil {
-		return nil, err
-	}
-	s.MemoryPressure = mp
-
-	ip, err := parsePressureFile("/proc/pressure/io")
-	if err != nil {
-		return nil, err
-	}
-	s.IOPressure = ip
-
-	return s, nil
+	return newSysSampler()
 }

--- a/executor/resources/sys_linux.go
+++ b/executor/resources/sys_linux.go
@@ -1,0 +1,93 @@
+package resources
+
+import (
+	"os"
+	"time"
+
+	"github.com/moby/buildkit/executor/resources/types"
+	"github.com/prometheus/procfs"
+)
+
+func newSysSampler() (*Sampler[*types.SysSample], error) {
+	pfs, err := procfs.NewDefaultFS()
+	if err != nil {
+		return nil, err
+	}
+
+	return NewSampler(2*time.Second, 20, func(tm time.Time) (*types.SysSample, error) {
+		return sampleSys(pfs, tm)
+	}), nil
+}
+
+func sampleSys(proc procfs.FS, tm time.Time) (*types.SysSample, error) {
+	stat, err := proc.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	s := &types.SysSample{
+		Timestamp_: tm,
+	}
+
+	s.CPUStat = &types.SysCPUStat{
+		User:      stat.CPUTotal.User,
+		Nice:      stat.CPUTotal.Nice,
+		System:    stat.CPUTotal.System,
+		Idle:      stat.CPUTotal.Idle,
+		Iowait:    stat.CPUTotal.Iowait,
+		IRQ:       stat.CPUTotal.IRQ,
+		SoftIRQ:   stat.CPUTotal.SoftIRQ,
+		Steal:     stat.CPUTotal.Steal,
+		Guest:     stat.CPUTotal.Guest,
+		GuestNice: stat.CPUTotal.GuestNice,
+	}
+
+	s.ProcStat = &types.ProcStat{
+		ContextSwitches:  stat.ContextSwitches,
+		ProcessCreated:   stat.ProcessCreated,
+		ProcessesRunning: stat.ProcessesRunning,
+	}
+
+	mem, err := proc.Meminfo()
+	if err != nil {
+		return nil, err
+	}
+
+	s.MemoryStat = &types.SysMemoryStat{
+		Total:     mem.MemTotal,
+		Free:      mem.MemFree,
+		Buffers:   mem.Buffers,
+		Cached:    mem.Cached,
+		Active:    mem.Active,
+		Inactive:  mem.Inactive,
+		Swap:      mem.SwapTotal,
+		Available: mem.MemAvailable,
+		Dirty:     mem.Dirty,
+		Writeback: mem.Writeback,
+		Slab:      mem.Slab,
+	}
+
+	if _, err := os.Lstat("/proc/pressure"); err != nil {
+		return s, nil
+	}
+
+	cp, err := parsePressureFile("/proc/pressure/cpu")
+	if err != nil {
+		return nil, err
+	}
+	s.CPUPressure = cp
+
+	mp, err := parsePressureFile("/proc/pressure/memory")
+	if err != nil {
+		return nil, err
+	}
+	s.MemoryPressure = mp
+
+	ip, err := parsePressureFile("/proc/pressure/io")
+	if err != nil {
+		return nil, err
+	}
+	s.IOPressure = ip
+
+	return s, nil
+}

--- a/executor/resources/sys_nolinux.go
+++ b/executor/resources/sys_nolinux.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package resources
+
+import "github.com/moby/buildkit/executor/resources/types"
+
+func newSysSampler() (*Sampler[*types.SysSample], error) {
+	return nil, nil
+}

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -416,8 +416,11 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 
 	defer j.Discard()
 
-	usage := s.sysSampler.Record()
-	defer usage.Close(false)
+	var usage *resources.Sub[*resourcetypes.SysSample]
+	if s.sysSampler != nil {
+		usage = s.sysSampler.Record()
+		defer usage.Close(false)
+	}
 
 	var res *frontend.Result
 	var resProv *Result


### PR DESCRIPTION
- backport of https://github.com/moby/buildkit/pull/4040
- relates to https://github.com/moby/buildkit/pull/3860
- relates to https://github.com/moby/moby/pull/45966#issuecomment-1643548223
- relates to https://github.com/moby/moby/pull/46035

Commit 509cfa3916386d3d736ff9754c5caa8969724c4a (https://github.com/moby/buildkit/pull/3860) introduced the SysSampler, which measures resource consumption. However, for this it depends on prometheus' procfs. That package does not have build-tags but is a Linux-only implementation, which (by default) attempts to access `/proc`; https://github.com/prometheus/procfs/blob/v0.9.0/fs.go#L26-L33 https://github.com/prometheus/procfs/blob/v0.9.0/internal/fs/fs.go#L23-L24

This patch splits the implementation of "resource" into platform-specific files, and stubs out the NewSysSampler() on non-Linux platforms.



(cherry picked from commit ce332e1952fe30cef17fac2667f9e67b97afcdf9)