### PR TITLE
Add support for JSON formatted logs

### DIFF
--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -14,6 +14,10 @@ type Config struct {
 
 	// Entitlements e.g. security.insecure, network.host
 	Entitlements []string `toml:"insecure-entitlements"`
+
+	// LogFormat is the format of the logs. It can be "json" or "text".
+	Log LogConfig `toml:"log"`
+
 	// GRPC configuration settings
 	GRPC GRPCConfig `toml:"grpc"`
 
@@ -27,6 +31,10 @@ type Config struct {
 	DNS *DNSConfig `toml:"dns"`
 
 	History *HistoryConfig `toml:"history"`
+}
+
+type LogConfig struct {
+	Format string `toml:"format"`
 }
 
 type GRPCConfig struct {

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -171,6 +171,12 @@ func main() {
 			Usage: "listening address (socket or tcp)",
 			Value: &cli.StringSlice{defaultConf.GRPC.Address[0]},
 		},
+		// Add format flag to control log formatter
+		cli.StringFlag{
+			Name:  "log-format",
+			Usage: "log formatter: json or text",
+			Value: "text",
+		},
 		cli.StringFlag{
 			Name:  "group",
 			Usage: "group (name or gid) which will own all Unix socket listening addresses",
@@ -223,7 +229,16 @@ func main() {
 			return err
 		}
 
-		logrus.SetFormatter(&logrus.TextFormatter{FullTimestamp: true})
+		logFormat := cfg.Log.Format
+		switch logFormat {
+		case "json":
+			logrus.SetFormatter(&logrus.JSONFormatter{})
+		case "text", "":
+			logrus.SetFormatter(&logrus.TextFormatter{FullTimestamp: true})
+		default:
+			return errors.Errorf("unsupported log type %q", logFormat)
+		}
+
 		if cfg.Debug {
 			logrus.SetLevel(logrus.DebugLevel)
 		}
@@ -470,7 +485,9 @@ func applyMainFlags(c *cli.Context, cfg *config.Config) error {
 	if c.IsSet("root") {
 		cfg.Root = c.String("root")
 	}
-
+	if c.IsSet("log-format") {
+		cfg.Log.Format = c.String("log-format")
+	}
 	if c.IsSet("addr") || len(cfg.GRPC.Address) == 0 {
 		cfg.GRPC.Address = c.StringSlice("addr")
 	}

--- a/docs/buildkitd.toml.md
+++ b/docs/buildkitd.toml.md
@@ -18,6 +18,10 @@ root = "/var/lib/buildkit"
 # insecure-entitlements allows insecure entitlements, disabled by default.
 insecure-entitlements = [ "network.host", "security.insecure" ]
 
+[log]
+  # log formatter: json or text
+  format = "text"
+
 [grpc]
   address = [ "tcp://0.0.0.0:1234" ]
   # debugAddress is address for attaching go profiles and debuggers.

--- a/docs/reference/buildctl.md
+++ b/docs/reference/buildctl.md
@@ -24,6 +24,7 @@ COMMANDS:
 GLOBAL OPTIONS:
    --debug                enable debug output in logs
    --addr value           buildkitd address (default: "unix:///run/buildkit/buildkitd.sock")
+   --log-format value     log formatter: json or text (default: "text")
    --tlsservername value  buildkitd server name for certificate validation
    --tlscacert value      CA certificate for validation
    --tlscert value        client certificate


### PR DESCRIPTION
### Description ###

This pull-request introduce a configuration option to set the log format to JSON. The option is available both via the config file and CLI arguments.

Solves https://github.com/moby/buildkit/issues/3133


### How to use it ###

config file entry
```toml
[log]
  format = "json"
```

CLIs argument:
- `buildkitd --log-format json`
- `buildctl --log-format json`

### Notes ###

Original work from @moeghanem and @benjamin010095. I forked https://github.com/moby/buildkit/pull/3824 and squashed the commits into a single one.
See also:
- https://github.com/moby/buildkit/pull/3824
- https://github.com/moby/buildkit/pull/3823
- https://github.com/moby/buildkit/pull/3822