### PR TITLE
[0.11] integration: missing cache compat check for s3 and azblob

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -4740,7 +4740,11 @@ func testBasicLocalCacheImportExport(t *testing.T, sb integration.Sandbox) {
 }
 
 func testBasicS3CacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
+	integration.CheckFeatureCompat(t, sb,
+		integration.FeatureCacheExport,
+		integration.FeatureCacheImport,
+		integration.FeatureCacheBackendS3,
+	)
 
 	opts := integration.MinioOpts{
 		Region:          "us-east-1",
@@ -4778,7 +4782,11 @@ func testBasicS3CacheImportExport(t *testing.T, sb integration.Sandbox) {
 }
 
 func testBasicAzblobCacheImportExport(t *testing.T, sb integration.Sandbox) {
-	integration.CheckFeatureCompat(t, sb, integration.FeatureCacheExport)
+	integration.CheckFeatureCompat(t, sb,
+		integration.FeatureCacheExport,
+		integration.FeatureCacheImport,
+		integration.FeatureCacheBackendAzblob,
+	)
 
 	opts := integration.AzuriteOpts{
 		AccountName: "azblobcacheaccount",


### PR DESCRIPTION
* follow-up https://github.com/moby/moby/pull/45981#issuecomment-1646218160

https://github.com/moby/buildkit/pull/3713 didn't include cache backend compat check for `s3` and `azblob` as they were not yet backported to this branch (done in https://github.com/moby/buildkit/pull/4030).