### PR TITLE
exporter/containerimage: new option: rewrite-timestamp (Apply `SOURCE_DATE_EPOCH` to file timestamps)

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,8 @@ Keys supported by image output:
 * `name-canonical=true`: add additional canonical name `name@<digest>`
 * `compression=<uncompressed|gzip|estargz|zstd>`: choose compression type for layers newly created and cached, gzip is default value. estargz should be used with `oci-mediatypes=true`.
 * `compression-level=<value>`: compression level for gzip, estargz (0-9) and zstd (0-22)
+* `rewrite-timestamp=true` (Present in the `master` branch <!-- TODO: v0.13-->): rewrite the file timestamps to the `SOURCE_DATE_EPOCH` value.
+   See [`docs/build-repro.md`](docs/build-repro.md) for how to specify the `SOURCE_DATE_EPOCH` value.
 * `force-compression=true`: forcefully apply `compression` option to all layers (including already existing layers)
 * `store=true`: store the result images to the worker's (e.g. containerd) image store as well as ensures that the image has all blobs in the content store (default `true`). Ignored if the worker doesn't have image store (e.g. OCI worker).
 * `annotation.<key>=<value>`: attach an annotation with the respective `key` and `value` to the built image

--- a/cache/blobs.go
+++ b/cache/blobs.go
@@ -14,6 +14,7 @@ import (
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/compression"
+	"github.com/moby/buildkit/util/converter"
 	"github.com/moby/buildkit/util/flightcontrol"
 	"github.com/moby/buildkit/util/winlayers"
 	digest "github.com/opencontainers/go-digest"
@@ -422,7 +423,7 @@ func ensureCompression(ctx context.Context, ref *immutableRef, comp compression.
 		}
 
 		// Resolve converters
-		layerConvertFunc, err := getConverter(ctx, ref.cm.ContentStore, desc, comp)
+		layerConvertFunc, err := converter.New(ctx, ref.cm.ContentStore, desc, comp)
 		if err != nil {
 			return struct{}{}, err
 		} else if layerConvertFunc == nil {

--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/moby/buildkit/solver"
 	"github.com/moby/buildkit/util/compression"
 	"github.com/moby/buildkit/util/contentutil"
+	"github.com/moby/buildkit/util/converter"
 	"github.com/moby/buildkit/util/iohelper"
 	"github.com/moby/buildkit/util/leaseutil"
 	"github.com/moby/buildkit/util/overlay"
@@ -1423,7 +1424,7 @@ func testSharingCompressionVariant(ctx context.Context, t *testing.T, co *cmOut,
 			require.NoError(t, err, "compression: %v", c)
 			uDgst := bDesc.Digest
 			if c != compression.Uncompressed {
-				convertFunc, err := getConverter(ctx, co.cs, bDesc, compression.New(compression.Uncompressed))
+				convertFunc, err := converter.New(ctx, co.cs, bDesc, compression.New(compression.Uncompressed))
 				require.NoError(t, err, "compression: %v", c)
 				uDesc, err := convertFunc(ctx, co.cs, bDesc)
 				require.NoError(t, err, "compression: %v", c)
@@ -1558,7 +1559,7 @@ func TestConversion(t *testing.T) {
 					testName := fmt.Sprintf("%s=>%s", i, j)
 
 					// Prepare the source compression type
-					convertFunc, err := getConverter(egctx, store, orgDesc, compSrc)
+					convertFunc, err := converter.New(egctx, store, orgDesc, compSrc)
 					require.NoError(t, err, testName)
 					srcDesc := &orgDesc
 					if convertFunc != nil {
@@ -1567,7 +1568,7 @@ func TestConversion(t *testing.T) {
 					}
 
 					// Convert the blob
-					convertFunc, err = getConverter(egctx, store, *srcDesc, compDest)
+					convertFunc, err = converter.New(egctx, store, *srcDesc, compDest)
 					require.NoError(t, err, testName)
 					resDesc := srcDesc
 					if convertFunc != nil {
@@ -1576,7 +1577,7 @@ func TestConversion(t *testing.T) {
 					}
 
 					// Check the uncompressed digest is the same as the original
-					convertFunc, err = getConverter(egctx, store, *resDesc, compression.New(compression.Uncompressed))
+					convertFunc, err = converter.New(egctx, store, *resDesc, compression.New(compression.Uncompressed))
 					require.NoError(t, err, testName)
 					recreatedDesc := resDesc
 					if convertFunc != nil {

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -274,6 +274,13 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 				tagDone(nil)
 
 				if e.unpack {
+					if opts.RewriteTimestamp {
+						// e.unpackImage cannot be used because src ref does not point to the rewritten image
+						///
+						// TODO: change e.unpackImage so that it takes Result[Remote] as parameter.
+						// https://github.com/moby/buildkit/pull/4057#discussion_r1324106088
+						return nil, nil, errors.New("exporter option \"rewrite-timestamp\" conflicts with \"unpack\"")
+					}
 					if err := e.unpackImage(ctx, img, src, session.NewGroup(sessionID)); err != nil {
 						return nil, nil, err
 					}
@@ -310,7 +317,18 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 				}
 			}
 			if e.push {
-				err := e.pushImage(ctx, src, sessionID, targetName, desc.Digest)
+				if opts.RewriteTimestamp {
+					annotations := map[digest.Digest]map[string]string{}
+					addAnnotations(annotations, *desc)
+					// e.pushImage cannot be used because src ref does not point to the rewritten image
+					//
+					// TODO: change e.pushImage so that it takes Result[Remote] as parameter.
+					// https://github.com/moby/buildkit/pull/4057#discussion_r1324106088
+					err = push.Push(ctx, e.opt.SessionManager, sessionID, e.opt.ImageWriter.opt.ContentStore, e.opt.ImageWriter.ContentStore(),
+						desc.Digest, targetName, e.insecure, e.opt.RegistryHosts, e.pushByDigest, annotations)
+				} else {
+					err = e.pushImage(ctx, src, sessionID, targetName, desc.Digest)
+				}
 				if err != nil {
 					return nil, nil, errors.Wrapf(err, "failed to push %v", targetName)
 				}

--- a/exporter/containerimage/exptypes/keys.go
+++ b/exporter/containerimage/exptypes/keys.go
@@ -72,4 +72,8 @@ var (
 	// Value: int (0-9) for gzip and estargz
 	// Value: int (0-22) for zstd
 	OptKeyCompressionLevel ImageExporterOptKey = "compression-level"
+
+	// Rewrite timestamps in layers to match SOURCE_DATE_EPOCH
+	// Value: bool <true|false>
+	OptKeyRewriteTimestamp ImageExporterOptKey = "rewrite-timestamp"
 )

--- a/exporter/containerimage/opts.go
+++ b/exporter/containerimage/opts.go
@@ -21,6 +21,7 @@ type ImageCommitOpts struct {
 	Epoch       *time.Time
 
 	ForceInlineAttestations bool // force inline attestations to be attached
+	RewriteTimestamp        bool // rewrite timestamps in layers to match the epoch
 }
 
 func (c *ImageCommitOpts) Load(ctx context.Context, opt map[string]string) (map[string]string, error) {
@@ -52,6 +53,8 @@ func (c *ImageCommitOpts) Load(ctx context.Context, opt map[string]string) (map[
 			err = parseBool(&c.ForceInlineAttestations, k, v)
 		case exptypes.OptKeyPreferNondistLayers:
 			err = parseBool(&c.RefCfg.PreferNonDistributable, k, v)
+		case exptypes.OptKeyRewriteTimestamp:
+			err = parseBool(&c.RewriteTimestamp, k, v)
 		default:
 			rest[k] = v
 		}

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -28,6 +28,8 @@ import (
 	attestationTypes "github.com/moby/buildkit/util/attestation"
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/compression"
+	"github.com/moby/buildkit/util/contentutil"
+	"github.com/moby/buildkit/util/converter"
 	"github.com/moby/buildkit/util/progress"
 	"github.com/moby/buildkit/util/purl"
 	"github.com/moby/buildkit/util/system"
@@ -134,7 +136,14 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 
 		config := exptypes.ParseKey(inp.Metadata, exptypes.ExporterImageConfigKey, p)
 		inlineCache := exptypes.ParseKey(inp.Metadata, exptypes.ExporterInlineCache, p)
-		mfstDesc, configDesc, err := ic.commitDistributionManifest(ctx, opts, ref, config, &remotes[0], annotations, inlineCache, opts.Epoch, session.NewGroup(sessionID))
+		remote := &remotes[0]
+		if opts.RewriteTimestamp {
+			remote, err = ic.rewriteRemoteWithEpoch(ctx, opts, remote)
+			if err != nil {
+				return nil, err
+			}
+		}
+		mfstDesc, configDesc, err := ic.commitDistributionManifest(ctx, opts, ref, config, remote, annotations, inlineCache, opts.Epoch, session.NewGroup(sessionID))
 		if err != nil {
 			return nil, err
 		}
@@ -197,6 +206,13 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 		if remote == nil {
 			remote = &solver.Remote{
 				Provider: ic.opt.ContentStore,
+			}
+		}
+
+		if opts.RewriteTimestamp {
+			remote, err = ic.rewriteRemoteWithEpoch(ctx, opts, remote)
+			if err != nil {
+				return nil, err
 			}
 		}
 
@@ -322,6 +338,52 @@ func (ic *ImageWriter) exportLayers(ctx context.Context, refCfg cacheconfig.RefC
 	err := layersDone(eg.Wait())
 	tracing.FinishWithError(span, err)
 	return out, err
+}
+
+// rewriteImageLayerWithEpoch rewrites the file timestamps in the layer blob to match the epoch, and returns a new descriptor that points to
+// the new blob.
+//
+// If no conversion is needed, this returns nil without error.
+func rewriteImageLayerWithEpoch(ctx context.Context, cs content.Store, desc ocispecs.Descriptor, comp compression.Config, epoch *time.Time) (*ocispecs.Descriptor, error) {
+	converterFn, err := converter.NewWithRewriteTimestamp(ctx, cs, desc, comp, epoch)
+	if err != nil {
+		return nil, err
+	}
+	if converterFn == nil {
+		return nil, nil
+	}
+	return converterFn(ctx, cs, desc)
+}
+
+func (ic *ImageWriter) rewriteRemoteWithEpoch(ctx context.Context, opts *ImageCommitOpts, remote *solver.Remote) (*solver.Remote, error) {
+	if opts.Epoch == nil {
+		bklog.G(ctx).Warn("rewrite-timestamp is specified, but no source-date-epoch was found")
+		return remote, nil
+	}
+	remoteDescriptors := remote.Descriptors
+	cs := contentutil.NewStoreWithProvider(ic.opt.ContentStore, remote.Provider)
+	eg, ctx := errgroup.WithContext(ctx)
+	rewriteDone := progress.OneOff(ctx,
+		fmt.Sprintf("rewriting layers with source-date-epoch %d (%s)", opts.Epoch.Unix(), opts.Epoch.String()))
+	for i, desc := range remoteDescriptors {
+		i, desc := i, desc
+		eg.Go(func() error {
+			if rewrittenDesc, err := rewriteImageLayerWithEpoch(ctx, cs, desc, opts.RefCfg.Compression, opts.Epoch); err != nil {
+				bklog.G(ctx).WithError(err).Warnf("failed to rewrite layer %d/%d to match source-date-epoch %d (%s)",
+					i+1, len(remoteDescriptors), opts.Epoch.Unix(), opts.Epoch.String())
+			} else if rewrittenDesc != nil {
+				remoteDescriptors[i] = *rewrittenDesc
+			}
+			return nil
+		})
+	}
+	if err := rewriteDone(eg.Wait()); err != nil {
+		return nil, err
+	}
+	return &solver.Remote{
+		Provider:    cs,
+		Descriptors: remoteDescriptors,
+	}, nil
 }
 
 func (ic *ImageWriter) commitDistributionManifest(ctx context.Context, opts *ImageCommitOpts, ref cache.ImmutableRef, config []byte, remote *solver.Remote, annotations *Annotations, inlineCache []byte, epoch *time.Time, sg session.Group) (*ocispecs.Descriptor, *ocispecs.Descriptor, error) {

--- a/util/contentutil/storewithprovider.go
+++ b/util/contentutil/storewithprovider.go
@@ -1,0 +1,24 @@
+package contentutil
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/content"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func NewStoreWithProvider(cs content.Store, p content.Provider) content.Store {
+	return &storeWithProvider{Store: cs, p: p}
+}
+
+type storeWithProvider struct {
+	content.Store
+	p content.Provider
+}
+
+func (cs *storeWithProvider) ReaderAt(ctx context.Context, desc ocispecs.Descriptor) (content.ReaderAt, error) {
+	if ra, err := cs.p.ReaderAt(ctx, desc); err == nil {
+		return ra, nil
+	}
+	return cs.Store.ReaderAt(ctx, desc)
+}

--- a/util/converter/converter.go
+++ b/util/converter/converter.go
@@ -1,4 +1,4 @@
-package cache
+package converter
 
 import (
 	"bufio"
@@ -20,9 +20,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-// getConverter returns converter function according to the specified compression type.
+// New returns converter function according to the specified compression type.
 // If no conversion is needed, this returns nil without error.
-func getConverter(ctx context.Context, cs content.Store, desc ocispecs.Descriptor, comp compression.Config) (converter.ConvertFunc, error) {
+func New(ctx context.Context, cs content.Store, desc ocispecs.Descriptor, comp compression.Config) (converter.ConvertFunc, error) {
 	if needs, err := comp.Type.NeedsConversion(ctx, cs, desc); err != nil {
 		return nil, errors.Wrapf(err, "failed to determine conversion needs")
 	} else if !needs {

--- a/util/converter/converter.go
+++ b/util/converter/converter.go
@@ -1,11 +1,13 @@
 package converter
 
 import (
+	"archive/tar"
 	"bufio"
 	"context"
 	"fmt"
 	"io"
 	"sync"
+	"time"
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
@@ -14,6 +16,7 @@ import (
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/compression"
+	"github.com/moby/buildkit/util/converter/tarconverter"
 	"github.com/moby/buildkit/util/iohelper"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -23,9 +26,20 @@ import (
 // New returns converter function according to the specified compression type.
 // If no conversion is needed, this returns nil without error.
 func New(ctx context.Context, cs content.Store, desc ocispecs.Descriptor, comp compression.Config) (converter.ConvertFunc, error) {
-	if needs, err := comp.Type.NeedsConversion(ctx, cs, desc); err != nil {
+	return NewWithRewriteTimestamp(ctx, cs, desc, comp, nil)
+}
+
+// NewWithRewriteTimestamp returns converter function according to the specified compression type and the epoch.
+// If no conversion is needed, this returns nil without error.
+func NewWithRewriteTimestamp(ctx context.Context, cs content.Store, desc ocispecs.Descriptor, comp compression.Config, rewriteTimestamp *time.Time) (converter.ConvertFunc, error) {
+	needs, err := comp.Type.NeedsConversion(ctx, cs, desc)
+	if err != nil {
 		return nil, errors.Wrapf(err, "failed to determine conversion needs")
-	} else if !needs {
+	}
+	if !needs && rewriteTimestamp != nil {
+		needs = desc.Annotations[labelRewrittenTimestamp] != fmt.Sprintf("%d", rewriteTimestamp.UTC().Unix())
+	}
+	if !needs {
 		// No conversion. No need to return an error here.
 		return nil, nil
 	}
@@ -38,21 +52,37 @@ func New(ctx context.Context, cs content.Store, desc ocispecs.Descriptor, comp c
 	c := conversion{target: comp}
 	c.compress, c.finalize = comp.Type.Compress(ctx, comp)
 	c.decompress = from.Decompress
+	c.rewriteTimestamp = rewriteTimestamp
 
 	return (&c).convert, nil
 }
 
 type conversion struct {
-	target     compression.Config
-	decompress compression.Decompressor
-	compress   compression.Compressor
-	finalize   compression.Finalizer
+	target           compression.Config
+	decompress       compression.Decompressor
+	compress         compression.Compressor
+	finalize         compression.Finalizer
+	rewriteTimestamp *time.Time
 }
 
 var bufioPool = sync.Pool{
 	New: func() interface{} {
 		return nil
 	},
+}
+
+func rewriteTimestampInTarHeader(epoch time.Time) tarconverter.HeaderConverter {
+	return func(hdr *tar.Header) {
+		if hdr.ModTime.After(epoch) {
+			hdr.ModTime = epoch
+		}
+		if hdr.AccessTime.After(epoch) {
+			hdr.AccessTime = epoch
+		}
+		if hdr.ChangeTime.After(epoch) {
+			hdr.ChangeTime = epoch
+		}
+	}
 }
 
 func (c *conversion) convert(ctx context.Context, cs content.Store, desc ocispecs.Descriptor) (*ocispecs.Descriptor, error) {
@@ -86,11 +116,17 @@ func (c *conversion) convert(ctx context.Context, cs content.Store, desc ocispec
 
 	// convert this layer
 	diffID := digest.Canonical.Digester()
-	rdr, err := c.decompress(ctx, cs, desc)
+	decR, err := c.decompress(ctx, cs, desc)
 	if err != nil {
 		return nil, err
 	}
-	defer rdr.Close()
+	defer decR.Close()
+	rdr := decR
+	if c.rewriteTimestamp != nil {
+		tcR := tarconverter.NewReader(decR, rewriteTimestampInTarHeader(*c.rewriteTimestamp))
+		defer tcR.Close()
+		rdr = tcR
+	}
 	if _, err := io.Copy(zw, io.TeeReader(rdr, diffID.Hash())); err != nil {
 		return nil, err
 	}
@@ -101,6 +137,9 @@ func (c *conversion) convert(ctx context.Context, cs content.Store, desc ocispec
 		return nil, errors.Wrap(err, "failed to flush diff during conversion")
 	}
 	labelz[labels.LabelUncompressed] = diffID.Digest().String() // update diffID label
+	if c.rewriteTimestamp != nil {
+		labelz[labelRewrittenTimestamp] = fmt.Sprintf("%d", c.rewriteTimestamp.UTC().Unix())
+	}
 	if err = w.Commit(ctx, 0, "", content.WithLabels(labelz)); err != nil && !errdefs.IsAlreadyExists(err) {
 		return nil, err
 	}
@@ -117,6 +156,9 @@ func (c *conversion) convert(ctx context.Context, cs content.Store, desc ocispec
 	newDesc.Digest = info.Digest
 	newDesc.Size = info.Size
 	newDesc.Annotations = map[string]string{labels.LabelUncompressed: diffID.Digest().String()}
+	if c.rewriteTimestamp != nil {
+		newDesc.Annotations[labelRewrittenTimestamp] = fmt.Sprintf("%d", c.rewriteTimestamp.UTC().Unix())
+	}
 	if c.finalize != nil {
 		a, err := c.finalize(ctx, cs)
 		if err != nil {
@@ -140,3 +182,5 @@ func (w *onceWriteCloser) Close() (err error) {
 	})
 	return
 }
+
+const labelRewrittenTimestamp = "buildkit/rewritten-timestamp"

--- a/util/converter/tarconverter/tarconverter.go
+++ b/util/converter/tarconverter/tarconverter.go
@@ -1,0 +1,49 @@
+package tarconverter
+
+import (
+	"archive/tar"
+	"io"
+)
+
+type HeaderConverter func(*tar.Header)
+
+// NewReader returns a reader that applies headerConverter.
+// Forked from https://github.com/moby/moby/blob/v24.0.6/pkg/archive/copy.go#L308-L373 .
+func NewReader(srcContent io.Reader, headerConverter HeaderConverter) io.ReadCloser {
+	rebased, w := io.Pipe()
+
+	go func() {
+		srcTar := tar.NewReader(srcContent)
+		rebasedTar := tar.NewWriter(w)
+
+		for {
+			hdr, err := srcTar.Next()
+			if err == io.EOF {
+				// Signals end of archive.
+				rebasedTar.Close()
+				w.Close()
+				return
+			}
+			if err != nil {
+				w.CloseWithError(err)
+				return
+			}
+			if headerConverter != nil {
+				headerConverter(hdr)
+			}
+			if err = rebasedTar.WriteHeader(hdr); err != nil {
+				w.CloseWithError(err)
+				return
+			}
+
+			// Ignoring GoSec G110. See https://github.com/moby/moby/blob/v24.0.6/pkg/archive/copy.go#L355-L363
+			//nolint:gosec // G110: Potential DoS vulnerability via decompression bomb (gosec)
+			if _, err = io.Copy(rebasedTar, srcTar); err != nil {
+				w.CloseWithError(err)
+				return
+			}
+		}
+	}()
+
+	return rebased
+}

--- a/util/converter/tarconverter/tarconverter_test.go
+++ b/util/converter/tarconverter/tarconverter_test.go
@@ -1,0 +1,41 @@
+package tarconverter
+
+import (
+	"archive/tar"
+	"bytes"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func createTar(t testing.TB, name string, b []byte) []byte {
+	buf := bytes.NewBuffer(nil)
+	tw := tar.NewWriter(buf)
+	hdr := tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     name,
+		Size:     int64(len(b)),
+		Mode:     0o644,
+		ModTime:  time.Now(),
+	}
+	assert.NoError(t, tw.WriteHeader(&hdr))
+	_, err := tw.Write(b)
+	assert.NoError(t, err)
+	assert.NoError(t, tw.Close())
+	return buf.Bytes()
+}
+
+// https://github.com/moby/buildkit/pull/4057#issuecomment-1693484361
+func TestPaddingForReader(t *testing.T) {
+	inB := createTar(t, "foo", []byte("hi"))
+	assert.Equal(t, 2048, len(inB))
+	r := NewReader(bytes.NewReader(inB), func(hdr *tar.Header) {
+		hdr.ModTime = time.Unix(0, 0)
+	})
+	outB, err := io.ReadAll(r)
+	assert.NoError(t, err)
+	assert.NoError(t, r.Close())
+	assert.Equal(t, len(inB), len(outB))
+}


### PR DESCRIPTION
`rewrite-timestamp` rewrites timestamps in layers for reproducible builds.

When a layer is rewritten, an annotation `buildkit/rewritten-epoch=<INT64>` is set to the layer.

Example:
```
buildctl build
  --frontend dockerfile.v0 \
  --opt build-arg:SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH} \
  --output type=oci,dest=dest.tar,rewrite-timestamp=true \
  ...
```

Alternative to:
- #3560



- - -


With this commit, the following workarounds mentioned in [`docs/build-repro.md`](https://github.com/moby/buildkit/blob/v0.11.2/docs/build-repro.md#caveats) are no longer needed for reproducible builds:

> ```dockerfile
> # Limit the timestamp upper bound to SOURCE_DATE_EPOCH.
> # Workaround for https://github.com/moby/buildkit/issues/3180
> ARG SOURCE_DATE_EPOCH
> RUN find $( ls / | grep -E -v "^(dev|mnt|proc|sys)$" ) -newermt "@${SOURCE_DATE_EPOCH}" -writable -xdev | xargs touch --date="@${SOURCE_DATE_EPOCH}" --no-dereference
> ```

> ```dockerfile
> # Squash the entire stage for resetting the whiteout timestamps.
> # Workaround for https://github.com/moby/buildkit/issues/3168
> FROM scratch
> COPY --from=0 / /
> ```


<details>
<summary>Backup</summary
<p>

https://github.com/moby/buildkit/pull/4057/commits/39c3a49812e223516b58671dbbb2e4fa28942f95 : Abandoned version, contaminates cache

</p>
</details>