### PR TITLE
frontend/dockerfile/dockerignore: assorted cleanups

### DIFF
--- a/frontend/dockerfile/dockerignore/dockerignore.go
+++ b/frontend/dockerfile/dockerignore/dockerignore.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"path/filepath"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // ReadAll reads an ignore file from a reader and returns the list of file
@@ -69,7 +67,7 @@ func ReadAll(reader io.Reader) ([]string, error) {
 		excludes = append(excludes, pattern)
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, errors.Wrap(err, "error reading .dockerignore")
+		return nil, err
 	}
 	return excludes, nil
 }

--- a/frontend/dockerui/config.go
+++ b/frontend/dockerui/config.go
@@ -80,7 +80,8 @@ type Client struct {
 	g           flightcontrol.Group[*buildContext]
 	bopts       client.BuildOpts
 
-	dockerignore []byte
+	dockerignore     []byte
+	dockerignoreName string
 }
 
 type SBOM struct {
@@ -375,6 +376,7 @@ func (bc *Client) ReadEntrypoint(ctx context.Context, lang string, opts ...llb.L
 	})
 	if err == nil {
 		bc.dockerignore = dt
+		bc.dockerignoreName = bctx.filename + ".dockerignore"
 	}
 
 	return &Source{
@@ -435,13 +437,14 @@ func (bc *Client) MainContext(ctx context.Context, opts ...llb.LocalOption) (*ll
 			dt = []byte{}
 		}
 		bc.dockerignore = dt
+		bc.dockerignoreName = DefaultDockerignoreName
 	}
 
 	var excludes []string
 	if len(bc.dockerignore) != 0 {
 		excludes, err = dockerignore.ReadAll(bytes.NewBuffer(bc.dockerignore))
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to parse dockerignore")
+			return nil, errors.Wrapf(err, "failed parsing %s", bc.dockerignoreName)
 		}
 	}
 

--- a/frontend/dockerui/namedcontext.go
+++ b/frontend/dockerui/namedcontext.go
@@ -208,7 +208,7 @@ func (bc *Client) namedContextRecursive(ctx context.Context, name string, nameWi
 			if len(dt) != 0 {
 				excludes, err = dockerignore.ReadAll(bytes.NewBuffer(dt))
 				if err != nil {
-					return nil, nil, err
+					return nil, nil, errors.Wrapf(err, "failed parsing %s", DefaultDockerignoreName)
 				}
 			}
 		}


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/4457

I'm considering moving this package to https://github.com/moby/patternmatcher (but no final "decision" yet). At least let's clean up this package a bit in case.

### frontend/dockerfile/dockerignore: cleanup unit test

- don't use a temp-file for the test as all we need is a reader
- use a const and string-literal for the test-content, which makes it
  slightly more readable
- don't use hard-coded tests for each line, but use an "expected" slice
- don't fail early if line-numbers don't match

### frontend/dockerfile/dockerignore: touch-up godoc and code

Use "doc links" where possible, and better describe the function.

Before:

<img width="1308" alt="Screenshot 2023-07-25 at 10 25 09" src="https://github.com/moby/buildkit/assets/1804568/6ca70c8e-1598-476e-8d8c-4a5a70d1c93c">


After:

<img width="1310" alt="Screenshot 2023-07-25 at 10 24 37" src="https://github.com/moby/buildkit/assets/1804568/b6e85bd3-b09e-4a5f-9ef6-8bf256ae685c">


### frontend/dockerfile/dockerignore: remove hard-coded filename from error

While this function would usually be used for read a `.dockerignore` file,
it accepts a Reader and can also be used to handle ignore patterns from
other files (e.g. `Dockerfile.dockerignore`) or other sources. The error
was also wrapped multiple times in some code-paths, which could lead to
an error being formatted as:

    failed to parse dockerignore: error reading .dockerignore: <some error>

Let's remove mention of the `.dockerignore` filename from the error, and
leave it to the caller to include the filename.