### PR TITLE
nydus: fix missing imports

### DIFF
--- a/cache/compression_nydus.go
+++ b/cache/compression_nydus.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/labels"
 	"github.com/moby/buildkit/cache/config"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/util/compression"

--- a/util/compression/nydus.go
+++ b/util/compression/nydus.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/labels"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"


### PR DESCRIPTION
https://github.com/moby/buildkit/pull/4058 refactored to use `github.com/containerd/containerd`, however, the import was not added to files with the nydus build tag.