### PR TITLE
chore: remove old `no_{oci,containerd}_worker` build tags

### DIFF
--- a/cmd/buildkitd/main_containerd_worker.go
+++ b/cmd/buildkitd/main_containerd_worker.go
@@ -1,5 +1,5 @@
-//go:build (linux && !no_containerd_worker) || (windows && !no_containerd_worker)
-// +build linux,!no_containerd_worker windows,!no_containerd_worker
+//go:build linux || windows
+// +build linux windows
 
 package main
 

--- a/cmd/buildkitd/main_oci_worker.go
+++ b/cmd/buildkitd/main_oci_worker.go
@@ -1,5 +1,5 @@
-//go:build linux && !no_oci_worker
-// +build linux,!no_oci_worker
+//go:build linux
+// +build linux
 
 package main
 

--- a/examples/buildkit0/buildkit.go
+++ b/examples/buildkit0/buildkit.go
@@ -18,8 +18,8 @@ type buildOpt struct {
 func main() {
 	var opt buildOpt
 	flag.BoolVar(&opt.withContainerd, "with-containerd", true, "enable containerd worker")
-	flag.StringVar(&opt.containerd, "containerd", "v1.2.9", "containerd version")
-	flag.StringVar(&opt.runc, "runc", "v1.0.0-rc8", "runc version")
+	flag.StringVar(&opt.containerd, "containerd", "v1.7.2", "containerd version")
+	flag.StringVar(&opt.runc, "runc", "v1.1.7", "runc version")
 	flag.Parse()
 
 	bk := buildkit(opt)

--- a/examples/buildkit0/buildkit.go
+++ b/examples/buildkit0/buildkit.go
@@ -63,9 +63,6 @@ func buildkit(opt buildOpt) llb.State {
 		Run(llb.Shlex("git clone https://github.com/moby/buildkit.git /go/src/github.com/moby/buildkit")).
 		Dir("/go/src/github.com/moby/buildkit")
 
-	buildkitdOCIWorkerOnly := src.
-		Run(llb.Shlex("go build -o /bin/buildkitd.oci_only -tags no_containerd_worker ./cmd/buildkitd"))
-
 	buildkitd := src.
 		Run(llb.Shlex("go build -o /bin/buildkitd ./cmd/buildkitd"))
 
@@ -75,11 +72,9 @@ func buildkit(opt buildOpt) llb.State {
 	r := llb.Image("docker.io/library/alpine:latest")
 	r = copy(buildctl.Root(), "/bin/buildctl", r, "/bin/")
 	r = copy(runc(opt.runc), "/usr/bin/runc", r, "/bin/")
+	r = copy(buildkitd.Root(), "/bin/buildkitd", r, "/bin/")
 	if opt.withContainerd {
 		r = copy(containerd(opt.containerd), "/go/src/github.com/containerd/containerd/bin/containerd", r, "/bin/")
-		r = copy(buildkitd.Root(), "/bin/buildkitd", r, "/bin/")
-	} else {
-		r = copy(buildkitdOCIWorkerOnly.Root(), "/bin/buildkitd.oci_only", r, "/bin/")
 	}
 	return r
 }

--- a/examples/buildkit1/buildkit.go
+++ b/examples/buildkit1/buildkit.go
@@ -18,8 +18,8 @@ type buildOpt struct {
 func main() {
 	var opt buildOpt
 	flag.BoolVar(&opt.withContainerd, "with-containerd", true, "enable containerd worker")
-	flag.StringVar(&opt.containerd, "containerd", "v1.2.9", "containerd version")
-	flag.StringVar(&opt.runc, "runc", "v1.0.0-rc8", "runc version")
+	flag.StringVar(&opt.containerd, "containerd", "v1.7.2", "containerd version")
+	flag.StringVar(&opt.runc, "runc", "v1.1.7", "runc version")
 	flag.Parse()
 
 	bk := buildkit(opt)

--- a/examples/buildkit2/buildkit.go
+++ b/examples/buildkit2/buildkit.go
@@ -18,8 +18,8 @@ type buildOpt struct {
 func main() {
 	var opt buildOpt
 	flag.BoolVar(&opt.withContainerd, "with-containerd", true, "enable containerd worker")
-	flag.StringVar(&opt.containerd, "containerd", "v1.2.9", "containerd version")
-	flag.StringVar(&opt.runc, "runc", "v1.0.0-rc8", "runc version")
+	flag.StringVar(&opt.containerd, "containerd", "v1.7.2", "containerd version")
+	flag.StringVar(&opt.runc, "runc", "v1.1.7", "runc version")
 	flag.Parse()
 
 	bk := buildkit(opt)

--- a/examples/buildkit3/buildkit.go
+++ b/examples/buildkit3/buildkit.go
@@ -83,23 +83,22 @@ func buildkit(opt buildOpt) llb.State {
 	}
 	run := goRepo(goBuildBase(), repo, src)
 
-	buildkitdOCIWorkerOnly := run(llb.Shlex("go build -o /out/buildkitd.oci_only -tags no_containerd_worker ./cmd/buildkitd"))
-
 	buildkitd := run(llb.Shlex("go build -o /out/buildkitd ./cmd/buildkitd"))
 
 	buildctl := run(llb.Shlex("go build -o /out/buildctl ./cmd/buildctl"))
 
 	r := llb.Scratch().With(
 		copyAll(buildctl, "/"),
+		copyAll(buildkitd, "/"),
 		copyAll(runc(opt.runc), "/"),
 	)
 
 	if opt.withContainerd {
-		return r.With(
+		r = r.With(
 			copyAll(containerd(opt.containerd), "/"),
-			copyAll(buildkitd, "/"))
+		)
 	}
-	return r.With(copyAll(buildkitdOCIWorkerOnly, "/"))
+	return r
 }
 
 func copyAll(src llb.State, destPath string) llb.StateOption {

--- a/examples/buildkit3/buildkit.go
+++ b/examples/buildkit3/buildkit.go
@@ -19,8 +19,8 @@ type buildOpt struct {
 func main() {
 	var opt buildOpt
 	flag.BoolVar(&opt.withContainerd, "with-containerd", true, "enable containerd worker")
-	flag.StringVar(&opt.containerd, "containerd", "v1.2.9", "containerd version")
-	flag.StringVar(&opt.runc, "runc", "v1.0.0-rc8", "runc version")
+	flag.StringVar(&opt.containerd, "containerd", "v1.7.2", "containerd version")
+	flag.StringVar(&opt.runc, "runc", "v1.1.7", "runc version")
 	flag.StringVar(&opt.buildkit, "buildkit", "master", "buildkit version")
 	flag.Parse()
 

--- a/examples/buildkit4/buildkit.go
+++ b/examples/buildkit4/buildkit.go
@@ -21,8 +21,8 @@ type buildOpt struct {
 func main() {
 	var opt buildOpt
 	flag.BoolVar(&opt.withContainerd, "with-containerd", true, "enable containerd worker")
-	flag.StringVar(&opt.containerd, "containerd", "v1.5.9", "containerd version")
-	flag.StringVar(&opt.runc, "runc", "v1.1.0", "runc version")
+	flag.StringVar(&opt.containerd, "containerd", "v1.7.2", "containerd version")
+	flag.StringVar(&opt.runc, "runc", "v1.1.7", "runc version")
 	flag.StringVar(&opt.buildkit, "buildkit", "master", "buildkit version")
 	flag.StringVar(&opt.installPrefix, "prefix", "/usr/local/bin", "path under which binaries should be installed")
 	flag.Parse()

--- a/examples/buildkit4/buildkit.go
+++ b/examples/buildkit4/buildkit.go
@@ -86,21 +86,14 @@ func buildkit(opt buildOpt) llb.State {
 	}
 	run := goRepo(goBuildBase(), repo, src)
 
-	buildkitdOCIWorkerOnly := prefixed(
-		run(llb.Shlex("go build -o /out/buildkitd.oci_only -tags no_containerd_worker ./cmd/buildkitd")),
-		opt.installPrefix,
-	)
-
 	buildkitd := prefixed(run(llb.Shlex("go build -o /out/buildkitd ./cmd/buildkitd")), opt.installPrefix)
 
 	buildctl := prefixed(run(llb.Shlex("go build -o /out/buildctl ./cmd/buildctl")), opt.installPrefix)
 
-	inputs := []llb.State{buildctl, prefixed(runc(opt.runc), opt.installPrefix)}
+	inputs := []llb.State{buildctl, buildkitd, prefixed(runc(opt.runc), opt.installPrefix)}
 
 	if opt.withContainerd {
 		inputs = append(inputs, prefixed(containerd(opt.containerd), opt.installPrefix), buildkitd)
-	} else {
-		inputs = append(inputs, buildkitdOCIWorkerOnly)
 	}
 	return llb.Merge(inputs)
 }

--- a/examples/gobuild/main.go
+++ b/examples/gobuild/main.go
@@ -36,7 +36,7 @@ func run() error {
 		Source:    src,
 		MountPath: "/go/src/github.com/moby/buildkit",
 		Pkg:       "github.com/moby/buildkit/cmd/buildkitd",
-		BuildTags: []string{"no_containerd_worker"},
+		BuildTags: []string{},
 	})
 	if err != nil {
 		return err

--- a/worker/containerd/containerd_test.go
+++ b/worker/containerd/containerd_test.go
@@ -1,5 +1,5 @@
-//go:build linux && !no_containerd_worker
-// +build linux,!no_containerd_worker
+//go:build linux
+// +build linux
 
 package containerd
 

--- a/worker/runc/runc_test.go
+++ b/worker/runc/runc_test.go
@@ -1,5 +1,5 @@
-//go:build linux && !no_runc_worker
-// +build linux,!no_runc_worker
+//go:build linux
+// +build linux
 
 package runc
 


### PR DESCRIPTION
https://github.com/moby/buildkit/pull/3243 removed the `buildkitd.oci_only` and `buildkitd.containerd_only` binaries.

This PR cleans up the old build tags that were used for this, which we can now tidy up, since they shouldn't be in use anymore(?)