### PR TITLE
hack: add linting for multiple combinations of build tags

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,9 +5,6 @@ run:
 
   modules-download-mode: vendor
 
-  build-tags:
-    - dfrunsecurity
-
 linters:
   enable:
     - depguard

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -79,9 +79,22 @@ group "validate" {
 }
 
 target "lint" {
+  name = "lint-${buildtags.name}"
   inherits = ["_common"]
   dockerfile = "./hack/dockerfiles/lint.Dockerfile"
   output = ["type=cacheonly"]
+  target = buildtags.target
+  args = {
+    BUILDTAGS = buildtags.tags
+  }
+  matrix = {
+    buildtags = [
+      { name = "default", tags = "", target = "golangci-lint" },
+      { name = "labs", tags = "dfrunsecurity", target = "golangci-lint" },
+      { name = "nydus", tags = "nydus", target = "golangci-lint" },
+      { name = "yaml", tags = "", target = "yamllint" },
+    ]
+  }
 }
 
 target "validate-vendor" {

--- a/hack/dockerfiles/lint.Dockerfile
+++ b/hack/dockerfiles/lint.Dockerfile
@@ -2,13 +2,24 @@
 
 ARG GO_VERSION=1.20
 
-FROM golang:${GO_VERSION}-alpine
+FROM golang:${GO_VERSION}-alpine AS base
 ENV GOFLAGS="-buildvcs=false"
 RUN apk add --no-cache gcc musl-dev yamllint
 RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.52.2
 WORKDIR /go/src/github.com/moby/buildkit
+
+FROM base as golangci-lint
+ARG BUILDTAGS
+RUN --mount=target=/go/src/github.com/moby/buildkit --mount=target=/root/.cache,type=cache,sharing=locked \
+  GOARCH=amd64 golangci-lint run --build-tags "${BUILDTAGS}" && \
+  GOARCH=arm64 golangci-lint run --build-tags "${BUILDTAGS}" && \
+  touch /golangci-lint.done
+
+FROM base as yamllint
 RUN --mount=target=/go/src/github.com/moby/buildkit --mount=target=/root/.cache,type=cache \
-  GOARCH=amd64 golangci-lint run && \
-  GOARCH=arm64 golangci-lint run
-RUN --mount=target=/go/src/github.com/moby/buildkit --mount=target=/root/.cache,type=cache \
-  yamllint -c .yamllint.yml --strict .
+  yamllint -c .yamllint.yml --strict . && \
+  touch /yamllint.done
+
+FROM scratch
+COPY --link --from=golangci-lint /golangci-lint.done /
+COPY --link --from=yamllint /yamllint.done /


### PR DESCRIPTION
See https://github.com/moby/buildkit/pull/4067 and https://github.com/moby/buildkit/pull/4066.

Previously, we weren't linting the nydus tag either locally or in CI, so it was possible for things to slip. This PR adds linting for the nydus tag, and allows to easily extend this in the future.
	
We can't just add new build-tags to the golangci-lint config, since this tests only the combination of all of the provided tags.  For the instance of nydus, we need to test with *and* without the build tag.

To do this, we lift the build tag logic into bake, and use the new matrix feature (though, note we can't actually run the golangci lint stages in parallel since 1. they all try and use all the CPU cores available, and 2. they play fun games when running at the same time that gives slightly bizarre and difficult to reproduce lint errors).