### PR TITLE
dockerfile: add new context subrequest

### DIFF
--- a/client/llb/source.go
+++ b/client/llb/source.go
@@ -407,6 +407,10 @@ func Local(name string, opts ...LocalOption) State {
 			addCap(&gi.Constraints, pb.CapSourceLocalDiffer)
 		}
 	}
+	if gi.Truncate {
+		attrs[pb.AttrLocalTruncate] = "true"
+		addCap(&gi.Constraints, pb.CapSourceLocalTruncate)
+	}
 
 	addCap(&gi.Constraints, pb.CapSourceLocal)
 
@@ -475,6 +479,12 @@ func Differ(t DiffType, required bool) LocalOption {
 			Type:     t,
 			Required: required,
 		}
+	})
+}
+
+func Truncate() LocalOption {
+	return localOptionFunc(func(li *LocalInfo) {
+		li.Truncate = true
 	})
 }
 
@@ -556,6 +566,7 @@ type LocalInfo struct {
 	FollowPaths     string
 	SharedKeyHint   string
 	Differ          DifferInfo
+	Truncate        bool
 }
 
 func HTTP(url string, opts ...HTTPOption) State {

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -61,6 +61,7 @@ type ConvertOpt struct {
 	MetaResolver   llb.ImageMetaResolver
 	LLBCaps        *apicaps.CapSet
 	Warn           func(short, url string, detail [][]byte, location *parser.Range)
+	ContextOpts    []llb.LocalOption
 }
 
 type SBOMTargets struct {
@@ -133,6 +134,14 @@ func ListTargets(ctx context.Context, dt []byte) (*targets.List, error) {
 		l.Targets = append(l.Targets, t)
 	}
 	return l, nil
+}
+
+func BuildContext(ctx context.Context, dt []byte, opt ConvertOpt) (*llb.State, error) {
+	ds, err := toDispatchState(ctx, dt, opt)
+	if err != nil {
+		return nil, err
+	}
+	return &ds.opt.buildContext, nil
 }
 
 func toDispatchState(ctx context.Context, dt []byte, opt ConvertOpt) (*dispatchState, error) {
@@ -563,7 +572,7 @@ func toDispatchState(ctx context.Context, dt []byte, opt ConvertOpt) (*dispatchS
 		target.image.Config.Labels[k] = v
 	}
 
-	opts := []llb.LocalOption{}
+	opts := append([]llb.LocalOption{}, opt.ContextOpts...)
 	if includePatterns := normalizeContextPaths(ctxPaths); includePatterns != nil {
 		opts = append(opts, llb.FollowPaths(includePatterns))
 	}

--- a/frontend/subrequests/context/context.go
+++ b/frontend/subrequests/context/context.go
@@ -1,0 +1,77 @@
+package context
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/frontend/subrequests"
+)
+
+const RequestSubrequestsContext = "frontend.context"
+
+var SubrequestsContextDefinition = subrequests.Request{
+	Name:        RequestSubrequestsContext,
+	Version:     "1.0.0",
+	Type:        subrequests.TypeRPC,
+	Description: "",
+	Opts: []subrequests.Named{
+		{
+			Name:        "target",
+			Description: "Target build stage",
+		},
+	},
+	Metadata: []subrequests.Named{
+		{Name: "result.json"},
+		{Name: "result.txt"},
+	},
+}
+
+type Context struct {
+	Files []File `json:"files,omitempty"`
+}
+
+type File struct {
+	Name string `json:"name"`
+	Size int64  `json:"size"`
+}
+
+func (c Context) ToResult() (*client.Result, error) {
+	res := client.NewResult()
+	dt, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	res.AddMeta("result.json", dt)
+
+	b := bytes.NewBuffer(nil)
+	if err := PrintContext(dt, b); err != nil {
+		return nil, err
+	}
+	res.AddMeta("result.txt", b.Bytes())
+
+	res.AddMeta("version", []byte(SubrequestsContextDefinition.Version))
+	return res, nil
+}
+
+func PrintContext(dt []byte, w io.Writer) error {
+	var o Context
+
+	if err := json.Unmarshal(dt, &o); err != nil {
+		return err
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
+	fmt.Fprintf(tw, "NAME\tSIZE\n")
+
+	for _, f := range o.Files {
+		fmt.Fprintf(tw, "%s\t%d\n", f.Name, f.Size)
+	}
+	tw.Flush()
+	fmt.Fprintln(tw)
+
+	return nil
+}

--- a/session/filesync/diffcopy.go
+++ b/session/filesync/diffcopy.go
@@ -71,7 +71,7 @@ func (wc *streamWriterCloser) Close() error {
 	return nil
 }
 
-func recvDiffCopy(ds grpc.ClientStream, dest string, cu CacheUpdater, progress progressCb, differ fsutil.DiffType, filter func(string, *fstypes.Stat) bool) (err error) {
+func recvDiffCopy(ds grpc.ClientStream, dest string, cu CacheUpdater, progress progressCb, differ fsutil.DiffType, filter func(string, *fstypes.Stat) bool, truncate bool) (err error) {
 	st := time.Now()
 	defer func() {
 		bklog.G(ds.Context()).Debugf("diffcopy took: %v", time.Since(st))
@@ -95,6 +95,7 @@ func recvDiffCopy(ds grpc.ClientStream, dest string, cu CacheUpdater, progress p
 		ProgressCb:    progress,
 		Filter:        fsutil.FilterFunc(filter),
 		Differ:        differ,
+		Truncate:      truncate,
 	}))
 }
 

--- a/session/filesync/filesync.go
+++ b/session/filesync/filesync.go
@@ -142,7 +142,7 @@ type progressCb func(int, bool)
 type protocol struct {
 	name   string
 	sendFn func(stream Stream, fs fsutil.FS, progress progressCb) error
-	recvFn func(stream grpc.ClientStream, destDir string, cu CacheUpdater, progress progressCb, differ fsutil.DiffType, mapFunc func(string, *fstypes.Stat) bool) error
+	recvFn func(stream grpc.ClientStream, destDir string, cu CacheUpdater, progress progressCb, differ fsutil.DiffType, mapFunc func(string, *fstypes.Stat) bool, truncate bool) error
 }
 
 var supportedProtocols = []protocol{
@@ -165,6 +165,7 @@ type FSSendRequestOpt struct {
 	ProgressCb       func(int, bool)
 	Filter           func(string, *fstypes.Stat) bool
 	Differ           fsutil.DiffType
+	Truncate         bool
 }
 
 // CacheUpdater is an object capable of sending notifications for the cache hash changes
@@ -234,7 +235,7 @@ func FSSync(ctx context.Context, c session.Caller, opt FSSendRequestOpt) error {
 		panic(fmt.Sprintf("invalid protocol: %q", pr.name))
 	}
 
-	return pr.recvFn(stream, opt.DestDir, opt.CacheUpdater, opt.ProgressCb, opt.Differ, opt.Filter)
+	return pr.recvFn(stream, opt.DestDir, opt.CacheUpdater, opt.ProgressCb, opt.Differ, opt.Filter, opt.Truncate)
 }
 
 // NewFSSyncTargetDir allows writing into a directory

--- a/solver/pb/attr.go
+++ b/solver/pb/attr.go
@@ -12,6 +12,7 @@ const AttrIncludePatterns = "local.includepattern"
 const AttrFollowPaths = "local.followpaths"
 const AttrExcludePatterns = "local.excludepatterns"
 const AttrSharedKeyHint = "local.sharedkeyhint"
+const AttrLocalTruncate = "local.truncate"
 
 const AttrLLBDefinitionFilename = "llbbuild.filename"
 

--- a/solver/pb/caps.go
+++ b/solver/pb/caps.go
@@ -21,6 +21,7 @@ const (
 	CapSourceLocalExcludePatterns apicaps.CapID = "source.local.excludepatterns"
 	CapSourceLocalSharedKeyHint   apicaps.CapID = "source.local.sharedkeyhint"
 	CapSourceLocalDiffer          apicaps.CapID = "source.local.differ"
+	CapSourceLocalTruncate        apicaps.CapID = "source.local.truncate"
 
 	CapSourceGit              apicaps.CapID = "source.git"
 	CapSourceGitKeepDir       apicaps.CapID = "source.git.keepgitdir"

--- a/source/identifier.go
+++ b/source/identifier.go
@@ -158,6 +158,10 @@ func FromLLB(op *pb.Op_Source, platform *pb.Platform) (Identifier, error) {
 				case pb.AttrLocalDifferNone:
 					id.Differ = fsutil.DiffNone
 				}
+			case pb.AttrLocalTruncate:
+				if v == "true" {
+					id.Truncate = true
+				}
 			}
 		}
 	}
@@ -256,6 +260,7 @@ type LocalIdentifier struct {
 	FollowPaths     []string
 	SharedKeyHint   string
 	Differ          fsutil.DiffType
+	Truncate        bool
 }
 
 func NewLocalIdentifier(str string) (*LocalIdentifier, error) {

--- a/source/local/local.go
+++ b/source/local/local.go
@@ -126,6 +126,9 @@ func (ls *localSourceHandler) snapshotWithAnySession(ctx context.Context, g sess
 
 func (ls *localSourceHandler) snapshot(ctx context.Context, caller session.Caller) (out cache.ImmutableRef, retErr error) {
 	sharedKey := ls.src.Name + ":" + ls.src.SharedKeyHint + ":" + caller.SharedKey() // TODO: replace caller.SharedKey() with source based hint from client(absolute-path+nodeid)
+	if ls.src.Truncate {
+		sharedKey += ":truncate"
+	}
 
 	var mutable cache.MutableRef
 	sis, err := searchSharedKey(ctx, ls.cm, sharedKey)
@@ -195,6 +198,7 @@ func (ls *localSourceHandler) snapshot(ctx context.Context, caller session.Calle
 		CacheUpdater:     &cacheUpdater{cc, mount.IdentityMapping()},
 		ProgressCb:       newProgressHandler(ctx, "transferring "+ls.src.Name+":"),
 		Differ:           ls.src.Differ,
+		Truncate:         ls.src.Truncate,
 	}
 
 	if idmap := mount.IdentityMapping(); idmap != nil {


### PR DESCRIPTION
Fixes https://github.com/moby/buildkit/issues/1181.

Opening as a draft to get some early feedback on the approach.

This PR adds a new `context` subrequest to the dockerfile frontend that allows inspecting the files that *would* be transferred for a build.

To actually get details of the files in the context, we hack fsutil (I can open an upstream PR if this approach seems good) to support a new `Truncate` option. If `Truncate` is set, then we only get the file stat details, and don't actually request the file from the client, instead calling truncate on the file to get it to the right size (so we actually set all the file details except for the content) -- this file shouldn't be stored on disk, since on most file systems this will just create a sparse file.

Not entirely sure on the output format - at the moment, it just lists every file with their sizes, but it might be nice to group by directory and allow controlling the depth (similar to `du`).