### PR TITLE
executor: fix resource sampler goroutine leak

### DIFF
--- a/executor/resources/monitor.go
+++ b/executor/resources/monitor.go
@@ -56,6 +56,10 @@ func (r *cgroupRecord) Start() {
 	r.closeSampler = s.Close
 }
 
+func (r *cgroupRecord) Close() {
+	r.close()
+}
+
 func (r *cgroupRecord) CloseAsync(next func(context.Context) error) error {
 	go func() {
 		r.close()
@@ -158,6 +162,9 @@ func (r *nopRecord) Wait() error {
 
 func (r *nopRecord) Samples() (*types.Samples, error) {
 	return nil, nil
+}
+
+func (r *nopRecord) Close() {
 }
 
 func (r *nopRecord) CloseAsync(next func(context.Context) error) error {

--- a/executor/resources/types/types.go
+++ b/executor/resources/types/types.go
@@ -9,6 +9,7 @@ import (
 
 type Recorder interface {
 	Start()
+	Close()
 	CloseAsync(func(context.Context) error) error
 	Wait() error
 	Samples() (*Samples, error)

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -335,6 +335,9 @@ func (w *runcExecutor) Run(ctx context.Context, id string, root executor.Mount, 
 
 	err = exitError(ctx, err)
 	if err != nil {
+		if rec != nil {
+			rec.Close()
+		}
 		releaseContainer(context.TODO())
 		return nil, err
 	}


### PR DESCRIPTION
Before this, the runc executor did not close the cgroupRecord when the container exited non-zero, which resulted in goroutines leaking.

---

Verified the fix manually by getting goroutine stack dumps after builds that included failed execs finished, which previously showed a bunch of goroutines like this:
```
goroutine 748062 [select]:
github.com/moby/buildkit/executor/resources.(*Sampler[...]).run(0x1905f80)
  /go/pkg/mod/github.com/moby/buildkit@v0.12.1-0.20230723195917-40aabfe76809/executor/resources/sampler.go:92 +0x70
created by github.com/moby/buildkit/executor/resources.(*Sampler[...]).Record
  /go/pkg/mod/github.com/moby/buildkit@v0.12.1-0.20230723195917-40aabfe76809/executor/resources/sampler.go:83 +0x184
```
and now after the fix they are gone. Not sure if there's reasonable ways of adding an integ test for this at this time.