### PR TITLE
filesync: remove deprecated override-excludes

### DIFF
--- a/session/filesync/filesync.go
+++ b/session/filesync/filesync.go
@@ -21,7 +21,6 @@ import (
 )
 
 const (
-	keyOverrideExcludes   = "override-excludes"
 	keyIncludePatterns    = "include-patterns"
 	keyExcludePatterns    = "exclude-patterns"
 	keyFollowPaths        = "followpaths"
@@ -36,9 +35,8 @@ type fsSyncProvider struct {
 }
 
 type SyncedDir struct {
-	Dir      string
-	Excludes []string
-	Map      func(string, *fstypes.Stat) fsutil.MapResult
+	Dir string
+	Map func(string, *fstypes.Stat) fsutil.MapResult
 }
 
 type DirSource interface {
@@ -99,9 +97,6 @@ func (sp *fsSyncProvider) handle(method string, stream grpc.ServerStream) (retEr
 	}
 
 	excludes := opts[keyExcludePatterns]
-	if len(dir.Excludes) != 0 && (len(opts[keyOverrideExcludes]) == 0 || opts[keyOverrideExcludes][0] != "true") {
-		excludes = dir.Excludes
-	}
 	includes := opts[keyIncludePatterns]
 
 	followPaths := opts[keyFollowPaths]
@@ -155,16 +150,15 @@ var supportedProtocols = []protocol{
 
 // FSSendRequestOpt defines options for FSSend request
 type FSSendRequestOpt struct {
-	Name             string
-	IncludePatterns  []string
-	ExcludePatterns  []string
-	FollowPaths      []string
-	OverrideExcludes bool // deprecated: this is used by docker/cli for automatically loading .dockerignore from the directory
-	DestDir          string
-	CacheUpdater     CacheUpdater
-	ProgressCb       func(int, bool)
-	Filter           func(string, *fstypes.Stat) bool
-	Differ           fsutil.DiffType
+	Name            string
+	IncludePatterns []string
+	ExcludePatterns []string
+	FollowPaths     []string
+	DestDir         string
+	CacheUpdater    CacheUpdater
+	ProgressCb      func(int, bool)
+	Filter          func(string, *fstypes.Stat) bool
+	Differ          fsutil.DiffType
 }
 
 // CacheUpdater is an object capable of sending notifications for the cache hash changes
@@ -188,9 +182,6 @@ func FSSync(ctx context.Context, c session.Caller, opt FSSendRequestOpt) error {
 	}
 
 	opts := make(map[string][]string)
-	if opt.OverrideExcludes {
-		opts[keyOverrideExcludes] = []string{"true"}
-	}
 
 	if opt.IncludePatterns != nil {
 		opts[keyIncludePatterns] = opt.IncludePatterns

--- a/source/local/local.go
+++ b/source/local/local.go
@@ -186,15 +186,14 @@ func (ls *localSourceHandler) snapshot(ctx context.Context, caller session.Calle
 	}
 
 	opt := filesync.FSSendRequestOpt{
-		Name:             ls.src.Name,
-		IncludePatterns:  ls.src.IncludePatterns,
-		ExcludePatterns:  ls.src.ExcludePatterns,
-		FollowPaths:      ls.src.FollowPaths,
-		OverrideExcludes: false,
-		DestDir:          dest,
-		CacheUpdater:     &cacheUpdater{cc, mount.IdentityMapping()},
-		ProgressCb:       newProgressHandler(ctx, "transferring "+ls.src.Name+":"),
-		Differ:           ls.src.Differ,
+		Name:            ls.src.Name,
+		IncludePatterns: ls.src.IncludePatterns,
+		ExcludePatterns: ls.src.ExcludePatterns,
+		FollowPaths:     ls.src.FollowPaths,
+		DestDir:         dest,
+		CacheUpdater:    &cacheUpdater{cc, mount.IdentityMapping()},
+		ProgressCb:      newProgressHandler(ctx, "transferring "+ls.src.Name+":"),
+		Differ:          ls.src.Differ,
 	}
 
 	if idmap := mount.IdentityMapping(); idmap != nil {


### PR DESCRIPTION
Found this while poking through filesync code, and thought I'd propose this.

It looks like the `override-excludes` property has been deprecated for several years - I can't find where this is actually used in the docker cli, so I think it may be worth finally actually removing. Maybe there's some reason we should still hang onto it? As far as I can tell though, it was never really used:

```
❯ git remote -v
origin	git@github.com:jedevc/cli.git (fetch)
origin	git@github.com:jedevc/cli.git (push)
upstream	git@github.com:docker/cli.git (fetch)
upstream	git@github.com:docker/cli.git (push)
$ git log upstream/master -SOverrideExcludes
commit 6fef143dbcf5fdcb436d05cf8e67d56c24bc4e6e
Author: CrazyMax <crazy-max@users.noreply.github.com>
Date:   Thu Feb 3 10:37:55 2022 +0100

    Set buildx as default builder
    
    Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>

commit a0113c3a448cb1ed875f2116eb8436ee8bd97bfc
Author: Simon Ferquel <simon.ferquel@docker.com>
Date:   Mon Aug 7 11:52:40 2017 +0200

    updated vendoring
    
    Signed-off-by: Simon Ferquel <simon.ferquel@docker.com>

commit 4adf701567e4e64226e2e3622375b78a612b2198 (HEAD)
Author: Tonis Tiigi <tonistiigi@gmail.com>
Date:   Mon May 15 14:13:34 2017 -0700

    vendor: update moby
    
    Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
```

@tonistiigi do you have more context for this? Or should we be good to just go and remove this?