### PR TITLE
client: modify SolveOpt to take fsutil.FS objects

### DIFF
--- a/cache/util/fsutil.go
+++ b/cache/util/fsutil.go
@@ -90,17 +90,17 @@ type ReadDirRequest struct {
 func ReadDir(ctx context.Context, mount snapshot.Mountable, req ReadDirRequest) ([]*fstypes.Stat, error) {
 	var (
 		rd []*fstypes.Stat
-		wo fsutil.WalkOpt
+		fo fsutil.FilterOpt
 	)
 	if req.IncludePattern != "" {
-		wo.IncludePatterns = append(wo.IncludePatterns, req.IncludePattern)
+		fo.IncludePatterns = append(fo.IncludePatterns, req.IncludePattern)
 	}
 	err := withMount(ctx, mount, func(root string) error {
 		fp, err := fs.RootPath(root, req.Path)
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		return fsutil.Walk(ctx, fp, &wo, func(path string, info os.FileInfo, err error) error {
+		return fsutil.Walk(ctx, fp, &fo, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				return errors.Wrapf(err, "walking %q", root)
 			}

--- a/exporter/local/export.go
+++ b/exporter/local/export.go
@@ -108,8 +108,8 @@ func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source
 
 			if !e.opts.PlatformSplit {
 				// check for duplicate paths
-				err = outputFS.Walk(ctx, func(p string, fi os.FileInfo, err error) error {
-					if fi.IsDir() {
+				err = outputFS.Walk(ctx, "", func(p string, entry os.DirEntry, err error) error {
+					if entry.IsDir() {
 						return nil
 					}
 					if err != nil && !errors.Is(err, os.ErrNotExist) {

--- a/exporter/local/fs.go
+++ b/exporter/local/fs.go
@@ -98,9 +98,14 @@ func CreateFS(ctx context.Context, sessionID string, k string, ref cache.Immutab
 		cleanup = lm.Unmount
 	}
 
+	outputFS, err := fsutil.NewFS(src)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// wrap the output filesystem, applying appropriate filters
 	filterOpt := &fsutil.FilterOpt{}
 	var idMapFunc func(p string, st *fstypes.Stat) fsutil.MapResult
-
 	if idmap != nil {
 		idMapFunc = func(p string, st *fstypes.Stat) fsutil.MapResult {
 			uid, gid, err := idmap.ToContainer(idtools.Identity{
@@ -115,26 +120,23 @@ func CreateFS(ctx context.Context, sessionID string, k string, ref cache.Immutab
 			return fsutil.MapResultKeep
 		}
 	}
-
 	filterOpt.Map = func(p string, st *fstypes.Stat) fsutil.MapResult {
 		res := fsutil.MapResultKeep
 		if idMapFunc != nil {
+			// apply host uid/gid
 			res = idMapFunc(p, st)
 		}
 		if opt.Epoch != nil {
+			// apply used-specified epoch time
 			st.ModTime = opt.Epoch.UnixNano()
 		}
 		return res
-	}
-
-	outputFS, err := fsutil.NewFS(src)
-	if err != nil {
-		return nil, nil, err
 	}
 	outputFS, err = fsutil.NewFilterFS(outputFS, filterOpt)
 	if err != nil {
 		return nil, nil, err
 	}
+
 	attestations = attestation.Filter(attestations, nil, map[string][]byte{
 		result.AttestationInlineOnlyKey: []byte(strconv.FormatBool(true)),
 	})

--- a/exporter/local/fs.go
+++ b/exporter/local/fs.go
@@ -98,7 +98,7 @@ func CreateFS(ctx context.Context, sessionID string, k string, ref cache.Immutab
 		cleanup = lm.Unmount
 	}
 
-	walkOpt := &fsutil.WalkOpt{}
+	filterOpt := &fsutil.FilterOpt{}
 	var idMapFunc func(p string, st *fstypes.Stat) fsutil.MapResult
 
 	if idmap != nil {
@@ -116,7 +116,7 @@ func CreateFS(ctx context.Context, sessionID string, k string, ref cache.Immutab
 		}
 	}
 
-	walkOpt.Map = func(p string, st *fstypes.Stat) fsutil.MapResult {
+	filterOpt.Map = func(p string, st *fstypes.Stat) fsutil.MapResult {
 		res := fsutil.MapResultKeep
 		if idMapFunc != nil {
 			res = idMapFunc(p, st)
@@ -127,7 +127,14 @@ func CreateFS(ctx context.Context, sessionID string, k string, ref cache.Immutab
 		return res
 	}
 
-	outputFS := fsutil.NewFS(src, walkOpt)
+	outputFS, err := fsutil.NewFS(src)
+	if err != nil {
+		return nil, nil, err
+	}
+	outputFS, err = fsutil.NewFilterFS(outputFS, filterOpt)
+	if err != nil {
+		return nil, nil, err
+	}
 	attestations = attestation.Filter(attestations, nil, map[string][]byte{
 		result.AttestationInlineOnlyKey: []byte(strconv.FormatBool(true)),
 	})
@@ -137,11 +144,11 @@ func CreateFS(ctx context.Context, sessionID string, k string, ref cache.Immutab
 	}
 	if len(attestations) > 0 {
 		subjects := []intoto.Subject{}
-		err = outputFS.Walk(ctx, func(path string, info fs.FileInfo, err error) error {
+		err = outputFS.Walk(ctx, "", func(path string, entry fs.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}
-			if !info.Mode().IsRegular() {
+			if !entry.Type().IsRegular() {
 				return nil
 			}
 			f, err := outputFS.Open(path)

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spdx/tools-golang v0.5.1
 	github.com/stretchr/testify v1.8.4
-	github.com/tonistiigi/fsutil v0.0.0-20230629203738-36ef4d8c0dbb
+	github.com/tonistiigi/fsutil v0.0.0-20230825212630-f09800878302
 	github.com/tonistiigi/go-actions-cache v0.0.0-20220404170428-0bdeb6e1eac7
 	github.com/tonistiigi/go-archvariant v1.0.0
 	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea

--- a/go.sum
+++ b/go.sum
@@ -1206,8 +1206,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tommy-muehle/go-mnd v1.1.1/go.mod h1:dSUh0FtTP8VhvkL1S+gUR1OKd9ZnSaozuI6r3m6wOig=
 github.com/tommy-muehle/go-mnd v1.3.1-0.20200224220436-e6f9a994e8fa/go.mod h1:dSUh0FtTP8VhvkL1S+gUR1OKd9ZnSaozuI6r3m6wOig=
 github.com/tonistiigi/fsutil v0.0.0-20201103201449-0834f99b7b85/go.mod h1:a7cilN64dG941IOXfhJhlH0qB92hxJ9A1ewrdUmJ6xo=
-github.com/tonistiigi/fsutil v0.0.0-20230629203738-36ef4d8c0dbb h1:uUe8rNyVXM8moActoBol6Xf6xX2GMr7SosR2EywMvGg=
-github.com/tonistiigi/fsutil v0.0.0-20230629203738-36ef4d8c0dbb/go.mod h1:SxX/oNQ/ag6Vaoli547ipFK9J7BZn5JqJG0JE8lf8bA=
+github.com/tonistiigi/fsutil v0.0.0-20230825212630-f09800878302 h1:ZT8ibgassurSISJ1Pj26NsM3vY2jxFZn63Nd/TpHmRw=
+github.com/tonistiigi/fsutil v0.0.0-20230825212630-f09800878302/go.mod h1:9kMVqMyQ/Sx2df5LtnGG+nbrmiZzCS7V6gjW3oGHsvI=
 github.com/tonistiigi/go-actions-cache v0.0.0-20220404170428-0bdeb6e1eac7 h1:8eY6m1mjgyB8XySUR7WvebTM8D/Vs86jLJzD/Tw7zkc=
 github.com/tonistiigi/go-actions-cache v0.0.0-20220404170428-0bdeb6e1eac7/go.mod h1:qqvyZqkfwkoJuPU/bw61bItaoO0SJ8YSW0vSVRRvsRg=
 github.com/tonistiigi/go-archvariant v1.0.0 h1:5LC1eDWiBNflnTF1prCiX09yfNHIxDC/aukdhCdTyb0=

--- a/session/filesync/filesync_test.go
+++ b/session/filesync/filesync_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/moby/buildkit/session/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tonistiigi/fsutil"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -18,9 +19,11 @@ func TestFileSyncIncludePatterns(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
+	tmpFS, err := fsutil.NewFS(tmpDir)
+	require.NoError(t, err)
 	destDir := t.TempDir()
 
-	err := os.WriteFile(filepath.Join(tmpDir, "foo"), []byte("content1"), 0600)
+	err = os.WriteFile(filepath.Join(tmpDir, "foo"), []byte("content1"), 0600)
 	require.NoError(t, err)
 
 	err = os.WriteFile(filepath.Join(tmpDir, "bar"), []byte("content2"), 0600)
@@ -32,7 +35,7 @@ func TestFileSyncIncludePatterns(t *testing.T) {
 	m, err := session.NewManager()
 	require.NoError(t, err)
 
-	fs := NewFSSyncProvider(StaticDirSource{"test0": {Dir: tmpDir}})
+	fs := NewFSSyncProvider(StaticDirSource{"test0": tmpFS})
 	s.Allow(fs)
 
 	dialer := session.Dialer(testutil.TestStream(testutil.Handler(m.HandleConn)))

--- a/util/staticfs/merge.go
+++ b/util/staticfs/merge.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"path/filepath"
 
 	"github.com/tonistiigi/fsutil"
 	"golang.org/x/sync/errgroup"
@@ -26,9 +25,9 @@ func NewMergeFS(lower, upper fsutil.FS) *MergeFS {
 }
 
 type record struct {
-	path string
-	fi   fs.FileInfo
-	err  error
+	path  string
+	entry fs.DirEntry
+	err   error
 }
 
 func (r *record) key() string {
@@ -38,16 +37,16 @@ func (r *record) key() string {
 	return convertPathToKey(r.path)
 }
 
-func (mfs *MergeFS) Walk(ctx context.Context, fn filepath.WalkFunc) error {
+func (mfs *MergeFS) Walk(ctx context.Context, target string, fn fs.WalkDirFunc) error {
 	ch1 := make(chan *record, 10)
 	ch2 := make(chan *record, 10)
 
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
 		defer close(ch1)
-		return mfs.Lower.Walk(ctx, func(path string, info fs.FileInfo, err error) error {
+		return mfs.Lower.Walk(ctx, target, func(path string, entry fs.DirEntry, err error) error {
 			select {
-			case ch1 <- &record{path: path, fi: info, err: err}:
+			case ch1 <- &record{path: path, entry: entry, err: err}:
 			case <-ctx.Done():
 			}
 			return ctx.Err()
@@ -55,9 +54,9 @@ func (mfs *MergeFS) Walk(ctx context.Context, fn filepath.WalkFunc) error {
 	})
 	eg.Go(func() error {
 		defer close(ch2)
-		return mfs.Upper.Walk(ctx, func(path string, info fs.FileInfo, err error) error {
+		return mfs.Upper.Walk(ctx, target, func(path string, entry fs.DirEntry, err error) error {
 			select {
-			case ch2 <- &record{path: path, fi: info, err: err}:
+			case ch2 <- &record{path: path, entry: entry, err: err}:
 			case <-ctx.Done():
 			}
 			return ctx.Err()
@@ -75,13 +74,13 @@ func (mfs *MergeFS) Walk(ctx context.Context, fn filepath.WalkFunc) error {
 				break
 			}
 			if !ok2 || ok1 && key1 < key2 {
-				if err := fn(next1.path, next1.fi, next1.err); err != nil {
+				if err := fn(next1.path, next1.entry, next1.err); err != nil {
 					return err
 				}
 				next1, ok1 = <-ch1
 				key1 = next1.key()
 			} else if !ok1 || ok2 && key1 >= key2 {
-				if err := fn(next2.path, next2.fi, next2.err); err != nil {
+				if err := fn(next2.path, next2.entry, next2.err); err != nil {
 					return err
 				}
 				if ok1 && key1 == key2 {

--- a/util/staticfs/merge_test.go
+++ b/util/staticfs/merge_test.go
@@ -38,7 +38,9 @@ func TestMerge(t *testing.T) {
 	require.Equal(t, []byte("barbarbar"), data)
 
 	var files []string
-	err = fs.Walk(context.TODO(), func(path string, info iofs.FileInfo, err error) error {
+	err = fs.Walk(context.TODO(), "", func(path string, entry iofs.DirEntry, err error) error {
+		require.NoError(t, err)
+		info, err := entry.Info()
 		require.NoError(t, err)
 		switch path {
 		case "foo":
@@ -87,7 +89,7 @@ func TestMerge(t *testing.T) {
 	require.True(t, os.IsNotExist(err))
 
 	files = nil
-	err = fs.Walk(context.TODO(), func(path string, info iofs.FileInfo, err error) error {
+	err = fs.Walk(context.TODO(), "", func(path string, entry iofs.DirEntry, err error) error {
 		require.NoError(t, err)
 		files = append(files, path)
 		return nil

--- a/util/staticfs/static_test.go
+++ b/util/staticfs/static_test.go
@@ -29,7 +29,9 @@ func TestStatic(t *testing.T) {
 	require.True(t, os.IsNotExist(err))
 
 	var files []string
-	err = fs.Walk(context.TODO(), func(path string, info iofs.FileInfo, err error) error {
+	err = fs.Walk(context.TODO(), "", func(path string, entry iofs.DirEntry, err error) error {
+		require.NoError(t, err)
+		info, err := entry.Info()
 		require.NoError(t, err)
 		switch path {
 		case "foo":

--- a/vendor/github.com/tonistiigi/fsutil/filter.go
+++ b/vendor/github.com/tonistiigi/fsutil/filter.go
@@ -2,25 +2,35 @@ package fsutil
 
 import (
 	"context"
+	"io"
 	gofs "io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/moby/patternmatcher"
 	"github.com/pkg/errors"
 	"github.com/tonistiigi/fsutil/types"
 )
 
-type WalkOpt struct {
+type FilterOpt struct {
+	// IncludePatterns requires that the path matches at least one of the
+	// specified patterns.
 	IncludePatterns []string
+
+	// ExcludePatterns requires that the path does not match any of the
+	// specified patterns.
 	ExcludePatterns []string
-	// FollowPaths contains symlinks that are resolved into include patterns
-	// before performing the fs walk
+
+	// FollowPaths contains symlinks that are resolved into IncludePatterns
+	// at the time of the call to NewFilterFS.
 	FollowPaths []string
-	Map         MapFunc
+
+	// Map is called for each path that is included in the result.
+	// The function can modify the stat info for each element, while the result
+	// of the function controls both how Walk continues.
+	Map MapFunc
 }
 
 type MapFunc func(string, *types.Stat) MapResult
@@ -43,33 +53,41 @@ const (
 	MapResultSkipDir
 )
 
-func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) error {
-	root, err := filepath.EvalSymlinks(p)
-	if err != nil {
-		return errors.WithStack(&os.PathError{Op: "resolve", Path: root, Err: err})
-	}
-	rootFI, err := os.Stat(root)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	if !rootFI.IsDir() {
-		return errors.WithStack(&os.PathError{Op: "walk", Path: root, Err: syscall.ENOTDIR})
+type filterFS struct {
+	fs FS
+
+	includeMatcher              *patternmatcher.PatternMatcher
+	excludeMatcher              *patternmatcher.PatternMatcher
+	onlyPrefixIncludes          bool
+	onlyPrefixExcludeExceptions bool
+
+	mapFn MapFunc
+}
+
+// NewFilterFS creates a new FS that filters the given FS using the given
+// FilterOpt.
+
+// The returned FS will not contain any paths that do not match the provided
+// include and exclude patterns, or that are are exlcluded using the mapping
+// function.
+//
+// The FS is assumed to be a snapshot of the filesystem at the time of the
+// call to NewFilterFS. If the underlying filesystem changes, calls to the
+// underlying FS may be inconsistent.
+func NewFilterFS(fs FS, opt *FilterOpt) (FS, error) {
+	if opt == nil {
+		return fs, nil
 	}
 
-	var (
-		includePatterns []string
-		includeMatcher  *patternmatcher.PatternMatcher
-		excludeMatcher  *patternmatcher.PatternMatcher
-	)
-
-	if opt != nil && opt.IncludePatterns != nil {
+	var includePatterns []string
+	if opt.IncludePatterns != nil {
 		includePatterns = make([]string, len(opt.IncludePatterns))
 		copy(includePatterns, opt.IncludePatterns)
 	}
-	if opt != nil && opt.FollowPaths != nil {
-		targets, err := FollowLinks(p, opt.FollowPaths)
+	if opt.FollowPaths != nil {
+		targets, err := FollowLinks(fs, opt.FollowPaths)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if targets != nil {
 			includePatterns = append(includePatterns, targets...)
@@ -82,11 +100,18 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 		patternChars += `\`
 	}
 
-	onlyPrefixIncludes := true
-	if len(includePatterns) != 0 {
+	var (
+		includeMatcher              *patternmatcher.PatternMatcher
+		excludeMatcher              *patternmatcher.PatternMatcher
+		err                         error
+		onlyPrefixIncludes          = true
+		onlyPrefixExcludeExceptions = true
+	)
+
+	if len(includePatterns) > 0 {
 		includeMatcher, err = patternmatcher.New(includePatterns)
 		if err != nil {
-			return errors.Wrapf(err, "invalid includepatterns: %s", opt.IncludePatterns)
+			return nil, errors.Wrapf(err, "invalid includepatterns: %s", opt.IncludePatterns)
 		}
 
 		for _, p := range includeMatcher.Patterns() {
@@ -98,11 +123,10 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 
 	}
 
-	onlyPrefixExcludeExceptions := true
-	if opt != nil && opt.ExcludePatterns != nil {
+	if len(opt.ExcludePatterns) > 0 {
 		excludeMatcher, err = patternmatcher.New(opt.ExcludePatterns)
 		if err != nil {
-			return errors.Wrapf(err, "invalid excludepatterns: %s", opt.ExcludePatterns)
+			return nil, errors.Wrapf(err, "invalid excludepatterns: %s", opt.ExcludePatterns)
 		}
 
 		for _, p := range excludeMatcher.Patterns() {
@@ -113,10 +137,41 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 		}
 	}
 
+	return &filterFS{
+		fs:                          fs,
+		includeMatcher:              includeMatcher,
+		excludeMatcher:              excludeMatcher,
+		onlyPrefixIncludes:          onlyPrefixIncludes,
+		onlyPrefixExcludeExceptions: onlyPrefixExcludeExceptions,
+		mapFn:                       opt.Map,
+	}, nil
+}
+
+func (fs *filterFS) Open(p string) (io.ReadCloser, error) {
+	if fs.includeMatcher != nil {
+		m, err := fs.includeMatcher.MatchesOrParentMatches(p)
+		if err != nil {
+			return nil, err
+		}
+		if !m {
+			return nil, errors.Wrapf(os.ErrNotExist, "open %s", p)
+		}
+	}
+	if fs.excludeMatcher != nil {
+		m, err := fs.excludeMatcher.MatchesOrParentMatches(p)
+		if err != nil {
+			return nil, err
+		}
+		if m {
+			return nil, errors.Wrapf(os.ErrNotExist, "open %s", p)
+		}
+	}
+	return fs.fs.Open(p)
+}
+
+func (fs *filterFS) Walk(ctx context.Context, target string, fn gofs.WalkDirFunc) error {
 	type visitedDir struct {
-		fi               os.FileInfo
-		path             string
-		origpath         string
+		entry            gofs.DirEntry
 		pathWithSep      string
 		includeMatchInfo patternmatcher.MatchInfo
 		excludeMatchInfo patternmatcher.MatchInfo
@@ -126,34 +181,22 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 	// used only for include/exclude handling
 	var parentDirs []visitedDir
 
-	seenFiles := make(map[uint64]string)
-	return filepath.WalkDir(root, func(path string, dirEntry gofs.DirEntry, walkErr error) (retErr error) {
+	return fs.fs.Walk(ctx, target, func(path string, dirEntry gofs.DirEntry, walkErr error) (retErr error) {
 		defer func() {
 			if retErr != nil && isNotExist(retErr) {
 				retErr = filepath.SkipDir
 			}
 		}()
 
-		origpath := path
-		path, err = filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		// Skip root
-		if path == "." {
-			return nil
-		}
-
 		var (
 			dir   visitedDir
 			isDir bool
-			fi    gofs.FileInfo
 		)
 		if dirEntry != nil {
 			isDir = dirEntry.IsDir()
 		}
 
-		if includeMatcher != nil || excludeMatcher != nil {
+		if fs.includeMatcher != nil || fs.excludeMatcher != nil {
 			for len(parentDirs) != 0 {
 				lastParentDir := parentDirs[len(parentDirs)-1].pathWithSep
 				if strings.HasPrefix(path, lastParentDir) {
@@ -163,15 +206,8 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 			}
 
 			if isDir {
-				fi, err = dirEntry.Info()
-				if err != nil {
-					return err
-				}
-
 				dir = visitedDir{
-					fi:          fi,
-					path:        path,
-					origpath:    origpath,
+					entry:       dirEntry,
 					pathWithSep: path + string(filepath.Separator),
 				}
 			}
@@ -179,12 +215,12 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 
 		skip := false
 
-		if includeMatcher != nil {
+		if fs.includeMatcher != nil {
 			var parentIncludeMatchInfo patternmatcher.MatchInfo
 			if len(parentDirs) != 0 {
 				parentIncludeMatchInfo = parentDirs[len(parentDirs)-1].includeMatchInfo
 			}
-			m, matchInfo, err := includeMatcher.MatchesUsingParentResults(path, parentIncludeMatchInfo)
+			m, matchInfo, err := fs.includeMatcher.MatchesUsingParentResults(path, parentIncludeMatchInfo)
 			if err != nil {
 				return errors.Wrap(err, "failed to match includepatterns")
 			}
@@ -194,11 +230,11 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 			}
 
 			if !m {
-				if isDir && onlyPrefixIncludes {
+				if isDir && fs.onlyPrefixIncludes {
 					// Optimization: we can skip walking this dir if no include
 					// patterns could match anything inside it.
 					dirSlash := path + string(filepath.Separator)
-					for _, pat := range includeMatcher.Patterns() {
+					for _, pat := range fs.includeMatcher.Patterns() {
 						if pat.Exclusion() {
 							continue
 						}
@@ -214,12 +250,12 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 			}
 		}
 
-		if excludeMatcher != nil {
+		if fs.excludeMatcher != nil {
 			var parentExcludeMatchInfo patternmatcher.MatchInfo
 			if len(parentDirs) != 0 {
 				parentExcludeMatchInfo = parentDirs[len(parentDirs)-1].excludeMatchInfo
 			}
-			m, matchInfo, err := excludeMatcher.MatchesUsingParentResults(path, parentExcludeMatchInfo)
+			m, matchInfo, err := fs.excludeMatcher.MatchesUsingParentResults(path, parentExcludeMatchInfo)
 			if err != nil {
 				return errors.Wrap(err, "failed to match excludepatterns")
 			}
@@ -229,16 +265,16 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 			}
 
 			if m {
-				if isDir && onlyPrefixExcludeExceptions {
+				if isDir && fs.onlyPrefixExcludeExceptions {
 					// Optimization: we can skip walking this dir if no
 					// exceptions to exclude patterns could match anything
 					// inside it.
-					if !excludeMatcher.Exclusions() {
+					if !fs.excludeMatcher.Exclusions() {
 						return filepath.SkipDir
 					}
 
 					dirSlash := path + string(filepath.Separator)
-					for _, pat := range excludeMatcher.Patterns() {
+					for _, pat := range fs.excludeMatcher.Patterns() {
 						if !pat.Exclusion() {
 							continue
 						}
@@ -261,7 +297,7 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 			return walkErr
 		}
 
-		if includeMatcher != nil || excludeMatcher != nil {
+		if fs.includeMatcher != nil || fs.excludeMatcher != nil {
 			defer func() {
 				if isDir {
 					parentDirs = append(parentDirs, dir)
@@ -275,25 +311,21 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 
 		dir.calledFn = true
 
-		// The FileInfo might have already been read further up.
-		if fi == nil {
-			fi, err = dirEntry.Info()
-			if err != nil {
-				return err
-			}
-		}
-
-		stat, err := mkstat(origpath, path, fi, seenFiles)
+		fi, err := dirEntry.Info()
 		if err != nil {
 			return err
+		}
+		stat, ok := fi.Sys().(*types.Stat)
+		if !ok {
+			return errors.WithStack(&os.PathError{Path: path, Err: syscall.EBADMSG, Op: "fileinfo without stat info"})
 		}
 
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			if opt != nil && opt.Map != nil {
-				result := opt.Map(stat.Path, stat)
+			if fs.mapFn != nil {
+				result := fs.mapFn(stat.Path, stat)
 				if result == MapResultSkipDir {
 					return filepath.SkipDir
 				} else if result == MapResultExclude {
@@ -304,9 +336,13 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 				if parentDir.calledFn {
 					continue
 				}
-				parentStat, err := mkstat(parentDir.origpath, parentDir.path, parentDir.fi, seenFiles)
+				parentFi, err := parentDir.entry.Info()
 				if err != nil {
 					return err
+				}
+				parentStat, ok := parentFi.Sys().(*types.Stat)
+				if !ok {
+					return errors.WithStack(&os.PathError{Path: path, Err: syscall.EBADMSG, Op: "fileinfo without stat info"})
 				}
 
 				select {
@@ -314,24 +350,58 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 					return ctx.Err()
 				default:
 				}
-				if opt != nil && opt.Map != nil {
-					result := opt.Map(parentStat.Path, parentStat)
+				if fs.mapFn != nil {
+					result := fs.mapFn(parentStat.Path, parentStat)
 					if result == MapResultSkipDir || result == MapResultExclude {
 						continue
 					}
 				}
 
-				if err := fn(parentStat.Path, &StatInfo{parentStat}, nil); err != nil {
+				if err := fn(parentStat.Path, &DirEntryInfo{Stat: parentStat}, nil); err != nil {
 					return err
 				}
 				parentDirs[i].calledFn = true
 			}
-			if err := fn(stat.Path, &StatInfo{stat}, nil); err != nil {
+			if err := fn(stat.Path, &DirEntryInfo{Stat: stat}, nil); err != nil {
 				return err
 			}
 		}
 		return nil
 	})
+}
+
+func Walk(ctx context.Context, p string, opt *FilterOpt, fn filepath.WalkFunc) error {
+	f, err := NewFS(p)
+	if err != nil {
+		return err
+	}
+	f, err = NewFilterFS(f, opt)
+	if err != nil {
+		return err
+	}
+	return f.Walk(ctx, "/", func(path string, d gofs.DirEntry, err error) error {
+		var info gofs.FileInfo
+		if d != nil {
+			var err2 error
+			info, err2 = d.Info()
+			if err == nil {
+				err = err2
+			}
+		}
+		return fn(path, info, err)
+	})
+}
+
+func WalkDir(ctx context.Context, p string, opt *FilterOpt, fn gofs.WalkDirFunc) error {
+	f, err := NewFS(p)
+	if err != nil {
+		return err
+	}
+	f, err = NewFilterFS(f, opt)
+	if err != nil {
+		return err
+	}
+	return f.Walk(ctx, "/", fn)
 }
 
 func patternWithoutTrailingGlob(p *patternmatcher.Pattern) string {
@@ -342,29 +412,6 @@ func patternWithoutTrailingGlob(p *patternmatcher.Pattern) string {
 	patStr = strings.TrimSuffix(patStr, string(filepath.Separator)+"**")
 	patStr = strings.TrimSuffix(patStr, string(filepath.Separator)+"*")
 	return patStr
-}
-
-type StatInfo struct {
-	*types.Stat
-}
-
-func (s *StatInfo) Name() string {
-	return filepath.Base(s.Stat.Path)
-}
-func (s *StatInfo) Size() int64 {
-	return s.Stat.Size_
-}
-func (s *StatInfo) Mode() os.FileMode {
-	return os.FileMode(s.Stat.Mode)
-}
-func (s *StatInfo) ModTime() time.Time {
-	return time.Unix(s.Stat.ModTime/1e9, s.Stat.ModTime%1e9)
-}
-func (s *StatInfo) IsDir() bool {
-	return s.Mode().IsDir()
-}
-func (s *StatInfo) Sys() interface{} {
-	return s.Stat
 }
 
 func isNotExist(err error) bool {

--- a/vendor/github.com/tonistiigi/fsutil/followlinks.go
+++ b/vendor/github.com/tonistiigi/fsutil/followlinks.go
@@ -1,17 +1,21 @@
 package fsutil
 
 import (
+	"context"
+	gofs "io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
 	strings "strings"
+	"syscall"
 
 	"github.com/pkg/errors"
+	"github.com/tonistiigi/fsutil/types"
 )
 
-func FollowLinks(root string, paths []string) ([]string, error) {
-	r := &symlinkResolver{root: root, resolved: map[string]struct{}{}}
+func FollowLinks(fs FS, paths []string) ([]string, error) {
+	r := &symlinkResolver{fs: fs, resolved: map[string]struct{}{}}
 	for _, p := range paths {
 		if err := r.append(p); err != nil {
 			return nil, err
@@ -26,7 +30,7 @@ func FollowLinks(root string, paths []string) ([]string, error) {
 }
 
 type symlinkResolver struct {
-	root     string
+	fs       FS
 	resolved map[string]struct{}
 }
 
@@ -76,10 +80,9 @@ func (r *symlinkResolver) append(p string) error {
 }
 
 func (r *symlinkResolver) readSymlink(p string, allowWildcard bool) ([]string, error) {
-	realPath := filepath.Join(r.root, p)
 	base := filepath.Base(p)
 	if allowWildcard && containsWildcards(base) {
-		fis, err := os.ReadDir(filepath.Dir(realPath))
+		fis, err := readDir(r.fs, filepath.Dir(p))
 		if err != nil {
 			if isNotFound(err) {
 				return nil, nil
@@ -99,27 +102,106 @@ func (r *symlinkResolver) readSymlink(p string, allowWildcard bool) ([]string, e
 		return out, nil
 	}
 
-	fi, err := os.Lstat(realPath)
+	entry, err := statFile(r.fs, p)
 	if err != nil {
 		if isNotFound(err) {
 			return nil, nil
 		}
 		return nil, errors.WithStack(err)
 	}
-	if fi.Mode()&os.ModeSymlink == 0 {
+	if entry == nil {
 		return nil, nil
 	}
-	link, err := os.Readlink(realPath)
+	if entry.Type()&os.ModeSymlink == 0 {
+		return nil, nil
+	}
+
+	fi, err := entry.Info()
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	link = filepath.Clean(link)
+	stat, ok := fi.Sys().(*types.Stat)
+	if !ok {
+		return nil, errors.WithStack(&os.PathError{Path: p, Err: syscall.EBADMSG, Op: "fileinfo without stat info"})
+	}
+
+	link := filepath.Clean(stat.Linkname)
 	if filepath.IsAbs(link) {
 		return []string{link}, nil
 	}
 	return []string{
 		filepath.Join(string(filepath.Separator), filepath.Join(filepath.Dir(p), link)),
 	}, nil
+}
+
+func statFile(fs FS, root string) (os.DirEntry, error) {
+	var out os.DirEntry
+
+	root = filepath.Clean(root)
+	if root == "/" || root == "." {
+		return nil, nil
+	}
+
+	err := fs.Walk(context.TODO(), root, func(p string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if p != root {
+			return errors.Errorf("expected single entry %q but got %q", root, p)
+		}
+		out = entry
+		if entry.IsDir() {
+			return filepath.SkipDir
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if out == nil {
+		return nil, errors.Wrapf(os.ErrNotExist, "readFile %s", root)
+	}
+	return out, nil
+}
+
+func readDir(fs FS, root string) ([]os.DirEntry, error) {
+	var out []os.DirEntry
+
+	root = filepath.Clean(root)
+	if root == "/" || root == "." {
+		root = "."
+		out = make([]gofs.DirEntry, 0)
+	}
+
+	err := fs.Walk(context.TODO(), root, func(p string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if p == root {
+			if !entry.IsDir() {
+				return errors.WithStack(&os.PathError{Op: "walk", Path: root, Err: syscall.ENOTDIR})
+			}
+			out = make([]gofs.DirEntry, 0)
+			return nil
+		}
+		if out == nil {
+			return errors.Errorf("expected to read parent entry %q before child %q", root, p)
+		}
+		out = append(out, entry)
+		if entry.IsDir() {
+			return filepath.SkipDir
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if out == nil && root != "." {
+		return nil, errors.Wrapf(os.ErrNotExist, "readDir %s", root)
+	}
+	return out, nil
 }
 
 func containsWildcards(name string) bool {

--- a/vendor/github.com/tonistiigi/fsutil/send.go
+++ b/vendor/github.com/tonistiigi/fsutil/send.go
@@ -144,7 +144,11 @@ func (s *sender) sendFile(h *sendHandle) error {
 
 func (s *sender) walk(ctx context.Context) error {
 	var i uint32 = 0
-	err := s.fs.Walk(ctx, func(path string, fi os.FileInfo, err error) error {
+	err := s.fs.Walk(ctx, "/", func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		fi, err := entry.Info()
 		if err != nil {
 			return err
 		}

--- a/vendor/github.com/tonistiigi/fsutil/tarwriter.go
+++ b/vendor/github.com/tonistiigi/fsutil/tarwriter.go
@@ -15,8 +15,13 @@ import (
 
 func WriteTar(ctx context.Context, fs FS, w io.Writer) error {
 	tw := tar.NewWriter(w)
-	err := fs.Walk(ctx, func(path string, fi os.FileInfo, err error) error {
+	err := fs.Walk(ctx, "/", func(path string, entry os.DirEntry, err error) error {
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+
+		fi, err := entry.Info()
+		if err != nil {
 			return err
 		}
 		stat, ok := fi.Sys().(*types.Stat)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -742,7 +742,7 @@ github.com/spdx/tools-golang/spdx/v2/v2_3
 ## explicit; go 1.20
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
-# github.com/tonistiigi/fsutil v0.0.0-20230629203738-36ef4d8c0dbb
+# github.com/tonistiigi/fsutil v0.0.0-20230825212630-f09800878302
 ## explicit; go 1.19
 github.com/tonistiigi/fsutil
 github.com/tonistiigi/fsutil/copy


### PR DESCRIPTION
This patch modifies the function signature of the FSSync provider to take an fsutil.FS instead of a simple raw path resolved to the client's root filesystem, and follows this through to allow specifying fsutil.FS objects on the SolveOpt itself.

Internally, we were already creating an fsutil.FS to Send to the buildkit server, however, this abstraction didn't reach the session attachable parameters, so we couldn't provide our own custom FS implementation.

The rationale behind this change is to allow providing more abstract custom filesystem implementations to a BuildKit client. This way, we can start to build from filesystems that might not be on disk - for example, we could use our Static filesystem implementation in tests to prevent creating lots of temporary directories, or we could use our Merge filesystem implementation to allow easily creating variants of a single context.