### PR TITLE
ci(test-os): bump actions

### DIFF
--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -93,10 +93,10 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Cache Vagrant boxes
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.vagrant.d/boxes
           key: ${{ runner.os }}-vagrant-${{ hashFiles('hack/Vagrantfile.freebsd13') }}
@@ -110,7 +110,7 @@ jobs:
         run: |
           vagrant ssh -- "cp /vagrant/hack/dockerfiles/freebsd-smoke.Dockerfile /vagrant/cmd/buildctl/Dockerfile"
           vagrant ssh -- "cd /vagrant/cmd/buildctl; go run . build --frontend dockerfile.v0 --local context=. --local dockerfile=."
-
-      - name: Print BuildKit logs
+      -
+        name: Print BuildKit logs
         if: always()
         run: vagrant ssh -- "sudo cat /vagrant/run-logs/buildkitd"


### PR DESCRIPTION
Fix warnings in ci:

![image](https://github.com/moby/buildkit/assets/1951866/0eea89bb-7d2d-4452-be09-d76b3f6d8c10)
