### PR TITLE
test: add HasFeatureCompat helper

### DIFF
--- a/util/testutil/integration/sandbox.go
+++ b/util/testutil/integration/sandbox.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/shlex"
 	"github.com/moby/buildkit/util/bklog"
+	"github.com/pkg/errors"
 )
 
 const buildkitdConfigFile = "buildkitd.toml"
@@ -157,6 +158,13 @@ func FormatLogs(m map[string]*bytes.Buffer) string {
 
 func CheckFeatureCompat(t *testing.T, sb Sandbox, features map[string]struct{}, reason ...string) {
 	t.Helper()
+	if err := HasFeatureCompat(t, sb, features, reason...); err != nil {
+		t.Skipf(err.Error())
+	}
+}
+
+func HasFeatureCompat(t *testing.T, sb Sandbox, features map[string]struct{}, reason ...string) error {
+	t.Helper()
 	if len(reason) == 0 {
 		t.Fatal("no reason provided")
 	}
@@ -172,6 +180,7 @@ func CheckFeatureCompat(t *testing.T, sb Sandbox, features map[string]struct{}, 
 		}
 	}
 	if len(ereasons) > 0 {
-		t.Skipf("%s worker can not currently run this test due to missing features (%s)", sb.Name(), strings.Join(ereasons, ", "))
+		return errors.Errorf("%s worker can not currently run this test due to missing features (%s)", sb.Name(), strings.Join(ereasons, ", "))
 	}
+	return nil
 }

--- a/util/testutil/workers/features.go
+++ b/util/testutil/workers/features.go
@@ -61,3 +61,7 @@ var features = map[string]struct{}{
 func CheckFeatureCompat(t *testing.T, sb integration.Sandbox, reason ...string) {
 	integration.CheckFeatureCompat(t, sb, features, reason...)
 }
+
+func HasFeatureCompat(t *testing.T, sb integration.Sandbox, reason ...string) error {
+	return integration.HasFeatureCompat(t, sb, features, reason...)
+}


### PR DESCRIPTION
This is intended to act as a helper to allow checking for the presence of sandbox worker features without skipping a test (which allows for defining different behavior if a feature is available or not).