### PR TITLE
docs: update gcpolicy percentage to refer to total space

### DIFF
--- a/docs/buildkitd.toml.md
+++ b/docs/buildkitd.toml.md
@@ -72,7 +72,7 @@ insecure-entitlements = [ "network.host", "security.insecure" ]
 
   [[worker.oci.gcpolicy]]
     # keepBytes can be an integer number of bytes (e.g. 512000000), a string
-    # with a unit (e.g. "512MB"), or a string percentage of available disk
+    # with a unit (e.g. "512MB"), or a string percentage of the total disk
     # space (e.g. "10%")
     keepBytes = "512MB"
     # keepDuration can be an integer number of seconds (e.g. 172800), or a


### PR DESCRIPTION
Fixes https://github.com/moby/buildkit/issues/4115.

In https://github.com/moby/buildkit/pull/3773 we added configurable percentages, however, the associated docs mention that the percentage is of "available disk space", which is technically incorrect. It should be "total disk space".