### PR TITLE
Add option to specify containerd runtime

### DIFF
--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -112,6 +112,7 @@ type ContainerdConfig struct {
 	Labels    map[string]string `toml:"labels"`
 	Platforms []string          `toml:"platforms"`
 	Namespace string            `toml:"namespace"`
+	Runtime   string            `toml:"runtime"`
 	GCConfig
 	NetworkConfig
 	Snapshotter string `toml:"snapshotter"`

--- a/cmd/buildkitd/config/load_test.go
+++ b/cmd/buildkitd/config/load_test.go
@@ -40,6 +40,7 @@ foo="bar"
 
 [worker.containerd]
 namespace="non-default"
+runtime="exotic"
 platforms=["linux/amd64"]
 address="containerd.sock"
 [[worker.containerd.gcpolicy]]
@@ -103,6 +104,7 @@ searchDomains=["example.com"]
 
 	require.Equal(t, 0, len(cfg.Workers.OCI.GCPolicy))
 	require.Equal(t, "non-default", cfg.Workers.Containerd.Namespace)
+	require.Equal(t, "exotic", cfg.Workers.Containerd.Runtime)
 	require.Equal(t, 3, len(cfg.Workers.Containerd.GCPolicy))
 
 	require.Nil(t, cfg.Workers.Containerd.GC)

--- a/docs/buildkitd.toml.md
+++ b/docs/buildkitd.toml.md
@@ -93,6 +93,7 @@ insecure-entitlements = [ "network.host", "security.insecure" ]
   enabled = true
   platforms = [ "linux/amd64", "linux/arm64" ]
   namespace = "buildkit"
+  runtime = "io.containerd.runc.v2"
   gc = true
   # gckeepstorage sets storage limit for default gc profile, in MB.
   gckeepstorage = 9000

--- a/worker/containerd/containerd.go
+++ b/worker/containerd/containerd.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 
@@ -30,9 +29,6 @@ import (
 // NewWorkerOpt creates a WorkerOpt.
 func NewWorkerOpt(root string, address, snapshotterName, ns string, rootless bool, labels map[string]string, dns *oci.DNSConfig, nopt netproviders.Opt, apparmorProfile string, selinux bool, parallelismSem *semaphore.Weighted, traceSocket string, opts ...containerd.ClientOpt) (base.WorkerOpt, error) {
 	opts = append(opts, containerd.WithDefaultNamespace(ns))
-	if runtime.GOOS == "freebsd" {
-		opts = append(opts, containerd.WithDefaultRuntime("wtf.sbk.runj.v1"))
-	}
 
 	client, err := containerd.New(address, opts...)
 	if err != nil {


### PR DESCRIPTION
Thoughts: it could just be `runtime` or `default runtime`, hinting that in the future specific build run can override it.