### PR TITLE
buildkitd: add grpc.health.v1.Health service

### DIFF
--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -67,6 +67,8 @@ import (
 	tracev1 "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthv1 "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
 )
 
@@ -309,6 +311,7 @@ func main() {
 		}
 		defer controller.Close()
 
+		healthv1.RegisterHealthServer(server, health.NewServer())
 		controller.Register(server)
 		reflection.Register(server)
 


### PR DESCRIPTION
Fixes https://github.com/moby/buildkit/issues/3591.

Buildkitd now supports a health service:

	$ grpcurl -plaintext localhost:1234 list
	...
	grpc.health.v1.Health
	...

Which can be used to implement a lightweight health check on the running server:

	$ grpcurl -plaintext localhost:1234 grpc.health.v1.Health/Check
	{
	  "status": "SERVING"
	}