### PR TITLE
ci: dump context on failure

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -178,3 +178,7 @@ jobs:
         with:
           name: test-reports
           path: ./bin/testreports
+      -
+        name: Dump context
+        if: failure()
+        uses: crazy-max/ghaction-dump-context@v2

--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -85,6 +85,10 @@ jobs:
         with:
           name: test-reports
           path: ./bin/testreports
+      -
+        name: Dump context
+        if: failure()
+        uses: crazy-max/ghaction-dump-context@v2
 
   test-freebsd-amd64:
     runs-on: macos-12
@@ -120,3 +124,7 @@ jobs:
         if: always()
         run: |
           vagrant ssh -- "sudo cat /vagrant/.tmp/logs/containerd"
+      -
+        name: Dump context
+        if: failure()
+        uses: crazy-max/ghaction-dump-context@v2


### PR DESCRIPTION
Can't manage to repro https://github.com/moby/buildkit/issues/4146 so trying to correlate with specific runner configuration by dumping runner context on failure.