### PR TITLE
chore: remove suffix detection on tests

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -244,7 +244,7 @@ func testIntegration(t *testing.T, funcs ...func(t *testing.T, sb integration.Sa
 	)
 
 	integration.Run(t, integration.TestFuncs(
-		testBridgeNetworkingDNSNoRootless,
+		testBridgeNetworkingDNS,
 	),
 		mirrors,
 		integration.WithMatrix("netmode", map[string]interface{}{
@@ -323,11 +323,14 @@ func testBridgeNetworking(t *testing.T, sb integration.Sandbox) {
 	require.Error(t, err)
 }
 
-func testBridgeNetworkingDNSNoRootless(t *testing.T, sb integration.Sandbox) {
-	workers.CheckFeatureCompat(t, sb, workers.FeatureCNINetwork)
+func testBridgeNetworkingDNS(t *testing.T, sb integration.Sandbox) {
 	if os.Getenv("BUILDKIT_RUN_NETWORK_INTEGRATION_TESTS") == "" {
 		t.SkipNow()
 	}
+	if sb.Rootless() {
+		t.SkipNow()
+	}
+	workers.CheckFeatureCompat(t, sb, workers.FeatureCNINetwork)
 
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)

--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -183,17 +183,12 @@ func Run(t *testing.T, testCases []Test, opt ...TestOpt) {
 				name := fn + "/worker=" + br.Name() + mv.functionSuffix()
 				func(fn, testName string, br Worker, tc Test, mv matrixValue) {
 					ok := t.Run(testName, func(t *testing.T) {
-						if strings.Contains(fn, "NoRootless") && br.Rootless() {
-							// skip sandbox setup
-							t.Skip("rootless")
-						}
-						ctx := appcontext.Context()
-						if !strings.HasSuffix(fn, "NoParallel") {
-							t.Parallel()
-						}
+						t.Parallel()
+
 						require.NoError(t, sandboxLimiter.Acquire(context.TODO(), 1))
 						defer sandboxLimiter.Release(1)
 
+						ctx := appcontext.Context()
 						sb, closer, err := newSandbox(ctx, br, mirror, mv)
 						require.NoError(t, err)
 						t.Cleanup(func() { _ = closer() })


### PR DESCRIPTION
NoParallel suffixes are not used anywhere, and the NoRootless suffix is only used in one place - we can remove that usage to be inline with the rest of the network tests.