### PR TITLE
solver: wrap gRPC codes.NotFound on unknown build ID

### DIFF
--- a/client/build_test.go
+++ b/client/build_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/moby/buildkit/solver/errdefs"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/entitlements"
+	"github.com/moby/buildkit/util/grpcerrors"
 	utilsystem "github.com/moby/buildkit/util/system"
 	"github.com/moby/buildkit/util/testutil/echoserver"
 	"github.com/moby/buildkit/util/testutil/integration"
@@ -31,6 +32,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh/agent"
+	"google.golang.org/grpc/codes"
 )
 
 func TestClientGatewayIntegration(t *testing.T) {
@@ -334,6 +336,7 @@ func testUnknownBuildID(t *testing.T, sb integration.Sandbox) {
 	_, err = g.Ping(ctx, &gatewayapi.PingRequest{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no such job")
+	require.Equal(t, grpcerrors.Code(err), codes.NotFound)
 }
 
 // testClientGatewayContainerCancelOnRelease is testing that all running

--- a/control/gateway/gateway.go
+++ b/control/gateway/gateway.go
@@ -8,6 +8,7 @@ import (
 	"github.com/moby/buildkit/client/buildid"
 	"github.com/moby/buildkit/frontend/gateway"
 	gwapi "github.com/moby/buildkit/frontend/gateway/pb"
+	"github.com/moby/buildkit/solver/errdefs"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 )
@@ -73,7 +74,7 @@ func (gwf *GatewayForwarder) lookupForwarder(ctx context.Context) (gateway.LLBBr
 	for {
 		select {
 		case <-ctx.Done():
-			return nil, errors.Errorf("no such job %s", bid)
+			return nil, errdefs.NewUnknownJobError(bid)
 		default:
 		}
 		fwd, ok := gwf.builds[bid]

--- a/solver/errdefs/jobs.go
+++ b/solver/errdefs/jobs.go
@@ -1,0 +1,23 @@
+package errdefs
+
+import (
+	"fmt"
+
+	"google.golang.org/grpc/codes"
+)
+
+type UnknownJobError struct {
+	id string
+}
+
+func (e *UnknownJobError) Code() codes.Code {
+	return codes.NotFound
+}
+
+func (e *UnknownJobError) Error() string {
+	return fmt.Sprintf("no such job %s", e.id)
+}
+
+func NewUnknownJobError(id string) error {
+	return &UnknownJobError{id: id}
+}

--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -484,7 +484,7 @@ func (jl *Solver) Get(id string) (*Job, error) {
 	for {
 		select {
 		case <-ctx.Done():
-			return nil, errors.Errorf("no such job %s", id)
+			return nil, errdefs.NewUnknownJobError(id)
 		default:
 		}
 		j, ok := jl.jobs[id]

--- a/solver/scheduler_test.go
+++ b/solver/scheduler_test.go
@@ -3315,6 +3315,17 @@ func TestInputRequestDeadlock(t *testing.T) {
 	j2 = nil
 }
 
+func TestUnknownBuildID(t *testing.T) {
+	s := NewSolver(SolverOpt{
+		ResolveOpFunc: testOpResolver,
+	})
+	defer s.Close()
+
+	_, err := s.Get(identity.NewID())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no such job")
+}
+
 func generateSubGraph(nodes int) (Edge, int) {
 	if nodes == 1 {
 		value := rand.Int() % 500 //nolint:gosec


### PR DESCRIPTION
Atm it returns `codes.Unknown`:

```
rpc error: code = Unknown desc = no such job <buildid>
```

But we should explicitly wrap `codes.NotFound`.