### PR TITLE
solver: fix possible race for provenance ResolveImageConfig

### DIFF
--- a/solver/llbsolver/provenance.go
+++ b/solver/llbsolver/provenance.go
@@ -136,12 +136,14 @@ func (b *provenanceBridge) ResolveImageConfig(ctx context.Context, ref string, o
 		return "", "", nil, err
 	}
 
+	b.mu.Lock()
 	b.images = append(b.images, provenance.ImageSource{
 		Ref:      ref,
 		Platform: opt.Platform,
 		Digest:   dgst,
 		Local:    opt.ResolverType == llb.ResolverTypeOCILayout,
 	})
+	b.mu.Unlock()
 	return ref, dgst, config, nil
 }
 


### PR DESCRIPTION
ResolveImageConfig can be called concurrently - for example, by dockerfile2llb during conversion, we loop through each stage and resolve the base image for that stage.

In the case that two calls to ResolveImageConfig finish at roughly the same time, we can hit an edge case where we attempt to modify the bridge's image records at the same time.

To fix this, we just need to use the bridge's mutex to prevent concurrent access here.

This should fix the following stack trace found in CI (https://github.com/moby/buildkit/actions/runs/5889475633/job/15972815280?pr=4041):

    sandbox.go:144: goroutine 1079 [running]:
    sandbox.go:144: github.com/moby/buildkit/solver/llbsolver.(*provenanceBridge).ResolveImageConfig(0xc000431e00, {0x1c2b040?, 0xc0008e5b30?}, {0xc00094ba00?, 0xc0003728f0?}, {0x0, 0xc0006cb580, {0x19ba868, 0x7}, {0xc0008f7500, ...}, ...})
    sandbox.go:144: 	/src/solver/llbsolver/provenance.go:139 +0x1fb
    sandbox.go:144: github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb.toDispatchState.func3.1()
    sandbox.go:144: 	/src/frontend/dockerfile/dockerfile2llb/convert.go:405 +0x5fe
    sandbox.go:144: golang.org/x/sync/errgroup.(*Group).Go.func1()
    sandbox.go:144: 	/src/vendor/golang.org/x/sync/errgroup/errgroup.go:75 +0x64
    sandbox.go:144: created by golang.org/x/sync/errgroup.(*Group).Go
    sandbox.go:144: 	/src/vendor/golang.org/x/sync/errgroup/errgroup.go:72 +0xa5
    --- FAIL: TestIntegration/TestNoCache/worker=oci-rootless/frontend=builtin (4.45s)

No other explanation for this failure makes sense - `b` cannot be `nil` at this point, since a call to `b.llbBridge.ResolveImageConfig` has just succeeded (also because that would be very strange).

Note: I can't manage to reproduce this with the race checker, so I'm not actually 100% sure that this is the issue that caused the CI failure, but the code here is definitely not thread-safe, so at the very least, this improves that.