### PR TITLE
dockerfile2llb: filter unused paths for named contexts

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert_runmount.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_runmount.go
@@ -31,6 +31,7 @@ func detectRunMount(cmd *command, allDispatchStates *dispatchStates) bool {
 				stn = &dispatchState{
 					stage:        instructions.Stage{BaseName: from},
 					deps:         make(map[*dispatchState]struct{}),
+					paths:        make(map[string]struct{}),
 					unregistered: true,
 				}
 			}
@@ -136,6 +137,9 @@ func dispatchRunMounts(d *dispatchState, c *instructions.RunCommand, sources []*
 
 		if mount.From == "" {
 			d.ctxPaths[path.Join("/", filepath.ToSlash(mount.Source))] = struct{}{}
+		} else {
+			source := sources[i]
+			source.paths[path.Join("/", filepath.ToSlash(mount.Source))] = struct{}{}
 		}
 	}
 	return out, nil

--- a/frontend/dockerui/config.go
+++ b/frontend/dockerui/config.go
@@ -95,7 +95,7 @@ type Source struct {
 
 type ContextOpt struct {
 	NoDockerignore bool
-	LocalOpts      []llb.LocalOption
+	AsyncLocalOpts func() []llb.LocalOption
 	Platform       *ocispecs.Platform
 	ResolveMode    string
 	CaptureDigest  *digest.Digest
@@ -473,11 +473,8 @@ func (bc *Client) NamedContext(ctx context.Context, name string, opt ContextOpt)
 	}
 	pname := name + "::" + platforms.Format(platforms.Normalize(pp))
 	st, img, err := bc.namedContext(ctx, name, pname, opt)
-	if err != nil {
-		return nil, nil, err
-	}
-	if st != nil {
-		return st, img, nil
+	if err != nil || st != nil {
+		return st, img, err
 	}
 	return bc.namedContext(ctx, name, name, opt)
 }


### PR DESCRIPTION
This changes the llb generation in `dockerfile2llb` to add the
`llb.FollowPaths` option when named contexts are used in the same way
that happens with the default context.

This means that dockerfiles that look like this:

```
FROM scratch
COPY --from=mynamedctx ./a.txt /a.txt
```

Will only load the file `a.txt`. This behavior is consistent with the
default context.

This also removes the unused []llb.LocalOption from ContextOpt and
replaces it with an async counterpart. This is needed because we
initialize the named context before we know which paths are needed for
the filter.

Fixes #1765.