### PR TITLE
progressui: json mode for a buffered json output

### DIFF
--- a/cmd/buildctl/build.go
+++ b/cmd/buildctl/build.go
@@ -46,7 +46,7 @@ var buildCommand = cli.Command{
 		},
 		cli.StringFlag{
 			Name:  "progress",
-			Usage: "Set type of progress (auto, plain, tty, rawjson). Use plain to show container output",
+			Usage: "Set type of progress (auto, plain, tty, json, rawjson). Use plain to show container output",
 			Value: "auto",
 		},
 		cli.StringFlag{

--- a/docs/reference/buildctl.md
+++ b/docs/reference/buildctl.md
@@ -63,7 +63,7 @@ USAGE:
 
 OPTIONS:
    --output value, -o value          Define exports for build result, e.g. --output type=image,name=docker.io/username/image,push=true
-   --progress value                  Set type of progress (auto, plain, tty, rawjson). Use plain to show container output (default: "auto")
+   --progress value                  Set type of progress (auto, plain, tty, json, rawjson). Use plain to show container output (default: "auto")
    --trace value                     Path to trace file. Defaults to no tracing.
    --local value                     Allow build access to the local directory
    --oci-layout value                Allow build access to the local OCI layout

--- a/util/progress/progressui/json.go
+++ b/util/progress/progressui/json.go
@@ -1,0 +1,40 @@
+package progressui
+
+import (
+	"time"
+
+	digest "github.com/opencontainers/go-digest"
+)
+
+type Vertex struct {
+	Digest   digest.Digest          `json:"digest,omitempty"`
+	Inputs   []digest.Digest        `json:"inputs,omitempty"`
+	Name     string                 `json:"name,omitempty"`
+	Started  *time.Time             `json:"started,omitempty"`
+	Duration *float64               `json:"duration,omitempty"`
+	Cached   bool                   `json:"cached,omitempty"`
+	Error    string                 `json:"error,omitempty"`
+	Statuses []VertexStatus         `json:"statuses,omitempty"`
+	Logs     map[string][]VertexLog `json:"logs,omitempty"`
+	Warnings []VertexWarning        `json:"warnings,omitempty"`
+}
+
+type VertexStatus struct {
+	ID       string     `json:"id"`
+	Name     string     `json:"name,omitempty"`
+	Total    int64      `json:"total,omitempty"`
+	Started  *time.Time `json:"started,omitempty"`
+	Duration *float64   `json:"duration,omitempty"`
+}
+
+type VertexLog struct {
+	Timestamp float64 `json:"ts"`
+	Message   string  `json:"msg"`
+}
+
+type VertexWarning struct {
+	Level  int      `json:"level,omitempty"`
+	Short  string   `json:"short,omitempty"`
+	Detail []string `json:"detail,omitempty"`
+	URL    string   `json:"url,omitempty"`
+}


### PR DESCRIPTION
This adds a json progress mode to the progressui. This json mode, in 
contrast to `rawjson`, produces an aggregated json output for each vertex
after the vertex has completed.

The primary use of this progress output is for machine tools to parse to
determine the details of the build. For raw events and interactive tooling,
`rawjson` is a better option due to providing more real time detail.

Related to #4113.