### PR TITLE
util/progress: silence go test -race

### DIFF
--- a/util/progress/progress_test.go
+++ b/util/progress/progress_test.go
@@ -25,8 +25,8 @@ func TestProgress(t *testing.T) {
 		return saveProgress(ctx, pr, &trace)
 	})
 
-	pw, _, ctx := NewFromContext(ctx, WithMetadata("tag", "foo"))
-	s, err = calc(ctx, 5, "calc")
+	pw, _, ctx2 := NewFromContext(ctx, WithMetadata("tag", "foo"))
+	s, err = calc(ctx2, 5, "calc")
 	pw.Close()
 	assert.NoError(t, err)
 	assert.Equal(t, 15, s)


### PR DESCRIPTION
Without this commit, `go test -race ./util/progress` sees a race due to the
shadowed `ctx` variable.

```
==================
WARNING: DATA RACE
Read at 0x00c000206040 by goroutine 25:
  github.com/moby/buildkit/util/progress.TestProgress.func1()
      github.com/moby/buildkit/util/progress/progress_test.go:25 +0x44
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      golang.org/x/sync@v0.1.0/errgroup/errgroup.go:75 +0x6c

Previous write at 0x00c000206040 by goroutine 6:
  github.com/moby/buildkit/util/progress.TestProgress()
      github.com/moby/buildkit/util/progress/progress_test.go:28 +0x4a0
  testing.tRunner()
      testing/testing.go:1576 +0x188
  testing.(*T).Run.func1()
      testing/testing.go:1629 +0x40

Goroutine 25 (running) created at:
  golang.org/x/sync/errgroup.(*Group).Go()
      golang.org/x/sync@v0.1.0/errgroup/errgroup.go:72 +0x10c
  github.com/moby/buildkit/util/progress.TestProgress()
      github.com/moby/buildkit/util/progress/progress_test.go:24 +0x360
  testing.tRunner()
      testing/testing.go:1576 +0x188
  testing.(*T).Run.func1()
      testing/testing.go:1629 +0x40

Goroutine 6 (running) created at:
  testing.(*T).Run()
      testing/testing.go:1629 +0x5e4
  testing.runTests.func1()
      testing/testing.go:2036 +0x80
  testing.tRunner()
      testing/testing.go:1576 +0x188
  testing.runTests()
      testing/testing.go:2034 +0x700
  testing.(*M).Run()
      testing/testing.go:1906 +0x950
  main.main()
      _testmain.go:49 +0x300
==================
==================
WARNING: DATA RACE
Read at 0x00c000202390 by goroutine 26:
  context.(*valueCtx).Done()
      <autogenerated>:1 +0x34
  github.com/moby/buildkit/util/progress.(*progressReader).Read.func1()
      github.com/moby/buildkit/util/progress/progress.go:126 +0xac

Previous write at 0x00c000202390 by goroutine 6:
  context.WithValue()
      context/context.go:593 +0xac
  github.com/moby/buildkit/util/progress.FromContext.func1()
      github.com/moby/buildkit/util/progress/progress.go:42 +0x168
  github.com/moby/buildkit/util/progress.NewFromContext()
      github.com/moby/buildkit/util/progress/progress.go:51 +0x60
  github.com/moby/buildkit/util/progress.TestProgress()
      github.com/moby/buildkit/util/progress/progress_test.go:28 +0x488
  testing.tRunner()
      testing/testing.go:1576 +0x188
  testing.(*T).Run.func1()
      testing/testing.go:1629 +0x40

Goroutine 26 (running) created at:
  github.com/moby/buildkit/util/progress.(*progressReader).Read()
      github.com/moby/buildkit/util/progress/progress.go:120 +0x15c
  github.com/moby/buildkit/util/progress.saveProgress()
      github.com/moby/buildkit/util/progress/progress_test.go:125 +0x48
  github.com/moby/buildkit/util/progress.TestProgress.func1()
      github.com/moby/buildkit/util/progress/progress_test.go:25 +0x60
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      golang.org/x/sync@v0.1.0/errgroup/errgroup.go:75 +0x6c

Goroutine 6 (running) created at:
  testing.(*T).Run()
      testing/testing.go:1629 +0x5e4
  testing.runTests.func1()
      testing/testing.go:2036 +0x80
  testing.tRunner()
      testing/testing.go:1576 +0x188
  testing.runTests()
      testing/testing.go:2034 +0x700
  testing.(*M).Run()
      testing/testing.go:1906 +0x950
  main.main()
      _testmain.go:49 +0x300
==================
--- FAIL: TestProgressNested (0.07s)
    testing.go:1446: race detected during execution of test
--- FAIL: TestProgress (0.10s)
    testing.go:1446: race detected during execution of test
FAIL
FAIL    github.com/moby/buildkit/util/progress  0.112s
FAIL
```