### PR TITLE
FreeBSD CI: cross-compile binaries

### DIFF
--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -94,10 +94,25 @@ jobs:
     runs-on: macos-12
     env:
       VAGRANT_VAGRANTFILE: hack/Vagrantfile.freebsd13
+      GOOS: freebsd
     steps:
       -
         name: Checkout
         uses: actions/checkout@v3
+      -
+        name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "${{ env.GO_VERSION }}"
+          cache: true
+
+      - name: Build buildkitd binary
+        run: |
+          go build ./cmd/buildkitd
+
+      - name: Build buildctl binary
+        run: |
+          go build ./cmd/buildctl
       -
         name: Cache Vagrant boxes
         uses: actions/cache@v3

--- a/hack/Vagrantfile.freebsd13
+++ b/hack/Vagrantfile.freebsd13
@@ -13,7 +13,7 @@ Vagrant.configure("2") do |config|
       #!/usr/bin/env bash
       set -eux -o pipefail
       kldload nullfs
-      pkg install -y go git containerd runj
+      pkg install -y git containerd runj
       mkdir -p /vagrant/coverage /vagrant/.tmp/logs
     SHELL
   end
@@ -23,8 +23,8 @@ Vagrant.configure("2") do |config|
       #!/usr/bin/env bash
       set -eux -o pipefail
       cd /vagrant
-      go build -o /usr/bin/buildkitd ./cmd/buildkitd
-      type /usr/bin/buildkitd
+      install -m 755 buildkitd /usr/local/bin/buildkitd
+      type /usr/local/bin/buildkitd
       buildkitd --version
     SHELL
   end
@@ -34,8 +34,8 @@ Vagrant.configure("2") do |config|
       #!/usr/bin/env bash
       set -eux -o pipefail
       cd /vagrant
-      go build -o /usr/bin/buildctl ./cmd/buildctl
-      type /usr/bin/buildctl
+      install -m 755 buildctl /usr/local/bin/buildctl
+      type /usr/local/bin/buildctl
     SHELL
   end
 
@@ -53,7 +53,7 @@ Vagrant.configure("2") do |config|
       #!/usr/bin/env bash
       set -eux -o pipefail
       mkdir -p /run/buildkit
-      daemon -o /vagrant/.tmp/logs/buildkitd /usr/bin/buildkitd --addr=unix:///run/buildkit/buildkitd.sock
+      daemon -o /vagrant/.tmp/logs/buildkitd /usr/local/bin/buildkitd --addr=unix:///run/buildkit/buildkitd.sock
       sleep 3
     SHELL
   end


### PR DESCRIPTION
Sometimes, vagrant provisioning fails on build step. This may be mitigated by factoring the build step out of the vagrant box and cross-compiling FreeBSD binaries instead.

This change

- Adds steps to setup go, and compile binaries on the host machine
- Adjusts vagrant provisioners accordingly