### PR TITLE
fix(metadata): close store on exit

### DIFF
--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -211,6 +211,9 @@ func NewWorker(ctx context.Context, opt WorkerOpt) (*Worker, error) {
 
 func (w *Worker) Close() error {
 	var rerr error
+	if err := w.MetadataStore.Close(); err != nil {
+		rerr = multierror.Append(rerr, err)
+	}
 	for _, provider := range w.NetworkProviders {
 		if err := provider.Close(); err != nil {
 			rerr = multierror.Append(rerr, err)


### PR DESCRIPTION
I've recently had corruption in bolt and while reviewing the code I happened to notice that
the metastore was not closed.   I don't have any reason to believe this caused my corruption issue
but probably good to do.