### PR TITLE
fix: check snapshot labels to avoid panic

### DIFF
--- a/cache/refs.go
+++ b/cache/refs.go
@@ -1099,8 +1099,10 @@ func (sr *immutableRef) prepareRemoteSnapshotsStargzMode(ctx context.Context, s 
 					if err == nil { // usable as remote snapshot without unlazying.
 						defer func() {
 							// Remove tmp labels appended in this func
-							for k := range tmpLabels {
-								info.Labels[k] = ""
+							if info.Labels != nil {
+								for k := range tmpLabels {
+									info.Labels[k] = ""
+								}
 							}
 							if _, err := r.cm.Snapshotter.Update(ctx, info, tmpFields...); err != nil {
 								bklog.G(ctx).Warn(errors.Wrapf(err,

--- a/cache/refs.go
+++ b/cache/refs.go
@@ -1103,6 +1103,13 @@ func (sr *immutableRef) prepareRemoteSnapshotsStargzMode(ctx context.Context, s 
 								for k := range tmpLabels {
 									info.Labels[k] = ""
 								}
+							} else {
+								// We are logging here to track to try to debug when and why labels are nil.
+								// Log can be removed when not happening anymore.
+								bklog.G(ctx).
+									WithField("snapshotID", snapshotID).
+									WithField("name", info.Name).
+									Debug("snapshots exist but labels are nil")
 							}
 							if _, err := r.cm.Snapshotter.Update(ctx, info, tmpFields...); err != nil {
 								bklog.G(ctx).Warn(errors.Wrapf(err,


### PR DESCRIPTION
I saw a panic while using the stargz snapshotter caused by the labels being nil.

My wild-guess as to why labels is nil is that the stargz snapshotter could not find a bolt bucket:

https://github.com/containerd/containerd/blob/b0a7f08aa7490a3d43787b9f2b444e4b20b96f8c/metadata/boltutil/helpers.go#L53 

