### PR TITLE
llb: avoid duplicate instances of sourcemaps in provenance

### DIFF
--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -170,6 +170,7 @@ var allTests = integration.TestFuncs(
 	testMultiPlatformWarnings,
 	testNilContextInSolveGateway,
 	testCopyUnicodePath,
+	testFrontendDeduplicateSources,
 )
 
 // Tests that depend on the `security.*` entitlements


### PR DESCRIPTION
If build contains multiple subbuilds all of their sources are tracked in provenance attestations. When some subbuilds are coming from same source file (eg. same Dockerfile but different targets) currently the same file would appear in multiple times. This detects such duplicates and makes sure definitions from multiple subbuilds can map to same file.