### PR TITLE
fix: use sha256 for merge/diff op cache maps

### DIFF
--- a/solver/llbsolver/ops/diff.go
+++ b/solver/llbsolver/ops/diff.go
@@ -55,7 +55,7 @@ func (d *diffOp) CacheMap(ctx context.Context, group session.Group, index int) (
 	}
 
 	cm := &solver.CacheMap{
-		Digest: digest.Digest(dt),
+		Digest: digest.FromBytes(dt),
 		Deps: make([]struct {
 			Selector          digest.Digest
 			ComputeDigestFunc solver.ResultBasedCacheFunc

--- a/solver/llbsolver/ops/merge.go
+++ b/solver/llbsolver/ops/merge.go
@@ -47,7 +47,7 @@ func (m *mergeOp) CacheMap(ctx context.Context, group session.Group, index int) 
 	}
 
 	cm := &solver.CacheMap{
-		Digest: digest.Digest(dt),
+		Digest: digest.FromBytes(dt),
 		Deps: make([]struct {
 			Selector          digest.Digest
 			ComputeDigestFunc solver.ResultBasedCacheFunc


### PR DESCRIPTION
The digest of the merge/diff ops' CacheMap would be json strings like:

```
{"Type":"buildkit.merge.v0","Merge":{"inputs":[{"input":0},{"input":1}]}}
```

rather than a sha256.

I'm not sure what will happen with this change.

Also, even with this change I think all merge ops with two inputs would still hash to the same digest.  Is this ok?

I checked on all the other ops and they all correctly are sha256.

