### PR TITLE
use bklog instead of logrus

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,7 +39,7 @@ linters-settings:
   forbidigo:
     forbid:
       - '^fmt\.Errorf(# use errors\.Errorf instead)?$'
-      - 'logrus\.(Trace|Debug|Info|Warn|Warning|Error|Fatal)(f|ln)?\((# use bklog\.G\(ctx\) instead of logrus directly)?'
+      - '^logrus\.(Trace|Debug|Info|Warn|Warning|Error|Fatal)(f|ln)?(# use bklog\.G or bklog\.L instead of logrus directly)?$'
   importas:
     alias:
       - pkg: "github.com/opencontainers/image-spec/specs-go/v1"

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -285,7 +285,7 @@ func main() {
 		// Stop if we are registering or unregistering against Windows SCM.
 		stop, err := registerUnregisterService(cfg.Root)
 		if err != nil {
-			logrus.Fatal(err)
+			bklog.L.Fatal(err)
 		}
 		if stop {
 			return nil
@@ -332,7 +332,7 @@ func main() {
 
 		// Launch as a Windows Service if necessary
 		if err := launchService(server); err != nil {
-			logrus.Fatal(err)
+			bklog.L.Fatal(err)
 		}
 
 		errCh := make(chan error, 1)

--- a/executor/resources/monitor.go
+++ b/executor/resources/monitor.go
@@ -11,9 +11,9 @@ import (
 	"time"
 
 	"github.com/moby/buildkit/executor/resources/types"
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/network"
 	"github.com/prometheus/procfs"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -229,7 +229,7 @@ func NewMonitor() (*Monitor, error) {
 			return
 		}
 		if err := prepareCgroupControllers(); err != nil {
-			logrus.Warnf("failed to prepare cgroup controllers: %+v", err)
+			bklog.L.Warnf("failed to prepare cgroup controllers: %+v", err)
 		}
 	})
 
@@ -280,7 +280,7 @@ func prepareCgroupControllers() error {
 		}
 		if err := os.WriteFile(filepath.Join(defaultMountpoint, cgroupSubtreeFile), []byte("+"+c), 0); err != nil {
 			// ignore error
-			logrus.Warnf("failed to enable cgroup controller %q: %+v", c, err)
+			bklog.L.Warnf("failed to enable cgroup controller %q: %+v", c, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
follow-up https://github.com/moby/buildkit/pull/3705

Looks to be an oversight from https://github.com/moby/buildkit/pull/3860.