### PR TITLE
ci: update github actions to latest stable

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Expose GitHub Runtime
         uses: crazy-max/ghaction-github-runtime@v2
@@ -91,7 +91,7 @@ jobs:
             });
       -
         name: Build
-        uses: docker/bake-action@v2
+        uses: docker/bake-action@v3
         with:
           targets: integration-tests-base
           set: |
@@ -126,7 +126,7 @@ jobs:
           done
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Expose GitHub Runtime
         uses: crazy-max/ghaction-github-runtime@v2

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -62,7 +62,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Prepare
         id: prep
@@ -102,7 +102,7 @@ jobs:
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       -
@@ -149,7 +149,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Expose GitHub Runtime
         uses: crazy-max/ghaction-github-runtime@v2

--- a/.github/workflows/dockerd.yml
+++ b/.github/workflows/dockerd.yml
@@ -42,7 +42,7 @@ jobs:
       -
         name: Build
         if: ${{ env.DOCKER_BUILD == 'true' }}
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: ${{ env.DOCKER_VERSION }}
           target: binary
@@ -93,7 +93,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Expose GitHub Runtime
         uses: crazy-max/ghaction-github-runtime@v2

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -90,7 +90,7 @@ jobs:
           fi
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Expose GitHub Runtime
         uses: crazy-max/ghaction-github-runtime@v2

--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -37,13 +37,12 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: "${{ env.GO_VERSION }}"
-          cache: true
       -
         name: Install gotestsum
         run: |
@@ -98,13 +97,12 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: "${{ env.GO_VERSION }}"
-          cache: true
 
       - name: Build buildkitd binary
         run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Matrix
         id: targets
@@ -45,7 +45,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -55,6 +55,6 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Validate
-        uses: docker/bake-action@v2
+        uses: docker/bake-action@v3
         with:
           targets: ${{ matrix.target }}


### PR DESCRIPTION
Github Actions are not kept up to date. We have the Dependabot conf https://github.com/moby/buildkit/blob/master/.github/dependabot.yml though but does not seem handled on the repo.

@tonistiigi Can you check if Dependabot is disabled on the repo? I think it should be under https://github.com/moby/buildkit/settings/security_analysis

![image](https://github.com/moby/buildkit/assets/1951866/ba9df2af-4aa1-4b1a-80d9-e9b287a29d6b)
