### PR TITLE
Manually implement `client.Wait` backoffs

### DIFF
--- a/cmd/buildctl/common/common.go
+++ b/cmd/buildctl/common/common.go
@@ -16,8 +16,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 	"go.opentelemetry.io/otel/trace"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/backoff"
 )
 
 // ResolveClient resolves a client from CLI args
@@ -68,12 +66,6 @@ func ResolveClient(c *cli.Context) (*client.Client, error) {
 	}
 
 	opts := []client.ClientOpt{client.WithFailFast()}
-
-	backoffConfig := backoff.DefaultConfig
-	backoffConfig.MaxDelay = 1 * time.Second
-	opts = append(opts, client.WithGRPCDialOption(
-		grpc.WithConnectParams(grpc.ConnectParams{Backoff: backoffConfig}),
-	))
 
 	ctx := CommandContext(c)
 


### PR DESCRIPTION
:hammer_and_wrench: Fixes regression https://github.com/moby/buildkit/issues/4164, while preserving the spirit of https://github.com/moby/buildkit/pull/4015.
:arrow_backward: Reverts #4015.

When calling `client.Wait`, we want to avoid the default backoff behavior, because we want to achieve a quick response back once the server becomes active.
    
To do this, without modifying the entire client's exponential backoff configuration, we can use `conn.ResetConnectBackoff`, while attempting to reconnect every second.

Here are some common scenarios under the new `client.Wait` implementation:

- Server is listening: the call to `Info` succeeds quickly, and we return.
- Server is listening, but is behind several proxies and so latency is high: the call to `Info` succeeds slowly (up to `minConnectTimeout=20s`), and we return.
  - Note: if the server cannot be reached in fewer than `minConnectTimeout`, then `client.Wait` will never return.
- Server is not listening and gets `"connection refused"`: the call to `Info` fails quickly, and we wait a second before retrying.
- Server is not listening and does not respond (e.g. firewall dropping packets): the call to `Info` fails slowly (by default after `minConnectTimeout=20s`). After the call fails, we wait a second before retrying.

This PR is split into two commits:
- The first resolves #4164, and fixes the regression from #4015, and will need to be cherry-picked to buildx (since it affects the remote driver).
- The second re-implements #4015 by making more substantial changes to `client.Wait`.