### PR TITLE
fix: return err when unable to hash

### DIFF
--- a/source/http/source.go
+++ b/source/http/source.go
@@ -169,7 +169,7 @@ func (hs *httpSourceHandler) CacheKey(ctx context.Context, g session.Group, inde
 
 	uh, err := hs.urlHash()
 	if err != nil {
-		return "", "", nil, false, nil
+		return "", "", nil, false, err
 	}
 
 	// look up metadata(previously stored headers) for that URL


### PR DESCRIPTION
I found this minor mistake not returning an err while reading the sources.  Looks like this was introduced during a refactor some time ago.