### PR TITLE
docs: Add `[dns]` snippet to `buildkitd.toml` example file

### DIFF
--- a/docs/buildkitd.toml.md
+++ b/docs/buildkitd.toml.md
@@ -22,6 +22,11 @@ insecure-entitlements = [ "network.host", "security.insecure" ]
   # log formatter: json or text
   format = "text"
 
+[dns]
+  nameservers=["1.1.1.1","8.8.8.8"]
+  options=["edns0"]
+  searchDomains=["example.com"]
+
 [grpc]
   address = [ "tcp://0.0.0.0:1234" ]
   # debugAddress is address for attaching go profiles and debuggers.


### PR DESCRIPTION
This support exists but was not documented in the example file.

It was implemented in [PR #1040](https://github.com/moby/buildkit/pull/1040/files#diff-505703229c6ae3d8dc2cac5ffce71376d27b24c18f119fa55d34d7c51105f034R55-R58) (June 2019), and that test snippet now lives here:

https://github.com/moby/buildkit/blob/97e0efaab19ba9881505a8b699d517b8ed413718/cmd/buildkitd/config/load_test.go#L67-L70

Closes: https://github.com/moby/buildkit/issues/3045