### PR TITLE
v0.11: backport llbsolver: fix policy rule ordering

### DIFF
--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -977,27 +977,21 @@ func loadEntitlements(b solver.Builder) (entitlements.Set, error) {
 }
 
 func loadSourcePolicy(b solver.Builder) (*spb.Policy, error) {
-	set := make(map[spb.Rule]struct{}, 0)
+	var srcPol spb.Policy
 	err := b.EachValue(context.TODO(), keySourcePolicy, func(v interface{}) error {
 		x, ok := v.(spb.Policy)
 		if !ok {
 			return errors.Errorf("invalid source policy %T", v)
 		}
 		for _, f := range x.Rules {
-			set[*f] = struct{}{}
+			r := *f
+			srcPol.Rules = append(srcPol.Rules, &r)
 		}
+		srcPol.Version = x.Version
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
-	var srcPol *spb.Policy
-	if len(set) > 0 {
-		srcPol = &spb.Policy{}
-		for k := range set {
-			k := k
-			srcPol.Rules = append(srcPol.Rules, &k)
-		}
-	}
-	return srcPol, nil
+	return &srcPol, nil
 }


### PR DESCRIPTION
Backports https://github.com/moby/buildkit/pull/4014 to v0.11 so we can pull this into moby v24.

--

The older of rules in policy matters. Eg. in [DENY *, ALLOW ref] mixing the order would deny all sources so map can't be used to deduplicate the rules.


(cherry picked from commit 22d84461e4ed2e861c15ee1a1695dc75da27a9e3)