### PR TITLE
authprovider: Fix error return from Credentials when logger is nil

### DIFF
--- a/session/auth/authprovider/authprovider.go
+++ b/session/auth/authprovider/authprovider.go
@@ -152,7 +152,7 @@ func (ap *authProvider) Credentials(ctx context.Context, req *auth.CredentialsRe
 		defer ap.mu.Unlock()
 		_, ok := ap.loggerCache[req.Host]
 		ap.loggerCache[req.Host] = struct{}{}
-		if !ok {
+		if !ok && ap.logger != nil {
 			return resp, progresswriter.Wrap(fmt.Sprintf("[auth] sharing credentials for %s", req.Host), ap.logger, func(progresswriter.SubLogger) error {
 				return err
 			})


### PR DESCRIPTION
This would segfault if SetLogger had not been called, because progresswriter.Wrap returns nil when its logger arg is nil, causing Credentials to return nil, nil.