### PR TITLE
`go fmt cache/blobs_nolinux.go`

### DIFF
--- a/cache/blobs_nolinux.go
+++ b/cache/blobs_nolinux.go
@@ -6,8 +6,8 @@ package cache
 import (
 	"context"
 
-	"github.com/moby/buildkit/util/compression"
 	"github.com/containerd/containerd/mount"
+	"github.com/moby/buildkit/util/compression"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )


### PR DESCRIPTION
Looks like the CI have been skipping gofmt check for non-linux Go files.
