### PR TITLE
ci(test-os): increase vm boot time to 10m

### DIFF
--- a/hack/Vagrantfile.freebsd13
+++ b/hack/Vagrantfile.freebsd13
@@ -6,6 +6,7 @@ Vagrant.configure("2") do |config|
     fbsd_13_2.vm.box = "freebsd/FreeBSD-13.2-RELEASE"
   end
 
+  config.vm.boot_timeout = 600
   config.vm.synced_folder ".", "/vagrant", type: "rsync"
 
   config.vm.provision "init", type: "shell", run: "once" do |sh|


### PR DESCRIPTION
related to: https://github.com/moby/buildkit/actions/runs/6194835878/job/16818500910#step:5:65

![image](https://github.com/moby/buildkit/assets/1951866/1db87d32-dfc9-401e-a68c-f428d30b3e97)

Vagrant VM can take some time to boot. Increase to 10m (default 5m).