### PR TITLE
dockerfile2llb: avoid prepending empty BUILDKIT_CACHE_MOUNT_NS

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert_runmount.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_runmount.go
@@ -110,7 +110,11 @@ func dispatchRunMounts(d *dispatchState, c *instructions.RunCommand, sources []*
 			if mount.CacheID == "" {
 				mount.CacheID = path.Clean(mount.Target)
 			}
-			mountOpts = append(mountOpts, llb.AsPersistentCacheDir(opt.cacheIDNamespace+"/"+mount.CacheID, sharing))
+			cacheID := mount.CacheID
+			if opt.cacheIDNamespace != "" {
+				cacheID = path.Join(opt.cacheIDNamespace, mount.CacheID)
+			}
+			mountOpts = append(mountOpts, llb.AsPersistentCacheDir(cacheID, sharing))
 		}
 		target := mount.Target
 		if !filepath.IsAbs(filepath.Clean(mount.Target)) {


### PR DESCRIPTION
Prior to this commit, the "id" string in `RUN --mount=type=cache,id=...` did not match the actual ID.