### PR TITLE
Revert "Update buildkitd.toml.md"

### DIFF
--- a/docs/buildkitd.toml.md
+++ b/docs/buildkitd.toml.md
@@ -94,7 +94,7 @@ insecure-entitlements = [ "network.host", "security.insecure" ]
   platforms = [ "linux/amd64", "linux/arm64" ]
   namespace = "buildkit"
   gc = true
-  # gckeepstorage sets storage limit for default gc profile, in MB.
+  # gckeepstorage sets storage limit for default gc profile, in bytes.
   gckeepstorage = 9000
   # maintain a pool of reusable CNI network namespaces to amortize the overhead
   # of allocating and releasing the namespaces


### PR DESCRIPTION
This reverts commit fd8e32debced4a82e57094fb3bc2e471f8faff34. gckeepstorage is indeed in byte units.

Closes: #2922