### PR TITLE
solver: correctly set the content selector with multiple bind mounts references

### DIFF
--- a/solver/llbsolver/ops/exec_test.go
+++ b/solver/llbsolver/ops/exec_test.go
@@ -3,6 +3,9 @@ package ops
 import (
 	"testing"
 
+	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/solver/pb"
+	digest "github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,4 +27,73 @@ func TestDedupPaths(t *testing.T) {
 
 	res = dedupePaths([]string{"foo/bar/baz", "foo/bara", "foo/bar/bax", "foo/bar"})
 	require.Equal(t, []string{"foo/bar", "foo/bara"}, res)
+}
+
+func TestExecOp_getMountDeps(t *testing.T) {
+	v1 := &vertex{name: "local://context"}
+	v2 := &vertex{
+		name: "foo",
+		inputs: []solver.Edge{
+			{Vertex: v1, Index: 0},
+		},
+	}
+	op2, err := NewExecOp(v2, &pb.Op_Exec{
+		Exec: &pb.ExecOp{
+			Meta: &pb.Meta{
+				Args: []string{"/bin/bash", "-l"},
+			},
+			Mounts: []*pb.Mount{
+				{
+					Input:    pb.Empty,
+					Dest:     "/",
+					Readonly: true,
+					Output:   pb.SkipOutput,
+				},
+				{
+					Input:    pb.InputIndex(0),
+					Selector: "b.txt",
+					Dest:     "/test/b.txt",
+					Output:   pb.SkipOutput,
+				},
+				{
+					Input:  pb.InputIndex(0),
+					Dest:   "/test/data",
+					Output: pb.SkipOutput,
+				},
+			},
+		},
+	}, nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	deps, err := op2.getMountDeps()
+	require.NoError(t, err)
+
+	require.Len(t, deps, 1)
+	require.Len(t, deps[0].Selectors, 0)
+	require.False(t, deps[0].NoContentBasedHash)
+}
+
+type vertex struct {
+	name   string
+	inputs []solver.Edge
+}
+
+func (v *vertex) Digest() digest.Digest {
+	return digest.FromString(v.name)
+}
+
+func (v *vertex) Sys() interface{} {
+	return v
+}
+
+func (v *vertex) Options() solver.VertexOptions {
+	return solver.VertexOptions{}
+}
+
+func (v *vertex) Inputs() []solver.Edge {
+	return v.inputs
+}
+
+func (v *vertex) Name() string {
+	return v.name
 }


### PR DESCRIPTION
Correctly set the content based selector when multiple bind mounts refer
to the same source. Previously, a selector that referred to the root
filesystem would be ignored. This is because a blank selector refers to
the root filesystem.

When two bind mounts referred to the same dependency, one mount would
add a selector while the other would be skipped. This caused the cache
key to be only computed based on the more narrow filesystem which caused
erroneous cache hits.

Now, the creation of the selector includes the root filesystem for
consideration. It fills in `/` as the selector and then removes it later
so that we don't narrow the selection in an invalid way.

Fixes #4123.