### PR TITLE
docs: note that gckeepstorage can take different types

### DIFF
--- a/docs/buildkitd.toml.md
+++ b/docs/buildkitd.toml.md
@@ -59,6 +59,9 @@ insecure-entitlements = [ "network.host", "security.insecure" ]
   # running rootless buildkit inside a container.
   noProcessSandbox = false
   gc = true
+  # gckeepstorage can be an integer number of bytes (e.g. 512000000), a string
+  # with a unit (e.g. "512MB"), or a string percentage of the total disk
+  # space (e.g. "10%")
   gckeepstorage = 9000
   # alternate OCI worker binary name(example 'crun'), by default either 
   # buildkit-runc or runc binary is used


### PR DESCRIPTION
Follow up from https://github.com/moby/buildkit/pull/4264

See:
https://github.com/moby/buildkit/blob/f77e5212cdeb35111e58b8895bb047bea8eb1ee0/cmd/buildkitd/config/config.go#L63-L67

Maybe at some point, we should auto-generate the default config from the code? If that sounds good, we could open a beginner-friendly issue to note that.