### PR TITLE
diff: gzip with custom level should be compressed by BuildKit's differ

### DIFF
--- a/cache/blobs.go
+++ b/cache/blobs.go
@@ -189,7 +189,7 @@ func computeBlobChain(ctx context.Context, sr *immutableRef, createIfNeeded bool
 					}
 				}
 
-				if desc.Digest == "" && !isTypeWindows(sr) && comp.Type.NeedsComputeDiffBySelf() {
+				if desc.Digest == "" && !isTypeWindows(sr) && comp.Type.NeedsComputeDiffBySelf(comp) {
 					// These compression types aren't supported by containerd differ. So try to compute diff on buildkit side.
 					// This case can be happen on containerd worker + non-overlayfs snapshotter (e.g. native).
 					// See also: https://github.com/containerd/containerd/issues/4263

--- a/util/compression/compression.go
+++ b/util/compression/compression.go
@@ -26,7 +26,7 @@ type Type interface {
 	Compress(ctx context.Context, comp Config) (compressorFunc Compressor, finalize Finalizer)
 	Decompress(ctx context.Context, cs content.Store, desc ocispecs.Descriptor) (io.ReadCloser, error)
 	NeedsConversion(ctx context.Context, cs content.Store, desc ocispecs.Descriptor) (bool, error)
-	NeedsComputeDiffBySelf() bool
+	NeedsComputeDiffBySelf(comp Config) bool
 	OnlySupportOCITypes() bool
 	NeedsForceCompression() bool
 	MediaType() string

--- a/util/compression/estargz.go
+++ b/util/compression/estargz.go
@@ -134,7 +134,7 @@ func (c estargzType) NeedsConversion(ctx context.Context, cs content.Store, desc
 	return true, nil
 }
 
-func (c estargzType) NeedsComputeDiffBySelf() bool {
+func (c estargzType) NeedsComputeDiffBySelf(comp Config) bool {
 	return true
 }
 

--- a/util/compression/gzip.go
+++ b/util/compression/gzip.go
@@ -38,8 +38,9 @@ func (c gzipType) NeedsConversion(ctx context.Context, cs content.Store, desc oc
 	return true, nil
 }
 
-func (c gzipType) NeedsComputeDiffBySelf() bool {
-	return false
+func (c gzipType) NeedsComputeDiffBySelf(comp Config) bool {
+	// we allow compressing it with a customized compression level that containerd differ doesn't support so we compress it by self.
+	return comp.Level != nil
 }
 
 func (c gzipType) OnlySupportOCITypes() bool {

--- a/util/compression/nydus.go
+++ b/util/compression/nydus.go
@@ -104,7 +104,7 @@ func (c nydusType) NeedsConversion(ctx context.Context, cs content.Store, desc o
 	return true, nil
 }
 
-func (c nydusType) NeedsComputeDiffBySelf() bool {
+func (c nydusType) NeedsComputeDiffBySelf(comp Config) bool {
 	return true
 }
 

--- a/util/compression/uncompressed.go
+++ b/util/compression/uncompressed.go
@@ -40,7 +40,7 @@ func (c uncompressedType) NeedsConversion(ctx context.Context, cs content.Store,
 	return true, nil
 }
 
-func (c uncompressedType) NeedsComputeDiffBySelf() bool {
+func (c uncompressedType) NeedsComputeDiffBySelf(comp Config) bool {
 	return false
 }
 

--- a/util/compression/zstd.go
+++ b/util/compression/zstd.go
@@ -34,7 +34,7 @@ func (c zstdType) NeedsConversion(ctx context.Context, cs content.Store, desc oc
 	return true, nil
 }
 
-func (c zstdType) NeedsComputeDiffBySelf() bool {
+func (c zstdType) NeedsComputeDiffBySelf(comp Config) bool {
 	return true
 }
 


### PR DESCRIPTION
Fixes https://github.com/moby/buildkit/pull/4210#discussion_r1322863998

> containerd-rootless test uses containerd worker + native snapshotter. In this configuration, buildkitd relies on containred's differ via containerd client that doesn't support changing the compression level. So this doesn't produce the difference for the created blob. 

With containerd worker + non-overlayfs-snapshotter configuration, we've been using containerd's differ via containerd client but the compression level can't be applied in this configuration. This commit fixes this issue by compressing gzip with customized compression level on BuildKit't differ instead of containerd's differ. Uncompressed blobs and gzip blobs without customized compression level are still handled by containerd's differ.
