### PR TITLE
integration: set otel socket path through buildkit config

### DIFF
--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -57,8 +57,8 @@ type Sandbox interface {
 
 // BackendConfig is used to configure backends created by a worker.
 type BackendConfig struct {
-	Logs       map[string]*bytes.Buffer
-	ConfigFile string
+	Logs         map[string]*bytes.Buffer
+	DaemonConfig []ConfigUpdater
 }
 
 type Worker interface {
@@ -303,7 +303,7 @@ mirrors=["%s"]
 `, in, mc)
 }
 
-func writeConfig(updaters []ConfigUpdater) (string, error) {
+func WriteConfig(updaters []ConfigUpdater) (string, error) {
 	tmpdir, err := os.MkdirTemp("", "bktest_config")
 	if err != nil {
 		return "", err
@@ -320,7 +320,7 @@ func writeConfig(updaters []ConfigUpdater) (string, error) {
 	if err := os.WriteFile(filepath.Join(tmpdir, buildkitdConfigFile), []byte(s), 0644); err != nil {
 		return "", err
 	}
-	return tmpdir, nil
+	return filepath.Join(tmpdir, buildkitdConfigFile), nil
 }
 
 func runMirror(t *testing.T, mirroredImages map[string]string) (host string, _ func() error, err error) {


### PR DESCRIPTION
follow-up https://github.com/docker/buildx/pull/2035#discussion_r1323764389
related to https://github.com/moby/buildkit/pull/4101

Set otel socket path in integration tests using buildkit config instead of setting the `otel-socket-path` flag to avoid breaking change with older buildkit version.

tested in https://github.com/docker/buildx/pull/2060