### PR TITLE
hack: update BUILDKIT_DEBUG handling

### DIFF
--- a/hack/images
+++ b/hack/images
@@ -70,11 +70,6 @@ if [[ "$versionTag" == "$TAG" ]]; then
   fi
 fi
 
-debugFlags=""
-if [ -n "$BUILDKIT_DEBUG" ]; then
-  debugFlags="--build-arg BUILDKIT_DEBUG=$BUILDKIT_DEBUG"
-fi
-
 importCacheFlags=""
 for tagName in $tagNames; do
   importCacheFlags="$importCacheFlags--cache-from=type=registry,ref=$tagName "
@@ -103,5 +98,5 @@ if [[ "$RELEASE" = "true" ]] && [[ "$GITHUB_ACTIONS" = "true" ]]; then
   nocacheFilterFlag="--no-cache-filter=git,buildkit-export,gobuild-base"
 fi
 
-buildxCmd build $platformFlag $targetFlag $importCacheFlags $exportCacheFlags $tagFlags $debugFlags $outputFlag $nocacheFilterFlag $attestFlags \
+buildxCmd build --build-arg BUILDKIT_DEBUG $platformFlag $targetFlag $importCacheFlags $exportCacheFlags $tagFlags $outputFlag $nocacheFilterFlag $attestFlags \
   $currentcontext

--- a/hack/shell
+++ b/hack/shell
@@ -6,13 +6,8 @@ function clean() {
   docker rmi $(cat $iidfile)
 }
 
-build_args=
-if [ "$BUILDKIT_DEBUG" -ne 0 ]; then
-  build_args="--build-arg BUILDKIT_DEBUG=1"
-fi
-
 iidfile=$(mktemp -t docker-iidfile.XXXXXXXXXX)
-DOCKER_BUILDKIT=1 docker build --iidfile $iidfile $build_args --target dev-env .
+DOCKER_BUILDKIT=1 docker build --iidfile $iidfile --build-arg BUILDKIT_DEBUG --target dev-env .
 
 trap clean EXIT
 SSH=


### PR DESCRIPTION
`-ne` comparison errors `./hack/shell: line 10: [: : integer expression expected` on empty value. As we just need to pass the env as build-arg, no extra variable is needed.