### PR TITLE
Make output window configurable: BUILDKIT_TERMHEIGHT

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Join `#buildkit` channel on [Docker Community Slack](https://dockr.ly/comm-slack
 - [Building multi-platform images](#building-multi-platform-images)
   - [Configuring `buildctl`](#configuring-buildctl)
     - [Color Output Controls](#color-output-controls)
+    - [Number of log lines (for active steps in tty mode)](#number-of-log-lines-for-active-steps-in-tty-mode)
 - [Contributing](#contributing)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -790,6 +791,9 @@ Please refer to [`docs/multi-platform.md`](docs/multi-platform.md).
 Parsing errors will be reported but ignored. This will result in default color values being used where needed.
 
 - [The list of pre-defined colors](https://github.com/moby/buildkit/blob/master/util/progress/progressui/colors.go).
+
+#### Number of log lines (for active steps in tty mode)
+You can change how many log lines are visible for active steps in tty mode by setting `BUILDKIT_TTY_LOG_LINES` to a number (default: 6).
 
 ## Contributing
 

--- a/util/progress/progressui/display.go
+++ b/util/progress/progressui/display.go
@@ -310,7 +310,6 @@ func (d *rawJSONDisplay) done() {
 	// No actions needed.
 }
 
-const termHeight = 6
 const termPad = 10
 
 type displayInfo struct {

--- a/util/progress/progressui/init.go
+++ b/util/progress/progressui/init.go
@@ -3,6 +3,7 @@ package progressui
 import (
 	"os"
 	"runtime"
+	"strconv"
 
 	"github.com/morikuni/aec"
 )
@@ -11,6 +12,8 @@ var colorRun aec.ANSI
 var colorCancel aec.ANSI
 var colorWarning aec.ANSI
 var colorError aec.ANSI
+
+var termHeight = 6
 
 func init() {
 	// As recommended on https://no-color.org/
@@ -33,5 +36,14 @@ func init() {
 	if _, ok := os.LookupEnv("BUILDKIT_COLORS"); ok {
 		envColorString := os.Getenv("BUILDKIT_COLORS")
 		setUserDefinedTermColors(envColorString)
+	}
+
+	// Make the terminal height configurable at runtime.
+	termHeightStr := os.Getenv("BUILDKIT_TTY_LOG_LINES")
+	if termHeightStr != "" {
+		termHeightVal, err := strconv.Atoi(termHeightStr)
+		if err == nil && termHeightVal > 0 {
+			termHeight = termHeightVal
+		}
 	}
 }


### PR DESCRIPTION
The output window was previously hard-coded to a height of 6; this patch makes it configurable at run-time by setting the BUILDKIT_TERMHEIGHT environment variable.