### PR TITLE
ci(test): fix unhandled buildkitd tags

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -151,6 +151,8 @@ jobs:
           set: |
             *.cache-from=type=gha,scope=${{ inputs.cache_scope }}
             *.output=type=docker,name=${{ env.TEST_IMAGE_ID }}
+        env:
+          BUILDKITD_TAGS: ${{ matrix.tags }}
       -
         name: Test
         continue-on-error: ${{ matrix.tags == 'nydus' }}
@@ -158,7 +160,6 @@ jobs:
           export TEST_REPORT_SUFFIX=-${{ github.job }}-$(echo "${{ matrix.pkg }}-${{ matrix.skip-integration-tests }}-${{ matrix.kind }}-${{ matrix.worker }}-${{ matrix.tags }}" | tr -dc '[:alnum:]-\n\r' | tr '[:upper:]' '[:lower:]')
           if [ -n "${{ matrix.tags }}" ]; then
             TESTFLAGS="${TESTFLAGS} --tags=${{ matrix.tags }}"
-            export BUILDKITD_TAGS="${{ matrix.tags }}"
           fi
           if [ -n "${{ matrix.worker }}" ]; then
             export TESTFLAGS="${TESTFLAGS} --run=//worker=${{ matrix.worker }}$"


### PR DESCRIPTION
Reported by @jedevc 

This is a regression from https://github.com/moby/buildkit/pull/4048: https://github.com/moby/buildkit/actions/runs/6337159614/job/17211754423?pr=4288#step:8:1478

```
=== Failed
=== FAIL: client TestNydusIntegration/TestBuildExportNydusWithHybrid/worker=containerd (6.35s)
    client_nydus_test.go:79: 
        	Error Trace:	/src/client/client_nydus_test.go:79
        	            				/src/client/client_nydus_test.go:133
        	            				/src/util/testutil/integration/run.go:91
        	            				/src/util/testutil/integration/run.go:205
        	Error:      	Received unexpected error:
        	            	unsupported compression type nydus
        	            	github.com/moby/buildkit/util/stack.Enable
        	            		/src/util/stack/stack.go:77
        	            	github.com/moby/buildkit/util/grpcerrors.FromGRPC
        	            		/src/util/grpcerrors/grpcerrors.go:198
        	            	github.com/moby/buildkit/util/grpcerrors.UnaryClientInterceptor
        	            		/src/util/grpcerrors/intercept.go:41
        	            	google.golang.org/grpc.(*ClientConn).Invoke
        	            		/src/vendor/google.golang.org/grpc/call.go:35
        	            	github.com/moby/buildkit/api/services/control.(*controlClient).Solve
        	            		/src/api/services/control/control.pb.go:2208
        	            	github.com/moby/buildkit/client.(*Client).solve.func2
        	            		/src/client/solve.go:258
        	            	golang.org/x/sync/errgroup.(*Group).Go.func1
        	            		/src/vendor/golang.org/x/sync/errgroup/errgroup.go:75
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1598
        	            	failed to solve
        	            	github.com/moby/buildkit/client.(*Client).solve.func2
        	            		/src/client/solve.go:273
        	            	golang.org/x/sync/errgroup.(*Group).Go.func1
        	            		/src/vendor/golang.org/x/sync/errgroup/errgroup.go:75
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1598
        	Test:       	TestNydusIntegration/TestBuildExportNydusWithHybrid/worker=containerd
```

As we now build the integration tests image early we need to set `BUILDKITD_TAGS` at this step.