### PR TITLE
docs: fix incorrect option name in containerd runtime config

### DIFF
--- a/docs/buildkitd.toml.md
+++ b/docs/buildkitd.toml.md
@@ -108,7 +108,7 @@ insecure-entitlements = [ "network.host", "security.insecure" ]
 
   # configure the containerd runtime
   [worker.containerd.runtime]
-    runtime = "io.containerd.runc.v2"
+    name = "io.containerd.runc.v2"
     options = { BinaryName = "runc" }
 
   [[worker.containerd.gcpolicy]]


### PR DESCRIPTION
Noticed by @slonopotamus in https://github.com/moby/buildkit/pull/4279#discussion_r1339137943