### PR TITLE
[WIP] docs: script for generating config docs

### DIFF
--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -6,7 +6,10 @@ import (
 
 // Config provides containerd configuration data for the server
 type Config struct {
+	// Debug is boolean
 	Debug bool `toml:"debug"`
+
+	// Trace is boolean
 	Trace bool `toml:"trace"`
 
 	// Root is the path to a directory where buildkit will store persistent data
@@ -21,17 +24,22 @@ type Config struct {
 	// GRPC configuration settings
 	GRPC GRPCConfig `toml:"grpc"`
 
+	// OTEL is OTEL
 	OTEL OTELConfig `toml:"otel"`
 
+	// Worker is Worker
 	Workers struct {
 		OCI        OCIConfig        `toml:"oci"`
 		Containerd ContainerdConfig `toml:"containerd"`
 	} `toml:"worker"`
 
+	// Registry is Registry
 	Registries map[string]resolverconfig.RegistryConfig `toml:"registry"`
 
+	// DNS is DNS
 	DNS *DNSConfig `toml:"dns"`
 
+	// History is a config for build history API that stores information about completed build commands
 	History *HistoryConfig `toml:"history"`
 }
 
@@ -148,6 +156,8 @@ type DNSConfig struct {
 }
 
 type HistoryConfig struct {
-	MaxAge     Duration `toml:"maxAge"`
-	MaxEntries int64    `toml:"maxEntries"`
+	// maxAge is the maximum age of history entries to keep, in seconds.
+	MaxAge Duration `toml:"maxAge"`
+	// maxEntries is the maximum number of history entries to keep.
+	MaxEntries int64 `toml:"maxEntries"`
 }

--- a/cmd/buildkitd/config/config_test.go
+++ b/cmd/buildkitd/config/config_test.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"reflect"
+	"testing"
+)
+
+func TestGenerateDocs(t *testing.T) {
+	fset := token.NewFileSet()
+	node, err := parser.ParseFile(fset, "config.go", nil, parser.ParseComments)
+	if err != nil {
+		fmt.Println("Error parsing code:", err)
+		return
+	}
+
+	configType := reflect.TypeOf(Config{})
+	for i := 0; i < configType.NumField(); i++ {
+		field := configType.Field(i)
+		fieldName := field.Name
+		tagToml := field.Tag.Get("toml")
+
+		comment := findComment(node, fieldName)
+		if comment != nil {
+			fmt.Printf("#%s\n", comment.Text[2:])
+			fmt.Printf("[%v]\n", tagToml)
+			fmt.Printf("\n")
+		}
+	}
+}
+
+func findComment(node *ast.File, fieldName string) *ast.Comment {
+	for _, decl := range node.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok || genDecl.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range genDecl.Specs {
+			typeSpec, ok := spec.(*ast.TypeSpec)
+			if !ok || typeSpec.Name.Name != "Config" {
+				continue
+			}
+			if structType, ok := typeSpec.Type.(*ast.StructType); ok {
+				for _, field := range structType.Fields.List {
+					for _, name := range field.Names {
+						if name.Name == fieldName {
+							if len(field.Doc.List) > 0 {
+								return field.Doc.List[0]
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This pr introduces an initial solution to extract comments associated with a Config struct and then generate the config docs. The current implementation only supports single-level structs; nested structs are not supported yet. It will solve issue #4274. If this initial approach is accepted, I plan to make it complete. 

A few questions to make it clearer:
- Where will be this script placed? Should it be in docs/generate.go?

(cc @jedevc)