### PR TITLE
util/resolver: Fix insecure mirrors

### DIFF
--- a/util/resolver/resolver.go
+++ b/util/resolver/resolver.go
@@ -130,9 +130,10 @@ func NewRegistryConfig(m map[string]config.RegistryConfig) docker.RegistryHosts 
 
 			var out []docker.RegistryHost
 
-			for _, mirror := range c.Mirrors {
-				h := newMirrorRegistryHost(mirror)
-				hosts, err := fillInsecureOpts(mirror, m[mirror], h)
+			for _, rawMirror := range c.Mirrors {
+				h := newMirrorRegistryHost(rawMirror)
+				mirrorHost := h.Host
+				hosts, err := fillInsecureOpts(mirrorHost, m[mirrorHost], h)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
- related to: https://github.com/moby/moby/pull/45992
- related to: https://github.com/docker/buildx/issues/1642

Mirrors in `RegistryConfig.Mirrors` can be specified using a full URL (schema, trailing slashes) but registries in the input map are keyed by their hostname.

Previous code used the mirror URL as key which resulted in an empty `RegistryConfig` being passed to the `fillInsecureOpts` function and didn't set the insecure options.

Use Host part of the parsed registry as a key instead.