### PR TITLE
[0.12 backport] util/resolver: Fix insecure mirrors

### DIFF
--- a/util/resolver/resolver.go
+++ b/util/resolver/resolver.go
@@ -130,9 +130,10 @@ func NewRegistryConfig(m map[string]config.RegistryConfig) docker.RegistryHosts 
 
 			var out []docker.RegistryHost
 
-			for _, mirror := range c.Mirrors {
-				h := newMirrorRegistryHost(mirror)
-				hosts, err := fillInsecureOpts(mirror, m[mirror], h)
+			for _, rawMirror := range c.Mirrors {
+				h := newMirrorRegistryHost(rawMirror)
+				mirrorHost := h.Host
+				hosts, err := fillInsecureOpts(mirrorHost, m[mirrorHost], h)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
- backport: https://github.com/moby/buildkit/pull/4293

Mirrors in `RegistryConfig.Mirrors` can be specified using a full URL (schema, trailing slashes) but registries in the input map are keyed by their hostname.

Previous code used the mirror URL as key which resulted in an empty `RegistryConfig` being passed to the `fillInsecureOpts` function and didn't set the insecure options.

Use Host part of the parsed registry as a key instead.


(cherry picked from commit ec655579da0192d785bf9c99e4a9946deee4c555)