### PR TITLE
[v0.12] Cherry-picks for v0.12.3

### DIFF
--- a/cmd/buildctl/common/common.go
+++ b/cmd/buildctl/common/common.go
@@ -16,8 +16,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 	"go.opentelemetry.io/otel/trace"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/backoff"
 )
 
 // ResolveClient resolves a client from CLI args
@@ -68,12 +66,6 @@ func ResolveClient(c *cli.Context) (*client.Client, error) {
 	}
 
 	opts := []client.ClientOpt{client.WithFailFast()}
-
-	backoffConfig := backoff.DefaultConfig
-	backoffConfig.MaxDelay = 1 * time.Second
-	opts = append(opts, client.WithGRPCDialOption(
-		grpc.WithConnectParams(grpc.ConnectParams{Backoff: backoffConfig}),
-	))
 
 	ctx := CommandContext(c)
 

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -722,6 +722,7 @@ func newController(c *cli.Context, cfg *config.Config) (*control.Controller, err
 		Entitlements:              cfg.Entitlements,
 		TraceCollector:            tc,
 		HistoryDB:                 historyDB,
+		CacheStore:                cacheStorage,
 		LeaseManager:              w.LeaseManager(),
 		ContentStore:              w.ContentStore(),
 		HistoryConfig:             cfg.History,

--- a/executor/oci/spec.go
+++ b/executor/oci/spec.go
@@ -137,7 +137,7 @@ func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mou
 		return nil, nil, err
 	}
 
-	if cgroupNamespaceSupported() {
+	if cgroupV2NamespaceSupported() {
 		s.Linux.Namespaces = append(s.Linux.Namespaces, specs.LinuxNamespace{
 			Type: specs.CgroupNamespace,
 		})

--- a/executor/oci/spec_unix.go
+++ b/executor/oci/spec_unix.go
@@ -149,9 +149,13 @@ func getTracingSocket() string {
 
 func cgroupNamespaceSupported() bool {
 	cgroupNSOnce.Do(func() {
-		if _, err := os.Stat("/proc/self/ns/cgroup"); !os.IsNotExist(err) {
-			supportsCgroupNS = true
+		if _, err := os.Stat("/proc/self/ns/cgroup"); os.IsNotExist(err) {
+			return
 		}
+		if _, err := os.Stat("/sys/fs/cgroup/cgroup.subtree_control"); os.IsNotExist(err) {
+			return
+		}
+		supportsCgroupNS = true
 	})
 	return supportsCgroupNS
 }

--- a/executor/oci/spec_unix.go
+++ b/executor/oci/spec_unix.go
@@ -147,7 +147,11 @@ func getTracingSocket() string {
 	return fmt.Sprintf("unix://%s", tracingSocketPath)
 }
 
-func cgroupNamespaceSupported() bool {
+func cgroupV2NamespaceSupported() bool {
+	// Check if cgroups v2 namespaces are supported.  Trying to do cgroup
+	// namespaces with cgroups v1 results in EINVAL when we encounter a
+	// non-standard hierarchy.
+	// See https://github.com/moby/buildkit/issues/4108
 	cgroupNSOnce.Do(func() {
 		if _, err := os.Stat("/proc/self/ns/cgroup"); os.IsNotExist(err) {
 			return

--- a/executor/oci/spec_windows.go
+++ b/executor/oci/spec_windows.go
@@ -64,6 +64,6 @@ func getTracingSocket() string {
 	return fmt.Sprintf("npipe://%s", filepath.ToSlash(tracingSocketPath))
 }
 
-func cgroupNamespaceSupported() bool {
+func cgroupV2NamespaceSupported() bool {
 	return false
 }

--- a/frontend/dockerfile/dockerfile_provenance_test.go
+++ b/frontend/dockerfile/dockerfile_provenance_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -16,16 +17,20 @@ import (
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/content/local"
+	"github.com/containerd/containerd/content/proxy"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/continuity/fs/fstest"
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	provenanceCommon "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
+	controlapi "github.com/moby/buildkit/api/services/control"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/frontend/dockerui"
 	gateway "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/solver/llbsolver/provenance"
+	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/contentutil"
 	"github.com/moby/buildkit/util/testutil"
 	"github.com/moby/buildkit/util/testutil/integration"
@@ -1122,4 +1127,155 @@ func testDockerIgnoreMissingProvenance(t *testing.T, sb integration.Sandbox) {
 		},
 	}, "", frontend, nil)
 	require.NoError(t, err)
+}
+
+func testFrontendDeduplicateSources(t *testing.T, sb integration.Sandbox) {
+	ctx := sb.Context()
+
+	c, err := client.New(ctx, sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	dockerfile := []byte(`
+FROM scratch as base
+COPY foo foo2
+
+FROM linked
+COPY bar bar2
+`)
+
+	dir, err := integration.Tmpdir(
+		t,
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+		fstest.CreateFile("foo", []byte("data"), 0600),
+		fstest.CreateFile("bar", []byte("data2"), 0600),
+	)
+	require.NoError(t, err)
+
+	f := getFrontend(t, sb)
+
+	b := func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
+		res, err := f.SolveGateway(ctx, c, gateway.SolveRequest{
+			FrontendOpt: map[string]string{
+				"target": "base",
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		ref, err := res.SingleRef()
+		if err != nil {
+			return nil, err
+		}
+		st, err := ref.ToState()
+		if err != nil {
+			return nil, err
+		}
+
+		def, err := st.Marshal(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		dt, ok := res.Metadata["containerimage.config"]
+		if !ok {
+			return nil, errors.Errorf("no containerimage.config in metadata")
+		}
+
+		dt, err = json.Marshal(map[string][]byte{
+			"containerimage.config": dt,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		res, err = f.SolveGateway(ctx, c, gateway.SolveRequest{
+			FrontendOpt: map[string]string{
+				"context:linked":        "input:baseinput",
+				"input-metadata:linked": string(dt),
+			},
+			FrontendInputs: map[string]*pb.Definition{
+				"baseinput": def.ToPB(),
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		return res, nil
+	}
+
+	product := "buildkit_test"
+
+	destDir := t.TempDir()
+
+	ref := identity.NewID()
+
+	_, err = c.Build(ctx, client.SolveOpt{
+		LocalDirs: map[string]string{
+			dockerui.DefaultLocalNameDockerfile: dir,
+			dockerui.DefaultLocalNameContext:    dir,
+		},
+		Exports: []client.ExportEntry{
+			{
+				Type:      client.ExporterLocal,
+				OutputDir: destDir,
+			},
+		},
+		Ref: ref,
+	}, product, b, nil)
+	require.NoError(t, err)
+
+	dt, err := os.ReadFile(filepath.Join(destDir, "foo2"))
+	require.NoError(t, err)
+	require.Equal(t, "data", string(dt))
+
+	dt, err = os.ReadFile(filepath.Join(destDir, "bar2"))
+	require.NoError(t, err)
+	require.Equal(t, "data2", string(dt))
+
+	history, err := c.ControlClient().ListenBuildHistory(ctx, &controlapi.BuildHistoryRequest{
+		Ref:       ref,
+		EarlyExit: true,
+	})
+	require.NoError(t, err)
+
+	store := proxy.NewContentStore(c.ContentClient())
+
+	var provDt []byte
+	for {
+		ev, err := history.Recv()
+		if err != nil {
+			require.Equal(t, io.EOF, err)
+			break
+		}
+		require.Equal(t, ref, ev.Record.Ref)
+
+		for _, prov := range ev.Record.Result.Attestations {
+			if len(prov.Annotations) == 0 || prov.Annotations["in-toto.io/predicate-type"] != "https://slsa.dev/provenance/v0.2" {
+				t.Logf("skipping non-slsa provenance: %s", prov.MediaType)
+				continue
+			}
+
+			provDt, err = content.ReadBlob(ctx, store, ocispecs.Descriptor{
+				MediaType: prov.MediaType,
+				Digest:    prov.Digest,
+				Size:      prov.Size_,
+			})
+			require.NoError(t, err)
+		}
+	}
+
+	require.NotEqual(t, len(provDt), 0)
+
+	var pred provenance.ProvenancePredicate
+	require.NoError(t, json.Unmarshal(provDt, &pred))
+
+	sources := pred.Metadata.BuildKitMetadata.Source.Infos
+
+	require.Equal(t, 1, len(sources))
+	require.Equal(t, "Dockerfile", sources[0].Filename)
+	require.Equal(t, "Dockerfile", sources[0].Language)
+
+	require.Equal(t, dockerfile, sources[0].Data)
+	require.NotEqual(t, 0, len(sources[0].Definition))
 }

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -169,6 +169,7 @@ var allTests = integration.TestFuncs(
 	testMultiPlatformWarnings,
 	testNilContextInSolveGateway,
 	testCopyUnicodePath,
+	testFrontendDeduplicateSources,
 )
 
 // Tests that depend on the `security.*` entitlements

--- a/solver/bboltcachestorage/storage.go
+++ b/solver/bboltcachestorage/storage.go
@@ -54,6 +54,10 @@ func (s *Store) Exists(id string) bool {
 	return exists
 }
 
+func (s *Store) Close() error {
+	return s.db.Close()
+}
+
 func (s *Store) Walk(fn func(id string) error) error {
 	ids := make([]string, 0)
 	if err := s.db.View(func(tx *bolt.Tx) error {

--- a/solver/llbsolver/provenance.go
+++ b/solver/llbsolver/provenance.go
@@ -137,12 +137,14 @@ func (b *provenanceBridge) ResolveImageConfig(ctx context.Context, ref string, o
 		return "", "", nil, err
 	}
 
+	b.mu.Lock()
 	b.images = append(b.images, provenance.ImageSource{
 		Ref:      ref,
 		Platform: opt.Platform,
 		Digest:   dgst,
 		Local:    opt.ResolverType == llb.ResolverTypeOCILayout,
 	})
+	b.mu.Unlock()
 	return ref, dgst, config, nil
 }
 

--- a/source/http/httpsource.go
+++ b/source/http/httpsource.go
@@ -127,7 +127,7 @@ func (hs *httpSourceHandler) CacheKey(ctx context.Context, g session.Group, inde
 
 	uh, err := hs.urlHash()
 	if err != nil {
-		return "", "", nil, false, nil
+		return "", "", nil, false, err
 	}
 
 	// look up metadata(previously stored headers) for that URL

--- a/util/imageutil/config.go
+++ b/util/imageutil/config.go
@@ -156,6 +156,7 @@ func Config(ctx context.Context, str string, resolver remotes.Resolver, cache Co
 	}
 
 	children := childrenConfigHandler(cache, platform)
+	children = images.LimitManifests(children, platform, 1)
 
 	dslHandler, err := docker.AppendDistributionSourceLabel(cache, ref.String())
 	if err != nil {

--- a/util/imageutil/config_test.go
+++ b/util/imageutil/config_test.go
@@ -1,0 +1,207 @@
+package imageutil
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"math/rand"
+	"testing"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/platforms"
+	"github.com/containerd/containerd/remotes"
+	digest "github.com/opencontainers/go-digest"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigMultiplatform(t *testing.T) {
+	ctx := context.Background()
+
+	cc := &testCache{}
+
+	pAmd64 := platforms.MustParse("linux/amd64")
+	cfgDescAmd64 := cc.Add(t, ocispecs.Image{Platform: pAmd64}, ocispecs.MediaTypeImageConfig, nil)
+	mfstAmd64 := ocispecs.Manifest{MediaType: ocispecs.MediaTypeImageManifest, Config: cfgDescAmd64}
+
+	// Add linux/amd64 to the cache
+	descAmd64 := cc.Add(t, mfstAmd64, mfstAmd64.MediaType, &pAmd64)
+
+	// Make a compatible manifest but do not add to the cache
+	p386 := platforms.MustParse("linux/386")
+	cfgDesc386 := cc.Add(t, ocispecs.Image{Platform: p386}, ocispecs.MediaTypeImageConfig, nil)
+	mfst386 := ocispecs.Manifest{MediaType: ocispecs.MediaTypeImageManifest, Config: cfgDesc386}
+	_, desc386 := makeDesc(t, mfst386, mfst386.MediaType, &p386)
+
+	// And add an extra non-compataible platform
+	pArm64 := platforms.MustParse("linux/arm64")
+	cfgDescArm64 := cc.Add(t, ocispecs.Image{Platform: pArm64}, ocispecs.MediaTypeImageConfig, nil)
+	mfstArm64 := ocispecs.Manifest{MediaType: ocispecs.MediaTypeImageManifest, Config: cfgDescArm64}
+	_, descArm64 := makeDesc(t, mfst386, mfstArm64.MediaType, &pArm64)
+
+	idx := ocispecs.Index{
+		MediaType: ocispecs.MediaTypeImageIndex,
+		Manifests: []ocispecs.Descriptor{desc386, descAmd64, descArm64},
+	}
+
+	check := func(t *testing.T) {
+		t.Helper()
+
+		idxDesc := cc.Add(t, idx, idx.MediaType, nil)
+		r := &testResolver{cc: cc, resolve: func(ctx context.Context, ref string) (string, ocispecs.Descriptor, error) {
+			return ref, idxDesc, nil
+		}}
+
+		// Now we should be able to get the amd64 config without fetching anything from the remote
+		// If it tries to fetch from the remote this will error out.
+		const ref = "example.com/test:latest"
+		_, _, dt, err := Config(ctx, ref, r, cc, nil, &pAmd64, nil)
+		require.NoError(t, err)
+
+		var cfg ocispecs.Image
+		require.NoError(t, json.Unmarshal(dt, &cfg))
+		// Validate this is the amd64 config
+		require.True(t, platforms.OnlyStrict(cfg.Platform).Match(pAmd64))
+
+		// Make sure it doesn't select a non-matching platform
+		pArmv7 := platforms.MustParse("linux/arm/v7")
+		_, _, _, err = Config(ctx, ref, r, cc, nil, &pArmv7, nil)
+		require.ErrorIs(t, err, errdefs.ErrNotFound)
+	}
+
+	check(t)
+
+	// Shuffle the manifests around and make sure it still works
+	rand.Shuffle(len(idx.Manifests), func(i, j int) {
+		idx.Manifests[i], idx.Manifests[j] = idx.Manifests[j], idx.Manifests[i]
+	})
+	check(t)
+}
+
+type testCache struct {
+	content.Manager
+	content map[digest.Digest]content.ReaderAt
+}
+
+func (testCache) Info(ctx context.Context, dgst digest.Digest) (content.Info, error) {
+	return content.Info{}, nil
+}
+
+func (testCache) Update(context.Context, content.Info, ...string) (content.Info, error) {
+	return content.Info{}, nil
+}
+
+func (*testCache) Writer(ctx context.Context, opts ...content.WriterOpt) (content.Writer, error) {
+	// This needs to be implemented because the content helpers will open a writer to use as a lock
+	return nopWriter{}, nil
+}
+
+type nopWriter struct{}
+
+func (nopWriter) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (nopWriter) Close() error {
+	return nil
+}
+
+func (nopWriter) Commit(ctx context.Context, size int64, expected digest.Digest, opts ...content.Opt) error {
+	return nil
+}
+
+func (nopWriter) Status() (content.Status, error) {
+	return content.Status{}, nil
+}
+
+func (nopWriter) Truncate(size int64) error {
+	return nil
+}
+
+func (nopWriter) Digest() digest.Digest {
+	panic("not implemented")
+}
+
+func makeDesc(t *testing.T, item any, mt string, p *ocispecs.Platform) ([]byte, ocispecs.Descriptor) {
+	t.Helper()
+
+	dt, err := json.Marshal(item)
+	require.NoError(t, err)
+
+	return dt, ocispecs.Descriptor{
+		MediaType: mt,
+		Digest:    digest.FromBytes(dt),
+		Size:      int64(len(dt)),
+		Platform:  p,
+	}
+}
+
+func (c *testCache) Add(t *testing.T, item any, mt string, p *ocispecs.Platform) ocispecs.Descriptor {
+	if c.content == nil {
+		c.content = make(map[digest.Digest]content.ReaderAt)
+	}
+
+	dt, desc := makeDesc(t, item, mt, p)
+	c.content[desc.Digest] = &sectionNopCloser{io.NewSectionReader(bytes.NewReader(dt), 0, int64(len(dt)))}
+	return desc
+}
+
+type sectionNopCloser struct {
+	*io.SectionReader
+}
+
+func (*sectionNopCloser) Close() error {
+	return nil
+}
+
+func (c *testCache) ReaderAt(ctx context.Context, desc ocispecs.Descriptor) (content.ReaderAt, error) {
+	ra, ok := c.content[desc.Digest]
+	if !ok {
+		return nil, errdefs.ErrNotFound
+	}
+	return ra, nil
+}
+
+type testResolver struct {
+	resolve func(ctx context.Context, ref string) (string, ocispecs.Descriptor, error)
+	cc      ContentCache
+}
+
+type fetcherFunc func(context.Context, ocispecs.Descriptor) (io.ReadCloser, error)
+
+func (f fetcherFunc) Fetch(ctx context.Context, desc ocispecs.Descriptor) (io.ReadCloser, error) {
+	return f(ctx, desc)
+}
+
+func (r *testResolver) Fetcher(ctx context.Context, ref string) (remotes.Fetcher, error) {
+	return fetcherFunc(func(ctx context.Context, desc ocispecs.Descriptor) (io.ReadCloser, error) {
+		ra, err := r.cc.ReaderAt(ctx, desc)
+		if err != nil {
+			return nil, err
+		}
+		return &raReader{ReaderAt: ra, Closer: ra}, nil
+	}), nil
+}
+
+type raReader struct {
+	io.ReaderAt
+	io.Closer
+
+	pos int
+}
+
+func (r *raReader) Read(p []byte) (int, error) {
+	n, err := r.ReaderAt.ReadAt(p, int64(r.pos))
+	r.pos += n
+	return n, err
+}
+
+func (r *testResolver) Resolve(ctx context.Context, ref string) (string, ocispecs.Descriptor, error) {
+	return r.resolve(ctx, ref)
+}
+
+func (r *testResolver) Pusher(context.Context, string) (remotes.Pusher, error) {
+	panic("not implemented")
+}

--- a/util/pull/pullprogress/progress.go
+++ b/util/pull/pullprogress/progress.go
@@ -129,6 +129,10 @@ func trackProgress(ctx context.Context, desc ocispecs.Descriptor, manager PullMa
 
 		info, err := manager.Info(ctx, desc.Digest)
 		if err == nil {
+			// info.CreatedAt could be before started if parallel pull just completed
+			if info.CreatedAt.Before(started) {
+				started = info.CreatedAt
+			}
 			pw.Write(desc.Digest.String(), progress.Status{
 				Current:   int(info.Size),
 				Total:     int(info.Size),

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -211,6 +211,9 @@ func NewWorker(ctx context.Context, opt WorkerOpt) (*Worker, error) {
 
 func (w *Worker) Close() error {
 	var rerr error
+	if err := w.MetadataStore.Close(); err != nil {
+		rerr = multierror.Append(rerr, err)
+	}
 	for _, provider := range w.NetworkProviders {
 		if err := provider.Close(); err != nil {
 			rerr = multierror.Append(rerr, err)


### PR DESCRIPTION
See https://github.com/moby/buildkit/pull/4157#issuecomment-1745150754 - looks like we have 2 relatively nasty known issues in v0.12.2 that users have encountered (including a panic):

- https://github.com/moby/buildkit/pull/4200
- https://github.com/moby/buildkit/pull/4157
- https://github.com/moby/buildkit/pull/4293 (already cherry-picked in https://github.com/moby/buildkit/pull/4297)

And some more minor issues with a relatively low foot-print that would benefit from making it to a release:

- https://github.com/moby/buildkit/pull/4190 (not a clean cherry-pick, since https://github.com/moby/buildkit/pull/4093 refactored the number of `Tmpdir` returns)
- https://github.com/moby/buildkit/pull/4183
- https://github.com/moby/buildkit/pull/4185
- https://github.com/moby/buildkit/pull/4189
- https://github.com/moby/buildkit/pull/4201
- https://github.com/moby/buildkit/pull/4308
- https://github.com/moby/buildkit/pull/4311
