### PR TITLE
Don't support cgroupns on cgroups v1

### DIFF
--- a/executor/oci/spec.go
+++ b/executor/oci/spec.go
@@ -138,7 +138,7 @@ func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mou
 		return nil, nil, err
 	}
 
-	if cgroupNamespaceSupported() {
+	if cgroupV2NamespaceSupported() {
 		s.Linux.Namespaces = append(s.Linux.Namespaces, specs.LinuxNamespace{
 			Type: specs.CgroupNamespace,
 		})

--- a/executor/oci/spec_freebsd.go
+++ b/executor/oci/spec_freebsd.go
@@ -56,6 +56,6 @@ func getTracingSocket() string {
 	return ""
 }
 
-func cgroupNamespaceSupported() bool {
+func cgroupV2NamespaceSupported() bool {
 	return false
 }

--- a/executor/oci/spec_linux.go
+++ b/executor/oci/spec_linux.go
@@ -150,9 +150,13 @@ func getTracingSocket() string {
 
 func cgroupNamespaceSupported() bool {
 	cgroupNSOnce.Do(func() {
-		if _, err := os.Stat("/proc/self/ns/cgroup"); !os.IsNotExist(err) {
-			supportsCgroupNS = true
+		if _, err := os.Stat("/proc/self/ns/cgroup"); os.IsNotExist(err) {
+			return
 		}
+		if _, err := os.Stat("/sys/fs/cgroup/cgroup.subtree_control"); os.IsNotExist(err) {
+			return
+		}
+		supportsCgroupNS = true
 	})
 	return supportsCgroupNS
 }

--- a/executor/oci/spec_linux.go
+++ b/executor/oci/spec_linux.go
@@ -148,7 +148,11 @@ func getTracingSocket() string {
 	return fmt.Sprintf("unix://%s", tracingSocketPath)
 }
 
-func cgroupNamespaceSupported() bool {
+func cgroupV2NamespaceSupported() bool {
+	// Check if cgroups v2 namespaces are supported.  Trying to do cgroup
+	// namespaces with cgroups v1 results in EINVAL when we encounter a
+	// non-standard hierarchy.
+	// See https://github.com/moby/buildkit/issues/4108
 	cgroupNSOnce.Do(func() {
 		if _, err := os.Stat("/proc/self/ns/cgroup"); os.IsNotExist(err) {
 			return

--- a/executor/oci/spec_windows.go
+++ b/executor/oci/spec_windows.go
@@ -97,6 +97,6 @@ func getTracingSocket() string {
 	return fmt.Sprintf("npipe://%s", filepath.ToSlash(tracingSocketPath))
 }
 
-func cgroupNamespaceSupported() bool {
+func cgroupV2NamespaceSupported() bool {
 	return false
 }


### PR DESCRIPTION
Possibly fixes #4108.

Note that I have no idea what I'm doing; I'm basing the new stat call on what the tests in #4003 are doing (on the assumption that if it is not compatible with the test, it was probably what broke my use cases too).  Any suggestions on what to do instead (or even just PRs that replace this one) very welcome.