### PR TITLE
session: fix grpc message size limits for tar streams

### DIFF
--- a/session/filesync/diffcopy.go
+++ b/session/filesync/diffcopy.go
@@ -47,6 +47,22 @@ type streamWriterCloser struct {
 }
 
 func (wc *streamWriterCloser) Write(dt []byte) (int, error) {
+	// grpc-go has a 4MB limit on messages by default. Split large messages
+	// so we don't get close to that limit.
+	const maxChunkSize = 3 * 1024 * 1024
+	if len(dt) > maxChunkSize {
+		n1, err := wc.Write(dt[:maxChunkSize])
+		if err != nil {
+			return n1, err
+		}
+		dt = dt[maxChunkSize:]
+		var n2 int
+		if n2, err = wc.Write(dt); err != nil {
+			return n1 + n2, err
+		}
+		return n1 + n2, nil
+	}
+
 	if err := wc.ClientStream.SendMsg(&BytesMessage{Data: dt}); err != nil {
 		// SendMsg return EOF on remote errors
 		if errors.Is(err, io.EOF) {

--- a/session/grpc.go
+++ b/session/grpc.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/containerd/containerd/defaults"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/grpcerrors"
@@ -44,6 +45,8 @@ func grpcClientConn(ctx context.Context, conn net.Conn) (context.Context, *grpc.
 	dialOpts := []grpc.DialOption{
 		dialer,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(defaults.DefaultMaxRecvMsgSize)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(defaults.DefaultMaxSendMsgSize)),
 	}
 
 	if span := trace.SpanFromContext(ctx); span.SpanContext().IsValid() {


### PR DESCRIPTION
When exporting tar stream (with SBOM) it is possible to hit grpc message size limits atm. While we raise the limits to 16MB for grpc control API, we don't currently do the same for the session API.

This can be reproduced with:

```
FROM laurentgoderre689/tar-too-big
RUN echo "Hello World"
```
```
docker buildx b . --platform linux/amd64 -t blah --sbom=true --provenance=true -o type=tar,dest=tar.tar
```

The first commit makes it so that the tar producer never sends chunks bigger than 3MB in a single message.

The second commit raises the limits on the client side to match control API. Only one of the fixes is needed to fix the issue in the reproducer. The second commit is for consistency and to fix the issue in case a new client accesses the old daemon.

The third commit is for `uploadprovider` which is used in the case build context is provided as a tar stream. This is unrelated to the reproducer but it looks like the current implementation could theoretically be similarly affected. I'm not sure if there is a way to reproduce this in practice.