### PR TITLE
gateway: restore original filename in StatFile error message

### DIFF
--- a/cache/util/fsutil.go
+++ b/cache/util/fsutil.go
@@ -128,6 +128,16 @@ func StatFile(ctx context.Context, mount snapshot.Mountable, path string) (*fsty
 			return errors.WithStack(err)
 		}
 		if st, err = fsutil.Stat(fp); err != nil {
+			// The filename here is internal to the mount, so we can restore
+			// the request base path for error reporting.
+			// See os.DirFS.Open for details.
+			err1 := err
+			if err := errors.Cause(err); err != nil {
+				err1 = err
+			}
+			if pe, ok := err1.(*os.PathError); ok {
+				pe.Path = path
+			}
 			return errors.WithStack(err)
 		}
 		return nil


### PR DESCRIPTION
Follow-up to #3990, but this time for `StatFile` as well.

> This case is a little bit trickier, since it is wrapped by `errors.WithStack` as well, but we can use `errors.Cause` to extract the original error to modify it.

Messages returned by `fsutil.Stat` are guaranteed to return a `PathError` wrapped by a stack trace (since it calls `os.Lstat`). However, as these error messages are printed, they include the temporary directory for the mounted reference which is not useful to the caller.

On an error, we can restore the filename in the `PathError` to the requested filename, as also seen in `os.DirFS`.