### PR TITLE
dockerfile: use glibc to build riscv64

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -135,6 +135,51 @@ jobs:
           path: ${{ env.DESTDIR }}/*
           if-no-files-found: error
 
+  prepare-smoketest:
+    runs-on: ubuntu-20.04
+    outputs:
+      matrix: ${{ steps.platforms.outputs.matrix }}
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Create matrix
+        id: platforms
+        run: |
+          matrix="$(docker buildx bake binaries-smoketest --print | jq -cr '.target."binaries-smoketest".platforms')"
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+
+  smoketest:
+    runs-on: ubuntu-20.04
+    needs:
+      - prepare-smoketest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ${{ fromJson(needs.prepare-smoketest.outputs.matrix) }}
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: ${{ env.SETUP_BUILDX_VERSION }}
+          driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
+          buildkitd-flags: --debug
+      -
+        name: Test
+        uses: docker/bake-action@v4
+        with:
+          targets: binaries-smoketest
+          set: |
+            *.platform=${{ matrix.platform }}
+
   image:
     runs-on: ubuntu-22.04
     needs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -379,5 +379,18 @@ ENV BUILDKIT_HOST=unix:///run/user/1000/buildkit/buildkitd.sock
 VOLUME /home/user/.local/share/buildkit
 ENTRYPOINT ["rootlesskit", "buildkitd"]
 
+# smoke tests
+FROM --platform=$TARGETPLATFORM buildkit-export AS binaries-smoketest
+WORKDIR /usr/local/bin
+COPY --from=binaries / .
+RUN apk add --no-cache file
+RUN <<EOT
+  set -ex
+  file buildkitd
+  buildkitd --version
+  file buildkit-runc
+  buildkit-runc --version
+EOT
+
 # buildkit builds the buildkit container image
 FROM buildkit-$TARGETOS${BUILDKIT_DEBUG:+-debug} AS buildkit

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -90,6 +90,20 @@ target "binaries-cross" {
   ]
 }
 
+target "binaries-smoketest" {
+  inherits = ["_common"]
+  target = "binaries-smoketest"
+  output = ["type=cacheonly"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm/v7",
+    "linux/arm64",
+    "linux/s390x",
+    "linux/ppc64le",
+    "linux/riscv64"
+  ]
+}
+
 target "release" {
   inherits = ["binaries-cross"]
   target = "release"


### PR DESCRIPTION
Try to mitigate #4316 so we can release 0.12.3.

With this change binaries (runc and buildkitd) will be built with glibc on riscv64. As we are building static binaries this is fine to keep alpine as base image. Adds smoke tests in our pipeline as well.