### PR TITLE
solver: protect against nil rres upon errors

### DIFF
--- a/solver/cachemanager.go
+++ b/solver/cachemanager.go
@@ -176,7 +176,11 @@ func (c *cacheManager) Load(ctx context.Context, rec *CacheRecord) (rres Result,
 		"stack":         bklog.TraceLevelOnlyStack(),
 	})
 	defer func() {
-		lg.WithError(rerr).WithField("return_result", rres.ID()).Trace("cache manager")
+		rresID := "<nil>"
+		if rres != nil {
+			rresID = rres.ID()
+		}
+		lg.WithError(rerr).WithField("return_result", rresID).Trace("cache manager")
 	}()
 
 	c.mu.RLock()


### PR DESCRIPTION
If any of the `Load()` calls return an error, such as `not found`; then the `rres` pointer might be nil, which causes the deferred error message to panic.