### PR TITLE
Update opencontainers/image-spec to v1.1.0-rc5

### DIFF
--- a/cache/remotecache/inline/inline.go
+++ b/cache/remotecache/inline/inline.go
@@ -1,4 +1,4 @@
-package registry
+package inline
 
 import (
 	"context"

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1172,7 +1172,7 @@ func testFrontendImageNaming(t *testing.T, sb integration.Sandbox) {
 			require.True(t, ok)
 
 			var index ocispecs.Index
-			err = json.Unmarshal(m["index.json"].Data, &index)
+			err = json.Unmarshal(m[ocispecs.ImageIndexFile].Data, &index)
 			require.NoError(t, err)
 			require.Equal(t, 2, index.SchemaVersion)
 			require.Equal(t, 1, len(index.Manifests))
@@ -1949,7 +1949,7 @@ func testOCILayoutSource(t *testing.T, sb integration.Sandbox) {
 	}
 
 	var index ocispecs.Index
-	err = json.Unmarshal(m["index.json"].Data, &index)
+	err = json.Unmarshal(m[ocispecs.ImageIndexFile].Data, &index)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(index.Manifests))
 	digest := index.Manifests[0].Digest
@@ -2080,7 +2080,7 @@ func testOCILayoutPlatformSource(t *testing.T, sb integration.Sandbox) {
 	}
 
 	var index ocispecs.Index
-	err = json.Unmarshal(m["index.json"].Data, &index)
+	err = json.Unmarshal(m[ocispecs.ImageIndexFile].Data, &index)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(index.Manifests))
 	digest := index.Manifests[0].Digest
@@ -2599,25 +2599,25 @@ func testOCIExporter(t *testing.T, sb integration.Sandbox) {
 		require.True(t, ok)
 
 		var index ocispecs.Index
-		err = json.Unmarshal(m["index.json"].Data, &index)
+		err = json.Unmarshal(m[ocispecs.ImageIndexFile].Data, &index)
 		require.NoError(t, err)
 		require.Equal(t, 2, index.SchemaVersion)
 		require.Equal(t, 1, len(index.Manifests))
 
 		var mfst ocispecs.Manifest
-		err = json.Unmarshal(m["blobs/sha256/"+index.Manifests[0].Digest.Hex()].Data, &mfst)
+		err = json.Unmarshal(m[ocispecs.ImageBlobsDir+"/sha256/"+index.Manifests[0].Digest.Hex()].Data, &mfst)
 		require.NoError(t, err)
 		require.Equal(t, 2, len(mfst.Layers))
 
 		var ociimg ocispecs.Image
-		err = json.Unmarshal(m["blobs/sha256/"+mfst.Config.Digest.Hex()].Data, &ociimg)
+		err = json.Unmarshal(m[ocispecs.ImageBlobsDir+"/sha256/"+mfst.Config.Digest.Hex()].Data, &ociimg)
 		require.NoError(t, err)
 		require.Equal(t, "layers", ociimg.RootFS.Type)
 		require.Equal(t, 2, len(ociimg.RootFS.DiffIDs))
 
-		_, ok = m["blobs/sha256/"+mfst.Layers[0].Digest.Hex()]
+		_, ok = m[ocispecs.ImageBlobsDir+"/sha256/"+mfst.Layers[0].Digest.Hex()]
 		require.True(t, ok)
-		_, ok = m["blobs/sha256/"+mfst.Layers[1].Digest.Hex()]
+		_, ok = m[ocispecs.ImageBlobsDir+"/sha256/"+mfst.Layers[1].Digest.Hex()]
 		require.True(t, ok)
 
 		if exp != ExporterDocker {
@@ -2724,7 +2724,7 @@ func testOCIExporterContentStore(t *testing.T, sb integration.Sandbox) {
 				require.Contains(t, m, filename+"/")
 			} else {
 				require.Contains(t, m, filename)
-				if filename == "index.json" {
+				if filename == ocispecs.ImageIndexFile {
 					// this file has a timestamp in it, so we can't compare
 					return nil
 				}
@@ -3711,18 +3711,18 @@ func testBuildExportZstd(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 
 	var index ocispecs.Index
-	err = json.Unmarshal(m["index.json"].Data, &index)
+	err = json.Unmarshal(m[ocispecs.ImageIndexFile].Data, &index)
 	require.NoError(t, err)
 
 	var mfst ocispecs.Manifest
-	err = json.Unmarshal(m["blobs/sha256/"+index.Manifests[0].Digest.Hex()].Data, &mfst)
+	err = json.Unmarshal(m[ocispecs.ImageBlobsDir+"/sha256/"+index.Manifests[0].Digest.Hex()].Data, &mfst)
 	require.NoError(t, err)
 
 	lastLayer := mfst.Layers[len(mfst.Layers)-1]
 	require.Equal(t, ocispecs.MediaTypeImageLayer+"+zstd", lastLayer.MediaType)
 
 	zstdLayerDigest := lastLayer.Digest.Hex()
-	require.Equal(t, m["blobs/sha256/"+zstdLayerDigest].Data[:4], []byte{0x28, 0xb5, 0x2f, 0xfd})
+	require.Equal(t, m[ocispecs.ImageBlobsDir+"/sha256/"+zstdLayerDigest].Data[:4], []byte{0x28, 0xb5, 0x2f, 0xfd})
 
 	// repeat without oci mediatype
 	outW, err = os.Create(out)
@@ -3748,10 +3748,10 @@ func testBuildExportZstd(t *testing.T, sb integration.Sandbox) {
 	m, err = testutil.ReadTarToMap(dt, false)
 	require.NoError(t, err)
 
-	err = json.Unmarshal(m["index.json"].Data, &index)
+	err = json.Unmarshal(m[ocispecs.ImageIndexFile].Data, &index)
 	require.NoError(t, err)
 
-	err = json.Unmarshal(m["blobs/sha256/"+index.Manifests[0].Digest.Hex()].Data, &mfst)
+	err = json.Unmarshal(m[ocispecs.ImageBlobsDir+"/sha256/"+index.Manifests[0].Digest.Hex()].Data, &mfst)
 	require.NoError(t, err)
 
 	lastLayer = mfst.Layers[len(mfst.Layers)-1]
@@ -3833,11 +3833,11 @@ func testPullZstdImage(t *testing.T, sb integration.Sandbox) {
 			require.NoError(t, err)
 
 			var index ocispecs.Index
-			err = json.Unmarshal(m["index.json"].Data, &index)
+			err = json.Unmarshal(m[ocispecs.ImageIndexFile].Data, &index)
 			require.NoError(t, err)
 
 			var mfst ocispecs.Manifest
-			err = json.Unmarshal(m["blobs/sha256/"+index.Manifests[0].Digest.Hex()].Data, &mfst)
+			err = json.Unmarshal(m[ocispecs.ImageBlobsDir+"/sha256/"+index.Manifests[0].Digest.Hex()].Data, &mfst)
 			require.NoError(t, err)
 
 			firstLayer := mfst.Layers[0]
@@ -3848,7 +3848,7 @@ func testPullZstdImage(t *testing.T, sb integration.Sandbox) {
 			}
 
 			zstdLayerDigest := firstLayer.Digest.Hex()
-			require.Equal(t, m["blobs/sha256/"+zstdLayerDigest].Data[:4], []byte{0x28, 0xb5, 0x2f, 0xfd})
+			require.Equal(t, m[ocispecs.ImageBlobsDir+"/sha256/"+zstdLayerDigest].Data[:4], []byte{0x28, 0xb5, 0x2f, 0xfd})
 		})
 	}
 }
@@ -4744,13 +4744,13 @@ func testZstdLocalCacheExport(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 
 	var index ocispecs.Index
-	dt, err := os.ReadFile(filepath.Join(destDir, "index.json"))
+	dt, err := os.ReadFile(filepath.Join(destDir, ocispecs.ImageIndexFile))
 	require.NoError(t, err)
 	err = json.Unmarshal(dt, &index)
 	require.NoError(t, err)
 
 	var layerIndex ocispecs.Index
-	dt, err = os.ReadFile(filepath.Join(destDir, "blobs/sha256/"+index.Manifests[0].Digest.Hex()))
+	dt, err = os.ReadFile(filepath.Join(destDir, ocispecs.ImageBlobsDir+"/sha256/"+index.Manifests[0].Digest.Hex()))
 	require.NoError(t, err)
 	err = json.Unmarshal(dt, &layerIndex)
 	require.NoError(t, err)
@@ -4759,7 +4759,7 @@ func testZstdLocalCacheExport(t *testing.T, sb integration.Sandbox) {
 	require.Equal(t, ocispecs.MediaTypeImageLayer+"+zstd", lastLayer.MediaType)
 
 	zstdLayerDigest := lastLayer.Digest.Hex()
-	dt, err = os.ReadFile(filepath.Join(destDir, "blobs/sha256/"+zstdLayerDigest))
+	dt, err = os.ReadFile(filepath.Join(destDir, ocispecs.ImageBlobsDir+"/sha256/"+zstdLayerDigest))
 	require.NoError(t, err)
 	require.Equal(t, dt[:4], []byte{0x28, 0xb5, 0x2f, 0xfd})
 }
@@ -5611,11 +5611,11 @@ func testSnapshotWithMultipleBlobs(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 
 	var index ocispecs.Index
-	err = json.Unmarshal(m["index.json"].Data, &index)
+	err = json.Unmarshal(m[ocispecs.ImageIndexFile].Data, &index)
 	require.NoError(t, err)
 
 	var mfst ocispecs.Manifest
-	err = json.Unmarshal(m["blobs/sha256/"+index.Manifests[0].Digest.Hex()].Data, &mfst)
+	err = json.Unmarshal(m[ocispecs.ImageBlobsDir+"/sha256/"+index.Manifests[0].Digest.Hex()].Data, &mfst)
 	require.NoError(t, err)
 
 	dt, err = os.ReadFile(out2)
@@ -5624,14 +5624,14 @@ func testSnapshotWithMultipleBlobs(t *testing.T, sb integration.Sandbox) {
 	m, err = testutil.ReadTarToMap(dt, false)
 	require.NoError(t, err)
 
-	err = json.Unmarshal(m["index.json"].Data, &index)
+	err = json.Unmarshal(m[ocispecs.ImageIndexFile].Data, &index)
 	require.NoError(t, err)
 
-	err = json.Unmarshal(m["blobs/sha256/"+index.Manifests[0].Digest.Hex()].Data, &index)
+	err = json.Unmarshal(m[ocispecs.ImageBlobsDir+"/sha256/"+index.Manifests[0].Digest.Hex()].Data, &index)
 	require.NoError(t, err)
 
 	var mfst2 ocispecs.Manifest
-	err = json.Unmarshal(m["blobs/sha256/"+index.Manifests[0].Digest.Hex()].Data, &mfst2)
+	err = json.Unmarshal(m[ocispecs.ImageBlobsDir+"/sha256/"+index.Manifests[0].Digest.Hex()].Data, &mfst2)
 	require.NoError(t, err)
 
 	require.NotEqual(t, mfst.Layers[0].Digest, mfst2.Layers[0].Digest)
@@ -6103,16 +6103,16 @@ func testDuplicateWhiteouts(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 
 	var index ocispecs.Index
-	err = json.Unmarshal(m["index.json"].Data, &index)
+	err = json.Unmarshal(m[ocispecs.ImageIndexFile].Data, &index)
 	require.NoError(t, err)
 
 	var mfst ocispecs.Manifest
-	err = json.Unmarshal(m["blobs/sha256/"+index.Manifests[0].Digest.Hex()].Data, &mfst)
+	err = json.Unmarshal(m[ocispecs.ImageBlobsDir+"/sha256/"+index.Manifests[0].Digest.Hex()].Data, &mfst)
 	require.NoError(t, err)
 
 	lastLayer := mfst.Layers[len(mfst.Layers)-1]
 
-	layer, ok := m["blobs/sha256/"+lastLayer.Digest.Hex()]
+	layer, ok := m[ocispecs.ImageBlobsDir+"/sha256/"+lastLayer.Digest.Hex()]
 	require.True(t, ok)
 
 	m, err = testutil.ReadTarToMap(layer.Data, true)
@@ -6172,16 +6172,16 @@ func testWhiteoutParentDir(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 
 	var index ocispecs.Index
-	err = json.Unmarshal(m["index.json"].Data, &index)
+	err = json.Unmarshal(m[ocispecs.ImageIndexFile].Data, &index)
 	require.NoError(t, err)
 
 	var mfst ocispecs.Manifest
-	err = json.Unmarshal(m["blobs/sha256/"+index.Manifests[0].Digest.Hex()].Data, &mfst)
+	err = json.Unmarshal(m[ocispecs.ImageBlobsDir+"/sha256/"+index.Manifests[0].Digest.Hex()].Data, &mfst)
 	require.NoError(t, err)
 
 	lastLayer := mfst.Layers[len(mfst.Layers)-1]
 
-	layer, ok := m["blobs/sha256/"+lastLayer.Digest.Hex()]
+	layer, ok := m[ocispecs.ImageBlobsDir+"/sha256/"+lastLayer.Digest.Hex()]
 	require.True(t, ok)
 
 	m, err = testutil.ReadTarToMap(layer.Data, true)
@@ -6236,16 +6236,16 @@ func testMoveParentDir(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 
 	var index ocispecs.Index
-	err = json.Unmarshal(m["index.json"].Data, &index)
+	err = json.Unmarshal(m[ocispecs.ImageIndexFile].Data, &index)
 	require.NoError(t, err)
 
 	var mfst ocispecs.Manifest
-	err = json.Unmarshal(m["blobs/sha256/"+index.Manifests[0].Digest.Hex()].Data, &mfst)
+	err = json.Unmarshal(m[ocispecs.ImageBlobsDir+"/sha256/"+index.Manifests[0].Digest.Hex()].Data, &mfst)
 	require.NoError(t, err)
 
 	lastLayer := mfst.Layers[len(mfst.Layers)-1]
 
-	layer, ok := m["blobs/sha256/"+lastLayer.Digest.Hex()]
+	layer, ok := m[ocispecs.ImageBlobsDir+"/sha256/"+lastLayer.Digest.Hex()]
 	require.True(t, ok)
 
 	m, err = testutil.ReadTarToMap(layer.Data, true)
@@ -7793,21 +7793,21 @@ func testExportAnnotations(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 
 	var layout ocispecs.Index
-	err = json.Unmarshal(m["index.json"].Data, &layout)
+	err = json.Unmarshal(m[ocispecs.ImageIndexFile].Data, &layout)
 	require.Equal(t, "generic index descriptor", layout.Manifests[0].Annotations["gid"])
 	require.Equal(t, "generic index descriptor opt", layout.Manifests[0].Annotations["gido"])
 	require.Equal(t, created, layout.Manifests[0].Annotations[ocispecs.AnnotationCreated])
 	require.NoError(t, err)
 
 	var index ocispecs.Index
-	err = json.Unmarshal(m["blobs/sha256/"+layout.Manifests[0].Digest.Hex()].Data, &index)
+	err = json.Unmarshal(m[ocispecs.ImageBlobsDir+"/sha256/"+layout.Manifests[0].Digest.Hex()].Data, &index)
 	require.Equal(t, "generic index", index.Annotations["gi"])
 	require.Equal(t, "generic index opt", index.Annotations["gio"])
 	require.NoError(t, err)
 
 	for _, desc := range index.Manifests {
 		var mfst ocispecs.Manifest
-		err = json.Unmarshal(m["blobs/sha256/"+desc.Digest.Hex()].Data, &mfst)
+		err = json.Unmarshal(m[ocispecs.ImageBlobsDir+"/sha256/"+desc.Digest.Hex()].Data, &mfst)
 		require.NoError(t, err)
 
 		require.Equal(t, "generic default", mfst.Annotations["gd"])
@@ -9226,8 +9226,8 @@ func testMultipleCacheExports(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	ensureFile(t, filepath.Join(cacheOutDir, "index.json"))
-	ensureFile(t, filepath.Join(cacheOutDir2, "index.json"))
+	ensureFile(t, filepath.Join(cacheOutDir, ocispecs.ImageIndexFile))
+	ensureFile(t, filepath.Join(cacheOutDir2, ocispecs.ImageIndexFile))
 
 	dgst := res.ExporterResponse[exptypes.ExporterImageDigestKey]
 
@@ -9452,7 +9452,7 @@ func readImageTimestamps(dt []byte) (*imageTimestamps, error) {
 	}
 
 	var index ocispecs.Index
-	if err := json.Unmarshal(m["index.json"].Data, &index); err != nil {
+	if err := json.Unmarshal(m[ocispecs.ImageIndexFile].Data, &index); err != nil {
 		return nil, err
 	}
 	if len(index.Manifests) != 1 {
@@ -9463,7 +9463,7 @@ func readImageTimestamps(dt []byte) (*imageTimestamps, error) {
 	res.FromAnnotation = index.Manifests[0].Annotations[ocispecs.AnnotationCreated]
 
 	var mfst ocispecs.Manifest
-	if err := json.Unmarshal(m["blobs/sha256/"+index.Manifests[0].Digest.Hex()].Data, &mfst); err != nil {
+	if err := json.Unmarshal(m[ocispecs.ImageBlobsDir+"/sha256/"+index.Manifests[0].Digest.Hex()].Data, &mfst); err != nil {
 		return nil, err
 	}
 	// don't unmarshal to image type so we get the original string value
@@ -9476,7 +9476,7 @@ func readImageTimestamps(dt []byte) (*imageTimestamps, error) {
 		Created string    `json:"created"`
 	}{}
 
-	if err := json.Unmarshal(m["blobs/sha256/"+mfst.Config.Digest.Hex()].Data, &img); err != nil {
+	if err := json.Unmarshal(m[ocispecs.ImageBlobsDir+"/sha256/"+mfst.Config.Digest.Hex()].Data, &img); err != nil {
 		return nil, err
 	}
 

--- a/client/ociindex/ociindex.go
+++ b/client/ociindex/ociindex.go
@@ -12,9 +12,6 @@ import (
 )
 
 const (
-	// indexFile is the name of the index file
-	indexFile = "index.json"
-
 	// lockFileSuffix is the suffix of the lock file
 	lockFileSuffix = ".lock"
 )
@@ -26,7 +23,7 @@ type StoreIndex struct {
 }
 
 func NewStoreIndex(storePath string) StoreIndex {
-	indexPath := path.Join(storePath, indexFile)
+	indexPath := path.Join(storePath, ocispecs.ImageIndexFile)
 	layoutPath := path.Join(storePath, ocispecs.ImageLayoutFile)
 	return StoreIndex{
 		indexPath:  indexPath,

--- a/frontend/dockerfile/dockerfile_provenance_test.go
+++ b/frontend/dockerfile/dockerfile_provenance_test.go
@@ -925,7 +925,7 @@ EOF
 	require.NoError(t, err)
 
 	var index ocispecs.Index
-	dt, err := os.ReadFile(filepath.Join(ocidir, "index.json"))
+	dt, err := os.ReadFile(filepath.Join(ocidir, ocispecs.ImageIndexFile))
 	require.NoError(t, err)
 	err = json.Unmarshal(dt, &index)
 	require.NoError(t, err)

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -1311,13 +1311,13 @@ COPY Dockerfile .
 	require.NoError(t, err)
 
 	var idx ocispecs.Index
-	err = json.Unmarshal(m["index.json"].Data, &idx)
+	err = json.Unmarshal(m[ocispecs.ImageIndexFile].Data, &idx)
 	require.NoError(t, err)
 
 	mlistHex := idx.Manifests[0].Digest.Hex()
 
 	idx = ocispecs.Index{}
-	err = json.Unmarshal(m["blobs/sha256/"+mlistHex].Data, &idx)
+	err = json.Unmarshal(m[ocispecs.ImageBlobsDir+"/sha256/"+mlistHex].Data, &idx)
 	require.NoError(t, err)
 
 	require.Equal(t, 2, len(idx.Manifests))
@@ -1334,13 +1334,13 @@ COPY Dockerfile .
 			require.Equal(t, exp.p, platforms.Format(*idx.Manifests[i].Platform))
 
 			var mfst ocispecs.Manifest
-			err = json.Unmarshal(m["blobs/sha256/"+idx.Manifests[i].Digest.Hex()].Data, &mfst)
+			err = json.Unmarshal(m[ocispecs.ImageBlobsDir+"/sha256/"+idx.Manifests[i].Digest.Hex()].Data, &mfst)
 			require.NoError(t, err)
 
 			require.Equal(t, 1, len(mfst.Layers))
 
 			var img ocispecs.Image
-			err = json.Unmarshal(m["blobs/sha256/"+mfst.Config.Digest.Hex()].Data, &img)
+			err = json.Unmarshal(m[ocispecs.ImageBlobsDir+"/sha256/"+mfst.Config.Digest.Hex()].Data, &img)
 			require.NoError(t, err)
 
 			require.Equal(t, exp.entrypoint, img.Config.Entrypoint)
@@ -1437,13 +1437,13 @@ COPY arch-$TARGETARCH whoami
 	require.NoError(t, err)
 
 	var idx ocispecs.Index
-	err = json.Unmarshal(m["index.json"].Data, &idx)
+	err = json.Unmarshal(m[ocispecs.ImageIndexFile].Data, &idx)
 	require.NoError(t, err)
 
 	mlistHex := idx.Manifests[0].Digest.Hex()
 
 	idx = ocispecs.Index{}
-	err = json.Unmarshal(m["blobs/sha256/"+mlistHex].Data, &idx)
+	err = json.Unmarshal(m[ocispecs.ImageBlobsDir+"/sha256/"+mlistHex].Data, &idx)
 	require.NoError(t, err)
 
 	require.Equal(t, 3, len(idx.Manifests))
@@ -1462,17 +1462,17 @@ COPY arch-$TARGETARCH whoami
 			require.Equal(t, exp.p, platforms.Format(*idx.Manifests[i].Platform))
 
 			var mfst ocispecs.Manifest
-			err = json.Unmarshal(m["blobs/sha256/"+idx.Manifests[i].Digest.Hex()].Data, &mfst)
+			err = json.Unmarshal(m[ocispecs.ImageBlobsDir+"/sha256/"+idx.Manifests[i].Digest.Hex()].Data, &mfst)
 			require.NoError(t, err)
 
 			require.Equal(t, 1, len(mfst.Layers))
 
-			m2, err := testutil.ReadTarToMap(m["blobs/sha256/"+mfst.Layers[0].Digest.Hex()].Data, true)
+			m2, err := testutil.ReadTarToMap(m[ocispecs.ImageBlobsDir+"/sha256/"+mfst.Layers[0].Digest.Hex()].Data, true)
 			require.NoError(t, err)
 			require.Equal(t, exp.dt, string(m2["whoami"].Data))
 
 			var img ocispecs.Image
-			err = json.Unmarshal(m["blobs/sha256/"+mfst.Config.Digest.Hex()].Data, &img)
+			err = json.Unmarshal(m[ocispecs.ImageBlobsDir+"/sha256/"+mfst.Config.Digest.Hex()].Data, &img)
 			require.NoError(t, err)
 
 			require.Equal(t, exp.os, img.OS)
@@ -5628,7 +5628,7 @@ func testNamedOCILayoutContext(t *testing.T, sb integration.Sandbox) {
 	}
 
 	var index ocispecs.Index
-	err = json.Unmarshal(m["index.json"].Data, &index)
+	err = json.Unmarshal(m[ocispecs.ImageIndexFile].Data, &index)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(index.Manifests))
 	digest := index.Manifests[0].Digest.Hex()
@@ -5752,7 +5752,7 @@ ENV foo=bar
 	}
 
 	var index ocispecs.Index
-	err = json.Unmarshal(m["index.json"].Data, &index)
+	err = json.Unmarshal(m[ocispecs.ImageIndexFile].Data, &index)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(index.Manifests))
 	digest := index.Manifests[0].Digest.Hex()
@@ -5794,17 +5794,17 @@ FROM nonexistent AS base
 	m, err = testutil.ReadTarToMap(outW.Bytes(), false)
 	require.NoError(t, err)
 
-	err = json.Unmarshal(m["index.json"].Data, &index)
+	err = json.Unmarshal(m[ocispecs.ImageIndexFile].Data, &index)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(index.Manifests))
 	digest = index.Manifests[0].Digest.Hex()
 
 	var mfst ocispecs.Manifest
-	require.NoError(t, json.Unmarshal(m["blobs/sha256/"+digest].Data, &mfst))
+	require.NoError(t, json.Unmarshal(m[ocispecs.ImageBlobsDir+"/sha256/"+digest].Data, &mfst))
 	digest = mfst.Config.Digest.Hex()
 
 	var cfg ocispecs.Image
-	require.NoError(t, json.Unmarshal(m["blobs/sha256/"+digest].Data, &cfg))
+	require.NoError(t, json.Unmarshal(m[ocispecs.ImageBlobsDir+"/sha256/"+digest].Data, &cfg))
 
 	require.Equal(t, "/test", cfg.Config.WorkingDir)
 	require.Contains(t, cfg.Config.Env, "foo=bar")
@@ -6118,17 +6118,17 @@ COPY Dockerfile .
 	require.NoError(t, err)
 
 	var idx ocispecs.Index
-	err = json.Unmarshal(m["index.json"].Data, &idx)
+	err = json.Unmarshal(m[ocispecs.ImageIndexFile].Data, &idx)
 	require.NoError(t, err)
 
 	mlistHex := idx.Manifests[0].Digest.Hex()
 
 	var mfst ocispecs.Manifest
-	err = json.Unmarshal(m["blobs/sha256/"+mlistHex].Data, &mfst)
+	err = json.Unmarshal(m[ocispecs.ImageBlobsDir+"/sha256/"+mlistHex].Data, &mfst)
 	require.NoError(t, err)
 
 	var img ocispecs.Image
-	err = json.Unmarshal(m["blobs/sha256/"+mfst.Config.Digest.Hex()].Data, &img)
+	err = json.Unmarshal(m[ocispecs.ImageBlobsDir+"/sha256/"+mfst.Config.Digest.Hex()].Data, &img)
 	require.NoError(t, err)
 
 	require.Equal(t, tm.Unix(), img.Created.Unix())

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/moby/sys/signal v0.7.0
 	github.com/morikuni/aec v1.0.0
 	github.com/opencontainers/go-digest v1.0.0
-	github.com/opencontainers/image-spec v1.1.0-rc3
+	github.com/opencontainers/image-spec v1.1.0-rc5
 	github.com/opencontainers/runc v1.1.9
 	github.com/opencontainers/runtime-spec v1.1.0-rc.2
 	github.com/opencontainers/selinux v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -983,8 +983,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.0/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/opencontainers/image-spec v1.1.0-rc3 h1:fzg1mXZFj8YdPeNkRXMg+zb88BFV0Ys52cJydRwBkb8=
-github.com/opencontainers/image-spec v1.1.0-rc3/go.mod h1:X4pATf0uXsnn3g5aiGIsVnJBR4mxhKzfwmvK/B2NTm8=
+github.com/opencontainers/image-spec v1.1.0-rc5 h1:Ygwkfw9bpDvs+c9E34SdgGOj41dX/cbdlwvlWt0pnFI=
+github.com/opencontainers/image-spec v1.1.0-rc5/go.mod h1:X4pATf0uXsnn3g5aiGIsVnJBR4mxhKzfwmvK/B2NTm8=
 github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc10/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/annotations.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/annotations.go
@@ -59,10 +59,4 @@ const (
 
 	// AnnotationBaseImageName is the annotation key for the image reference of the image's base image.
 	AnnotationBaseImageName = "org.opencontainers.image.base.name"
-
-	// AnnotationArtifactCreated is the annotation key for the date and time on which the artifact was built, conforming to RFC 3339.
-	AnnotationArtifactCreated = "org.opencontainers.artifact.created"
-
-	// AnnotationArtifactDescription is the annotation key for the human readable description for the artifact.
-	AnnotationArtifactDescription = "org.opencontainers.artifact.description"
 )

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/descriptor.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/descriptor.go
@@ -21,7 +21,7 @@ import digest "github.com/opencontainers/go-digest"
 // when marshalled to JSON.
 type Descriptor struct {
 	// MediaType is the media type of the object this schema refers to.
-	MediaType string `json:"mediaType,omitempty"`
+	MediaType string `json:"mediaType"`
 
 	// Digest is the digest of the targeted content.
 	Digest digest.Digest `json:"digest"`
@@ -52,7 +52,7 @@ type Descriptor struct {
 // Platform describes the platform which the image in the manifest runs on.
 type Platform struct {
 	// Architecture field specifies the CPU architecture, for example
-	// `amd64` or `ppc64`.
+	// `amd64` or `ppc64le`.
 	Architecture string `json:"architecture"`
 
 	// OS specifies the operating system, for example `linux` or `windows`.
@@ -69,4 +69,12 @@ type Platform struct {
 	// Variant is an optional field specifying a variant of the CPU, for
 	// example `v7` to specify ARMv7 when architecture is `arm`.
 	Variant string `json:"variant,omitempty"`
+}
+
+// DescriptorEmptyJSON is the descriptor of a blob with content of `{}`.
+var DescriptorEmptyJSON = Descriptor{
+	MediaType: MediaTypeEmptyJSON,
+	Digest:    `sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`,
+	Size:      2,
+	Data:      []byte(`{}`),
 }

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/index.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/index.go
@@ -24,8 +24,14 @@ type Index struct {
 	// MediaType specifies the type of this document data structure e.g. `application/vnd.oci.image.index.v1+json`
 	MediaType string `json:"mediaType,omitempty"`
 
+	// ArtifactType specifies the IANA media type of artifact when the manifest is used for an artifact.
+	ArtifactType string `json:"artifactType,omitempty"`
+
 	// Manifests references platform specific manifests.
 	Manifests []Descriptor `json:"manifests"`
+
+	// Subject is an optional link from the image manifest to another manifest forming an association between the image manifest and the other manifest.
+	Subject *Descriptor `json:"subject,omitempty"`
 
 	// Annotations contains arbitrary metadata for the image index.
 	Annotations map[string]string `json:"annotations,omitempty"`

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/layout.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/layout.go
@@ -15,10 +15,14 @@
 package v1
 
 const (
-	// ImageLayoutFile is the file name of oci image layout file
+	// ImageLayoutFile is the file name containing ImageLayout in an OCI Image Layout
 	ImageLayoutFile = "oci-layout"
 	// ImageLayoutVersion is the version of ImageLayout
 	ImageLayoutVersion = "1.0.0"
+	// ImageIndexFile is the file name of the entry point for references and descriptors in an OCI Image Layout
+	ImageIndexFile = "index.json"
+	// ImageBlobsDir is the directory name containing content addressable blobs in an OCI Image Layout
+	ImageBlobsDir = "blobs"
 )
 
 // ImageLayout is the structure in the "oci-layout" file, found in the root

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/manifest.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/manifest.go
@@ -39,11 +39,3 @@ type Manifest struct {
 	// Annotations contains arbitrary metadata for the image manifest.
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
-
-// ScratchDescriptor is the descriptor of a blob with content of `{}`.
-var ScratchDescriptor = Descriptor{
-	MediaType: MediaTypeScratch,
-	Digest:    `sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`,
-	Size:      2,
-	Data:      []byte(`{}`),
-}

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/mediatype.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/mediatype.go
@@ -70,6 +70,6 @@ const (
 	// MediaTypeImageConfig specifies the media type for the image configuration.
 	MediaTypeImageConfig = "application/vnd.oci.image.config.v1+json"
 
-	// MediaTypeScratch specifies the media type for an unused blob containing the value `{}`
-	MediaTypeScratch = "application/vnd.oci.scratch.v1+json"
+	// MediaTypeEmptyJSON specifies the media type for an unused blob containing the value `{}`
+	MediaTypeEmptyJSON = "application/vnd.oci.empty.v1+json"
 )

--- a/vendor/github.com/opencontainers/image-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/version.go
@@ -25,7 +25,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc.3"
+	VersionDev = "-rc.5"
 )
 
 // Version is the specification version that the package types support.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -658,7 +658,7 @@ github.com/morikuni/aec
 # github.com/opencontainers/go-digest v1.0.0
 ## explicit; go 1.13
 github.com/opencontainers/go-digest
-# github.com/opencontainers/image-spec v1.1.0-rc3
+# github.com/opencontainers/image-spec v1.1.0-rc5
 ## explicit; go 1.18
 github.com/opencontainers/image-spec/identity
 github.com/opencontainers/image-spec/specs-go


### PR DESCRIPTION
Broken out of #4331 since the actual change there may not be the right solution, and landing this lets me rebase that PR down to the essentials before possibly archiving it.

Changes per https://github.com/opencontainers/image-spec/compare/v1.1.0-rc3...v1.1.0-rc5. None of the changes required corresponding changes in the BuildKit source.

I took the opportunity to replace a bunch of existing strings with newly-added constants from image-spec. (If this is a concern, it'd be trivial to drop or split into a different commit)

The original motivation for updating image-spec was to get access to `DescriptorEmptyJSON`, which was renamed from `ScratchDescriptor` and had its media type changed. BuildKit had no existing users of this value, or the related media types.

Also, some other small fixes in-passing:
* ~~Fix docs-upstream GitHub Action~~
* Correct package name for inline remote-cache source