### PR TITLE
Skip export of caches with no layers to OCI structures

### DIFF
--- a/cache/remotecache/export.go
+++ b/cache/remotecache/export.go
@@ -11,6 +11,7 @@ import (
 	v1 "github.com/moby/buildkit/cache/remotecache/v1"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/compression"
 	"github.com/moby/buildkit/util/contentutil"
 	"github.com/moby/buildkit/util/progress"
@@ -183,6 +184,11 @@ func (ce *contentCacheExporter) Finalize(ctx context.Context) (map[string]string
 	config, descs, err := ce.chains.Marshal(ctx)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(config.Layers) == 0 {
+		bklog.G(ctx).Warn("failed to match any cache with layers")
+		return nil, progress.OneOff(ctx, "skipping cache export for empty result")(nil)
 	}
 
 	cache, err := NewExportableCache(ce.oci, ce.imageManifest)


### PR DESCRIPTION
These happen when a container image is built using only metadata actions, and hence does not generate any filesystem changes.

Such a degenerate cache is not interesting, and some OCI registries reject OCI images with no layers.

Specifically, this only affects the `registry` and `local` exporters.

The `inline` exporter already early-outs in this case with the same warning, and the `gha`, `s3`, and `azblob` exporters are unchanged.

This should finally resolve the last vestiges of negative user experience in https://github.com/aws/containers-roadmap/issues/876.