### PR TITLE
Add Unikraft to the list of BuildKit users

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ BuildKit is used by the following projects:
 -   [envd](https://github.com/tensorchord/envd/)
 -   [Depot](https://depot.dev)
 -   [Namespace](https://namespace.so)
+-   [Unikraft](https://unikraft.org)
 
 ## Quick start
 


### PR DESCRIPTION
Unikraft enables users to build unikernels using BuildKit.

It allows builds to be decoupled from the dependencies on the underlying host machine.