### PR TITLE
Dockerfile: update containerd binary to v1.7.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile-upstream:master
 
 ARG RUNC_VERSION=v1.1.9
-ARG CONTAINERD_VERSION=v1.7.2
+ARG CONTAINERD_VERSION=v1.7.7
 # containerd v1.6 for integration tests
 ARG CONTAINERD_ALT_VERSION_16=v1.6.24
 ARG REGISTRY_VERSION=2.8.0


### PR DESCRIPTION
- relates to https://github.com/moby/buildkit/pull/4315

full diff: https://github.com/containerd/containerd/compare/v1.7.2...v1.7.7