### PR TITLE
[0.12] cherry-picks 0.12.3 take 2

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -25,7 +25,7 @@ env:
   SETUP_BUILDX_VERSION: "latest"
   SETUP_BUILDKIT_IMAGE: "moby/buildkit:latest"
   IMAGE_NAME: "moby/buildkit"
-  PLATFORMS: "linux/amd64,linux/arm/v7,linux/arm64,linux/s390x,linux/ppc64le,linux/riscv64"
+  PLATFORMS: "linux/amd64,linux/arm/v7,linux/arm64,linux/s390x,linux/ppc64le"
   DESTDIR: "./bin"
 
 jobs:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -23,7 +23,7 @@ env:
   SETUP_BUILDX_VERSION: "latest"
   SETUP_BUILDKIT_TAG: "moby/buildkit:latest"
   IMAGE_NAME: "docker/dockerfile-upstream"
-  PLATFORMS: "linux/386,linux/amd64,linux/arm/v7,linux/arm64,linux/mips,linux/mipsle,linux/mips64,linux/mips64le,linux/s390x,linux/ppc64le,linux/riscv64"
+  PLATFORMS: "linux/386,linux/amd64,linux/arm/v7,linux/arm64,linux/mips,linux/mipsle,linux/mips64,linux/mips64le,linux/s390x,linux/ppc64le"
 
 jobs:
   test:

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -56,7 +56,8 @@ target "binaries-cross" {
     "linux/arm64",
     "linux/s390x",
     "linux/ppc64le",
-    "linux/riscv64",
+    # TODO: enable back once https://github.com/moby/buildkit/issues/4316 is fixed
+    // "linux/riscv64",
     "windows/amd64",
     "windows/arm64"
   ]


### PR DESCRIPTION
backports of:
* https://github.com/moby/buildkit/pull/4344
