### PR TITLE
solver: fix printing progress messages after merged edges

### DIFF
--- a/util/progress/multiwriter.go
+++ b/util/progress/multiwriter.go
@@ -18,6 +18,8 @@ type MultiWriter struct {
 	meta    map[string]interface{}
 }
 
+var _ rawProgressWriter = &MultiWriter{}
+
 func NewMultiWriter(opts ...WriterOption) *MultiWriter {
 	mw := &MultiWriter{
 		writers: map[rawProgressWriter]struct{}{},


### PR DESCRIPTION
fixes #4330

~depends on #4285~

When different LLB vertexes (eg. parallel requests referencing
local sources from different sessions) generate the same cache keys
during solve, they are merged together into a single operation.

Currently, when this happened, the progress for the vertex that
was dropped got lost. This fixes this case by adding the
progressWriter of the redirected vertex as a target to the
source one.

This should also work with multiple levels of merged edges,
just multiple nested multiwriters as well.

