### PR TITLE
[0.12 backport] fix riscv64 build

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -25,7 +25,7 @@ env:
   SETUP_BUILDX_VERSION: "latest"
   SETUP_BUILDKIT_IMAGE: "moby/buildkit:latest"
   IMAGE_NAME: "moby/buildkit"
-  PLATFORMS: "linux/amd64,linux/arm/v7,linux/arm64,linux/s390x,linux/ppc64le"
+  PLATFORMS: "linux/amd64,linux/arm/v7,linux/arm64,linux/s390x,linux/ppc64le,linux/riscv64"
   DESTDIR: "./bin"
 
 jobs:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -23,7 +23,7 @@ env:
   SETUP_BUILDX_VERSION: "latest"
   SETUP_BUILDKIT_TAG: "moby/buildkit:latest"
   IMAGE_NAME: "docker/dockerfile-upstream"
-  PLATFORMS: "linux/386,linux/amd64,linux/arm/v7,linux/arm64,linux/mips,linux/mipsle,linux/mips64,linux/mips64le,linux/s390x,linux/ppc64le"
+  PLATFORMS: "linux/386,linux/amd64,linux/arm/v7,linux/arm64,linux/mips,linux/mipsle,linux/mips64,linux/mips64le,linux/s390x,linux/ppc64le,linux/riscv64"
 
 jobs:
   test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ ARG GOTESTSUM_VERSION=v1.9.0
 
 ARG GO_VERSION=1.20
 ARG ALPINE_VERSION=3.18
+ARG XX_VERSION=1.3.0
 
 # minio for s3 integration tests
 FROM minio/minio:${MINIO_VERSION} AS minio
@@ -34,7 +35,7 @@ FROM alpine:edge@sha256:2d01a16bab53a8405876cec4c27235d47455a7b72b75334c614f2fb0
 FROM alpine-$TARGETARCH AS alpinebase
 
 # xx is a helper for cross-compilation
-FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.2.1 AS xx
+FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
 
 # go base image
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS golatest

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -56,8 +56,7 @@ target "binaries-cross" {
     "linux/arm64",
     "linux/s390x",
     "linux/ppc64le",
-    # TODO: enable back once https://github.com/moby/buildkit/issues/4316 is fixed
-    // "linux/riscv64",
+    "linux/riscv64",
     "windows/amd64",
     "windows/arm64"
   ]


### PR DESCRIPTION
backport of:
* https://github.com/moby/buildkit/pull/4348