### PR TITLE
cache: fix cache leak

### DIFF
--- a/cache/manager.go
+++ b/cache/manager.go
@@ -322,6 +322,7 @@ func (cm *cacheManager) init(ctx context.Context) error {
 			bklog.G(ctx).Debugf("could not load snapshot %s: %+v", si.ID(), err)
 			cm.MetadataStore.Clear(si.ID())
 			cm.LeaseManager.Delete(ctx, leases.Lease{ID: si.ID()})
+			cm.LeaseManager.Delete(ctx, leases.Lease{ID: si.ID() + "-variants"})
 		}
 	}
 	return nil


### PR DESCRIPTION
After loading snapshot failed  in the func init(), the compression variants lease was not cleaned, resulting in cache data not being garbage collected；

After run `buildctl prune --all`，there are still hundreds of GB of data remaining in the  /var/lib/buildkit/runc-overlayfs/content/blobs/sha256/ directory；

the error info：
level=debug msg="could not load snapshot zy9eqBpcso79doeajneev8iii: not found\n..."

Signed-off-by: fanjiyun.fjy <fanjiyun.fjy@alibaba-inc.com>
