### PR TITLE
dockerfile: smoke tests for binaries

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -29,30 +29,6 @@ env:
   DESTDIR: "./bin"
 
 jobs:
-  test:
-    uses: ./.github/workflows/.test.yml
-    with:
-      cache_scope: build-integration-tests
-      pkgs: ./client ./cmd/buildctl ./worker/containerd ./solver ./frontend
-      kinds: integration
-      codecov_flags: core
-      includes: |
-        - pkg: ./...
-          skip-integration-tests: 1
-          typ: integration gateway
-        - pkg: ./client
-          worker: containerd
-          tags: nydus
-          typ: integration
-        - pkg: ./client
-          worker: oci
-          tags: nydus
-          typ: integration
-        - pkg: ./...
-          tags: nydus
-          skip-integration-tests: 1
-          typ: integration
-
   prepare:
     runs-on: ubuntu-22.04
     outputs:
@@ -134,6 +110,32 @@ jobs:
           name: buildkit
           path: ${{ env.DESTDIR }}/*
           if-no-files-found: error
+
+  test:
+    uses: ./.github/workflows/.test.yml
+    needs:
+      - binaries
+    with:
+      cache_scope: build-integration-tests
+      pkgs: ./client ./cmd/buildctl ./worker/containerd ./solver ./frontend
+      kinds: integration
+      codecov_flags: core
+      includes: |
+        - pkg: ./...
+          skip-integration-tests: 1
+          typ: integration gateway
+        - pkg: ./client
+          worker: containerd
+          tags: nydus
+          typ: integration
+        - pkg: ./client
+          worker: oci
+          tags: nydus
+          typ: integration
+        - pkg: ./...
+          tags: nydus
+          skip-integration-tests: 1
+          typ: integration
 
   image:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
follow-up https://github.com/moby/buildkit/pull/4356#issuecomment-1772463447

Our pipeline run tests regardless if binaries are broken. This adds smoke test to built binaries (runc, buildctl, buildkitd) and also makes test job depends on binaries one so we avoid unnecessary build queues.