### PR TITLE
buildkitd: fix debug handler listener

### DIFF
--- a/cmd/buildkitd/debug.go
+++ b/cmd/buildkitd/debug.go
@@ -43,6 +43,10 @@ func setupDebugHandlers(addr string) error {
 		ReadHeaderTimeout: time.Minute,
 	}
 	bklog.L.Debugf("debug handlers listening at %s", addr)
-	go server.ListenAndServe()
+	go func() {
+		if err := server.Serve(l); err != nil {
+			bklog.L.Errorf("failed to serve debug handlers: %v", err)
+		}
+	}()
 	return nil
 }


### PR DESCRIPTION
The debug address handler was not serving because of the double listen. Regression from https://github.com/moby/buildkit/pull/3650/files#diff-6e528092fd700dc985cf83b9fe8ae2bed31a01bb8abfabf9c3d3a9007407a5bd