### PR TITLE
llbsolver: fix possible deadlock in history listen

### DIFF
--- a/solver/llbsolver/history.go
+++ b/solver/llbsolver/history.go
@@ -762,6 +762,9 @@ func (h *HistoryQueue) Listen(ctx context.Context, req *controlapi.BuildHistoryR
 		}()
 	}
 
+	// make a copy of events for active builds so we don't keep a lock during grpc send
+	actives := make([]*controlapi.BuildHistoryEvent, 0, len(h.active))
+
 	for _, e := range h.active {
 		if req.Ref != "" && e.Ref != req.Ref {
 			continue
@@ -769,13 +772,19 @@ func (h *HistoryQueue) Listen(ctx context.Context, req *controlapi.BuildHistoryR
 		if _, ok := h.deleted[e.Ref]; ok {
 			continue
 		}
-		sub.send(&controlapi.BuildHistoryEvent{
+		actives = append(actives, &controlapi.BuildHistoryEvent{
 			Type:   controlapi.BuildHistoryEventType_STARTED,
 			Record: e,
 		})
 	}
 
 	h.mu.Unlock()
+
+	for _, e := range actives {
+		if err := f(e); err != nil {
+			return err
+		}
+	}
 
 	if !req.ActiveOnly {
 		events := []*controlapi.BuildHistoryEvent{}


### PR DESCRIPTION
The events for currently active builds were sent through pubsub channel instead of directly to the current request, like it was done for completed builds for example.

This meant that if there were more active builds running than the pubsub channel buffer (32), the sends will block. Because the history API mutex is held in this process, it will eventually block the requests for builds that try to update their history records.