### PR TITLE
ci(test-os): increase vm boot time to 15m

### DIFF
--- a/hack/Vagrantfile.freebsd13
+++ b/hack/Vagrantfile.freebsd13
@@ -6,7 +6,7 @@ Vagrant.configure("2") do |config|
     fbsd_13_2.vm.box = "freebsd/FreeBSD-13.2-RELEASE"
   end
 
-  config.vm.boot_timeout = 600
+  config.vm.boot_timeout = 900
   config.vm.synced_folder ".", "/vagrant", type: "rsync"
 
   config.vm.provision "init", type: "shell", run: "once" do |sh|


### PR DESCRIPTION
Related to https://github.com/moby/buildkit/actions/runs/6593087661/job/17915050926?pr=4362#step:5:48

![image](https://github.com/moby/buildkit/assets/1951866/bf74d343-4b13-4faf-bd4e-1db624c56348)

Same as https://github.com/moby/buildkit/pull/4235. Hopefully this is enough now.