### PR TITLE
Refactor NewWorkerOpt function so it accepts a pre-created containerd client

### DIFF
--- a/cmd/buildkitd/main_containerd_worker.go
+++ b/cmd/buildkitd/main_containerd_worker.go
@@ -321,7 +321,13 @@ func containerdWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([
 			Options: opts,
 		}
 	}
-	opt, err := containerd.NewWorkerOpt(common.config.Root, cfg.Address, snapshotter, cfg.Namespace, cfg.Rootless, cfg.Labels, dns, nc, common.config.Workers.Containerd.ApparmorProfile, common.config.Workers.Containerd.SELinux, parallelismSem, common.traceSocket, runtime, ctd.WithTimeout(60*time.Second))
+
+	client, err := ctd.New(cfg.Address, ctd.WithTimeout(60*time.Second), ctd.WithDefaultNamespace(cfg.Namespace))
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to connect client to %q . make sure containerd is running", cfg.Address)
+	}
+
+	opt, err := containerd.NewWorkerOpt(common.config.Root, client, snapshotter, cfg.Rootless, cfg.Labels, dns, nc, common.config.Workers.Containerd.ApparmorProfile, common.config.Workers.Containerd.SELinux, parallelismSem, common.traceSocket, runtime)
 	if err != nil {
 		return nil, err
 	}

--- a/worker/containerd/containerd_test.go
+++ b/worker/containerd/containerd_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/containerd/containerd"
 	"github.com/moby/buildkit/util/network/netproviders"
 	"github.com/moby/buildkit/util/testutil/integration"
 	"github.com/moby/buildkit/util/testutil/workers"
@@ -31,8 +32,10 @@ func TestContainerdWorkerIntegration(t *testing.T) {
 
 func newWorkerOpt(t *testing.T, addr string) base.WorkerOpt {
 	tmpdir := t.TempDir()
+	client, err := containerd.New(addr, containerd.WithDefaultNamespace("buildkit-test"))
+	require.NoError(t, err)
 	rootless := false
-	workerOpt, err := NewWorkerOpt(tmpdir, addr, "overlayfs", "buildkit-test", rootless, nil, nil, netproviders.Opt{Mode: "host"}, "", false, nil, "", nil)
+	workerOpt, err := NewWorkerOpt(tmpdir, client, "overlayfs", rootless, nil, nil, netproviders.Opt{Mode: "host"}, "", false, nil, "", nil)
 	require.NoError(t, err)
 	return workerOpt
 }


### PR DESCRIPTION
This gives calling side more flexibility and allows to avoid creation of redundant client in Moby.