### PR TITLE
Readme: Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Join `#buildkit` channel on [Docker Community Slack](https://dockr.ly/comm-slack
 > **Note**
 >
 > If you are visiting this repo for the usage of BuildKit-only Dockerfile features
-> like `RUN --mount=type=(bind|cache|tmpfs|secret|ssh)`, please refer to [`frontend/dockerfile/docs/reference.md`](frontend/dockerfile/docs/reference.md)
+> like `RUN --mount=type=(bind|cache|tmpfs|secret|ssh)`, please refer to [`frontend/dockerfile/docs/reference.md`](./frontend/dockerfile/docs/reference.md)
 
 > **Note**
 >


### PR DESCRIPTION
The link of `BuildKit-only Dockerfile features` is broken if viewing from the [repo homepage](https://github.com/moby/buildkit). This PR fixes this issue.