### PR TITLE
ci(test-os): fix freebsd job

### DIFF
--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -116,7 +116,7 @@ jobs:
           retention-days: 1
 
   test-freebsd-amd64:
-    runs-on: macos-12
+    runs-on: macos-13
     needs:
       - build-freebsd-amd64
     env:
@@ -140,6 +140,19 @@ jobs:
           key: ${{ runner.os }}-vagrant-${{ hashFiles('hack/Vagrantfile.freebsd13') }}
           restore-keys: |
             ${{ runner.os }}-vagrant-
+      -
+        name: Install vagrant and VirtualBox
+        run: |
+          set -x
+          brew tap hashicorp/tap
+          brew install hashicorp/tap/hashicorp-vagrant
+          brew install --cask virtualbox
+      -
+        name: Check versions
+        run: |
+          set -x
+          vagrant --version
+          VBoxManage -v
       -
         name: Set up vagrant
         run: |


### PR DESCRIPTION
follow-up https://github.com/moby/buildkit/pull/4368#issuecomment-1779186247

Switch to `macos-13` runner which looks reliable after several runs. Vagrant and VirtualBox are not pre-installed on this runner so needs an extra step to install them.