### PR TITLE
fix usage loss for snapshots with labels in MergeSnapshotter

### DIFF
--- a/snapshot/merge.go
+++ b/snapshot/merge.go
@@ -185,12 +185,14 @@ func mergeUsageOf(info snapshots.Info) (usage snapshots.Usage, ok bool, rerr err
 	if info.Labels == nil {
 		return snapshots.Usage{}, false, nil
 	}
+	hasMergeUsageLabel := false
 	if str, ok := info.Labels[mergeUsageSizeLabel]; ok {
 		i, err := strconv.Atoi(str)
 		if err != nil {
 			return snapshots.Usage{}, false, err
 		}
 		usage.Size = int64(i)
+		hasMergeUsageLabel = true
 	}
 	if str, ok := info.Labels[mergeUsageInodesLabel]; ok {
 		i, err := strconv.Atoi(str)
@@ -198,6 +200,10 @@ func mergeUsageOf(info snapshots.Info) (usage snapshots.Usage, ok bool, rerr err
 			return snapshots.Usage{}, false, err
 		}
 		usage.Inodes = int64(i)
+		hasMergeUsageLabel = true
+	}
+	if !hasMergeUsageLabel {
+		return snapshots.Usage{}, false, nil
 	}
 	return usage, true, nil
 }


### PR DESCRIPTION
In mergeSnapshotter.Usage(), if a snapshot Stat returned labels that are unrelated to MergeUsage, the actual Usage() was not called, and it returned empty usage.
So add relevant conditions in mergeUsageOf() to ensure that Usage() is called if the labels are unrelated to mergeUsage.