### PR TITLE
frontend/dockerfile/dockerfile2llb: errmsg: quote build target

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -317,7 +317,7 @@ func toDispatchState(ctx context.Context, dt []byte, opt ConvertOpt) (*dispatchS
 		var ok bool
 		target, ok = allDispatchStates.findStateByName(opt.Target)
 		if !ok {
-			return nil, errors.Errorf("target stage %s could not be found", opt.Target)
+			return nil, errors.Errorf("target stage %q could not be found", opt.Target)
 		}
 	}
 


### PR DESCRIPTION
Hi,
The build target is not quoted and it makes it difficult for some persons to see what the problem is.

By quoting it we emphasize that the target name is variable.

Related to https://github.com/moby/moby/pull/46754

Thanks and cheers !