### PR TITLE
docs: retarget dockerfile reference link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Join `#buildkit` channel on [Docker Community Slack](https://dockr.ly/comm-slack
 > **Note**
 >
 > If you are visiting this repo for the usage of BuildKit-only Dockerfile features
-> like `RUN --mount=type=(bind|cache|tmpfs|secret|ssh)`, please refer to [`frontend/dockerfile/docs/reference.md`](./frontend/dockerfile/docs/reference.md)
+> like `RUN --mount=type=(bind|cache|tmpfs|secret|ssh)`, please refer to the
+> [Dockerfile reference](https://docs.docker.com/engine/reference/builder/).
 
 > **Note**
 >


### PR DESCRIPTION
Follow-up https://github.com/moby/buildkit/pull/4369, fixes https://github.com/moby/buildkit/issues/4140.

For users looking for Dockerfile-only features, it feels reasonable to just point people to the docker docs, instead of using a relative link.

Relative links in NOTE blocks still look broken, but it doesn't seem apparent that GitHub will fix it anytime soon :cry: