### PR TITLE
git: add missing RedactCredentials call in cache description

### DIFF
--- a/source/git/source.go
+++ b/source/git/source.go
@@ -468,7 +468,7 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context, g session.Group) (out 
 		}
 	}
 
-	checkoutRef, err := gs.cache.New(ctx, nil, g, cache.WithRecordType(client.UsageRecordTypeGitCheckout), cache.WithDescription(fmt.Sprintf("git snapshot for %s#%s", gs.src.Remote, ref)))
+	checkoutRef, err := gs.cache.New(ctx, nil, g, cache.WithRecordType(client.UsageRecordTypeGitCheckout), cache.WithDescription(fmt.Sprintf("git snapshot for %s#%s", urlutil.RedactCredentials(gs.src.Remote), ref)))
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create new mutable for %s", urlutil.RedactCredentials(gs.src.Remote))
 	}


### PR DESCRIPTION
It's possible for a git url to contain encoded credentials - even though this practice is not recommended. For safety, we attempt to censor the credentials before putting them into cache descriptions and error messages.

However, we were previously missing one of these, and we would put an uncensored git url into the git checkout snapshot cache ref description.

I've manually checked all other usages of `gs.Src.Remote`, and it looks like this is the only case of `urlutil.RedactCredentials` missing.