### PR TITLE
containerd: support custom shim path 

### DIFF
--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -131,6 +131,7 @@ type ContainerdConfig struct {
 
 type ContainerdRuntime struct {
 	Name    string                 `toml:"name"`
+	Path    string                 `toml:"path"`
 	Options map[string]interface{} `toml:"options"`
 }
 

--- a/cmd/buildkitd/config/load_test.go
+++ b/cmd/buildkitd/config/load_test.go
@@ -44,6 +44,7 @@ platforms=["linux/amd64"]
 address="containerd.sock"
 [worker.containerd.runtime]
 name="exotic"
+path="/usr/bin/exotic"
 options.foo="bar"
 [[worker.containerd.gcpolicy]]
 all=true
@@ -107,6 +108,7 @@ searchDomains=["example.com"]
 	require.Equal(t, 0, len(cfg.Workers.OCI.GCPolicy))
 	require.Equal(t, "non-default", cfg.Workers.Containerd.Namespace)
 	require.Equal(t, "exotic", cfg.Workers.Containerd.Runtime.Name)
+	require.Equal(t, "/usr/bin/exotic", cfg.Workers.Containerd.Runtime.Path)
 	require.Equal(t, "bar", cfg.Workers.Containerd.Runtime.Options["foo"])
 	require.Equal(t, 3, len(cfg.Workers.Containerd.GCPolicy))
 

--- a/cmd/buildkitd/main_containerd_worker.go
+++ b/cmd/buildkitd/main_containerd_worker.go
@@ -322,6 +322,7 @@ func containerdWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([
 
 		runtime = &containerd.RuntimeInfo{
 			Name:    cfg.Runtime.Name,
+			Path:    cfg.Runtime.Path,
 			Options: opts,
 		}
 	}

--- a/docs/buildkitd.toml.md
+++ b/docs/buildkitd.toml.md
@@ -109,6 +109,7 @@ insecure-entitlements = [ "network.host", "security.insecure" ]
   # configure the containerd runtime
   [worker.containerd.runtime]
     name = "io.containerd.runc.v2"
+    path = "/path/to/containerd/runc/shim"
     options = { BinaryName = "runc" }
 
   [[worker.containerd.gcpolicy]]

--- a/executor/containerdexecutor/executor.go
+++ b/executor/containerdexecutor/executor.go
@@ -179,8 +179,7 @@ func (w *containerdExecutor) Run(ctx context.Context, id string, root executor.M
 	if err != nil {
 		return nil, err
 	}
-
-	task, err := container.NewTask(ctx, cio.NewCreator(cioOpts...), taskOpts)
+	task, err := container.NewTask(ctx, cio.NewCreator(cioOpts...), taskOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/executor/containerdexecutor/executor.go
+++ b/executor/containerdexecutor/executor.go
@@ -56,6 +56,7 @@ type OnCreateRuntimer interface {
 
 type RuntimeInfo struct {
 	Name    string
+	Path    string
 	Options any
 }
 
@@ -178,6 +179,9 @@ func (w *containerdExecutor) Run(ctx context.Context, id string, root executor.M
 	taskOpts, err := details.getTaskOpts()
 	if err != nil {
 		return nil, err
+	}
+	if w.runtime != nil && w.runtime.Path != "" {
+		taskOpts = append(taskOpts, containerd.WithRuntimePath(w.runtime.Path))
 	}
 	task, err := container.NewTask(ctx, cio.NewCreator(cioOpts...), taskOpts...)
 	if err != nil {

--- a/executor/containerdexecutor/executor_unix.go
+++ b/executor/containerdexecutor/executor_unix.go
@@ -161,7 +161,7 @@ func (w *containerdExecutor) createOCISpec(ctx context.Context, id, resolvConf, 
 	return spec, releaseAll, nil
 }
 
-func (d *containerState) getTaskOpts() (containerd.NewTaskOpts, error) {
+func (d *containerState) getTaskOpts() ([]containerd.NewTaskOpts, error) {
 	rootfs := containerd.WithRootFS([]mount.Mount{{
 		Source:  d.rootfsPath,
 		Type:    "bind",
@@ -174,7 +174,7 @@ func (d *containerState) getTaskOpts() (containerd.NewTaskOpts, error) {
 			Options: []string{},
 		}})
 	}
-	return rootfs, nil
+	return []containerd.NewTaskOpts{rootfs}, nil
 }
 
 func setArgs(spec *specs.Process, args []string) {

--- a/executor/containerdexecutor/executor_windows.go
+++ b/executor/containerdexecutor/executor_windows.go
@@ -96,8 +96,8 @@ func (w *containerdExecutor) createOCISpec(ctx context.Context, id, resolvConf, 
 	return spec, releaseAll, nil
 }
 
-func (d *containerState) getTaskOpts() (containerd.NewTaskOpts, error) {
-	return containerd.WithRootFS(d.rootMounts), nil
+func (d *containerState) getTaskOpts() ([]containerd.NewTaskOpts, error) {
+	return []containerd.NewTaskOpts{containerd.WithRootFS(d.rootMounts)}, nil
 }
 
 func setArgs(spec *specs.Process, args []string) {


### PR DESCRIPTION
Follow-up to https://github.com/moby/buildkit/pull/4279

[Like CRI](https://github.com/containerd/containerd/blob/de55dfc0f184aa6ed19de4dc02a3a4bae3476c88/pkg/cri/config/config.go#L46-L49), we should support custom shim paths. We can just add this as a new config field `path` under the runtime object.

While `name` can be either the name of a custom shim (from which a path is derived), or a path itself, if configured as a path, no options can be provided - this is because to derive the type for the options struct, we need the name to be a member of a well-known set ([currently runc and hcs](https://github.com/moby/buildkit/blob/25e9aa8d396f706a6f1e7d6c98ae578574669b8f/cmd/buildkitd/main_containerd_worker.go#L374-L384)).

With this patch, it's now possible to configure a runtime with a custom shim at a non-default path, and include it's options (which was previously not possible to do in buildkit).
