### PR TITLE
ci(test-os): enable SSH keep alive in vagrant vm

### DIFF
--- a/hack/Vagrantfile.freebsd13
+++ b/hack/Vagrantfile.freebsd13
@@ -8,6 +8,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.boot_timeout = 900
   config.vm.synced_folder ".", "/vagrant", type: "rsync"
+  config.ssh.keep_alive = true
 
   config.vm.provision "init", type: "shell", run: "once" do |sh|
     sh.inline = <<~SHELL


### PR DESCRIPTION
related to https://github.com/moby/buildkit/actions/runs/6811552818/job/18522186374#step:8:27

![image](https://github.com/moby/buildkit/assets/1951866/ce0184b2-ff84-4b59-b372-d6a203182f89)
