### PR TITLE
Failures to find buildkit-qemu-$arch are not properly reported

### DIFF
--- a/solver/llbsolver/ops/exec_binfmt.go
+++ b/solver/llbsolver/ops/exec_binfmt.go
@@ -13,7 +13,6 @@ import (
 	"github.com/moby/buildkit/snapshot"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/archutil"
-	"github.com/moby/buildkit/util/bklog"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	copy "github.com/tonistiigi/fsutil/copy"
@@ -120,8 +119,8 @@ func getEmulator(ctx context.Context, p *pb.Platform, idmap *idtools.IdentityMap
 
 	fn, err := exec.LookPath("buildkit-qemu-" + a)
 	if err != nil {
-		bklog.G(ctx).Warn(err.Error()) // TODO: remove this with pull support
-		return nil, nil                // no emulator available
+		// Pass this FileNotFound" error back up the stack as emulation will not be possible
+		return nil, err
 	}
 
 	return &emulator{path: fn}, nil


### PR DESCRIPTION
When the buildkit binaries are not available on the host, the docker build log only contains a cryptic `0.252 exec /bin/sh: exec format error` or similar.  The only way to learn about the problem is by inspecting the journalctl logs and seeing `msg="exec: \"buildkit-qemu-arm\": executable file not found in $PATH"`.  This change should more directly percolate the error up the stack.