### PR TITLE
docs: Fix formatting for warning callouts

### DIFF
--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -707,7 +707,7 @@ The command is run in the host's network environment (similar to
 > which needs to be enabled when starting the buildkitd daemon with
 > `--allow-insecure-entitlement network.host` flag or in [buildkitd config](https://github.com/moby/buildkit/blob/master/docs/buildkitd.toml.md),
 > and for a build request with [`--allow network.host` flag](https://docs.docker.com/engine/reference/commandline/buildx_build/#allow).
-{:.warning}
+{ .warning }
 
 ## RUN --security
 
@@ -727,7 +727,7 @@ This is equivalent to running `docker run --privileged`.
 > enabled when starting the buildkitd daemon with
 > `--allow-insecure-entitlement security.insecure` flag or in [buildkitd config](https://github.com/moby/buildkit/blob/master/docs/buildkitd.toml.md),
 > and for a build request with [`--allow security.insecure` flag](https://docs.docker.com/engine/reference/commandline/buildx_build/#allow).
-{:.warning}
+{ .warning }
 
 #### Example: check entitlements
 
@@ -1958,7 +1958,7 @@ ARG buildno
 > 
 > Refer to the [`RUN --mount=type=secret`](#run---mounttypesecret) section to
 > learn about secure ways to use secrets when building images.
-{:.warning}
+{ .warning }
 
 ### Default values
 


### PR DESCRIPTION
In the Dockerfile reference ([1](https://docs.docker.com/engine/reference/builder/#run---networkhost), [2](https://docs.docker.com/engine/reference/builder/#run---securityinsecure), [3](https://docs.docker.com/engine/reference/builder/#arg)), the warning callouts were not rendered as intended, as shown in the picture below. Note the background color, the "i" icon and the trailing class attribute (`{:.warning}`):

![The screenshot of an incorrectly rendered warning callout. The background color is blue, the title has "i" icon and there is a trailing class attribute](https://github.com/moby/buildkit/assets/59369226/4673d324-8161-4121-a636-bd964026bc73)

Here is how they should appear instead (content not relevant to the issue):

![The screenshot of a correctly rendered warning callout. The background color is red, the title has "X" icon and there is no trailing directive](https://github.com/moby/buildkit/assets/59369226/34d02a90-6148-4390-95d5-929a8f052c2d)

The PR updates the class attribute to match [the Formatting Guide](https://docs.docker.com/contribute/components/call-outs/).