### PR TITLE
buildctl: Add insecure config for registry-auth-tlscontext flag

### DIFF
--- a/cmd/buildctl/build.go
+++ b/cmd/buildctl/build.go
@@ -107,7 +107,7 @@ var buildCommand = cli.Command{
 		},
 		cli.StringSliceFlag{
 			Name:  "registry-auth-tlscontext",
-			Usage: "Overwrite TLS configuration when authenticating with registries, e.g. --registry-auth-tlscontext host=https://myserver:2376,ca=/path/to/my/ca.crt,cert=/path/to/my/cert.crt,key=/path/to/my/key.crt",
+			Usage: "Overwrite TLS configuration when authenticating with registries, e.g. --registry-auth-tlscontext host=https://myserver:2376,insecure=false,ca=/path/to/my/ca.crt,cert=/path/to/my/cert.crt,key=/path/to/my/key.crt",
 		},
 	},
 }

--- a/docs/reference/buildctl.md
+++ b/docs/reference/buildctl.md
@@ -78,7 +78,7 @@ OPTIONS:
    --metadata-file value             Output build metadata (e.g., image digest) to a file as JSON
    --source-policy-file value        Read source policy file from a JSON file
    --ref-file value                  Write build ref to a file
-   --registry-auth-tlscontext value  Overwrite TLS configuration when authenticating with registries, e.g. --registry-auth-tlscontext host=https://myserver:2376,ca=/path/to/my/ca.crt,cert=/path/to/my/cert.crt,key=/path/to/my/key.crt
+   --registry-auth-tlscontext value  Overwrite TLS configuration when authenticating with registries, e.g. --registry-auth-tlscontext host=https://myserver:2376,insecure=false,ca=/path/to/my/ca.crt,cert=/path/to/my/cert.crt,key=/path/to/my/key.crt
    
 ```
 <!---GENERATE_END-->

--- a/session/auth/authprovider/authconfig.go
+++ b/session/auth/authprovider/authconfig.go
@@ -2,6 +2,7 @@ package authprovider
 
 type AuthTLSConfig struct {
 	RootCAs  []string
+	Insecure bool
 	KeyPairs []TLSKeyPair
 }
 

--- a/session/auth/authprovider/authprovider.go
+++ b/session/auth/authprovider/authprovider.go
@@ -178,6 +178,9 @@ func (ap *authProvider) tlsConfig(host string) (*tls.Config, error) {
 		}
 		tc.Certificates = append(tc.Certificates, cert)
 	}
+	if c.Insecure {
+		tc.InsecureSkipVerify = true
+	}
 	return tc, nil
 }
 


### PR DESCRIPTION
### What this PR does / why we need it:

push image to self-signed certificate registry will throw `failed to authorize: failed to fetch oauth token: Post \"https://harbor/service/token\": tls: failed to verify certificate: x509: certificate signed by unknown authority` .

I have to provide the certificate using the`--registry-auth-tlscontext` flag.  But in most usage scenarios, I cannot provide the certificate file. 

### Additional usage docs, etc.:

when i build and push image to self-signed harbor `harbor-registry.com`， and not provide cert

`buildctl build --frontend dockerfile.v0 -local context=. -local dockerfile=./ --opt  filename=Dockerfile --opt platform="linux/amd64" --output type=image,name=harbor-registry.com/demo/demo:latest,push=true,registry.insecure=true --registry-auth-tlscontext host=harbor-registry.com,insecure=true`