### PR TITLE
docs: refresh dockerfile frontend reference

### DIFF
--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -1,13 +1,13 @@
 # Dockerfile reference
 
 Docker can build images automatically by reading the instructions from a
-`Dockerfile`. A `Dockerfile` is a text document that contains all the commands a
+Dockerfile. A Dockerfile is a text document that contains all the commands a
 user could call on the command line to assemble an image. This page describes
-the commands you can use in a `Dockerfile`.
+the commands you can use in a Dockerfile.
 
 ## Format
 
-Here is the format of the `Dockerfile`:
+Here is the format of the Dockerfile:
 
 ```dockerfile
 # Comment
@@ -17,15 +17,15 @@ INSTRUCTION arguments
 The instruction is not case-sensitive. However, convention is for them to
 be UPPERCASE to distinguish them from arguments more easily.
 
-Docker runs instructions in a `Dockerfile` in order. A `Dockerfile` **must
+Docker runs instructions in a Dockerfile in order. A Dockerfile **must
 begin with a `FROM` instruction**. This may be after [parser
 directives](#parser-directives), [comments](#format), and globally scoped
-[ARGs](#arg). The `FROM` instruction specifies the [*Parent
-Image*](https://docs.docker.com/glossary/#parent-image) from which you are
+[ARGs](#arg). The `FROM` instruction specifies the [parent
+image](https://docs.docker.com/glossary/#parent-image) from which you are
 building. `FROM` may only be preceded by one or more `ARG` instructions, which
-declare arguments that are used in `FROM` lines in the `Dockerfile`.
+declare arguments that are used in `FROM` lines in the Dockerfile.
 
-Docker treats lines that *begin* with `#` as a comment, unless the line is
+BuildKit treats lines that begin with `#` as a comment, unless the line is
 a valid [parser directive](#parser-directives). A `#` marker anywhere
 else in a line is treated as an argument. This allows statements like:
 
@@ -34,9 +34,9 @@ else in a line is treated as an argument. This allows statements like:
 RUN echo 'we are running some # of cool things'
 ```
 
-Comment lines are removed before the Dockerfile instructions are executed, which
-means that the comment in the following example is not handled by the shell
-executing the `echo` command, and both examples below are equivalent:
+Comment lines are removed before the Dockerfile instructions are executed.
+The comment in the following example is removed before the shell executes
+the `echo` command.
 
 ```dockerfile
 RUN echo hello \
@@ -44,12 +44,14 @@ RUN echo hello \
 world
 ```
 
+The following examples is equivalent.
+
 ```dockerfile
 RUN echo hello \
 world
 ```
 
-Line continuation characters are not supported in comments.
+Comments don't support line continuation characters.
 
 > **Note on whitespace**
 >
@@ -63,15 +65,15 @@ Line continuation characters are not supported in comments.
 >     RUN echo hello
 > RUN echo world
 > ```
-> 
+>
 > ```dockerfile
 > # this is a comment-line
 > RUN echo hello
 > RUN echo world
 > ```
-> 
-> Note however, that whitespace in instruction _arguments_, such as the commands
-> following `RUN`, are preserved, so the following example prints `    hello    world`
+>
+> Whitespace in instruction arguments, however, isn't ignored.
+> The following example prints `    hello    world`
 > with leading whitespace as specified:
 >
 > ```dockerfile
@@ -83,21 +85,20 @@ Line continuation characters are not supported in comments.
 ## Parser directives
 
 Parser directives are optional, and affect the way in which subsequent lines
-in a `Dockerfile` are handled. Parser directives do not add layers to the build,
-and will not be shown as a build step. Parser directives are written as a
+in a Dockerfile are handled. Parser directives don't add layers to the build,
+and don't show up as build steps. Parser directives are written as a
 special type of comment in the form `# directive=value`. A single directive
 may only be used once.
 
-Once a comment, empty line or builder instruction has been processed, Docker
+Once a comment, empty line or builder instruction has been processed, BuildKit
 no longer looks for parser directives. Instead it treats anything formatted
-as a parser directive as a comment and does not attempt to validate if it might
-be a parser directive. Therefore, all parser directives must be at the very
-top of a `Dockerfile`.
+as a parser directive as a comment and doesn't attempt to validate if it might
+be a parser directive. Therefore, all parser directives must be at the
+top of a Dockerfile.
 
-Parser directives are not case-sensitive. However, convention is for them to
-be lowercase. Convention is also to include a blank line following any
-parser directives. Line continuation characters are not supported in parser
-directives.
+Parser directives aren't case-sensitive, but they're lowercase by convention.
+It's also conventional to include a blank line following any parser directives.
+Line continuation characters aren't supported in parser directives.
 
 Due to these rules, the following examples are all invalid:
 
@@ -117,14 +118,14 @@ Invalid due to appearing twice:
 FROM ImageName
 ```
 
-Treated as a comment due to appearing after a builder instruction:
+Treated as a comment because it appears after a builder instruction:
 
 ```dockerfile
 FROM ImageName
 # directive=value
 ```
 
-Treated as a comment due to appearing after a comment which is not a parser
+Treated as a comment because it appears after a comment that isn't a parser
 directive:
 
 ```dockerfile
@@ -133,13 +134,13 @@ directive:
 FROM ImageName
 ```
 
-The unknown directive is treated as a comment due to not being recognized. In
-addition, the known directive is treated as a comment due to appearing after
-a comment which is not a parser directive.
+The following `unknowndirective` is treated as a comment because it isn't
+recognized. The known `syntax` directive is treated as a comment because it
+appears after a comment that isn't a parser directive.
 
 ```dockerfile
 # unknowndirective=value
-# knowndirective=value
+# syntax=value
 ```
 
 Non line-breaking whitespace is permitted in a parser directive. Hence, the
@@ -171,34 +172,34 @@ page for more information.
 ### escape
 
 ```dockerfile
-# escape=\ (backslash)
+# escape=\
 ```
 
 Or
 
 ```dockerfile
-# escape=` (backtick)
+# escape=`
 ```
 
 The `escape` directive sets the character used to escape characters in a
-`Dockerfile`. If not specified, the default escape character is `\`.
+Dockerfile. If not specified, the default escape character is `\`.
 
 The escape character is used both to escape characters in a line, and to
-escape a newline. This allows a `Dockerfile` instruction to
+escape a newline. This allows a Dockerfile instruction to
 span multiple lines. Note that regardless of whether the `escape` parser
-directive is included in a `Dockerfile`, *escaping is not performed in
-a `RUN` command, except at the end of a line.*
+directive is included in a Dockerfile, escaping is not performed in
+a `RUN` command, except at the end of a line.
 
 Setting the escape character to `` ` `` is especially useful on
 `Windows`, where `\` is the directory path separator. `` ` `` is consistent
 with [Windows PowerShell](https://technet.microsoft.com/en-us/library/hh847755.aspx).
 
 Consider the following example which would fail in a non-obvious way on
-`Windows`. The second `\` at the end of the second line would be interpreted as an
+Windows. The second `\` at the end of the second line would be interpreted as an
 escape for the newline, instead of a target of the escape from the first `\`.
 Similarly, the `\` at the end of the third line would, assuming it was actually
 handled as an instruction, cause it be treated as a line continuation. The result
-of this dockerfile is that second and third lines are considered a single
+of this Dockerfile is that second and third lines are considered a single
 instruction:
 
 ```dockerfile
@@ -222,11 +223,11 @@ PS E:\myproject>
 
 One solution to the above would be to use `/` as the target of both the `COPY`
 instruction, and `dir`. However, this syntax is, at best, confusing as it is not
-natural for paths on `Windows`, and at worst, error prone as not all commands on
-`Windows` support `/` as the path separator.
+natural for paths on Windows, and at worst, error prone as not all commands on
+Windows support `/` as the path separator.
 
-By adding the `escape` parser directive, the following `Dockerfile` succeeds as
-expected with the use of natural platform semantics for file paths on `Windows`:
+By adding the `escape` parser directive, the following Dockerfile succeeds as
+expected with the use of natural platform semantics for file paths on Windows:
 
 ```dockerfile
 # escape=`
@@ -272,10 +273,10 @@ PS E:\myproject>
 
 Environment variables (declared with [the `ENV` statement](#env)) can also be
 used in certain instructions as variables to be interpreted by the
-`Dockerfile`. Escapes are also handled for including variable-like syntax
+Dockerfile. Escapes are also handled for including variable-like syntax
 into a statement literally.
 
-Environment variables are notated in the `Dockerfile` either with
+Environment variables are notated in the Dockerfile either with
 `$variable_name` or `${variable_name}`. They are treated equivalently and the
 brace syntax is typically used to address issues with variable names with no
 whitespace, like `${foo}_bar`.
@@ -305,7 +306,7 @@ COPY \$FOO /quux # COPY $FOO /quux
 ```
 
 Environment variables are supported by the following list of instructions in
-the `Dockerfile`:
+the Dockerfile:
 
 - `ADD`
 - `COPY`
@@ -319,8 +320,15 @@ the `Dockerfile`:
 - `WORKDIR`
 - `ONBUILD` (when combined with one of the supported instructions above)
 
-Environment variable substitution will use the same value for each variable
-throughout the entire instruction. In other words, in this example:
+You can also use environment variables with `RUN`, `CMD`, and `ENTRYPOINT`
+instructions, but in those cases the variable substitution is handled by the
+command shell, not the builder. Note that instructions using the exec form
+don't invoke a command shell automatically. See [Variable
+substitution](#variable-substitution).
+
+Environment variable substitution use the same value for each variable
+throughout the entire instruction. Changing the value of a variable only takes
+effect in subsequent instructions. Consider the following example:
 
 ```dockerfile
 ENV abc=hello
@@ -328,15 +336,116 @@ ENV abc=bye def=$abc
 ENV ghi=$abc
 ```
 
-will result in `def` having a value of `hello`, not `bye`. However,
-`ghi` will have a value of `bye` because it is not part of the same instruction
-that set `abc` to `bye`.
+- The value of `def` becomes `hello`
+- The value of `ghi` becomes `bye`
 
 ## .dockerignore file
 
 You can use `.dockerignore` file to exclude files and directories from the
 build context. For more information, see
-[.dockerignore file](https://docs.docker.com/build/building/context#dockerignore-files/).
+[.dockerignore file](https://docs.docker.com/build/building/context/#dockerignore-files).
+
+## Shell and exec form
+
+The `RUN`, `CMD`, and `ENTRYPOINT` instructions all have two possible forms:
+
+- `INSTRUCTION ["executable","param1","param2"]` (exec form)
+- `INSTRUCTION command param1 param2` (shell form)
+
+The exec form makes it possible to avoid shell string munging, and to invoke
+commands using a specific command shell, or any other executable. It uses a
+JSON array syntax, where each element in the array is a command, flag, or
+argument.
+
+The shell form is more relaxed, and emphasizes ease of use, flexibility, and
+readability. The shell form automatically uses a command shell, whereas the
+exec form does not.
+
+### Exec form
+
+The exec form is parsed as a JSON array, which means that
+you must use double-quotes (") around words, not single-quotes (').
+
+```dockerfile
+ENTRYPOINT ["/bin/bash", "-c", "echo", "hello"]
+```
+
+The exec form is best used to specify an `ENTRYPOINT` instruction, combined
+with `CMD` for setting default arguments that can be overridden at runtime. For
+more information, see [ENTRYPOINT](#entrypoint).
+
+#### Variable substitution
+
+Using the exec form doesn't automatically invoke a command shell. This means
+that normal shell processing, such as variable substitution, doesn't happen.
+For example, `RUN [ "echo", "$HOME" ]` won't handle variable substitution for
+`$HOME`.
+
+If you want shell processing then either use the shell form or execute a shell
+directly with the exec form, for example: `RUN [ "sh", "-c", "echo $HOME" ]`.
+When using the exec form and executing a shell directly, as in the case for the
+shell form, it's the shell that's doing the environment variable substitution,
+not the builder.
+
+#### Backslashes
+
+In exec form, you must escape backslashes. This is particularly relevant on
+Windows where the backslash is the path separator. The following line would
+otherwise be treated as shell form due to not being valid JSON, and fail in an
+unexpected way:
+
+```dockerfile
+RUN ["c:\windows\system32\tasklist.exe"]
+```
+
+The correct syntax for this example is:
+
+```dockerfile
+RUN ["c:\\windows\\system32\\tasklist.exe"]
+```
+
+### Shell form
+
+Unlike the exec form, instructions using the shell form always use a command
+shell. The shell form doesn't use the JSON array format, instead it's a regular
+string. The shell form string lets you escape newlines using the [escape
+character](#escape) (backslash by default) to continue a single instruction
+onto the next line. This makes it easier to use with longer commands, because
+it lets you split them up into multiple lines. For example, consider these two
+lines:
+
+```dockerfile
+RUN source $HOME/.bashrc && \
+echo $HOME
+```
+
+They're equivalent to the following line:
+
+```dockerfile
+RUN source $HOME/.bashrc && echo $HOME
+```
+
+You can also use heredocs with the shell form to break up a command:
+
+```dockerfile
+RUN <<EOF
+source $HOME/.bashrc && \
+echo $HOME
+EOF
+```
+
+For more information about heredocs, see [Here-documents](#here-documents).
+
+### Use a different shell
+
+You can change the default shell using the `SHELL` command. For example:
+
+```dockerfile
+SHELL ["/bin/bash", "-c"]
+RUN echo hello
+```
+
+For more information, see [SHELL](#shell).
 
 ## FROM
 
@@ -357,14 +466,13 @@ FROM [--platform=<platform>] <image>[@<digest>] [AS <name>]
 ```
 
 The `FROM` instruction initializes a new build stage and sets the
-[*Base Image*](https://docs.docker.com/glossary/#base-image) for subsequent instructions. As such, a
-valid `Dockerfile` must start with a `FROM` instruction. The image can be
-any valid image – it is especially easy to start by **pulling an image** from
-the [*Public Repositories*](https://docs.docker.com/docker-hub/repos/).
+[base image](https://docs.docker.com/glossary/#base-image) for subsequent
+instructions. As such, a valid Dockerfile must start with a `FROM` instruction.
+The image can be any valid image.
 
-- `ARG` is the only instruction that may precede `FROM` in the `Dockerfile`.
+- `ARG` is the only instruction that may precede `FROM` in the Dockerfile.
   See [Understand how ARG and FROM interact](#understand-how-arg-and-from-interact).
-- `FROM` can appear multiple times within a single `Dockerfile` to
+- `FROM` can appear multiple times within a single Dockerfile to
   create multiple images or use one build stage as a dependency for another.
   Simply make a note of the last image ID output by the commit before each new
   `FROM` instruction. Each `FROM` instruction clears any state created by previous
@@ -374,7 +482,7 @@ the [*Public Repositories*](https://docs.docker.com/docker-hub/repos/).
   `COPY --from=<name>` instructions to refer to the image built in this stage.
 - The `tag` or `digest` values are optional. If you omit either of them, the
   builder assumes a `latest` tag by default. The builder returns an error if it
-  cannot find the `tag` value.
+  can't find the `tag` value.
 
 The optional `--platform` flag can be used to specify the platform of the image
 in case `FROM` references a multi-platform image. For example, `linux/amd64`,
@@ -412,77 +520,32 @@ RUN echo $VERSION > image_version
 
 ## RUN
 
-RUN has 2 forms:
-
-- `RUN <command>` (*shell* form, the command is run in a shell, which by
-default is `/bin/sh -c` on Linux or `cmd /S /C` on Windows)
-- `RUN ["executable", "param1", "param2"]` (*exec* form)
-
-The `RUN` instruction will execute any commands in a new layer on top of the
-current image and commit the results. The resulting committed image will be
-used for the next step in the `Dockerfile`.
-
-Layering `RUN` instructions and generating commits conforms to the core
-concepts of Docker where commits are cheap and containers can be created from
-any point in an image's history, much like source control.
-
-The *exec* form makes it possible to avoid shell string munging, and to `RUN`
-commands using a base image that does not contain the specified shell executable.
-
-The default shell for the *shell* form can be changed using the `SHELL`
-command.
-
-In the *shell* form you can use a `\` (backslash) to continue a single
-RUN instruction onto the next line. For example, consider these two lines:
+The `RUN` instruction will execute any commands to create a new layer on top of
+the current image. The added layer is used in the next step in the Dockerfile.
 
 ```dockerfile
-RUN /bin/bash -c 'source $HOME/.bashrc && \
-echo $HOME'
+RUN apt-get update
+RUN apt-get install -y curl
 ```
 
-Together they are equivalent to this single line:
+You can specify `CMD` instructions using
+[shell or exec forms](#shell-and-exec-form):
+
+- `RUN ["executable","param1","param2"]` (exec form)
+- `RUN command param1 param2` (shell form)
+
+The shell form is most commonly used, and lets you more easily break up longer
+instructions into multiple lines, either using newline [escapes](#escape), or
+with [heredocs](#here-documents):
 
 ```dockerfile
-RUN /bin/bash -c 'source $HOME/.bashrc && echo $HOME'
+RUN <<EOF
+apt-get update
+apt-get install -y curl
+EOF
 ```
 
-To use a different shell, other than '/bin/sh', use the *exec* form passing in
-the desired shell. For example:
-
-```dockerfile
-RUN ["/bin/bash", "-c", "echo hello"]
-```
-
-> **Note**
->
-> The *exec* form is parsed as a JSON array, which means that
-> you must use double-quotes (") around words not single-quotes (').
-
-Unlike the *shell* form, the *exec* form does not invoke a command shell.
-This means that normal shell processing does not happen. For example,
-`RUN [ "echo", "$HOME" ]` will not do variable substitution on `$HOME`.
-If you want shell processing then either use the *shell* form or execute
-a shell directly, for example: `RUN [ "sh", "-c", "echo $HOME" ]`.
-When using the exec form and executing a shell directly, as in the case for
-the shell form, it is the shell that is doing the environment variable
-expansion, not docker.
-
-> **Note**
->
-> In the *JSON* form, it is necessary to escape backslashes. This is
-> particularly relevant on Windows where the backslash is the path separator.
-> The following line would otherwise be treated as *shell* form due to not
-> being valid JSON, and fail in an unexpected way:
->
-> ```dockerfile
-> RUN ["c:\windows\system32\tasklist.exe"]
-> ```
-> 
-> The correct syntax for this example is:
->
-> ```dockerfile
-> RUN ["c:\\windows\\system32\\tasklist.exe"]
-> ```
+### Cache invalidation for RUN instructions
 
 The cache for `RUN` instructions isn't invalidated automatically during
 the next build. The cache for an instruction like
@@ -490,7 +553,7 @@ the next build. The cache for an instruction like
 cache for `RUN` instructions can be invalidated by using the `--no-cache`
 flag, for example `docker build --no-cache`.
 
-See the [`Dockerfile` Best Practices
+See the [Dockerfile Best Practices
 guide](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/) for more information.
 
 The cache for `RUN` instructions can be invalidated by [`ADD`](#add) and [`COPY`](#copy) instructions.
@@ -513,9 +576,9 @@ Syntax: `--mount=[type=<TYPE>][,option=<value>[,option=<value>]...]`
 ### Mount types
 
 | Type                                     | Description                                                                                               |
-|------------------------------------------|-----------------------------------------------------------------------------------------------------------|
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------- |
 | [`bind`](#run---mounttypebind) (default) | Bind-mount context directories (read-only).                                                               |
-| [`cache`](#run---mounttypecache)         | Mount a temporary directory to cache directories for compilers and package managers.                  |
+| [`cache`](#run---mounttypecache)         | Mount a temporary directory to cache directories for compilers and package managers.                      |
 | [`secret`](#run---mounttypesecret)       | Allow the build container to access secure files such as private keys without baking them into the image. |
 | [`ssh`](#run---mounttypessh)             | Allow the build container to access SSH keys via SSH agents, with support for passphrases.                |
 
@@ -524,29 +587,29 @@ Syntax: `--mount=[type=<TYPE>][,option=<value>[,option=<value>]...]`
 This mount type allows binding files or directories to the build container. A
 bind mount is read-only by default.
 
-| Option               | Description                                                                          |
-|----------------------|--------------------------------------------------------------------------------------|
-| `target`[^1]         | Mount path.                                                                          |
-| `source`             | Source path in the `from`. Defaults to the root of the `from`.                       |
-| `from`               | Build stage or image name for the root of the source. Defaults to the build context. |
-| `rw`,`readwrite`     | Allow writes on the mount. Written data will be discarded.                           |
+| Option           | Description                                                                          |
+| ---------------- | ------------------------------------------------------------------------------------ |
+| `target`[^1]     | Mount path.                                                                          |
+| `source`         | Source path in the `from`. Defaults to the root of the `from`.                       |
+| `from`           | Build stage or image name for the root of the source. Defaults to the build context. |
+| `rw`,`readwrite` | Allow writes on the mount. Written data will be discarded.                           |
 
 ### RUN --mount=type=cache
 
 This mount type allows the build container to cache directories for compilers
 and package managers.
 
-| Option              | Description                                                                                                                                                                                                                                                                |
-|---------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `id`                | Optional ID to identify separate/different caches. Defaults to value of `target`.                                                                                                                                                                                          |
-| `target`[^1]        | Mount path.                                                                                                                                                                                                                                                                |
-| `ro`,`readonly`     | Read-only if set.                                                                                                                                                                                                                                                          |
-| `sharing`           | One of `shared`, `private`, or `locked`. Defaults to `shared`. A `shared` cache mount can be used concurrently by multiple writers. `private` creates a new mount if there are multiple writers. `locked` pauses the second writer until the first one releases the mount. |
-| `from`              | Build stage to use as a base of the cache mount. Defaults to empty directory.                                                                                                                                                                                              |
-| `source`            | Subpath in the `from` to mount. Defaults to the root of the `from`.                                                                                                                                                                                                        |
-| `mode`              | File mode for new cache directory in octal. Default `0755`.                                                                                                                                                                                                                |
-| `uid`               | User ID for new cache directory. Default `0`.                                                                                                                                                                                                                              |
-| `gid`               | Group ID for new cache directory. Default `0`.                                                                                                                                                                                                                             |
+| Option          | Description                                                                                                                                                                                                                                                                |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`            | Optional ID to identify separate/different caches. Defaults to value of `target`.                                                                                                                                                                                          |
+| `target`[^1]    | Mount path.                                                                                                                                                                                                                                                                |
+| `ro`,`readonly` | Read-only if set.                                                                                                                                                                                                                                                          |
+| `sharing`       | One of `shared`, `private`, or `locked`. Defaults to `shared`. A `shared` cache mount can be used concurrently by multiple writers. `private` creates a new mount if there are multiple writers. `locked` pauses the second writer until the first one releases the mount. |
+| `from`          | Build stage to use as a base of the cache mount. Defaults to empty directory.                                                                                                                                                                                              |
+| `source`        | Subpath in the `from` to mount. Defaults to the root of the `from`.                                                                                                                                                                                                        |
+| `mode`          | File mode for new cache directory in octal. Default `0755`.                                                                                                                                                                                                                |
+| `uid`           | User ID for new cache directory. Default `0`.                                                                                                                                                                                                                              |
+| `gid`           | Group ID for new cache directory. Default `0`.                                                                                                                                                                                                                             |
 
 Contents of the cache directories persists between builder invocations without
 invalidating the instruction cache. Cache mounts should only be used for better
@@ -583,26 +646,26 @@ case.
 
 ### RUN --mount=type=tmpfs
 
-This mount type allows mounting tmpfs in the build container.
+This mount type allows mounting `tmpfs` in the build container.
 
-| Option              | Description                                           |
-|---------------------|-------------------------------------------------------|
-| `target`[^1]        | Mount path.                                           |
-| `size`              | Specify an upper limit on the size of the filesystem. |
+| Option       | Description                                           |
+| ------------ | ----------------------------------------------------- |
+| `target`[^1] | Mount path.                                           |
+| `size`       | Specify an upper limit on the size of the filesystem. |
 
 ### RUN --mount=type=secret
 
 This mount type allows the build container to access secure files such as
 private keys without baking them into the image.
 
-| Option              | Description                                                                                       |
-|---------------------|---------------------------------------------------------------------------------------------------|
-| `id`                | ID of the secret. Defaults to basename of the target path.                                        |
-| `target`            | Mount path. Defaults to `/run/secrets/` + `id`.                                                   |
-| `required`          | If set to `true`, the instruction errors out when the secret is unavailable. Defaults to `false`. |
-| `mode`              | File mode for secret file in octal. Default `0400`.                                               |
-| `uid`               | User ID for secret file. Default `0`.                                                             |
-| `gid`               | Group ID for secret file. Default `0`.                                                            |
+| Option     | Description                                                                                       |
+| ---------- | ------------------------------------------------------------------------------------------------- |
+| `id`       | ID of the secret. Defaults to basename of the target path.                                        |
+| `target`   | Mount path. Defaults to `/run/secrets/` + `id`.                                                   |
+| `required` | If set to `true`, the instruction errors out when the secret is unavailable. Defaults to `false`. |
+| `mode`     | File mode for secret file in octal. Default `0400`.                                               |
+| `uid`      | User ID for secret file. Default `0`.                                                             |
+| `gid`      | Group ID for secret file. Default `0`.                                                            |
 
 #### Example: access to S3
 
@@ -623,14 +686,14 @@ $ docker buildx build --secret id=aws,src=$HOME/.aws/credentials .
 This mount type allows the build container to access SSH keys via SSH agents,
 with support for passphrases.
 
-| Option              | Description                                                                                    |
-|---------------------|------------------------------------------------------------------------------------------------|
-| `id`                | ID of SSH agent socket or key. Defaults to "default".                                          |
-| `target`            | SSH agent socket path. Defaults to `/run/buildkit/ssh_agent.${N}`.                             |
-| `required`          | If set to `true`, the instruction errors out when the key is unavailable. Defaults to `false`. |
-| `mode`              | File mode for socket in octal. Default `0600`.                                                 |
-| `uid`               | User ID for socket. Default `0`.                                                               |
-| `gid`               | Group ID for socket. Default `0`.                                                              |
+| Option     | Description                                                                                    |
+| ---------- | ---------------------------------------------------------------------------------------------- |
+| `id`       | ID of SSH agent socket or key. Defaults to "default".                                          |
+| `target`   | SSH agent socket path. Defaults to `/run/buildkit/ssh_agent.${N}`.                             |
+| `required` | If set to `true`, the instruction errors out when the key is unavailable. Defaults to `false`. |
+| `mode`     | File mode for socket in octal. Default `0600`.                                                 |
+| `uid`      | User ID for socket. Default `0`.                                                               |
+| `gid`      | Group ID for socket. Default `0`.                                                              |
 
 #### Example: access to Gitlab
 
@@ -669,7 +732,7 @@ Syntax: `--network=<TYPE>`
 ### Network types
 
 | Type                                         | Description                            |
-|----------------------------------------------|----------------------------------------|
+| -------------------------------------------- | -------------------------------------- |
 | [`default`](#run---networkdefault) (default) | Run in the default network.            |
 | [`none`](#run---networknone)                 | Run with no network access.            |
 | [`host`](#run---networkhost)                 | Run in the host's network environment. |
@@ -703,7 +766,7 @@ The command is run in the host's network environment (similar to
 
 > **Warning**
 >
-> The use of `--network=host` is protected by the `network.host` entitlement, 
+> The use of `--network=host` is protected by the `network.host` entitlement,
 > which needs to be enabled when starting the buildkitd daemon with
 > `--allow-insecure-entitlement network.host` flag or in [buildkitd config](https://github.com/moby/buildkit/blob/master/docs/buildkitd.toml.md),
 > and for a build request with [`--allow network.host` flag](https://docs.docker.com/engine/reference/commandline/buildx_build/#allow).
@@ -736,6 +799,7 @@ This is equivalent to running `docker run --privileged`.
 FROM ubuntu
 RUN --security=insecure cat /proc/self/status | grep CapEff
 ```
+
 ```text
 #84 0.093 CapEff:	0000003fffffffff
 ```
@@ -746,70 +810,37 @@ Default sandbox mode can be activated via `--security=sandbox`, but that is no-o
 
 ## CMD
 
-The `CMD` instruction has three forms:
+The `CMD` instruction sets the command to be executed when running a container
+from an image.
 
-- `CMD ["executable","param1","param2"]` (*exec* form, this is the preferred form)
-- `CMD ["param1","param2"]` (as *default parameters to ENTRYPOINT*)
-- `CMD command param1 param2` (*shell* form)
+You can specify `CMD` instructions using
+[shell or exec forms](#shell-and-exec-form):
 
-There can only be one `CMD` instruction in a `Dockerfile`. If you list more than one `CMD`
-then only the last `CMD` will take effect.
+- `CMD ["executable","param1","param2"]` (exec form)
+- `CMD ["param1","param2"]` (exec form, as default parameters to `ENTRYPOINT`)
+- `CMD command param1 param2` (shell form)
 
-**The main purpose of a `CMD` is to provide defaults for an executing
-container.** These defaults can include an executable, or they can omit
-the executable, in which case you must specify an `ENTRYPOINT`
-instruction as well.
+There can only be one `CMD` instruction in a Dockerfile. If you list more than
+one `CMD`, only the last one takes effect.
 
-If `CMD` is used to provide default arguments for the `ENTRYPOINT` instruction,
-both the `CMD` and `ENTRYPOINT` instructions should be specified with the JSON
-array format.
-
-> **Note**
->
-> The *exec* form is parsed as a JSON array, which means that you must use
-> double-quotes (") around words not single-quotes (').
-
-Unlike the *shell* form, the *exec* form does not invoke a command shell.
-This means that normal shell processing does not happen. For example,
-`CMD [ "echo", "$HOME" ]` will not do variable substitution on `$HOME`.
-If you want shell processing then either use the *shell* form or execute
-a shell directly, for example: `CMD [ "sh", "-c", "echo $HOME" ]`.
-When using the exec form and executing a shell directly, as in the case for
-the shell form, it is the shell that is doing the environment variable
-expansion, not docker.
-
-When used in the shell or exec formats, the `CMD` instruction sets the command
-to be executed when running the image.
-
-If you use the *shell* form of the `CMD`, then the `<command>` will execute in
-`/bin/sh -c`:
-
-```dockerfile
-FROM ubuntu
-CMD echo "This is a test." | wc -
-```
-
-If you want to **run your** `<command>` **without a shell** then you must
-express the command as a JSON array and give the full path to the executable.
-**This array form is the preferred format of `CMD`.** Any additional parameters
-must be individually expressed as strings in the array:
-
-```dockerfile
-FROM ubuntu
-CMD ["/usr/bin/wc","--help"]
-```
+The purpose of a `CMD` is to provide defaults for an executing container. These
+defaults can include an executable, or they can omit the executable, in which
+case you must specify an `ENTRYPOINT` instruction as well.
 
 If you would like your container to run the same executable every time, then
 you should consider using `ENTRYPOINT` in combination with `CMD`. See
-[*ENTRYPOINT*](#entrypoint).
+[`ENTRYPOINT`](#entrypoint). If the user specifies arguments to `docker run`
+then they will override the default specified in `CMD`, but still use the
+default `ENTRYPOINT`.
 
-If the user specifies arguments to `docker run` then they will override the
-default specified in `CMD`.
+If `CMD` is used to provide default arguments for the `ENTRYPOINT` instruction,
+both the `CMD` and `ENTRYPOINT` instructions should be specified in the
+[exec form](#exec-form).
 
 > **Note**
 >
-> Do not confuse `RUN` with `CMD`. `RUN` actually runs a command and commits
-> the result; `CMD` does not execute anything at build time, but specifies
+> Don't confuse `RUN` with `CMD`. `RUN` actually runs a command and commits
+> the result; `CMD` doesn't execute anything at build time, but specifies
 > the intended command for the image.
 
 ## LABEL
@@ -846,7 +877,7 @@ LABEL multi.label1="value1" \
 ```
 
 > **Note**
-> 
+>
 > Be sure to use double quotes and not single quotes. Particularly when you are
 > using string interpolation (e.g. `LABEL example="foo-$ENV_VAR"`), single
 > quotes will take the string as is without unpacking the variable's value.
@@ -857,12 +888,10 @@ the most-recently-applied value overrides any previously-set value.
 
 To view an image's labels, use the `docker image inspect` command. You can use
 the `--format` option to show just the labels;
- 
-{% raw %}
+
 ```console
 $ docker image inspect --format='{{json .Config.Labels}}' myimage
 ```
-{% endraw %}
 
 ```json
 {
@@ -882,7 +911,7 @@ $ docker image inspect --format='{{json .Config.Labels}}' myimage
 MAINTAINER <name>
 ```
 
-The `MAINTAINER` instruction sets the *Author* field of the generated images.
+The `MAINTAINER` instruction sets the _Author_ field of the generated images.
 The `LABEL` instruction is a much more flexible version of this and you should use
 it instead, as it enables setting any metadata you require, and can be viewed
 easily, for example with `docker inspect`. To set a label corresponding to the
@@ -902,11 +931,11 @@ EXPOSE <port> [<port>/<protocol>...]
 
 The `EXPOSE` instruction informs Docker that the container listens on the
 specified network ports at runtime. You can specify whether the port listens on
-TCP or UDP, and the default is TCP if the protocol is not specified.
+TCP or UDP, and the default is TCP if you don't specify a protocol.
 
-The `EXPOSE` instruction does not actually publish the port. It functions as a
+The `EXPOSE` instruction doesn't actually publish the port. It functions as a
 type of documentation between the person who builds the image and the person who
-runs the container, about which ports are intended to be published. To actually
+runs the container, about which ports are intended to be published. To
 publish the port when running the container, use the `-p` flag on `docker run`
 to publish and map one or more ports, or the `-P` flag to publish all exposed
 ports and map them to high-order ports.
@@ -926,7 +955,7 @@ EXPOSE 80/udp
 
 In this case, if you use `-P` with `docker run`, the port will be exposed once
 for TCP and once for UDP. Remember that `-P` uses an ephemeral high-ordered host
-port on the host, so the port will not be the same for TCP and UDP.
+port on the host, so TCP and UDP doesn't use the same port.
 
 Regardless of the `EXPOSE` settings, you can override them at runtime by using
 the `-p` flag. For example
@@ -990,7 +1019,7 @@ image, consider setting a value for a single command instead:
 ```dockerfile
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y ...
 ```
- 
+
 Or using [`ARG`](#arg), which is not persisted in the final image:
 
 ```dockerfile
@@ -1006,7 +1035,7 @@ RUN apt-get update && apt-get install -y ...
 > ```dockerfile
 > ENV MY_VAR my-value
 > ```
-> 
+>
 > This syntax does not allow for multiple environment-variables to be set in a
 > single `ENV` instruction, and can be confusing. For example, the following
 > sets a single environment variable (`ONE`) with value `"TWO= THREE=world"`:
@@ -1014,7 +1043,7 @@ RUN apt-get update && apt-get install -y ...
 > ```dockerfile
 > ENV ONE TWO= THREE=world
 > ```
-> 
+>
 > The alternative syntax is supported for backward compatibility, but discouraged
 > for the reasons outlined above, and may be removed in a future release.
 
@@ -1032,7 +1061,7 @@ The latter form is required for paths containing whitespace.
 > **Note**
 >
 > The `--chown` and `--chmod` features are only supported on Dockerfiles used to build Linux containers,
-> and will not work on Windows containers. Since user and group ownership concepts do
+> and doesn't work on Windows containers. Since user and group ownership concepts do
 > not translate between Linux and Windows, the use of `/etc/passwd` and `/etc/group` for
 > translating user and group names to IDs restricts this feature to only be viable
 > for Linux OS-based containers.
@@ -1089,7 +1118,6 @@ named `arr[0].txt`, use the following;
 ADD arr[[]0].txt /mydir/
 ```
 
-
 All new files and directories are created with a UID and GID of 0, unless the
 optional `--chown` flag specifies a given username, groupname, or UID/GID
 combination to request specific ownership of the content added. The
@@ -1109,84 +1137,83 @@ ADD --chown=10:11 files* /somedir/
 ADD --chown=myuser:mygroup --chmod=655 files* /somedir/
 ```
 
-If the container root filesystem does not contain either `/etc/passwd` or
+If the container root filesystem doesn't contain either `/etc/passwd` or
 `/etc/group` files and either user or group names are used in the `--chown`
 flag, the build will fail on the `ADD` operation. Using numeric IDs requires
-no lookup and will not depend on container root filesystem content.
+no lookup and doesn't depend on container root filesystem content.
 
 In the case where `<src>` is a remote file URL, the destination will
 have permissions of 600. If the remote file being retrieved has an HTTP
 `Last-Modified` header, the timestamp from that header will be used
 to set the `mtime` on the destination file. However, like any other file
-processed during an `ADD`, `mtime` will not be included in the determination
+processed during an `ADD`, `mtime` isn't included in the determination
 of whether or not the file has changed and the cache should be updated.
 
 > **Note**
 >
-> If you build by passing a `Dockerfile` through STDIN (`docker
-> build - < somefile`), there is no build context, so the `Dockerfile`
+> If you build by passing a Dockerfile through STDIN (`docker
+build - < somefile`), there is no build context, so the Dockerfile
 > can only contain a URL based `ADD` instruction. You can also pass a
 > compressed archive through STDIN: (`docker build - < archive.tar.gz`),
-> the `Dockerfile` at the root of the archive and the rest of the
+> the Dockerfile at the root of the archive and the rest of the
 > archive will be used as the context of the build.
 
 If your URL files are protected using authentication, you need to use `RUN wget`,
 `RUN curl` or use another tool from within the container as the `ADD` instruction
-does not support authentication.
+doesn't support authentication.
 
 > **Note**
 >
 > The first encountered `ADD` instruction will invalidate the cache for all
 > following instructions from the Dockerfile if the contents of `<src>` have
 > changed. This includes invalidating the cache for `RUN` instructions.
-> See the [`Dockerfile` Best Practices
-guide – Leverage build cache](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#leverage-build-cache)
+> See the [Dockerfile Best Practices
+> guide – Leverage build cache](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#leverage-build-cache)
 > for more information.
-
 
 `ADD` obeys the following rules:
 
-- The `<src>` path must be inside the *context* of the build;
-  you cannot `ADD ../something /something`, because the first step of a
-  `docker build` is to send the context directory (and subdirectories) to the
-  docker daemon.
+- The `<src>` path must be inside the build context;
+  you can't use `COPY ../something /something`, because the builder can only
+  access files from the context, and `../something` specifies a parent file or
+  directory of the build context root.
 
-- If `<src>` is a URL and `<dest>` does not end with a trailing slash, then a
-  file is downloaded from the URL and copied to `<dest>`.
+- If `<src>` is a directory, the entire contents of the directory are copied,
+  including filesystem metadata.
 
 - If `<src>` is a URL and `<dest>` does end with a trailing slash, then the
   filename is inferred from the URL and the file is downloaded to
   `<dest>/<filename>`. For instance, `ADD http://example.com/foobar /` would
   create the file `/foobar`. The URL must have a nontrivial path so that an
   appropriate filename can be discovered in this case (`http://example.com`
-  will not work).
+  doesn't work).
 
 - If `<src>` is a directory, the entire contents of the directory are copied,
   including filesystem metadata.
 
-> **Note**
->
-> The directory itself is not copied, just its contents.
+  > **Note**
+  >
+  > The directory itself isn't copied, only its contents.
 
-- If `<src>` is a *local* tar archive in a recognized compression format
-  (identity, gzip, bzip2 or xz) then it is unpacked as a directory. Resources
-  from *remote* URLs are **not** decompressed. When a directory is copied or
-  unpacked, it has the same behavior as `tar -x`, the result is the union of:
+- If `<src>` is a local `tar` archive in a recognized compression format
+  (`identity`, `gzip`, `bzip2` or `xz`) then it's unpacked as a directory. Resources
+  from remote URLs aren't decompressed. When a directory is copied or
+  unpacked, it has the same behavior as `tar -x`. The result is the union of:
 
-    1. Whatever existed at the destination path and
-    2. The contents of the source tree, with conflicts resolved in favor
-       of "2." on a file-by-file basis.
+  1. Whatever existed at the destination path and
+  2. The contents of the source tree, with conflicts resolved in favor
+     of "2." on a file-by-file basis.
 
   > **Note**
   >
   > Whether a file is identified as a recognized compression format or not
   > is done solely based on the contents of the file, not the name of the file.
-  > For example, if an empty file happens to end with `.tar.gz` this will not
-  > be recognized as a compressed file and **will not** generate any kind of
+  > For example, if an empty file happens to end with `.tar.gz` this isn't
+  > recognized as a compressed file and doesn't generate any kind of
   > decompression error message, rather the file will simply be copied to the
   > destination.
 
-- If `<src>` is any other kind of file, it is copied individually along with
+- If `<src>` is any other kind of file, it's copied individually along with
   its metadata. In this case, if `<dest>` ends with a trailing slash `/`, it
   will be considered a directory and the contents of `<src>` will be written
   at `<dest>/base(<src>)`.
@@ -1195,10 +1222,10 @@ guide – Leverage build cache](https://docs.docker.com/develop/develop-images/d
   use of a wildcard, then `<dest>` must be a directory, and it must end with
   a slash `/`.
 
-- If `<dest>` does not end with a trailing slash, it will be considered a
+- If `<dest>` doesn't end with a trailing slash, it will be considered a
   regular file and the contents of `<src>` will be written at `<dest>`.
 
-- If `<dest>` doesn't exist, it is created along with all missing directories
+- If `<dest>` doesn't exist, it's created, along with all missing directories
   in its path.
 
 ### Verifying a remote file checksum `ADD --checksum=<checksum> <http src> <dest>`
@@ -1211,10 +1238,11 @@ ADD --checksum=sha256:24454f830cdb571e2c4ad15481119c43b3cafd48dd869a9b2945d1036d
 
 The `--checksum` flag only supports HTTP sources currently.
 
-### Adding a git repository `ADD <git ref> <dir>`
+### Adding a Git repository `ADD <git ref> <dir>`
 
-This form allows adding a git repository to an image directly, without using the `git` command inside the image:
-```
+This form allows adding a Git repository to an image directly, without using the `git` command inside the image:
+
+```dockerfile
 ADD [--keep-git-dir=<boolean>] <git ref> <dir>
 ```
 
@@ -1264,7 +1292,7 @@ This latter form is required for paths containing whitespace
 > **Note**
 >
 > The `--chown` and `--chmod` features are only supported on Dockerfiles used to build Linux containers,
-> and will not work on Windows containers. Since user and group ownership concepts do
+> and doesn't work on Windows containers. Since user and group ownership concepts do
 > not translate between Linux and Windows, the use of `/etc/passwd` and `/etc/group` for
 > translating user and group names to IDs restricts this feature to only be viable for
 > Linux OS-based containers.
@@ -1334,7 +1362,7 @@ COPY --chown=10:11 files* /somedir/
 COPY --chown=myuser:mygroup --chmod=644 files* /somedir/
 ```
 
-If the container root filesystem does not contain either `/etc/passwd` or
+If the container root filesystem doesn't contain either `/etc/passwd` or
 `/etc/group` files and either user or group names are used in the `--chown`
 flag, the build will fail on the `COPY` operation. Using numeric IDs requires
 no lookup and does not depend on container root filesystem content.
@@ -1352,19 +1380,19 @@ attempted to be used instead.
 
 `COPY` obeys the following rules:
 
-- The `<src>` path must be inside the *context* of the build;
-  you cannot `COPY ../something /something`, because the first step of a
-  `docker build` is to send the context directory (and subdirectories) to the
-  docker daemon.
+- The `<src>` path must be inside the build context;
+  you can't use `COPY ../something /something`, because the builder can only
+  access files from the context, and `../something` specifies a parent file or
+  directory of the build context root.
 
 - If `<src>` is a directory, the entire contents of the directory are copied,
   including filesystem metadata.
 
-> **Note**
->
-> The directory itself is not copied, just its contents.
+  > **Note**
+  >
+  > The directory itself isn't copied, only its contents.
 
-- If `<src>` is any other kind of file, it is copied individually along with
+- If `<src>` is any other kind of file, it's copied individually along with
   its metadata. In this case, if `<dest>` ends with a trailing slash `/`, it
   will be considered a directory and the contents of `<src>` will be written
   at `<dest>/base(<src>)`.
@@ -1373,19 +1401,19 @@ attempted to be used instead.
   use of a wildcard, then `<dest>` must be a directory, and it must end with
   a slash `/`.
 
-- If `<dest>` does not end with a trailing slash, it will be considered a
+- If `<dest>` doesn't end with a trailing slash, it will be considered a
   regular file and the contents of `<src>` will be written at `<dest>`.
 
-- If `<dest>` doesn't exist, it is created along with all missing directories
+- If `<dest>` doesn't exist, it's created, along with all missing directories
   in its path.
-  
+
 > **Note**
 >
 > The first encountered `COPY` instruction will invalidate the cache for all
 > following instructions from the Dockerfile if the contents of `<src>` have
 > changed. This includes invalidating the cache for `RUN` instructions.
-> See the [`Dockerfile` Best Practices
-guide – Leverage build cache](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#leverage-build-cache)
+> See the [Dockerfile Best Practices
+> guide – Leverage build cache](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#leverage-build-cache)
 > for more information.
 
 ## COPY --link
@@ -1457,7 +1485,6 @@ path, using `--link` is always recommended. The performance of `--link` is
 equivalent or better than the default behavior and, it creates much better
 conditions for cache reuse.
 
-
 ## COPY --parents
 
 > **Note**
@@ -1499,49 +1526,50 @@ with the `--parents` flag, the Buildkit is capable of packing multiple
 
 ## ENTRYPOINT
 
-ENTRYPOINT has two forms:
-
-The *exec* form, which is the preferred form:
-
-```dockerfile
-ENTRYPOINT ["executable", "param1", "param2"]
-```
-
-The *shell* form:
-
-```dockerfile
-ENTRYPOINT command param1 param2
-```
-
 An `ENTRYPOINT` allows you to configure a container that will run as an executable.
 
-For example, the following starts nginx with its default content, listening
-on port 80:
+`ENTRYPOINT` has two possible forms:
+
+- The exec form, which is the preferred form:
+
+  ```dockerfile
+  ENTRYPOINT ["executable", "param1", "param2"]
+  ```
+
+- The shell form:
+
+  ```dockerfile
+  ENTRYPOINT command param1 param2
+  ```
+
+For more information about the different forms, see [Shell and exec form](#shell-and-exec-form).
+
+The following command starts a container from the `nginx` with its default
+content, listening on port 80:
 
 ```console
 $ docker run -i -t --rm -p 80:80 nginx
 ```
 
 Command line arguments to `docker run <image>` will be appended after all
-elements in an *exec* form `ENTRYPOINT`, and will override all elements specified
+elements in an exec form `ENTRYPOINT`, and will override all elements specified
 using `CMD`.
-This allows arguments to be passed to the entry point, i.e., `docker run <image> -d`
-will pass the `-d` argument to the entry point.
-You can override the `ENTRYPOINT` instruction using the `docker run --entrypoint`
-flag.
 
-The *shell* form prevents any `CMD` or `run` command line arguments from being
-used, but has the disadvantage that your `ENTRYPOINT` will be started as a
-subcommand of `/bin/sh -c`, which does not pass signals.
-This means that the executable will not be the container's `PID 1` - and
-will _not_ receive Unix signals - so your executable will not receive a
-`SIGTERM` from `docker stop <container>`.
+This allows arguments to be passed to the entry point, i.e., `docker run
+<image> -d` will pass the `-d` argument to the entry point. You can override
+the `ENTRYPOINT` instruction using the `docker run --entrypoint` flag.
 
-Only the last `ENTRYPOINT` instruction in the `Dockerfile` will have an effect.
+The shell form of `ENTRYPOINT` prevents any `CMD` command line arguments from
+being used. It also starts your `ENTRYPOINT` as a subcommand of `/bin/sh -c`,
+which does not pass signals. This means that the executable will not be the
+container's `PID 1`, and will not receive Unix signals. In this case, your
+executable doesn't receive a `SIGTERM` from `docker stop <container>`.
+
+Only the last `ENTRYPOINT` instruction in the Dockerfile will have an effect.
 
 ### Exec form ENTRYPOINT example
 
-You can use the *exec* form of `ENTRYPOINT` to set fairly stable default commands
+You can use the exec form of `ENTRYPOINT` to set fairly stable default commands
 and arguments and then use either form of `CMD` to set additional defaults that
 are more likely to be changed.
 
@@ -1578,7 +1606,7 @@ root         7  0.0  0.1  15572  2164 ?        R+   08:25   0:00 ps aux
 
 And you can gracefully request `top` to shut down using `docker stop test`.
 
-The following `Dockerfile` shows using the `ENTRYPOINT` to run Apache in the
+The following Dockerfile shows using the `ENTRYPOINT` to run Apache in the
 foreground (i.e., as `PID 1`):
 
 ```dockerfile
@@ -1669,21 +1697,7 @@ sys	0m 0.03s
 > **Note**
 >
 > You can override the `ENTRYPOINT` setting using `--entrypoint`,
-> but this can only set the binary to *exec* (no `sh -c` will be used).
-
-> **Note**
->
-> The *exec* form is parsed as a JSON array, which means that
-> you must use double-quotes (") around words not single-quotes (').
-
-Unlike the *shell* form, the *exec* form does not invoke a command shell.
-This means that normal shell processing does not happen. For example,
-`ENTRYPOINT [ "echo", "$HOME" ]` will not do variable substitution on `$HOME`.
-If you want shell processing then either use the *shell* form or execute
-a shell directly, for example: `ENTRYPOINT [ "sh", "-c", "echo $HOME" ]`.
-When using the exec form and executing a shell directly, as in the case for
-the shell form, it is the shell that is doing the environment variable
-expansion, not docker.
+> but this can only set the binary to exec (no `sh -c` will be used).
 
 ### Shell form ENTRYPOINT example
 
@@ -1776,15 +1790,15 @@ There are few rules that describe their co-operation.
 2. `ENTRYPOINT` should be defined when using the container as an executable.
 
 3. `CMD` should be used as a way of defining default arguments for an `ENTRYPOINT` command
-or for executing an ad-hoc command in a container.
+   or for executing an ad-hoc command in a container.
 
 4. `CMD` will be overridden when running the container with alternative arguments.
 
 The table below shows what command is executed for different `ENTRYPOINT` / `CMD` combinations:
 
 |                                | No ENTRYPOINT              | ENTRYPOINT exec_entry p1_entry | ENTRYPOINT ["exec_entry", "p1_entry"]          |
-|:-------------------------------|:---------------------------|:-------------------------------|:-----------------------------------------------|
-| **No CMD**                     | *error, not allowed*       | /bin/sh -c exec_entry p1_entry | exec_entry p1_entry                            |
+| :----------------------------- | :------------------------- | :----------------------------- | :--------------------------------------------- |
+| **No CMD**                     | error, not allowed         | /bin/sh -c exec_entry p1_entry | exec_entry p1_entry                            |
 | **CMD ["exec_cmd", "p1_cmd"]** | exec_cmd p1_cmd            | /bin/sh -c exec_entry p1_entry | exec_entry p1_entry exec_cmd p1_cmd            |
 | **CMD exec_cmd p1_cmd**        | /bin/sh -c exec_cmd p1_cmd | /bin/sh -c exec_entry p1_entry | exec_entry p1_entry /bin/sh -c exec_cmd p1_cmd |
 
@@ -1806,7 +1820,7 @@ containers. The value can be a JSON array, `VOLUME ["/var/log/"]`, or a plain
 string with multiple arguments, such as `VOLUME /var/log` or `VOLUME /var/log
 /var/db`. For more information/examples and mounting instructions via the
 Docker client, refer to
-[*Share Directories via Volumes*](https://docs.docker.com/storage/volumes/)
+[_Share Directories via Volumes_](https://docs.docker.com/storage/volumes/)
 documentation.
 
 The `docker run` command initializes the newly created volume with any data
@@ -1821,12 +1835,12 @@ VOLUME /myvol
 ```
 
 This Dockerfile results in an image that causes `docker run` to
-create a new mount point at `/myvol` and copy the  `greeting` file
+create a new mount point at `/myvol` and copy the `greeting` file
 into the newly created volume.
 
 ### Notes about specifying volumes
 
-Keep the following things in mind about volumes in the `Dockerfile`.
+Keep the following things in mind about volumes in the Dockerfile.
 
 - **Volumes on Windows-based containers**: When using Windows-based containers,
   the destination of a volume inside the container must be one of:
@@ -1845,7 +1859,7 @@ Keep the following things in mind about volumes in the `Dockerfile`.
   portability, since a given host directory can't be guaranteed to be available
   on all hosts. For this reason, you can't mount a host directory from
   within the Dockerfile. The `VOLUME` instruction does not support specifying a `host-dir`
-  parameter.  You must specify the mountpoint when you create or run the container.
+  parameter. You must specify the mountpoint when you create or run the container.
 
 ## USER
 
@@ -1874,6 +1888,7 @@ runtime, runs the relevant `ENTRYPOINT` and `CMD` commands.
 >
 > On Windows, the user must be created first if it's not a built-in account.
 > This can be done with the `net user` command called as part of a Dockerfile.
+{ .warning }
 
 ```dockerfile
 FROM microsoft/windowsservercore
@@ -1890,11 +1905,11 @@ WORKDIR /path/to/workdir
 ```
 
 The `WORKDIR` instruction sets the working directory for any `RUN`, `CMD`,
-`ENTRYPOINT`, `COPY` and `ADD` instructions that follow it in the `Dockerfile`.
+`ENTRYPOINT`, `COPY` and `ADD` instructions that follow it in the Dockerfile.
 If the `WORKDIR` doesn't exist, it will be created even if it's not used in any
-subsequent `Dockerfile` instruction.
+subsequent Dockerfile instruction.
 
-The `WORKDIR` instruction can be used multiple times in a `Dockerfile`. If a
+The `WORKDIR` instruction can be used multiple times in a Dockerfile. If a
 relative path is provided, it will be relative to the path of the previous
 `WORKDIR` instruction. For example:
 
@@ -1905,10 +1920,10 @@ WORKDIR c
 RUN pwd
 ```
 
-The output of the final `pwd` command in this `Dockerfile` would be `/a/b/c`.
+The output of the final `pwd` command in this Dockerfile would be `/a/b/c`.
 
 The `WORKDIR` instruction can resolve environment variables previously set using
-`ENV`. You can only use environment variables explicitly set in the `Dockerfile`.
+`ENV`. You can only use environment variables explicitly set in the Dockerfile.
 For example:
 
 ```dockerfile
@@ -1917,13 +1932,13 @@ WORKDIR $DIRPATH/$DIRNAME
 RUN pwd
 ```
 
-The output of the final `pwd` command in this `Dockerfile` would be
+The output of the final `pwd` command in this Dockerfile would be
 `/path/$DIRNAME`
 
-If not specified, the default working directory is `/`. In practice, if you aren't building a Dockerfile from scratch (`FROM scratch`), 
+If not specified, the default working directory is `/`. In practice, if you aren't building a Dockerfile from scratch (`FROM scratch`),
 the `WORKDIR` may likely be set by the base image you're using.
 
-Therefore, to avoid unintended operations in unknown directories, it is best practice to set your `WORKDIR` explicitly.
+Therefore, to avoid unintended operations in unknown directories, it's best practice to set your `WORKDIR` explicitly.
 
 ## ARG
 
@@ -1950,12 +1965,12 @@ ARG buildno
 # ...
 ```
 
-> **Warning:**
+> **Warning**
 >
 > It is not recommended to use build-time variables for passing secrets like
 > GitHub keys, user credentials etc. Build-time variable values are visible to
 > any user of the image with the `docker history` command.
-> 
+>
 > Refer to the [`RUN --mount=type=secret`](#run---mounttypesecret) section to
 > learn about secure ways to use secrets when building images.
 { .warning }
@@ -1977,8 +1992,8 @@ at build-time, the builder uses the default.
 ### Scope
 
 An `ARG` variable definition comes into effect from the line on which it is
-defined in the `Dockerfile` not from the argument's use on the command-line or
-elsewhere.  For example, consider this Dockerfile:
+defined in the Dockerfile not from the argument's use on the command-line or
+elsewhere. For example, consider this Dockerfile:
 
 ```dockerfile
 FROM busybox
@@ -2120,7 +2135,7 @@ When building this Dockerfile, the `HTTP_PROXY` is preserved in the
 This feature is only available when using the [BuildKit](https://docs.docker.com/build/buildkit/)
 backend.
 
-Docker predefines a set of `ARG` variables with information on the platform of
+BuildKit supports a predefined set of `ARG` variables with information on the platform of
 the node performing the build (build platform) and on the platform of the
 resulting image (target platform). The target platform can be specified with
 the `--platform` flag on `docker build`.
@@ -2150,19 +2165,19 @@ RUN echo "I'm building for $TARGETPLATFORM"
 
 ### BuildKit built-in build args
 
-| Arg                                   | Type   | Description                                                                                                                                                                                                    |
-|---------------------------------------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `BUILDKIT_CACHE_MOUNT_NS`             | String | Set optional cache ID namespace.                                                                                                                                                                               |
-| `BUILDKIT_CONTEXT_KEEP_GIT_DIR`       | Bool   | Trigger git context to keep the `.git` directory.                                                                                                                                                              |
-| `BUILDKIT_INLINE_CACHE`[^2]           | Bool   | Inline cache metadata to image config or not.                                                                                                                                                                  |
-| `BUILDKIT_MULTI_PLATFORM`             | Bool   | Opt into deterministic output regardless of multi-platform output or not.                                                                                                                                      |
-| `BUILDKIT_SANDBOX_HOSTNAME`           | String | Set the hostname (default `buildkitsandbox`)                                                                                                                                                                   |
-| `BUILDKIT_SYNTAX`                     | String | Set frontend image                                                                                                                                                                                             |
-| `SOURCE_DATE_EPOCH`                   | Int    | Set the UNIX timestamp for created image and layers. More info from [reproducible builds](https://reproducible-builds.org/docs/source-date-epoch/). Supported since Dockerfile 1.5, BuildKit 0.11              |
+| Arg                             | Type   | Description                                                                                                                                                                                       |
+| ------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `BUILDKIT_CACHE_MOUNT_NS`       | String | Set optional cache ID namespace.                                                                                                                                                                  |
+| `BUILDKIT_CONTEXT_KEEP_GIT_DIR` | Bool   | Trigger Git context to keep the `.git` directory.                                                                                                                                                 |
+| `BUILDKIT_INLINE_CACHE`[^2]     | Bool   | Inline cache metadata to image config or not.                                                                                                                                                     |
+| `BUILDKIT_MULTI_PLATFORM`       | Bool   | Opt into deterministic output regardless of multi-platform output or not.                                                                                                                         |
+| `BUILDKIT_SANDBOX_HOSTNAME`     | String | Set the hostname (default `buildkitsandbox`)                                                                                                                                                      |
+| `BUILDKIT_SYNTAX`               | String | Set frontend image                                                                                                                                                                                |
+| `SOURCE_DATE_EPOCH`             | Int    | Set the Unix timestamp for created image and layers. More info from [reproducible builds](https://reproducible-builds.org/docs/source-date-epoch/). Supported since Dockerfile 1.5, BuildKit 0.11 |
 
 #### Example: keep `.git` dir
 
-When using a Git context, `.git` dir is not kept on git checkouts. It can be
+When using a Git context, `.git` dir is not kept on checkouts. It can be
 useful to keep it around if you want to retrieve git information during
 your build:
 
@@ -2187,7 +2202,7 @@ build, then a "cache miss" occurs upon its first usage, not its definition. In
 particular, all `RUN` instructions following an `ARG` instruction use the `ARG`
 variable implicitly (as an environment variable), thus can cause a cache miss.
 All predefined `ARG` variables are exempt from caching unless there is a
-matching `ARG` statement in the `Dockerfile`.
+matching `ARG` statement in the Dockerfile.
 
 For example, consider these two Dockerfile:
 
@@ -2204,10 +2219,10 @@ RUN echo hello
 ```
 
 If you specify `--build-arg CONT_IMG_VER=<value>` on the command line, in both
-cases, the specification on line 2 does not cause a cache miss; line 3 does
-cause a cache miss.`ARG CONT_IMG_VER` causes the RUN line to be identified
+cases, the specification on line 2 doesn't cause a cache miss; line 3 does
+cause a cache miss. `ARG CONT_IMG_VER` causes the `RUN` line to be identified
 as the same as running `CONT_IMG_VER=<value> echo hello`, so if the `<value>`
-changes, we get a cache miss.
+changes, you get a cache miss.
 
 Consider another example under the same command line:
 
@@ -2233,7 +2248,7 @@ ENV CONT_IMG_VER=hello
 RUN echo $CONT_IMG_VER
 ```
 
-Line 3 does not cause a cache miss because the value of `CONT_IMG_VER` is a
+Line 3 doesn't cause a cache miss because the value of `CONT_IMG_VER` is a
 constant (`hello`). As a result, the environment variables and values used on
 the `RUN` (line 4) doesn't change between builds.
 
@@ -2243,11 +2258,11 @@ the `RUN` (line 4) doesn't change between builds.
 ONBUILD <INSTRUCTION>
 ```
 
-The `ONBUILD` instruction adds to the image a *trigger* instruction to
+The `ONBUILD` instruction adds to the image a trigger instruction to
 be executed at a later time, when the image is used as the base for
 another build. The trigger will be executed in the context of the
 downstream build, as if it had been inserted immediately after the
-`FROM` instruction in the downstream `Dockerfile`.
+`FROM` instruction in the downstream Dockerfile.
 
 Any build instruction can be registered as a trigger.
 
@@ -2257,12 +2272,12 @@ daemon which may be customized with user-specific configuration.
 
 For example, if your image is a reusable Python application builder, it
 will require application source code to be added in a particular
-directory, and it might require a build script to be called *after*
+directory, and it might require a build script to be called after
 that. You can't just call `ADD` and `RUN` now, because you don't yet
 have access to the application source code, and it will be different for
 each application build. You could simply provide application developers
-with a boilerplate `Dockerfile` to copy-paste into their application, but
-that is inefficient, error-prone and difficult to update because it
+with a boilerplate Dockerfile to copy-paste into their application, but
+that's inefficient, error-prone and difficult to update because it
 mixes with application-specific code.
 
 The solution is to use `ONBUILD` to register advance instructions to
@@ -2272,7 +2287,7 @@ Here's how it works:
 
 1. When it encounters an `ONBUILD` instruction, the builder adds a
    trigger to the metadata of the image being built. The instruction
-   does not otherwise affect the current build.
+   doesn't otherwise affect the current build.
 2. At the end of the build, a list of all triggers is stored in the
    image manifest, under the key `OnBuild`. They can be inspected with
    the `docker inspect` command.
@@ -2284,7 +2299,7 @@ Here's how it works:
    build to fail. If all triggers succeed, the `FROM` instruction
    completes and the build continues as usual.
 4. Triggers are cleared from the final image after being executed. In
-   other words they are not inherited by "grand-children" builds.
+   other words they aren't inherited by "grand-children" builds.
 
 For example you might add something like this:
 
@@ -2296,10 +2311,12 @@ ONBUILD RUN /usr/local/bin/python-build --dir /app/src
 > **Warning**
 >
 > Chaining `ONBUILD` instructions using `ONBUILD ONBUILD` isn't allowed.
+{ .warning }
 
 > **Warning**
 >
 > The `ONBUILD` instruction may not trigger `FROM` or `MAINTAINER` instructions.
+{ .warning }
 
 ## STOPSIGNAL
 
@@ -2324,11 +2341,11 @@ The `HEALTHCHECK` instruction has two forms:
 - `HEALTHCHECK NONE` (disable any healthcheck inherited from the base image)
 
 The `HEALTHCHECK` instruction tells Docker how to test a container to check that
-it is still working. This can detect cases such as a web server that is stuck in
+it's still working. This can detect cases such as a web server stuck in
 an infinite loop and unable to handle new connections, even though the server
 process is still running.
 
-When a container has a healthcheck specified, it has a _health status_ in
+When a container has a healthcheck specified, it has a health status in
 addition to its normal status. This status is initially `starting`. Whenever a
 health check passes, it becomes `healthy` (whatever state it was previously in).
 After a certain number of consecutive failures, it becomes `unhealthy`.
@@ -2362,15 +2379,15 @@ There can only be one `HEALTHCHECK` instruction in a Dockerfile. If you list
 more than one then only the last `HEALTHCHECK` will take effect.
 
 The command after the `CMD` keyword can be either a shell command (e.g. `HEALTHCHECK
-CMD /bin/check-running`) or an _exec_ array (as with other Dockerfile commands;
+CMD /bin/check-running`) or an exec array (as with other Dockerfile commands;
 see e.g. `ENTRYPOINT` for details).
 
 The command's exit status indicates the health status of the container.
 The possible values are:
 
 - 0: success - the container is healthy and ready for use
-- 1: unhealthy - the container is not working correctly
-- 2: reserved - do not use this exit code
+- 1: unhealthy - the container isn't working correctly
+- 2: reserved - don't use this exit code
 
 For example, to check every five minutes or so that a web-server is able to
 serve the site's main page within three seconds:
@@ -2388,16 +2405,15 @@ are stored currently).
 When the health status of a container changes, a `health_status` event is
 generated with the new status.
 
-
 ## SHELL
 
 ```dockerfile
 SHELL ["executable", "parameters"]
 ```
 
-The `SHELL` instruction allows the default shell used for the *shell* form of
+The `SHELL` instruction allows the default shell used for the shell form of
 commands to be overridden. The default shell on Linux is `["/bin/sh", "-c"]`, and on
-Windows is `["cmd", "/S", "/C"]`. The `SHELL` instruction *must* be written in JSON
+Windows is `["cmd", "/S", "/C"]`. The `SHELL` instruction must be written in JSON
 form in a Dockerfile.
 
 The `SHELL` instruction is particularly useful on Windows where there are
@@ -2426,7 +2442,7 @@ RUN echo hello
 ```
 
 The following instructions can be affected by the `SHELL` instruction when the
-*shell* form of them is used in a Dockerfile: `RUN`, `CMD` and `ENTRYPOINT`.
+shell form of them is used in a Dockerfile: `RUN`, `CMD` and `ENTRYPOINT`.
 
 The following example is a common pattern found on Windows which can be
 streamlined by using the `SHELL` instruction:
@@ -2435,26 +2451,26 @@ streamlined by using the `SHELL` instruction:
 RUN powershell -command Execute-MyCmdlet -param1 "c:\foo.txt"
 ```
 
-The command invoked by docker will be:
+The command invoked by the builder will be:
 
 ```powershell
 cmd /S /C powershell -command Execute-MyCmdlet -param1 "c:\foo.txt"
 ```
 
-This is inefficient for two reasons. First, there is an un-necessary cmd.exe command
-processor (aka shell) being invoked. Second, each `RUN` instruction in the *shell*
-form requires an extra `powershell -command` prefixing the command.
+This is inefficient for two reasons. First, there is an unnecessary `cmd.exe`
+command processor (aka shell) being invoked. Second, each `RUN` instruction in
+the shell form requires an extra `powershell -command` prefixing the command.
 
 To make this more efficient, one of two mechanisms can be employed. One is to
-use the JSON form of the RUN command such as:
+use the JSON form of the `RUN` command such as:
 
 ```dockerfile
 RUN ["powershell", "-command", "Execute-MyCmdlet", "-param1 \"c:\\foo.txt\""]
 ```
 
-While the JSON form is unambiguous and does not use the un-necessary cmd.exe,
+While the JSON form is unambiguous and does not use the unnecessary `cmd.exe`,
 it does require more verbosity through double-quoting and escaping. The alternate
-mechanism is to use the `SHELL` instruction and the *shell* form,
+mechanism is to use the `SHELL` instruction and the shell form,
 making a more natural syntax for Windows users, especially when combined with
 the `escape` parser directive:
 
@@ -2602,6 +2618,7 @@ For examples of Dockerfiles, refer to:
 - The ["build images" section](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/)
 - The ["get started" tutorial](https://docs.docker.com/get-started/)
 - The [language-specific getting started guides](https://docs.docker.com/language/)
+- The [build guide](https://docs.docker.com/build/guide/)
 
 [^1]: Value required
 [^2]: For Docker-integrated [BuildKit](https://docs.docker.com/build/buildkit/#getting-started) and `docker buildx build`


### PR DESCRIPTION
Had a go at trying to improve some style & verbiage of the dockerfile frontend reference.

I also tried to deduplicate and consolidate some of the gotchas around the shell and exec forms, and created a section for that.