### PR TITLE
docs: update builtctl.md to fix markdown links and typo

### DIFF
--- a/docs/reference/buildctl.md
+++ b/docs/reference/buildctl.md
@@ -88,8 +88,8 @@ OPTIONS:
 The build consists of the following key elements:
 
 * [frontend definition](#frontend): parses the build descriptor, e.g. dockerfile
-* [local sources](#local_sources): sets relevant directories and files passed to the build
-* [frontend options](#frontend_options): options that are relevant to the particular frontend
+* [local sources](#local-sources): sets relevant directories and files passed to the build
+* [frontend options](#frontend-options): options that are relevant to the particular frontend
 * [output](#output): defines what format of output to use and where to place it
 * [cache](#cache): defines where to export the cache generated during the build to, or where to import from
 
@@ -183,7 +183,7 @@ $ buildctl build --frontend dockerfile.v0 --local context=. --local dockerfile=.
 #### gateway-specific options
 
 The `gateway.v0` frontend passes all of its `--opt` options on to the OCI image that is called to convert the
-input to LLB. The one requires option is `--opt source=<image>`, which defines the OCI image to use to convert
+input to LLB. The one required option is `--opt source=<image>`, which defines the OCI image to use to convert
 the input to LLB.
 
 For example:


### PR DESCRIPTION
#### Issue: N/A

#### Description:
This change updates buildctl.md to

1. fix the markdown links for local sources and frontend options
2. resolve a typo to denote **_source_** as the one ~requires~ -> *required* gateway-specific option

#### Testing:
Validated the markdown links are working using VSCode local preview.