### PR TITLE
String substitution in variable expansion

### DIFF
--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -320,6 +320,20 @@ directive in your Dockerfile:
   string=foobarbaz echo ${string%%b*}   # foo
   ```
 
+- `${variable/pattern/replacement}` replace the first occurrence of `pattern`
+  in `variable` with `replacement`
+
+  ```bash
+  string=foobarbaz echo ${string/ba/fo}  # fooforbaz
+  ```
+
+- `${variable//pattern/replacement}` replaces all occurrences of `pattern`
+  in `variable` with `replacement`
+
+  ```bash
+  string=foobarbaz echo ${string//ba/fo}  # fooforfoz
+  ```
+
 In all cases, `word` can be any string, including additional environment
 variables.
 


### PR DESCRIPTION
One of the variable expansion functions missing from #4287 was string substition, so I implemented it.

Motivating example:

```dockerfile
ARG VERSION=1.2.3
ARG URL=https://github.com/foo-corp/foo/releases/download/$VERSION/foo-$VERSION-${TARGETARCH}.tar.gz
ADD ${URL//arm64/aarch64} /tmp/foo.tar.gz
RUN tar -xf /tmp/foo.tar.gz
```

The two parts following the variable name (pattern and replacement) need to be parsed separately with `processStopWords`, otherwise variable expansion could cause a `/` in a variable referenced in the pattern to be interpreted as separator between patern and replacement. This means that the second `/` is required (i.e. `${foo/bar/}` to remove `bar`, compared to `${foo/bar}` as accepted by various shells).

On the positive side, wildcards and slashes in referenced variables are handled correctly (e.g. `PAT='*/'; REPL='.../'; ${FOO/$PAT/$REPL}`). 