### PR TITLE
dockerfile: remove duplicate layer chains from provenance attestation

### DIFF
--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -169,6 +169,7 @@ var allTests = integration.TestFuncs(
 	testNilContextInSolveGateway,
 	testCopyUnicodePath,
 	testFrontendDeduplicateSources,
+	testDuplicateLayersProvenance,
 )
 
 // Tests that depend on the `security.*` entitlements


### PR DESCRIPTION
When a step in the dockerfile is a dependency of multiple other steps in
the dockerfile, the provenance attestation would record the layer chain
for that step multiple times even with the same layer chain.

This is because the provenance attestation reuses the exporter mechanic
and the exporter mechanic would need to visit this same step multiple
times to produce the appropriate cache entries.

Since these duplicate layer chains aren't intentional, this modifies the
provenance attestation capture to detect these duplicates and remove
them.

Fixes #4143.