### PR TITLE
docs: explain attestation-inline=false

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,8 @@ Keys supported by image output:
   * `<type>` specifies what object to attach to, and can be any of `manifest` (the default), `manifest-descriptor`, `index` and `index-descriptor`
   * `<platform>` specifies which objects to attach to (by default, all), and is the same key passed into the `platform` opt, see [`docs/multi-platform.md`](docs/multi-platform.md).
   * See [`docs/annotations.md`](docs/annotations.md) for more details.
+* `attestation-inline=false`: Prevent attaching an [attestation manifest](./docs/attestations/) to the built image.
+  This option is expected to be used as a workaround for compatibility issue with third party registry implementations that do not properly implement the OCI Distribution Spec.
 
 If credentials are required, `buildctl` will attempt to read Docker configuration file `$DOCKER_CONFIG/config.json`.
 `$DOCKER_CONFIG` defaults to `~/.docker`.

--- a/docs/attestations/attestation-storage.md
+++ b/docs/attestations/attestation-storage.md
@@ -213,3 +213,9 @@ Attestation body containing the SBOM data listing the packages used during the b
     "spdxVersion": "SPDX-2.2",
     ...
 ```
+
+## Tips
+### Preventing attaching attestation manifests
+
+To prevent attaching an attestation manifest to the built image, specify an image exporter option `attestation-inline=false`.
+This option is expected to be used as a workaround for compatibility issue with third party registry implementations that do not properly implement the OCI Distribution Spec.


### PR DESCRIPTION
This option is expected to be used as a workaround for compatibility issue with third party registry implementations that do not properly implement the OCI Distribution Spec.

It is reported that GitLab Container Registry needs this.
https://github.com/moby/moby/issues/28394#issuecomment-1823177654
( Thanks to @slonopotamus )