### PR TITLE
llbsolver: fix possible panic when setting event to nil

### DIFF
--- a/solver/llbsolver/history.go
+++ b/solver/llbsolver/history.go
@@ -819,7 +819,7 @@ func (h *HistoryQueue) Listen(ctx context.Context, req *controlapi.BuildHistoryR
 		}
 		h.mu.Unlock()
 		for _, e := range events {
-			if e.Record == nil {
+			if e == nil || e.Record == nil {
 				continue
 			}
 			if err := f(e); err != nil {


### PR DESCRIPTION
When a record is marked for deletion the event is set to nil but we don't check if it's nil when sending events which could cause a panic.