### PR TITLE
replace context.WithCancel with WithCancelCause

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,6 +42,8 @@ linters-settings:
       - '^fmt\.Errorf(# use errors\.Errorf instead)?$'
       - '^logrus\.(Trace|Debug|Info|Warn|Warning|Error|Fatal)(f|ln)?(# use bklog\.G or bklog\.L instead of logrus directly)?$'
       - '^context\.WithCancel(# use context\.WithCancelCause instead)?$'
+      - '^context\.WithTimeout(# use context\.WithTimeoutCause instead)?$'
+      - '^context\.WithDeadline(# use context\.WithDeadline instead)?$'
       - '^ctx\.Err(# use context\.Cause instead)?$'
   importas:
     alias:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,6 +41,8 @@ linters-settings:
     forbid:
       - '^fmt\.Errorf(# use errors\.Errorf instead)?$'
       - '^logrus\.(Trace|Debug|Info|Warn|Warning|Error|Fatal)(f|ln)?(# use bklog\.G or bklog\.L instead of logrus directly)?$'
+      - '^context\.WithCancel(# use context\.WithCancelCause instead)?$'
+      - '^ctx\.Err(# use context\.Cause instead)?$'
   importas:
     alias:
       - pkg: "github.com/opencontainers/image-spec/specs-go/v1"

--- a/cache/manager.go
+++ b/cache/manager.go
@@ -1258,7 +1258,7 @@ func (cm *cacheManager) prune(ctx context.Context, ch chan client.UsageInfo, opt
 
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return context.Cause(ctx)
 	default:
 		return cm.prune(ctx, ch, opt)
 	}

--- a/cache/remotecache/azblob/exporter.go
+++ b/cache/remotecache/azblob/exporter.go
@@ -150,8 +150,9 @@ func (ce *exporter) uploadManifest(ctx context.Context, manifestKey string, read
 		return errors.Wrap(err, "error creating container client")
 	}
 
-	ctx, cnclFn := context.WithTimeout(ctx, time.Minute*5)
-	defer cnclFn()
+	ctx, cnclFn := context.WithCancelCause(ctx)
+	ctx, _ = context.WithTimeoutCause(ctx, time.Minute*5, errors.WithStack(context.DeadlineExceeded))
+	defer cnclFn(errors.WithStack(context.Canceled))
 
 	_, err = blobClient.Upload(ctx, reader, &azblob.BlockBlobUploadOptions{})
 	if err != nil {
@@ -170,8 +171,9 @@ func (ce *exporter) uploadBlobIfNotExists(ctx context.Context, blobKey string, r
 		return errors.Wrap(err, "error creating container client")
 	}
 
-	uploadCtx, cnclFn := context.WithTimeout(ctx, time.Minute*5)
-	defer cnclFn()
+	uploadCtx, cnclFn := context.WithCancelCause(ctx)
+	uploadCtx, _ = context.WithTimeoutCause(uploadCtx, time.Minute*5, errors.WithStack(context.DeadlineExceeded))
+	defer cnclFn(errors.WithStack(context.Canceled))
 
 	// Only upload if the blob doesn't exist
 	eTagAny := azblob.ETagAny

--- a/cache/remotecache/local/local.go
+++ b/cache/remotecache/local/local.go
@@ -105,8 +105,9 @@ func getContentStore(ctx context.Context, sm *session.Manager, g session.Group, 
 	if sessionID == "" {
 		return nil, errors.New("local cache exporter/importer requires session")
 	}
-	timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+	timeoutCtx, cancel := context.WithCancelCause(context.Background())
+	timeoutCtx, _ = context.WithTimeoutCause(timeoutCtx, 5*time.Second, errors.WithStack(context.DeadlineExceeded))
+	defer cancel(errors.WithStack(context.Canceled))
 
 	caller, err := sm.Get(timeoutCtx, sessionID, false)
 	if err != nil {

--- a/client/build_test.go
+++ b/client/build_test.go
@@ -933,7 +933,7 @@ func testClientGatewayContainerPID1Tty(t *testing.T, sb integration.Sandbox) {
 	output := bytes.NewBuffer(nil)
 
 	b := func(ctx context.Context, c client.Client) (*client.Result, error) {
-		ctx, timeout := context.WithTimeout(ctx, 10*time.Second)
+		ctx, timeout := context.WithTimeoutCause(ctx, 10*time.Second, nil)
 		defer timeout()
 
 		st := llb.Image("busybox:latest")
@@ -1015,7 +1015,7 @@ func testClientGatewayContainerCancelPID1Tty(t *testing.T, sb integration.Sandbo
 	output := bytes.NewBuffer(nil)
 
 	b := func(ctx context.Context, c client.Client) (*client.Result, error) {
-		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		ctx, cancel := context.WithTimeoutCause(ctx, 10*time.Second, nil)
 		defer cancel()
 
 		st := llb.Image("busybox:latest")
@@ -1141,7 +1141,7 @@ func testClientGatewayContainerExecTty(t *testing.T, sb integration.Sandbox) {
 	inputR, inputW := io.Pipe()
 	output := bytes.NewBuffer(nil)
 	b := func(ctx context.Context, c client.Client) (*client.Result, error) {
-		ctx, timeout := context.WithTimeout(ctx, 10*time.Second)
+		ctx, timeout := context.WithTimeoutCause(ctx, 10*time.Second, nil)
 		defer timeout()
 		st := llb.Image("busybox:latest")
 
@@ -1233,7 +1233,7 @@ func testClientGatewayContainerCancelExecTty(t *testing.T, sb integration.Sandbo
 	inputR, inputW := io.Pipe()
 	output := bytes.NewBuffer(nil)
 	b := func(ctx context.Context, c client.Client) (*client.Result, error) {
-		ctx, timeout := context.WithTimeout(ctx, 10*time.Second)
+		ctx, timeout := context.WithTimeoutCause(ctx, 10*time.Second, nil)
 		defer timeout()
 		st := llb.Image("busybox:latest")
 
@@ -2132,7 +2132,7 @@ func testClientGatewayContainerSignal(t *testing.T, sb integration.Sandbox) {
 	product := "buildkit_test"
 
 	b := func(ctx context.Context, c client.Client) (*client.Result, error) {
-		ctx, timeout := context.WithTimeout(ctx, 10*time.Second)
+		ctx, timeout := context.WithTimeoutCause(ctx, 10*time.Second, nil)
 		defer timeout()
 
 		st := llb.Image("busybox:latest")

--- a/client/build_test.go
+++ b/client/build_test.go
@@ -1266,8 +1266,8 @@ func testClientGatewayContainerCancelExecTty(t *testing.T, sb integration.Sandbo
 		defer pid1.Wait()
 		defer ctr.Release(ctx)
 
-		execCtx, cancel := context.WithCancel(ctx)
-		defer cancel()
+		execCtx, cancel := context.WithCancelCause(ctx)
+		defer cancel(errors.WithStack(context.Canceled))
 
 		prompt := newTestPrompt(execCtx, t, inputW, output)
 		pid2, err := ctr.Start(execCtx, client.StartRequest{
@@ -1281,7 +1281,7 @@ func testClientGatewayContainerCancelExecTty(t *testing.T, sb integration.Sandbo
 		require.NoError(t, err)
 
 		prompt.SendExpect("echo hi", "hi")
-		cancel()
+		cancel(errors.WithStack(context.Canceled))
 
 		err = pid2.Wait()
 		require.ErrorIs(t, err, context.Canceled)

--- a/client/client.go
+++ b/client/client.go
@@ -205,7 +205,7 @@ func (c *Client) Wait(ctx context.Context) error {
 
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return context.Cause(ctx)
 		case <-time.After(time.Second):
 		}
 		c.conn.ResetConnectBackoff()

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -9832,7 +9832,7 @@ func testLLBMountPerformance(t *testing.T, sb integration.Sandbox) {
 	def, err := st.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	timeoutCtx, cancel := context.WithTimeout(sb.Context(), time.Minute)
+	timeoutCtx, cancel := context.WithTimeoutCause(sb.Context(), time.Minute, nil)
 	defer cancel()
 	_, err = c.Solve(timeoutCtx, def, SolveOpt{}, nil)
 	require.NoError(t, err)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -7407,8 +7407,8 @@ func testInvalidExporter(t *testing.T, sb integration.Sandbox) {
 
 // moby/buildkit#492
 func testParallelLocalBuilds(t *testing.T, sb integration.Sandbox) {
-	ctx, cancel := context.WithCancel(sb.Context())
-	defer cancel()
+	ctx, cancel := context.WithCancelCause(sb.Context())
+	defer cancel(errors.WithStack(context.Canceled))
 
 	c, err := New(ctx, sb.Address())
 	require.NoError(t, err)

--- a/client/llb/async.go
+++ b/client/llb/async.go
@@ -61,7 +61,7 @@ func (as *asyncState) Do(ctx context.Context, c *Constraints) error {
 		if err != nil {
 			select {
 			case <-ctx.Done():
-				if errors.Is(err, ctx.Err()) {
+				if errors.Is(err, context.Cause(ctx)) {
 					return res, err
 				}
 			default:

--- a/cmd/buildctl/common/common.go
+++ b/cmd/buildctl/common/common.go
@@ -91,9 +91,10 @@ func ResolveClient(c *cli.Context) (*client.Client, error) {
 
 	timeout := time.Duration(c.GlobalInt("timeout"))
 	if timeout > 0 {
-		ctx2, cancel := context.WithTimeout(ctx, timeout*time.Second)
+		ctx2, cancel := context.WithCancelCause(ctx)
+		ctx2, _ = context.WithTimeoutCause(ctx2, timeout*time.Second, errors.WithStack(context.DeadlineExceeded))
 		ctx = ctx2
-		defer cancel()
+		defer cancel(errors.WithStack(context.Canceled))
 	}
 
 	cl, err := client.New(ctx, c.GlobalString("addr"), opts...)

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -223,8 +223,8 @@ func main() {
 		if os.Geteuid() > 0 {
 			return errors.New("rootless mode requires to be executed as the mapped root in a user namespace; you may use RootlessKit for setting up the namespace")
 		}
-		ctx, cancel := context.WithCancel(appcontext.Context())
-		defer cancel()
+		ctx, cancel := context.WithCancelCause(appcontext.Context())
+		defer cancel(errors.WithStack(context.Canceled))
 
 		cfg, err := config.LoadFile(c.GlobalString("config"))
 		if err != nil {
@@ -344,9 +344,9 @@ func main() {
 		select {
 		case serverErr := <-errCh:
 			err = serverErr
-			cancel()
+			cancel(err)
 		case <-ctx.Done():
-			err = ctx.Err()
+			err = context.Cause(ctx)
 		}
 
 		bklog.G(ctx).Infof("stopping server")
@@ -634,14 +634,14 @@ func unaryInterceptor(globalCtx context.Context, tp trace.TracerProvider) grpc.U
 	withTrace := otelgrpc.UnaryServerInterceptor(otelgrpc.WithTracerProvider(tp), otelgrpc.WithPropagators(propagators))
 
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
-		ctx, cancel := context.WithCancel(ctx)
-		defer cancel()
+		ctx, cancel := context.WithCancelCause(ctx)
+		defer cancel(errors.WithStack(context.Canceled))
 
 		go func() {
 			select {
 			case <-ctx.Done():
 			case <-globalCtx.Done():
-				cancel()
+				cancel(context.Cause(globalCtx))
 			}
 		}()
 

--- a/control/control.go
+++ b/control/control.go
@@ -505,10 +505,10 @@ func (c *Controller) Session(stream controlapi.Control_SessionServer) error {
 	conn, closeCh, opts := grpchijack.Hijack(stream)
 	defer conn.Close()
 
-	ctx, cancel := context.WithCancel(stream.Context())
+	ctx, cancel := context.WithCancelCause(stream.Context())
 	go func() {
 		<-closeCh
-		cancel()
+		cancel(errors.WithStack(context.Canceled))
 	}()
 
 	err := c.opt.SessionManager.HandleConn(ctx, conn, opts)

--- a/control/gateway/gateway.go
+++ b/control/gateway/gateway.go
@@ -59,8 +59,9 @@ func (gwf *GatewayForwarder) lookupForwarder(ctx context.Context) (gateway.LLBBr
 		return nil, errors.New("no buildid found in context")
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
-	defer cancel()
+	ctx, cancel := context.WithCancelCause(ctx)
+	ctx, _ = context.WithTimeoutCause(ctx, 3*time.Second, errors.WithStack(context.DeadlineExceeded))
+	defer cancel(errors.WithStack(context.Canceled))
 
 	go func() {
 		<-ctx.Done()

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -532,8 +532,9 @@ func (k procKiller) Kill(ctx context.Context) (err error) {
 
 	// this timeout is generally a no-op, the Kill ctx should already have a
 	// shorter timeout but here as a fail-safe for future refactoring.
-	ctx, timeout := context.WithTimeout(ctx, 10*time.Second)
-	defer timeout()
+	ctx, cancel := context.WithCancelCause(ctx)
+	ctx, _ = context.WithTimeoutCause(ctx, 10*time.Second, errors.WithStack(context.DeadlineExceeded))
+	defer cancel(errors.WithStack(context.Canceled))
 
 	if k.pidfile == "" {
 		// for `runc run` process we use `runc kill` to terminate the process
@@ -615,17 +616,17 @@ func runcProcessHandle(ctx context.Context, killer procKiller) (*procHandle, con
 		for {
 			select {
 			case <-ctx.Done():
-				killCtx, timeout := context.WithTimeout(context.Background(), 7*time.Second)
+				killCtx, timeout := context.WithCancelCause(context.Background())
+				killCtx, _ = context.WithTimeoutCause(killCtx, 7*time.Second, errors.WithStack(context.DeadlineExceeded))
 				if err := p.killer.Kill(killCtx); err != nil {
 					select {
 					case <-killCtx.Done():
-						timeout()
 						cancel(errors.WithStack(context.Cause(ctx)))
 						return
 					default:
 					}
 				}
-				timeout()
+				timeout(errors.WithStack(context.Canceled))
 				select {
 				case <-time.After(50 * time.Millisecond):
 				case <-p.ended:
@@ -673,10 +674,11 @@ func (p *procHandle) WaitForReady(ctx context.Context) error {
 // We wait for up to 10s for the runc pid to be reported.  If the started
 // callback is non-nil it will be called after receiving the pid.
 func (p *procHandle) WaitForStart(ctx context.Context, startedCh <-chan int, started func()) error {
-	startedCtx, timeout := context.WithTimeout(ctx, 10*time.Second)
-	defer timeout()
+	ctx, cancel := context.WithCancelCause(ctx)
+	ctx, _ = context.WithTimeoutCause(ctx, 10*time.Second, errors.WithStack(context.DeadlineExceeded))
+	defer cancel(errors.WithStack(context.Canceled))
 	select {
-	case <-startedCtx.Done():
+	case <-ctx.Done():
 		return errors.New("go-runc started message never received")
 	case runcPid, ok := <-startedCh:
 		if !ok {

--- a/exporter/local/export.go
+++ b/exporter/local/export.go
@@ -61,8 +61,9 @@ func (e *localExporter) Config() *exporter.Config {
 }
 
 func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source, sessionID string) (map[string]string, exporter.DescriptorReference, error) {
-	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
+	timeoutCtx, cancel := context.WithCancelCause(ctx)
+	timeoutCtx, _ = context.WithTimeoutCause(timeoutCtx, 5*time.Second, errors.WithStack(context.DeadlineExceeded))
+	defer cancel(errors.WithStack(context.Canceled))
 
 	if e.opts.Epoch == nil {
 		if tm, ok, err := epoch.ParseSource(inp); err != nil {

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -198,8 +198,9 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 		return nil, nil, errors.Errorf("invalid variant %q", e.opt.Variant)
 	}
 
-	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
+	timeoutCtx, cancel := context.WithCancelCause(ctx)
+	timeoutCtx, _ = context.WithTimeoutCause(timeoutCtx, 5*time.Second, errors.WithStack(context.DeadlineExceeded))
+	defer cancel(errors.WithStack(context.Canceled))
 
 	caller, err := e.opt.SessionManager.Get(timeoutCtx, sessionID, false)
 	if err != nil {

--- a/exporter/tar/export.go
+++ b/exporter/tar/export.go
@@ -143,8 +143,9 @@ func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source
 		fs = d.FS
 	}
 
-	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
+	timeoutCtx, cancel := context.WithCancelCause(ctx)
+	timeoutCtx, _ = context.WithTimeoutCause(timeoutCtx, 5*time.Second, errors.WithStack(context.DeadlineExceeded))
+	defer cancel(errors.WithStack(context.Canceled))
 
 	caller, err := e.opt.SessionManager.Get(timeoutCtx, sessionID, false)
 	if err != nil {

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -2692,8 +2692,9 @@ COPY . .
 		fstest.CreateFile(".dockerignore", []byte("!\n"), 0600),
 	)
 
-	ctx, cancel := context.WithTimeout(sb.Context(), 15*time.Second)
-	defer cancel()
+	ctx, cancel := context.WithCancelCause(sb.Context())
+	ctx, _ = context.WithTimeoutCause(ctx, 15*time.Second, errors.WithStack(context.DeadlineExceeded))
+	defer cancel(errors.WithStack(context.Canceled))
 
 	c, err := client.New(ctx, sb.Address())
 	require.NoError(t, err)

--- a/frontend/gateway/container/container.go
+++ b/frontend/gateway/container/container.go
@@ -48,7 +48,7 @@ type Mount struct {
 }
 
 func NewContainer(ctx context.Context, w worker.Worker, sm *session.Manager, g session.Group, req NewContainerRequest) (client.Container, error) {
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancelCause(ctx)
 	eg, ctx := errgroup.WithContext(ctx)
 	platform := opspb.Platform{
 		OS:           runtime.GOOS,
@@ -300,7 +300,7 @@ type gatewayContainer struct {
 	mu         sync.Mutex
 	cleanup    []func() error
 	ctx        context.Context
-	cancel     func()
+	cancel     func(error)
 }
 
 func (gwCtr *gatewayContainer) Start(ctx context.Context, req client.StartRequest) (client.ContainerProcess, error) {
@@ -408,7 +408,7 @@ func (gwCtr *gatewayContainer) loadSecretEnv(ctx context.Context, secretEnv []*p
 func (gwCtr *gatewayContainer) Release(ctx context.Context) error {
 	gwCtr.mu.Lock()
 	defer gwCtr.mu.Unlock()
-	gwCtr.cancel()
+	gwCtr.cancel(errors.WithStack(context.Canceled))
 	err1 := gwCtr.errGroup.Wait()
 
 	var err2 error

--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -456,7 +456,7 @@ func newBridgeForwarder(ctx context.Context, llbBridge frontend.FrontendLLBBridg
 }
 
 func serveLLBBridgeForwarder(ctx context.Context, llbBridge frontend.FrontendLLBBridge, workers worker.Infos, inputs map[string]*opspb.Definition, sid string, sm *session.Manager) (*llbBridgeForwarder, context.Context, error) {
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancelCause(ctx)
 	lbf := newBridgeForwarder(ctx, llbBridge, workers, inputs, sid, sm)
 	server := grpc.NewServer(grpc.UnaryInterceptor(grpcerrors.UnaryServerInterceptor), grpc.StreamInterceptor(grpcerrors.StreamServerInterceptor))
 	grpc_health_v1.RegisterHealthServer(server, health.NewServer())
@@ -469,7 +469,7 @@ func serveLLBBridgeForwarder(ctx context.Context, llbBridge frontend.FrontendLLB
 		default:
 			lbf.isErrServerClosed = true
 		}
-		cancel()
+		cancel(errors.WithStack(context.Canceled))
 	}()
 
 	return lbf, ctx, nil
@@ -1322,8 +1322,8 @@ func (lbf *llbBridgeForwarder) ExecProcess(srv pb.LLBBridge_ExecProcessServer) e
 					return stack.Enable(status.Errorf(codes.NotFound, "container %q previously released or not created", id))
 				}
 
-				initCtx, initCancel := context.WithCancel(context.Background())
-				defer initCancel()
+				initCtx, initCancel := context.WithCancelCause(context.Background())
+				defer initCancel(errors.WithStack(context.Canceled))
 
 				pio := newProcessIO(pid, init.Fds)
 				pios[pid] = pio

--- a/frontend/gateway/grpcclient/client.go
+++ b/frontend/gateway/grpcclient/client.go
@@ -43,8 +43,9 @@ type GrpcClient interface {
 }
 
 func New(ctx context.Context, opts map[string]string, session, product string, c pb.LLBBridgeClient, w []client.WorkerInfo) (GrpcClient, error) {
-	pingCtx, pingCancel := context.WithTimeout(ctx, 15*time.Second)
-	defer pingCancel()
+	pingCtx, pingCancel := context.WithCancelCause(ctx)
+	pingCtx, _ = context.WithTimeoutCause(pingCtx, 15*time.Second, errors.WithStack(context.DeadlineExceeded))
+	defer pingCancel(errors.WithStack(context.Canceled))
 	resp, err := c.Ping(pingCtx, &pb.PingRequest{})
 	if err != nil {
 		return nil, err

--- a/frontend/gateway/grpcclient/client.go
+++ b/frontend/gateway/grpcclient/client.go
@@ -616,7 +616,7 @@ func (b *procMessageForwarder) Close() {
 type messageForwarder struct {
 	client pb.LLBBridgeClient
 	ctx    context.Context
-	cancel func()
+	cancel func(error)
 	eg     *errgroup.Group
 	mu     sync.Mutex
 	pids   map[string]*procMessageForwarder
@@ -630,7 +630,7 @@ type messageForwarder struct {
 }
 
 func newMessageForwarder(ctx context.Context, client pb.LLBBridgeClient) *messageForwarder {
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancelCause(ctx)
 	eg, ctx := errgroup.WithContext(ctx)
 	return &messageForwarder{
 		client: client,
@@ -719,7 +719,7 @@ func (m *messageForwarder) Send(msg *pb.ExecMessage) error {
 }
 
 func (m *messageForwarder) Release() error {
-	m.cancel()
+	m.cancel(errors.WithStack(context.Canceled))
 	return m.eg.Wait()
 }
 
@@ -949,7 +949,7 @@ func (ctr *container) Start(ctx context.Context, req client.StartRequest) (clien
 				closeDoneOnce.Do(func() {
 					close(done)
 				})
-				return ctx.Err()
+				return context.Cause(ctx)
 			}
 
 			if file := msg.GetFile(); file != nil {
@@ -1145,7 +1145,7 @@ func grpcClientConn(ctx context.Context) (context.Context, *grpc.ClientConn, err
 		return nil, nil, errors.Wrap(err, "failed to create grpc client")
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancelCause(ctx)
 	_ = cancel
 	// go monitorHealth(ctx, cc, cancel)
 

--- a/session/filesync/filesync.go
+++ b/session/filesync/filesync.go
@@ -195,8 +195,8 @@ func FSSync(ctx context.Context, c session.Caller, opt FSSendRequestOpt) error {
 
 	opts[keyDirName] = []string{opt.Name}
 
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(errors.WithStack(context.Canceled))
 
 	client := NewFileSyncClient(c.Conn())
 

--- a/session/group.go
+++ b/session/group.go
@@ -72,8 +72,9 @@ func (sm *Manager) Any(ctx context.Context, g Group, f func(context.Context, str
 			return errors.Errorf("no active sessions")
 		}
 
-		timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		defer cancel()
+		timeoutCtx, cancel := context.WithCancelCause(ctx)
+		timeoutCtx, _ = context.WithTimeoutCause(timeoutCtx, 5*time.Second, errors.WithStack(context.DeadlineExceeded))
+		defer cancel(errors.WithStack(context.Canceled))
 		c, err := sm.Get(timeoutCtx, id, false)
 		if err != nil {
 			lastErr = err

--- a/session/grpc.go
+++ b/session/grpc.go
@@ -74,14 +74,14 @@ func grpcClientConn(ctx context.Context, conn net.Conn) (context.Context, *grpc.
 		return nil, nil, errors.Wrap(err, "failed to create grpc client")
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancelCause(ctx)
 	go monitorHealth(ctx, cc, cancel)
 
 	return ctx, cc, nil
 }
 
-func monitorHealth(ctx context.Context, cc *grpc.ClientConn, cancelConn func()) {
-	defer cancelConn()
+func monitorHealth(ctx context.Context, cc *grpc.ClientConn, cancelConn func(error)) {
+	defer cancelConn(errors.WithStack(context.Canceled))
 	defer cc.Close()
 
 	ticker := time.NewTicker(5 * time.Second)

--- a/session/manager.go
+++ b/session/manager.go
@@ -99,8 +99,8 @@ func (sm *Manager) HandleConn(ctx context.Context, conn net.Conn, opts map[strin
 
 // caller needs to take lock, this function will release it
 func (sm *Manager) handleConn(ctx context.Context, conn net.Conn, opts map[string][]string) error {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(errors.WithStack(context.Canceled))
 
 	opts = canonicalHeaders(opts)
 
@@ -156,8 +156,8 @@ func (sm *Manager) Get(ctx context.Context, id string, noWait bool) (Caller, err
 		id = p[1]
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(errors.WithStack(context.Canceled))
 
 	go func() {
 		<-ctx.Done()
@@ -173,7 +173,7 @@ func (sm *Manager) Get(ctx context.Context, id string, noWait bool) (Caller, err
 		select {
 		case <-ctx.Done():
 			sm.mu.Unlock()
-			return nil, errors.Wrapf(ctx.Err(), "no active session for %s", id)
+			return nil, errors.Wrapf(context.Cause(ctx), "no active session for %s", id)
 		default:
 		}
 		var ok bool

--- a/session/session.go
+++ b/session/session.go
@@ -42,7 +42,7 @@ type Session struct {
 	name        string
 	sharedKey   string
 	ctx         context.Context
-	cancelCtx   func()
+	cancelCtx   func(error)
 	done        chan struct{}
 	grpcServer  *grpc.Server
 	conn        net.Conn
@@ -107,11 +107,11 @@ func (s *Session) Run(ctx context.Context, dialer Dialer) error {
 		s.mu.Unlock()
 		return nil
 	}
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancelCause(ctx)
 	s.cancelCtx = cancel
 	s.done = make(chan struct{})
 
-	defer cancel()
+	defer cancel(errors.WithStack(context.Canceled))
 	defer close(s.done)
 
 	meta := make(map[string][]string)

--- a/session/sshforward/copy.go
+++ b/session/sshforward/copy.go
@@ -39,7 +39,7 @@ func Copy(ctx context.Context, conn io.ReadWriteCloser, stream Stream, closeStre
 			select {
 			case <-ctx.Done():
 				conn.Close()
-				return ctx.Err()
+				return context.Cause(ctx)
 			default:
 			}
 			if _, err := conn.Write(p.Data); err != nil {
@@ -65,7 +65,7 @@ func Copy(ctx context.Context, conn io.ReadWriteCloser, stream Stream, closeStre
 			}
 			select {
 			case <-ctx.Done():
-				return ctx.Err()
+				return context.Cause(ctx)
 			default:
 			}
 			p := &BytesMessage{Data: buf[:n]}

--- a/session/sshforward/ssh.go
+++ b/session/sshforward/ssh.go
@@ -26,7 +26,7 @@ func (s *server) run(ctx context.Context, l net.Listener, id string) error {
 
 	eg.Go(func() error {
 		<-ctx.Done()
-		return ctx.Err()
+		return context.Cause(ctx)
 	})
 
 	eg.Go(func() error {

--- a/snapshot/diffapply_unix.go
+++ b/snapshot/diffapply_unix.go
@@ -600,8 +600,10 @@ func (d *differ) doubleWalkingChanges(ctx context.Context, handle func(context.C
 		if prevErr != nil {
 			return prevErr
 		}
-		if ctx.Err() != nil {
-			return ctx.Err()
+		select {
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		default:
 		}
 
 		if kind == fs.ChangeKindUnmodified {
@@ -689,8 +691,11 @@ func (d *differ) overlayChanges(ctx context.Context, handle func(context.Context
 		if prevErr != nil {
 			return prevErr
 		}
-		if ctx.Err() != nil {
-			return ctx.Err()
+
+		select {
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		default:
 		}
 
 		if kind == fs.ChangeKindUnmodified {

--- a/solver/errdefs/context.go
+++ b/solver/errdefs/context.go
@@ -14,7 +14,7 @@ func IsCanceled(ctx context.Context, err error) bool {
 		return true
 	}
 	// grpc does not set cancel correctly when stream gets cancelled and then Recv is called
-	if err != nil && ctx.Err() == context.Canceled {
+	if err != nil && context.Cause(ctx) == context.Canceled {
 		// when this error comes from containerd it is not typed at all, just concatenated string
 		if strings.Contains(err.Error(), "EOF") {
 			return true

--- a/solver/internal/pipe/pipe.go
+++ b/solver/internal/pipe/pipe.go
@@ -70,11 +70,11 @@ type Status struct {
 func NewWithFunction(f func(context.Context) (interface{}, error)) (*Pipe, func()) {
 	p := New(Request{})
 
-	ctx, cancel := context.WithCancel(context.TODO())
+	ctx, cancel := context.WithCancelCause(context.TODO())
 
 	p.OnReceiveCompletion = func() {
 		if req := p.Sender.Request(); req.Canceled {
-			cancel()
+			cancel(errors.WithStack(context.Canceled))
 		}
 	}
 

--- a/solver/internal/pipe/pipe_test.go
+++ b/solver/internal/pipe/pipe_test.go
@@ -14,7 +14,7 @@ func TestPipe(t *testing.T) {
 	f := func(ctx context.Context) (interface{}, error) {
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, context.Cause(ctx)
 		case <-runCh:
 			return "res0", nil
 		}
@@ -56,7 +56,7 @@ func TestPipeCancel(t *testing.T) {
 	f := func(ctx context.Context) (interface{}, error) {
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, context.Cause(ctx)
 		case <-runCh:
 			return "res0", nil
 		}
@@ -88,5 +88,5 @@ func TestPipeCancel(t *testing.T) {
 	require.Equal(t, st.Completed, true)
 	require.Equal(t, st.Canceled, true)
 	require.Error(t, st.Err)
-	require.Equal(t, st.Err, context.Canceled)
+	require.ErrorIs(t, st.Err, context.Canceled)
 }

--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -488,8 +488,9 @@ func (jl *Solver) NewJob(id string) (*Job, error) {
 }
 
 func (jl *Solver) Get(id string) (*Job, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
-	defer cancel()
+	ctx, cancel := context.WithCancelCause(context.Background())
+	ctx, _ = context.WithTimeoutCause(ctx, 6*time.Second, errors.WithStack(context.DeadlineExceeded))
+	defer cancel(errors.WithStack(context.Canceled))
 
 	go func() {
 		<-ctx.Done()

--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -255,7 +255,7 @@ type Job struct {
 	startedTime   time.Time
 	completedTime time.Time
 
-	progressCloser func()
+	progressCloser func(error)
 	SessionID      string
 	uniqueID       string // unique ID is used for provenance. We use a different field that client can't control
 }
@@ -589,7 +589,7 @@ func (j *Job) walkProvenance(ctx context.Context, e Edge, f func(ProvenanceProvi
 }
 
 func (j *Job) CloseProgress() {
-	j.progressCloser()
+	j.progressCloser(errors.WithStack(context.Canceled))
 	j.pw.Close()
 }
 
@@ -790,7 +790,7 @@ func (s *sharedOp) CalcSlowCache(ctx context.Context, index Index, p PreprocessF
 				if errdefs.IsCanceled(ctx, err) {
 					complete = false
 					releaseError(err)
-					err = errors.Wrap(ctx.Err(), err.Error())
+					err = errors.Wrap(context.Cause(ctx), err.Error())
 				}
 			default:
 			}
@@ -856,7 +856,7 @@ func (s *sharedOp) CacheMap(ctx context.Context, index int) (resp *cacheMapResp,
 				if errdefs.IsCanceled(ctx, err) {
 					complete = false
 					releaseError(err)
-					err = errors.Wrap(ctx.Err(), err.Error())
+					err = errors.Wrap(context.Cause(ctx), err.Error())
 				}
 			default:
 			}
@@ -935,7 +935,7 @@ func (s *sharedOp) Exec(ctx context.Context, inputs []Result) (outputs []Result,
 				if errdefs.IsCanceled(ctx, err) {
 					complete = false
 					releaseError(err)
-					err = errors.Wrap(ctx.Err(), err.Error())
+					err = errors.Wrap(context.Cause(ctx), err.Error())
 				}
 			default:
 			}

--- a/solver/llbsolver/history.go
+++ b/solver/llbsolver/history.go
@@ -835,7 +835,7 @@ func (h *HistoryQueue) Listen(ctx context.Context, req *controlapi.BuildHistoryR
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return context.Cause(ctx)
 		case e := <-sub.ch:
 			if req.Ref != "" && req.Ref != e.Record.Ref {
 				continue

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -484,7 +484,7 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 		case <-fwd.Done():
 			res, err = fwd.Result()
 		case <-ctx.Done():
-			err = ctx.Err()
+			err = context.Cause(ctx)
 		}
 		if err != nil {
 			return nil, err

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -195,8 +195,9 @@ func (s *Solver) recordBuildHistory(ctx context.Context, id string, req frontend
 			}
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-		defer cancel()
+		ctx, cancel := context.WithCancelCause(context.Background())
+		ctx, _ = context.WithTimeoutCause(ctx, 20*time.Second, errors.WithStack(context.DeadlineExceeded))
+		defer cancel(errors.WithStack(context.Canceled))
 
 		var mu sync.Mutex
 		ch := make(chan *client.SolveStatus)

--- a/solver/llbsolver/vertex.go
+++ b/solver/llbsolver/vertex.go
@@ -206,8 +206,10 @@ func recomputeDigests(ctx context.Context, all map[digest.Digest]*pb.Op, visited
 
 	var mutated bool
 	for _, input := range op.Inputs {
-		if ctx.Err() != nil {
-			return "", ctx.Err()
+		select {
+		case <-ctx.Done():
+			return "", context.Cause(ctx)
+		default:
 		}
 
 		iDgst, err := recomputeDigests(ctx, all, visited, input.Digest)

--- a/solver/progress.go
+++ b/solver/progress.go
@@ -91,7 +91,7 @@ func (j *Job) Status(ctx context.Context, ch chan *client.SolveStatus) error {
 
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return context.Cause(ctx)
 		case ch <- ss:
 		}
 	}

--- a/solver/scheduler.go
+++ b/solver/scheduler.go
@@ -245,8 +245,8 @@ func (s *scheduler) build(ctx context.Context, edge Edge) (CachedResult, error) 
 	}
 	s.mu.Unlock()
 
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(errors.WithStack(context.Canceled))
 
 	go func() {
 		<-ctx.Done()

--- a/source/containerimage/ocilayout.go
+++ b/source/containerimage/ocilayout.go
@@ -123,8 +123,9 @@ func (r *ociLayoutResolver) info(ctx context.Context, ref reference.Spec) (conte
 
 func (r *ociLayoutResolver) withCaller(ctx context.Context, f func(context.Context, session.Caller) error) error {
 	if r.store.SessionID != "" {
-		timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		defer cancel()
+		timeoutCtx, cancel := context.WithCancelCause(ctx)
+		timeoutCtx, _ = context.WithTimeoutCause(timeoutCtx, 5*time.Second, errors.WithStack(context.DeadlineExceeded))
+		defer cancel(errors.WithStack(context.Canceled))
 
 		caller, err := r.sm.Get(timeoutCtx, r.store.SessionID, false)
 		if err != nil {

--- a/source/git/source_test.go
+++ b/source/git/source_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/moby/buildkit/util/progress"
 	"github.com/moby/buildkit/util/progress/logs"
 	"github.com/moby/buildkit/util/winlayers"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	bolt "go.etcd.io/bbolt"
@@ -663,7 +664,7 @@ func logProgressStreams(ctx context.Context, t *testing.T) context.Context {
 	pr, ctx, cancel := progress.NewContext(ctx)
 	done := make(chan struct{})
 	t.Cleanup(func() {
-		cancel()
+		cancel(errors.WithStack(context.Canceled))
 		<-done
 	})
 	go func() {

--- a/source/local/source.go
+++ b/source/local/source.go
@@ -141,8 +141,9 @@ func (ls *localSourceHandler) Snapshot(ctx context.Context, g session.Group) (ca
 		return ls.snapshotWithAnySession(ctx, g)
 	}
 
-	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
+	timeoutCtx, cancel := context.WithCancelCause(ctx)
+	timeoutCtx, _ = context.WithTimeoutCause(timeoutCtx, 5*time.Second, errors.WithStack(context.DeadlineExceeded))
+	defer cancel(errors.WithStack(context.Canceled))
 
 	caller, err := ls.sm.Get(timeoutCtx, sessionID, false)
 	if err != nil {

--- a/util/flightcontrol/flightcontrol.go
+++ b/util/flightcontrol/flightcontrol.go
@@ -90,7 +90,7 @@ type call[T any] struct {
 	fn   func(ctx context.Context) (T, error)
 	once sync.Once
 
-	closeProgressWriter func()
+	closeProgressWriter func(error)
 	progressState       *progressState
 	progressCtx         context.Context
 }
@@ -115,9 +115,9 @@ func newCall[T any](fn func(ctx context.Context) (T, error)) *call[T] {
 }
 
 func (c *call[T]) run() {
-	defer c.closeProgressWriter()
-	ctx, cancel := context.WithCancel(c.ctx)
-	defer cancel()
+	defer c.closeProgressWriter(errors.WithStack(context.Canceled))
+	ctx, cancel := context.WithCancelCause(c.ctx)
+	defer cancel(errors.WithStack(context.Canceled))
 	v, err := c.fn(ctx)
 	c.mu.Lock()
 	c.result = v
@@ -155,8 +155,8 @@ func (c *call[T]) wait(ctx context.Context) (v T, err error) {
 		c.progressState.add(pw)
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(errors.WithStack(context.Canceled))
 
 	c.ctxs = append(c.ctxs, ctx)
 
@@ -175,7 +175,7 @@ func (c *call[T]) wait(ctx context.Context) (v T, err error) {
 		if ok {
 			c.progressState.close(pw)
 		}
-		return empty, ctx.Err()
+		return empty, context.Cause(ctx)
 	case <-c.ready:
 		return c.result, c.err // shared not implemented yet
 	}
@@ -262,7 +262,9 @@ func (sc *sharedContext[T]) checkDone() bool {
 	for _, ctx := range sc.ctxs {
 		select {
 		case <-ctx.Done():
-			err = ctx.Err()
+			// Cause can't be used here because this error is returned for Err() in custom context
+			// implementation and unfortunately stdlib does not allow defining Cause() for custom contexts
+			err = ctx.Err() //nolint: forbidigo
 		default:
 			sc.mu.Unlock()
 			return false

--- a/util/overlay/overlay_linux.go
+++ b/util/overlay/overlay_linux.go
@@ -161,8 +161,10 @@ func Changes(ctx context.Context, changeFn fs.ChangeFunc, upperdir, upperdirView
 		if err != nil {
 			return err
 		}
-		if ctx.Err() != nil {
-			return ctx.Err()
+		select {
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		default:
 		}
 
 		// Rebase path

--- a/util/progress/multireader.go
+++ b/util/progress/multireader.go
@@ -11,14 +11,15 @@ type MultiReader struct {
 	main        Reader
 	initialized bool
 	done        chan struct{}
-	writers     map[*progressWriter]func()
+	doneCause   error
+	writers     map[*progressWriter]func(error)
 	sent        []*Progress
 }
 
 func NewMultiReader(pr Reader) *MultiReader {
 	mr := &MultiReader{
 		main:    pr,
-		writers: make(map[*progressWriter]func()),
+		writers: make(map[*progressWriter]func(error)),
 		done:    make(chan struct{}),
 	}
 	return mr
@@ -46,9 +47,9 @@ func (mr *MultiReader) Reader(ctx context.Context) Reader {
 
 	go func() {
 		if isBehind {
-			close := func() {
+			close := func(err error) {
 				w.Close()
-				closeWriter()
+				closeWriter(err)
 			}
 			i := 0
 			for {
@@ -58,11 +59,11 @@ func (mr *MultiReader) Reader(ctx context.Context) Reader {
 				if count == 0 {
 					select {
 					case <-ctx.Done():
-						close()
+						close(context.Cause(ctx))
 						mr.mu.Unlock()
 						return
 					case <-mr.done:
-						close()
+						close(mr.doneCause)
 						mr.mu.Unlock()
 						return
 					default:
@@ -77,7 +78,7 @@ func (mr *MultiReader) Reader(ctx context.Context) Reader {
 					if i%100 == 0 {
 						select {
 						case <-ctx.Done():
-							close()
+							close(context.Cause(ctx))
 							return
 						default:
 						}
@@ -110,10 +111,12 @@ func (mr *MultiReader) handle() error {
 		if err != nil {
 			if err == io.EOF {
 				mr.mu.Lock()
+				cancelErr := context.Canceled
 				for w, c := range mr.writers {
 					w.Close()
-					c()
+					c(cancelErr)
 				}
+				mr.doneCause = cancelErr
 				close(mr.done)
 				mr.mu.Unlock()
 				return nil

--- a/util/progress/progress_test.go
+++ b/util/progress/progress_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sync/errgroup"
 )
@@ -31,7 +32,7 @@ func TestProgress(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 15, s)
 
-	cancelProgress()
+	cancelProgress(errors.WithStack(context.Canceled))
 	err = eg.Wait()
 	assert.NoError(t, err)
 
@@ -56,7 +57,7 @@ func TestProgressNested(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 6, s)
 
-	cancelProgress()
+	cancelProgress(errors.WithStack(context.Canceled))
 
 	err = eg.Wait()
 	assert.NoError(t, err)
@@ -74,7 +75,7 @@ func calc(ctx context.Context, total int, name string) (int, error) {
 	for i := 1; i <= total; i++ {
 		select {
 		case <-ctx.Done():
-			return 0, ctx.Err()
+			return 0, context.Cause(ctx)
 		case <-time.After(10 * time.Millisecond):
 		}
 		if i == total {

--- a/util/progress/progressui/display.go
+++ b/util/progress/progressui/display.go
@@ -99,7 +99,7 @@ func (d Display) UpdateFrom(ctx context.Context, ch chan *client.SolveStatus) ([
 	for {
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, context.Cause(ctx)
 		case <-ticker.C:
 			d.disp.refresh()
 		case ss, ok := <-ch:

--- a/util/staticfs/merge.go
+++ b/util/staticfs/merge.go
@@ -49,7 +49,7 @@ func (mfs *MergeFS) Walk(ctx context.Context, target string, fn fs.WalkDirFunc) 
 			case ch1 <- &record{path: path, entry: entry, err: err}:
 			case <-ctx.Done():
 			}
-			return ctx.Err()
+			return context.Cause(ctx)
 		})
 	})
 	eg.Go(func() error {
@@ -59,7 +59,7 @@ func (mfs *MergeFS) Walk(ctx context.Context, target string, fn fs.WalkDirFunc) 
 			case ch2 <- &record{path: path, entry: entry, err: err}:
 			case <-ctx.Done():
 			}
-			return ctx.Err()
+			return context.Cause(ctx)
 		})
 	})
 

--- a/util/testutil/integration/registry.go
+++ b/util/testutil/integration/registry.go
@@ -67,8 +67,9 @@ http:
 	}
 	deferF.Append(stop)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+	ctx, cancel := context.WithCancelCause(context.Background())
+	ctx, _ = context.WithTimeoutCause(ctx, 5*time.Second, errors.WithStack(context.DeadlineExceeded))
+	defer cancel(errors.WithStack(context.Canceled))
 	url, err = detectPort(ctx, rc)
 	if err != nil {
 		return "", nil, err

--- a/util/tracing/otlptracegrpc/client.go
+++ b/util/tracing/otlptracegrpc/client.go
@@ -71,8 +71,9 @@ func (c *client) UploadTraces(ctx context.Context, protoSpans []*tracepb.Resourc
 
 	ctx, cancel := c.connection.ContextWithStop(ctx)
 	defer cancel(errors.WithStack(context.Canceled))
-	ctx, tCancel := context.WithTimeout(ctx, 30*time.Second)
-	defer tCancel()
+	ctx, tCancel := context.WithCancelCause(ctx)
+	ctx, _ = context.WithTimeoutCause(ctx, 30*time.Second, errors.WithStack(context.DeadlineExceeded))
+	defer tCancel(errors.WithStack(context.Canceled))
 
 	ctx = c.connection.ContextWithMetadata(ctx)
 	err := func() error {

--- a/util/tracing/otlptracegrpc/client.go
+++ b/util/tracing/otlptracegrpc/client.go
@@ -70,7 +70,7 @@ func (c *client) UploadTraces(ctx context.Context, protoSpans []*tracepb.Resourc
 	}
 
 	ctx, cancel := c.connection.ContextWithStop(ctx)
-	defer cancel()
+	defer cancel(errors.WithStack(context.Canceled))
 	ctx, tCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer tCancel()
 

--- a/worker/tests/common.go
+++ b/worker/tests/common.go
@@ -49,7 +49,7 @@ func TestWorkerExec(t *testing.T, w *base.Worker) {
 	id := identity.NewID()
 
 	// verify pid1 exits when stdin sees EOF
-	ctxTimeout, cancelTimeout := context.WithTimeout(ctx, 5*time.Second)
+	ctxTimeout, cancelTimeout := context.WithTimeoutCause(ctx, 5*time.Second, nil)
 	started := make(chan struct{})
 	pipeR, pipeW := io.Pipe()
 	go func() {

--- a/worker/tests/common.go
+++ b/worker/tests/common.go
@@ -38,7 +38,7 @@ func NewCtx(s string) context.Context {
 
 func TestWorkerExec(t *testing.T, w *base.Worker) {
 	ctx := NewCtx("buildkit-test")
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancelCause(ctx)
 	sm, err := session.NewManager()
 	require.NoError(t, err)
 
@@ -151,7 +151,7 @@ func TestWorkerExec(t *testing.T, w *base.Worker) {
 	require.Empty(t, stderr.String())
 
 	// stop pid1
-	cancel()
+	cancel(errors.WithStack(context.Canceled))
 
 	err = eg.Wait()
 	// we expect pid1 to get canceled after we test the exec
@@ -248,8 +248,8 @@ func TestWorkerCancel(t *testing.T, w *base.Worker) {
 
 	started := make(chan struct{})
 
-	pid1Ctx, pid1Cancel := context.WithCancel(ctx)
-	defer pid1Cancel()
+	pid1Ctx, pid1Cancel := context.WithCancelCause(ctx)
+	defer pid1Cancel(errors.WithStack(context.Canceled))
 
 	var (
 		pid1Err, pid2Err error
@@ -273,8 +273,8 @@ func TestWorkerCancel(t *testing.T, w *base.Worker) {
 		t.Error("Unexpected timeout waiting for pid1 to start")
 	}
 
-	pid2Ctx, pid2Cancel := context.WithCancel(ctx)
-	defer pid2Cancel()
+	pid2Ctx, pid2Cancel := context.WithCancelCause(ctx)
+	defer pid2Cancel(errors.WithStack(context.Canceled))
 
 	started = make(chan struct{})
 
@@ -299,11 +299,11 @@ func TestWorkerCancel(t *testing.T, w *base.Worker) {
 		t.Error("Unexpected timeout waiting for pid2 to start")
 	}
 
-	pid2Cancel()
+	pid2Cancel(errors.WithStack(context.Canceled))
 	<-pid2Done
 	require.Contains(t, pid2Err.Error(), "exit code: 137", "pid2 exits with sigkill")
 
-	pid1Cancel()
+	pid1Cancel(errors.WithStack(context.Canceled))
 	<-pid1Done
 	require.Contains(t, pid1Err.Error(), "exit code: 137", "pid1 exits with sigkill")
 }


### PR DESCRIPTION
Start to bring some sanity to the "context canceled" errors without a stacktrace.

TODO:
- ~Same for Deadline/Timeout~ see https://github.com/moby/buildkit/pull/4457#discussion_r1414356689
- ~For cases that do `defer cancel()` we could have a helper that adds fallback handling for code paths (in vendor) that return  `ctx.Err()` directly and add the stacktrace from the `Cause()` still to the error.~ let's do this in follow-up as not directly related