### PR TITLE
Maintain annotations on s3cache

### DIFF
--- a/cache/remotecache/v1/spec.go
+++ b/cache/remotecache/v1/spec.go
@@ -20,10 +20,11 @@ type CacheLayer struct {
 }
 
 type LayerAnnotations struct {
-	MediaType string        `json:"mediaType,omitempty"`
-	DiffID    digest.Digest `json:"diffID,omitempty"`
-	Size      int64         `json:"size,omitempty"`
-	CreatedAt time.Time     `json:"createdAt,omitempty"`
+	MediaType  string            `json:"mediaType,omitempty"`
+	DiffID     digest.Digest     `json:"diffID,omitempty"`
+	Size       int64             `json:"size,omitempty"`
+	CreatedAt  time.Time         `json:"createdAt,omitempty"`
+	Additional map[string]string `json:"additional,omitempty"`
 }
 
 type CacheRecord struct {


### PR DESCRIPTION
When using the S3 cache during image builds annotations are lost. Typically in my case required annotations for `estargz` snapshotter are lost:
```
"annotations": {
	"containerd.io/snapshot/stargz/toc.digest": "sha256:ac217dd6a251f674108a8ab20e523eb218743eef5bc7fe19d7f34f6c31bfbcf5",
	"io.containers.estargz.uncompressed-size": "18432"
}
```

This allows maintaining any layer annotations.