### PR TITLE
add an option to show JSON cache metrics

### DIFF
--- a/cmd/buildctl/build.go
+++ b/cmd/buildctl/build.go
@@ -111,7 +111,7 @@ var buildCommand = cli.Command{
 			Usage: "Overwrite TLS configuration when authenticating with registries, e.g. --registry-auth-tlscontext host=https://myserver:2376,insecure=false,ca=/path/to/my/ca.crt,cert=/path/to/my/cert.crt,key=/path/to/my/key.crt",
 		},
 		cli.StringFlag{
-			Name:  "json-cache-metrics",
+			Name:  "debug-json-cache-metrics",
 			Usage: "Where to output json cache metrics, use 'stdout' or 'stderr' for standard (error) output.",
 		},
 	},
@@ -149,7 +149,7 @@ func openTraceFile(clicontext *cli.Context) (*os.File, error) {
 }
 
 func openCacheMetricsFile(clicontext *cli.Context) (*os.File, error) {
-	switch out := clicontext.String("json-cache-metrics"); out {
+	switch out := clicontext.String("debug-json-cache-metrics"); out {
 	case "stdout":
 		return os.Stdout, nil
 	case "stderr":

--- a/cmd/buildctl/cachemetrics.go
+++ b/cmd/buildctl/cachemetrics.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/util/progress/progresswriter"
+	digest "github.com/opencontainers/go-digest"
+)
+
+type vtxInfo struct {
+	cached    bool
+	completed bool
+	from      bool
+	name      string
+}
+
+func tailVTXInfo(ctx context.Context, pw progresswriter.Writer, metricsCh <-chan *client.SolveStatus) map[digest.Digest]*vtxInfo {
+	fromRegexp := regexp.MustCompile(`^\[.*\] FROM`)
+
+	vtxMap := make(map[digest.Digest]*vtxInfo)
+	for st := range metricsCh {
+		for _, vtx := range st.Vertexes {
+			if _, ok := vtxMap[vtx.Digest]; !ok {
+				vtxMap[vtx.Digest] = &vtxInfo{
+					name: vtx.Name,
+				}
+			}
+			if fromRegexp.MatchString(vtx.Name) {
+				vtxMap[vtx.Digest].from = true
+			}
+			if vtx.Cached {
+				vtxMap[vtx.Digest].cached = true
+			}
+			if vtx.Completed != nil {
+				vtxMap[vtx.Digest].completed = true
+			}
+		}
+	}
+	return vtxMap
+}
+
+func outputCacheMetrics(out *os.File, startTime time.Time, vtxMap map[digest.Digest]*vtxInfo) {
+	metrics := struct {
+		Total            int64 `json:"total"`
+		Completed        int64 `json:"completed"`
+		UserTotal        int64 `json:"user_total"`
+		UserCached       int64 `json:"user_cached"`
+		UserCompleted    int64 `json:"user_completed"`
+		UserCacheable    int64 `json:"user_cacheable"`
+		From             int64 `json:"from"`
+		Miss             int64 `json:"miss"`
+		ClientDurationMS int64 `json:"client_duration_ms"`
+	}{
+		ClientDurationMS: time.Since(startTime).Milliseconds(),
+	}
+	for _, vtx := range vtxMap {
+		metrics.Total++
+		if vtx.completed {
+			metrics.Completed++
+		}
+		if strings.HasPrefix(vtx.name, "[internal]") ||
+			strings.HasPrefix(vtx.name, "[auth]") ||
+			strings.HasPrefix(vtx.name, "importing cache") ||
+			strings.HasPrefix(vtx.name, "exporting ") {
+			continue
+		}
+		metrics.UserTotal++
+		metrics.UserCacheable++
+		if vtx.cached {
+			metrics.UserCached++
+		} else if !vtx.from {
+			metrics.Miss++
+			fmt.Fprintf(out, "cache miss: %s\n", vtx.name)
+		}
+		if vtx.completed {
+			metrics.UserCompleted++
+		}
+		if vtx.from {
+			metrics.From++
+			metrics.UserCacheable--
+		}
+	}
+	dt, _ := json.Marshal(metrics)
+	fmt.Fprintln(out, string(dt))
+}

--- a/docs/reference/buildctl.md
+++ b/docs/reference/buildctl.md
@@ -79,6 +79,7 @@ OPTIONS:
    --source-policy-file value        Read source policy file from a JSON file
    --ref-file value                  Write build ref to a file
    --registry-auth-tlscontext value  Overwrite TLS configuration when authenticating with registries, e.g. --registry-auth-tlscontext host=https://myserver:2376,insecure=false,ca=/path/to/my/ca.crt,cert=/path/to/my/cert.crt,key=/path/to/my/key.crt
+   --debug-json-cache-metrics value  Where to output json cache metrics, use 'stdout' or 'stderr' for standard (error) output.
    
 ```
 <!---GENERATE_END-->


### PR DESCRIPTION
Hello there,

this adds a new `json-cache-metrics` parameter to write to an `os.File`. Handy in deamonless mode, mode with which it is a bit hard to scrape metrics the good way. 

At first it was just writting to stderr like the rest, after everything is done. But while seeking the end of log file to just get the last line _works_, it turned out a bit brittle at scale (in our case). 

So I made it possible to pick a file just like for `trace`. (But also kept the std(out/err) option, nice locally)

LMK what you think.

Closes #4445 