### PR TITLE
chore: tidy up removal of digest algorithm

### DIFF
--- a/solver/cachemanager.go
+++ b/solver/cachemanager.go
@@ -439,7 +439,7 @@ func (c *cacheManager) getIDFromDeps(k *CacheKey) string {
 
 func rootKey(dgst digest.Digest, output Index) digest.Digest {
 	if strings.HasPrefix(dgst.String(), "random:") {
-		return digest.Digest("random:" + strings.TrimPrefix(digest.FromBytes([]byte(fmt.Sprintf("%s@%d", dgst, output))).String(), digest.Canonical.String()+":"))
+		return digest.Digest("random:" + digest.FromBytes([]byte(fmt.Sprintf("%s@%d", dgst, output))).Encoded())
 	}
 	return digest.FromBytes([]byte(fmt.Sprintf("%s@%d", dgst, output)))
 }

--- a/solver/llbsolver/ops/source.go
+++ b/solver/llbsolver/ops/source.go
@@ -90,7 +90,7 @@ func (s *SourceOp) CacheMap(ctx context.Context, g session.Group, index int) (*s
 
 	dgst := digest.FromBytes([]byte(sourceCacheType + ":" + k))
 	if strings.HasPrefix(k, "session:") {
-		dgst = digest.Digest("random:" + strings.TrimPrefix(dgst.String(), dgst.Algorithm().String()+":"))
+		dgst = digest.Digest("random:" + dgst.Encoded())
 	}
 
 	return &solver.CacheMap{


### PR DESCRIPTION
Just a tiny cleanup while I was in the area :broom: :broom: 

In these cases, we can just call digest.Encoded(), instead of needing to play around with removing the prefix.