### PR TITLE
util/tracing/detect: separate from bklog package

### DIFF
--- a/util/tracing/detect/detect.go
+++ b/util/tracing/detect/detect.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/moby/buildkit/util/bklog"
+	"github.com/moby/buildkit/util/tracing/tracelogger"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -85,6 +85,9 @@ func getExporter() (sdktrace.SpanExporter, error) {
 	if Recorder != nil {
 		Recorder.SpanExporter = exp
 		exp = Recorder
+
+		// enable log with traceID when a valid exporter was detected.
+		tracelogger.Enable(true)
 	}
 	return exp, nil
 }
@@ -96,9 +99,6 @@ func detect() error {
 	if err != nil || exp == nil {
 		return err
 	}
-
-	// enable log with traceID when valid exporter
-	bklog.EnableLogWithTraceID(true)
 
 	res, err := resource.Detect(context.Background(), serviceNameDetector{})
 	if err != nil {

--- a/util/tracing/detect/detect.go
+++ b/util/tracing/detect/detect.go
@@ -26,7 +26,10 @@ type detector struct {
 var ServiceName string
 var Recorder *TraceRecorder
 
-var detectors map[string]detector
+var detectors = map[string]detector{
+	"otlp": {f: otlpExporter, priority: 10},
+}
+
 var once sync.Once
 var tp trace.TracerProvider
 var exporter sdktrace.SpanExporter

--- a/util/tracing/detect/detect.go
+++ b/util/tracing/detect/detect.go
@@ -31,7 +31,7 @@ var once sync.Once
 var tp trace.TracerProvider
 var exporter sdktrace.SpanExporter
 var closers []func(context.Context) error
-var err error
+var errDetect error
 
 func Register(name string, exp ExporterDetector, priority int) {
 	if detectors == nil {
@@ -122,13 +122,13 @@ func detect() error {
 
 func TracerProvider() (trace.TracerProvider, error) {
 	once.Do(func() {
-		if err1 := detect(); err1 != nil {
-			err = err1
+		if err := detect(); err != nil {
+			errDetect = err
 		}
 	})
 	b, _ := strconv.ParseBool(os.Getenv("OTEL_IGNORE_ERROR"))
-	if err != nil && !b {
-		return nil, err
+	if errDetect != nil && !b {
+		return nil, errDetect
 	}
 	return tp, nil
 }

--- a/util/tracing/detect/otlp.go
+++ b/util/tracing/detect/otlp.go
@@ -11,10 +11,6 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
-func init() {
-	Register("otlp", otlpExporter, 10)
-}
-
 func otlpExporter() (sdktrace.SpanExporter, error) {
 	set := os.Getenv("OTEL_TRACES_EXPORTER") == "otlp" || os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT") != "" || os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT") != ""
 	if !set {

--- a/util/tracing/tracelogger/tracelogging.go
+++ b/util/tracing/tracelogger/tracelogging.go
@@ -1,0 +1,35 @@
+// Package tracelogger provides a logger with trace- and span-ID's if tracing
+// is enabled.
+//
+// It is separate from [github.com/moby/buildkit/util/tracing/detect] so that
+// it can be imported without registering detectors.
+package tracelogger
+
+import (
+	"context"
+
+	"github.com/containerd/log"
+	"go.opentelemetry.io/otel/trace"
+)
+
+var enabled bool
+
+// Enable sets whether trace-ID logging must be enabled or disabled. It does
+// not perform any synchronization, and is not suitable for concurrent use.
+func Enable(v bool) {
+	enabled = v
+}
+
+// Get returns a logger with trace- and span-ID's if tracing is enabled. It
+// returns logger unmodified if tracing is not enabled.
+func Get(ctx context.Context, parentLogger *log.Entry) *log.Entry {
+	if enabled {
+		if spanContext := trace.SpanFromContext(ctx).SpanContext(); spanContext.IsValid() {
+			return parentLogger.WithFields(log.Fields{
+				"traceID": spanContext.TraceID(),
+				"spanID":  spanContext.SpanID(),
+			})
+		}
+	}
+	return parentLogger
+}


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/4698#discussion_r1416978861
- relates to https://github.com/moby/moby/pull/46830

### util/tracing/detect: rename package-level "err" var

This error is used to persist errors that occurred during detection
(ran in a sync.Once). Using `err` as variable name for this error
made it more likely to be inadvertently shadowed.

### util/tracing/detect: don't use init() to register default otlp detector

The otlp detector was registered unconditionally; looks like no init()
function is needed for that.

### util/tracing/detect: separate from bklog package

Separate detection from BuildKit's logger, with the potential to
separate this package from the BuildKit module.

This patch introduces a new "tracelogger" package, which allows
decorating an existing logger with trace- and span-ID's.