### PR TITLE
chore: remove unneccessary WithFailFast option

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -59,9 +59,6 @@ func New(ctx context.Context, address string, opts ...ClientOpt) (*Client, error
 	var creds *withCredentials
 
 	for _, o := range opts {
-		if _, ok := o.(*withFailFast); ok {
-			gopts = append(gopts, grpc.FailOnNonTempDialError(true))
-		}
 		if credInfo, ok := o.(*withCredentials); ok {
 			if creds == nil {
 				creds = &withCredentials{}
@@ -214,14 +211,6 @@ func (c *Client) Wait(ctx context.Context) error {
 
 func (c *Client) Close() error {
 	return c.conn.Close()
-}
-
-type withFailFast struct{}
-
-func (*withFailFast) isClientOpt() {}
-
-func WithFailFast() ClientOpt {
-	return &withFailFast{}
 }
 
 type withDialer struct {

--- a/cmd/buildctl/common/common.go
+++ b/cmd/buildctl/common/common.go
@@ -65,10 +65,8 @@ func ResolveClient(c *cli.Context) (*client.Client, error) {
 		key = c.GlobalString("tlskey")
 	}
 
-	opts := []client.ClientOpt{client.WithFailFast()}
-
 	ctx := CommandContext(c)
-
+	var opts []client.ClientOpt
 	if span := trace.SpanFromContext(ctx); span.SpanContext().IsValid() {
 		opts = append(opts, client.WithTracerProvider(span.TracerProvider()))
 

--- a/examples/build-using-dockerfile/main.go
+++ b/examples/build-using-dockerfile/main.go
@@ -80,7 +80,7 @@ func action(clicontext *cli.Context) error {
 	if tag := clicontext.String("tag"); tag == "" {
 		return errors.New("tag is not specified")
 	}
-	c, err := client.New(ctx, clicontext.String("buildkit-addr"), client.WithFailFast())
+	c, err := client.New(ctx, clicontext.String("buildkit-addr"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
`WithFailFast` was not actually causing any change in behavior, so we can remove the option completely.

The option set `FailOnNonTempDialError(true)` on the gRPC connection. However, the help text for this method option [declares](https://github.com/moby/buildkit/blob/-/vendor/google.golang.org/grpc/dialoptions.go#L470-L471) that it "does not do anything useful unless you are also using `WithBlock()`" - which we do not do. I've verified that the only client-side code path that actually handles this option is under a check for if `WithBlock()` was also used.

We can remove this option instead of fixing it, since the need for this functionality has been replaced by the more buildkit-native client.Wait function - this function also correctly waits for the buildkit server to begin running, and to start serving requests (which is generally the desired behaviour).

If users actually desire this option (which was not fully working previously), they can use the `WithGRPCDialOption`, and pass `FailOnNonTempDialError(true)` directly, alongside `WithBlock`.