### PR TITLE
ci(test-os): retry logic for freebsd smoke tests step

### DIFF
--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -159,8 +159,12 @@ jobs:
           vagrant up --no-tty
       -
         name: Smoke test
-        run: |
-          vagrant up --provision-with=test-smoke
+        uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4  # v2.9.0
+        with:
+          timeout_minutes: 20
+          max_attempts: 5
+          command: |
+            vagrant up --provision-with=test-smoke
       -
         name: BuildKit logs
         if: always()


### PR DESCRIPTION
related to https://github.com/moby/buildkit/issues/4444

Mitigate flaky freebsd tests with a retry logic.