### PR TITLE
ci(buildkit): set timeout to image job

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -27,6 +27,7 @@ env:
   IMAGE_NAME: "moby/buildkit"
   PLATFORMS: "linux/amd64,linux/arm/v7,linux/arm64,linux/s390x,linux/ppc64le,linux/riscv64"
   DESTDIR: "./bin"
+  BUILD_TIMEOUT: "900"  # 15 minutes
 
 jobs:
   prepare:
@@ -160,6 +161,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v3
         with:
           version: ${{ env.SETUP_BUILDX_VERSION }}
@@ -175,8 +177,14 @@ jobs:
       -
         name: Build ${{ needs.prepare.outputs.tag }}
         run: |
-          ./hack/images "${{ needs.prepare.outputs.tag }}" "$IMAGE_NAME" "${{ needs.prepare.outputs.push }}"
+          timeout ${BUILD_TIMEOUT} ./hack/images "${{ needs.prepare.outputs.tag }}" "$IMAGE_NAME" "${{ needs.prepare.outputs.push }}"
+          if [ $? -eq 124 ]; then
+            echo "::error::Build timed out after ${BUILD_TIMEOUT} seconds"
+            docker kill --signal=SIGQUIT buildx_buildkit_${{ steps.buildx.outputs.name }}
+            exit 1
+          fi
         env:
+          BUILDX_CMD: docker --debug buildx
           RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
           TARGET: ${{ matrix.target-stage }}
           CACHE_FROM: type=gha,scope=image${{ matrix.target-stage }}


### PR DESCRIPTION
related to https://github.com/moby/buildkit/pull/4477#issuecomment-1851198008

Image build seems to hang and job timed out after 6h (default on GitHub Actions) for the past few days:
* https://github.com/moby/buildkit/actions/runs/7183260509/job/19562224050?pr=4460#step:13:464
* https://github.com/moby/buildkit/actions/runs/7163256834/job/19502241344?pr=4477#step:13:461

```
  time="2023-12-11T06:13:24Z" level=debug msg="diff applied" d=2.806054ms digest="sha256:1f5f54dd06e9d17c845fb7c5fdf944c3160d6c4a7a8c645ee8b08e5618c0e65a" media=application/vnd.oci.image.layer.v1.tar+gzip size=942 spanID=62556bbbe3ab4d04 traceID=ca85fd7fcf30de02e721e83aa9c1c2e5
  time="2023-12-11T06:13:24Z" level=debug msg="Using single walk diff for /tmp/buildkit-mount4051339310"
  time="2023-12-11T06:13:24Z" level=debug msg="> creating xiytdlg99ck50ouj0ghtlxhtm [/bin/syft-scanner]" span="[linux/riscv64] generating sbom using docker.io/docker/buildkit-syft-scanner:stable-1" spanID=b1b778eff0601a70 traceID=ca85fd7fcf30de02e721e83aa9c1c2e5
```

Unfortunately we don't have a stacktrace in BuildKit logs because the worklflow is canceled by the runner. 

This change sets a timeout of 15 minutes and send SIGQUIT to the BuildKit container so we can get a stacktrace.