### PR TITLE
lint: set proper cache key for golangci-lint target

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -122,6 +122,7 @@ target "lint" {
   output = ["type=cacheonly"]
   target = buildtags.target
   args = {
+    TARGETNAME = buildtags.name
     BUILDTAGS = buildtags.tags
   }
   platforms = buildtags.target == "golangci-lint" && GOLANGCI_LINT_MULTIPLATFORM != null ? [

--- a/hack/dockerfiles/lint.Dockerfile
+++ b/hack/dockerfiles/lint.Dockerfile
@@ -19,10 +19,11 @@ COPY --link --from=xx / /
 WORKDIR /go/src/github.com/moby/buildkit
 
 FROM base as golangci-lint
+ARG TARGETNAME
 ARG BUILDTAGS
 ARG TARGETPLATFORM
 RUN --mount=target=/go/src/github.com/moby/buildkit \
-    --mount=target=/root/.cache,type=cache,id=lint-cache-$TARGETPLATFORM \
+    --mount=target=/root/.cache,type=cache,id=lint-cache-${TARGETNAME}-${TARGETPLATFORM} \
   xx-go --wrap && \
   golangci-lint run --build-tags "${BUILDTAGS}" && \
   touch /golangci-lint.done


### PR DESCRIPTION
reported by @jsternberg 

```
 > [lint-nydus golangci-lint 1/1] RUN --mount=target=/go/src/github.com/moby/buildkit     --mount=target=/root/.cache,type=cache,id=lint-cache-linux/arm64   xx-go --wrap &&   golangci-lint run --build-tags "nydus" &&   touch /golangci-lint.done:
61.01 cmd/buildkitd/main.go:17:46: directive `//nolint:staticcheck // SA1019 deprecated` is unused for linter "staticcheck" (nolintlint)
61.01   "github.com/containerd/containerd/pkg/seed" //nolint:staticcheck // SA1019 deprecated
61.01                                               ^
61.01 cmd/buildkitd/main.go:80:2: directive `//nolint:staticcheck // SA1019 deprecated` is unused for linter "staticcheck" (nolintlint)
61.01   //nolint:staticcheck // SA1019 deprecated
61.01   ^
```

Cache is shared across targets (`default`, `labs`, `nydus`) but should have its own key.