### PR TITLE
tests: enable previously skipped tests

### DIFF
--- a/source/http/source_test.go
+++ b/source/http/source_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/containerd/containerd/content/local"
@@ -28,10 +27,6 @@ import (
 )
 
 func TestHTTPSource(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Depends on unimplemented containerd bind-mount support on Windows")
-	}
-
 	t.Parallel()
 	ctx := context.TODO()
 
@@ -147,10 +142,6 @@ func TestHTTPSource(t *testing.T) {
 }
 
 func TestHTTPDefaultName(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Depends on unimplemented containerd bind-mount support on Windows")
-	}
-
 	t.Parallel()
 	ctx := context.TODO()
 
@@ -217,10 +208,6 @@ func TestHTTPInvalidURL(t *testing.T) {
 }
 
 func TestHTTPChecksum(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Depends on unimplemented containerd bind-mount support on Windows")
-	}
-
 	t.Parallel()
 	ctx := context.TODO()
 


### PR DESCRIPTION
This enables 3 tests that had been previously skipped due to the lack of Windows support initially.
The remaining ones in that group, see #4485, will need some code modifications to be enabled.

--
- [ ] cache/contenthash/checksum_test.go `createRef`
- [ ] cache/manager_test.go `TestSnapshotExtract`
- [ ] cache/manager_test.go `TestExtractOnMutable`
- [ ] cache/manager_test.go `TestMergeOp`
- [ ] cache/manager_test.go `TestDiffOp`
- [ ] source/git/source_test.go `testRepeatedFetch`
- [ ] source/git/source_test.go `testFetchBySHA`
- [ ] source/git/source_test.go `testFetchByTag`
- [ ] source/git/source_test.go `testMultipleRepos`
- [ ] source/git/source_test.go `TestCredentialRedaction`
- [ ] source/git/source_test.go `testSubdir`
- [x] source/http/source_test.go `TestHTTPSource`
- [x] source/http/source_test.go `TestHTTPChecksum`
- [x] source/http/source_test.go `TestHTTPDefaultName`