### PR TITLE
Enable users to specify the User-Agent header

### DIFF
--- a/client/llb/source.go
+++ b/client/llb/source.go
@@ -584,6 +584,9 @@ func HTTP(url string, opts ...HTTPOption) State {
 		attrs[pb.AttrHTTPGID] = strconv.Itoa(hi.GID)
 		addCap(&hi.Constraints, pb.CapSourceHTTPUIDGID)
 	}
+	if hi.UserAgent != "" {
+		attrs[pb.AttrHTTPUserAgent] = hi.UserAgent
+	}
 
 	addCap(&hi.Constraints, pb.CapSourceHTTP)
 	source := NewSource(url, attrs, hi.Constraints)
@@ -592,11 +595,12 @@ func HTTP(url string, opts ...HTTPOption) State {
 
 type HTTPInfo struct {
 	constraintsWrapper
-	Checksum digest.Digest
-	Filename string
-	Perm     int
-	UID      int
-	GID      int
+	Checksum  digest.Digest
+	Filename  string
+	Perm      int
+	UID       int
+	GID       int
+	UserAgent string
 }
 
 type HTTPOption interface {
@@ -631,6 +635,12 @@ func Chown(uid, gid int) HTTPOption {
 	return httpOptionFunc(func(hi *HTTPInfo) {
 		hi.UID = uid
 		hi.GID = gid
+	})
+}
+
+func UserAgent(userAgent string) HTTPOption {
+	return httpOptionFunc(func(hi *HTTPInfo) {
+		hi.UserAgent = userAgent
 	})
 }
 

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -745,6 +745,7 @@ func dispatch(d *dispatchState, cmd command, opt dispatchOpt) error {
 				checksum:     checksum,
 				location:     c.Location(),
 				opt:          opt,
+				userAgent:    c.UserAgent,
 			})
 		}
 		if err == nil {
@@ -1135,6 +1136,12 @@ func dispatchCopy(d *dispatchState, cfg copyConfig) error {
 		}
 	}
 
+	if cfg.userAgent != "" {
+		if !isHTTPSource(cfg.params.SourcePaths[0]) {
+			return errors.New("user-agent can't be specified for non-HTTP sources")
+		}
+	}
+
 	commitMessage := bytes.NewBufferString("")
 	if cfg.isAddCommand {
 		commitMessage.WriteString("ADD")
@@ -1188,7 +1195,7 @@ func dispatchCopy(d *dispatchState, cfg copyConfig) error {
 				}
 			}
 
-			st := llb.HTTP(src, llb.Filename(f), llb.Checksum(cfg.checksum), dfCmd(cfg.params))
+			st := llb.HTTP(src, llb.Filename(f), llb.Checksum(cfg.checksum), llb.UserAgent(cfg.userAgent), dfCmd(cfg.params))
 
 			opts := append([]llb.CopyOption{&llb.CopyInfo{
 				Mode:           mode,
@@ -1317,6 +1324,7 @@ type copyConfig struct {
 	parents      bool
 	location     []parser.Range
 	opt          dispatchOpt
+	userAgent    string
 }
 
 func dispatchMaintainer(d *dispatchState, c *instructions.MaintainerCommand) error {

--- a/frontend/dockerfile/dockerfile_adduseragent_test.go
+++ b/frontend/dockerfile/dockerfile_adduseragent_test.go
@@ -1,0 +1,80 @@
+package dockerfile
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/containerd/continuity/fs/fstest"
+	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/frontend/dockerui"
+	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/stretchr/testify/require"
+)
+
+var addUseragentTests = integration.TestFuncs(
+	testAddUseragent,
+)
+
+func init() {
+	allTests = append(allTests, addUseragentTests...)
+}
+
+func testAddUseragent(t *testing.T, sb integration.Sandbox) {
+	integration.SkipOnPlatform(t, "windows")
+	f := getFrontend(t, sb)
+	f.RequiresBuildctl(t)
+
+	var capturedUserAgent string
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		capturedUserAgent = r.Header.Get("User-Agent")
+		_, _ = w.Write([]byte("content"))
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	defer server.Close()
+
+	c, err := client.New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	t.Run("Custom User-Agent", func(t *testing.T) {
+		dockerfile := []byte(fmt.Sprintf(`
+FROM scratch
+ADD --user-agent="%s" %s /tmp/foo
+`, "Mozilla/5.0 (Linux) Foo 5.0", server.URL))
+		dir := integration.Tmpdir(
+			t,
+			fstest.CreateFile("Dockerfile", dockerfile, 0600),
+		)
+		_, err := f.Solve(sb.Context(), c, client.SolveOpt{
+			LocalDirs: map[string]string{
+				dockerui.DefaultLocalNameDockerfile: dir,
+				dockerui.DefaultLocalNameContext:    dir,
+			},
+		}, nil)
+		require.NoError(t, err)
+		require.Equal(t, "Mozilla/5.0 (Linux) Foo 5.0", capturedUserAgent)
+	})
+	t.Run("NonHTTPSource", func(t *testing.T) {
+		foo := []byte("local file")
+		dockerfile := []byte(fmt.Sprintf(`
+FROM scratch
+ADD --user-agent=%s foo /tmp/foo
+`, "Foo"))
+		dir := integration.Tmpdir(
+			t,
+			fstest.CreateFile("foo", foo, 0600),
+			fstest.CreateFile("Dockerfile", dockerfile, 0600),
+		)
+		_, err := f.Solve(sb.Context(), c, client.SolveOpt{
+			LocalDirs: map[string]string{
+				dockerui.DefaultLocalNameDockerfile: dir,
+				dockerui.DefaultLocalNameContext:    dir,
+			},
+		}, nil)
+		require.Error(t, err, "user-agent can't be specified for non-HTTP sources")
+	})
+}

--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -1299,6 +1299,15 @@ ADD --checksum=sha256:24454f830cdb571e2c4ad15481119c43b3cafd48dd869a9b2945d1036d
 
 The `--checksum` flag only supports HTTP sources currently.
 
+### Specifying a custom HTTP user agent `ADD --user-agent=<user-agent>`
+The user agent used for the HTTP request can be customized with the `--user-agent` flag:
+
+```dockerfile
+ADD --user-agent=Wget/1.21.4 https://mirrors.edge.kernel.org/pub/linux/kernel/Historic/linux-0.01.tar.gz /
+```
+
+The `--user-agent` flag only supports HTTP sources currently.
+
 ### Adding a Git repository `ADD <git ref> <dir>`
 
 This form allows adding a Git repository to an image directly, without using the `git` command inside the image:

--- a/frontend/dockerfile/instructions/commands.go
+++ b/frontend/dockerfile/instructions/commands.go
@@ -244,6 +244,7 @@ type AddCommand struct {
 	Link       bool
 	KeepGitDir bool // whether to keep .git dir, only meaningful for git sources
 	Checksum   string
+	UserAgent  string
 }
 
 func (c *AddCommand) Expand(expander SingleWordExpander) error {

--- a/frontend/dockerfile/instructions/parse.go
+++ b/frontend/dockerfile/instructions/parse.go
@@ -289,6 +289,7 @@ func parseAdd(req parseRequest) (*AddCommand, error) {
 	flLink := req.flags.AddBool("link", false)
 	flKeepGitDir := req.flags.AddBool("keep-git-dir", false)
 	flChecksum := req.flags.AddString("checksum", "")
+	flUserAgent := req.flags.AddString("user-agent", "")
 	if err := req.flags.Parse(); err != nil {
 		return nil, err
 	}
@@ -306,6 +307,7 @@ func parseAdd(req parseRequest) (*AddCommand, error) {
 		Link:            flLink.Value == "true",
 		KeepGitDir:      flKeepGitDir.Value == "true",
 		Checksum:        flChecksum.Value,
+		UserAgent:       flUserAgent.Value,
 	}, nil
 }
 

--- a/solver/pb/attr.go
+++ b/solver/pb/attr.go
@@ -20,6 +20,7 @@ const AttrHTTPFilename = "http.filename"
 const AttrHTTPPerm = "http.perm"
 const AttrHTTPUID = "http.uid"
 const AttrHTTPGID = "http.gid"
+const AttrHTTPUserAgent = "http.useragent"
 
 const AttrImageResolveMode = "image.resolvemode"
 const AttrImageResolveModeDefault = "default"

--- a/source/http/identifier.go
+++ b/source/http/identifier.go
@@ -17,13 +17,14 @@ func NewHTTPIdentifier(str string, tls bool) (*HTTPIdentifier, error) {
 }
 
 type HTTPIdentifier struct {
-	TLS      bool
-	URL      string
-	Checksum digest.Digest
-	Filename string
-	Perm     int
-	UID      int
-	GID      int
+	TLS       bool
+	URL       string
+	Checksum  digest.Digest
+	Filename  string
+	Perm      int
+	UID       int
+	GID       int
+	UserAgent string
 }
 
 var _ source.Identifier = (*HTTPIdentifier)(nil)

--- a/source/http/source.go
+++ b/source/http/source.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/moby/buildkit/version"
+
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/session"
@@ -92,6 +94,8 @@ func (hs *httpSource) Identifier(scheme, ref string, attrs map[string]string, pl
 				return nil, err
 			}
 			id.GID = int(i)
+		case pb.AttrHTTPUserAgent:
+			id.UserAgent = v
 		}
 	}
 
@@ -214,6 +218,12 @@ func (hs *httpSourceHandler) CacheKey(ctx context.Context, g session.Group, inde
 	}
 
 	client := hs.client(g)
+
+	if hs.src.UserAgent != "" {
+		req.Header.Set("User-Agent", hs.src.UserAgent)
+	} else {
+		req.Header.Set("User-Agent", version.UserAgent())
+	}
 
 	// Some servers seem to have trouble supporting If-None-Match properly even
 	// though they return ETag-s. So first, optionally try a HEAD request with


### PR DESCRIPTION
To allow specifying a custom user agent, the llb.HTTP now has a new HTTPOption named UserAgent allowing the user to specify a custom User-Agent header for the http request.

This is also exposed in the Dockerfile frontend with an additional argument --user-agent=<user-agent> in the ADD command.

In case no User-Agent header is set, the default BuildKit User-Agent is now being used instead of the default Golang one to be more consistent with other requests buildkit is making (i.e. requesting images).