### PR TITLE
Fix scratch multi-platform images

### DIFF
--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -292,6 +292,9 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 						refs = append(refs, src.Ref)
 					}
 					for _, ref := range src.Refs {
+						if ref == nil {
+							continue
+						}
 						refs = append(refs, ref)
 					}
 					eg, ctx := errgroup.WithContext(ctx)
@@ -358,6 +361,9 @@ func (e *imageExporterInstance) pushImage(ctx context.Context, src *exporter.Sou
 		refs = append(refs, src.Ref)
 	}
 	for _, ref := range src.Refs {
+		if ref == nil {
+			continue
+		}
 		refs = append(refs, ref)
 	}
 

--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -682,14 +682,15 @@ func (lbf *llbBridgeForwarder) Solve(ctx context.Context, req *pb.SolveRequest) 
 		ids := make(map[string]string, len(res.Refs))
 		defs := make(map[string]*opspb.Definition, len(res.Refs))
 		for k, ref := range res.Refs {
-			id := identity.NewID()
-			if ref == nil {
-				id = ""
-			} else {
+			var id string
+			var def *opspb.Definition
+			if ref != nil {
+				id = identity.NewID()
+				def = ref.Definition()
 				lbf.refs[id] = ref
 			}
 			ids[k] = id
-			defs[k] = ref.Definition()
+			defs[k] = def
 		}
 
 		if req.AllowResultArrayRef {
@@ -703,12 +704,10 @@ func (lbf *llbBridgeForwarder) Solve(ctx context.Context, req *pb.SolveRequest) 
 		}
 	} else {
 		ref := res.Ref
-		id := identity.NewID()
-
+		var id string
 		var def *opspb.Definition
-		if ref == nil {
-			id = ""
-		} else {
+		if ref != nil {
+			id = identity.NewID()
 			def = ref.Definition()
 			lbf.refs[id] = ref
 		}

--- a/solver/llbsolver/provenance.go
+++ b/solver/llbsolver/provenance.go
@@ -80,6 +80,9 @@ func (b *provenanceBridge) requests(r *frontend.Result) (*resultRequests, error)
 	}
 
 	for k, ref := range r.Refs {
+		if ref == nil {
+			continue
+		}
 		r, ok := b.findByResult(ref)
 		if !ok {
 			return nil, errors.Errorf("could not find request for ref %s", ref.ID())

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -269,6 +269,9 @@ func (s *Solver) recordBuildHistory(ctx context.Context, id string, req frontend
 			}
 
 			for k, r := range res.Refs {
+				if r == nil {
+					continue
+				}
 				k, r := k, r
 				cp := res.Provenance.Refs[k]
 				eg.Go(func() error {
@@ -719,6 +722,9 @@ func addProvenanceToResult(res *frontend.Result, br *provenanceBridge) (*Result,
 		out.Provenance.Refs = make(map[string]*provenance.Capture, len(res.Refs))
 	}
 	for k, ref := range res.Refs {
+		if ref == nil {
+			continue
+		}
 		cp, err := getProvenance(ref, reqs.refs[k].bridge, k, reqs)
 		if err != nil {
 			return nil, err

--- a/solver/result/result.go
+++ b/solver/result/result.go
@@ -142,6 +142,10 @@ func EachRef[U comparable, V comparable](a *Result[U], b *Result[V], fn func(U, 
 	return err
 }
 
+// ConvertResult transforms a Result[U] into a Result[V], using a transfomer
+// function that converts a U to a V. Zero values of type U are converted to
+// zero values of type V directly, without passing through the transformer
+// function.
 func ConvertResult[U comparable, V comparable](r *Result[U], fn func(U) (V, error)) (*Result[V], error) {
 	var zero U
 
@@ -160,6 +164,8 @@ func ConvertResult[U comparable, V comparable](r *Result[U], fn func(U) (V, erro
 	}
 	for k, r := range r.Refs {
 		if r == zero {
+			var zero V
+			r2.Refs[k] = zero
 			continue
 		}
 		r2.Refs[k], err = fn(r)


### PR DESCRIPTION
Fixes https://github.com/docker/build-push-action/issues/1024.

The main fix is a bug in `ConvertResult` that accidentally discarded zero-values. This essentially meant that images that had nil entries in the refs map (i.e. scratch images) would lose those - this caused an error in the exporter: `cannot export multiple platforms without multi-platform enabled`.

Everything else is a fix needed to not get `nil` panics everywhere - there are certain parts of the code that never saw `nil` in the `Refs` map, so these now need to be handled (and mostly skipped over).

## Skipping over attestations

@tonistiigi raised this in https://github.com/moby/buildkit/commit/3c1deef413acc96397e08e285a2ac1450be1fcde#r135018757.

Note from the commit message:
> Instead, we just skip over nil refs. This isn't ideal - we *should* be able generate provenance for a nil ref. However, 1. this isn't handled for llb.Scratch as a single-platform result, and 2. this is tricky, since the ResultProxy is nil at this point (so there's no ID to match on). This should be ok for a quick fix, but we can come back and fix this later.

If the `ResultProxy` is `nil` there's no ID that we can match for `findByResult` - to allow provenance for nil reference (which we should do), then we'd need to have a ResultProxy for this empty result.

Here's an example of where this matters: we do two builds on a `provenanceBridge`, and both of them have multi-platform scratch results (so nil in the refs entry). If we pass `nil` to `findByResult`, which one of these should match? We have no way of working backwards to it.

A potential fix to this problem (but one I think is out-of-scope for here) is we need to make sure the `ResultProxy` is never nil so that we can track it for provenance - essentially make sure that even when `req.Definition.Def` below is `nil`, that we still have a proxy:

https://github.com/moby/buildkit/blob/3c0fe5ee5192b45e1413798de6f4761f6c090351/solver/llbsolver/provenance.go#L175-L177

This feels a bit more invasive, and I'm less confident about that change than the rest of this, so figured it would make sense to submit this as a patch, and we could discuss about the rest of it as a follow-up.