### PR TITLE
[0.11 backport] hack/test: allow ALPINE_VERSION to be set from env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ ARG AZURITE_VERSION=3.18.0
 
 ARG GO_VERSION=1.19
 ARG ALPINE_VERSION=3.17
+ARG XX_VERSION=1.3.0
 
 # minio for s3 integration tests
 FROM minio/minio:${MINIO_VERSION} AS minio
@@ -33,7 +34,7 @@ FROM alpine:edge@sha256:c223f84e05c23c0571ce8decefef818864869187e1a3ea47719412e2
 FROM alpine-$TARGETARCH AS alpinebase
 
 # xx is a helper for cross-compilation
-FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.2.1 AS xx
+FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
 
 # go base image
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS golatest

--- a/hack/images
+++ b/hack/images
@@ -7,9 +7,9 @@ PUSH=$3
 . $(dirname $0)/util
 set -eu -o pipefail
 
-: ${RELEASE=false}
-: ${PLATFORMS=}
-: ${TARGET=}
+: "${RELEASE=false}"
+: "${PLATFORMS=}"
+: "${TARGET=}"
 
 versionTag=$(git describe --always --tags --match "v[0-9]*")
 

--- a/hack/test
+++ b/hack/test
@@ -3,17 +3,17 @@
 . $(dirname $0)/util
 set -eu -o pipefail
 
-: ${GO_VERSION=}
-: ${TEST_INTEGRATION=}
-: ${TEST_GATEWAY=}
-: ${TEST_DOCKERFILE=}
-: ${TEST_DOCKERD=}
-: ${TEST_DOCKERD_BINARY=$(which dockerd)}
-: ${TEST_COVERAGE=}
-: ${TEST_KEEP_CACHE=}
-: ${DOCKERFILE_RELEASES=}
-: ${BUILDKIT_WORKER_RANDOM=}
-: ${BUILDKITD_TAGS=}
+: "${GO_VERSION=}"
+: "${TEST_INTEGRATION=}"
+: "${TEST_GATEWAY=}"
+: "${TEST_DOCKERFILE=}"
+: "${TEST_DOCKERD=}"
+: "${TEST_DOCKERD_BINARY=$(which dockerd)}"
+: "${TEST_COVERAGE=}"
+: "${TEST_KEEP_CACHE=}"
+: "${DOCKERFILE_RELEASES=}"
+: "${BUILDKIT_WORKER_RANDOM=}"
+: "${BUILDKITD_TAGS=}"
 
 if [ "$TEST_DOCKERD" == "1" ]; then
   if [ ! -f "$TEST_DOCKERD_BINARY" ]; then

--- a/hack/test
+++ b/hack/test
@@ -3,6 +3,7 @@
 . $(dirname $0)/util
 set -eu -o pipefail
 
+: "${ALPINE_VERSION=}"
 : "${GO_VERSION=}"
 : "${TEST_INTEGRATION=}"
 : "${TEST_GATEWAY=}"
@@ -62,6 +63,7 @@ if [ "$TEST_COVERAGE" = "1" ]; then
 fi
 
 buildxCmd build $cacheFromFlags \
+  --build-arg ALPINE_VERSION \
   --build-arg GO_VERSION \
   --build-arg "BUILDKITD_TAGS=$BUILDKITD_TAGS" \
   --target "integration-tests" \


### PR DESCRIPTION
partial / modified backports of;

- https://github.com/moby/buildkit/commit/5955ccf77c3618970d336821fd75857155f9b6b9 (part of https://github.com/moby/buildkit/pull/4348)
- https://github.com/moby/buildkit/commit/bb18da8347f6e8f6c810f28d70d5c6ba23bf63bf (part of https://github.com/moby/buildkit/pull/4048)
- https://github.com/moby/buildkit/pull/4541