### PR TITLE
[0.12 backport] hack/test: allow ALPINE_VERSION to be set from env

### DIFF
--- a/hack/images
+++ b/hack/images
@@ -7,9 +7,9 @@ PUSH=$3
 . $(dirname $0)/util
 set -eu -o pipefail
 
-: ${RELEASE=false}
-: ${PLATFORMS=}
-: ${TARGET=}
+: "${RELEASE=false}"
+: "${PLATFORMS=}"
+: "${TARGET=}"
 
 versionTag=$(git describe --always --tags --match "v[0-9]*")
 

--- a/hack/test
+++ b/hack/test
@@ -3,23 +3,25 @@
 . $(dirname $0)/util
 set -eu -o pipefail
 
-: ${GO_VERSION=}
-: ${HTTP_PROXY=}
-: ${HTTPS_PROXY=}
-: ${NO_PROXY=}
-: ${TEST_INTEGRATION=}
-: ${TEST_GATEWAY=}
-: ${TEST_DOCKERFILE=}
-: ${TEST_DOCKERD=}
-: ${TEST_DOCKERD_BINARY=$(which dockerd)}
-: ${TEST_REPORT_SUFFIX=}
-: ${TEST_KEEP_CACHE=}
-: ${GOBUILDFLAGS=}
-: ${VERIFYFLAGS=}
-: ${CGO_ENABLED=}
-: ${DOCKERFILE_RELEASES=}
-: ${BUILDKIT_WORKER_RANDOM=}
-: ${BUILDKITD_TAGS=}
+: "${GO_VERSION=}"
+: "${HTTP_PROXY=}"
+: "${HTTPS_PROXY=}"
+: "${NO_PROXY=}"
+
+: "${TEST_INTEGRATION=}"
+: "${TEST_GATEWAY=}"
+: "${TEST_DOCKERFILE=}"
+: "${TEST_DOCKERD=}"
+: "${TEST_DOCKERD_BINARY=$(which dockerd)}"
+: "${TEST_REPORT_SUFFIX=}"
+: "${TEST_KEEP_CACHE=}"
+
+: "${GOBUILDFLAGS=}"
+: "${VERIFYFLAGS=}"
+: "${CGO_ENABLED=}"
+: "${DOCKERFILE_RELEASES=}"
+: "${BUILDKIT_WORKER_RANDOM=}"
+: "${BUILDKITD_TAGS=}"
 
 if [ "$TEST_DOCKERD" == "1" ]; then
   if [ ! -f "$TEST_DOCKERD_BINARY" ]; then

--- a/hack/test
+++ b/hack/test
@@ -3,6 +3,7 @@
 . $(dirname $0)/util
 set -eu -o pipefail
 
+: "${ALPINE_VERSION=}"
 : "${GO_VERSION=}"
 : "${HTTP_PROXY=}"
 : "${HTTPS_PROXY=}"
@@ -77,6 +78,7 @@ if [[ "$GOBUILDFLAGS" == *"-race"* ]]; then
 fi
 
 buildxCmd build $cacheFromFlags \
+  --build-arg ALPINE_VERSION \
   --build-arg GO_VERSION \
   --build-arg BUILDKITD_TAGS \
   --build-arg HTTP_PROXY \


### PR DESCRIPTION
partial / modified backports of;

- https://github.com/moby/buildkit/commit/bb18da8347f6e8f6c810f28d70d5c6ba23bf63bf (part of https://github.com/moby/buildkit/pull/4048)
- https://github.com/moby/buildkit/pull/4541

relates to:

- https://github.com/moby/moby/pull/47054#issuecomment-1884715610