### PR TITLE
solver: ensure each ref in the result map is evaluated

### DIFF
--- a/solver/llbsolver/provenance.go
+++ b/solver/llbsolver/provenance.go
@@ -180,7 +180,7 @@ func (b *provenanceBridge) Solve(ctx context.Context, req frontend.SolveRequest,
 	}
 	if req.Evaluate {
 		err = res.EachRef(func(ref solver.ResultProxy) error {
-			_, err := res.Ref.Result(ctx)
+			_, err := ref.Result(ctx)
 			return err
 		})
 	}


### PR DESCRIPTION
There was a reasonably significant typo in [`d709afd` (#3137)](https://github.com/moby/buildkit/pull/3137/commits/d709afdb96f539c49836f5874f7331a11287bee0), yikes.

Came across this while working in the area :scream: Slightly terrifying, I clearly wasn't playing close attention :cry: 

I don't think this is on a critical code-path anywhere, doing `Evaluate` on a frontend provided result was designed to be used in https://github.com/docker/buildx/pull/1197, but I don't think ever became relied-upon functionality.