### PR TITLE
rootless: use `~/.config/buildkit/cni.json`

### DIFF
--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -448,7 +448,11 @@ func setDefaultNetworkConfig(nc config.NetworkConfig) config.NetworkConfig {
 		nc.Mode = "auto"
 	}
 	if nc.CNIConfigPath == "" {
-		nc.CNIConfigPath = appdefaults.DefaultCNIConfigPath
+		if isRootlessConfig() {
+			nc.CNIConfigPath = appdefaults.UserCNIConfigPath
+		} else {
+			nc.CNIConfigPath = appdefaults.DefaultCNIConfigPath
+		}
 	}
 	if nc.CNIBinaryPath == "" {
 		nc.CNIBinaryPath = appdefaults.DefaultCNIBinDir

--- a/util/appdefaults/appdefaults_unix.go
+++ b/util/appdefaults/appdefaults_unix.go
@@ -17,6 +17,10 @@ const (
 	DefaultCNIConfigPath = "/etc/buildkit/cni.json"
 )
 
+var (
+	UserCNIConfigPath = filepath.Join(UserConfigDir(), "cni.json")
+)
+
 // UserAddress typically returns /run/user/$UID/buildkit/buildkitd.sock
 func UserAddress() string {
 	//  pam_systemd sets XDG_RUNTIME_DIR but not other dirs.

--- a/util/appdefaults/appdefaults_windows.go
+++ b/util/appdefaults/appdefaults_windows.go
@@ -16,6 +16,10 @@ var (
 	DefaultCNIConfigPath = filepath.Join(ConfigDir, "cni.json")
 )
 
+var (
+	UserCNIConfigPath = DefaultCNIConfigPath
+)
+
 func UserAddress() string {
 	return Address
 }


### PR DESCRIPTION
Prior to this commit, the path of `/etc/buildkit/cni.json` was hard-coded for rootless users too