### PR TITLE
appcontext/tracing: make `InitContext` public

### DIFF
--- a/util/tracing/env/traceenv.go
+++ b/util/tracing/env/traceenv.go
@@ -14,10 +14,10 @@ const (
 )
 
 func init() {
-	appcontext.Register(initContext)
+	appcontext.Register(InitContext)
 }
 
-func initContext(ctx context.Context) context.Context {
+func InitContext(ctx context.Context) context.Context {
 	// open-telemetry/opentelemetry-specification#740
 	parent := os.Getenv("TRACEPARENT")
 	state := os.Getenv("TRACESTATE")


### PR DESCRIPTION
Make `detect.InitContext` public as opposed to only available through the use of contexts from `appcontext` so that downstream users (e.g. buildx) can keep the OTEL context utils without having to use `appcontext` - see: https://github.com/docker/buildx/pull/2184