### PR TITLE
hack: add otel collector, prometheus, and grafana to compose file

### DIFF
--- a/docs/dev/remote-debugging.md
+++ b/docs/dev/remote-debugging.md
@@ -23,11 +23,10 @@ you limit the host port to the loopback interface (localhost) to prevent exposin
 computers.
 
 ```bash
-$ docker run --privileged -d \
+$ docker run --privileged --name buildkit-dev -d \
     -p 127.0.0.1:5000:5000 \
-    -p 127.0.0.1:1234:1234 \
     --restart always \
-    moby/buildkit:local --addr tcp://0.0.0.0:1234
+    moby/buildkit:local
 ```
 
 It's also useful to use `--restart always` when debugging. Delve will always shutdown the program with `SIGTERM` when
@@ -42,7 +41,7 @@ it's running through the debugger without optimizations.
 If using `docker` to run builds, you can inform docker about this new instance of buildkit by running the following:
 
 ```bash
-$ docker buildx create --name=dev --driver=remote tcp://127.0.0.1:1234
+$ docker buildx create --name=dev --driver=remote docker-container://buildkit-dev
 ```
 
 You can then set the builder in one of the following ways:

--- a/hack/compose
+++ b/hack/compose
@@ -1,31 +1,7 @@
 #!/usr/bin/env bash
 
-# Use to set up a dev environment for buildkit.
-# Not meant for production deployments.
-# Use the same way you would use docker compose.
-#
-#     $ hack/compose up -d --build
-#
-# Can be extended for local development by adding
-# a compose.override.yaml file to the same directory.
-#
-# Additional config files for extra services can
-# also be placed in the same folder and they will
-# be automatically ignored by git.
-#
-# To access the newly created development buildkit,
-# use either:
-#
-#     $ buildctl --addr tcp://127.0.0.1:1234 ...
-#
-# or alternatively configure a new builder with buildx.
-#
-#     $ docker buildx create \
-#         --bootstrap \
-#         --name dev \
-#         --driver remote \
-#         tcp://127.0.0.1:1234
-#     $ docker buildx --builder dev ...
+# Use to set up a dev environment for buildkit using docker compose.
+# See composefiles/README.md for more details.
 
 . $(dirname $0)/util
 set -eu -o pipefail
@@ -33,8 +9,8 @@ set -eu -o pipefail
 filesDir=$(dirname $0)/composefiles
 
 args=(compose '-f' "$filesDir/compose.yaml")
-if [ -f "$filesDir/compose.override.yaml" ]; then
-  args+=('-f' "$filesDir/compose.override.yaml")
+if [ -f "$filesDir/override/compose.yaml" ]; then
+  args+=('-f' "$filesDir/override/compose.yaml")
 fi
 
 dockerCmd "${args[@]}" "$@"

--- a/hack/composefiles/.gitignore
+++ b/hack/composefiles/.gitignore
@@ -1,8 +1,0 @@
-# Exclude everything to allow this folder to be used for other service
-# configurations.
-*
-
-# Specifically allow certain configuration files.
-!.gitignore
-!buildkitd.toml
-!compose.yaml

--- a/hack/composefiles/README.md
+++ b/hack/composefiles/README.md
@@ -1,0 +1,80 @@
+# Buildkit Docker Compose
+
+The `hack/compose` script provides a convenient development environment for building and testing buildkit with some
+useful supporting services and configuration using docker compose to assemble the environment.
+This configuration is not meant for production deployments.
+
+## Usage
+
+The primary way to use the script is as a substitute to `docker compose`.
+
+```bash
+$ hack/compose up -d
+```
+
+All arguments to this script will be forwarded to `docker compose`.
+This will use the `moby/buildkit:local` image to create a buildkit container.
+The image can be either built with `make images` or the `--build` flag can be used.
+
+```bash
+$ hack/compose up -d --build
+```
+
+To access the newly created development buildkit, use either:
+
+```bash
+$ buildctl --addr docker-container://buildkit-dev ...
+```
+
+or alternatively configure a new builder with buildx.
+
+```bash
+$ docker buildx create \
+    --bootstrap \
+    --name dev \
+    --driver remote \
+    docker-container://buildkit-dev
+```
+
+## Extending Configuration
+
+The compose definition can be extended by adding a `override/compose.yaml` file within this directory.
+The `override` directory has already been created. Additional configuration files in this directory are automatically
+ignored by git avoid accidentally committing local files.
+
+## Running the debugger
+
+The debugger is exposed for the local buildkit when `--build` is used to build the local image.
+This can be accessed using delve or any GUI client that uses delve (such as JetBrains GoLand).
+
+```bash
+$ dlv connect localhost:5000
+```
+
+More detailed documentation on remote debugging is [here](https://github.com/moby/buildkit/blob/master/docs/dev/remote-debugging.md#connecting-to-the-port-command-line).
+
+## OpenTelemetry
+
+OpenTelemetry is automatically configured for both traces and metrics.
+These can be visualized through Jaeger for Traces and Grafana for Metrics.
+
+### Traces
+
+Traces are sent to [Jaeger](http://localhost:16686).
+Traces that happen in `buildctl` and `buildx` are automatically sent to `buildkit` which forwards them to Jaeger.
+
+### Metrics
+
+Metrics are stored in Prometheus and can be visualized with [Grafana](http://localhost:3000).
+The username is `moby` and password is `moby`.
+
+Metrics from `buildkit` are automatically sent to Prometheus.
+`buildctl` does not produce any metrics and metrics from `buildx` are not automatically forwarded.
+
+To send metrics from `buildx`, OTEL can be configured using environment variables.
+
+```bash
+$ OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=http://localhost:4317 \
+    BUILDX_EXPERIMENTAL=true \
+    buildx --builder dev build ...
+```

--- a/hack/composefiles/buildkitd.toml
+++ b/hack/composefiles/buildkitd.toml
@@ -1,5 +1,4 @@
 debug = true
 
 [grpc]
-  address = [ "tcp://0.0.0.0:1234" ]
   debugAddress = "0.0.0.0:6060"

--- a/hack/composefiles/compose.yaml
+++ b/hack/composefiles/compose.yaml
@@ -8,28 +8,77 @@ services:
         BUILDKIT_DEBUG: 1
     image: moby/buildkit:local
     ports:
-      - 127.0.0.1:1234:1234
       - 127.0.0.1:5000:5000
       - 127.0.0.1:6060:6060
     restart: always
     privileged: true
     environment:
       DELVE_PORT: 5000
-      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://jaeger:4317
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
     configs:
       - source: buildkit_config
         target: /etc/buildkit/buildkitd.toml
     volumes:
       - buildkit:/var/lib/buildkit
+    depends_on:
+      - otel-collector
 
   jaeger:
     image: jaegertracing/all-in-one:latest
     ports:
       - 127.0.0.1:16686:16686
 
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.92.0
+    configs:
+      - source: otelcol_config
+        target: /etc/otelcol-contrib/config.yaml
+    ports:
+      - 127.0.0.1:4317:4317
+    depends_on:
+      - jaeger
+
+  prometheus:
+    image: prom/prometheus:v2.48.1
+    configs:
+      - source: prometheus_config
+        target: /etc/prometheus/prometheus.yml
+    volumes:
+      - prometheus:/prometheus
+    depends_on:
+      - otel-collector
+
+  grafana:
+    image: grafana/grafana-oss:10.2.3
+    configs:
+      - source: grafana_config
+        target: /etc/grafana/grafana.ini
+      - source: grafana_datasources_config
+        target: /etc/grafana/provisioning/datasources/datasources.yaml
+    ports:
+      - 127.0.0.1:3000:3000
+    volumes:
+      - grafana:/var/lib/grafana
+    depends_on:
+      - prometheus
+
 volumes:
   buildkit:
+  prometheus:
+  grafana:
 
 configs:
   buildkit_config:
     file: ./buildkitd.toml
+
+  otelcol_config:
+    file: ./otelcol.yaml
+
+  prometheus_config:
+    file: ./prometheus.yml
+
+  grafana_config:
+    file: ./grafana.ini
+
+  grafana_datasources_config:
+    file: ./datasources.yaml

--- a/hack/composefiles/datasources.yaml
+++ b/hack/composefiles/datasources.yaml
@@ -1,0 +1,15 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    jsonData:
+      httpMethod: POST
+      manageAlerts: false
+      prometheusType: Prometheus
+      prometheusVersion: 2.48.1
+      cacheLevel: 'None'
+      disableRecordingRules: false
+      incrementalQueryOverlapWindow: 10m
+      exemplarTraceIdDestinations: []

--- a/hack/composefiles/grafana.ini
+++ b/hack/composefiles/grafana.ini
@@ -1,0 +1,3 @@
+[security]
+admin_user = moby
+admin_password = moby

--- a/hack/composefiles/otelcol.yaml
+++ b/hack/composefiles/otelcol.yaml
@@ -1,0 +1,27 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+exporters:
+  otlp/jaeger:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
+
+  prometheus:
+    endpoint: 0.0.0.0:8000
+    resource_to_telemetry_conversion:
+      enabled: true
+    metric_expiration: 1m
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlp/jaeger]
+
+    metrics:
+      receivers: [otlp]
+      exporters: [prometheus]

--- a/hack/composefiles/override/.gitignore
+++ b/hack/composefiles/override/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/hack/composefiles/prometheus.yml
+++ b/hack/composefiles/prometheus.yml
@@ -1,0 +1,6 @@
+scrape_configs:
+  - job_name: otel
+    scrape_interval: 1m
+    static_configs:
+      - targets:
+          - "otel-collector:8000"

--- a/util/tracing/detect/otlp.go
+++ b/util/tracing/detect/otlp.go
@@ -11,7 +11,6 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
@@ -77,19 +76,11 @@ func otlpMetricExporter() (sdkmetric.Exporter, error) {
 
 	switch proto {
 	case "grpc":
-		return otlpmetricgrpc.New(context.Background(),
-			otlpmetricgrpc.WithTemporalitySelector(deltaTemporality),
-		)
+		return otlpmetricgrpc.New(context.Background())
 	case "http/protobuf":
-		return otlpmetrichttp.New(context.Background(),
-			otlpmetrichttp.WithTemporalitySelector(deltaTemporality),
-		)
+		return otlpmetrichttp.New(context.Background())
 	// case "http/json": // unsupported by library
 	default:
 		return nil, errors.Errorf("unsupported otlp protocol %v", proto)
 	}
-}
-
-func deltaTemporality(_ sdkmetric.InstrumentKind) metricdata.Temporality {
-	return metricdata.DeltaTemporality
 }


### PR DESCRIPTION
This includes the otel collector and uses the otel collector to direct
traces and metrics to the correct services. This is intended to act as
more of what a pipeline might look like in a production environment for
the traces and metrics.

Traces are forwarded from the otel collector directly to jaeger similar
to how that was configured before.

Metrics are forwarded to the prometheus exporter which prometheus will
use to scrape the metrics. A grafana instance has been included to use
with the prometheus instance to visualize the data. The default username
and password is `moby/moby` and the URL for the prometheus instance is
`http://prometheus:9090`. This state along with any dashboards will be
retained in your local development environment through a volume.