### PR TITLE
scheduler: always edge merge in one direction

### DIFF
--- a/solver/scheduler.go
+++ b/solver/scheduler.go
@@ -186,7 +186,7 @@ func (s *scheduler) dispatch(e *edge) {
 				if e.isDep(origEdge) || origEdge.isDep(e) {
 					bklog.G(context.TODO()).Debugf("skip merge due to dependency")
 				} else {
-					bklog.G(context.TODO()).Debugf("merging edge %s to %s\n", e.edge.Vertex.Name(), origEdge.edge.Vertex.Name())
+					bklog.G(context.TODO()).Debugf("merging edge %s[%d] to %s[%d]\n", e.edge.Vertex.Name(), e.edge.Index, origEdge.edge.Vertex.Name(), origEdge.edge.Index)
 					if s.mergeTo(origEdge, e) {
 						s.ef.setEdge(e.edge, origEdge)
 					}

--- a/solver/scheduler.go
+++ b/solver/scheduler.go
@@ -186,9 +186,14 @@ func (s *scheduler) dispatch(e *edge) {
 				if e.isDep(origEdge) || origEdge.isDep(e) {
 					bklog.G(context.TODO()).Debugf("skip merge due to dependency")
 				} else {
-					bklog.G(context.TODO()).Debugf("merging edge %s[%d] to %s[%d]\n", e.edge.Vertex.Name(), e.edge.Index, origEdge.edge.Vertex.Name(), origEdge.edge.Index)
-					if s.mergeTo(origEdge, e) {
-						s.ef.setEdge(e.edge, origEdge)
+					dest, src := origEdge, e
+					if s.ef.hasOwner(origEdge.edge, e.edge) {
+						dest, src = src, dest
+					}
+
+					bklog.G(context.TODO()).Debugf("merging edge %s[%d] to %s[%d]\n", src.edge.Vertex.Name(), src.edge.Index, dest.edge.Vertex.Name(), dest.edge.Index)
+					if s.mergeTo(dest, src) {
+						s.ef.setEdge(src.edge, dest)
 					}
 				}
 			}
@@ -351,6 +356,7 @@ func (s *scheduler) mergeTo(target, src *edge) bool {
 type edgeFactory interface {
 	getEdge(Edge) *edge
 	setEdge(Edge, *edge)
+	hasOwner(Edge, Edge) bool
 }
 
 type pipeFactory struct {

--- a/solver/scheduler_test.go
+++ b/solver/scheduler_test.go
@@ -3560,7 +3560,7 @@ func (v *vertexConst) Acquire(ctx context.Context) (ReleaseFunc, error) {
 	return func() {}, nil
 }
 
-// vtxSum returns a vertex that ourputs sum of its inputs plus a constant
+// vtxSum returns a vertex that outputs sum of its inputs plus a constant
 func vtxSum(v int, opt vtxOpt) *vertexSum {
 	if opt.cacheKeySeed == "" {
 		opt.cacheKeySeed = fmt.Sprintf("sum-%d-%d", v, len(opt.inputs))
@@ -3601,7 +3601,7 @@ func (v *vertexSum) Acquire(ctx context.Context) (ReleaseFunc, error) {
 
 func vtxSubBuild(g Edge, opt vtxOpt) *vertexSubBuild {
 	if opt.cacheKeySeed == "" {
-		opt.cacheKeySeed = fmt.Sprintf("sum-%s", identity.NewID())
+		opt.cacheKeySeed = fmt.Sprintf("sub-%s", identity.NewID())
 	}
 	if opt.name == "" {
 		opt.name = opt.cacheKeySeed + "-" + identity.NewID()

--- a/util/progress/multiwriter.go
+++ b/util/progress/multiwriter.go
@@ -36,6 +36,15 @@ func (ps *MultiWriter) Add(pw Writer) {
 	if !ok {
 		return
 	}
+	if pws, ok := rw.(*MultiWriter); ok {
+		if pws.contains(ps) {
+			// this would cause a deadlock, so we should panic instead
+			// NOTE: this can be caused by a cycle in the scheduler states,
+			// which is created by a series of unfortunate edge merges
+			panic("multiwriter loop detected")
+		}
+	}
+
 	ps.mu.Lock()
 	plist := make([]*Progress, 0, len(ps.items))
 	plist = append(plist, ps.items...)
@@ -101,4 +110,25 @@ func (ps *MultiWriter) writeRawProgress(p *Progress) error {
 
 func (ps *MultiWriter) Close() error {
 	return nil
+}
+
+func (ps *MultiWriter) contains(pw rawProgressWriter) bool {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	_, ok := ps.writers[pw]
+	if ok {
+		return true
+	}
+
+	for w := range ps.writers {
+		w, ok := w.(*MultiWriter)
+		if !ok {
+			continue
+		}
+		if w.contains(pw) {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
Resolves https://github.com/moby/buildkit/pull/4347#issuecomment-1889353650.

Previously, the scheduler could create cycles in the edges it merged:

> Essentially, what appears to happen is that we have two vertexes, A and B. Both of these vertexes seem to have at least two edges, A1/A2 and B1/B2. Somehow, we perform a merge that merges A1 into B1, but then merges B2 into A2.

Prior to #4347 this could (at worst) lead to a slight unnecessary inefficiency, where we would execute both A and B (even though both of their edges be merged so we'd never need to perform both of them). However, after this PR, we can accidentally deadlock, due to attempting to nest progress writers.