### PR TITLE
dockerfile: add source location to circular dependency error

### DIFF
--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -93,7 +93,9 @@ func Build(ctx context.Context, c client.Client) (_ *client.Result, err error) {
 	defer func() {
 		var el *parser.ErrorLocation
 		if errors.As(err, &el) {
-			err = wrapSource(err, src.SourceMap, el.Location)
+			for _, l := range el.Locations {
+				err = wrapSource(err, src.SourceMap, l)
+			}
 		}
 	}()
 

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -231,7 +231,7 @@ func toDispatchState(ctx context.Context, dt []byte, opt ConvertOpt) (*dispatchS
 
 		ds := &dispatchState{
 			stage:          st,
-			deps:           make(map[*dispatchState]struct{}),
+			deps:           make(map[*dispatchState]instructions.Command),
 			ctxPaths:       make(map[string]struct{}),
 			paths:          make(map[string]struct{}),
 			stageName:      st.Name,
@@ -337,7 +337,7 @@ func toDispatchState(ctx context.Context, dt []byte, opt ConvertOpt) (*dispatchS
 			d.commands[i] = newCmd
 			for _, src := range newCmd.sources {
 				if src != nil {
-					d.deps[src] = struct{}{}
+					d.deps[src] = cmd
 					if src.unregistered {
 						allDispatchStates.addState(src)
 					}
@@ -346,8 +346,8 @@ func toDispatchState(ctx context.Context, dt []byte, opt ConvertOpt) (*dispatchS
 		}
 	}
 
-	if has, state := hasCircularDependency(allDispatchStates.states); has {
-		return nil, errors.Errorf("circular dependency detected on stage: %s", state.stageName)
+	if err := validateCircularDependency(allDispatchStates.states); err != nil {
+		return nil, err
 	}
 
 	if len(allDispatchStates.states) == 1 {
@@ -648,7 +648,7 @@ func toCommand(ic instructions.Command, allDispatchStates *dispatchStates) (comm
 				if !ok {
 					stn = &dispatchState{
 						stage:        instructions.Stage{BaseName: c.From, Location: ic.Location()},
-						deps:         make(map[*dispatchState]struct{}),
+						deps:         make(map[*dispatchState]instructions.Command),
 						paths:        make(map[string]struct{}),
 						unregistered: true,
 					}
@@ -821,7 +821,7 @@ type dispatchState struct {
 	stage     instructions.Stage
 	base      *dispatchState
 	noinit    bool
-	deps      map[*dispatchState]struct{}
+	deps      map[*dispatchState]instructions.Command
 	buildArgs []instructions.KeyValuePairOptional
 	commands  []command
 	// ctxPaths marks the paths this dispatchState uses from the build context.
@@ -1607,39 +1607,40 @@ func findReachable(from *dispatchState) (ret []*dispatchState) {
 	return ret
 }
 
-func hasCircularDependency(states []*dispatchState) (bool, *dispatchState) {
-	var visit func(state *dispatchState) bool
+func validateCircularDependency(states []*dispatchState) error {
+	var visit func(state *dispatchState) instructions.Command
 	if states == nil {
-		return false, nil
+		return nil
 	}
 	visited := make(map[*dispatchState]struct{})
 	path := make(map[*dispatchState]struct{})
 
-	visit = func(state *dispatchState) bool {
+	visit = func(state *dispatchState) instructions.Command {
 		_, ok := visited[state]
 		if ok {
-			return false
+			return nil
 		}
 		visited[state] = struct{}{}
 		path[state] = struct{}{}
-		for dep := range state.deps {
-			_, ok = path[dep]
-			if ok {
-				return true
+		for dep, c := range state.deps {
+			if _, ok := path[dep]; ok {
+				return c
 			}
-			if visit(dep) {
-				return true
+			if c := visit(dep); c != nil {
+				return c
 			}
 		}
 		delete(path, state)
-		return false
+		return nil
 	}
 	for _, state := range states {
-		if visit(state) {
-			return true, state
+		if c := visit(state); c != nil {
+			err := errors.Errorf("circular dependency detected on stage: %s", state.stageName)
+			err = parser.WithLocation(err, c.Location())
+			return err
 		}
 	}
-	return false, nil
+	return nil
 }
 
 func normalizeContextPaths(paths map[string]struct{}) []string {

--- a/frontend/dockerfile/dockerfile2llb/convert_runmount.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_runmount.go
@@ -30,7 +30,7 @@ func detectRunMount(cmd *command, allDispatchStates *dispatchStates) bool {
 			if !ok {
 				stn = &dispatchState{
 					stage:        instructions.Stage{BaseName: from},
-					deps:         make(map[*dispatchState]struct{}),
+					deps:         make(map[*dispatchState]instructions.Command),
 					paths:        make(map[string]struct{}),
 					unregistered: true,
 				}

--- a/frontend/dockerfile/parser/errors.go
+++ b/frontend/dockerfile/parser/errors.go
@@ -7,7 +7,7 @@ import (
 
 // ErrorLocation gives a location in source code that caused the error
 type ErrorLocation struct {
-	Location []Range
+	Locations [][]Range
 	error
 }
 
@@ -39,11 +39,12 @@ func WithLocation(err error, location []Range) error {
 	}
 	var el *ErrorLocation
 	if errors.As(err, &el) {
+		el.Locations = append(el.Locations, location)
 		return err
 	}
 	return stack.Enable(&ErrorLocation{
-		error:    err,
-		Location: location,
+		error:     err,
+		Locations: [][]Range{location},
 	})
 }
 


### PR DESCRIPTION
Update the detection and handling of circular dependency validation.

New output:

```
# buildctl build --frontend dockerfile.v0 --local context=. --local dockerfile=.
[+] Building 0.0s (1/1) FINISHED
 => [internal] load build definition from Dockerfile                                                                           0.0s
 => => transferring dockerfile: 197B                                                                                           0.0s
Dockerfile:9
--------------------
   7 |
   8 |     FROM alpine AS build
   9 | >>> COPY --from=target /Dockerfile /d2
  10 |
  11 |     FROM target
--------------------
Dockerfile:3
--------------------
   1 |
   2 |     FROM busybox AS target
   3 | >>> COPY --from=build / /out
   4 |
   5 |     FROM target as b
--------------------
error: failed to solve: circular dependency detected on stage: target
```