### PR TITLE
dockerfile: validate order when linking stages

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert_runmount.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_runmount.go
@@ -70,7 +70,11 @@ func dispatchRunMounts(d *dispatchState, c *instructions.RunCommand, sources []*
 		}
 		st := opt.buildContext
 		if mount.From != "" {
-			st = sources[i].state
+			src := sources[i]
+			st = src.state
+			if !src.noinit {
+				return nil, errors.Errorf("cannot mount from stage %q to %q, stage needs to be defined before current command", mount.From, mount.Target)
+			}
 		}
 		var mountOpts []llb.MountOption
 		if mount.Type == instructions.MountTypeTmpfs {


### PR DESCRIPTION
Dockerfile stages always needed to be in order (you can not refer to a stage that is defined after your current command), but the behavior for incorrect order was undefined instead of consistently erroring.

Previously copying from a stage defined later would usually cause an error about a missing source file that could have been quite confusing. When the source path was "/" then the behavior could have been worse and resulted in COPY passing without error, without any files actually being copied (or only files from base image being copied).

This validates the order when on COPY and mount dispatch, returns proper error with correct source code location.

```
Dockerfile:5
--------------------
   3 |
   4 |     FROM busybox AS target
   5 | >>> COPY --from=build / /out
   6 |
   7 |     FROM alpine AS build
--------------------
error: failed to solve: cannot copy from stage "build", it needs to be defined before current stage "target"
```