### PR TITLE
history: wrap os.ErrNotExist errors

### DIFF
--- a/solver/llbsolver/history.go
+++ b/solver/llbsolver/history.go
@@ -326,7 +326,7 @@ func (h *HistoryQueue) delete(ref string, sync bool) error {
 	if err := h.opt.DB.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(recordsBucket))
 		if b == nil {
-			return os.ErrNotExist
+			return errors.Wrapf(os.ErrNotExist, "failed to retrieve bucket %s", recordsBucket)
 		}
 		err1 := b.Delete([]byte(ref))
 		var opts []leases.DeleteOpt
@@ -393,11 +393,11 @@ func (h *HistoryQueue) UpdateRef(ctx context.Context, ref string, upt func(r *co
 	if err := h.opt.DB.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(recordsBucket))
 		if b == nil {
-			return os.ErrNotExist
+			return errors.Wrapf(os.ErrNotExist, "failed to retrieve bucket %s", recordsBucket)
 		}
 		dt := b.Get([]byte(ref))
 		if dt == nil {
-			return os.ErrNotExist
+			return errors.Wrapf(os.ErrNotExist, "failed to retrieve ref %s", ref)
 		}
 
 		if err := br.Unmarshal(dt); err != nil {
@@ -433,11 +433,11 @@ func (h *HistoryQueue) Status(ctx context.Context, ref string, st chan<- *client
 	if err := h.opt.DB.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(recordsBucket))
 		if b == nil {
-			return os.ErrNotExist
+			return errors.Wrapf(os.ErrNotExist, "failed to retrieve bucket %s", recordsBucket)
 		}
 		dt := b.Get([]byte(ref))
 		if dt == nil {
-			return os.ErrNotExist
+			return errors.Wrapf(os.ErrNotExist, "failed to retrieve ref %s", ref)
 		}
 
 		if err := br.Unmarshal(dt); err != nil {


### PR DESCRIPTION
While debugging around, I found some instances of os.ErrNotExist appearing in the logs from the history API - however, no stack traces were available, since they're not wrapped.

This patch just adds wrapping for them, with some additional debbuging info.