### PR TITLE
Dockerfile: update dind script to latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -341,7 +341,7 @@ ARG AZURITE_VERSION
 RUN apk add --no-cache nodejs npm \
   && npm install -g azurite@${AZURITE_VERSION}
 # The entrypoint script is needed for enabling nested cgroup v2 (https://github.com/moby/buildkit/issues/3265#issuecomment-1309631736)
-RUN curl -Ls https://raw.githubusercontent.com/moby/moby/v20.10.21/hack/dind > /docker-entrypoint.sh \
+RUN curl -Ls https://raw.githubusercontent.com/moby/moby/v25.0.1/hack/dind > /docker-entrypoint.sh \
   && chmod 0755 /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]
 # musl is needed to directly use the registry binary that is built on alpine


### PR DESCRIPTION
- hack/dind: update comments around AppArmor
- Update blogpost URL
- Modify the DinD entrypoint scripts to make the issue reproducible inside DinD container.


Full diff (`git diff v20.10.21:hack/dind v25.0.1:hack/dind`);

```patch
git diff v20.10.21:hack/dind v25.0.1:hack/dind
diff --git a/hack/dind b/hack/dind
index 087270a7a8..456ba861a6 100755
--- a/hack/dind
+++ b/hack/dind
@@ -3,7 +3,7 @@ set -e

 # DinD: a wrapper script which allows docker to be run inside a docker container.
 # Original version by Jerome Petazzoni <jerome@docker.com>
-# See the blog post: https://blog.docker.com/2013/09/docker-can-now-run-within-docker/
+# See the blog post: https://www.docker.com/blog/docker-can-now-run-within-docker/
 #
 # This script should be executed inside a docker container in privileged mode
 # ('docker run --privileged', introduced in docker 0.6).
@@ -11,8 +11,39 @@ set -e
 # Usage: dind CMD [ARG...]

 # apparmor sucks and Docker needs to know that it's in a container (c) @tianon
+#
+# Set the container env-var, so that AppArmor is enabled in the daemon and
+# containerd when running docker-in-docker.
+#
+# see: https://github.com/containerd/containerd/blob/787943dc1027a67f3b52631e084db0d4a6be2ccc/pkg/apparmor/apparmor_linux.go#L29-L45
+# see: https://github.com/moby/moby/commit/de191e86321f7d3136ff42ff75826b8107399497
 export container=docker

+# Allow AppArmor to work inside the container;
+#
+#     aa-status
+#     apparmor filesystem is not mounted.
+#     apparmor module is loaded.
+#
+#     mount -t securityfs none /sys/kernel/security
+#
+#     aa-status
+#     apparmor module is loaded.
+#     30 profiles are loaded.
+#     30 profiles are in enforce mode.
+#       /snap/snapd/18357/usr/lib/snapd/snap-confine
+#       ...
+#
+# Note: https://0xn3va.gitbook.io/cheat-sheets/container/escaping/sensitive-mounts#sys-kernel-security
+#
+#     ## /sys/kernel/security
+#
+#     In /sys/kernel/security mounted the securityfs interface, which allows
+#     configuration of Linux Security Modules. This allows configuration of
+#     AppArmor policies, and so access to this may allow a container to disable
+#     its MAC system.
+#
+# Given that we're running privileged already, this should not be an issue.
 if [ -d /sys/kernel/security ] && ! mountpoint -q /sys/kernel/security; then
        mount -t securityfs none /sys/kernel/security || {
                echo >&2 'Could not mount /sys/kernel/security.'
@@ -37,6 +68,10 @@ if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
                > /sys/fs/cgroup/cgroup.subtree_control
 fi

+# Change mount propagation to shared to make the environment more similar to a
+# modern Linux system, e.g. with SystemD as PID 1.
+mount --make-rshared /
+
 if [ $# -gt 0 ]; then
        exec "$@"
 fi
```
