### PR TITLE
oci: fix error handling on submount calls

### DIFF
--- a/executor/oci/spec.go
+++ b/executor/oci/spec.go
@@ -233,12 +233,12 @@ func (s *submounts) subMount(m mount.Mount, subPath string) (mount.Mount, error)
 	}
 	h, err := hashstructure.Hash(m, hashstructure.FormatV2, nil)
 	if err != nil {
-		return mount.Mount{}, nil
+		return mount.Mount{}, err
 	}
 	if mr, ok := s.m[h]; ok {
 		sm, err := sub(mr.mount, subPath)
 		if err != nil {
-			return mount.Mount{}, nil
+			return mount.Mount{}, err
 		}
 		return sm, nil
 	}


### PR DESCRIPTION
I can't see any reason why these `nil` returns could be intentional, so changing to correct error returns.