### PR TITLE
solver: use errors.Is when checking context.Cause()

### DIFF
--- a/solver/errdefs/context.go
+++ b/solver/errdefs/context.go
@@ -14,7 +14,7 @@ func IsCanceled(ctx context.Context, err error) bool {
 		return true
 	}
 	// grpc does not set cancel correctly when stream gets cancelled and then Recv is called
-	if err != nil && context.Cause(ctx) == context.Canceled {
+	if err != nil && errors.Is(context.Cause(ctx), context.Canceled) {
 		// when this error comes from containerd it is not typed at all, just concatenated string
 		if strings.Contains(err.Error(), "EOF") {
 			return true


### PR DESCRIPTION
Since the change to replace uses of `context.WithCancel` with `WithCancelCause` in #4457, we've also begun wrapping all cancellations using `errors.WithStack`. This means that these would not directly match context.Canceled, so we need to make sure to use `errors.Is`.

I spotted this while reading over #4457 in more detail again, I wonder if this is the source of a particular deadlock we're encountering where gRPC streams aren't shutting down (though this may or may not be the actual root cause lol). That said, this code definitely seems wrong.

Ideally, we should have some linter check to prevent comparing errors like this *at all* - direct comparisons on errors should be the exception rather than the rule. cc @crazy-max do you know if this exists?