### PR TITLE
chore: remove noisy rootlesskit cni log

### DIFF
--- a/util/network/cniprovider/cni_linux.go
+++ b/util/network/cniprovider/cni_linux.go
@@ -94,6 +94,5 @@ func withDetachedNetNSIfAny(ctx context.Context, fn func(context.Context) error)
 			})
 		}
 	}
-	bklog.G(ctx).Debug("Not entering RootlessKit's detached netns")
 	return fn(ctx)
 }


### PR DESCRIPTION
Follow-up to https://github.com/moby/buildkit/pull/4546.

Because `withDetachedNetNSIfAny` is called in `Sample`, it regularly gets called, leaving this debug message throughout the logs if CNI is enabled (even when rootlesskit is disabled).