### PR TITLE
chore: close solver resources on shutdown

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -130,11 +130,12 @@ func (c *Controller) Close() error {
 	if err := c.opt.WorkerController.Close(); err != nil {
 		rerr = multierror.Append(rerr, err)
 	}
-
 	if err := c.opt.CacheStore.Close(); err != nil {
 		rerr = multierror.Append(rerr, err)
 	}
-
+	if err := c.solver.Close(); err != nil {
+		rerr = multierror.Append(rerr, err)
+	}
 	return rerr
 }
 

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -123,6 +123,12 @@ func New(opt Opt) (*Solver, error) {
 	return s, nil
 }
 
+func (s *Solver) Close() error {
+	s.solver.Close()
+	err := s.sysSampler.Close()
+	return err
+}
+
 func (s *Solver) resolver() solver.ResolveOpFunc {
 	return func(v solver.Vertex, b solver.Builder) (solver.Op, error) {
 		w, err := s.resolveWorker()


### PR DESCRIPTION
The solver has a Close method to shutdown the scheduler, which releases a goroutine. We should call it on shutdown.

While in the area, we can also close the `sysSampler`.

This shouldn't affect anything, but noticed that we should probably do this for consistency (I just noticed it while poking around `scheduler_test.go`. Also if we want better `SIGTERM` handling at some point, this feels like something that could potentially trip us up in implementing that.