### PR TITLE
Add --chown and --chmod to commitMessage for ADD/COPY command

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -1155,6 +1155,13 @@ func dispatchCopy(d *dispatchState, cfg copyConfig) error {
 		commitMessage.WriteString("COPY")
 	}
 
+	if cfg.chown != "" {
+		commitMessage.WriteString(" " + "--chown=" + cfg.chown)
+	}
+	if cfg.chmod != "" {
+		commitMessage.WriteString(" " + "--chmod=" + cfg.chmod)
+	}
+
 	var a *llb.FileAction
 
 	for _, src := range cfg.params.SourcePaths {

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -1155,6 +1155,9 @@ func dispatchCopy(d *dispatchState, cfg copyConfig) error {
 		commitMessage.WriteString("COPY")
 	}
 
+	if cfg.parents {
+		commitMessage.WriteString(" " + "--parents")
+	}
 	if cfg.chown != "" {
 		commitMessage.WriteString(" " + "--chown=" + cfg.chown)
 	}


### PR DESCRIPTION
I think the commit message of the COPY/ADD command should include chown/chmod information for clarity. 