### PR TITLE
Fix missing chown/chmod when using parents flag with ADD/COPY command

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -1219,23 +1219,23 @@ func dispatchCopy(d *dispatchState, cfg copyConfig) error {
 				return errors.Wrap(err, "removing drive letter")
 			}
 
+			var patterns []string
+			if cfg.parents {
+				path := strings.TrimPrefix(src, "/")
+				patterns = []string{path}
+				src = "/"
+			}
+
 			opts := append([]llb.CopyOption{&llb.CopyInfo{
 				Mode:                mode,
 				FollowSymlinks:      true,
 				CopyDirContentsOnly: true,
+				IncludePatterns:     patterns,
 				AttemptUnpack:       cfg.isAddCommand,
 				CreateDestPath:      true,
 				AllowWildcard:       true,
 				AllowEmptyWildcard:  true,
 			}}, copyOpt...)
-
-			if cfg.parents {
-				path := strings.TrimPrefix(src, "/")
-				opts = append(opts, &llb.CopyInfo{
-					IncludePatterns: []string{path},
-				})
-				src = "/"
-			}
 
 			if a == nil {
 				a = llb.Copy(cfg.source, src, dest, opts...)


### PR DESCRIPTION
When using the parents flag, it will add CopyInfo to the end of opts
https://github.com/moby/buildkit/blob/ef61ad133d7fd20632eb964dfc78292360f2f09d/frontend/dockerfile/dockerfile2llb/convert.go#L1232-L1238

And since it's the last, it will replace any opts in front. So the chmod/chown flags in front will be disabled (like they don't exist).
https://github.com/moby/buildkit/blob/ef61ad133d7fd20632eb964dfc78292360f2f09d/client/llb/fileop.go#L481-L483

We should take it forward. Like this
https://github.com/moby/buildkit/blob/ef61ad133d7fd20632eb964dfc78292360f2f09d/frontend/dockerfile/dockerfile2llb/convert.go#L1206-L1209