### PR TITLE
chore: fix remotecache/v1/doc.go

### DIFF
--- a/cache/remotecache/v1/doc.go
+++ b/cache/remotecache/v1/doc.go
@@ -30,7 +30,6 @@ package cacheimport
 //    },
 //    {
 //      "digest": "sha256:deadbeef",
-//      "output": 1,                   <- optional output index
 //      "layers": [                    <- optional array of layer pointers
 //        {
 //          "createdat": "",


### PR DESCRIPTION
This file mistakenly included an output index field. This field never seemed to exist, the output index is actually part of the record digest (see `rootKey`).

This mistake seems to have been here right at the very beginning in https://github.com/moby/buildkit/commit/7b5fc36f5f94ffa396c8646927f1b3cff512a205#diff-f1af45f50b0c62e0be01b77072ad6d5239cb0fc726fb841ed95decf086e000dc.

Compare the `spec.go` source of truth in that commit:

```go
type CacheRecord struct {
	Results []CacheResult  `json:"layers,omitempty"`
	Digest  digest.Digest  `json:"digest,omitempty"`
	Inputs  [][]CacheInput `json:"inputs,omitempty"`
}
```

vs the misleading `doc.go`:

```go
//    {
//      "digest": "sha256:deadbeef",
//      "output": 1,                   <- optional output index
//      "layers": [                    <- optional array or layer chains
//        {
//          "createdat": "",
//          "layer": 1,                <- index to the layer
//        }
```