### PR TITLE
update runc to v1.1.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:master
 
-ARG RUNC_VERSION=v1.1.11
+ARG RUNC_VERSION=v1.1.12
 ARG CONTAINERD_VERSION=v1.7.11
 # containerd v1.6 for integration tests
 ARG CONTAINERD_ALT_VERSION_16=v1.6.24


### PR DESCRIPTION
Brings in the fix for GHSA-xr7r-f8xq-vfvv