### PR TITLE
exec: add extra validation for submount sources

### DIFF
--- a/executor/oci/spec.go
+++ b/executor/oci/spec.go
@@ -13,7 +13,6 @@ import (
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/pkg/userns"
-	"github.com/containerd/continuity/fs"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/mitchellh/hashstructure/v2"
 	"github.com/moby/buildkit/executor"
@@ -218,6 +217,7 @@ func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mou
 type mountRef struct {
 	mount   mount.Mount
 	unmount func() error
+	subRefs map[string]mountRef
 }
 
 type submounts struct {
@@ -236,9 +236,16 @@ func (s *submounts) subMount(m mount.Mount, subPath string) (mount.Mount, error)
 		return mount.Mount{}, err
 	}
 	if mr, ok := s.m[h]; ok {
-		sm, err := sub(mr.mount, subPath)
+		if sm, ok := mr.subRefs[subPath]; ok {
+			return sm.mount, nil
+		}
+		sm, unmount, err := sub(mr.mount, subPath)
 		if err != nil {
 			return mount.Mount{}, err
+		}
+		mr.subRefs[subPath] = mountRef{
+			mount:   sm,
+			unmount: unmount,
 		}
 		return sm, nil
 	}
@@ -271,11 +278,16 @@ func (s *submounts) subMount(m mount.Mount, subPath string) (mount.Mount, error)
 			Options: opts,
 		},
 		unmount: lm.Unmount,
+		subRefs: map[string]mountRef{},
 	}
 
-	sm, err := sub(s.m[h].mount, subPath)
+	sm, unmount, err := sub(s.m[h].mount, subPath)
 	if err != nil {
 		return mount.Mount{}, err
+	}
+	s.m[h].subRefs[subPath] = mountRef{
+		mount:   sm,
+		unmount: unmount,
 	}
 	return sm, nil
 }
@@ -286,19 +298,13 @@ func (s *submounts) cleanup() {
 	for _, m := range s.m {
 		func(m mountRef) {
 			go func() {
+				for _, sm := range m.subRefs {
+					sm.unmount()
+				}
 				m.unmount()
 				wg.Done()
 			}()
 		}(m)
 	}
 	wg.Wait()
-}
-
-func sub(m mount.Mount, subPath string) (mount.Mount, error) {
-	src, err := fs.RootPath(m.Source, subPath)
-	if err != nil {
-		return mount.Mount{}, err
-	}
-	m.Source = src
-	return m, nil
 }

--- a/executor/oci/spec_freebsd.go
+++ b/executor/oci/spec_freebsd.go
@@ -1,7 +1,9 @@
 package oci
 
 import (
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/oci"
+	"github.com/containerd/continuity/fs"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/moby/buildkit/solver/pb"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -58,4 +60,13 @@ func getTracingSocket() string {
 
 func cgroupV2NamespaceSupported() bool {
 	return false
+}
+
+func sub(m mount.Mount, subPath string) (mount.Mount, func() error, error) {
+	src, err := fs.RootPath(m.Source, subPath)
+	if err != nil {
+		return mount.Mount{}, nil, err
+	}
+	m.Source = src
+	return m, func() error { return nil }, nil
 }

--- a/executor/oci/spec_windows.go
+++ b/executor/oci/spec_windows.go
@@ -11,7 +11,9 @@ import (
 	"strings"
 
 	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/oci"
+	"github.com/containerd/continuity/fs"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/moby/buildkit/solver/pb"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -99,4 +101,13 @@ func getTracingSocket() string {
 
 func cgroupV2NamespaceSupported() bool {
 	return false
+}
+
+func sub(m mount.Mount, subPath string) (mount.Mount, func() error, error) {
+	src, err := fs.RootPath(m.Source, subPath)
+	if err != nil {
+		return mount.Mount{}, nil, err
+	}
+	m.Source = src
+	return m, func() error { return nil }, nil
 }

--- a/snapshot/localmounter_freebsd.go
+++ b/snapshot/localmounter_freebsd.go
@@ -20,7 +20,7 @@ func (lm *localMounter) Mount() (string, error) {
 		lm.release = release
 	}
 
-	if len(lm.mounts) == 1 && lm.mounts[0].Type == "nullfs" {
+	if !lm.forceRemount && len(lm.mounts) == 1 && lm.mounts[0].Type == "nullfs" {
 		ro := false
 		for _, opt := range lm.mounts[0].Options {
 			if opt == "ro" {

--- a/snapshot/localmounter_linux.go
+++ b/snapshot/localmounter_linux.go
@@ -2,6 +2,7 @@ package snapshot
 
 import (
 	"os"
+	"path/filepath"
 	"syscall"
 
 	"github.com/containerd/containerd/mount"
@@ -31,30 +32,48 @@ func (lm *localMounter) Mount() (string, error) {
 		}
 	}
 
+	var isFile bool
 	if len(lm.mounts) == 1 && (lm.mounts[0].Type == "bind" || lm.mounts[0].Type == "rbind") {
-		ro := false
-		for _, opt := range lm.mounts[0].Options {
-			if opt == "ro" {
-				ro = true
-				break
+		if !lm.forceRemount {
+			ro := false
+			for _, opt := range lm.mounts[0].Options {
+				if opt == "ro" {
+					ro = true
+					break
+				}
+			}
+			if !ro {
+				return lm.mounts[0].Source, nil
 			}
 		}
-		if !ro {
-			return lm.mounts[0].Source, nil
+		fi, err := os.Stat(lm.mounts[0].Source)
+		if err != nil {
+			return "", err
+		}
+		if !fi.IsDir() {
+			isFile = true
 		}
 	}
 
-	dir, err := os.MkdirTemp("", "buildkit-mount")
+	dest, err := os.MkdirTemp("", "buildkit-mount")
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create temp dir")
 	}
 
-	if err := mount.All(lm.mounts, dir); err != nil {
-		os.RemoveAll(dir)
-		return "", errors.Wrapf(err, "failed to mount %s: %+v", dir, lm.mounts)
+	if isFile {
+		dest = filepath.Join(dest, "file")
+		if err := os.WriteFile(dest, []byte{}, 0644); err != nil {
+			os.RemoveAll(dest)
+			return "", errors.Wrap(err, "failed to create temp file")
+		}
 	}
-	lm.target = dir
-	return dir, nil
+
+	if err := mount.All(lm.mounts, dest); err != nil {
+		os.RemoveAll(dest)
+		return "", errors.Wrapf(err, "failed to mount %s: %+v", dest, lm.mounts)
+	}
+	lm.target = dest
+	return dest, nil
 }
 
 func (lm *localMounter) Unmount() error {


### PR DESCRIPTION
While submount paths were already validated there are some cases where the parent mount may not be immutable while the submount is created.

Fix for https://github.com/moby/buildkit/security/advisories/GHSA-m3r6-h7wv-7xxv

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
(cherry picked from commit 2529ec4121bcd8c35bcd96218083da175c2e5b77)