### PR TITLE
ci: update gha to account for node 16 deprecation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      # ignore this dependency
+      # it seems a bug with dependabot as pining to commit sha should not
+      # trigger a new version: https://github.com/docker/buildx/pull/2222#issuecomment-1919092153
+      - dependency-name: "docker/docs"
     labels:
       - "dependencies"
       - "bot"

--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -63,7 +63,7 @@ jobs:
       -
         name: Set outputs
         id: set
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const yaml = require('js-yaml');

--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -183,7 +183,7 @@ jobs:
       -
         name: Generate annotations
         if: always()
-        uses: crazy-max/.github/.github/actions/gotest-annotations@5af0882e0496d2f7e98a53ae4048e3d86682496f
+        uses: crazy-max/.github/.github/actions/gotest-annotations@fa6141aedf23596fb8bdcceab9cce8dadaa31bd9
         with:
           directory: ./bin/testreports
       -

--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -123,11 +123,20 @@ jobs:
         include: ${{ fromJson(needs.prepare.outputs.includes) }}
     steps:
       -
-        name: Environment variables
+        name: Prepare
         run: |
           for l in "${{ inputs.env }}"; do
             echo "${l?}" >> $GITHUB_ENV
           done
+          echo "TEST_REPORT_NAME=${{ github.job }}-$(echo "${{ matrix.pkg }}-${{ matrix.skip-integration-tests }}-${{ matrix.kind }}-${{ matrix.worker }}-${{ matrix.tags }}" | tr -dc '[:alnum:]-\n\r' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+          testFlags="${{ env.TESTFLAGS }}"
+          if [ -n "${{ matrix.tags }}" ]; then
+            testFlags="${testFlags} --tags=${{ matrix.tags }}"
+          fi
+          if [ -n "${{ matrix.worker }}" ]; then
+            testFlags="${testFlags} --run=//worker=${{ matrix.worker }}$"
+          fi
+          echo "TESTFLAGS=${testFlags}" >> $GITHUB_ENV
       -
         name: Checkout
         uses: actions/checkout@v4
@@ -157,15 +166,9 @@ jobs:
       -
         name: Test
         run: |
-          export TEST_REPORT_SUFFIX=-${{ github.job }}-$(echo "${{ matrix.pkg }}-${{ matrix.skip-integration-tests }}-${{ matrix.kind }}-${{ matrix.worker }}-${{ matrix.tags }}" | tr -dc '[:alnum:]-\n\r' | tr '[:upper:]' '[:lower:]')
-          if [ -n "${{ matrix.tags }}" ]; then
-            TESTFLAGS="${TESTFLAGS} --tags=${{ matrix.tags }}"
-          fi
-          if [ -n "${{ matrix.worker }}" ]; then
-            export TESTFLAGS="${TESTFLAGS} --run=//worker=${{ matrix.worker }}$"
-          fi
           ./hack/test ${{ matrix.kind }}
         env:
+          TEST_REPORT_SUFFIX: -${{ env.TEST_REPORT_NAME }}
           TEST_COVERAGE: 1
           TESTPKGS: ${{ matrix.pkg }}
           SKIP_INTEGRATION_TESTS: ${{ matrix.skip-integration-tests }}
@@ -186,9 +189,9 @@ jobs:
       -
         name: Upload test reports
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: test-reports
+          name: test-reports-${{ env.TEST_REPORT_NAME }}
           path: ./bin/testreports
       -
         name: Dump context

--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -173,7 +173,7 @@ jobs:
       -
         name: Send to Codecov
         if: always()
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           directory: ./bin/testreports
           flags: ${{ matrix.codecov_flags }}

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -108,9 +108,9 @@ jobs:
           CACHE_TO: type=gha,scope=binaries-${{ env.PLATFORM_PAIR }}
       -
         name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: buildkit
+          name: buildkit-${{ env.PLATFORM_PAIR }}
           path: ${{ env.DESTDIR }}/*
           if-no-files-found: error
 
@@ -195,10 +195,11 @@ jobs:
     steps:
       -
         name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: buildkit
           path: ${{ env.DESTDIR }}
+          pattern: buildkit-*
+          merge-multiple: true
       -
         name: List artifacts
         run: |

--- a/.github/workflows/dockerd.yml
+++ b/.github/workflows/dockerd.yml
@@ -7,7 +7,7 @@ on:
       version:
         description: 'Docker version'
         required: true
-        default: '23.0.1'
+        default: '25.0.2'
 
 env:
   SETUP_BUILDX_VERSION: "latest"
@@ -23,7 +23,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const version = `${{ inputs.version }}` || '23.0.1';
+            const version = `${{ inputs.version }}` || '25.0.2';
             let build = 'true';
             try {
               new URL(version);

--- a/.github/workflows/dockerd.yml
+++ b/.github/workflows/dockerd.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       -
         name: Prepare
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const version = `${{ inputs.version }}` || '25.0.2';

--- a/.github/workflows/dockerd.yml
+++ b/.github/workflows/dockerd.yml
@@ -63,7 +63,7 @@ jobs:
           wget -qO- "https://download.docker.com/linux/static/stable/x86_64/docker-${{ env.DOCKER_VERSION }}.tgz" | tar xvz --strip 1
       -
         name: Upload dockerd
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dockerd
           path: /tmp/moby/dockerd
@@ -109,7 +109,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Download dockerd
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dockerd
           path: ./build/

--- a/.github/workflows/docs-upstream.yml
+++ b/.github/workflows/docs-upstream.yml
@@ -1,8 +1,6 @@
-# this workflow runs the remote validate bake target from docker/docker.github.io
-# to check if yaml reference docs and markdown files used in this repo are still
-# valid: https://github.com/docker/docs/blob/98c7c9535063ae4cd2cd0a31478a21d16d2f07a3/docker-bake.hcl#L34-L36
-# path filters reflects the files that are used as remote resource in this
-# repo: https://github.com/docker/docs/blob/d5312d53e255a24e421dfe6c3344359e10271cb8/_config.yml#L202-L217
+# this workflow runs the remote validate bake target from docker/docs to check
+# if yaml reference docs and markdown files used in this repo are still valid
+# https://github.com/docker/docker.github.io/blob/98c7c9535063ae4cd2cd0a31478a21d16d2f07a3/docker-bake.hcl#L34-L36
 name: docs-upstream
 
 concurrency:
@@ -30,6 +28,6 @@ on:
 
 jobs:
   validate:
-    uses: docker/docs/.github/workflows/validate-upstream.yml@main
+    uses: docker/docs/.github/workflows/validate-upstream.yml@919a9b9104a34a40b30d116529bcce589a544d1c  # pin for artifact v4 support: https://github.com/docker/docs/pull/19220
     with:
       module-name: moby/buildkit

--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -93,7 +93,7 @@ jobs:
       -
         name: Send to Codecov
         if: always()
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           directory: ./bin/testreports
           env_vars: RUNNER_OS

--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -101,7 +101,7 @@ jobs:
       -
         name: Generate annotations
         if: always()
-        uses: crazy-max/.github/.github/actions/gotest-annotations@5af0882e0496d2f7e98a53ae4048e3d86682496f
+        uses: crazy-max/.github/.github/actions/gotest-annotations@fa6141aedf23596fb8bdcceab9cce8dadaa31bd9
         with:
           directory: ./bin/testreports
       -

--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -107,9 +107,9 @@ jobs:
       -
         name: Upload test reports
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: test-reports
+          name: test-reports-${{ matrix.os }}
           path: ./bin/testreports
       -
         name: Dump context
@@ -134,7 +134,7 @@ jobs:
             *.platform=freebsd/amd64
       -
         name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: buildkit-freebsd-amd64
           path: ${{ env.DESTDIR }}/*
@@ -154,7 +154,7 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: buildkit-freebsd-amd64
           path: ${{ env.DESTDIR }}


### PR DESCRIPTION
Follow-up
* https://github.com/docker/buildx/pull/2210
* https://github.com/docker/buildx/pull/2212
* https://github.com/docker/buildx/pull/2227
* https://github.com/moby/moby/pull/47250
* https://github.com/moby/moby/pull/47263

Update remaining GHA following the deprecation notice from GitHub:

> Please update the following actions to use Node.js 20: actions/github-script@v6. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
