### PR TITLE
chore: refactor IsGitTransport to avoid duplication

### DIFF
--- a/source/git/identifier.go
+++ b/source/git/identifier.go
@@ -2,13 +2,11 @@ package git
 
 import (
 	"path"
-	"strings"
 
 	"github.com/moby/buildkit/solver/llbsolver/provenance"
 	"github.com/moby/buildkit/source"
 	srctypes "github.com/moby/buildkit/source/types"
 	"github.com/moby/buildkit/util/gitutil"
-	"github.com/moby/buildkit/util/sshutil"
 )
 
 type GitIdentifier struct {
@@ -23,7 +21,7 @@ type GitIdentifier struct {
 }
 
 func NewGitIdentifier(remoteURL string) (*GitIdentifier, error) {
-	if !isGitTransport(remoteURL) {
+	if !gitutil.IsGitTransport(remoteURL) {
 		remoteURL = "https://" + remoteURL
 	}
 	u, err := gitutil.ParseURL(remoteURL)
@@ -76,10 +74,4 @@ func (id *GitIdentifier) Capture(c *provenance.Capture, pin string) error {
 		})
 	}
 	return nil
-}
-
-// isGitTransport returns true if the provided str is a git transport by inspecting
-// the prefix of the string for known protocols used in git.
-func isGitTransport(str string) bool {
-	return strings.HasPrefix(str, "http://") || strings.HasPrefix(str, "https://") || strings.HasPrefix(str, "git://") || strings.HasPrefix(str, "ssh://") || sshutil.IsImplicitSSHTransport(str)
 }

--- a/source/git/source.go
+++ b/source/git/source.go
@@ -81,7 +81,7 @@ func (gs *gitSource) Identifier(scheme, ref string, attrs map[string]string, pla
 				id.KeepGitDir = true
 			}
 		case pb.AttrFullRemoteURL:
-			if !isGitTransport(v) {
+			if !gitutil.IsGitTransport(v) {
 				v = "https://" + v
 			}
 			id.Remote = v

--- a/util/gitutil/git_url.go
+++ b/util/gitutil/git_url.go
@@ -96,6 +96,15 @@ func ParseURL(remote string) (*GitURL, error) {
 	return nil, ErrUnknownProtocol
 }
 
+func IsGitTransport(remote string) bool {
+	if proto := protoRegexp.FindString(remote); proto != "" {
+		proto = strings.ToLower(strings.TrimSuffix(proto, "://"))
+		_, ok := supportedProtos[proto]
+		return ok
+	}
+	return sshutil.IsImplicitSSHTransport(remote)
+}
+
 func fromURL(url *url.URL) *GitURL {
 	withoutFragment := *url
 	withoutFragment.Fragment = ""


### PR DESCRIPTION
Building on top of #4326.

We still have a weird `isGitTransport` implementation that I originally missed - this meant that we could have easily diverged in the future.