### PR TITLE
Update fallback logic to only fallback with previous host

### DIFF
--- a/util/resolver/resolver.go
+++ b/util/resolver/resolver.go
@@ -209,17 +209,17 @@ func newDefaultTransport() *http.Transport {
 }
 
 type httpFallback struct {
-	super    http.RoundTripper
-	fallback bool
+	super http.RoundTripper
+	host  string
 }
 
 func (f *httpFallback) RoundTrip(r *http.Request) (*http.Response, error) {
-	if !f.fallback {
+	// only fall back if the same host had previously fell back
+	if f.host != r.URL.Host {
 		resp, err := f.super.RoundTrip(r)
 		var tlsErr tls.RecordHeaderError
 		if errors.As(err, &tlsErr) && string(tlsErr.RecordHeader[:]) == "HTTP/" {
-			// Server gave HTTP response to HTTPS client
-			f.fallback = true
+			f.host = r.URL.Host
 		} else {
 			return resp, err
 		}


### PR DESCRIPTION
Currently a localhost http registry will still attempt http after a redirect to an https host. The http fallback should only apply to the same host which previously had a fallback to http. The caching of the host is only an optimization and not necessary to function correctly, multiple fallback hosts using the same transport would still work.

See https://github.com/moby/moby/issues/47240