### PR TITLE
add missing fallback from new frontend to daemon without sourceresolver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile-upstream:master
+# syntax=docker/dockerfile-upstream:master@sha256:cd94315a37d63ca11498df06c59883d86fa5b662b0fe5dfee7ad5b7086e95fdf
 
 ARG RUNC_VERSION=v1.1.12
 ARG CONTAINERD_VERSION=v1.7.11

--- a/frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile
+++ b/frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile-upstream:master
+# syntax=docker/dockerfile-upstream:master@@sha256:cd94315a37d63ca11498df06c59883d86fa5b662b0fe5dfee7ad5b7086e95fdf
 
 ARG GO_VERSION=1.21
 

--- a/frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile
+++ b/frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile-upstream:master@@sha256:cd94315a37d63ca11498df06c59883d86fa5b662b0fe5dfee7ad5b7086e95fdf
+# syntax=docker/dockerfile-upstream:master@sha256:cd94315a37d63ca11498df06c59883d86fa5b662b0fe5dfee7ad5b7086e95fdf
 
 ARG GO_VERSION=1.21
 


### PR DESCRIPTION
This fallback case was accidentally left out of https://github.com/moby/buildkit/pull/4563/files

It can appear for example if new dockerfile frontend resolves SBOM generator image.