### PR TITLE
exporter: make OnBuild omiteempty

### DIFF
--- a/exporter/containerimage/image/docker_image.go
+++ b/exporter/containerimage/image/docker_image.go
@@ -35,7 +35,7 @@ type ImageConfig struct {
 
 	Healthcheck *HealthConfig `json:",omitempty"` // Healthcheck describes how to check the container is healthy
 
-	OnBuild []string          // ONBUILD metadata that were defined on the image Dockerfile
+	OnBuild []string          `json:",omitempty"` // ONBUILD metadata that were defined on the image Dockerfile
 	Shell   strslice.StrSlice `json:",omitempty"` // Shell for shell-form of RUN, CMD, ENTRYPOINT
 }
 

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -6867,7 +6867,7 @@ RUN rm -f /foo-2010.1
 RUN rm -f /foo-2030.1
 `)
 
-	const expectedDigest = "sha256:29f2980a804038b0f910af98e9ddb18bfa4d5514995ee6bb4343ddf621a4e183"
+	const expectedDigest = "sha256:3eb3c164e3420bbfcf52c34f1e40ee66631d69445e934175b779551c729f80df"
 
 	dir := integration.Tmpdir(
 		t,


### PR DESCRIPTION
- relates to https://github.com/moby/buildkit/pull/4634#discussion_r1486335753

Aligning with the docker image spec;
https://github.com/moby/docker-image-spec/blob/f1d00ebd2d6d6805170d5543dbca4b850f35f9af/specs-go/v1/image.go#L30C19-L30C100
