### PR TITLE
Revert "temporarily use older frontend to unblock CI"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile-upstream:master@sha256:cd94315a37d63ca11498df06c59883d86fa5b662b0fe5dfee7ad5b7086e95fdf
+# syntax=docker/dockerfile-upstream:master
 
 ARG RUNC_VERSION=v1.1.12
 ARG CONTAINERD_VERSION=v1.7.11

--- a/frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile
+++ b/frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile-upstream:master@sha256:cd94315a37d63ca11498df06c59883d86fa5b662b0fe5dfee7ad5b7086e95fdf
+# syntax=docker/dockerfile-upstream:master
 
 ARG GO_VERSION=1.21
 


### PR DESCRIPTION
This reverts commit 0184fde3dba7ccb3f9c2dbe352409600b5ccfa5d.

This should not be needed anymore once new master version has finished building. #4647