### PR TITLE
make sure iptables installed in release image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -220,7 +220,7 @@ FROM scratch AS release
 COPY --link --from=releaser /out/ /
 
 FROM alpinebase AS buildkit-export
-RUN apk add --no-cache fuse3 git openssh pigz xz \
+RUN apk add --no-cache fuse3 git openssh pigz xz iptables ip6tables \
   && ln -s fusermount3 /usr/bin/fusermount
 COPY --link examples/buildctl-daemonless/buildctl-daemonless.sh /usr/bin/
 VOLUME /var/lib/buildkit


### PR DESCRIPTION
Needed for bridge networking.

I'm not quite sure what has changed since the bridge support was added as I do remember testing it with buildx back then. The test suite did not catch this as iptables is installed in the integration-tests stage.

fix #4637