### PR TITLE
client: fix result history media type with dockerd moby

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2808,7 +2808,11 @@ func testMultipleExporters(t *testing.T, sb integration.Sandbox) {
 
 		if workers.IsTestDockerd() {
 			require.Len(t, ev.Record.Result.Results, 1)
-			require.Equal(t, images.MediaTypeDockerSchema2Manifest, ev.Record.Result.Results[0].MediaType)
+			if workers.IsTestDockerdMoby(sb) {
+				require.Equal(t, images.MediaTypeDockerSchema2Config, ev.Record.Result.Results[0].MediaType)
+			} else {
+				require.Equal(t, images.MediaTypeDockerSchema2Manifest, ev.Record.Result.Results[0].MediaType)
+			}
 		} else {
 			require.Len(t, ev.Record.Result.Results, 2)
 			require.Equal(t, images.MediaTypeDockerSchema2Manifest, ev.Record.Result.Results[0].MediaType)


### PR DESCRIPTION
related to https://github.com/moby/moby/pull/47364#discussion_r1492394675

Currently, when exporting with moby exporter using dockerd without containerd snap, the history doesn't produce any result in the history. This might have been an oversight when vendoring buildkit 0.11 on moby.

I think it should at least return the config (`application/vnd.docker.container.image.v1+json`) in this case which @vvoland has implemented in https://github.com/moby/moby/pull/47364 (https://github.com/moby/moby/commit/5555a658cfbb81bc440f9bd3a8cc58df513f3d6d)

So fix this test to take that into account.