### PR TITLE
dockerfile: build containerd from source for freebsd

### DIFF
--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -25,9 +25,20 @@ env:
   DESTDIR: "./bin"
 
 jobs:
-  build-windows-amd64:
+  build:
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - windows/amd64
+          - freebsd/amd64
     steps:
+      -
+        name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
       -
         name: Checkout
         uses: actions/checkout@v4
@@ -41,14 +52,18 @@ jobs:
           provenance: false
           targets: binaries-for-test
           set: |
-            *.platform=windows/amd64
-            *.cache-from=type=gha,scope=binaries-test-windows
-            *.cache-to=type=gha,scope=binaries-test-windows
+            *.platform=${{ matrix.platform }}
+            *.cache-from=type=gha,scope=binaries-for-test-${{ env.PLATFORM_PAIR }}
+            *.cache-to=type=gha,scope=binaries-for-test-${{ env.PLATFORM_PAIR }}
+      -
+        name: List artifacts
+        run: |
+          tree -nh ${{ env.DESTDIR }}
       -
         name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: buildkit-windows-amd64
+          name: buildkit-${{ env.PLATFORM_PAIR }}
           path: ${{ env.DESTDIR }}/*
           if-no-files-found: error
           retention-days: 1
@@ -56,7 +71,7 @@ jobs:
   test-windows-amd64:
     runs-on: windows-2022
     needs:
-      - build-windows-amd64
+      - build
     steps:
       -
         name: Checkout
@@ -119,35 +134,10 @@ jobs:
         if: failure()
         uses: crazy-max/ghaction-dump-context@v2
 
-  build-freebsd-amd64:
-    runs-on: ubuntu-22.04
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      -
-        name: Build
-        uses: docker/bake-action@v4
-        with:
-          targets: binaries
-          set: |
-            *.platform=freebsd/amd64
-      -
-        name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: buildkit-freebsd-amd64
-          path: ${{ env.DESTDIR }}/*
-          if-no-files-found: error
-          retention-days: 1
-
   test-freebsd-amd64:
     runs-on: macos-13
     needs:
-      - build-freebsd-amd64
+      - build
     env:
       VAGRANT_VAGRANTFILE: hack/Vagrantfile.freebsd13
       GOOS: freebsd

--- a/Dockerfile
+++ b/Dockerfile
@@ -243,14 +243,17 @@ RUN --mount=from=containerd-src,src=/usr/src/containerd,rw \
   git fetch origin
   git checkout -q "$CONTAINERD_VERSION"
   mkdir /out
+  ext=""
   if [ "$(xx-info os)" = "windows" ]; then
-    CGO_ENABLED=0 make STATIC=1 binaries
-    mv bin/containerd.exe bin/containerd-shim* bin/ctr* /out
-  else
+    ext=".exe"
+  fi
+  if [ "$(xx-info os)" = "linux" ]; then
     make bin/containerd
     make bin/containerd-shim-runc-v2
-    make bin/ctr
-    mv bin/containerd bin/containerd-shim* bin/ctr* /out
+    mv bin/containerd bin/containerd-shim* /out
+  else
+    CGO_ENABLED=0 make STATIC=1 binaries
+    mv bin/containerd${ext} bin/containerd-shim* /out
   fi
 EOT
 
@@ -263,13 +266,17 @@ RUN --mount=from=containerd-src,src=/usr/src/containerd,rw \
   git fetch origin
   git checkout -q "$CONTAINERD_ALT_VERSION_16"
   mkdir /out
+  ext=""
   if [ "$(xx-info os)" = "windows" ]; then
-    CGO_ENABLED=0 make STATIC=1 binaries
-    mv bin/containerd.exe bin/containerd-shim* /out
-  else
+    ext=".exe"
+  fi
+  if [ "$(xx-info os)" = "linux" ]; then
     make bin/containerd
     make bin/containerd-shim-runc-v2
     mv bin/containerd bin/containerd-shim* /out
+  else
+    CGO_ENABLED=0 make STATIC=1 binaries
+    mv bin/containerd${ext} bin/containerd-shim* /out
   fi
 EOT
 

--- a/hack/Vagrantfile.freebsd13
+++ b/hack/Vagrantfile.freebsd13
@@ -15,7 +15,7 @@ Vagrant.configure("2") do |config|
       #!/usr/bin/env bash
       set -eux -o pipefail
       kldload nullfs
-      pkg install -y git containerd runj
+      pkg install -y git runj
       mkdir -p /vagrant/coverage /vagrant/.tmp/logs
     SHELL
   end
@@ -45,6 +45,8 @@ Vagrant.configure("2") do |config|
     sh.inline = <<~SHELL
       #!/usr/bin/env bash
       set -eux -o pipefail
+      cd /vagrant
+      install -m 755 bin/containerd /bin/containerd
       containerd --version
       daemon -o /vagrant/.tmp/logs/containerd containerd
     SHELL


### PR DESCRIPTION
* needs #4652 

Builds containerd from source in the Dockerfile to avoid drifting with freebsd packages installed in vagrant image and merge windows and freebsd build to use the same `binaries-for-test` target in ci workflow.

cc @akhramov