### PR TITLE
ci: set codecov token

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -180,6 +180,7 @@ jobs:
         with:
           directory: ./bin/testreports
           flags: ${{ matrix.codecov_flags }}
+          token: ${{ secrets.CODECOV_TOKEN }}  # used to upload coverage reports: https://github.com/moby/buildkit/pull/4660#issue-2142122533
       -
         name: Generate annotations
         if: always()

--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -98,6 +98,7 @@ jobs:
           directory: ./bin/testreports
           env_vars: RUNNER_OS
           flags: unit
+          token: ${{ secrets.CODECOV_TOKEN }}  # used to upload coverage reports: https://github.com/moby/buildkit/pull/4660#issue-2142122533
       -
         name: Generate annotations
         if: always()


### PR DESCRIPTION
related to https://github.com/moby/buildkit/actions/runs/7957965041/job/21723057849#step:9:41

![image](https://github.com/moby/buildkit/assets/1951866/a4c8ceec-95f2-44c3-ab2f-91af8fd1ce2c)

Since https://github.com/codecov/codecov-action/releases/tag/v4.0.0, the token is now required for public repos when the action runs on a branch/tag of this repo. But contributors creating PRs from their forks to the upstream repo will be able to get coverage information from Codecov. I guess this is because they don't have access to the secret. This is related to https://about.codecov.io/blog/january-product-update-updating-the-codecov-ci-uploaders-to-the-codecov-cli/

As discussed with @thaJeztah, an org-wide secret has been created so it can be used across repos of this org to fix this issue.