### PR TITLE
examples/dockerfile2llb: remove unused `-partial-metadata-file`

### DIFF
--- a/examples/dockerfile2llb/main.go
+++ b/examples/dockerfile2llb/main.go
@@ -19,7 +19,6 @@ import (
 type buildOpt struct {
 	target                 string
 	partialImageConfigFile string
-	partialMetadataFile    string
 }
 
 func main() {
@@ -32,7 +31,6 @@ func xmain() error {
 	var opt buildOpt
 	flag.StringVar(&opt.target, "target", "", "target stage")
 	flag.StringVar(&opt.partialImageConfigFile, "partial-image-config-file", "", "Output partial image config as a JSON file")
-	flag.StringVar(&opt.partialMetadataFile, "partial-metadata-file", "", "Output partial metadata sa a JSON file")
 	flag.Parse()
 
 	df, err := io.ReadAll(os.Stdin)


### PR DESCRIPTION
`-partial-metadata-file` was substantially removed in 9acc6d30eb339d0fa6d3df94db450b693800f4a2 (`refactor buildinfo into provenance capture`)