### PR TITLE
Avoid applying `SOURCE_DATE_EPOCH` to base images

### DIFF
--- a/examples/dockerfile2llb/main.go
+++ b/examples/dockerfile2llb/main.go
@@ -19,6 +19,7 @@ import (
 type buildOpt struct {
 	target                 string
 	partialImageConfigFile string
+	baseImageConfigFile    string
 }
 
 func main() {
@@ -31,6 +32,7 @@ func xmain() error {
 	var opt buildOpt
 	flag.StringVar(&opt.target, "target", "", "target stage")
 	flag.StringVar(&opt.partialImageConfigFile, "partial-image-config-file", "", "Output partial image config as a JSON file")
+	flag.StringVar(&opt.baseImageConfigFile, "base-image-config-file", "", "Output base image config as a JSON file")
 	flag.Parse()
 
 	df, err := io.ReadAll(os.Stdin)
@@ -40,7 +42,7 @@ func xmain() error {
 
 	caps := pb.Caps.CapSet(pb.Caps.All())
 
-	state, img, _, err := dockerfile2llb.Dockerfile2LLB(appcontext.Context(), df, dockerfile2llb.ConvertOpt{
+	state, img, baseImg, _, err := dockerfile2llb.Dockerfile2LLB(appcontext.Context(), df, dockerfile2llb.ConvertOpt{
 		MetaResolver: imagemetaresolver.Default(),
 		LLBCaps:      &caps,
 		Config: dockerui.Config{
@@ -63,6 +65,12 @@ func xmain() error {
 			return err
 		}
 	}
+	if opt.baseImageConfigFile != "" {
+		if err := writeJSON(opt.baseImageConfigFile, baseImg); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/exporter/containerimage/exptypes/types.go
+++ b/exporter/containerimage/exptypes/types.go
@@ -13,6 +13,7 @@ const (
 	ExporterImageConfigKey       = "containerimage.config"
 	ExporterImageConfigDigestKey = "containerimage.config.digest"
 	ExporterImageDescriptorKey   = "containerimage.descriptor"
+	ExporterImageBaseConfigKey   = "containerimage.base.config"
 	ExporterPlatformsKey         = "refs.platforms"
 )
 
@@ -20,6 +21,7 @@ const (
 // a platform to become platform specific
 var KnownRefMetadataKeys = []string{
 	ExporterImageConfigKey,
+	ExporterImageBaseConfigKey,
 }
 
 type Platforms struct {

--- a/frontend/dockerfile/dockerfile2llb/image.go
+++ b/frontend/dockerfile/dockerfile2llb/image.go
@@ -15,6 +15,14 @@ func clone(src dockerspec.DockerOCIImage) dockerspec.DockerOCIImage {
 	return img
 }
 
+func cloneX(src *dockerspec.DockerOCIImage) *dockerspec.DockerOCIImage {
+	if src == nil {
+		return nil
+	}
+	img := clone(*src)
+	return &img
+}
+
 func emptyImage(platform ocispecs.Platform) dockerspec.DockerOCIImage {
 	img := dockerspec.DockerOCIImage{}
 	img.Architecture = platform.Architecture


### PR DESCRIPTION
The exporter fetches the base image config via the `ExporterImageBaseConfigKey` metadata to detect the immutable layer diffIDs and the history objects.

Fix #4614


 NOTE: For a multi-stage Dockerfile like below, the base image refers to `busybox`, not to `foo`:
```dockerfile
FROM busybox AS foo
FROM foo AS bar
```