### PR TITLE
dockerfile: implement hooks for `RUN` instructions

### DIFF
--- a/frontend/dockerfile/dockerfile_insthook_test.go
+++ b/frontend/dockerfile/dockerfile_insthook_test.go
@@ -1,0 +1,76 @@
+package dockerfile
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/containerd/continuity/fs/fstest"
+	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/frontend/dockerui"
+	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/stretchr/testify/require"
+	"github.com/tonistiigi/fsutil"
+)
+
+var instHookTests = integration.TestFuncs(
+	testInstructionHook,
+)
+
+func testInstructionHook(t *testing.T, sb integration.Sandbox) {
+	integration.SkipOnPlatform(t, "windows")
+	f := getFrontend(t, sb)
+
+	dockerfile := []byte(`
+FROM busybox AS base
+RUN echo "$FOO" >/foo
+
+FROM scratch
+COPY --from=base /foo /foo
+`)
+
+	dir := integration.Tmpdir(
+		t,
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+	)
+	destDir := t.TempDir()
+
+	c, err := client.New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	build := func(attrs map[string]string) string {
+		_, err = f.Solve(sb.Context(), c, client.SolveOpt{
+			FrontendAttrs: attrs,
+			Exports: []client.ExportEntry{
+				{
+					Type:      client.ExporterLocal,
+					OutputDir: destDir,
+				},
+			},
+			LocalMounts: map[string]fsutil.FS{
+				dockerui.DefaultLocalNameDockerfile: dir,
+				dockerui.DefaultLocalNameContext:    dir,
+			},
+		}, nil)
+		require.NoError(t, err)
+		p := filepath.Join(destDir, "foo")
+		b, err := os.ReadFile(p)
+		require.NoError(t, err)
+		return strings.TrimSpace(string(b))
+	}
+
+	require.Equal(t, "", build(nil))
+
+	const hook = `
+{
+  "RUN": {
+    "entrypoint": ["/dev/.dfhook/bin/busybox", "env", "FOO=BAR"],
+    "mounts": [
+      {"from": "busybox:uclibc", "target": "/dev/.dfhook"}
+    ]
+  }
+}`
+	require.Equal(t, "BAR", build(map[string]string{"hook": hook}))
+}

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -285,6 +285,8 @@ func TestIntegration(t *testing.T) {
 			"granted": networkHostGranted,
 			"denied":  networkHostDenied,
 		}))...)
+
+	integration.Run(t, instHookTests, opts...)
 }
 
 func testEmptyStringArgInEnv(t *testing.T, sb integration.Sandbox) {

--- a/frontend/dockerfile/instructions/commands.go
+++ b/frontend/dockerfile/instructions/commands.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
+	"github.com/moby/buildkit/frontend/dockerui/types"
 	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
@@ -352,7 +353,7 @@ type ShellDependantCmdLine struct {
 //	RUN ["echo", "hi"]  # echo hi
 type RunCommand struct {
 	withNameAndCode
-	withExternalData
+	WithInstructionHook
 	ShellDependantCmdLine
 	FlagsUsed []string
 }
@@ -562,4 +563,22 @@ func (c *withExternalData) setExternalValue(k, v interface{}) {
 		c.m = map[interface{}]interface{}{}
 	}
 	c.m[k] = v
+}
+
+type WithInstructionHook struct {
+	withExternalData
+}
+
+const instHookKey = "dockerfile/run/instruction-hook"
+
+func (c *WithInstructionHook) GetInstructionHook() *types.InstructionHook {
+	x := c.getExternalValue(instHookKey)
+	if x == nil {
+		return nil
+	}
+	return x.(*types.InstructionHook)
+}
+
+func (c *WithInstructionHook) SetInstructionHook(h *types.InstructionHook) {
+	c.setExternalValue(instHookKey, h)
 }

--- a/frontend/dockerfile/instructions/commands_runmount.go
+++ b/frontend/dockerfile/instructions/commands_runmount.go
@@ -84,13 +84,22 @@ func setMountState(cmd *RunCommand, expander SingleWordExpander) error {
 	if st == nil {
 		return errors.Errorf("no mount state")
 	}
-	mounts := make([]*Mount, len(st.flag.StringValues))
-	for i, str := range st.flag.StringValues {
+	var mounts []*Mount
+	if hook := cmd.GetInstructionHook(); hook != nil && hook.Run != nil {
+		for _, m := range hook.Run.Mounts {
+			m := m
+			if err := validateMount(&m, false); err != nil {
+				return err
+			}
+			mounts = append(mounts, &m)
+		}
+	}
+	for _, str := range st.flag.StringValues {
 		m, err := parseMount(str, expander)
 		if err != nil {
 			return err
 		}
-		mounts[i] = m
+		mounts = append(mounts, m)
 	}
 	st.mounts = mounts
 	return nil

--- a/frontend/dockerfile/instructions/commands_runmount.go
+++ b/frontend/dockerfile/instructions/commands_runmount.go
@@ -5,19 +5,20 @@ import (
 	"strings"
 
 	"github.com/docker/go-units"
+	"github.com/moby/buildkit/frontend/dockerui/types"
 	"github.com/moby/buildkit/util/suggest"
 	"github.com/pkg/errors"
 	"github.com/tonistiigi/go-csvvalue"
 )
 
-type MountType string
+type MountType = types.MountType
 
 const (
-	MountTypeBind   MountType = "bind"
-	MountTypeCache  MountType = "cache"
-	MountTypeTmpfs  MountType = "tmpfs"
-	MountTypeSecret MountType = "secret"
-	MountTypeSSH    MountType = "ssh"
+	MountTypeBind   = types.MountTypeBind
+	MountTypeCache  = types.MountTypeCache
+	MountTypeTmpfs  = types.MountTypeTmpfs
+	MountTypeSecret = types.MountTypeSecret
+	MountTypeSSH    = types.MountTypeSSH
 )
 
 var allowedMountTypes = map[MountType]struct{}{
@@ -28,12 +29,12 @@ var allowedMountTypes = map[MountType]struct{}{
 	MountTypeSSH:    {},
 }
 
-type ShareMode string
+type ShareMode = types.ShareMode
 
 const (
-	MountSharingShared  ShareMode = "shared"
-	MountSharingPrivate ShareMode = "private"
-	MountSharingLocked  ShareMode = "locked"
+	MountSharingShared  = types.MountSharingShared
+	MountSharingPrivate = types.MountSharingPrivate
+	MountSharingLocked  = types.MountSharingLocked
 )
 
 var allowedSharingModes = map[ShareMode]struct{}{
@@ -112,23 +113,7 @@ type mountState struct {
 	mounts []*Mount
 }
 
-type Mount struct {
-	Type         MountType
-	From         string
-	Source       string
-	Target       string
-	ReadOnly     bool
-	SizeLimit    int64
-	CacheID      string
-	CacheSharing ShareMode
-	Required     bool
-	// Env optionally specifies the name of the environment variable for a secret.
-	// A pointer to an empty value uses the default
-	Env  *string
-	Mode *uint64
-	UID  *uint64
-	GID  *uint64
-}
+type Mount = types.Mount
 
 func parseMount(val string, expander SingleWordExpander) (*Mount, error) {
 	fields, err := csvvalue.Fields(val, nil)

--- a/frontend/dockerfile/instructions/commands_runmount.go
+++ b/frontend/dockerfile/instructions/commands_runmount.go
@@ -250,17 +250,24 @@ func parseMount(val string, expander SingleWordExpander) (*Mount, error) {
 		}
 	}
 
+	if err = validateMount(m, roAuto); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func validateMount(m *Mount, roAuto bool) error {
 	fileInfoAllowed := m.Type == MountTypeSecret || m.Type == MountTypeSSH || m.Type == MountTypeCache
 
 	if !fileInfoAllowed {
 		if m.Mode != nil {
-			return nil, errors.Errorf("mode not allowed for %q type mounts", m.Type)
+			return errors.Errorf("mode not allowed for %q type mounts", m.Type)
 		}
 		if m.UID != nil {
-			return nil, errors.Errorf("uid not allowed for %q type mounts", m.Type)
+			return errors.Errorf("uid not allowed for %q type mounts", m.Type)
 		}
 		if m.GID != nil {
-			return nil, errors.Errorf("gid not allowed for %q type mounts", m.Type)
+			return errors.Errorf("gid not allowed for %q type mounts", m.Type)
 		}
 	}
 
@@ -274,22 +281,22 @@ func parseMount(val string, expander SingleWordExpander) (*Mount, error) {
 
 	if m.Type == MountTypeSecret {
 		if m.From != "" {
-			return nil, errors.Errorf("secret mount should not have a from")
+			return errors.Errorf("secret mount should not have a from")
 		}
 		if m.CacheSharing != "" {
-			return nil, errors.Errorf("secret mount should not define sharing")
+			return errors.Errorf("secret mount should not define sharing")
 		}
 		if m.Source == "" && m.Target == "" && m.CacheID == "" {
-			return nil, errors.Errorf("invalid secret mount. one of source, target required")
+			return errors.Errorf("invalid secret mount. one of source, target required")
 		}
 		if m.Source != "" && m.CacheID != "" {
-			return nil, errors.Errorf("both source and id can't be set")
+			return errors.Errorf("both source and id can't be set")
 		}
 	}
 
 	if m.CacheSharing != "" && m.Type != MountTypeCache {
-		return nil, errors.Errorf("invalid cache sharing set for %v mount", m.Type)
+		return errors.Errorf("invalid cache sharing set for %v mount", m.Type)
 	}
 
-	return m, nil
+	return nil
 }

--- a/frontend/dockerfile/instructions/parse_heredoc_test.go
+++ b/frontend/dockerfile/instructions/parse_heredoc_test.go
@@ -28,7 +28,7 @@ func TestErrorCasesHeredoc(t *testing.T) {
 			t.Fatalf("Error when parsing Dockerfile: %s", err)
 		}
 		n := ast.AST.Children[0]
-		_, err = ParseInstruction(n)
+		_, err = ParseInstruction(n, ParseOpts{})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), c.expectedError)
 	}
@@ -166,7 +166,7 @@ EOF`,
 		require.NoError(t, err)
 
 		n := ast.AST.Children[0]
-		comm, err := ParseInstruction(n)
+		comm, err := ParseInstruction(n, ParseOpts{})
 		require.NoError(t, err)
 
 		sd := comm.(*CopyCommand).SourcesAndDest
@@ -248,7 +248,7 @@ EOF`,
 		require.NoError(t, err)
 
 		n := ast.AST.Children[0]
-		comm, err := ParseInstruction(n)
+		comm, err := ParseInstruction(n, ParseOpts{})
 		require.NoError(t, err)
 		require.Equal(t, c.shell, comm.(*RunCommand).PrependShell)
 		require.Equal(t, c.command, comm.(*RunCommand).CmdLine)

--- a/frontend/dockerfile/instructions/parse_test.go
+++ b/frontend/dockerfile/instructions/parse_test.go
@@ -21,7 +21,7 @@ func TestCommandsExactlyOneArgument(t *testing.T) {
 	for _, cmd := range commands {
 		ast, err := parser.Parse(strings.NewReader(cmd))
 		require.NoError(t, err)
-		_, err = ParseInstruction(ast.AST.Children[0])
+		_, err = ParseInstruction(ast.AST.Children[0], ParseOpts{})
 		require.EqualError(t, err, errExactlyOneArgument(cmd).Error())
 	}
 }
@@ -39,7 +39,7 @@ func TestCommandsAtLeastOneArgument(t *testing.T) {
 	for _, cmd := range commands {
 		ast, err := parser.Parse(strings.NewReader(cmd))
 		require.NoError(t, err)
-		_, err = ParseInstruction(ast.AST.Children[0])
+		_, err = ParseInstruction(ast.AST.Children[0], ParseOpts{})
 		require.EqualError(t, err, errAtLeastOneArgument(cmd).Error())
 	}
 }
@@ -53,7 +53,7 @@ func TestCommandsNoDestinationArgument(t *testing.T) {
 	for _, cmd := range commands {
 		ast, err := parser.Parse(strings.NewReader(cmd + " arg1"))
 		require.NoError(t, err)
-		_, err = ParseInstruction(ast.AST.Children[0])
+		_, err = ParseInstruction(ast.AST.Children[0], ParseOpts{})
 		require.EqualError(t, err, errNoDestinationArgument(cmd).Error())
 	}
 }
@@ -81,7 +81,7 @@ func TestCommandsTooManyArguments(t *testing.T) {
 				},
 			},
 		}
-		_, err := ParseInstruction(node)
+		_, err := ParseInstruction(node, ParseOpts{})
 		require.EqualError(t, err, errTooManyArguments(cmd).Error())
 	}
 }
@@ -106,7 +106,7 @@ func TestCommandsBlankNames(t *testing.T) {
 				},
 			},
 		}
-		_, err := ParseInstruction(node)
+		_, err := ParseInstruction(node, ParseOpts{})
 		require.EqualError(t, err, errBlankCommandNames(cmd).Error())
 	}
 }
@@ -124,7 +124,7 @@ func TestHealthCheckCmd(t *testing.T) {
 			},
 		},
 	}
-	cmd, err := ParseInstruction(node)
+	cmd, err := ParseInstruction(node, ParseOpts{})
 	require.NoError(t, err)
 	hc, ok := cmd.(*HealthCheckCommand)
 	require.Equal(t, true, ok)
@@ -167,7 +167,7 @@ func TestNilLinter(t *testing.T) {
 				t.Run(tc, func(t *testing.T) {
 					ast, err := parser.Parse(strings.NewReader("FROM busybox\n" + tc))
 					if err == nil {
-						_, _, _ = Parse(ast.AST, nil)
+						_, _, _ = Parse(ast.AST, nil, ParseOpts{})
 					}
 				})
 			}
@@ -191,7 +191,7 @@ ARG bar baz=123
 	ast, err := parser.Parse(bytes.NewBuffer([]byte(dt)))
 	require.NoError(t, err)
 
-	stages, meta, err := Parse(ast.AST, nil)
+	stages, meta, err := Parse(ast.AST, nil, ParseOpts{})
 	require.NoError(t, err)
 
 	require.Equal(t, "defines first stage", stages[0].Comment)
@@ -255,7 +255,7 @@ func TestErrorCases(t *testing.T) {
 			t.Fatalf("Error when parsing Dockerfile: %s", err)
 		}
 		n := ast.AST.Children[0]
-		_, err = ParseInstruction(n)
+		_, err = ParseInstruction(n, ParseOpts{})
 		require.ErrorContains(t, err, c.expectedError)
 	}
 }
@@ -267,7 +267,7 @@ func TestRunCmdFlagsUsed(t *testing.T) {
 	require.NoError(t, err)
 
 	n := ast.AST.Children[0]
-	c, err := ParseInstruction(n)
+	c, err := ParseInstruction(n, ParseOpts{})
 	require.NoError(t, err)
 	require.IsType(t, &RunCommand{}, c)
 	require.Equal(t, []string{"mount"}, c.(*RunCommand).FlagsUsed)

--- a/frontend/dockerui/types/hook.go
+++ b/frontend/dockerui/types/hook.go
@@ -1,0 +1,12 @@
+package types
+
+// InstructionHook provides a hooking mechanism for instructions of Dockerfile.
+type InstructionHook struct {
+	Run *RunInstructionHook `json:"RUN,omitempty"`
+}
+
+// RunInstructionHook provides a hooking mechanism for `RUN` instruction of Dockerfile.
+type RunInstructionHook struct {
+	Entrypoint []string `json:"entrypoint"`
+	Mounts     []Mount  `json:"mounts"`
+}

--- a/frontend/dockerui/types/mount.go
+++ b/frontend/dockerui/types/mount.go
@@ -19,19 +19,19 @@ const (
 )
 
 type Mount struct {
-	Type         MountType
-	From         string
-	Source       string
-	Target       string
-	ReadOnly     bool
-	SizeLimit    int64
-	CacheID      string
-	CacheSharing ShareMode
-	Required     bool
+	Type         MountType `json:"type,omitempty"`
+	From         string    `json:"from,omitempty"`
+	Source       string    `json:"source,omitempty"`
+	Target       string    `json:"target,omitempty"`
+	ReadOnly     bool      `json:"readOnly,omitempty"`
+	SizeLimit    int64     `json:"sizeLimit,omitempty"`
+	CacheID      string    `json:"cacheID,omitempty"`
+	CacheSharing ShareMode `json:"cacheSharing,omitempty"`
+	Required     bool      `json:"required,omitempty"`
 	// Env optionally specifies the name of the environment variable for a secret.
 	// A pointer to an empty value uses the default
-	Env  *string
-	Mode *uint64
-	UID  *uint64
-	GID  *uint65
+	Env  *string `json:"env,omitempty"`
+	Mode *uint64 `json:"mode,omitempty"`
+	UID  *uint64 `json:"uid,omitempty"`
+	GID  *uint64 `json:"gid,omitempty"`
 }

--- a/frontend/dockerui/types/mount.go
+++ b/frontend/dockerui/types/mount.go
@@ -1,0 +1,37 @@
+package types
+
+type MountType string
+
+const (
+	MountTypeBind   MountType = "bind"
+	MountTypeCache  MountType = "cache"
+	MountTypeTmpfs  MountType = "tmpfs"
+	MountTypeSecret MountType = "secret"
+	MountTypeSSH    MountType = "ssh"
+)
+
+type ShareMode string
+
+const (
+	MountSharingShared  ShareMode = "shared"
+	MountSharingPrivate ShareMode = "private"
+	MountSharingLocked  ShareMode = "locked"
+)
+
+type Mount struct {
+	Type         MountType
+	From         string
+	Source       string
+	Target       string
+	ReadOnly     bool
+	SizeLimit    int64
+	CacheID      string
+	CacheSharing ShareMode
+	Required     bool
+	// Env optionally specifies the name of the environment variable for a secret.
+	// A pointer to an empty value uses the default
+	Env  *string
+	Mode *uint64
+	UID  *uint64
+	GID  *uint65
+}

--- a/util/jsonutil/jsonutil.go
+++ b/util/jsonutil/jsonutil.go
@@ -1,0 +1,13 @@
+package jsonutil
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// UnmarshalStrict is similar to [json.Unmarshal] but strict.
+func UnmarshalStrict(b []byte, v any) error {
+	d := json.NewDecoder(bytes.NewReader(b))
+	d.DisallowUnknownFields()
+	return d.Decode(v)
+}


### PR DESCRIPTION
Close #4576

- - -

e.g.,
```bash
buildctl build \
  --frontend dockerfile.v0 \
  --opt hook="$(cat hook.json)"
```
with `hook.json` as follows:
```json
{
  "RUN": {
    "entrypoint": ["/dev/.dfhook/entrypoint"],
    "mounts": [
       {"from": "example.com/hook", "target": "/dev/.dfhook"},
       {"type": "secret", "source": "something", "target": "/etc/something"}
    ]
  }
}
```

This will let the frontend treat `RUN foo` as:
```dockerfile
RUN \
  --mount=from=example.com/hook,target=/dev/.dfhook \
  --mount=type=secret,source=something,target=/etc/something \
  /dev/.dfhook/entrypoint foo
```

`docker history` will still show this as `RUN foo`.

## Buildx integration
To specify `--opt` via buildx, see:
- https://github.com/docker/buildx/pull/2260

Eventually buildx should have a proper `--hook=<FILE>` option.
Probably, it should also read `~/.docker/buildx/hooks/*.json` by default.

## Use cases
### Reproducible builds
A hook can be used for wrapping `apt-get` command to use `snapshot.debian.org` for reproducing package versions without modifying the Dockerfile.

The `/dev/.dfhook/entrypoint` script can be like this:
```bash
#!/bin/bash
set -eu -o pipefail

: "${SOURCE_DATE_EPOCH:=$(stat --format=%Y /etc/apt/sources.list.d/debian.sources)}"
snapshot="$(printf "%(%Y%m%dT%H%M%SZ)T\n" "${SOURCE_DATE_EPOCH}")"
. /etc/os-release

# Rewrite /etc/apt to use snapshot.debian.org
cp -a /etc/apt /etc/apt.bak
rm -f /etc/apt/sources.list.d/debian.sources
cat <<EOF >>/etc/apt/sources.list
deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/${snapshot} ${VERSION_CODENAME} main
deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/${snapshot} ${VERSION_CODENAME}-security main
deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/${snapshot} ${VERSION_CODENAME}-updates main
EOF

# Run the command
set +e
"$@"
status=$?
set -e

# Restore /etc/apt
rm -rf /etc/apt
mv /etc/apt.bak /etc/apt

exit $status
```

A hook may also push/pull dpkg blobs to an OCI registry (or whatever) for efficient caching.

### Cross-compilation

`xx-apt`, etc. (https://github.com/tonistiigi/xx) can be reimplemented as a hook.

### Malware detection
A hook may use seccomp, etc. to hook the syscalls and detect malicious actions, etc.

### Enterprise networking

Enterprise networks often require installing a MITM proxy cert.
This can be easily automated with a hook.

## FAQs
- Q. Why not just modify Dockerfile?
  - A. Because it affects the history object in OCI Image Config and decreases reproducibility
