### PR TITLE
ci: inherit secrets from the caller workflow

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -116,6 +116,7 @@ jobs:
 
   test:
     uses: ./.github/workflows/.test.yml
+    secrets: inherit
     needs:
       - binaries
     with:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -28,6 +28,7 @@ env:
 jobs:
   test:
     uses: ./.github/workflows/.test.yml
+    secrets: inherit
     with:
       cache_scope: frontend-integration-tests
       pkgs: ./frontend/dockerfile


### PR DESCRIPTION
when making changes to handle the codecov token in https://github.com/moby/buildkit/pull/4660 I forgot to enable [secrets inheritance for our reusable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow), otherwise secret is not passed.