### PR TITLE
Fix case where TESTFLAGS may be unset

### DIFF
--- a/hack/test
+++ b/hack/test
@@ -22,6 +22,7 @@ set -eu -o pipefail
 : "${TEST_DOCKERD_BINARY=$(which dockerd)}"
 : "${TEST_REPORT_SUFFIX=}"
 : "${TEST_KEEP_CACHE=}"
+: "${TESTFLAGS=}"
 
 : "${DOCKERFILE_RELEASES=}"
 : "${BUILDKIT_WORKER_RANDOM=}"


### PR DESCRIPTION
Found this when executing `hack/test dockerfile`, it complains that `TESTFLAGS` is unset.