### PR TITLE
Revert "util/multiprovider: Implement Info"

### DIFF
--- a/cache/remote.go
+++ b/cache/remote.go
@@ -18,7 +18,6 @@ import (
 	"github.com/moby/buildkit/util/leaseutil"
 	"github.com/moby/buildkit/util/progress/logs"
 	"github.com/moby/buildkit/util/pull/pullprogress"
-	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
@@ -86,7 +85,7 @@ func (sr *immutableRef) GetRemotes(ctx context.Context, createIfNeeded bool, ref
 	return res, nil
 }
 
-func appendRemote(parents []*solver.Remote, desc ocispecs.Descriptor, p content.InfoReaderProvider) (res []*solver.Remote) {
+func appendRemote(parents []*solver.Remote, desc ocispecs.Descriptor, p content.Provider) (res []*solver.Remote) {
 	for _, pRemote := range parents {
 		provider := contentutil.NewMultiProvider(pRemote.Provider)
 		provider.Add(desc.Digest, p)
@@ -277,10 +276,6 @@ func (mp *lazyMultiProvider) ReaderAt(ctx context.Context, desc ocispecs.Descrip
 	return mp.mprovider.ReaderAt(ctx, desc)
 }
 
-func (mp *lazyMultiProvider) Info(ctx context.Context, dgst digest.Digest) (content.Info, error) {
-	return mp.mprovider.Info(ctx, dgst)
-}
-
 func (mp *lazyMultiProvider) Unlazy(ctx context.Context) error {
 	eg, egctx := errgroup.WithContext(ctx)
 	for _, p := range mp.plist {
@@ -307,16 +302,6 @@ func (p lazyRefProvider) ReaderAt(ctx context.Context, desc ocispecs.Descriptor)
 		return nil, err
 	}
 	return p.ref.cm.ContentStore.ReaderAt(ctx, desc)
-}
-
-func (p lazyRefProvider) Info(ctx context.Context, dgst digest.Digest) (content.Info, error) {
-	if dgst != p.desc.Digest {
-		return content.Info{}, errdefs.ErrNotFound
-	}
-	if err := p.Unlazy(ctx); err != nil {
-		return content.Info{}, errdefs.ErrNotFound
-	}
-	return p.ref.cm.ContentStore.Info(ctx, dgst)
 }
 
 func (p lazyRefProvider) Unlazy(ctx context.Context) error {

--- a/cache/remotecache/v1/chains.go
+++ b/cache/remotecache/v1/chains.go
@@ -10,7 +10,6 @@ import (
 	"github.com/moby/buildkit/solver"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 func NewCacheChains() *CacheChains {
@@ -119,20 +118,6 @@ type DescriptorProvider map[digest.Digest]DescriptorProviderPair
 type DescriptorProviderPair struct {
 	Descriptor ocispecs.Descriptor
 	Provider   content.Provider
-}
-
-func (p DescriptorProviderPair) ReaderAt(ctx context.Context, desc ocispecs.Descriptor) (content.ReaderAt, error) {
-	return p.Provider.ReaderAt(ctx, desc)
-}
-
-func (p DescriptorProviderPair) Info(ctx context.Context, dgst digest.Digest) (content.Info, error) {
-	if dgst != p.Descriptor.Digest {
-		return content.Info{}, errors.Errorf("content not found %s", dgst)
-	}
-	return content.Info{
-		Digest: p.Descriptor.Digest,
-		Size:   p.Descriptor.Size,
-	}, nil
 }
 
 // item is an implementation of a record in the cache chain. After validation,

--- a/cache/remotecache/v1/parse.go
+++ b/cache/remotecache/v1/parse.go
@@ -82,7 +82,7 @@ func parseRecord(cc CacheConfig, idx int, provider DescriptorProvider, t solver.
 			}
 
 			remote.Descriptors = append(remote.Descriptors, descPair.Descriptor)
-			mp.Add(descPair.Descriptor.Digest, descPair)
+			mp.Add(descPair.Descriptor.Digest, descPair.Provider)
 		}
 		if remote != nil {
 			remote.Provider = mp
@@ -123,12 +123,12 @@ func getRemoteChain(layers []CacheLayer, idx int, provider DescriptorProvider, v
 		}
 		r.Descriptors = append(r.Descriptors, descPair.Descriptor)
 		mp := contentutil.NewMultiProvider(r.Provider)
-		mp.Add(descPair.Descriptor.Digest, descPair)
+		mp.Add(descPair.Descriptor.Digest, descPair.Provider)
 		r.Provider = mp
 		return r, nil
 	}
 	return &solver.Remote{
 		Descriptors: []ocispecs.Descriptor{descPair.Descriptor},
-		Provider:    descPair,
+		Provider:    descPair.Provider,
 	}, nil
 }

--- a/solver/types.go
+++ b/solver/types.go
@@ -142,7 +142,7 @@ type CacheExporterRecord interface {
 // TODO: add closer to keep referenced data from getting deleted
 type Remote struct {
 	Descriptors []ocispecs.Descriptor
-	Provider    content.InfoReaderProvider
+	Provider    content.Provider
 }
 
 // CacheLink is a link between two cache records

--- a/util/contentutil/multiprovider.go
+++ b/util/contentutil/multiprovider.go
@@ -13,18 +13,18 @@ import (
 )
 
 // NewMultiProvider creates a new mutable provider with a base provider
-func NewMultiProvider(base content.InfoReaderProvider) *MultiProvider {
+func NewMultiProvider(base content.Provider) *MultiProvider {
 	return &MultiProvider{
 		base: base,
-		sub:  map[digest.Digest]content.InfoReaderProvider{},
+		sub:  map[digest.Digest]content.Provider{},
 	}
 }
 
 // MultiProvider is a provider backed by a mutable map of providers
 type MultiProvider struct {
 	mu   sync.RWMutex
-	base content.InfoReaderProvider
-	sub  map[digest.Digest]content.InfoReaderProvider
+	base content.Provider
+	sub  map[digest.Digest]content.Provider
 }
 
 func (mp *MultiProvider) SnapshotLabels(descs []ocispecs.Descriptor, index int) map[string]string {
@@ -85,22 +85,8 @@ func (mp *MultiProvider) ReaderAt(ctx context.Context, desc ocispecs.Descriptor)
 	return mp.base.ReaderAt(ctx, desc)
 }
 
-// Info returns a content.Info
-func (mp *MultiProvider) Info(ctx context.Context, dgst digest.Digest) (content.Info, error) {
-	mp.mu.RLock()
-	if p, ok := mp.sub[dgst]; ok {
-		mp.mu.RUnlock()
-		return p.Info(ctx, dgst)
-	}
-	mp.mu.RUnlock()
-	if mp.base == nil {
-		return content.Info{}, errors.Wrapf(errdefs.ErrNotFound, "content %v", dgst)
-	}
-	return mp.base.Info(ctx, dgst)
-}
-
 // Add adds a new child provider for a specific digest
-func (mp *MultiProvider) Add(dgst digest.Digest, p content.InfoReaderProvider) {
+func (mp *MultiProvider) Add(dgst digest.Digest, p content.Provider) {
 	mp.mu.Lock()
 	defer mp.mu.Unlock()
 	mp.sub[dgst] = p


### PR DESCRIPTION
This reverts commit 55afcdbc0d64ec0a9f3d43b84ac5a84a8f080388.

#4558
closes https://github.com/moby/buildkit/issues/4685

Breaks stargz CI

```
=== FAIL: client TestIntegration/TestStargzLazyRegistryCacheImportExport/worker=containerd-snapshotter-stargz (3.15s)
    client_test.go:4433: 
        	Error Trace:	/src/client/client_test.go:4433
        	            				/src/util/testutil/integration/run.go:93
        	            				/src/util/testutil/integration/run.go:207
        	Error:      	Target error should be in err chain:
        	            	expected: "not found"
        	            	in chain: 
        	Test:       	TestIntegration/TestStargzLazyRegistryCacheImportExport/worker=containerd-snapshotter-stargz
        	Messages:   	unexpected error <nil> on layer {MediaType:application/vnd.oci.image.layer.v1.tar+gzip Digest:sha256:51d2d8bd60757918ba85b62a1b87d7a61a6483a7d71f9a122e71223d06582379 Size:3422723 URLs:[] Annotations:map[containerd.io/snapshot/stargz/toc.digest:sha256:e0ff81df830bfb39861775515e8ef1a8cfd969af7fafd3a47b1fc554ed8d8ca7 io.containers.estargz.uncompressed-size:7716352] Data:[] Platform:<nil> ArtifactType:} (0)
  
```

@vvoland @ktock 