### PR TITLE
[Carry 4558]  util/multiprovider: Implement Info

### DIFF
--- a/cache/remotecache/v1/chains.go
+++ b/cache/remotecache/v1/chains.go
@@ -10,6 +10,7 @@ import (
 	"github.com/moby/buildkit/solver"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
 )
 
 func NewCacheChains() *CacheChains {
@@ -118,6 +119,20 @@ type DescriptorProvider map[digest.Digest]DescriptorProviderPair
 type DescriptorProviderPair struct {
 	Descriptor ocispecs.Descriptor
 	Provider   content.Provider
+}
+
+func (p DescriptorProviderPair) ReaderAt(ctx context.Context, desc ocispecs.Descriptor) (content.ReaderAt, error) {
+	return p.Provider.ReaderAt(ctx, desc)
+}
+
+func (p DescriptorProviderPair) Info(ctx context.Context, dgst digest.Digest) (content.Info, error) {
+	if dgst != p.Descriptor.Digest {
+		return content.Info{}, errors.Errorf("content not found %s", dgst)
+	}
+	return content.Info{
+		Digest: p.Descriptor.Digest,
+		Size:   p.Descriptor.Size,
+	}, nil
 }
 
 // item is an implementation of a record in the cache chain. After validation,

--- a/cache/remotecache/v1/parse.go
+++ b/cache/remotecache/v1/parse.go
@@ -82,7 +82,7 @@ func parseRecord(cc CacheConfig, idx int, provider DescriptorProvider, t solver.
 			}
 
 			remote.Descriptors = append(remote.Descriptors, descPair.Descriptor)
-			mp.Add(descPair.Descriptor.Digest, descPair.Provider)
+			mp.Add(descPair.Descriptor.Digest, descPair)
 		}
 		if remote != nil {
 			remote.Provider = mp
@@ -123,12 +123,12 @@ func getRemoteChain(layers []CacheLayer, idx int, provider DescriptorProvider, v
 		}
 		r.Descriptors = append(r.Descriptors, descPair.Descriptor)
 		mp := contentutil.NewMultiProvider(r.Provider)
-		mp.Add(descPair.Descriptor.Digest, descPair.Provider)
+		mp.Add(descPair.Descriptor.Digest, descPair)
 		r.Provider = mp
 		return r, nil
 	}
 	return &solver.Remote{
 		Descriptors: []ocispecs.Descriptor{descPair.Descriptor},
-		Provider:    descPair.Provider,
+		Provider:    descPair,
 	}, nil
 }

--- a/solver/types.go
+++ b/solver/types.go
@@ -142,7 +142,7 @@ type CacheExporterRecord interface {
 // TODO: add closer to keep referenced data from getting deleted
 type Remote struct {
 	Descriptors []ocispecs.Descriptor
-	Provider    content.Provider
+	Provider    content.InfoReaderProvider
 }
 
 // CacheLink is a link between two cache records


### PR DESCRIPTION
This PR carries #4558 (reverted in  #4686), fixing the patch to pass CI.
Based on that PR, this PR adds a patch (ca58fc5e6a1df73ad276a8938f6b706209c41a2b) to fix `DescriptorProviderPair` to export methods used by multiprovider (`UnlazySession` and `SnapshotLabels`). 
