### PR TITLE
cache(gha): add timeout attr for cache export/import

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,12 +506,12 @@ in your workflow to expose the runtime.
   * `max`: export all the layers of all intermediate steps
 * `scope=<scope>`: which scope cache object belongs to (default `buildkit`)
 * `ignore-error=<false|true>`: specify if error is ignored in case cache export fails (default: `false`)
-* `timeout=<duration>`: sets the timeout duration for cache export (default: `5m`)
+* `timeout=<duration>`: sets the timeout duration for cache export (default: `10m`)
 
 `--import-cache` options:
 * `type=gha`
 * `scope=<scope>`: which scope cache object belongs to (default `buildkit`)
-* `timeout=<duration>`: sets the timeout duration for cache import (default: `5m`)
+* `timeout=<duration>`: sets the timeout duration for cache import (default: `10m`)
 
 #### S3 cache (experimental)
 

--- a/README.md
+++ b/README.md
@@ -506,10 +506,12 @@ in your workflow to expose the runtime.
   * `max`: export all the layers of all intermediate steps
 * `scope=<scope>`: which scope cache object belongs to (default `buildkit`)
 * `ignore-error=<false|true>`: specify if error is ignored in case cache export fails (default: `false`)
+* `timeout=<duration>`: sets the timeout duration for cache export (default: `5m`)
 
 `--import-cache` options:
 * `type=gha`
 * `scope=<scope>`: which scope cache object belongs to (default `buildkit`)
+* `timeout=<duration>`: sets the timeout duration for cache import (default: `5m`)
 
 #### S3 cache (experimental)
 

--- a/cache/remotecache/gha/gha.go
+++ b/cache/remotecache/gha/gha.go
@@ -33,16 +33,20 @@ func init() {
 }
 
 const (
-	attrScope = "scope"
-	attrToken = "token"
-	attrURL   = "url"
-	version   = "1"
+	attrScope   = "scope"
+	attrTimeout = "timeout"
+	attrToken   = "token"
+	attrURL     = "url"
+	version     = "1"
+
+	defaultTimeout = 5 * time.Minute
 )
 
 type Config struct {
-	Scope string
-	URL   string
-	Token string
+	Scope   string
+	URL     string
+	Token   string
+	Timeout time.Duration
 }
 
 func getConfig(attrs map[string]string) (*Config, error) {
@@ -58,10 +62,19 @@ func getConfig(attrs map[string]string) (*Config, error) {
 	if !ok {
 		return nil, errors.Errorf("token not set for github actions cache")
 	}
+	timeout := defaultTimeout
+	if v, ok := attrs[attrTimeout]; ok {
+		var err error
+		timeout, err = time.ParseDuration(v)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse timeout for github actions cache")
+		}
+	}
 	return &Config{
-		Scope: scope,
-		URL:   url,
-		Token: token,
+		Scope:   scope,
+		URL:     url,
+		Token:   token,
+		Timeout: timeout,
 	}, nil
 }
 
@@ -85,7 +98,10 @@ type exporter struct {
 
 func NewExporter(c *Config) (remotecache.Exporter, error) {
 	cc := v1.NewCacheChains()
-	cache, err := actionscache.New(c.Token, c.URL, actionscache.Opt{Client: tracing.DefaultClient})
+	cache, err := actionscache.New(c.Token, c.URL, actionscache.Opt{
+		Client:  tracing.DefaultClient,
+		Timeout: c.Timeout,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +228,10 @@ type importer struct {
 }
 
 func NewImporter(c *Config) (remotecache.Importer, error) {
-	cache, err := actionscache.New(c.Token, c.URL, actionscache.Opt{Client: tracing.DefaultClient})
+	cache, err := actionscache.New(c.Token, c.URL, actionscache.Opt{
+		Client:  tracing.DefaultClient,
+		Timeout: c.Timeout,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/cache/remotecache/gha/gha.go
+++ b/cache/remotecache/gha/gha.go
@@ -39,7 +39,7 @@ const (
 	attrURL     = "url"
 	version     = "1"
 
-	defaultTimeout = 5 * time.Minute
+	defaultTimeout = 10 * time.Minute
 )
 
 type Config struct {


### PR DESCRIPTION
related to https://github.com/moby/buildkit/actions/runs/8062307240/job/22024437641?pr=4698#step:7:1683
closes #4705

![image](https://github.com/moby/buildkit/assets/1951866/8dc21bee-18dc-4e61-9e47-49073b993a00)

On repositories relying heavily on GitHub Actions Cache backend with BuildKit, it can take more than 5 minutes ([current default](https://github.com/tonistiigi/go-actions-cache/blob/0bdeb6e1eac762aa4c57a3e8ccc2fdfb68a3f3c4/cache.go#L145)) for the request to succeed due to GitHub rate limit or if export is quite huge (often sees with `mode=max`).

This PR adds a `timeout` attribute for GitHub Actions cache export/import (maybe import is not necessary) so user can specify a custom value if he wants to.

Also increases default timeout to 10 minutes.

If we are not ok with this change, we can just set `ignore-error=true` in our workflows to avoid failures on this repo, see https://github.com/moby/buildkit/pull/4705

@dvdksn Needs docs follow-up if accepted https://docs.docker.com/build/cache/backends/gha/