### PR TITLE
ci: set ignore-error to true to avoid gh rate limit error

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -94,7 +94,7 @@ jobs:
           targets: integration-tests-base
           set: |
             *.cache-from=type=gha,scope=${{ inputs.cache_scope }}
-            *.cache-to=type=gha,scope=${{ inputs.cache_scope }}
+            *.cache-to=type=gha,scope=${{ inputs.cache_scope }},ignore-error=true
 
   run:
     runs-on: ubuntu-22.04

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -105,7 +105,7 @@ jobs:
           RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
           PLATFORMS: ${{ matrix.platform }}
           CACHE_FROM: type=gha,scope=binaries-${{ env.PLATFORM_PAIR }}
-          CACHE_TO: type=gha,scope=binaries-${{ env.PLATFORM_PAIR }}
+          CACHE_TO: type=gha,scope=binaries-${{ env.PLATFORM_PAIR }},ignore-error=true
       -
         name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -184,7 +184,7 @@ jobs:
           RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
           TARGET: ${{ matrix.target-stage }}
           CACHE_FROM: type=gha,scope=image${{ matrix.target-stage }}
-          CACHE_TO: type=gha,scope=image${{ matrix.target-stage }}
+          CACHE_TO: type=gha,scope=image${{ matrix.target-stage }},ignore-error=true
 
   release:
     runs-on: ubuntu-22.04

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -122,7 +122,7 @@ jobs:
         env:
           RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
           CACHE_FROM: type=gha,scope=${{ env.CACHE_SCOPE }}
-          CACHE_TO: type=gha,scope=${{ env.CACHE_SCOPE }}
+          CACHE_TO: type=gha,scope=${{ env.CACHE_SCOPE }},ignore-error=true
 
   release:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -52,7 +52,7 @@ jobs:
           set: |
             *.platform=${{ matrix.platform }}
             *.cache-from=type=gha,scope=binaries-for-test-${{ env.PLATFORM_PAIR }}
-            *.cache-to=type=gha,scope=binaries-for-test-${{ env.PLATFORM_PAIR }}
+            *.cache-to=type=gha,scope=binaries-for-test-${{ env.PLATFORM_PAIR }},ignore-error=true
       -
         name: List artifacts
         run: |


### PR DESCRIPTION
alternative to https://github.com/moby/buildkit/pull/4702
closes #4702 

Sets `ignore-error=true` in our workflows to avoid it to fail if we are hitting the rate limit but don't set it in our integration test: https://github.com/moby/buildkit/blob/03caf1a405a5b402a3d0b485d6b0e3092760191b/client/client_test.go#L5711-L5719