### PR TITLE
Fix: Marshal Input Vertices in a consistent order

### DIFF
--- a/client/llb/exec.go
+++ b/client/llb/exec.go
@@ -439,15 +439,19 @@ func (e *ExecOp) Output() Output {
 
 func (e *ExecOp) Inputs() (inputs []Output) {
 	// make sure mounts are sorted
-	sort.Slice(e.mounts, func(i, j int) bool {
+	// the same sort occurs in (*ExecOp).Marshal, and this
+	// sort must be the same
+	sort.Slice(e.mounts, func(i int, j int) bool {
 		return e.mounts[i].target < e.mounts[j].target
 	})
 
-	seen := map[Output]bool{}
+	seen := map[Output]struct{}{}
 	for _, m := range e.mounts {
-		if m.source != nil && !seen[m.source] {
-			inputs = append(inputs, m.source)
-			seen[m.source] = true
+		if m.source != nil {
+			if _, ok := seen[m.source]; !ok {
+				inputs = append(inputs, m.source)
+				seen[m.source] = struct{}{}
+			}
 		}
 	}
 

--- a/client/llb/exec.go
+++ b/client/llb/exec.go
@@ -438,15 +438,19 @@ func (e *ExecOp) Output() Output {
 }
 
 func (e *ExecOp) Inputs() (inputs []Output) {
-	mm := map[Output]struct{}{}
+	// make sure mounts are sorted
+	sort.Slice(e.mounts, func(i, j int) bool {
+		return e.mounts[i].target < e.mounts[j].target
+	})
+
+	seen := map[Output]bool{}
 	for _, m := range e.mounts {
-		if m.source != nil {
-			mm[m.source] = struct{}{}
+		if m.source != nil && !seen[m.source] {
+			inputs = append(inputs, m.source)
+			seen[m.source] = true
 		}
 	}
-	for o := range mm {
-		inputs = append(inputs, o)
-	}
+
 	return
 }
 

--- a/client/llb/exec_test.go
+++ b/client/llb/exec_test.go
@@ -66,5 +66,4 @@ func TestExecOpMarshalConsistency(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, def.Def, def0.Def)
 	}
-
 }

--- a/client/llb/exec_test.go
+++ b/client/llb/exec_test.go
@@ -52,18 +52,21 @@ func TestValidGetMountIndex(t *testing.T) {
 }
 
 func TestExecOpMarshalConsistency(t *testing.T) {
+	var prevDef [][]byte
 	st := Image("busybox:latest").
 		Run(
 			Args([]string{"ls /a; ls /b"}),
 			AddMount("/b", Scratch().File(Mkfile("file1", 0644, []byte("file1 contents")))),
 		).AddMount("/a", Scratch().File(Mkfile("file2", 0644, []byte("file2 contents"))))
 
-	def0, err := st.Marshal(context.TODO())
-	require.NoError(t, err)
-
 	for i := 0; i < 100; i++ {
 		def, err := st.Marshal(context.TODO())
 		require.NoError(t, err)
-		require.Equal(t, def.Def, def0.Def)
+
+		if prevDef != nil {
+			require.Equal(t, def.Def, prevDef)
+		}
+
+		prevDef = def.Def
 	}
 }

--- a/client/llb/fileop_test.go
+++ b/client/llb/fileop_test.go
@@ -716,3 +716,20 @@ func last(t *testing.T, arr []pb.Op) (digest.Digest, int) {
 	require.Equal(t, 1, len(op.Inputs))
 	return op.Inputs[0].Digest, int(op.Inputs[0].Index)
 }
+
+func TestFileOpMarshalConsistency(t *testing.T) {
+	f1 := Scratch().File(Mkfile("/tmp", 0644, []byte("tmp 1")))
+	f2 := Scratch().File(Mkfile("/a", 0644, []byte("tmp 2")))
+	st := Image("foo").Dir("/tmp").
+		File(Copy(f1, "/foo", "/bar")).
+		File(Copy(f2, "/a", "/b"))
+
+	def0, err := st.Marshal(context.TODO())
+	for i := 0; i < 1000; i++ {
+		def, err := st.Marshal(context.TODO())
+		require.NoError(t, err)
+		require.Equal(t, def.Def, def0.Def)
+	}
+
+	require.NoError(t, err)
+}

--- a/client/llb/fileop_test.go
+++ b/client/llb/fileop_test.go
@@ -718,18 +718,22 @@ func last(t *testing.T, arr []pb.Op) (digest.Digest, int) {
 }
 
 func TestFileOpMarshalConsistency(t *testing.T) {
+	var prevDef [][]byte
+
 	f1 := Scratch().File(Mkfile("/tmp", 0644, []byte("tmp 1")))
 	f2 := Scratch().File(Mkfile("/a", 0644, []byte("tmp 2")))
 	st := Image("foo").Dir("/tmp").
 		File(Copy(f1, "/foo", "/bar")).
 		File(Copy(f2, "/a", "/b"))
 
-	def0, err := st.Marshal(context.TODO())
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < 100; i++ {
 		def, err := st.Marshal(context.TODO())
 		require.NoError(t, err)
-		require.Equal(t, def.Def, def0.Def)
-	}
 
-	require.NoError(t, err)
+		if prevDef != nil {
+			require.Equal(t, def.Def, prevDef)
+		}
+
+		prevDef = def.Def
+	}
 }

--- a/client/llb/state.go
+++ b/client/llb/state.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"sort"
 	"strings"
 
 	"github.com/containerd/containerd/platforms"
@@ -192,21 +191,7 @@ func marshal(ctx context.Context, v Vertex, def *Definition, s *sourceMapCollect
 		return def, nil
 	}
 
-	inputs := v.Inputs()
-	inps := map[Output]*pb.Input{}
-	for _, iv := range inputs {
-		inp, err := iv.ToInput(ctx, c)
-		if err != nil {
-			return nil, err
-		}
-		inps[iv] = inp
-	}
-
-	sort.Slice(inputs, func(i, j int) bool {
-		return inps[inputs[i]].Index < inps[inputs[j]].Index
-	})
-
-	for _, inp := range inputs {
+	for _, inp := range v.Inputs() {
 		var err error
 		def, err = marshal(ctx, inp.Vertex(ctx, c), def, s, cache, vertexCache, c)
 		if err != nil {

--- a/client/llb/state.go
+++ b/client/llb/state.go
@@ -191,18 +191,19 @@ func marshal(ctx context.Context, v Vertex, def *Definition, s *sourceMapCollect
 	if _, ok := vertexCache[v]; ok {
 		return def, nil
 	}
+
 	inputs := v.Inputs()
-	imap := map[Output]*pb.Input{}
+	inps := map[Output]*pb.Input{}
 	for _, iv := range inputs {
 		inp, err := iv.ToInput(ctx, c)
 		if err != nil {
 			return nil, err
 		}
-		imap[iv] = inp
+		inps[iv] = inp
 	}
 
 	sort.Slice(inputs, func(i, j int) bool {
-		return imap[inputs[i]].Index < imap[inputs[j]].Index
+		return inps[inputs[i]].Index < inps[inputs[j]].Index
 	})
 
 	for _, inp := range inputs {

--- a/client/llb/state.go
+++ b/client/llb/state.go
@@ -190,7 +190,6 @@ func marshal(ctx context.Context, v Vertex, def *Definition, s *sourceMapCollect
 	if _, ok := vertexCache[v]; ok {
 		return def, nil
 	}
-
 	for _, inp := range v.Inputs() {
 		var err error
 		def, err = marshal(ctx, inp.Vertex(ctx, c), def, s, cache, vertexCache, c)


### PR DESCRIPTION
This is a possible fix for #4695. I am opening to run against CI, as I've had trouble running full tests locally