### PR TITLE
gateway: mount metadata with nodev

### DIFF
--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -361,7 +361,7 @@ func (b *bindMount) Mount() ([]mount.Mount, func() error, error) {
 	return []mount.Mount{{
 		Type:    "bind",
 		Source:  b.dir,
-		Options: []string{"bind", "ro"},
+		Options: []string{"bind", "ro", "nosuid", "nodev", "noexec"},
 	}}, func() error { return nil }, nil
 }
 func (b *bindMount) IdentityMapping() *idtools.IdentityMapping {


### PR DESCRIPTION
On some systems this causes permission error if userns enabled.

fix #4556

Tbh. I do not know exactly what restriction controls this (it doesn't repro in regular systems as described in the issue) but `nodev` is what is causing the `EPERM` in the repro. The others are added for completeness.