### PR TITLE
Add MediaType in `index.json` when `--out type=oci`

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -3049,9 +3049,6 @@ func testNoTarOCIIndexMediaType(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	_, err = os.Stat(filepath.Join(outDir, "index.json"))
-	require.NoError(t, err)
-
 	dt, err := os.ReadFile(filepath.Join(outDir, "index.json"))
 	require.NoError(t, err)
 

--- a/client/ociindex/ociindex.go
+++ b/client/ociindex/ociindex.go
@@ -155,6 +155,9 @@ func insertDesc(index *ocispecs.Index, desc ocispecs.Descriptor, tag string) err
 	if index.SchemaVersion == 0 {
 		index.SchemaVersion = 2
 	}
+	if index.MediaType == "" {
+		index.MediaType = ocispecs.MediaTypeImageIndex
+	}
 	if tag != "" {
 		if desc.Annotations == nil {
 			desc.Annotations = make(map[string]string)

--- a/client/ociindex/ociindex.go
+++ b/client/ociindex/ociindex.go
@@ -102,6 +102,7 @@ func (s StoreIndex) Put(tag string, desc ocispecs.Descriptor) error {
 		}
 	}
 
+	setOCIIndexDefaults(&idx)
 	if err = insertDesc(&idx, desc, tag); err != nil {
 		return err
 	}
@@ -145,6 +146,19 @@ func (s StoreIndex) GetSingle() (*ocispecs.Descriptor, error) {
 	return nil, nil
 }
 
+// setOCIIndexDefaults updates zero values in index to their default values.
+func setOCIIndexDefaults(index *ocispecs.Index) {
+	if index == nil {
+		return
+	}
+	if index.SchemaVersion == 0 {
+		index.SchemaVersion = 2
+	}
+	if index.MediaType == "" {
+		index.MediaType = ocispecs.MediaTypeImageIndex
+	}
+}
+
 // insertDesc puts desc to index with tag.
 // Existing manifests with the same tag will be removed from the index.
 func insertDesc(index *ocispecs.Index, desc ocispecs.Descriptor, tag string) error {
@@ -152,12 +166,6 @@ func insertDesc(index *ocispecs.Index, desc ocispecs.Descriptor, tag string) err
 		return nil
 	}
 
-	if index.SchemaVersion == 0 {
-		index.SchemaVersion = 2
-	}
-	if index.MediaType == "" {
-		index.MediaType = ocispecs.MediaTypeImageIndex
-	}
 	if tag != "" {
 		if desc.Annotations == nil {
 			desc.Annotations = make(map[string]string)


### PR DESCRIPTION
Addresses issue #4595 and adds appropriate test. Specifically, this catches the case where `tar=false`, which is not covered by the incoming containerd fix. ( It should also happen fix the issue more generally, but getting the containerd was the *correct* fix in the general case. 😄 )