### PR TITLE
dockerfile: allow pivot point for --parents flag

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -1252,16 +1252,28 @@ func dispatchCopy(d *dispatchState, cfg copyConfig) error {
 				a = a.Copy(st, f, dest, opts...)
 			}
 		} else {
+			var patterns []string
+			if cfg.parents {
+				// detect optional pivot point
+				parent, pattern, ok := strings.Cut(src, "/./")
+				if !ok {
+					pattern = src
+					src = "/"
+				} else {
+					src = parent
+				}
+
+				pattern, err = system.NormalizePath("/", pattern, d.platform.OS, false)
+				if err != nil {
+					return errors.Wrap(err, "removing drive letter")
+				}
+
+				patterns = []string{strings.TrimPrefix(pattern, "/")}
+			}
+
 			src, err = system.NormalizePath("/", src, d.platform.OS, false)
 			if err != nil {
 				return errors.Wrap(err, "removing drive letter")
-			}
-
-			var patterns []string
-			if cfg.parents {
-				path := strings.TrimPrefix(src, "/")
-				patterns = []string{path}
-				src = "/"
 			}
 
 			opts := append([]llb.CopyOption{&llb.CopyInfo{

--- a/frontend/dockerfile/dockerfile_parents_test.go
+++ b/frontend/dockerfile/dockerfile_parents_test.go
@@ -18,6 +18,7 @@ import (
 
 var parentsTests = integration.TestFuncs(
 	testCopyParents,
+	testCopyRelativeParents,
 )
 
 func init() {
@@ -74,4 +75,109 @@ COPY --parents foo1/foo2/ba* .
 	dt, err = os.ReadFile(filepath.Join(destDir, "test/foo1/foo2/baz"))
 	require.NoError(t, err)
 	require.Equal(t, "testing2", string(dt))
+}
+
+func testCopyRelativeParents(t *testing.T, sb integration.Sandbox) {
+	f := getFrontend(t, sb)
+
+	dockerfile := []byte(`
+FROM alpine AS base
+WORKDIR /test
+RUN <<eot
+	set -ex
+	mkdir -p a/b/c/d/e
+	mkdir -p a/b2/c/d/e
+	mkdir -p a/b/c2/d/e
+	mkdir -p a/b/c2/d/e2
+	touch a/b/c/d/foo
+	touch a/b/c/d/e/bay
+	touch a/b2/c/d/e/bar
+	touch a/b/c2/d/e/baz
+	touch a/b/c2/d/e2/baz
+eot
+
+FROM alpine AS middle
+COPY --from=base --parents /test/a/b/./c/d /out/
+RUN <<eot
+	set -ex
+	[ -d /out/c/d/e ]
+	[ -f /out/c/d/foo ]
+	[ ! -d /out/a ]
+	[ ! -d /out/e ]
+eot
+
+FROM alpine AS end
+COPY --from=base --parents /test/a/b/c/d/. /out/
+RUN <<eot
+	set -ex
+	[ -d /out/test/a/b/c/d/e ]
+	[ -f /out/test/a/b/c/d/foo ]
+eot
+
+FROM alpine AS start
+COPY --from=base --parents ./test/a/b/c/d /out/
+RUN <<eot
+	set -ex
+	[ -d /out/test/a/b/c/d/e ]
+	[ -f /out/test/a/b/c/d/foo ]
+eot
+
+FROM alpine AS double
+COPY --from=base --parents /test/a/./b/./c /out/
+RUN <<eot
+	set -ex
+	[ -d /out/b/c/d/e ]
+	[ -f /out/b/c/d/foo ]
+eot
+
+FROM alpine AS wildcard
+COPY --from=base --parents /test/a/./*/c /out/
+RUN <<eot
+	set -ex
+	[ -d /out/b/c/d/e ]
+	[ -f /out/b2/c/d/e/bar ]
+eot
+
+FROM alpine AS doublewildcard
+COPY --from=base --parents /test/a/b*/./c/**/e /out/
+RUN <<eot
+	set -ex
+	[ -d /out/c/d/e ]
+	[ -f /out/c/d/e/bay ] # via b
+	[ -f /out/c/d/e/bar ] # via b2
+eot
+
+FROM alpine AS doubleinputs
+COPY --from=base --parents /test/a/b/c*/./d/**/baz /test/a/b*/./c/**/bar /out/
+RUN <<eot
+	set -ex
+	[ -f /out/d/e/baz ]
+	[ ! -f /out/d/e/bay ]
+	[ -f /out/d/e2/baz ]
+	[ -f /out/c/d/e/bar ] # via b2
+eot
+`)
+
+	dir := integration.Tmpdir(
+		t,
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+	)
+
+	c, err := client.New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	for _, target := range []string{"middle", "end", "start", "double", "wildcard", "doublewildcard", "doubleinputs"} {
+		t.Logf("target: %s", target)
+		_, err = f.Solve(sb.Context(), c, client.SolveOpt{
+			FrontendAttrs: map[string]string{
+				"target": target,
+			},
+			LocalMounts: map[string]fsutil.FS{
+				dockerui.DefaultLocalNameDockerfile: dir,
+				dockerui.DefaultLocalNameContext:    dir,
+			},
+		}, nil)
+		require.NoError(t, err)
+	}
 }

--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -1596,8 +1596,28 @@ COPY --parents ./x/a.txt ./y/a.txt /parents/
 # /parents/y/a.txt
 ```
 
-This behavior is analogous to the [Linux `cp` utility's](https://www.man7.org/linux/man-pages/man1/cp.1.html)
-`--parents` flag.
+This behavior is similar to the [Linux `cp` utility's](https://www.man7.org/linux/man-pages/man1/cp.1.html)
+`--parents` or [`rsync`](https://man7.org/linux/man-pages/man1/rsync.1.html) `--relative` flag.
+
+As with Rsync, it is possible to limit which parent directories are preserved by
+inserting a dot and a slash (`./`) into the source path. If such point exists, only parent
+directories after it will be preserved. This may be especially useful copies between stages
+with `--from` where the source paths need to be absolute.
+
+```dockerfile
+# syntax=docker/dockerfile-upstream:master-labs
+FROM scratch
+
+COPY --parents ./x/./y/*.txt /parents/
+
+# Build context:
+# ./x/y/a.txt
+# ./x/y/b.txt
+#
+# Output:
+# /parents/y/a.txt
+# /parents/y/b.txt
+```
 
 Note that, without the `--parents` flag specified, any filename collision will
 fail the Linux `cp` operation with an explicit error message

--- a/util/system/path.go
+++ b/util/system/path.go
@@ -27,7 +27,7 @@ func DefaultPathEnv(os string) string {
 
 // NormalizePath cleans the path based on the operating system the path is meant for.
 // It takes into account a potential parent path, and will join the path to the parent
-// if the path is relative. Additionally, it will apply the folliwing rules:
+// if the path is relative. Additionally, it will apply the following rules:
 //   - always return an absolute path
 //   - always strip drive letters for Windows paths
 //   - optionally keep the trailing slashes on paths


### PR DESCRIPTION
follow-up for #3001

Similarily to `rsync` `--relative` flag add support for `/./` pivot point to mark which parent directories as kept.

This is especially useful in multi-stage builds because `--from` paths need to be always full paths.

```
FROM ... AS base
RUN ./generate-lot-of-files -o /out/

FROM scratch
COPY --from=base --parents /out/./**/bin/ /
# /usr/bin/bar
# /usr/local/bin/foo
``` 

cc @DYefimov