### PR TITLE
fix: windows getting started guide for uniformity

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -89,6 +89,7 @@ Now that everything is setup, let's build a [simple _hello world_ image](https:/
     ```powershell
     Set-Content Dockerfile @"
     FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
+    USER ContainerAdministrator
     COPY hello.txt C:/
     RUN echo "Goodbye!" >> hello.txt
     CMD ["cmd", "/C", "type C:\\hello.txt"]


### PR DESCRIPTION
This adds `ContainerAdministrator` as the default user to guarantee a uniform experience on all the platforms. The previous guide would fail on WS2022 but work on WS2019 and Windows 11. The issue is being investigated here #4731