### PR TITLE
ci: enable multi-platform lint only for upstream repo

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -38,13 +38,17 @@ jobs:
     runs-on: ubuntu-22.04
     needs:
       - prepare
-    env:
-      GOLANGCI_LINT_MULTIPLATFORM: 1
     strategy:
       fail-fast: false
       matrix:
         target: ${{ fromJson(needs.prepare.outputs.targets) }}
     steps:
+      -
+        name: Prepare
+        run: |
+          if [ "$GITHUB_REPOSITORY" = "moby/buildkit" ]; then
+            echo "GOLANGCI_LINT_MULTIPLATFORM=1" >> $GITHUB_ENV
+          fi
       -
         name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
On moby we have a special threshold for public runners iirc but on some private repos outside this org, the linting against multi-platform fails with:

```
The hosted runner: GitHub Actions 271 lost communication with the server. Anything in your workflow that terminates the runner process, starves it for CPU/Memory, or blocks its network access can cause this error.
```

This change will enable multi-platform lint only for this repo.