### PR TITLE
detect: fix auto-detection of metric exporters to handle none correctly

### DIFF
--- a/util/tracing/detect/delegated/delegated.go
+++ b/util/tracing/detect/delegated/delegated.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/moby/buildkit/util/tracing/detect"
-	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
@@ -14,9 +13,9 @@ const maxBuffer = 256
 var exp = &Exporter{}
 
 func init() {
-	detect.Register("delegated", func() (sdktrace.SpanExporter, sdkmetric.Exporter, error) {
-		return exp, nil, nil
-	}, 100)
+	detect.Register("delegated", detect.TraceExporterDetector(func() (sdktrace.SpanExporter, error) {
+		return exp, nil
+	}), 100)
 }
 
 type Exporter struct {

--- a/util/tracing/detect/otlp.go
+++ b/util/tracing/detect/otlp.go
@@ -15,24 +15,15 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
+var otlpExporter = otlpExporterDetector{}
+
 func init() {
 	Register("otlp", otlpExporter, 10)
 }
 
-func otlpExporter() (sdktrace.SpanExporter, sdkmetric.Exporter, error) {
-	texp, err := otlpSpanExporter()
-	if err != nil {
-		return nil, nil, err
-	}
+type otlpExporterDetector struct{}
 
-	mexp, err := otlpMetricExporter()
-	if err != nil {
-		return nil, nil, err
-	}
-	return texp, mexp, nil
-}
-
-func otlpSpanExporter() (sdktrace.SpanExporter, error) {
+func (otlpExporterDetector) DetectTraceExporter() (sdktrace.SpanExporter, error) {
 	set := os.Getenv("OTEL_TRACES_EXPORTER") == "otlp" || os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT") != "" || os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT") != ""
 	if !set {
 		return nil, nil
@@ -61,7 +52,7 @@ func otlpSpanExporter() (sdktrace.SpanExporter, error) {
 	return otlptrace.New(context.Background(), c)
 }
 
-func otlpMetricExporter() (sdkmetric.Exporter, error) {
+func (otlpExporterDetector) DetectMetricExporter() (sdkmetric.Exporter, error) {
 	set := os.Getenv("OTEL_METRICS_EXPORTER") == "otlp" || os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT") != "" || os.Getenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT") != ""
 	if !set {
 		return nil, nil


### PR DESCRIPTION
The original design for adding metric exporters accidentally relied on
the traces exporter variable for enabling or disabling the metrics
exporter. It's normal for metrics to get auto-enabled with the same
environment variables that traces use, but it should also respond to
`none` for disabling.

Fixes #4743.