### PR TITLE
Add linting for Dockerfiles

### DIFF
--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -15,6 +15,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerui"
 	"github.com/moby/buildkit/frontend/gateway/client"
 	gwpb "github.com/moby/buildkit/frontend/gateway/pb"
+	"github.com/moby/buildkit/frontend/subrequests/lint"
 	"github.com/moby/buildkit/frontend/subrequests/outline"
 	"github.com/moby/buildkit/frontend/subrequests/targets"
 	"github.com/moby/buildkit/solver/errdefs"
@@ -84,6 +85,9 @@ func Build(ctx context.Context, c client.Client) (_ *client.Result, err error) {
 		},
 		ListTargets: func(ctx context.Context) (*targets.List, error) {
 			return dockerfile2llb.ListTargets(ctx, src.Data)
+		},
+		Lint: func(ctx context.Context) (*lint.WarningList, error) {
+			return dockerfile2llb.DockerfileLint(ctx, src.Data, convertOpt)
 		},
 	}); err != nil {
 		return nil, err

--- a/frontend/dockerfile/dockerfile2llb/convert_test.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_test.go
@@ -27,6 +27,57 @@ func toEnvMap(args []instructions.KeyValuePairOptional, env []string) map[string
 	return m
 }
 
+func TestDockerfileLinting(t *testing.T) {
+	t.Parallel()
+	df := `FROM scratch AS foo
+ENV FOO bar
+FROM foo
+COPY --from=foo f1 /
+	`
+	convertOpt := ConvertOpt{}
+	warningList, err := DockerfileLint(appcontext.Context(), []byte(df), convertOpt)
+	assert.NoError(t, err)
+	assert.Empty(t, warningList.Warnings)
+
+	df = `from scratch AS foo
+env FOO bar
+from foo
+copy --from=foo f1 /
+	`
+	warningList, err = DockerfileLint(appcontext.Context(), []byte(df), convertOpt)
+	assert.NoError(t, err)
+	assert.Empty(t, warningList.Warnings)
+
+	df = `FROM scratch AS FOO
+ENV FOO bar
+FROM foo
+COPY --from=FOO f1 /
+	`
+	convertOpt = ConvertOpt{}
+	warningList, err = DockerfileLint(appcontext.Context(), []byte(df), convertOpt)
+	assert.NoError(t, err)
+	assert.Len(t, warningList.Warnings, 2)
+
+	df = `FROM scratch AS Foo
+ENV FOO bar
+FROM foo
+COPY --from=Foo f1 /
+	`
+	convertOpt = ConvertOpt{}
+	warningList, err = DockerfileLint(appcontext.Context(), []byte(df), convertOpt)
+	assert.NoError(t, err)
+	assert.Len(t, warningList.Warnings, 2)
+
+	df = `FRom scratch AS foo
+env FOO bar
+from foo
+copy --from=foo f1 /
+	`
+	warningList, err = DockerfileLint(appcontext.Context(), []byte(df), convertOpt)
+	assert.NoError(t, err)
+	assert.Len(t, warningList.Warnings, 1)
+}
+
 func TestDockerfileParsing(t *testing.T) {
 	t.Parallel()
 	df := `FROM scratch

--- a/frontend/dockerfile/dockerfile_linter_test.go
+++ b/frontend/dockerfile/dockerfile_linter_test.go
@@ -1,0 +1,128 @@
+package dockerfile
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"sort"
+	"testing"
+
+	"github.com/containerd/continuity/fs/fstest"
+	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/frontend/dockerfile/linter"
+	"github.com/moby/buildkit/frontend/dockerui"
+	gateway "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/frontend/subrequests/lint"
+	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/moby/buildkit/util/testutil/workers"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"github.com/tonistiigi/fsutil"
+)
+
+var lintTests = integration.TestFuncs(
+	testLintRules,
+)
+
+func testLintRules(t *testing.T, sb integration.Sandbox) {
+	integration.SkipOnPlatform(t, "windows")
+	workers.CheckFeatureCompat(t, sb, workers.FeatureFrontendOutline)
+	f := getFrontend(t, sb)
+	if _, ok := f.(*clientFrontend); !ok {
+		t.Skip("only test with client frontend")
+	}
+
+	dockerfile := []byte(`
+# 'First' should produce a lint warning (lowercase stage name)
+FROM scratch as First
+
+# 'Run' should produce a lint warning (inconsistent command case)
+Run echo "Hello"
+
+# No lint warning
+run echo "World"
+
+# No lint warning
+RUN touch /file
+
+# No lint warning
+FROM scratch as second
+
+# 'First' should produce a lint warning (lowercase flags)
+COPY --from=First /file /file
+
+# No lint warning
+FROM scratch as target
+
+# No lint warning
+COPY --from=second /file /file
+`)
+
+	dir := integration.Tmpdir(
+		t,
+		fstest.CreateFile("Dockerfile", []byte(dockerfile), 0600),
+	)
+
+	c, err := client.New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	destDir, err := os.MkdirTemp("", "buildkit")
+	require.NoError(t, err)
+	defer os.RemoveAll(destDir)
+
+	called := false
+	frontend := func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
+		res, err := c.Solve(ctx, gateway.SolveRequest{
+			FrontendOpt: map[string]string{
+				"frontend.caps": "moby.buildkit.frontend.subrequests",
+				"requestid":     "frontend.lint",
+				"build-arg:BAR": "678",
+				"target":        "target",
+			},
+			Frontend: "dockerfile.v0",
+		})
+		require.NoError(t, err)
+
+		warnings, err := unmarshalLintWarnings(res)
+		require.NoError(t, err)
+		require.Len(t, warnings.Warnings, 3)
+
+		warningList := warnings.Warnings
+		sort.Slice(warningList, func(i, j int) bool {
+			return warningList[i].Location.Start.Line < warningList[j].Location.Start.Line
+		})
+
+		require.Equal(t, 3, warningList[0].Location.Start.Line)
+		require.Equal(t, linter.LinterRules[linter.RuleStageNameCasing].Short, warningList[0].Short)
+
+		require.Equal(t, 6, warningList[1].Location.Start.Line)
+		require.Equal(t, linter.LinterRules[linter.RuleCommandCasing].Short, warningList[1].Short)
+
+		require.Equal(t, 18, warningList[2].Location.Start.Line)
+		require.Equal(t, linter.LinterRules[linter.RuleFlagCasing].Short, warningList[2].Short)
+
+		called = true
+		return nil, nil
+	}
+	_, err = c.Build(sb.Context(), client.SolveOpt{
+		LocalMounts: map[string]fsutil.FS{
+			dockerui.DefaultLocalNameDockerfile: dir,
+		},
+	}, "", frontend, nil)
+	require.NoError(t, err)
+
+	require.True(t, called)
+}
+
+func unmarshalLintWarnings(res *gateway.Result) (*lint.WarningList, error) {
+	dt, ok := res.Metadata["result.json"]
+	if !ok {
+		return nil, errors.Errorf("missing frontend.lint")
+	}
+	var warnings lint.WarningList
+	if err := json.Unmarshal(dt, &warnings); err != nil {
+		return nil, err
+	}
+	return &warnings, nil
+}

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -246,6 +246,7 @@ func TestIntegration(t *testing.T) {
 		}))...)
 	integration.Run(t, heredocTests, opts...)
 	integration.Run(t, outlineTests, opts...)
+	integration.Run(t, lintTests, opts...)
 	integration.Run(t, targetsTests, opts...)
 
 	integration.Run(t, reproTests, append(opts,

--- a/frontend/dockerfile/instructions/parse_test.go
+++ b/frontend/dockerfile/instructions/parse_test.go
@@ -161,7 +161,8 @@ ARG bar baz=123
 	ast, err := parser.Parse(bytes.NewBuffer([]byte(dt)))
 	require.NoError(t, err)
 
-	stages, meta, err := Parse(ast.AST)
+	emptyCallback := func(short, url string, detail [][]byte, location *parser.Range) {}
+	stages, meta, err := Parse(ast.AST, emptyCallback)
 	require.NoError(t, err)
 
 	require.Equal(t, "defines first stage", stages[0].Comment)

--- a/frontend/dockerfile/linter/ruleset.go
+++ b/frontend/dockerfile/linter/ruleset.go
@@ -1,0 +1,118 @@
+package linter
+
+import (
+	"strings"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+)
+
+const (
+	RuleStageNameCasing = "StageNameCasing"
+	RuleFlagCasing      = "FlagCasing"
+	RuleCommandCasing   = "CommandCasing"
+)
+
+var LinterRules map[string]LinterRule
+
+type LinterRule struct {
+	Short       string
+	Description string
+}
+
+type Warning struct {
+	Short    string       `json:"short"`
+	Detail   [][]byte     `json:"detail"`
+	Location parser.Range `json:"location"`
+	Source   string       `json:"source"`
+}
+
+func init() {
+	LinterRules = map[string]LinterRule{
+		RuleStageNameCasing: {
+			Short:       "Lowercase Staging Name",
+			Description: "Stage names should be lowercase",
+		},
+		RuleFlagCasing: {
+			Short:       "Lowercase Command Flags",
+			Description: "Flags should be lowercase",
+		},
+		RuleCommandCasing: {
+			Short:       "Inconsistent Command Casing",
+			Description: "Commands should be in consistent casing (all lower or all upper)",
+		},
+	}
+}
+
+func isUpperCase(s string) bool {
+	return s == strings.ToUpper(s)
+}
+
+func isLowerCase(s string) bool {
+	return s == strings.ToLower(s)
+}
+
+func consistentCasing(s string) bool {
+	return isUpperCase(s) || isLowerCase(s)
+}
+
+func ValidateStageNameCasing(val interface{}) bool {
+	cmdArgs, ok := val.([]string)
+	if !ok {
+		return false
+	}
+	if len(cmdArgs) != 3 {
+		return true
+	}
+	stageName := cmdArgs[2]
+	return isLowerCase(stageName)
+}
+
+func ValidateFlagCasing(val interface{}) bool {
+	flags, ok := val.([]string)
+	if !ok {
+		return false
+	}
+	for _, flag := range flags {
+		if !isLowerCase(flag) {
+			return false
+		}
+	}
+	return true
+}
+
+func ValidateCommandCasing(val interface{}) bool {
+	cmd, ok := val.(string)
+	return ok && consistentCasing(cmd)
+}
+
+func ValidateNodeLintRules(node *parser.Node) []parser.Warning {
+	warnings := []parser.Warning{}
+	location := FirstNodeRange(node)
+	if !ValidateFlagCasing(node.Flags) {
+		flagCasing := LinterRules[RuleFlagCasing]
+		warnings = append(warnings, parser.Warning{
+			Short:    flagCasing.Short,
+			Detail:   [][]byte{[]byte(flagCasing.Description)},
+			Location: location,
+		})
+	}
+	if !ValidateCommandCasing(node.Value) {
+		commandCasing := LinterRules[RuleCommandCasing]
+		warnings = append(warnings, parser.Warning{
+			Short:    commandCasing.Short,
+			Detail:   [][]byte{[]byte(commandCasing.Description)},
+			Location: location,
+		})
+	}
+	return warnings
+}
+
+func FirstNodeRange(node *parser.Node) *parser.Range {
+	if len(node.Location()) > 0 {
+		return &node.Location()[0]
+	}
+	return &parser.Range{
+		Start: parser.Position{Line: node.StartLine},
+		End:   parser.Position{Line: node.EndLine},
+	}
+}

--- a/frontend/dockerui/requests.go
+++ b/frontend/dockerui/requests.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/frontend/subrequests"
+	"github.com/moby/buildkit/frontend/subrequests/lint"
 	"github.com/moby/buildkit/frontend/subrequests/outline"
 	"github.com/moby/buildkit/frontend/subrequests/targets"
 	"github.com/moby/buildkit/solver/errdefs"
@@ -19,6 +20,7 @@ const (
 type RequestHandler struct {
 	Outline     func(context.Context) (*outline.Outline, error)
 	ListTargets func(context.Context) (*targets.List, error)
+	Lint        func(context.Context) (*lint.WarningList, error)
 	AllowOther  bool
 }
 
@@ -53,6 +55,18 @@ func (bc *Client) HandleSubrequest(ctx context.Context, h RequestHandler) (*clie
 				return nil, true, nil
 			}
 			res, err := targets.ToResult()
+			return res, true, err
+		}
+	case lint.SubrequestLintDefinition.Name:
+		if f := h.Lint; f != nil {
+			warnings, err := f(ctx)
+			if err != nil {
+				return nil, false, err
+			}
+			if warnings == nil {
+				return nil, true, nil
+			}
+			res, err := warnings.ToResult()
 			return res, true, err
 		}
 	}

--- a/frontend/subrequests/lint/lint.go
+++ b/frontend/subrequests/lint/lint.go
@@ -1,0 +1,93 @@
+package lint
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+	"github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/frontend/subrequests"
+)
+
+const RequestLint = "frontend.lint"
+
+var SubrequestLintDefinition = subrequests.Request{
+	Name:        RequestLint,
+	Version:     "1.0.0",
+	Type:        subrequests.TypeRPC,
+	Description: "Lint a Dockerfile",
+	Opts:        []subrequests.Named{},
+	Metadata: []subrequests.Named{
+		{Name: "result.json"},
+		{Name: "result.txt"},
+	},
+}
+
+type Warning struct {
+	Short    string        `json:"short"`
+	Detail   [][]byte      `json:"detail"`
+	Location *parser.Range `json:"location"`
+	Filename string        `json:"filename"`
+	Source   []string      `json:"source"`
+}
+
+type WarningList struct {
+	Warnings []Warning `json:"warnings"`
+}
+
+func (warns WarningList) ToResult() (*client.Result, error) {
+	res := client.NewResult()
+	dt, err := json.MarshalIndent(warns, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	res.AddMeta("result.json", dt)
+
+	b := bytes.NewBuffer(nil)
+	if err := PrintLintViolations(dt, b); err != nil {
+		return nil, err
+	}
+	res.AddMeta("result.txt", b.Bytes())
+
+	res.AddMeta("version", []byte(SubrequestLintDefinition.Version))
+	return res, nil
+}
+
+func PrintLintViolations(dt []byte, w io.Writer) error {
+	var warnings WarningList
+
+	if err := json.Unmarshal(dt, &warnings); err != nil {
+		return err
+	}
+
+	// Group warnings by short
+	lintWarnings := make(map[string][]Warning)
+	lintWarningShorts := []string{}
+	for _, warning := range warnings.Warnings {
+		if _, ok := lintWarnings[warning.Short]; !ok {
+			lintWarningShorts = append(lintWarningShorts, warning.Short)
+			lintWarnings[warning.Short] = []Warning{}
+		}
+		lintWarnings[warning.Short] = append(lintWarnings[warning.Short], warning)
+	}
+	sort.Strings(lintWarningShorts)
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(tw, "Lint Warnings\n")
+	for _, short := range lintWarningShorts {
+		fmt.Fprintf(tw, "\t%s\n", short)
+		for _, warning := range lintWarnings[short] {
+			fmt.Fprintf(tw, "\t\t%s:%d\n", warning.Filename, warning.Location.Start.Line)
+			for _, line := range warning.Source {
+				fmt.Fprintf(tw, "\t\t%s\n", line)
+			}
+			fmt.Fprintf(tw, "\n")
+		}
+	}
+
+	return tw.Flush()
+}


### PR DESCRIPTION
We should define a set of rules for evaluating a good or bad Dockerfile. Create a method for evaluating the Dockerfile to ensure obvious issues are highlighted to the user.

This PR adds linting/linting-related warnings to buildkit and exposes this functionality for frontends to support, and introduces 3 linting rules around casing, specifically the casing of command names, stage names, and command flag values.

To use/test this directly, it's easiest for the experimental flag for buildx to be set to true, as below.

```
$ make images
$ docker buildx rm dev
$ docker buildx create --driver=docker-container --name=dev --driver-opt image=moby/buildkit:local --bootstrap
$ cd [some docker_project with a Dockerfile]
$ BUILDX_EXPERIMENTAL=true buildx build --builder=dev --print=lint .
```