### PR TITLE
docs: remove mention that buildkit warns about unconsumned build args

### DIFF
--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -2098,14 +2098,6 @@ flag.
 > learn about secure ways to use secrets when building images.
 { .warning }
 
-
-If you specify a build argument that wasn't defined in the Dockerfile,
-the build outputs a warning.
-
-```console
-[Warning] One or more build-args [foo] were not consumed.
-```
-
 A Dockerfile may include one or more `ARG` instructions. For example,
 the following is a valid Dockerfile:
 


### PR DESCRIPTION
BuildKit doesn't warn if a provided build argument is not consumed,
unlike the classic builder.

relates to:

- docker/docs#19565
- moby/buildkit#2128

