### PR TITLE
Add additional warnings for lint rules

### DIFF
--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -73,7 +73,7 @@ func Build(ctx context.Context, c client.Client) (_ *client.Result, err error) {
 		Client:       bc,
 		SourceMap:    src.SourceMap,
 		MetaResolver: c,
-		Warn: func(msg, url string, detail [][]byte, location *parser.Range) {
+		Warn: func(msg, url string, detail [][]byte, location []parser.Range) {
 			src.Warn(ctx, msg, warnOpts(location, detail, url))
 		},
 	}
@@ -236,21 +236,24 @@ func forwardGateway(ctx context.Context, c client.Client, ref string, cmdline st
 	})
 }
 
-func warnOpts(r *parser.Range, detail [][]byte, url string) client.WarnOpts {
+func warnOpts(r []parser.Range, detail [][]byte, url string) client.WarnOpts {
 	opts := client.WarnOpts{Level: 1, Detail: detail, URL: url}
 	if r == nil {
 		return opts
 	}
-	opts.Range = []*pb.Range{{
-		Start: pb.Position{
-			Line:      int32(r.Start.Line),
-			Character: int32(r.Start.Character),
-		},
-		End: pb.Position{
-			Line:      int32(r.End.Line),
-			Character: int32(r.End.Character),
-		},
-	}}
+	opts.Range = []*pb.Range{}
+	for _, r := range r {
+		opts.Range = append(opts.Range, &pb.Range{
+			Start: pb.Position{
+				Line:      int32(r.Start.Line),
+				Character: int32(r.Start.Character),
+			},
+			End: pb.Position{
+				Line:      int32(r.End.Line),
+				Character: int32(r.End.Character),
+			},
+		})
+	}
 	return opts
 }
 

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -139,10 +139,6 @@ func ListTargets(ctx context.Context, dt []byte) (*targets.List, error) {
 	return l, nil
 }
 
-func consistentCasing(s string) bool {
-	return s == strings.ToLower(s) || s == strings.ToUpper(s)
-}
-
 func toDispatchState(ctx context.Context, dt []byte, opt ConvertOpt) (*dispatchState, error) {
 	if len(dt) == 0 {
 		return nil, errors.Errorf("the Dockerfile cannot be empty")
@@ -202,7 +198,7 @@ func toDispatchState(ctx context.Context, dt []byte, opt ConvertOpt) (*dispatchS
 	}
 
 	for _, node := range dockerfile.AST.Children {
-		if !consistentCasing(node.Value) {
+		if !isConsistentCasing(node.Value) {
 			msg := linter.RuleCommandCasing.Format(node.Value)
 			linter.RuleCommandCasing.Run(opt.Warn, node.Location(), msg)
 		}
@@ -1951,4 +1947,8 @@ func isEnabledForStage(stage string, value string) bool {
 		}
 	}
 	return false
+}
+
+func isConsistentCasing(s string) bool {
+	return s == strings.ToLower(s) || s == strings.ToUpper(s)
 }

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -110,21 +110,6 @@ func Dockefile2Outline(ctx context.Context, dt []byte, opt ConvertOpt) (*outline
 	return &o, nil
 }
 
-func lintSourceInfo(srcMap *llb.SourceMap, srcRange *parser.Range) (filename string, source []string) {
-	if srcMap == nil {
-		return
-	}
-	filename = srcMap.Filename
-	if srcRange == nil {
-		return
-	}
-	lines := strings.Split(string(srcMap.Data), "\n")
-	start := srcRange.Start.Line
-	end := srcRange.End.Line
-	source = lines[start-1 : end]
-	return
-}
-
 func ListTargets(ctx context.Context, dt []byte) (*targets.List, error) {
 	dockerfile, err := parser.Parse(bytes.NewReader(dt))
 	if err != nil {
@@ -220,7 +205,7 @@ func toDispatchState(ctx context.Context, dt []byte, opt ConvertOpt) (*dispatchS
 		// lines, but we'll check the warning message to be sure.
 		if warning.URL == linter.RuleNoEmptyContinuations.URL {
 			location := []parser.Range{*warning.Location}
-			lintWarn(linter.RuleNoEmptyContinuations, "Empty Continuation Line", location)
+			lintWarn(linter.RuleNoEmptyContinuations, "Empty continuation line", location)
 		}
 	}
 

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -22,6 +22,7 @@ import (
 	"github.com/moby/buildkit/client/llb/imagemetaresolver"
 	"github.com/moby/buildkit/client/llb/sourceresolver"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+	"github.com/moby/buildkit/frontend/dockerfile/linter"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/moby/buildkit/frontend/dockerfile/shell"
 	"github.com/moby/buildkit/frontend/dockerui"
@@ -109,12 +110,51 @@ func Dockefile2Outline(ctx context.Context, dt []byte, opt ConvertOpt) (*outline
 	return &o, nil
 }
 
+func lintSourceInfo(srcMap *llb.SourceMap, srcRange *parser.Range) (filename string, source []string) {
+	if srcMap == nil {
+		return
+	}
+	filename = srcMap.Filename
+	if srcRange == nil {
+		return
+	}
+	lines := strings.Split(string(srcMap.Data), "\n")
+	start := srcRange.Start.Line
+	end := srcRange.End.Line
+	source = lines[start-1 : end]
+	return
+}
+
+func DockerfileLint(ctx context.Context, dt []byte, opt ConvertOpt) ([]linter.Warning, error) {
+	warnings := []linter.Warning{}
+	opt.Warn = func(short, url string, detail [][]byte, location *parser.Range) {
+		var source []string
+		var filename string
+		filename, source = lintSourceInfo(opt.SourceMap, location)
+		warnings = append(warnings, linter.Warning{
+			Short:    short,
+			Detail:   detail,
+			Location: location,
+			Filename: filename,
+			Source:   source,
+		})
+	}
+
+	_, err := toDispatchState(ctx, dt, opt)
+	if err != nil {
+		return nil, err
+	}
+	return warnings, nil
+}
+
 func ListTargets(ctx context.Context, dt []byte) (*targets.List, error) {
 	dockerfile, err := parser.Parse(bytes.NewReader(dt))
 	if err != nil {
 		return nil, err
 	}
-	stages, _, err := instructions.Parse(dockerfile.AST)
+
+	noWarn := func(string, string, [][]byte, *parser.Range) {}
+	stages, _, err := instructions.Parse(dockerfile.AST, noWarn)
 	if err != nil {
 		return nil, err
 	}
@@ -180,13 +220,18 @@ func toDispatchState(ctx context.Context, dt []byte, opt ConvertOpt) (*dispatchS
 		return nil, err
 	}
 
+	for _, node := range dockerfile.AST.Children {
+		warnings := linter.ValidateNodeLintRules(node)
+		dockerfile.Warnings = append(dockerfile.Warnings, warnings...)
+	}
+
 	for _, w := range dockerfile.Warnings {
 		opt.Warn(w.Short, w.URL, w.Detail, w.Location)
 	}
 
 	proxyEnv := proxyEnvFromBuildArgs(opt.BuildArgs)
 
-	stages, metaArgs, err := instructions.Parse(dockerfile.AST)
+	stages, metaArgs, err := instructions.Parse(dockerfile.AST, opt.Warn)
 	if err != nil {
 		return nil, err
 	}

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -182,14 +182,12 @@ func toDispatchState(ctx context.Context, dt []byte, opt ConvertOpt) (*dispatchS
 		return nil, err
 	}
 
-	// Moby still uses the `dockerfile.PrintWarnings` method to print warnings,
-	// which prevents us from meaningfully refactoring the `parser.Parse` method
-	// to accept a lint warning callback in the same way that the `instructions.Parse`
-	// method does. As a result, we need to manually iterate over the warnings
-	// and call the lint warning callback for each one.
+	// Moby still uses the `dockerfile.PrintWarnings` method to print non-empty
+	// continuation line warnings. We iterate over those warnings here.
 	for _, warning := range dockerfile.Warnings {
 		// The `dockerfile.Warnings` *should* only contain warnings about empty continuation
-		// lines, but we'll check the warning message to be sure.
+		// lines, but we'll check the warning message to be sure, so that we don't accidentally
+		// process warnings that are not related to empty continuation lines twice.
 		if warning.URL == linter.RuleNoEmptyContinuations.URL {
 			location := []parser.Range{*warning.Location}
 			msg := linter.RuleNoEmptyContinuations.Format()

--- a/frontend/dockerfile/dockerfile2llb/convert_test.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_test.go
@@ -27,57 +27,6 @@ func toEnvMap(args []instructions.KeyValuePairOptional, env []string) map[string
 	return m
 }
 
-func TestDockerfileLinting(t *testing.T) {
-	t.Parallel()
-	df := `FROM scratch AS foo
-ENV FOO bar
-FROM foo
-COPY --from=foo f1 /
-	`
-	convertOpt := ConvertOpt{}
-	warningList, err := DockerfileLint(appcontext.Context(), []byte(df), convertOpt)
-	assert.NoError(t, err)
-	assert.Empty(t, warningList)
-
-	df = `from scratch AS foo
-env FOO bar
-from foo
-copy --from=foo f1 /
-	`
-	warningList, err = DockerfileLint(appcontext.Context(), []byte(df), convertOpt)
-	assert.NoError(t, err)
-	assert.Empty(t, warningList)
-
-	df = `FROM scratch AS FOO
-ENV FOO bar
-FROM foo
-COPY --from=FOO f1 /
-	`
-	convertOpt = ConvertOpt{}
-	warningList, err = DockerfileLint(appcontext.Context(), []byte(df), convertOpt)
-	assert.NoError(t, err)
-	assert.Len(t, warningList, 2)
-
-	df = `FROM scratch AS Foo
-ENV FOO bar
-FROM foo
-COPY --from=Foo f1 /
-	`
-	convertOpt = ConvertOpt{}
-	warningList, err = DockerfileLint(appcontext.Context(), []byte(df), convertOpt)
-	assert.NoError(t, err)
-	assert.Len(t, warningList, 2)
-
-	df = `FRom scratch AS foo
-env FOO bar
-from foo
-copy --from=foo f1 /
-	`
-	warningList, err = DockerfileLint(appcontext.Context(), []byte(df), convertOpt)
-	assert.NoError(t, err)
-	assert.Len(t, warningList, 1)
-}
-
 func TestDockerfileParsing(t *testing.T) {
 	t.Parallel()
 	df := `FROM scratch

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -6846,17 +6846,17 @@ COPY Dockerfile .
 		return w1.Range[0].Start.Line < w2.Range[0].Start.Line
 	})
 
-	require.Equal(t, "Stage name 'BadStageName' should be lowercase (Dockerfile:3)", string(warnings[0].Short))
+	require.Equal(t, "Lint Rule 'StageNameCasing': Stage name 'BadStageName' should be lowercase (line 3)", string(warnings[0].Short))
 	require.Equal(t, "Stage names should be lowercase", string(warnings[0].Detail[0]))
 	require.Equal(t, "", warnings[0].URL)
 	require.Equal(t, 1, warnings[0].Level)
 
-	require.Equal(t, "Command 'Copy' should be consistently cased (Dockerfile:4)", string(warnings[1].Short))
+	require.Equal(t, "Lint Rule 'CommandCasing': Command 'Copy' should be consistently cased (line 4)", string(warnings[1].Short))
 	require.Equal(t, "Commands should be in consistent casing (all lower or all upper)", string(warnings[1].Detail[0]))
 	require.Equal(t, "", warnings[1].URL)
 	require.Equal(t, 1, warnings[1].Level)
 
-	require.Equal(t, "Empty continuation line (Dockerfile:7)", string(warnings[2].Short))
+	require.Equal(t, "Lint Rule 'NoEmptyContinuations': Empty continuation line (line 7)", string(warnings[2].Short))
 	require.Equal(t, "Empty continuation lines will become errors in a future release", string(warnings[2].Detail[0]))
 	require.Equal(t, "https://github.com/moby/moby/pull/33719", warnings[2].URL)
 }
@@ -6928,7 +6928,7 @@ COPY Dockerfile \
 
 	w := warnings[0]
 
-	require.Equal(t, "Empty continuation line (Dockerfile:5)", string(w.Short))
+	require.Equal(t, "Lint Rule 'NoEmptyContinuations': Empty continuation line (line 5)", string(w.Short))
 	require.Equal(t, 1, len(w.Detail))
 	require.Equal(t, "Empty continuation lines will become errors in a future release", string(w.Detail[0]))
 	require.Equal(t, "https://github.com/moby/moby/pull/33719", w.URL)

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -6831,7 +6831,7 @@ COPY Dockerfile \
 
 	w := warnings[0]
 
-	require.Equal(t, "Empty continuation line found in: COPY Dockerfile .", string(w.Short))
+	require.Equal(t, "Empty continuation line (Dockerfile:5)", string(w.Short))
 	require.Equal(t, 1, len(w.Detail))
 	require.Equal(t, "Empty continuation lines will become errors in a future release", string(w.Detail[0]))
 	require.Equal(t, "https://github.com/moby/moby/pull/33719", w.URL)

--- a/frontend/dockerfile/instructions/parse.go
+++ b/frontend/dockerfile/instructions/parse.go
@@ -98,8 +98,8 @@ func ParseInstructionWithLinter(node *parser.Node, lintWarn linter.LintWarnFunc)
 		return parseCopy(req)
 	case command.From:
 		if lintWarn != nil && !validStageNameCasing(req.args) {
-			short := fmt.Sprintf("Stage name '%s' should be lowercase", req.args[2])
-			lintWarn(linter.RuleStageNameCasing, short, node.Location())
+			msg := linter.RuleStageNameCasing.Format(req.args[2])
+			linter.RuleStageNameCasing.Run(lintWarn, node.Location(), msg)
 		}
 		return parseFrom(req)
 	case command.Onbuild:

--- a/frontend/dockerfile/instructions/parse.go
+++ b/frontend/dockerfile/instructions/parse.go
@@ -89,7 +89,7 @@ func ParseInstructionWithLinter(node *parser.Node, lintWarn linter.LintWarnFunc)
 	case command.Copy:
 		return parseCopy(req)
 	case command.From:
-		if lintWarn != nil && !isValidStageNameCasing(req.args) {
+		if lintWarn != nil && !isLowerCaseStageName(req.args) {
 			msg := linter.RuleStageNameCasing.Format(req.args[2])
 			linter.RuleStageNameCasing.Run(lintWarn, node.Location(), msg)
 		}
@@ -829,24 +829,12 @@ func allInstructionNames() []string {
 	return out
 }
 
-func isLowerCased(s string) bool {
-	return s == strings.ToLower(s)
-}
-
-func isUpperCased(s string) bool {
-	return s == strings.ToUpper(s)
-}
-
-func isConsistentCasing(s string) bool {
-	return isLowerCased(s) || isUpperCased(s)
-}
-
-func isValidStageNameCasing(cmdArgs []string) bool {
+func isLowerCaseStageName(cmdArgs []string) bool {
 	if len(cmdArgs) != 3 {
 		return true
 	}
 	stageName := cmdArgs[2]
-	return isLowerCased(stageName)
+	return stageName == strings.ToLower(stageName)
 }
 
 func doesFromCaseMatchAsCase(req parseRequest) bool {
@@ -856,12 +844,14 @@ func doesFromCaseMatchAsCase(req parseRequest) bool {
 	// consistent casing for the command is handled elsewhere.
 	// If the command is not consistent, there's no need to
 	// add an additional lint warning for the `as` argument.
-	if !isConsistentCasing(req.command) {
+	fromHasLowerCasing := req.command == strings.ToLower(req.command)
+	fromHasUpperCasing := req.command == strings.ToUpper(req.command)
+	if !fromHasLowerCasing && !fromHasUpperCasing {
 		return true
 	}
-	var lowerCaseCmd = isLowerCased(req.command)
-	if lowerCaseCmd {
-		return isLowerCased(req.args[1])
+
+	if fromHasLowerCasing {
+		return req.args[1] == strings.ToLower(req.args[1])
 	}
-	return isUpperCased(req.args[1])
+	return req.args[1] == strings.ToUpper(req.args[1])
 }

--- a/frontend/dockerfile/instructions/parse_test.go
+++ b/frontend/dockerfile/instructions/parse_test.go
@@ -161,8 +161,7 @@ ARG bar baz=123
 	ast, err := parser.Parse(bytes.NewBuffer([]byte(dt)))
 	require.NoError(t, err)
 
-	emptyCallback := func(short, url string, detail [][]byte, location *parser.Range) {}
-	stages, meta, err := Parse(ast.AST, emptyCallback)
+	stages, meta, err := Parse(ast.AST, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, "defines first stage", stages[0].Comment)

--- a/frontend/dockerfile/instructions/parse_test.go
+++ b/frontend/dockerfile/instructions/parse_test.go
@@ -161,7 +161,8 @@ ARG bar baz=123
 	ast, err := parser.Parse(bytes.NewBuffer([]byte(dt)))
 	require.NoError(t, err)
 
-	stages, meta, err := Parse(ast.AST)
+	emptyCallback := func(short, url string, detail [][]byte, location *parser.Range) {}
+	stages, meta, err := Parse(ast.AST, emptyCallback)
 	require.NoError(t, err)
 
 	require.Equal(t, "defines first stage", stages[0].Comment)

--- a/frontend/dockerfile/linter/linter.go
+++ b/frontend/dockerfile/linter/linter.go
@@ -1,0 +1,30 @@
+package linter
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+)
+
+type LinterRule[F any] struct {
+	Name        string
+	Description string
+	URL         string
+	Format      F
+}
+
+func (rule LinterRule[F]) Run(warn LintWarnFunc, location []parser.Range, txt ...string) {
+	startLine := 0
+	if len(location) > 0 {
+		startLine = location[0].Start.Line
+	}
+	if len(txt) == 0 {
+		txt = []string{rule.Description}
+	}
+	short := strings.Join(txt, " ")
+	short = fmt.Sprintf("Lint Rule '%s': %s (line %d)", rule.Name, short, startLine)
+	warn(short, rule.URL, [][]byte{[]byte(rule.Description)}, location)
+}
+
+type LintWarnFunc func(short, url string, detail [][]byte, location []parser.Range)

--- a/frontend/dockerfile/linter/ruleset.go
+++ b/frontend/dockerfile/linter/ruleset.go
@@ -1,110 +1,29 @@
 package linter
 
 import (
-	"strings"
-
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 )
 
-const (
-	RuleStageNameCasing = "StageNameCasing"
-	RuleFlagCasing      = "FlagCasing"
-	RuleCommandCasing   = "CommandCasing"
+var (
+	RuleStageNameCasing LinterRule = LinterRule{
+		Name:        "StageNameCasing",
+		Description: "Stage names should be lowercase",
+	}
+	RuleNoEmptyContinuations LinterRule = LinterRule{
+		Name:        "NoEmptyContinuations",
+		Description: "Empty continuation lines will become errors in a future release",
+		URL:         "https://github.com/moby/moby/pull/33719",
+	}
+	RuleCommandCasing LinterRule = LinterRule{
+		Name:        "CommandCasing",
+		Description: "Commands should be in consistent casing (all lower or all upper)",
+	}
 )
 
-var LinterRules map[string]LinterRule
-
 type LinterRule struct {
-	Short       string
+	Name        string
+	URL         string
 	Description string
 }
 
-type Warning struct {
-	Short    string        `json:"short"`
-	Detail   [][]byte      `json:"detail"`
-	Location *parser.Range `json:"location"`
-	Filename string        `json:"filename"`
-	Source   []string      `json:"source"`
-}
-
-func init() {
-	LinterRules = map[string]LinterRule{
-		RuleStageNameCasing: {
-			Short:       "Lowercase Staging Name",
-			Description: "Stage names should be lowercase",
-		},
-		RuleFlagCasing: {
-			Short:       "Lowercase Command Flags",
-			Description: "Flags should be lowercase",
-		},
-		RuleCommandCasing: {
-			Short:       "Inconsistent Command Casing",
-			Description: "Commands should be in consistent casing (all lower or all upper)",
-		},
-	}
-}
-
-func isUpperCase(s string) bool {
-	return s == strings.ToUpper(s)
-}
-
-func isLowerCase(s string) bool {
-	return s == strings.ToLower(s)
-}
-
-func consistentCasing(s string) bool {
-	return isUpperCase(s) || isLowerCase(s)
-}
-
-func ValidateStageNameCasing(cmdArgs []string) bool {
-	if len(cmdArgs) != 3 {
-		return true
-	}
-	stageName := cmdArgs[2]
-	return isLowerCase(stageName)
-}
-
-func ValidateFlagCasing(flags []string) bool {
-	for _, flag := range flags {
-		if !isLowerCase(flag) {
-			return false
-		}
-	}
-	return true
-}
-
-func ValidateCommandCasing(cmd string) bool {
-	return consistentCasing(cmd)
-}
-
-func ValidateNodeLintRules(node *parser.Node) []parser.Warning {
-	warnings := []parser.Warning{}
-	location := FirstNodeRange(node)
-	if !ValidateFlagCasing(node.Flags) {
-		flagCasing := LinterRules[RuleFlagCasing]
-		warnings = append(warnings, parser.Warning{
-			Short:    flagCasing.Short,
-			Detail:   [][]byte{[]byte(flagCasing.Description)},
-			Location: location,
-		})
-	}
-	if !ValidateCommandCasing(node.Value) {
-		commandCasing := LinterRules[RuleCommandCasing]
-		warnings = append(warnings, parser.Warning{
-			Short:    commandCasing.Short,
-			Detail:   [][]byte{[]byte(commandCasing.Description)},
-			Location: location,
-		})
-	}
-	return warnings
-}
-
-func FirstNodeRange(node *parser.Node) *parser.Range {
-	if len(node.Location()) > 0 {
-		return &node.Location()[0]
-	}
-	return &parser.Range{
-		Start: parser.Position{Line: node.StartLine},
-		End:   parser.Position{Line: node.EndLine},
-	}
-}
+type LintWarnFunc func(rule LinterRule, message string, location []parser.Range)

--- a/frontend/dockerfile/linter/ruleset.go
+++ b/frontend/dockerfile/linter/ruleset.go
@@ -12,6 +12,13 @@ var (
 			return fmt.Sprintf("Stage name '%s' should be lowercase", stageName)
 		},
 	}
+	RuleFromAsCasing = LinterRule[func(string, string) string]{
+		Name:        "FromAsCasing",
+		Description: "The 'as' keyword should match the case of the 'from' keyword",
+		Format: func(from, as string) string {
+			return fmt.Sprintf("'%s' and '%s' keywords' casing do not match", as, from)
+		},
+	}
 	RuleNoEmptyContinuations = LinterRule[func() string]{
 		Name:        "NoEmptyContinuations",
 		Description: "Empty continuation lines will become errors in a future release",

--- a/frontend/dockerfile/linter/ruleset.go
+++ b/frontend/dockerfile/linter/ruleset.go
@@ -1,0 +1,110 @@
+package linter
+
+import (
+	"strings"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+)
+
+const (
+	RuleStageNameCasing = "StageNameCasing"
+	RuleFlagCasing      = "FlagCasing"
+	RuleCommandCasing   = "CommandCasing"
+)
+
+var LinterRules map[string]LinterRule
+
+type LinterRule struct {
+	Short       string
+	Description string
+}
+
+type Warning struct {
+	Short    string        `json:"short"`
+	Detail   [][]byte      `json:"detail"`
+	Location *parser.Range `json:"location"`
+	Filename string        `json:"filename"`
+	Source   []string      `json:"source"`
+}
+
+func init() {
+	LinterRules = map[string]LinterRule{
+		RuleStageNameCasing: {
+			Short:       "Lowercase Staging Name",
+			Description: "Stage names should be lowercase",
+		},
+		RuleFlagCasing: {
+			Short:       "Lowercase Command Flags",
+			Description: "Flags should be lowercase",
+		},
+		RuleCommandCasing: {
+			Short:       "Inconsistent Command Casing",
+			Description: "Commands should be in consistent casing (all lower or all upper)",
+		},
+	}
+}
+
+func isUpperCase(s string) bool {
+	return s == strings.ToUpper(s)
+}
+
+func isLowerCase(s string) bool {
+	return s == strings.ToLower(s)
+}
+
+func consistentCasing(s string) bool {
+	return isUpperCase(s) || isLowerCase(s)
+}
+
+func ValidateStageNameCasing(cmdArgs []string) bool {
+	if len(cmdArgs) != 3 {
+		return true
+	}
+	stageName := cmdArgs[2]
+	return isLowerCase(stageName)
+}
+
+func ValidateFlagCasing(flags []string) bool {
+	for _, flag := range flags {
+		if !isLowerCase(flag) {
+			return false
+		}
+	}
+	return true
+}
+
+func ValidateCommandCasing(cmd string) bool {
+	return consistentCasing(cmd)
+}
+
+func ValidateNodeLintRules(node *parser.Node) []parser.Warning {
+	warnings := []parser.Warning{}
+	location := FirstNodeRange(node)
+	if !ValidateFlagCasing(node.Flags) {
+		flagCasing := LinterRules[RuleFlagCasing]
+		warnings = append(warnings, parser.Warning{
+			Short:    flagCasing.Short,
+			Detail:   [][]byte{[]byte(flagCasing.Description)},
+			Location: location,
+		})
+	}
+	if !ValidateCommandCasing(node.Value) {
+		commandCasing := LinterRules[RuleCommandCasing]
+		warnings = append(warnings, parser.Warning{
+			Short:    commandCasing.Short,
+			Detail:   [][]byte{[]byte(commandCasing.Description)},
+			Location: location,
+		})
+	}
+	return warnings
+}
+
+func FirstNodeRange(node *parser.Node) *parser.Range {
+	if len(node.Location()) > 0 {
+		return &node.Location()[0]
+	}
+	return &parser.Range{
+		Start: parser.Position{Line: node.StartLine},
+		End:   parser.Position{Line: node.EndLine},
+	}
+}

--- a/frontend/dockerfile/linter/ruleset.go
+++ b/frontend/dockerfile/linter/ruleset.go
@@ -37,8 +37,8 @@ var (
 	RuleFileConsistentCommandCasing = LinterRule[func(string, string) string]{
 		Name:        "FileConsistentCommandCasing",
 		Description: "All commands within the Dockerfile should use the same casing (either upper or lower)",
-		Format: func(firstCommand, violatingCommand string) string {
-			return fmt.Sprintf("Command '%s' should be consistently cased with '%s'", violatingCommand, firstCommand)
+		Format: func(violatingCommand, correctCasing string) string {
+			return fmt.Sprintf("Command '%s' should match the case of the command majority (%s)", violatingCommand, correctCasing)
 		},
 	}
 )

--- a/frontend/dockerfile/linter/ruleset.go
+++ b/frontend/dockerfile/linter/ruleset.go
@@ -1,29 +1,30 @@
 package linter
 
 import (
-	"github.com/moby/buildkit/frontend/dockerfile/parser"
+	"fmt"
 )
 
 var (
-	RuleStageNameCasing = LinterRule{
+	RuleStageNameCasing = LinterRule[func(string) string]{
 		Name:        "StageNameCasing",
 		Description: "Stage names should be lowercase",
+		Format: func(stageName string) string {
+			return fmt.Sprintf("Stage name '%s' should be lowercase", stageName)
+		},
 	}
-	RuleNoEmptyContinuations = LinterRule{
+	RuleNoEmptyContinuations = LinterRule[func() string]{
 		Name:        "NoEmptyContinuations",
 		Description: "Empty continuation lines will become errors in a future release",
 		URL:         "https://github.com/moby/moby/pull/33719",
+		Format: func() string {
+			return "Empty continuation line"
+		},
 	}
-	RuleCommandCasing = LinterRule{
+	RuleCommandCasing = LinterRule[func(string) string]{
 		Name:        "CommandCasing",
 		Description: "Commands should be in consistent casing (all lower or all upper)",
+		Format: func(command string) string {
+			return fmt.Sprintf("Command '%s' should be consistently cased", command)
+		},
 	}
 )
-
-type LinterRule struct {
-	Name        string
-	URL         string
-	Description string
-}
-
-type LintWarnFunc func(rule LinterRule, message string, location []parser.Range)

--- a/frontend/dockerfile/linter/ruleset.go
+++ b/frontend/dockerfile/linter/ruleset.go
@@ -5,16 +5,16 @@ import (
 )
 
 var (
-	RuleStageNameCasing LinterRule = LinterRule{
+	RuleStageNameCasing = LinterRule{
 		Name:        "StageNameCasing",
 		Description: "Stage names should be lowercase",
 	}
-	RuleNoEmptyContinuations LinterRule = LinterRule{
+	RuleNoEmptyContinuations = LinterRule{
 		Name:        "NoEmptyContinuations",
 		Description: "Empty continuation lines will become errors in a future release",
 		URL:         "https://github.com/moby/moby/pull/33719",
 	}
-	RuleCommandCasing LinterRule = LinterRule{
+	RuleCommandCasing = LinterRule{
 		Name:        "CommandCasing",
 		Description: "Commands should be in consistent casing (all lower or all upper)",
 	}

--- a/frontend/dockerfile/linter/ruleset.go
+++ b/frontend/dockerfile/linter/ruleset.go
@@ -27,11 +27,18 @@ var (
 			return "Empty continuation line"
 		},
 	}
-	RuleCommandCasing = LinterRule[func(string) string]{
-		Name:        "CommandCasing",
+	RuleSelfConsistentCommandCasing = LinterRule[func(string) string]{
+		Name:        "SelfConsistentCommandCasing",
 		Description: "Commands should be in consistent casing (all lower or all upper)",
 		Format: func(command string) string {
 			return fmt.Sprintf("Command '%s' should be consistently cased", command)
+		},
+	}
+	RuleFileConsistentCommandCasing = LinterRule[func(string, string) string]{
+		Name:        "FileConsistentCommandCasing",
+		Description: "All commands within the Dockerfile should use the same casing (either upper or lower)",
+		Format: func(firstCommand, violatingCommand string) string {
+			return fmt.Sprintf("Command '%s' should be consistently cased with '%s'", violatingCommand, firstCommand)
 		},
 	}
 )


### PR DESCRIPTION
We should define a set of rules for evaluating a good or bad Dockerfile. Create a method for evaluating the Dockerfile to ensure obvious issues are highlighted to the user.

This PR adds 3 additional lint warnings for the Dockerfile frontend:
- lowercased stage names
- lowercased command flag values
- consistently cased commands

These rules are definitely not the comprehensive list of linting warnings we should add, but instead represent an initial set, with more to come in additional PRs moving forward! 😄 

( This PR existed in a similar, previous PR #4751, but only implements the warnings. The additional `--print=lint` functionality will come in its own PR. 😄 )