### PR TITLE
Print lint warnings

### DIFF
--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -15,6 +15,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerui"
 	"github.com/moby/buildkit/frontend/gateway/client"
 	gwpb "github.com/moby/buildkit/frontend/gateway/pb"
+	"github.com/moby/buildkit/frontend/subrequests/lint"
 	"github.com/moby/buildkit/frontend/subrequests/outline"
 	"github.com/moby/buildkit/frontend/subrequests/targets"
 	"github.com/moby/buildkit/solver/errdefs"
@@ -84,6 +85,10 @@ func Build(ctx context.Context, c client.Client) (_ *client.Result, err error) {
 		},
 		ListTargets: func(ctx context.Context) (*targets.List, error) {
 			return dockerfile2llb.ListTargets(ctx, src.Data)
+		},
+		Lint: func(ctx context.Context) (*lint.LintResults, error) {
+			warnings, err := dockerfile2llb.DockerfileLint(ctx, src.Data, convertOpt)
+			return &lint.LintResults{Warnings: warnings}, err
 		},
 	}); err != nil {
 		return nil, err

--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -74,8 +74,8 @@ func Build(ctx context.Context, c client.Client) (_ *client.Result, err error) {
 		Client:       bc,
 		SourceMap:    src.SourceMap,
 		MetaResolver: c,
-		Warn: func(msg, url string, detail [][]byte, location []parser.Range) {
-			src.Warn(ctx, msg, warnOpts(location, detail, url))
+		Warn: func(rulename, description, url, msg string, location []parser.Range) {
+			src.Warn(ctx, msg, warnOpts(location, [][]byte{[]byte(description)}, url))
 		},
 	}
 

--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -87,8 +87,7 @@ func Build(ctx context.Context, c client.Client) (_ *client.Result, err error) {
 			return dockerfile2llb.ListTargets(ctx, src.Data)
 		},
 		Lint: func(ctx context.Context) (*lint.LintResults, error) {
-			warnings, err := dockerfile2llb.DockerfileLint(ctx, src.Data, convertOpt)
-			return &lint.LintResults{Warnings: warnings}, err
+			return dockerfile2llb.DockerfileLint(ctx, src.Data, convertOpt)
 		},
 	}); err != nil {
 		return nil, err

--- a/frontend/dockerfile/dockerfile_lint_test.go
+++ b/frontend/dockerfile/dockerfile_lint_test.go
@@ -1,0 +1,381 @@
+package dockerfile
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/containerd/continuity/fs/fstest"
+	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/frontend/dockerui"
+	gateway "github.com/moby/buildkit/frontend/gateway/client"
+
+	"github.com/moby/buildkit/frontend/subrequests/lint"
+	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/moby/buildkit/util/testutil/workers"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"github.com/tonistiigi/fsutil"
+)
+
+var lintTests = integration.TestFuncs(
+	testLintRequest,
+	testLintStageName,
+	testLintNoEmptyContinuations,
+)
+
+func testLintRequest(t *testing.T, sb integration.Sandbox) {
+	integration.SkipOnPlatform(t, "windows")
+	workers.CheckFeatureCompat(t, sb, workers.FeatureFrontendOutline)
+	f := getFrontend(t, sb)
+	if _, ok := f.(*clientFrontend); !ok {
+		t.Skip("only test with client frontend")
+	}
+
+	dockerfile := []byte(`
+	FROM scratch as target
+	COPY Dockerfile \
+
+	.
+	ARG inherited=box
+	copy Dockerfile /foo
+
+	FROM scratch AS target2
+	COPY Dockerfile /Dockerfile
+	`)
+
+	dir := integration.Tmpdir(
+		t,
+		fstest.CreateFile("Dockerfile", []byte(dockerfile), 0600),
+	)
+
+	c, err := client.New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	destDir, err := os.MkdirTemp("", "buildkit")
+	require.NoError(t, err)
+	defer os.RemoveAll(destDir)
+
+	called := false
+	frontend := func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
+		res, err := c.Solve(ctx, gateway.SolveRequest{
+			FrontendOpt: map[string]string{
+				"frontend.caps": "moby.buildkit.frontend.subrequests",
+				"requestid":     "frontend.lint",
+				"build-arg:BAR": "678",
+				"target":        "target",
+			},
+			Frontend: "dockerfile.v0",
+		})
+		require.NoError(t, err)
+
+		lintResults, err := unmarshalLintResults(res)
+		require.NoError(t, err)
+
+		require.Equal(t, 3, len(lintResults.Warnings))
+		sort.Slice(lintResults.Warnings, func(i, j int) bool {
+			// sort by line number in ascending order
+			return lintResults.Warnings[i].StartLine < lintResults.Warnings[j].StartLine
+		})
+		checkLintRequestWarnings(t, lintResults.Warnings, []lint.Warning{
+			{
+				RuleName:  "FromAsCasing",
+				Detail:    "'as' and 'FROM' keywords' casing do not match (line 2)",
+				Filename:  "Dockerfile",
+				StartLine: 2,
+				Source:    []string{"\tFROM scratch as target"},
+			},
+			{
+				RuleName:  "NoEmptyContinuations",
+				Detail:    "Empty continuation line (line 5)",
+				Filename:  "Dockerfile",
+				StartLine: 5,
+				Source:    []string{"\t."},
+			},
+			{
+				RuleName:  "FileConsistentCommandCasing",
+				Detail:    "Command 'copy' should match the case of the command majority (uppercase) (line 7)",
+				Filename:  "Dockerfile",
+				StartLine: 7,
+				Source:    []string{"\tcopy Dockerfile /foo"},
+			},
+		})
+		called = true
+		return nil, nil
+	}
+
+	_, err = c.Build(sb.Context(), client.SolveOpt{
+		LocalMounts: map[string]fsutil.FS{
+			dockerui.DefaultLocalNameDockerfile: dir,
+		},
+	}, "", frontend, nil)
+	require.NoError(t, err)
+
+	require.True(t, called)
+}
+
+func testLintStageName(t *testing.T, sb integration.Sandbox) {
+	dockerfile := []byte(`
+# warning: stage name should be lowercase
+FROM scratch AS BadStageName
+
+# warning: 'as' should match 'FROM' cmd casing.
+FROM scratch as base2
+
+FROM scratch AS base3
+`)
+	checkLinterWarnings(t, sb, dockerfile, []expectedLintWarning{
+		{
+			Short:  "Lint Rule 'StageNameCasing': Stage name 'BadStageName' should be lowercase (line 3)",
+			Detail: "Stage names should be lowercase",
+			Level:  1,
+		},
+		{
+			Short:  "Lint Rule 'FromAsCasing': 'as' and 'FROM' keywords' casing do not match (line 6)",
+			Detail: "The 'as' keyword should match the case of the 'from' keyword",
+			Level:  1,
+		},
+	})
+
+	dockerfile = []byte(`
+# warning: 'AS' should match 'from' cmd casing.
+from scratch AS base
+
+from scratch as base2
+`)
+	checkLinterWarnings(t, sb, dockerfile, []expectedLintWarning{
+		{
+			Short:  "Lint Rule 'FromAsCasing': 'AS' and 'from' keywords' casing do not match (line 3)",
+			Detail: "The 'as' keyword should match the case of the 'from' keyword",
+			Level:  1,
+		},
+	})
+}
+
+func testLintNoEmptyContinuations(t *testing.T, sb integration.Sandbox) {
+	dockerfile := []byte(`
+FROM scratch
+# warning: empty continuation line
+COPY Dockerfile \
+
+.
+COPY Dockerfile \
+.
+`)
+
+	checkLinterWarnings(t, sb, dockerfile, []expectedLintWarning{
+		{
+			Short:  "Lint Rule 'NoEmptyContinuations': Empty continuation line (line 6)",
+			Detail: "Empty continuation lines will become errors in a future release",
+			URL:    "https://github.com/moby/moby/pull/33719",
+			Level:  1,
+		},
+	})
+}
+
+func testSelfConsistentCommandCasing(t *testing.T, sb integration.Sandbox) {
+	dockerfile := []byte(`
+# warning: 'FROM' should be either lowercased or uppercased
+From scratch as base
+FROM scratch AS base2
+`)
+	checkLinterWarnings(t, sb, dockerfile, []expectedLintWarning{
+		{
+			Short:  "Lint Rule 'SelfConsistentCommandCasing': Command 'From' should be consistently cased (line 3)",
+			Detail: "Commands should be in consistent casing (all lower or all upper)",
+			Level:  1,
+		},
+	})
+	dockerfile = []byte(`
+# warning: 'FROM' should be either lowercased or uppercased
+frOM scratch as base
+from scratch as base2
+`)
+	checkLinterWarnings(t, sb, dockerfile, []expectedLintWarning{
+		{
+			Short:  "Lint Rule 'SelfConsistentCommandCasing': Command 'frOM' should be consistently cased (line 3)",
+			Detail: "Commands should be in consistent casing (all lower or all upper)",
+			Level:  1,
+		},
+	})
+}
+
+func testFileConsistentCommandCasing(t *testing.T, sb integration.Sandbox) {
+	dockerfile := []byte(`
+FROM scratch
+# warning: 'copy' should match command majority's casing (uppercase)
+copy Dockerfile /foo
+COPY Dockerfile /bar
+`)
+	checkLinterWarnings(t, sb, dockerfile, []expectedLintWarning{
+		{
+			Short:  "Lint Rule 'FileConsistentCommandCasing': Command 'copy' should match the case of the command majority (uppercase) (line 4)",
+			Detail: "All commands within the Dockerfile should use the same casing (either upper or lower)",
+			Level:  1,
+		},
+	})
+
+	dockerfile = []byte(`
+from scratch
+# warning: 'COPY' should match command majority's casing (lowercase)
+COPY Dockerfile /foo
+copy Dockerfile /bar
+`)
+	checkLinterWarnings(t, sb, dockerfile, []expectedLintWarning{
+		{
+			Short:  "Lint Rule 'FileConsistentCommandCasing': Command 'COPY' should match the case of the command majority (lowercase) (line 4)",
+			Detail: "All commands within the Dockerfile should use the same casing (either upper or lower)",
+			Level:  1,
+		},
+	})
+
+	dockerfile = []byte(`
+# warning: 'from' should match command majority's casing (uppercase)
+from scratch
+COPY Dockerfile /foo
+COPY Dockerfile /bar
+COPY Dockerfile /baz
+`)
+	checkLinterWarnings(t, sb, dockerfile, []expectedLintWarning{
+		{
+			Short:  "Lint Rule 'FileConsistentCommandCasing': Command 'from' should match the case of the command majority (uppercase) (line 3)",
+			Detail: "All commands within the Dockerfile should use the same casing (either upper or lower)",
+			Level:  1,
+		},
+	})
+
+	dockerfile = []byte(`
+# warning: 'FROM' should match command majority's casing (lowercase)
+FROM scratch
+copy Dockerfile /foo
+copy Dockerfile /bar
+copy Dockerfile /baz
+`)
+	checkLinterWarnings(t, sb, dockerfile, []expectedLintWarning{
+		{
+			Short:  "Lint Rule 'FileConsistentCommandCasing': Command 'FROM' should match the case of the command majority (lowercase) (line 3)",
+			Detail: "All commands within the Dockerfile should use the same casing (either upper or lower)",
+			Level:  1,
+		},
+	})
+
+	dockerfile = []byte(`
+from scratch
+copy Dockerfile /foo
+copy Dockerfile /bar
+`)
+	checkLinterWarnings(t, sb, dockerfile, []expectedLintWarning{})
+
+	dockerfile = []byte(`
+FROM scratch
+COPY Dockerfile /foo
+COPY Dockerfile /bar
+`)
+	checkLinterWarnings(t, sb, dockerfile, []expectedLintWarning{})
+}
+
+func checkLinterWarnings(t *testing.T, sb integration.Sandbox, dockerfile []byte, expected []expectedLintWarning) {
+	// As a note, this test depends on the `expected` lint
+	// warnings to be in order of appearance in the Dockerfile.
+
+	integration.SkipOnPlatform(t, "windows")
+	f := getFrontend(t, sb)
+
+	dir := integration.Tmpdir(
+		t,
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+	)
+
+	c, err := client.New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	status := make(chan *client.SolveStatus)
+	statusDone := make(chan struct{})
+	done := make(chan struct{})
+
+	var warnings []*client.VertexWarning
+
+	go func() {
+		defer close(statusDone)
+		for {
+			select {
+			case st, ok := <-status:
+				if !ok {
+					return
+				}
+				warnings = append(warnings, st.Warnings...)
+			case <-done:
+				return
+			}
+		}
+	}()
+
+	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
+		FrontendAttrs: map[string]string{
+			"platform": "linux/amd64,linux/arm64",
+		},
+		LocalMounts: map[string]fsutil.FS{
+			dockerui.DefaultLocalNameDockerfile: dir,
+			dockerui.DefaultLocalNameContext:    dir,
+		},
+	}, status)
+	require.NoError(t, err)
+
+	select {
+	case <-statusDone:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("timed out waiting for statusDone")
+	}
+
+	// two platforms only show one warning
+	require.Equal(t, len(expected), len(warnings))
+	sort.Slice(warnings, func(i, j int) bool {
+		w1 := warnings[i]
+		w2 := warnings[j]
+		if len(w1.Range) == 0 {
+			return true
+		} else if len(w2.Range) == 0 {
+			return false
+		}
+		return w1.Range[0].Start.Line < w2.Range[0].Start.Line
+	})
+	for i, w := range warnings {
+		require.Equal(t, expected[i].Short, string(w.Short))
+		require.Equal(t, expected[i].Detail, string(w.Detail[0]))
+		require.Equal(t, expected[i].URL, w.URL)
+		require.Equal(t, expected[i].Level, w.Level)
+	}
+}
+
+func checkLintRequestWarnings(t *testing.T, actual, expected []lint.Warning) {
+	require.Equal(t, len(expected), len(actual))
+
+	for i, expected := range expected {
+		actual := actual[i]
+		require.Equal(t, expected.RuleName, actual.RuleName)
+		require.Equal(t, expected.Detail, actual.Detail)
+		require.Equal(t, expected.Filename, actual.Filename)
+		require.Equal(t, expected.StartLine, actual.StartLine)
+		require.Equal(t, len(expected.Source), len(actual.Source))
+		for j, expectedSource := range expected.Source {
+			require.Equal(t, expectedSource, actual.Source[j])
+		}
+	}
+}
+
+func unmarshalLintResults(res *gateway.Result) (*lint.LintResults, error) {
+	dt, ok := res.Metadata["result.json"]
+	if !ok {
+		return nil, errors.Errorf("missing frontend.outline")
+	}
+	var l lint.LintResults
+	if err := json.Unmarshal(dt, &l); err != nil {
+		return nil, err
+	}
+	return &l, nil
+}

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -175,8 +175,6 @@ var allTests = integration.TestFuncs(
 	testDuplicatePlatformProvenance,
 	testDockerIgnoreMissingProvenance,
 	testSBOMScannerArgs,
-	testLintStageName,
-	testLintNoEmptyContinuations,
 	testSelfConsistentCommandCasing,
 	testFileConsistentCommandCasing,
 	testNilContextInSolveGateway,
@@ -247,6 +245,7 @@ func TestIntegration(t *testing.T) {
 			"granted": networkHostGranted,
 			"denied":  networkHostDenied,
 		}))...)
+	integration.Run(t, lintTests, opts...)
 	integration.Run(t, heredocTests, opts...)
 	integration.Run(t, outlineTests, opts...)
 	integration.Run(t, targetsTests, opts...)
@@ -6767,166 +6766,6 @@ ARG BUILDKIT_SBOM_SCAN_STAGE=true
 	require.Equal(t, 1, len(att.LayersRaw))
 }
 
-func testLintStageName(t *testing.T, sb integration.Sandbox) {
-	dockerfile := []byte(`
-# warning: stage name should be lowercase
-FROM scratch AS BadStageName
-
-# warning: 'as' should match 'FROM' cmd casing.
-FROM scratch as base2
-
-FROM scratch AS base3
-`)
-	checkLintWarnings(t, sb, dockerfile, []expectedLintWarning{
-		{
-			Short:  "Lint Rule 'StageNameCasing': Stage name 'BadStageName' should be lowercase (line 3)",
-			Detail: "Stage names should be lowercase",
-			Level:  1,
-		},
-		{
-			Short:  "Lint Rule 'FromAsCasing': 'as' and 'FROM' keywords' casing do not match (line 6)",
-			Detail: "The 'as' keyword should match the case of the 'from' keyword",
-			Level:  1,
-		},
-	})
-
-	dockerfile = []byte(`
-# warning: 'AS' should match 'from' cmd casing.
-from scratch AS base
-
-from scratch as base2
-`)
-	checkLintWarnings(t, sb, dockerfile, []expectedLintWarning{
-		{
-			Short:  "Lint Rule 'FromAsCasing': 'AS' and 'from' keywords' casing do not match (line 3)",
-			Detail: "The 'as' keyword should match the case of the 'from' keyword",
-			Level:  1,
-		},
-	})
-}
-
-func testLintNoEmptyContinuations(t *testing.T, sb integration.Sandbox) {
-	dockerfile := []byte(`
-FROM scratch
-# warning: empty continuation line
-COPY Dockerfile \
-
-.
-COPY Dockerfile \
-.
-`)
-
-	checkLintWarnings(t, sb, dockerfile, []expectedLintWarning{
-		{
-			Short:  "Lint Rule 'NoEmptyContinuations': Empty continuation line (line 6)",
-			Detail: "Empty continuation lines will become errors in a future release",
-			URL:    "https://github.com/moby/moby/pull/33719",
-			Level:  1,
-		},
-	})
-}
-
-func testSelfConsistentCommandCasing(t *testing.T, sb integration.Sandbox) {
-	dockerfile := []byte(`
-# warning: 'FROM' should be either lowercased or uppercased
-From scratch as base
-FROM scratch AS base2
-`)
-	checkLintWarnings(t, sb, dockerfile, []expectedLintWarning{
-		{
-			Short:  "Lint Rule 'SelfConsistentCommandCasing': Command 'From' should be consistently cased (line 3)",
-			Detail: "Commands should be in consistent casing (all lower or all upper)",
-			Level:  1,
-		},
-	})
-	dockerfile = []byte(`
-# warning: 'FROM' should be either lowercased or uppercased
-frOM scratch as base
-from scratch as base2
-`)
-	checkLintWarnings(t, sb, dockerfile, []expectedLintWarning{
-		{
-			Short:  "Lint Rule 'SelfConsistentCommandCasing': Command 'frOM' should be consistently cased (line 3)",
-			Detail: "Commands should be in consistent casing (all lower or all upper)",
-			Level:  1,
-		},
-	})
-}
-
-func testFileConsistentCommandCasing(t *testing.T, sb integration.Sandbox) {
-	dockerfile := []byte(`
-FROM scratch
-# warning: 'copy' should match command majority's casing (uppercase)
-copy Dockerfile /foo
-COPY Dockerfile /bar
-`)
-	checkLintWarnings(t, sb, dockerfile, []expectedLintWarning{
-		{
-			Short:  "Lint Rule 'FileConsistentCommandCasing': Command 'copy' should match the case of the command majority (uppercase) (line 4)",
-			Detail: "All commands within the Dockerfile should use the same casing (either upper or lower)",
-			Level:  1,
-		},
-	})
-
-	dockerfile = []byte(`
-from scratch
-# warning: 'COPY' should match command majority's casing (lowercase)
-COPY Dockerfile /foo
-copy Dockerfile /bar
-`)
-	checkLintWarnings(t, sb, dockerfile, []expectedLintWarning{
-		{
-			Short:  "Lint Rule 'FileConsistentCommandCasing': Command 'COPY' should match the case of the command majority (lowercase) (line 4)",
-			Detail: "All commands within the Dockerfile should use the same casing (either upper or lower)",
-			Level:  1,
-		},
-	})
-
-	dockerfile = []byte(`
-# warning: 'from' should match command majority's casing (uppercase)
-from scratch
-COPY Dockerfile /foo
-COPY Dockerfile /bar
-COPY Dockerfile /baz
-`)
-	checkLintWarnings(t, sb, dockerfile, []expectedLintWarning{
-		{
-			Short:  "Lint Rule 'FileConsistentCommandCasing': Command 'from' should match the case of the command majority (uppercase) (line 3)",
-			Detail: "All commands within the Dockerfile should use the same casing (either upper or lower)",
-			Level:  1,
-		},
-	})
-
-	dockerfile = []byte(`
-# warning: 'FROM' should match command majority's casing (lowercase)
-FROM scratch
-copy Dockerfile /foo
-copy Dockerfile /bar
-copy Dockerfile /baz
-`)
-	checkLintWarnings(t, sb, dockerfile, []expectedLintWarning{
-		{
-			Short:  "Lint Rule 'FileConsistentCommandCasing': Command 'FROM' should match the case of the command majority (lowercase) (line 3)",
-			Detail: "All commands within the Dockerfile should use the same casing (either upper or lower)",
-			Level:  1,
-		},
-	})
-
-	dockerfile = []byte(`
-from scratch
-copy Dockerfile /foo
-copy Dockerfile /bar
-`)
-	checkLintWarnings(t, sb, dockerfile, []expectedLintWarning{})
-
-	dockerfile = []byte(`
-FROM scratch
-COPY Dockerfile /foo
-COPY Dockerfile /bar
-`)
-	checkLintWarnings(t, sb, dockerfile, []expectedLintWarning{})
-}
-
 func testReproSourceDateEpoch(t *testing.T, sb integration.Sandbox) {
 	integration.SkipOnPlatform(t, "windows")
 	workers.CheckFeatureCompat(t, sb, workers.FeatureOCIExporter, workers.FeatureSourceDateEpoch)
@@ -7080,80 +6919,6 @@ COPY --link foo foo
 				require.Empty(t, l.Annotations["buildkit/rewritten-timestamp"])
 			}
 		})
-	}
-}
-
-func checkLintWarnings(t *testing.T, sb integration.Sandbox, dockerfile []byte, expected []expectedLintWarning) {
-	// As a note, this test depends on the `expected` lint
-	// warnings to be in order of appearance in the Dockerfile.
-
-	integration.SkipOnPlatform(t, "windows")
-	f := getFrontend(t, sb)
-
-	dir := integration.Tmpdir(
-		t,
-		fstest.CreateFile("Dockerfile", dockerfile, 0600),
-	)
-
-	c, err := client.New(sb.Context(), sb.Address())
-	require.NoError(t, err)
-	defer c.Close()
-
-	status := make(chan *client.SolveStatus)
-	statusDone := make(chan struct{})
-	done := make(chan struct{})
-
-	var warnings []*client.VertexWarning
-
-	go func() {
-		defer close(statusDone)
-		for {
-			select {
-			case st, ok := <-status:
-				if !ok {
-					return
-				}
-				warnings = append(warnings, st.Warnings...)
-			case <-done:
-				return
-			}
-		}
-	}()
-
-	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
-		FrontendAttrs: map[string]string{
-			"platform": "linux/amd64,linux/arm64",
-		},
-		LocalMounts: map[string]fsutil.FS{
-			dockerui.DefaultLocalNameDockerfile: dir,
-			dockerui.DefaultLocalNameContext:    dir,
-		},
-	}, status)
-	require.NoError(t, err)
-
-	select {
-	case <-statusDone:
-	case <-time.After(10 * time.Second):
-		t.Fatalf("timed out waiting for statusDone")
-	}
-
-	// two platforms only show one warning
-	require.Equal(t, len(expected), len(warnings))
-	sort.Slice(warnings, func(i, j int) bool {
-		w1 := warnings[i]
-		w2 := warnings[j]
-		if len(w1.Range) == 0 {
-			return true
-		} else if len(w2.Range) == 0 {
-			return false
-		}
-		return w1.Range[0].Start.Line < w2.Range[0].Start.Line
-	})
-	for i, w := range warnings {
-		require.Equal(t, expected[i].Short, string(w.Short))
-		require.Equal(t, expected[i].Detail, string(w.Detail[0]))
-		require.Equal(t, expected[i].URL, w.URL)
-		require.Equal(t, expected[i].Level, w.Level)
 	}
 }
 

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -175,8 +175,6 @@ var allTests = integration.TestFuncs(
 	testDuplicatePlatformProvenance,
 	testDockerIgnoreMissingProvenance,
 	testSBOMScannerArgs,
-	testSelfConsistentCommandCasing,
-	testFileConsistentCommandCasing,
 	testNilContextInSolveGateway,
 	testCopyUnicodePath,
 	testFrontendDeduplicateSources,

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -7300,13 +7300,6 @@ type nopWriteCloser struct {
 
 func (nopWriteCloser) Close() error { return nil }
 
-type expectedLintWarning struct {
-	Short  string
-	Detail string
-	URL    string
-	Level  int
-}
-
 type secModeSandbox struct{}
 
 func (*secModeSandbox) UpdateConfigFile(in string) string {

--- a/frontend/dockerfile/linter/linter.go
+++ b/frontend/dockerfile/linter/linter.go
@@ -22,9 +22,12 @@ func (rule LinterRule[F]) Run(warn LintWarnFunc, location []parser.Range, txt ..
 	if len(txt) == 0 {
 		txt = []string{rule.Description}
 	}
-	short := strings.Join(txt, " ")
-	short = fmt.Sprintf("Lint Rule '%s': %s (line %d)", rule.Name, short, startLine)
-	warn(short, rule.URL, [][]byte{[]byte(rule.Description)}, location)
+	short := LintFormatShort(rule.Name, strings.Join(txt, " "), startLine)
+	warn(rule.Name, rule.Description, rule.URL, short, location)
 }
 
-type LintWarnFunc func(short, url string, detail [][]byte, location []parser.Range)
+func LintFormatShort(rulename, msg string, startLine int) string {
+	return fmt.Sprintf("Lint Rule '%s': %s (line %d)", rulename, msg, startLine)
+}
+
+type LintWarnFunc func(rulename, description, url, fmtmsg string, location []parser.Range)

--- a/frontend/subrequests/lint/lint.go
+++ b/frontend/subrequests/lint/lint.go
@@ -1,0 +1,93 @@
+package lint
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/frontend/subrequests"
+)
+
+const RequestLint = "frontend.lint"
+
+var SubrequestLintDefinition = subrequests.Request{
+	Name:        RequestLint,
+	Version:     "1.0.0",
+	Type:        subrequests.TypeRPC,
+	Description: "Lint a Dockerfile",
+	Opts:        []subrequests.Named{},
+	Metadata: []subrequests.Named{
+		{Name: "result.json"},
+		{Name: "result.txt"},
+	},
+}
+
+type Warning struct {
+	RuleName  string   `json:"rule_name"`
+	Detail    string   `json:"detail"`
+	Filename  string   `json:"filename"`
+	Source    []string `json:"source"`
+	StartLine int      `json:"start_line"`
+}
+
+type LintResults struct {
+	Warnings []Warning `json:"warnings"`
+}
+
+func (warns LintResults) ToResult() (*client.Result, error) {
+	res := client.NewResult()
+	dt, err := json.MarshalIndent(warns, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	res.AddMeta("result.json", dt)
+
+	b := bytes.NewBuffer(nil)
+	if err := PrintLintViolations(dt, b); err != nil {
+		return nil, err
+	}
+	res.AddMeta("result.txt", b.Bytes())
+
+	res.AddMeta("version", []byte(SubrequestLintDefinition.Version))
+	return res, nil
+}
+
+func PrintLintViolations(dt []byte, w io.Writer) error {
+	var warnings LintResults
+
+	if err := json.Unmarshal(dt, &warnings); err != nil {
+		return err
+	}
+
+	// Here, we're grouping the warnings by rule name
+	lintWarnings := make(map[string][]Warning)
+	lintWarningRules := []string{}
+	for _, warning := range warnings.Warnings {
+		if _, ok := lintWarnings[warning.RuleName]; !ok {
+			lintWarningRules = append(lintWarningRules, warning.RuleName)
+			lintWarnings[warning.RuleName] = []Warning{}
+		}
+		lintWarnings[warning.RuleName] = append(lintWarnings[warning.RuleName], warning)
+	}
+	sort.Strings(lintWarningRules)
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	for _, rule := range lintWarningRules {
+		fmt.Fprintf(tw, "Lint Rule %s\n", rule)
+		for _, warning := range lintWarnings[rule] {
+			fmt.Fprintf(tw, "\t%s:%d\n", warning.Filename, warning.StartLine)
+			fmt.Fprintf(tw, "\t%s\n", warning.Detail)
+			for offset, source := range warning.Source {
+				fmt.Fprintf(tw, "\t\t%d\t|\t%s\n", warning.StartLine+offset, source)
+			}
+			fmt.Fprintln(tw)
+		}
+		fmt.Fprintln(tw)
+	}
+
+	return tw.Flush()
+}


### PR DESCRIPTION
Following on the footsteps of #4759, this adds support for an additional subrequest frontends can choose to implement for exposing linting errors and implements this subrequest for the `dockerfile` frontend.