### PR TITLE
Add bounds to termHeight when BUILDKIT_TTY_LOG_LINES is set

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/tonistiigi/go-actions-cache v0.0.0-20240320205438-9794bdbb2fb4
 	github.com/tonistiigi/go-archvariant v1.0.0
 	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea
-	github.com/tonistiigi/vt100 v0.0.0-20230623042737-f9a4f7ef6531
+	github.com/tonistiigi/vt100 v0.0.0-20240514184818-90bafcd6abab
 	github.com/urfave/cli v1.22.14
 	github.com/vishvananda/netlink v1.2.1-beta.2
 	go.etcd.io/bbolt v1.3.9

--- a/go.sum
+++ b/go.sum
@@ -402,8 +402,8 @@ github.com/tonistiigi/go-archvariant v1.0.0 h1:5LC1eDWiBNflnTF1prCiX09yfNHIxDC/a
 github.com/tonistiigi/go-archvariant v1.0.0/go.mod h1:TxFmO5VS6vMq2kvs3ht04iPXtu2rUT/erOnGFYfk5Ho=
 github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea h1:SXhTLE6pb6eld/v/cCndK0AMpt1wiVFb/YYmqB3/QG0=
 github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea/go.mod h1:WPnis/6cRcDZSUvVmezrxJPkiO87ThFYsoUiMwWNDJk=
-github.com/tonistiigi/vt100 v0.0.0-20230623042737-f9a4f7ef6531 h1:Y/M5lygoNPKwVNLMPXgVfsRT40CSFKXCxuU8LoHySjs=
-github.com/tonistiigi/vt100 v0.0.0-20230623042737-f9a4f7ef6531/go.mod h1:ulncasL3N9uLrVann0m+CDlJKWsIAP34MPcOJF6VRvc=
+github.com/tonistiigi/vt100 v0.0.0-20240514184818-90bafcd6abab h1:H6aJ0yKQ0gF49Qb2z5hI1UHxSQt4JMyxebFR15KnApw=
+github.com/tonistiigi/vt100 v0.0.0-20240514184818-90bafcd6abab/go.mod h1:ulncasL3N9uLrVann0m+CDlJKWsIAP34MPcOJF6VRvc=
 github.com/urfave/cli v1.22.14 h1:ebbhrRiGK2i4naQJr+1Xj92HXZCrK7MsyTS/ob3HnAk=
 github.com/urfave/cli v1.22.14/go.mod h1:X0eDS6pD6Exaclxm99NJ3FiCDRED7vIHpx2mDOHLvkA=
 github.com/vbatts/tar-split v0.11.5 h1:3bHCTIheBm1qFTcgh9oPu+nNBtX+XJIupG/vacinCts=

--- a/util/progress/progressui/display.go
+++ b/util/progress/progressui/display.go
@@ -743,6 +743,7 @@ func (t *trace) update(s *client.SolveStatus, termWidth int) {
 		v.jobCached = false
 		if v.term != nil {
 			if v.term.Width != termWidth {
+				termHeight = max(termHeightMin, min(termHeightInitial, v.term.Height-termHeightMin-1))
 				v.term.Resize(termHeight, termWidth-termPad)
 			}
 			v.termBytes += len(l.Data)
@@ -956,6 +957,7 @@ func setupTerminals(jobs []*job, height int, all bool) []*job {
 
 	numFree := height - 2 - numInUse
 	numToHide := 0
+	termHeight = max(termHeightMin, min(termHeightInitial, height-termHeightMin-1))
 	termLimit := termHeight + 3
 
 	for i := 0; numFree > termLimit && i < len(candidates); i++ {

--- a/util/progress/progressui/init.go
+++ b/util/progress/progressui/init.go
@@ -13,7 +13,10 @@ var colorCancel aec.ANSI
 var colorWarning aec.ANSI
 var colorError aec.ANSI
 
-var termHeight = 6
+const termHeightMin = 6
+
+var termHeightInitial = termHeightMin
+var termHeight = termHeightMin
 
 func init() {
 	// As recommended on https://no-color.org/
@@ -43,6 +46,7 @@ func init() {
 	if termHeightStr != "" {
 		termHeightVal, err := strconv.Atoi(termHeightStr)
 		if err == nil && termHeightVal > 0 {
+			termHeightInitial = termHeightVal
 			termHeight = termHeightVal
 		}
 	}

--- a/vendor/github.com/tonistiigi/vt100/vt100.go
+++ b/vendor/github.com/tonistiigi/vt100/vt100.go
@@ -200,6 +200,7 @@ func (v *VT100) Resize(y, x int) {
 		v.Height = y
 	} else if y < v.Height {
 		v.Content = v.Content[:y]
+		v.Format = v.Format[:y]
 		v.Height = y
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -776,7 +776,7 @@ github.com/tonistiigi/go-archvariant
 # github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea
 ## explicit
 github.com/tonistiigi/units
-# github.com/tonistiigi/vt100 v0.0.0-20230623042737-f9a4f7ef6531
+# github.com/tonistiigi/vt100 v0.0.0-20240514184818-90bafcd6abab
 ## explicit; go 1.12
 github.com/tonistiigi/vt100
 # github.com/urfave/cli v1.22.14


### PR DESCRIPTION
In order to print tty output, the termHeight for the vt100 module needs to be between 6 and (current window size - 7).

Fixes #4766.