### PR TITLE
rawjson output: remove indent so that every message is printed in one line

### DIFF
--- a/util/progress/progressui/display.go
+++ b/util/progress/progressui/display.go
@@ -285,7 +285,6 @@ type rawJSONDisplay struct {
 // output of status update events.
 func newRawJSONDisplay(w io.Writer, opts ...DisplayOpt) Display {
 	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
 	return Display{
 		disp: &rawJSONDisplay{
 			enc: enc,


### PR DESCRIPTION
Fixes #4769.