### PR TITLE
remotecache: fix missing CheckDescriptor method

### DIFF
--- a/cache/remotecache/v1/chains.go
+++ b/cache/remotecache/v1/chains.go
@@ -122,6 +122,8 @@ type DescriptorProviderPair struct {
 	Provider   content.Provider
 }
 
+var _ withCheckDescriptor = DescriptorProviderPair{}
+
 func (p DescriptorProviderPair) ReaderAt(ctx context.Context, desc ocispecs.Descriptor) (content.ReaderAt, error) {
 	return p.Provider.ReaderAt(ctx, desc)
 }
@@ -152,6 +154,13 @@ func (p DescriptorProviderPair) SnapshotLabels(descs []ocispecs.Descriptor, inde
 	}
 	if cd, ok := p.Provider.(snapshotLabels); ok {
 		return cd.SnapshotLabels(descs, index)
+	}
+	return nil
+}
+
+func (p DescriptorProviderPair) CheckDescriptor(ctx context.Context, desc ocispecs.Descriptor) error {
+	if cd, ok := p.Provider.(withCheckDescriptor); ok {
+		return cd.CheckDescriptor(ctx, desc)
 	}
 	return nil
 }

--- a/cache/remotecache/v1/utils.go
+++ b/cache/remotecache/v1/utils.go
@@ -12,6 +12,11 @@ import (
 	"github.com/pkg/errors"
 )
 
+type withCheckDescriptor interface {
+	// CheckDescriptor is additional method on Provider to check if the descriptor is available without opening the reader
+	CheckDescriptor(context.Context, ocispecs.Descriptor) error
+}
+
 // sortConfig sorts the config structure to make sure it is deterministic
 func sortConfig(cc *CacheConfig) {
 	type indexedLayer struct {
@@ -279,9 +284,7 @@ func marshalRemote(ctx context.Context, r *solver.Remote, state *marshalState) s
 		return ""
 	}
 
-	if cd, ok := r.Provider.(interface {
-		CheckDescriptor(context.Context, ocispecs.Descriptor) error
-	}); ok && len(r.Descriptors) > 0 {
+	if cd, ok := r.Provider.(withCheckDescriptor); ok && len(r.Descriptors) > 0 {
 		for _, d := range r.Descriptors {
 			if cd.CheckDescriptor(ctx, d) != nil {
 				return ""


### PR DESCRIPTION
fixes #4765

This method is needed by GHA cache backend to detect if Github deletes blobs from the cache because of
storage caps. It went missing when Info() support was added in #4558 for the same issue as https://github.com/moby/buildkit/pull/4558#discussion_r1502053565 . Later #4694 added back stargz method but not `CheckDescriptor`.

Overall we need to find a safer approach to this, especially because it is impossible to test because of being controlled by Github's storage. For this case, I think `CheckDescriptor` is not really needed anymore but can be replaced with `Info()` as commented in https://github.com/moby/buildkit/pull/4558#discussion_r1483429940 . But the stragz methods should not rely on interface detection either. The current PR is the minimal change that we can pick to v0.13 branch.

@vvoland @ktock 

@gibsondan and others, please confirm your build was importing cache from GHA.
