### PR TITLE
solver: stub out sysSampler close

### DIFF
--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -125,8 +125,10 @@ func New(opt Opt) (*Solver, error) {
 
 func (s *Solver) Close() error {
 	s.solver.Close()
-	err := s.sysSampler.Close()
-	return err
+	if s.sysSampler != nil {
+		return s.sysSampler.Close()
+	}
+	return nil
 }
 
 func (s *Solver) resolver() solver.ResolveOpFunc {


### PR DESCRIPTION
Fixes https://github.com/moby/buildkit/issues/4774.

Follow-up to https://github.com/moby/buildkit/pull/4040 (cc @thaJeztah) - this didn't resolve the access to `sysSampler.Close`, we need to stub this one out as well!