### PR TITLE
git: ensure file-looking git refs aren't parsed as URLs

### DIFF
--- a/util/gitutil/git_ref.go
+++ b/util/gitutil/git_ref.go
@@ -57,7 +57,9 @@ func ParseGitRef(ref string) (*GitRef, error) {
 		err    error
 	)
 
-	if strings.HasPrefix(ref, "github.com/") {
+	if strings.HasPrefix(ref, "./") || strings.HasPrefix(ref, "../") {
+		return nil, errdefs.ErrInvalidArgument
+	} else if strings.HasPrefix(ref, "github.com/") {
 		res.IndistinguishableFromLocal = true // Deprecated
 		remote = fromURL(&url.URL{
 			Scheme: "https",

--- a/util/gitutil/git_ref_test.go
+++ b/util/gitutil/git_ref_test.go
@@ -133,12 +133,21 @@ func TestParseGitRef(t *testing.T) {
 				SubDir:    "myfolder",
 			},
 		},
+		{
+			ref:      "./.git",
+			expected: nil,
+		},
+		{
+			ref:      ".git",
+			expected: nil,
+		},
 	}
 	for _, tt := range cases {
 		tt := tt
 		t.Run(tt.ref, func(t *testing.T) {
 			got, err := ParseGitRef(tt.ref)
 			if tt.expected == nil {
+				require.Nil(t, got)
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)


### PR DESCRIPTION
Fixes https://github.com/moby/buildkit/pull/4326#issuecomment-2000436261 (thanks @stephanos! :tada:)

URLs that look like `./path/to/file` and `../path/to/file` definitely aren't git URLs - so we should bail out early.

This was causing a weird issue where if you copied `./.git` this would be detected as a valid url parsing with `host = "."` and `path = "/git"`. The fix for this is to make sure that for these explicit file-like paths, we *never* parse them as url-refs.

Also some tests to make sure this doesn't break again!