### PR TITLE
oci: make mounting oci socket optional

### DIFF
--- a/executor/oci/spec.go
+++ b/executor/oci/spec.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"context"
+	"os"
 	"path"
 	"path/filepath"
 	"runtime"
@@ -197,8 +198,11 @@ func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mou
 	}
 
 	if tracingSocket != "" {
-		if mount := getTracingSocketMount(tracingSocket); mount != nil {
-			s.Mounts = append(s.Mounts, *mount)
+		// moby/buildkit#4764
+		if _, err := os.Stat(tracingSocket); err == nil {
+			if mount := getTracingSocketMount(tracingSocket); mount != nil {
+				s.Mounts = append(s.Mounts, *mount)
+			}
 		}
 	}
 


### PR DESCRIPTION
mitigation for https://github.com/moby/buildkit/issues/4764

The source path changed in v0.13 and there are reports that new path can cause error on starting a container. While this is investigated, check for missing path and make mounting optional like it was in v0.12.