### PR TITLE
remotecache: replace CheckDescriptor with Info

### DIFF
--- a/cache/remote.go
+++ b/cache/remote.go
@@ -313,10 +313,22 @@ func (p lazyRefProvider) Info(ctx context.Context, dgst digest.Digest) (content.
 	if dgst != p.desc.Digest {
 		return content.Info{}, errdefs.ErrNotFound
 	}
-	if err := p.Unlazy(ctx); err != nil {
-		return content.Info{}, errdefs.ErrNotFound
+	info, err := p.ref.cm.ContentStore.Info(ctx, dgst)
+	if err == nil {
+		return info, nil
 	}
-	return p.ref.cm.ContentStore.Info(ctx, dgst)
+
+	if isLazy, err1 := p.ref.isLazy(ctx); err1 != nil {
+		return content.Info{}, err1
+	} else if !isLazy {
+		return content.Info{}, err
+	}
+
+	// for lazy records don't unlazy without read request
+	return content.Info{
+		Digest: p.desc.Digest,
+		Size:   p.desc.Size,
+	}, nil
 }
 
 func (p lazyRefProvider) Unlazy(ctx context.Context) error {

--- a/cache/remotecache/v1/utils.go
+++ b/cache/remotecache/v1/utils.go
@@ -8,14 +8,8 @@ import (
 	"github.com/moby/buildkit/solver"
 	"github.com/moby/buildkit/util/bklog"
 	digest "github.com/opencontainers/go-digest"
-	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
-
-type withCheckDescriptor interface {
-	// CheckDescriptor is additional method on Provider to check if the descriptor is available without opening the reader
-	CheckDescriptor(context.Context, ocispecs.Descriptor) error
-}
 
 // sortConfig sorts the config structure to make sure it is deterministic
 func sortConfig(cc *CacheConfig) {
@@ -284,13 +278,14 @@ func marshalRemote(ctx context.Context, r *solver.Remote, state *marshalState) s
 		return ""
 	}
 
-	if cd, ok := r.Provider.(withCheckDescriptor); ok && len(r.Descriptors) > 0 {
+	if r.Provider != nil {
 		for _, d := range r.Descriptors {
-			if cd.CheckDescriptor(ctx, d) != nil {
+			if _, err := r.Provider.Info(ctx, d.Digest); err != nil {
 				return ""
 			}
 		}
 	}
+
 	var parentID string
 	if len(r.Descriptors) > 1 {
 		r2 := &solver.Remote{

--- a/util/contentutil/multiprovider.go
+++ b/util/contentutil/multiprovider.go
@@ -51,26 +51,6 @@ func (mp *MultiProvider) SnapshotLabels(descs []ocispecs.Descriptor, index int) 
 	return nil
 }
 
-func (mp *MultiProvider) CheckDescriptor(ctx context.Context, desc ocispecs.Descriptor) error {
-	type checkDescriptor interface {
-		CheckDescriptor(context.Context, ocispecs.Descriptor) error
-	}
-
-	mp.mu.RLock()
-	if p, ok := mp.sub[desc.Digest]; ok {
-		mp.mu.RUnlock()
-		if cd, ok := p.(checkDescriptor); ok {
-			return cd.CheckDescriptor(ctx, desc)
-		}
-	} else {
-		mp.mu.RUnlock()
-	}
-	if cd, ok := mp.base.(checkDescriptor); ok {
-		return cd.CheckDescriptor(ctx, desc)
-	}
-	return nil
-}
-
 // ReaderAt returns a content.ReaderAt
 func (mp *MultiProvider) ReaderAt(ctx context.Context, desc ocispecs.Descriptor) (content.ReaderAt, error) {
 	mp.mu.RLock()

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -472,14 +472,12 @@ func (w *Worker) Exporter(name string, sm *session.Manager) (exporter.Exporter, 
 }
 
 func (w *Worker) FromRemote(ctx context.Context, remote *solver.Remote) (ref cache.ImmutableRef, err error) {
-	if cd, ok := remote.Provider.(interface {
-		CheckDescriptor(context.Context, ocispecs.Descriptor) error
-	}); ok && len(remote.Descriptors) > 0 {
+	if len(remote.Descriptors) > 0 {
 		var eg errgroup.Group
 		for _, desc := range remote.Descriptors {
 			desc := desc
 			eg.Go(func() error {
-				if err := cd.CheckDescriptor(ctx, desc); err != nil {
+				if _, err := remote.Provider.Info(ctx, desc.Digest); err != nil {
 					return err
 				}
 				return nil


### PR DESCRIPTION
This tries to replace the `CheckDescriptor` interface detection with the `Info()` method that was added in v0.13 to the provider to avoid cases like https://github.com/moby/buildkit/pull/4771 .