### PR TITLE
gha: add support for batch checking existing keys

### DIFF
--- a/cache/remotecache/gha/gha.go
+++ b/cache/remotecache/gha/gha.go
@@ -33,20 +33,24 @@ func init() {
 }
 
 const (
-	attrScope   = "scope"
-	attrTimeout = "timeout"
-	attrToken   = "token"
-	attrURL     = "url"
-	version     = "1"
+	attrScope      = "scope"
+	attrTimeout    = "timeout"
+	attrToken      = "token"
+	attrURL        = "url"
+	attrRepository = "repository"
+	attrGHToken    = "ghtoken"
+	version        = "1"
 
 	defaultTimeout = 10 * time.Minute
 )
 
 type Config struct {
-	Scope   string
-	URL     string
-	Token   string
-	Timeout time.Duration
+	Scope      string
+	URL        string
+	Token      string // token for the Github Cache runtime API
+	GHToken    string // token for the Github REST API
+	Repository string
+	Timeout    time.Duration
 }
 
 func getConfig(attrs map[string]string) (*Config, error) {
@@ -62,6 +66,7 @@ func getConfig(attrs map[string]string) (*Config, error) {
 	if !ok {
 		return nil, errors.Errorf("token not set for github actions cache")
 	}
+
 	timeout := defaultTimeout
 	if v, ok := attrs[attrTimeout]; ok {
 		var err error
@@ -71,10 +76,12 @@ func getConfig(attrs map[string]string) (*Config, error) {
 		}
 	}
 	return &Config{
-		Scope:   scope,
-		URL:     url,
-		Token:   token,
-		Timeout: timeout,
+		Scope:      scope,
+		URL:        url,
+		Token:      token,
+		Timeout:    timeout,
+		GHToken:    attrs[attrGHToken],
+		Repository: attrs[attrRepository],
 	}, nil
 }
 
@@ -91,9 +98,11 @@ func ResolveCacheExporterFunc() remotecache.ResolveCacheExporterFunc {
 
 type exporter struct {
 	solver.CacheExporterTarget
-	chains *v1.CacheChains
-	cache  *actionscache.Cache
-	config *Config
+	chains     *v1.CacheChains
+	cache      *actionscache.Cache
+	config     *Config
+	keyMapOnce sync.Once
+	keyMap     map[string]struct{}
 }
 
 func NewExporter(c *Config) (remotecache.Exporter, error) {
@@ -118,8 +127,12 @@ func (ce *exporter) Config() remotecache.Config {
 	}
 }
 
+func (ce *exporter) blobKeyPrefix() string {
+	return "buildkit-blob-" + version + "-"
+}
+
 func (ce *exporter) blobKey(dgst digest.Digest) string {
-	return "buildkit-blob-" + version + "-" + dgst.String()
+	return ce.blobKeyPrefix() + dgst.String()
 }
 
 func (ce *exporter) indexKey() string {
@@ -131,6 +144,35 @@ func (ce *exporter) indexKey() string {
 	}
 	scope = digest.FromBytes([]byte(scope)).Hex()[:8]
 	return "index-" + ce.config.Scope + "-" + version + "-" + scope
+}
+
+func (ce *exporter) initActiveKeyMap(ctx context.Context) {
+	ce.keyMapOnce.Do(func() {
+		if ce.config.Repository == "" || ce.config.GHToken == "" {
+			return
+		}
+		m, err := ce.initActiveKeyMapOnce(ctx)
+		if err != nil {
+			bklog.G(ctx).Errorf("error initializing active key map: %v", err)
+			return
+		}
+		ce.keyMap = m
+	})
+}
+
+func (ce *exporter) initActiveKeyMapOnce(ctx context.Context) (map[string]struct{}, error) {
+	api, err := actionscache.NewRestAPI(ce.config.Repository, ce.config.GHToken, actionscache.Opt{
+		Client:  tracing.DefaultClient,
+		Timeout: ce.config.Timeout,
+	})
+	if err != nil {
+		return nil, err
+	}
+	keys, err := ce.cache.AllKeys(ctx, api, ce.blobKeyPrefix())
+	if err != nil {
+		return nil, err
+	}
+	return keys, nil
 }
 
 func (ce *exporter) Finalize(ctx context.Context) (map[string]string, error) {
@@ -159,13 +201,25 @@ func (ce *exporter) Finalize(ctx context.Context) (map[string]string, error) {
 			return nil, errors.Wrapf(err, "failed to parse uncompressed annotation")
 		}
 		diffID = dgst
+		ce.initActiveKeyMap(ctx)
 
 		key := ce.blobKey(dgstPair.Descriptor.Digest)
-		b, err := ce.cache.Load(ctx, key)
-		if err != nil {
-			return nil, err
+
+		exists := false
+		if ce.keyMap != nil {
+			if _, ok := ce.keyMap[key]; ok {
+				exists = true
+			}
+		} else {
+			b, err := ce.cache.Load(ctx, key)
+			if err != nil {
+				return nil, err
+			}
+			if b != nil {
+				exists = true
+			}
 		}
-		if b == nil {
+		if !exists {
 			layerDone := progress.OneOff(ctx, fmt.Sprintf("writing layer %s", l.Blob))
 			ra, err := dgstPair.Provider.ReaderAt(ctx, dgstPair.Descriptor)
 			if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/spdx/tools-golang v0.5.3
 	github.com/stretchr/testify v1.8.4
 	github.com/tonistiigi/fsutil v0.0.0-20240301111122-7525a1af2bb5
-	github.com/tonistiigi/go-actions-cache v0.0.0-20240227172821-a0b64f338598
+	github.com/tonistiigi/go-actions-cache v0.0.0-20240320205438-9794bdbb2fb4
 	github.com/tonistiigi/go-archvariant v1.0.0
 	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea
 	github.com/tonistiigi/vt100 v0.0.0-20230623042737-f9a4f7ef6531

--- a/go.sum
+++ b/go.sum
@@ -404,8 +404,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/tonistiigi/fsutil v0.0.0-20240301111122-7525a1af2bb5 h1:oZS8KCqAg62sxJkEq/Ppzqrb6EooqzWtL8Oaex7bc5c=
 github.com/tonistiigi/fsutil v0.0.0-20240301111122-7525a1af2bb5/go.mod h1:vbbYqJlnswsbJqWUcJN8fKtBhnEgldDrcagTgnBVKKM=
-github.com/tonistiigi/go-actions-cache v0.0.0-20240227172821-a0b64f338598 h1:DA/NDC0YbMdnfcOSUzAnbUZE6dSM54d+0hrBqG+bOfs=
-github.com/tonistiigi/go-actions-cache v0.0.0-20240227172821-a0b64f338598/go.mod h1:anhKd3mnC1shAbQj1Q4IJ+w6xqezxnyDYlx/yKa7IXM=
+github.com/tonistiigi/go-actions-cache v0.0.0-20240320205438-9794bdbb2fb4 h1:R0lM8Jo3aZL95yjQHWQti7nszllleKBxCs9uyFbykII=
+github.com/tonistiigi/go-actions-cache v0.0.0-20240320205438-9794bdbb2fb4/go.mod h1:anhKd3mnC1shAbQj1Q4IJ+w6xqezxnyDYlx/yKa7IXM=
 github.com/tonistiigi/go-archvariant v1.0.0 h1:5LC1eDWiBNflnTF1prCiX09yfNHIxDC/aukdhCdTyb0=
 github.com/tonistiigi/go-archvariant v1.0.0/go.mod h1:TxFmO5VS6vMq2kvs3ht04iPXtu2rUT/erOnGFYfk5Ho=
 github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea h1:SXhTLE6pb6eld/v/cCndK0AMpt1wiVFb/YYmqB3/QG0=

--- a/vendor/github.com/tonistiigi/go-actions-cache/rest.go
+++ b/vendor/github.com/tonistiigi/go-actions-cache/rest.go
@@ -1,0 +1,111 @@
+package actionscache
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+const (
+	apiURL  = "https://api.github.com"
+	perPage = 100
+)
+
+type RestAPI struct {
+	repo  string
+	token string
+	opt   Opt
+}
+
+type CacheKey struct {
+	ID           int    `json:"id"`
+	Ref          string `json:"ref"`
+	Key          string `json:"key"`
+	Version      string `json:"version"`
+	LastAccessed string `json:"last_accessed_at"`
+	CreatedAt    string `json:"created_at"`
+	SizeInBytes  int    `json:"size_in_bytes"`
+}
+
+func NewRestAPI(repo, token string, opt Opt) (*RestAPI, error) {
+	opt = optsWithDefaults(opt)
+	return &RestAPI{
+		repo:  repo,
+		token: token,
+		opt:   opt,
+	}, nil
+}
+
+func (r *RestAPI) httpReq(ctx context.Context, method string, url *url.URL) (*http.Request, error) {
+	req, err := http.NewRequest(method, url.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+r.token)
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	return req, nil
+}
+
+func (r *RestAPI) ListKeys(ctx context.Context, prefix, ref string) ([]CacheKey, error) {
+	var out []CacheKey
+	page := 1
+	for {
+		keys, total, err := r.listKeysPage(ctx, prefix, ref, page)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, keys...)
+		if total > page*perPage {
+			page++
+		} else {
+			break
+		}
+	}
+	return out, nil
+}
+
+func (r *RestAPI) listKeysPage(ctx context.Context, prefix, ref string, page int) ([]CacheKey, int, error) {
+	u, err := url.Parse(apiURL + "/repos/" + r.repo + "/actions/caches")
+	if err != nil {
+		return nil, 0, err
+	}
+	q := u.Query()
+	q.Set("per_page", strconv.Itoa(perPage))
+	if page > 0 {
+		q.Set("page", strconv.Itoa(page))
+	}
+	if prefix != "" {
+		q.Set("key", prefix)
+	}
+	if ref != "" {
+		q.Set("ref", ref)
+	}
+	u.RawQuery = q.Encode()
+
+	req, err := r.httpReq(ctx, "GET", u)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	resp, err := r.opt.Client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	dec := json.NewDecoder(resp.Body)
+	var keys struct {
+		Total  int        `json:"total_count"`
+		Caches []CacheKey `json:"actions_caches"`
+	}
+
+	if err := dec.Decode(&keys); err != nil {
+		return nil, 0, err
+	}
+
+	resp.Body.Close()
+	return keys.Caches, keys.Total, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -769,7 +769,7 @@ github.com/stretchr/testify/require
 github.com/tonistiigi/fsutil
 github.com/tonistiigi/fsutil/copy
 github.com/tonistiigi/fsutil/types
-# github.com/tonistiigi/go-actions-cache v0.0.0-20240227172821-a0b64f338598
+# github.com/tonistiigi/go-actions-cache v0.0.0-20240320205438-9794bdbb2fb4
 ## explicit; go 1.20
 github.com/tonistiigi/go-actions-cache
 # github.com/tonistiigi/go-archvariant v1.0.0


### PR DESCRIPTION
In order to avoid getting rate limited when checking if previous cache already exists use the Github REST API that supports listing active keys.

This means additional GITHUB_TOKEN access is also
needed in addition to the RUNTIME_TOKEN needed for the cache API. The implementation is done with a fallback - if GITHUB_TOKEN is passed then it is used, if not then the old method checking individual cache records is still used.

Depends on https://github.com/tonistiigi/go-actions-cache/pull/19