### PR TITLE
dockerfile: fix missing source mapping for COPY --link command

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -1340,11 +1340,10 @@ func dispatchCopy(d *dispatchState, cfg copyConfig) error {
 		copyOpts := []llb.ConstraintsOpt{
 			llb.Platform(*d.platform),
 		}
-		copy(copyOpts, fileOpt)
+		copyOpts = append(copyOpts, fileOpt...)
 		copyOpts = append(copyOpts, llb.ProgressGroup(pgID, pgName, true))
 
-		var mergeOpts []llb.ConstraintsOpt
-		copy(mergeOpts, fileOpt)
+		mergeOpts := append([]llb.ConstraintsOpt{}, fileOpt...)
 		d.cmdIndex--
 		mergeOpts = append(mergeOpts, llb.ProgressGroup(pgID, pgName, false), llb.WithCustomName(prefixCommand(d, "LINK "+name, d.prefixPlatform, &platform, env)))
 

--- a/frontend/dockerfile/dockerfile_provenance_test.go
+++ b/frontend/dockerfile/dockerfile_provenance_test.go
@@ -1,6 +1,7 @@
 package dockerfile
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -1128,6 +1129,123 @@ func testDockerIgnoreMissingProvenance(t *testing.T, sb integration.Sandbox) {
 		},
 	}, "", frontend, nil)
 	require.NoError(t, err)
+}
+
+func testCommandSourceMapping(t *testing.T, sb integration.Sandbox) {
+	integration.SkipOnPlatform(t, "windows")
+	ctx := sb.Context()
+
+	c, err := client.New(ctx, sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	dockerfile := []byte(`FROM alpine
+RUN echo "hello" > foo
+WORKDIR /tmp
+COPY foo foo2
+COPY --link foo foo3
+ADD bar bar`)
+
+	dir := integration.Tmpdir(
+		t,
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+		fstest.CreateFile("foo", []byte("data"), 0600),
+		fstest.CreateFile("bar", []byte("data2"), 0600),
+	)
+
+	registry, err := sb.NewRegistry()
+	if errors.Is(err, integration.ErrRequirements) {
+		t.Skip(err.Error())
+	}
+	require.NoError(t, err)
+
+	target := registry + "/buildkit/testsourcemappingprov:latest"
+	f := getFrontend(t, sb)
+
+	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
+		LocalMounts: map[string]fsutil.FS{
+			dockerui.DefaultLocalNameDockerfile: dir,
+			dockerui.DefaultLocalNameContext:    dir,
+		},
+		FrontendAttrs: map[string]string{
+			"attest:provenance": "mode=max",
+		},
+		Exports: []client.ExportEntry{
+			{
+				Type: client.ExporterImage,
+				Attrs: map[string]string{
+					"name": target,
+					"push": "true",
+				},
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	desc, provider, err := contentutil.ProviderFromRef(target)
+	require.NoError(t, err)
+	imgs, err := testutil.ReadImages(sb.Context(), provider, desc)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(imgs.Images))
+
+	expPlatform := platforms.Format(platforms.Normalize(platforms.DefaultSpec()))
+
+	img := imgs.Find(expPlatform)
+	require.NotNil(t, img)
+
+	att := imgs.FindAttestation(expPlatform)
+	type stmtT struct {
+		Predicate provenancetypes.ProvenancePredicate `json:"predicate"`
+	}
+	var stmt stmtT
+	require.NoError(t, json.Unmarshal(att.LayersRaw[0], &stmt))
+	pred := stmt.Predicate
+
+	def := pred.BuildConfig.Definition
+
+	steps := map[string]provenancetypes.BuildStep{}
+	for _, step := range def {
+		steps[step.ID] = step
+	}
+	// ensure all IDs are unique
+	require.Equal(t, len(steps), len(def))
+
+	src := pred.Metadata.BuildKitMetadata.Source
+
+	lines := make([]bool, bytes.Count(dockerfile, []byte("\n"))+1)
+
+	for id, loc := range src.Locations {
+		// - only context upload can be without source mapping
+		// - every step must only be in one line
+		// - perform bounds check for location
+		step, ok := steps[id]
+		require.True(t, ok, "definition for step %s not found", id)
+
+		if len(loc.Locations) == 0 {
+			s := step.Op.GetSource()
+			require.NotNil(t, s, "unmapped step %s is not source", id)
+			require.Equal(t, "local://context", s.Identifier)
+		} else if len(loc.Locations) >= 1 {
+			require.Equal(t, 1, len(loc.Locations), "step %s has more than one location", id)
+		}
+
+		for _, loc := range loc.Locations {
+			for _, r := range loc.Ranges {
+				require.Equal(t, r.Start.Line, r.End.Line, "step %s has range with multiple lines", id)
+
+				idx := r.Start.Line - 1
+				if idx < 0 || int(idx) >= len(lines) {
+					t.Fatalf("step %s has invalid range on line %d", id, idx)
+				}
+				lines[idx] = true
+			}
+		}
+	}
+
+	// ensure all lines are covered
+	for i, covered := range lines {
+		require.True(t, covered, "line %d is not covered", i+1)
+	}
 }
 
 func testFrontendDeduplicateSources(t *testing.T, sb integration.Sandbox) {

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -174,6 +174,7 @@ var allTests = integration.TestFuncs(
 	testNilProvenance,
 	testDuplicatePlatformProvenance,
 	testDockerIgnoreMissingProvenance,
+	testCommandSourceMapping,
 	testSBOMScannerArgs,
 	testMultiPlatformWarnings,
 	testNilContextInSolveGateway,


### PR DESCRIPTION
The `COPY --link` command lost its source mapping to the original Dockerfile when converted to LLB vertex. Regression from https://github.com/moby/buildkit/commit/cc1499e6d92722ce55ef34a08dac964a1778b636#diff-905097ba6a4e36b3afbb1204e52315791dc0915f2a845c768bc84c6af5db1e1fR1075 progressgroup PR. 

@sipsma The previous code is clearly incorrect as it is copying to nil slice (that does nothing), but do check that I didn't miss any progressgroup logic.

