### PR TITLE
use schema http if PlainHTTP is set

### DIFF
--- a/util/resolver/resolver.go
+++ b/util/resolver/resolver.go
@@ -141,8 +141,13 @@ func NewRegistryConfig(m map[string]config.RegistryConfig) docker.RegistryHosts 
 				host = "registry-1.docker.io"
 			}
 
+			schema := "https"
+			if c.PlainHTTP != nil && *c.PlainHTTP {
+				schema = "http"
+			}
+
 			h := docker.RegistryHost{
-				Scheme:       "https",
+				Scheme:       schema,
 				Client:       newDefaultClient(),
 				Host:         host,
 				Path:         "/v2",


### PR DESCRIPTION
fix buildkit not use configuration http flag in the build stage , it still pull image use https when `http` is specified in the configuration
