### PR TITLE
remotecache: allow exporting root cache records 

### DIFF
--- a/cache/remotecache/export.go
+++ b/cache/remotecache/export.go
@@ -36,6 +36,7 @@ type Exporter interface {
 
 type Config struct {
 	Compression compression.Config
+	WithRoots   bool
 }
 
 type CacheType int
@@ -63,9 +64,18 @@ func (data CacheType) String() string {
 	}
 }
 
-func NewExporter(ingester content.Ingester, ref string, oci bool, imageManifest bool, compressionConfig compression.Config) Exporter {
+func NewExporter(ingester content.Ingester, ref string, oci bool, imageManifest bool, compressionConfig compression.Config, withRoots bool) Exporter {
 	cc := v1.NewCacheChains()
-	return &contentCacheExporter{CacheExporterTarget: cc, chains: cc, ingester: ingester, oci: oci, imageManifest: imageManifest, ref: ref, comp: compressionConfig}
+	return &contentCacheExporter{
+		CacheExporterTarget: cc,
+		chains:              cc,
+		ingester:            ingester,
+		oci:                 oci,
+		imageManifest:       imageManifest,
+		ref:                 ref,
+		comp:                compressionConfig,
+		roots:               withRoots,
+	}
 }
 
 type ExportableCache struct {
@@ -167,6 +177,7 @@ type contentCacheExporter struct {
 	imageManifest bool
 	ref           string
 	comp          compression.Config
+	roots         bool
 }
 
 func (ce *contentCacheExporter) Name() string {
@@ -176,6 +187,7 @@ func (ce *contentCacheExporter) Name() string {
 func (ce *contentCacheExporter) Config() Config {
 	return Config{
 		Compression: ce.comp,
+		WithRoots:   ce.roots,
 	}
 }
 

--- a/cache/remotecache/local/local.go
+++ b/cache/remotecache/local/local.go
@@ -21,6 +21,7 @@ const (
 	attrDest             = "dest"
 	attrImageManifest    = "image-manifest"
 	attrOCIMediatypes    = "oci-mediatypes"
+	attrRoots            = "roots"
 	contentStoreIDPrefix = "local:"
 )
 
@@ -59,12 +60,21 @@ func ResolveCacheExporterFunc(sm *session.Manager) remotecache.ResolveCacheExpor
 			}
 			imageManifest = b
 		}
+		roots := true // default to true for local cache as prefer local cache sources to registry
+		if v, ok := attrs[attrRoots]; ok {
+			b, err := strconv.ParseBool(v)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to parse %s", attrRoots)
+			}
+			roots = b
+		}
+
 		csID := contentStoreIDPrefix + store
 		cs, err := getContentStore(ctx, sm, g, csID)
 		if err != nil {
 			return nil, err
 		}
-		return &exporter{remotecache.NewExporter(cs, "", ociMediatypes, imageManifest, compressionConfig)}, nil
+		return &exporter{remotecache.NewExporter(cs, "", ociMediatypes, imageManifest, compressionConfig, roots)}, nil
 	}
 }
 

--- a/cache/remotecache/registry/registry.go
+++ b/cache/remotecache/registry/registry.go
@@ -38,6 +38,7 @@ const (
 	attrRef           = "ref"
 	attrImageManifest = "image-manifest"
 	attrOCIMediatypes = "oci-mediatypes"
+	attrRoots         = "roots"
 	attrInsecure      = "registry.insecure"
 )
 
@@ -84,6 +85,14 @@ func ResolveCacheExporterFunc(sm *session.Manager, hosts docker.RegistryHosts) r
 			}
 			insecure = b
 		}
+		roots := false
+		if v, ok := attrs[attrRoots]; ok {
+			b, err := strconv.ParseBool(v)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to parse %s", attrRoots)
+			}
+			roots = b
+		}
 
 		scope, hosts := registryConfig(hosts, ref, "push", insecure)
 		remote := resolver.DefaultPool.GetResolver(hosts, refString, scope, sm, g)
@@ -91,7 +100,7 @@ func ResolveCacheExporterFunc(sm *session.Manager, hosts docker.RegistryHosts) r
 		if err != nil {
 			return nil, err
 		}
-		return &exporter{remotecache.NewExporter(contentutil.FromPusher(pusher), refString, ociMediatypes, imageManifest, compressionConfig)}, nil
+		return &exporter{remotecache.NewExporter(contentutil.FromPusher(pusher), refString, ociMediatypes, imageManifest, compressionConfig, roots)}, nil
 	}
 }
 

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -1340,11 +1340,10 @@ func dispatchCopy(d *dispatchState, cfg copyConfig) error {
 		copyOpts := []llb.ConstraintsOpt{
 			llb.Platform(*d.platform),
 		}
-		copy(copyOpts, fileOpt)
+		copyOpts = append(copyOpts, fileOpt...)
 		copyOpts = append(copyOpts, llb.ProgressGroup(pgID, pgName, true))
 
-		var mergeOpts []llb.ConstraintsOpt
-		copy(mergeOpts, fileOpt)
+		mergeOpts := append([]llb.ConstraintsOpt{}, fileOpt...)
 		d.cmdIndex--
 		mergeOpts = append(mergeOpts, llb.ProgressGroup(pgID, pgName, false), llb.WithCustomName(prefixCommand(d, "LINK "+name, d.prefixPlatform, &platform, env)))
 

--- a/frontend/dockerfile/dockerfile_provenance_test.go
+++ b/frontend/dockerfile/dockerfile_provenance_test.go
@@ -1,6 +1,7 @@
 package dockerfile
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -1128,6 +1129,123 @@ func testDockerIgnoreMissingProvenance(t *testing.T, sb integration.Sandbox) {
 		},
 	}, "", frontend, nil)
 	require.NoError(t, err)
+}
+
+func testCommandSourceMapping(t *testing.T, sb integration.Sandbox) {
+	integration.SkipOnPlatform(t, "windows")
+	ctx := sb.Context()
+
+	c, err := client.New(ctx, sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	dockerfile := []byte(`FROM alpine
+RUN echo "hello" > foo
+WORKDIR /tmp
+COPY foo foo2
+COPY --link foo foo3
+ADD bar bar`)
+
+	dir := integration.Tmpdir(
+		t,
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+		fstest.CreateFile("foo", []byte("data"), 0600),
+		fstest.CreateFile("bar", []byte("data2"), 0600),
+	)
+
+	registry, err := sb.NewRegistry()
+	if errors.Is(err, integration.ErrRequirements) {
+		t.Skip(err.Error())
+	}
+	require.NoError(t, err)
+
+	target := registry + "/buildkit/testsourcemappingprov:latest"
+	f := getFrontend(t, sb)
+
+	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
+		LocalMounts: map[string]fsutil.FS{
+			dockerui.DefaultLocalNameDockerfile: dir,
+			dockerui.DefaultLocalNameContext:    dir,
+		},
+		FrontendAttrs: map[string]string{
+			"attest:provenance": "mode=max",
+		},
+		Exports: []client.ExportEntry{
+			{
+				Type: client.ExporterImage,
+				Attrs: map[string]string{
+					"name": target,
+					"push": "true",
+				},
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	desc, provider, err := contentutil.ProviderFromRef(target)
+	require.NoError(t, err)
+	imgs, err := testutil.ReadImages(sb.Context(), provider, desc)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(imgs.Images))
+
+	expPlatform := platforms.Format(platforms.Normalize(platforms.DefaultSpec()))
+
+	img := imgs.Find(expPlatform)
+	require.NotNil(t, img)
+
+	att := imgs.FindAttestation(expPlatform)
+	type stmtT struct {
+		Predicate provenancetypes.ProvenancePredicate `json:"predicate"`
+	}
+	var stmt stmtT
+	require.NoError(t, json.Unmarshal(att.LayersRaw[0], &stmt))
+	pred := stmt.Predicate
+
+	def := pred.BuildConfig.Definition
+
+	steps := map[string]provenancetypes.BuildStep{}
+	for _, step := range def {
+		steps[step.ID] = step
+	}
+	// ensure all IDs are unique
+	require.Equal(t, len(steps), len(def))
+
+	src := pred.Metadata.BuildKitMetadata.Source
+
+	lines := make([]bool, bytes.Count(dockerfile, []byte("\n"))+1)
+
+	for id, loc := range src.Locations {
+		// - only context upload can be without source mapping
+		// - every step must only be in one line
+		// - perform bounds check for location
+		step, ok := steps[id]
+		require.True(t, ok, "definition for step %s not found", id)
+
+		if len(loc.Locations) == 0 {
+			s := step.Op.GetSource()
+			require.NotNil(t, s, "unmapped step %s is not source", id)
+			require.Equal(t, "local://context", s.Identifier)
+		} else if len(loc.Locations) >= 1 {
+			require.Equal(t, 1, len(loc.Locations), "step %s has more than one location", id)
+		}
+
+		for _, loc := range loc.Locations {
+			for _, r := range loc.Ranges {
+				require.Equal(t, r.Start.Line, r.End.Line, "step %s has range with multiple lines", id)
+
+				idx := r.Start.Line - 1
+				if idx < 0 || int(idx) >= len(lines) {
+					t.Fatalf("step %s has invalid range on line %d", id, idx)
+				}
+				lines[idx] = true
+			}
+		}
+	}
+
+	// ensure all lines are covered
+	for i, covered := range lines {
+		require.True(t, covered, "line %d is not covered", i+1)
+	}
 }
 
 func testFrontendDeduplicateSources(t *testing.T, sb integration.Sandbox) {

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -174,6 +174,7 @@ var allTests = integration.TestFuncs(
 	testNilProvenance,
 	testDuplicatePlatformProvenance,
 	testDockerIgnoreMissingProvenance,
+	testBaseImageLayersFromCachedBuild,
 	testCommandSourceMapping,
 	testSBOMScannerArgs,
 	testMultiPlatformWarnings,

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -174,6 +174,7 @@ var allTests = integration.TestFuncs(
 	testNilProvenance,
 	testDuplicatePlatformProvenance,
 	testDockerIgnoreMissingProvenance,
+	testCommandSourceMapping,
 	testSBOMScannerArgs,
 	testMultiPlatformWarnings,
 	testNilContextInSolveGateway,

--- a/solver/exporter.go
+++ b/solver/exporter.go
@@ -96,9 +96,9 @@ func (e *exporter) ExportTo(ctx context.Context, t CacheExporterTarget, opt Cach
 	if e.override != nil {
 		addRecord = *e.override
 	}
-
 	exportRecord := opt.ExportRoots
-	if len(deps) > 0 {
+	isRoot := len(deps) == 0
+	if !isRoot {
 		exportRecord = true
 	}
 
@@ -132,7 +132,7 @@ func (e *exporter) ExportTo(ctx context.Context, t CacheExporterTarget, opt Cach
 			}
 		}
 
-		if (remote == nil || opt.CompressionOpt != nil) && opt.Mode != CacheExportModeRemoteOnly {
+		if (remote == nil || opt.CompressionOpt != nil) && opt.Mode != CacheExportModeRemoteOnly && !isRoot {
 			res, err := cm.results.Load(ctx, res)
 			if err != nil {
 				return nil, err

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -655,6 +655,7 @@ func runCacheExporters(ctx context.Context, exporters []RemoteCacheExporter, j *
 						Mode:           exp.CacheExportMode,
 						Session:        g,
 						CompressionOpt: &compressionConfig,
+						ExportRoots:    exp.Config().WithRoots,
 					})
 					return err
 				}); err != nil {
@@ -921,7 +922,8 @@ func inlineCache(ctx context.Context, ie inlineCacheExporter, res solver.CachedR
 		ResolveRemotes: workerRefResolver(refCfg, true, g), // load as many compression blobs as possible
 		Mode:           solver.CacheExportModeMin,
 		Session:        g,
-		CompressionOpt: &compressionopt, // cache possible compression variants
+		CompressionOpt: &compressionopt, // cache possible compression variants,
+		ExportRoots:    true,
 	}); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Allow exporting layers of root sources, like base images to
remote cache. Normally, this is not done as it is considered
wasteful as pulling cache vs. pulling source image again
does not have benefits.

Skipping base images in cache has other side effects though,
for example provenance of a cached build that is on top of
previous base image does not list the layers for the
LLB image step because that step did not run (because its
children were fully cached) and the image step itself
does not have a layer chain associated with it in the cache.

Local source exports roots by default to allow air-gapped builds
with local cache sources if they only match the base image and
no records on top of them. A future follow-up could be to consider
exporting roots by default all the time but marking them in a
special way so they can be skipped from loading.