### PR TITLE
util/converter: fix diffID computation

### DIFF
--- a/util/converter/tarconverter/tarconverter.go
+++ b/util/converter/tarconverter/tarconverter.go
@@ -8,6 +8,7 @@ import (
 type HeaderConverter func(*tar.Header)
 
 // NewReader returns a reader that applies headerConverter.
+// srcContent is drained until hitting EOF.
 // Forked from https://github.com/moby/moby/blob/v24.0.6/pkg/archive/copy.go#L308-L373 .
 func NewReader(srcContent io.Reader, headerConverter HeaderConverter) io.ReadCloser {
 	rebased, w := io.Pipe()
@@ -21,7 +22,14 @@ func NewReader(srcContent io.Reader, headerConverter HeaderConverter) io.ReadClo
 			if err == io.EOF {
 				// Signals end of archive.
 				rebasedTar.Close()
-				w.Close()
+				// drain the reader into io.Discard, until hitting EOF
+				// https://github.com/moby/buildkit/pull/4807#discussion_r1544621787
+				_, err = io.Copy(io.Discard, srcContent)
+				if err != nil {
+					w.CloseWithError(err)
+				} else {
+					w.Close()
+				}
 				return
 			}
 			if err != nil {


### PR DESCRIPTION
The archive reader was not fully consumed on computating the diffID.

Fix #4805