### PR TITLE
chore: fix casing in containerd-alt-16 stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -259,7 +259,7 @@ RUN --mount=from=containerd-src,src=/usr/src/containerd,rw \
 EOT
 
 # containerd v1.6 for integration tests
-FROM containerd-base as containerd-alt-16
+FROM containerd-base AS containerd-alt-16
 ARG CONTAINERD_ALT_VERSION_16
 RUN --mount=from=containerd-src,src=/usr/src/containerd,rw \
     --mount=target=/root/.cache,type=cache <<EOT


### PR DESCRIPTION
Silences the following warning:

```
 1 warning found (use --debug to expand):
 - Lint Rule 'FromAsCasing': 'as' and 'FROM' keywords' casing do not match (line 262)
```