### PR TITLE
 fix: use unix path separator since windows path already normalized

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -1138,10 +1138,6 @@ func dispatchCopy(d *dispatchState, cfg copyConfig) error {
 		return err
 	}
 
-	if cfg.params.DestPath == "." || cfg.params.DestPath == "" || cfg.params.DestPath[len(cfg.params.DestPath)-1] == filepath.Separator {
-		dest += string(filepath.Separator)
-	}
-
 	var copyOpt []llb.CopyOption
 
 	if cfg.chown != "" {
@@ -1562,9 +1558,9 @@ func pathRelativeToWorkingDir(s llb.State, p string, platform ocispecs.Platform)
 	}
 
 	if system.IsAbs(p, platform.OS) {
-		return system.NormalizePath("/", p, platform.OS, false)
+		return system.NormalizePath("/", p, platform.OS, true)
 	}
-	return system.NormalizePath(dir, p, platform.OS, false)
+	return system.NormalizePath(dir, p, platform.OS, true)
 }
 
 func addEnv(env []string, k, v string) []string {

--- a/solver/llbsolver/file/backend.go
+++ b/solver/llbsolver/file/backend.go
@@ -139,7 +139,7 @@ func docopy(ctx context.Context, src, dest string, action pb.FileActionCopy, u *
 	}
 	destPath, err := cleanPath(action.Dest)
 	if err != nil {
-		return errors.Wrap(err, "cleaning path")
+		return errors.Wrap(err, "cleaning destination path")
 	}
 	if !action.CreateDestPath {
 		p, err := fs.RootPath(dest, filepath.Join("/", action.Dest))


### PR DESCRIPTION
In the case for Windows, this line at `frontend/dockerfile/dockerfile2llb/convert.go#L1142` was adding the `\\` to a path that is already normalized to unix-format, hence ending up with `dest` paths like: `/\\` for `C:\\` and `/test\\` for `C:\\test\\`.

https://github.com/moby/buildkit/blob/fb97e6defdc171d943c304565eeb72794ea0a648/frontend/dockerfile/dockerfile2llb/convert.go#L1142

The `src` paths are well normalized too at ~L1290:
https://github.com/moby/buildkit/blob/fb97e6defdc171d943c304565eeb72794ea0a648/frontend/dockerfile/dockerfile2llb/convert.go#L1287

This change removes the block of code and instead does the "/" appending using the `keepSlash` logic
that is in `system.NormalizePath` called in `pathRelativeToWorkingDir` function before.

Additionally in `solver/llbsolver/file/backend.go`, the error message is enhanced to specify "destination" path, since "source" path is also specified in it's error message. This was the "cleaning path" wrapped error reported in issue #4696 :
```
error: failed to solve: cleaning path: removing drive letter: UNC paths are not supported
```

fixes #4696