### PR TITLE
Remove unneeded dependencies from moby/moby

### DIFF
--- a/frontend/dockerfile/instructions/commands.go
+++ b/frontend/dockerfile/instructions/commands.go
@@ -3,8 +3,8 @@ package instructions
 import (
 	"strings"
 
-	"github.com/docker/docker/api/types/container"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
+	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -367,7 +367,7 @@ type CmdCommand struct {
 //	HEALTHCHECK <health-config>
 type HealthCheckCommand struct {
 	withNameAndCode
-	Health *container.HealthConfig
+	Health *dockerspec.HealthcheckConfig
 }
 
 // EntrypointCommand sets the default entrypoint of the container to use the

--- a/frontend/dockerfile/instructions/commands.go
+++ b/frontend/dockerfile/instructions/commands.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/strslice"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/pkg/errors"
 )
@@ -325,7 +324,7 @@ type ShellInlineFile struct {
 
 // ShellDependantCmdLine represents a cmdline optionally prepended with the shell
 type ShellDependantCmdLine struct {
-	CmdLine      strslice.StrSlice
+	CmdLine      []string
 	Files        []ShellInlineFile
 	PrependShell bool
 }
@@ -479,7 +478,7 @@ func (c *ArgCommand) Expand(expander SingleWordExpander) error {
 //	SHELL bash -e -c
 type ShellCommand struct {
 	withNameAndCode
-	Shell strslice.StrSlice
+	Shell []string
 }
 
 // Stage represents a bundled collection of commands.

--- a/frontend/dockerfile/instructions/parse.go
+++ b/frontend/dockerfile/instructions/parse.go
@@ -12,11 +12,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/docker/api/types/container"
 	"github.com/moby/buildkit/frontend/dockerfile/command"
 	"github.com/moby/buildkit/frontend/dockerfile/linter"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/moby/buildkit/util/suggest"
+	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -561,8 +561,10 @@ func parseOptInterval(f *Flag) (time.Duration, error) {
 	if d == 0 {
 		return 0, nil
 	}
-	if d < container.MinimumDuration {
-		return 0, errors.Errorf("Interval %#v cannot be less than %s", f.name, container.MinimumDuration)
+
+	const minimumDuration = time.Millisecond
+	if d < minimumDuration {
+		return 0, errors.Errorf("Interval %#v cannot be less than %s", f.name, minimumDuration)
 	}
 	return d, nil
 }
@@ -580,11 +582,11 @@ func parseHealthcheck(req parseRequest) (*HealthCheckCommand, error) {
 		if len(args) != 0 {
 			return nil, errors.New("HEALTHCHECK NONE takes no arguments")
 		}
-		cmd.Health = &container.HealthConfig{
+		cmd.Health = &dockerspec.HealthcheckConfig{
 			Test: []string{typ},
 		}
 	} else {
-		healthcheck := container.HealthConfig{}
+		healthcheck := dockerspec.HealthcheckConfig{}
 
 		flInterval := req.flags.AddString("interval", "")
 		flTimeout := req.flags.AddString("timeout", "")

--- a/frontend/dockerfile/instructions/parse.go
+++ b/frontend/dockerfile/instructions/parse.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/strslice"
 	"github.com/moby/buildkit/frontend/dockerfile/command"
 	"github.com/moby/buildkit/frontend/dockerfile/linter"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
@@ -475,12 +474,11 @@ func parseShellDependentCommand(req parseRequest, command string, emptyAsNil boo
 	}
 
 	args := handleJSONArgs(req.args, req.attributes)
-	cmd := strslice.StrSlice(args)
-	if emptyAsNil && len(cmd) == 0 {
-		cmd = nil
+	if emptyAsNil && len(args) == 0 {
+		args = nil
 	}
 	return ShellDependantCmdLine{
-		CmdLine:      cmd,
+		CmdLine:      args,
 		Files:        files,
 		PrependShell: !req.attributes["json"],
 	}, nil
@@ -582,9 +580,8 @@ func parseHealthcheck(req parseRequest) (*HealthCheckCommand, error) {
 		if len(args) != 0 {
 			return nil, errors.New("HEALTHCHECK NONE takes no arguments")
 		}
-		test := strslice.StrSlice{typ}
 		cmd.Health = &container.HealthConfig{
-			Test: test,
+			Test: []string{typ},
 		}
 	} else {
 		healthcheck := container.HealthConfig{}
@@ -610,7 +607,7 @@ func parseHealthcheck(req parseRequest) (*HealthCheckCommand, error) {
 				typ = "CMD-SHELL"
 			}
 
-			healthcheck.Test = strslice.StrSlice(append([]string{typ}, cmdSlice...))
+			healthcheck.Test = append([]string{typ}, cmdSlice...)
 		default:
 			return nil, errors.Errorf("Unknown type %#v in HEALTHCHECK (try CMD)", typ)
 		}
@@ -774,7 +771,7 @@ func parseShell(req parseRequest) (*ShellCommand, error) {
 		// SHELL ["powershell", "-command"]
 
 		return &ShellCommand{
-			Shell:           strslice.StrSlice(shellSlice),
+			Shell:           shellSlice,
 			withNameAndCode: newWithNameAndCode(req),
 		}, nil
 	default:

--- a/frontend/dockerfile/instructions/parse_heredoc_test.go
+++ b/frontend/dockerfile/instructions/parse_heredoc_test.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types/strslice"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/stretchr/testify/require"
 )
@@ -179,22 +178,22 @@ func TestRunHeredoc(t *testing.T) {
 	cases := []struct {
 		dockerfile string
 		shell      bool
-		command    strslice.StrSlice
+		command    []string
 		files      []ShellInlineFile
 	}{
 		{
 			dockerfile: `RUN ["ls", "/"]`,
-			command:    strslice.StrSlice{"ls", "/"},
+			command:    []string{"ls", "/"},
 			shell:      false,
 		},
 		{
 			dockerfile: `RUN ["<<EOF"]`,
-			command:    strslice.StrSlice{"<<EOF"},
+			command:    []string{"<<EOF"},
 			shell:      false,
 		},
 		{
 			dockerfile: "RUN ls /",
-			command:    strslice.StrSlice{"ls /"},
+			command:    []string{"ls /"},
 			shell:      true,
 		},
 		{
@@ -202,7 +201,7 @@ func TestRunHeredoc(t *testing.T) {
 ls /
 whoami
 EOF`,
-			command: strslice.StrSlice{"<<EOF"},
+			command: []string{"<<EOF"},
 			files: []ShellInlineFile{
 				{
 					Name: "EOF",
@@ -216,7 +215,7 @@ EOF`,
 print("hello")
 print("world")
 EOF`,
-			command: strslice.StrSlice{"<<'EOF' | python"},
+			command: []string{"<<'EOF' | python"},
 			files: []ShellInlineFile{
 				{
 					Name: "EOF",
@@ -231,7 +230,7 @@ print("world")
 			dockerfile: `RUN <<-EOF
 	echo test
 EOF`,
-			command: strslice.StrSlice{"<<-EOF"},
+			command: []string{"<<-EOF"},
 			files: []ShellInlineFile{
 				{
 					Name:  "EOF",

--- a/util/compression/compression.go
+++ b/util/compression/compression.go
@@ -251,5 +251,5 @@ func decompress(ctx context.Context, cs content.Store, desc ocispecs.Descriptor)
 			return nil, err
 		}
 	}
-	return &iohelper.ReadCloser{ReadCloser: r, CloseFunc: ra.Close}, nil
+	return iohelper.WithCloser(r, ra.Close), nil
 }

--- a/util/compression/uncompressed.go
+++ b/util/compression/uncompressed.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
-	"github.com/docker/docker/pkg/ioutils"
 	"github.com/moby/buildkit/util/iohelper"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -22,8 +21,7 @@ func (c uncompressedType) Decompress(ctx context.Context, cs content.Store, desc
 	if err != nil {
 		return nil, err
 	}
-	rdr := io.NewSectionReader(ra, 0, ra.Size())
-	return ioutils.NewReadCloserWrapper(rdr, ra.Close), nil
+	return iohelper.ReadCloser(ra), nil
 }
 
 func (c uncompressedType) NeedsConversion(ctx context.Context, cs content.Store, desc ocispecs.Descriptor) (bool, error) {

--- a/util/iohelper/helper.go
+++ b/util/iohelper/helper.go
@@ -15,18 +15,26 @@ func (w *NopWriteCloser) Close() error {
 	return nil
 }
 
-type ReadCloser struct {
-	io.ReadCloser
-	CloseFunc func() error
+type closeFunc func() error
+
+func (c closeFunc) Close() error {
+	return c()
 }
 
-func (rc *ReadCloser) Close() error {
-	err1 := rc.ReadCloser.Close()
-	err2 := rc.CloseFunc()
-	if err1 != nil {
-		return errors.Wrapf(err1, "failed to close: %v", err2)
+// WithCloser returns a ReadCloser with additional closer function.
+func WithCloser(r io.ReadCloser, closer func() error) io.ReadCloser {
+	var f closeFunc = func() error {
+		err1 := r.Close()
+		err2 := closer()
+		if err1 != nil {
+			return errors.Wrapf(err1, "failed to close: %v", err2)
+		}
+		return err2
 	}
-	return err2
+	return &readCloser{
+		Reader: r,
+		Closer: f,
+	}
 }
 
 type WriteCloser struct {
@@ -60,4 +68,23 @@ func (c *Counter) Size() (n int64) {
 	n = c.n
 	c.mu.Unlock()
 	return
+}
+
+type ReaderAtCloser interface {
+	io.ReaderAt
+	io.Closer
+	Size() int64
+}
+
+// ReadCloser returns a ReadCloser from ReaderAtCloser.
+func ReadCloser(in ReaderAtCloser) io.ReadCloser {
+	return &readCloser{
+		Reader: io.NewSectionReader(in, 0, in.Size()),
+		Closer: in,
+	}
+}
+
+type readCloser struct {
+	io.Reader
+	io.Closer
 }


### PR DESCRIPTION
In separate commits:
- Strsclice  - only difference from `[]string` is custom `Unmarshal` that we do not seem to use
- Healthcheck should not come from apitypes, but from spec types
- ioutils - different places were using different wrappers. Now all use the same. The code that previously used `pkg/ioutils` was not even correct iiuc as it called `Close()` on the error handler of `Read`.