### PR TITLE
add linting rules for undeclared args in from

### DIFF
--- a/frontend/dockerfile/dockerfile_lint_test.go
+++ b/frontend/dockerfile/dockerfile_lint_test.go
@@ -344,6 +344,13 @@ FROM ${BAR} AS base
 				Line:        3,
 				Level:       1,
 			},
+			{
+				RuleName:    "UndeclaredArgInFrom",
+				Description: "FROM command must use declared ARGs",
+				Detail:      "FROM argument 'BAR' is not declared",
+				Level:       1,
+				Line:        4,
+			},
 		},
 		StreamBuildErr:    "failed to solve: base name (${BAR}) should not be blank",
 		UnmarshalBuildErr: "base name (${BAR}) should not be blank",
@@ -360,11 +367,37 @@ COPY Dockerfile .
 	checkLinterWarnings(t, sb, &lintTestParams{Dockerfile: dockerfile})
 
 	dockerfile = []byte(`
-ARG platform=linux/amd64
-FROM --platform=$platform scratch
+ARG BUILDPLATFORM=linux/amd64
+FROM --platform=$BUILDPLATFORM scratch
 COPY Dockerfile .
 `)
 	checkLinterWarnings(t, sb, &lintTestParams{Dockerfile: dockerfile})
+
+	dockerfile = []byte(`
+FROM --platform=$BUILDPLATFORM scratch
+COPY Dockerfile .
+`)
+	checkLinterWarnings(t, sb, &lintTestParams{Dockerfile: dockerfile})
+
+	dockerfile = []byte(`
+FROM --platform=$BULIDPLATFORM scratch
+COPY Dockerfile .
+`)
+	checkLinterWarnings(t, sb, &lintTestParams{
+		Dockerfile: dockerfile,
+		Warnings: []expectedLintWarning{
+			{
+				RuleName:    "UndeclaredArgInFrom",
+				Description: "FROM command must use declared ARGs",
+				Detail:      "FROM argument 'BULIDPLATFORM' is not declared",
+				Level:       1,
+				Line:        2,
+			},
+		},
+		StreamBuildErr:    "failed to solve: failed to parse platform : \"\" is an invalid component of \"\": platform specifier component must match \"^[A-Za-z0-9_-]+$\": invalid argument",
+		UnmarshalBuildErr: "failed to parse platform : \"\" is an invalid component of \"\": platform specifier component must match \"^[A-Za-z0-9_-]+$\": invalid argument",
+		BuildErrLocation:  2,
+	})
 
 	dockerfile = []byte(`
 ARG tag=latest
@@ -434,7 +467,6 @@ func checkUnmarshal(t *testing.T, sb integration.Sandbox, lintTest *lintTestPara
 		},
 	}, "", frontend, nil)
 	require.NoError(t, err)
-
 	require.True(t, called)
 }
 
@@ -503,6 +535,7 @@ func checkProgressStream(t *testing.T, sb integration.Sandbox, lintTest *lintTes
 }
 
 func checkLinterWarnings(t *testing.T, sb integration.Sandbox, lintTest *lintTestParams) {
+	t.Helper()
 	sort.Slice(lintTest.Warnings, func(i, j int) bool {
 		return lintTest.Warnings[i].Line < lintTest.Warnings[j].Line
 	})

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -231,6 +231,10 @@ func init() {
 	}
 }
 
+func TestLint(t *testing.T) {
+	integration.Run(t, lintTests, opts...)
+}
+
 func TestIntegration(t *testing.T) {
 	integration.Run(t, allTests, opts...)
 

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -231,10 +231,6 @@ func init() {
 	}
 }
 
-func TestLint(t *testing.T) {
-	integration.Run(t, lintTests, opts...)
-}
-
 func TestIntegration(t *testing.T) {
 	integration.Run(t, allTests, opts...)
 

--- a/frontend/dockerfile/linter/ruleset.go
+++ b/frontend/dockerfile/linter/ruleset.go
@@ -63,4 +63,11 @@ var (
 			return "Maintainer instruction is deprecated in favor of using label"
 		},
 	}
+	RuleUndeclaredArgInFrom = LinterRule[func(string) string]{
+		Name:        "UndeclaredArgInFrom",
+		Description: "FROM command must use declared ARGs",
+		Format: func(baseArg string) string {
+			return fmt.Sprintf("FROM argument '%s' is not declared", baseArg)
+		},
+	}
 )

--- a/frontend/dockerfile/shell/lex.go
+++ b/frontend/dockerfile/shell/lex.go
@@ -58,7 +58,7 @@ func (s *Lex) ProcessWordWithMap(word string, env map[string]string) (string, er
 }
 
 type ProcessWordMatchesResult struct {
-	Word      string
+	Result    string
 	Matched   map[string]struct{}
 	Unmatched map[string]struct{}
 }
@@ -69,7 +69,7 @@ func (s *Lex) ProcessWordWithMatches(word string, env map[string]string) (Proces
 	sw := s.init(word, env)
 	word, _, err := sw.process(word)
 	return ProcessWordMatchesResult{
-		Word:      word,
+		Result:    word,
 		Matched:   sw.matches,
 		Unmatched: sw.nonmatches,
 	}, err

--- a/frontend/dockerfile/shell/lex.go
+++ b/frontend/dockerfile/shell/lex.go
@@ -57,12 +57,22 @@ func (s *Lex) ProcessWordWithMap(word string, env map[string]string) (string, er
 	return word, err
 }
 
+type ProcessWordMatchesResult struct {
+	Word      string
+	Matched   map[string]struct{}
+	Unmatched map[string]struct{}
+}
+
 // ProcessWordWithMatches will use the 'env' list of environment variables,
 // replace any env var references in 'word' and return the env that were used.
-func (s *Lex) ProcessWordWithMatches(word string, env map[string]string) (string, map[string]struct{}, error) {
+func (s *Lex) ProcessWordWithMatches(word string, env map[string]string) (ProcessWordMatchesResult, error) {
 	sw := s.init(word, env)
 	word, _, err := sw.process(word)
-	return word, sw.matches, err
+	return ProcessWordMatchesResult{
+		Word:      word,
+		Matched:   sw.matches,
+		Unmatched: sw.nonmatches,
+	}, err
 }
 
 func (s *Lex) ProcessWordsWithMap(word string, env map[string]string) ([]string, error) {
@@ -79,6 +89,7 @@ func (s *Lex) init(word string, env map[string]string) *shellWord {
 		rawQuotes:         s.RawQuotes,
 		rawEscapes:        s.RawEscapes,
 		matches:           make(map[string]struct{}),
+		nonmatches:        make(map[string]struct{}),
 	}
 	sw.scanner.Init(strings.NewReader(word))
 	return sw
@@ -98,6 +109,7 @@ type shellWord struct {
 	skipUnsetEnv      bool
 	skipProcessQuotes bool
 	matches           map[string]struct{}
+	nonmatches        map[string]struct{}
 }
 
 func (sw *shellWord) process(source string) (string, []string, error) {
@@ -511,6 +523,7 @@ func (sw *shellWord) getEnv(name string) (string, bool) {
 			return value, true
 		}
 	}
+	sw.nonmatches[name] = struct{}{}
 	return "", false
 }
 

--- a/frontend/dockerfile/shell/lex_test.go
+++ b/frontend/dockerfile/shell/lex_test.go
@@ -271,6 +271,7 @@ func TestProcessWithMatches(t *testing.T) {
 		expected    string
 		expectedErr bool
 		matches     map[string]struct{}
+		unmatched   map[string]struct{}
 	}{
 		{
 			input:    "x",
@@ -279,10 +280,11 @@ func TestProcessWithMatches(t *testing.T) {
 			matches:  nil,
 		},
 		{
-			input:    "x ${UNUSED}",
-			envs:     map[string]string{"DUMMY": "dummy"},
-			expected: "x ",
-			matches:  nil,
+			input:     "x ${UNUSED}",
+			envs:      map[string]string{"DUMMY": "dummy"},
+			expected:  "x ",
+			matches:   nil,
+			unmatched: map[string]struct{}{"UNUSED": {}},
 		},
 		{
 			input:    "x ${FOO}",
@@ -297,8 +299,9 @@ func TestProcessWithMatches(t *testing.T) {
 				"FOO": "xxx",
 				"BAR": "",
 			},
-			expected: "xxx  ccc",
-			matches:  map[string]struct{}{"FOO": {}, "BAR": {}},
+			expected:  "xxx  ccc",
+			matches:   map[string]struct{}{"FOO": {}, "BAR": {}},
+			unmatched: map[string]struct{}{"BAZ": {}},
 		},
 		{
 			input: "${FOO:-aaa} ${BAR:-bbb} ${BAZ:-ccc}",
@@ -306,8 +309,9 @@ func TestProcessWithMatches(t *testing.T) {
 				"FOO": "xxx",
 				"BAR": "",
 			},
-			expected: "xxx bbb ccc",
-			matches:  map[string]struct{}{"FOO": {}, "BAR": {}},
+			expected:  "xxx bbb ccc",
+			matches:   map[string]struct{}{"FOO": {}, "BAR": {}},
+			unmatched: map[string]struct{}{"BAZ": {}},
 		},
 
 		{
@@ -316,8 +320,9 @@ func TestProcessWithMatches(t *testing.T) {
 				"FOO": "xxx",
 				"BAR": "",
 			},
-			expected: "aaa bbb ",
-			matches:  map[string]struct{}{"FOO": {}, "BAR": {}},
+			expected:  "aaa bbb ",
+			matches:   map[string]struct{}{"FOO": {}, "BAR": {}},
+			unmatched: map[string]struct{}{"BAZ": {}},
 		},
 		{
 			input: "${FOO:+aaa} ${BAR:+bbb} ${BAZ:+ccc}",
@@ -325,8 +330,9 @@ func TestProcessWithMatches(t *testing.T) {
 				"FOO": "xxx",
 				"BAR": "",
 			},
-			expected: "aaa  ",
-			matches:  map[string]struct{}{"FOO": {}, "BAR": {}},
+			expected:  "aaa  ",
+			matches:   map[string]struct{}{"FOO": {}, "BAR": {}},
+			unmatched: map[string]struct{}{"BAZ": {}},
 		},
 
 		{
@@ -354,6 +360,7 @@ func TestProcessWithMatches(t *testing.T) {
 				"BAR": "",
 			},
 			expectedErr: true,
+			unmatched:   map[string]struct{}{"BAZ": {}},
 		},
 		{
 			input: "${FOO:?aaa}",
@@ -379,6 +386,7 @@ func TestProcessWithMatches(t *testing.T) {
 				"BAR": "",
 			},
 			expectedErr: true,
+			unmatched:   map[string]struct{}{"BAZ": {}},
 		},
 
 		{
@@ -431,10 +439,11 @@ func TestProcessWithMatches(t *testing.T) {
 			matches:  map[string]struct{}{"FOO": {}},
 		},
 		{
-			input:    "${ABC:-.}${FOO%x}${ABC:-.}",
-			envs:     map[string]string{"FOO": "xxyy"},
-			expected: ".xxyy.",
-			matches:  map[string]struct{}{"FOO": {}},
+			input:     "${ABC:-.}${FOO%x}${ABC:-.}",
+			envs:      map[string]string{"FOO": "xxyy"},
+			expected:  ".xxyy.",
+			matches:   map[string]struct{}{"FOO": {}},
+			unmatched: map[string]struct{}{"ABC": {}},
 		},
 		{
 			input:    "${FOO%%\\**\\*}",
@@ -481,8 +490,9 @@ func TestProcessWithMatches(t *testing.T) {
 		c := c
 		t.Run(c.input, func(t *testing.T) {
 			result, err := shlex.ProcessWordWithMatches(c.input, c.envs)
-			w := result.Word
+			w := result.Result
 			matches := result.Matched
+			unmatched := result.Unmatched
 			if c.expectedErr {
 				require.Error(t, err)
 				return
@@ -493,6 +503,11 @@ func TestProcessWithMatches(t *testing.T) {
 			require.Equal(t, len(c.matches), len(matches))
 			for k := range c.matches {
 				require.Contains(t, matches, k)
+			}
+
+			require.Equal(t, len(c.unmatched), len(unmatched))
+			for k := range c.unmatched {
+				require.Contains(t, unmatched, k)
 			}
 		})
 	}
@@ -514,7 +529,7 @@ func TestProcessWithMatchesPlatform(t *testing.T) {
 		"TARGETVARIANT": "v7",
 	})
 	require.NoError(t, err)
-	require.Equal(t, "something-v1.2.3.linux-arm-v7.tar.gz", results.Word)
+	require.Equal(t, "something-v1.2.3.linux-arm-v7.tar.gz", results.Result)
 
 	results, err = shlex.ProcessWordWithMatches(release, map[string]string{
 		"VERSION":       version,
@@ -523,7 +538,7 @@ func TestProcessWithMatchesPlatform(t *testing.T) {
 		"TARGETVARIANT": "",
 	})
 	require.NoError(t, err)
-	require.Equal(t, "something-v1.2.3.linux-arm64.tar.gz", results.Word)
+	require.Equal(t, "something-v1.2.3.linux-arm64.tar.gz", results.Result)
 
 	results, err = shlex.ProcessWordWithMatches(release, map[string]string{
 		"VERSION":    version,
@@ -532,5 +547,5 @@ func TestProcessWithMatchesPlatform(t *testing.T) {
 		// No "TARGETVARIANT": "",
 	})
 	require.NoError(t, err)
-	require.Equal(t, "something-v1.2.3.linux-arm64.tar.gz", results.Word)
+	require.Equal(t, "something-v1.2.3.linux-arm64.tar.gz", results.Result)
 }


### PR DESCRIPTION
This adds another linting rule related to unmatched ARGs in the FROM command.