### PR TITLE
git: restrict definition of git ref to previous behavior

### DIFF
--- a/util/gitutil/git_ref.go
+++ b/util/gitutil/git_ref.go
@@ -69,7 +69,7 @@ func ParseGitRef(ref string) (*GitRef, error) {
 	} else {
 		remote, err = ParseURL(ref)
 		if errors.Is(err, ErrUnknownProtocol) {
-			remote, err = ParseURL("https://" + ref)
+			return nil, err
 		}
 		if err != nil {
 			return nil, err

--- a/util/gitutil/git_ref_test.go
+++ b/util/gitutil/git_ref_test.go
@@ -67,11 +67,8 @@ func TestParseGitRef(t *testing.T) {
 			},
 		},
 		{
-			ref: "custom.xyz/moby/buildkit.git",
-			expected: &GitRef{
-				Remote:    "https://custom.xyz/moby/buildkit.git",
-				ShortName: "buildkit",
-			},
+			ref:      "custom.xyz/moby/buildkit.git",
+			expected: nil,
 		},
 		{
 			ref:      "https://github.com/moby/buildkit",


### PR DESCRIPTION
Fixes https://github.com/moby/buildkit/issues/4777 (again - thanks @raylu), and fixes https://github.com/moby/buildkit/issues/4846. See where this regression was introduced: https://github.com/moby/buildkit/pull/4142/files#diff-1bb11d110027d34708083bbbd69dbd446eadf916857680c279a31038268163b6L59-L60

During git refactoring, git refs accidentally became significantly broader in definition - specifically, files like "foo.bar/test.git" - is this a git repo at "foo.bar", or a local git directory?

We need to restrict this a lot more, previously, we only did this clever conversion for the "github.com" prefix. This restores this previous behavior.