### PR TITLE
avoid appending line info in lint detail

### DIFF
--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -11,6 +11,7 @@ import (
 	"github.com/moby/buildkit/frontend"
 	"github.com/moby/buildkit/frontend/attestations/sbom"
 	"github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb"
+	"github.com/moby/buildkit/frontend/dockerfile/linter"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/moby/buildkit/frontend/dockerui"
 	"github.com/moby/buildkit/frontend/gateway/client"
@@ -75,6 +76,11 @@ func Build(ctx context.Context, c client.Client) (_ *client.Result, err error) {
 		SourceMap:    src.SourceMap,
 		MetaResolver: c,
 		Warn: func(rulename, description, url, msg string, location []parser.Range) {
+			startLine := 0
+			if len(location) > 0 {
+				startLine = location[0].Start.Line
+			}
+			msg = linter.LintFormatShort(rulename, msg, startLine)
 			src.Warn(ctx, msg, warnOpts(location, [][]byte{[]byte(description)}, url))
 		},
 	}

--- a/frontend/dockerfile/dockerfile_lint_test.go
+++ b/frontend/dockerfile/dockerfile_lint_test.go
@@ -343,11 +343,10 @@ func checkVertexWarning(t *testing.T, warning *client.VertexWarning, expected ex
 }
 
 func checkLintWarning(t *testing.T, warning lint.Warning, expected expectedLintWarning) {
-	short := linter.LintFormatShort(expected.RuleName, expected.Detail, expected.Line)
 	require.Equal(t, expected.RuleName, warning.RuleName)
 	require.Equal(t, expected.Description, warning.Description)
 	require.Equal(t, expected.URL, warning.URL)
-	require.Equal(t, short, warning.Detail)
+	require.Equal(t, expected.Detail, warning.Detail)
 }
 
 func unmarshalLintResults(res *gateway.Result) (*lint.LintResults, error) {

--- a/frontend/dockerfile/linter/linter.go
+++ b/frontend/dockerfile/linter/linter.go
@@ -15,14 +15,10 @@ type LinterRule[F any] struct {
 }
 
 func (rule LinterRule[F]) Run(warn LintWarnFunc, location []parser.Range, txt ...string) {
-	startLine := 0
-	if len(location) > 0 {
-		startLine = location[0].Start.Line
-	}
 	if len(txt) == 0 {
 		txt = []string{rule.Description}
 	}
-	short := LintFormatShort(rule.Name, strings.Join(txt, " "), startLine)
+	short := strings.Join(txt, " ")
 	warn(rule.Name, rule.Description, rule.URL, short, location)
 }
 


### PR DESCRIPTION
Addresses #4851 by making it so that the specific style of "short" message that includes the line number isn't generated as part of the lint rule formatting, but rather as an additional step that the builder does (so we can still get that short style inline during the normal build process). 