### PR TITLE
vendor:  github.com/tonistiigi/fsutil @ 497d33b

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spdx/tools-golang v0.5.3
 	github.com/stretchr/testify v1.8.4
-	github.com/tonistiigi/fsutil v0.0.0-20240301111122-7525a1af2bb5
+	github.com/tonistiigi/fsutil v0.0.0-20240418180507-497d33b008ef
 	github.com/tonistiigi/go-actions-cache v0.0.0-20240320205438-9794bdbb2fb4
 	github.com/tonistiigi/go-archvariant v1.0.0
 	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea

--- a/go.sum
+++ b/go.sum
@@ -394,8 +394,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/tonistiigi/fsutil v0.0.0-20240301111122-7525a1af2bb5 h1:oZS8KCqAg62sxJkEq/Ppzqrb6EooqzWtL8Oaex7bc5c=
-github.com/tonistiigi/fsutil v0.0.0-20240301111122-7525a1af2bb5/go.mod h1:vbbYqJlnswsbJqWUcJN8fKtBhnEgldDrcagTgnBVKKM=
+github.com/tonistiigi/fsutil v0.0.0-20240418180507-497d33b008ef h1:1rshiFn5ka7/H9oGYXvRnV1BzhtWls2WSQZDrNwVsCA=
+github.com/tonistiigi/fsutil v0.0.0-20240418180507-497d33b008ef/go.mod h1:vbbYqJlnswsbJqWUcJN8fKtBhnEgldDrcagTgnBVKKM=
 github.com/tonistiigi/go-actions-cache v0.0.0-20240320205438-9794bdbb2fb4 h1:R0lM8Jo3aZL95yjQHWQti7nszllleKBxCs9uyFbykII=
 github.com/tonistiigi/go-actions-cache v0.0.0-20240320205438-9794bdbb2fb4/go.mod h1:anhKd3mnC1shAbQj1Q4IJ+w6xqezxnyDYlx/yKa7IXM=
 github.com/tonistiigi/go-archvariant v1.0.0 h1:5LC1eDWiBNflnTF1prCiX09yfNHIxDC/aukdhCdTyb0=

--- a/vendor/github.com/tonistiigi/fsutil/diff_containerd.go
+++ b/vendor/github.com/tonistiigi/fsutil/diff_containerd.go
@@ -111,7 +111,7 @@ func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b walkerFn, fil
 				if filter != nil {
 					filter(f2.path, &statCopy)
 				}
-				f2copy = &currentPath{path: filepath.FromSlash(f2.path), stat: &statCopy}
+				f2copy = &currentPath{path: f2.path, stat: &statCopy}
 			}
 			k, p := pathChange(f1, f2copy)
 			switch k {

--- a/vendor/github.com/tonistiigi/fsutil/send.go
+++ b/vendor/github.com/tonistiigi/fsutil/send.go
@@ -161,6 +161,7 @@ func (s *sender) walk(ctx context.Context) error {
 			return errors.WithStack(&os.PathError{Path: path, Err: syscall.EBADMSG, Op: "fileinfo without stat info"})
 		}
 		stat.Path = filepath.ToSlash(stat.Path)
+		stat.Linkname = filepath.ToSlash(stat.Linkname)
 		p := &types.Packet{
 			Type: types.PACKET_STAT,
 			Stat: stat,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -762,7 +762,7 @@ github.com/spdx/tools-golang/spdx/v2/v2_3
 ## explicit; go 1.20
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
-# github.com/tonistiigi/fsutil v0.0.0-20240301111122-7525a1af2bb5
+# github.com/tonistiigi/fsutil v0.0.0-20240418180507-497d33b008ef
 ## explicit; go 1.20
 github.com/tonistiigi/fsutil
 github.com/tonistiigi/fsutil/copy


### PR DESCRIPTION
Full diff: https://github.com/tonistiigi/fsutil/compare/7525a1af2bb5..497d33b

Summary changes:
- https://github.com/tonistiigi/fsutil/pull/195 receive: ensure callback errors are propagated
- https://github.com/tonistiigi/fsutil/pull/196 Fix file transfers from windows to linux fixes #4741
- https://github.com/tonistiigi/fsutil/pull/197 recv: translate linkname to wire format