### PR TITLE
fix: gc policy for windows to use 20% of disk space

### DIFF
--- a/cmd/buildkitd/config/gcpolicy_unix.go
+++ b/cmd/buildkitd/config/gcpolicy_unix.go
@@ -7,23 +7,13 @@ import (
 	"syscall"
 )
 
-func DetectDefaultGCCap() DiskSpace {
-	return DiskSpace{Percentage: 10}
-}
+var DiskSpacePercentage int64 = 10
 
-func (d DiskSpace) AsBytes(root string) int64 {
-	if d.Bytes != 0 {
-		return d.Bytes
-	}
-	if d.Percentage == 0 {
-		return 0
-	}
-
+func getDiskSize(root string) (int64, error) {
 	var st syscall.Statfs_t
 	if err := syscall.Statfs(root, &st); err != nil {
-		return defaultCap
+		return 0, err
 	}
 	diskSize := int64(st.Bsize) * int64(st.Blocks)
-	avail := diskSize * d.Percentage / 100
-	return (avail/(1<<30) + 1) * 1e9 // round up
+	return diskSize, nil
 }

--- a/cmd/buildkitd/config/gcpolicy_windows.go
+++ b/cmd/buildkitd/config/gcpolicy_windows.go
@@ -3,10 +3,29 @@
 
 package config
 
-func DetectDefaultGCCap() DiskSpace {
-	return DiskSpace{Bytes: defaultCap}
-}
+import (
+	"golang.org/x/sys/windows"
+)
 
-func (d DiskSpace) AsBytes(root string) int64 {
-	return d.Bytes
+// set as double that for Linux since
+// Windows images are generally larger.
+var DiskSpacePercentage int64 = 20
+
+func getDiskSize(root string) (int64, error) {
+	rootUTF16, err := windows.UTF16FromString(root)
+	if err != nil {
+		return 0, err
+	}
+	var freeAvailableBytes uint64
+	var totalBytes uint64
+	var totalFreeBytes uint64
+
+	if err := windows.GetDiskFreeSpaceEx(
+		&rootUTF16[0],
+		&freeAvailableBytes,
+		&totalBytes,
+		&totalFreeBytes); err != nil {
+		return 0, err
+	}
+	return int64(totalBytes), nil
 }


### PR DESCRIPTION
Initially we had the GC Policy for Windows use only 2 GB (2e9 bytes) of disk space and this was limiting for some build scenarios that need more than that, especially ServerCore images.

This commit makes the policy to use percentages as it is on Linux. Also going for 20%, double for that on Linux, since Windows images are generally larger. For instance, after the change, on a dev machine, the configured space was `74694367232 / (1 << 30) = 69.5 GiB`.

fixes #4858 docker/buildx#2411

---
**Before:**

```
> main.getGCPolicy() C:/dev/container-core/buildkit/cmd/buildkitd/main.go:875 (hits goroutine(1):1 total:1) (PC: 0x1e1347e)
   870:                         All:          rule.All,
   871:                         KeepBytes:    rule.KeepBytes.AsBytes(root),
   872:                         KeepDuration: rule.KeepDuration.Duration,
   873:                 })
   874:         }
=> 875:         return out
   876: }
   877:
   878: func getBuildkitVersion() client.BuildkitVersion {
   879:         return client.BuildkitVersion{
   880:                 Package:  version.Package,
(dlv) p out
[]github.com/moby/buildkit/client.PruneInfo len: 4, cap: 4, [
        {
                Filter: []string len: 1, cap: 1, [
                        "type==source.local,type==exec.cachemount,type==source.git.checko...+2 more",
                ],
                All: false,
                KeepDuration: 172800000000000,
                KeepBytes: 512000000,},
        {
                Filter: []string len: 0, cap: 0, nil,
                All: false,
                KeepDuration: 5184000000000000,
                KeepBytes: 2000000000,},
        {
                Filter: []string len: 0, cap: 0, nil,
                All: false,
                KeepDuration: 0,
                KeepBytes: 2000000000,},
        {
                Filter: []string len: 0, cap: 0, nil,
                All: true,
                KeepDuration: 0,
                KeepBytes: 2000000000,},
]
```

**After:**

```
> main.getGCPolicy() C:/dev/container-core/buildkit/cmd/buildkitd/main.go:875 (hits goroutine(1):1 total:1) (PC: 0x2c63a5e)
   870:                         All:          rule.All,
   871:                         KeepBytes:    rule.KeepBytes.AsBytes(root),
   872:                         KeepDuration: rule.KeepDuration.Duration,
   873:                 })
   874:         }
=> 875:         return out
   876: }
   877:
   878: func getBuildkitVersion() client.BuildkitVersion {
   879:         return client.BuildkitVersion{
   880:                 Package:  version.Package,
(dlv) p out
[]github.com/moby/buildkit/client.PruneInfo len: 4, cap: 4, [
        {
                Filter: []string len: 1, cap: 1, [
                        "type==source.local,type==exec.cachemount,type==source.git.checko...+2 more",
                ],
                All: false,
                KeepDuration: 172800000000000,
                KeepBytes: 512000000,},
        {
                Filter: []string len: 0, cap: 0, nil,
                All: false,
                KeepDuration: 5184000000000000,
                KeepBytes: 140000000000,},
        {
                Filter: []string len: 0, cap: 0, nil,
                All: false,
                KeepDuration: 0,
                KeepBytes: 140000000000,},
        {
                Filter: []string len: 0, cap: 0, nil,
                All: true,
                KeepDuration: 0,
                KeepBytes: 140000000000,},
]
```