### PR TITLE
docs: dockerfile reference title in front matter

### DIFF
--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -1,4 +1,6 @@
-# Dockerfile reference
+---
+title: Dockerfile reference
+---
 
 Docker can build images automatically by reading the instructions from a
 Dockerfile. A Dockerfile is a text document that contains all the commands a


### PR DESCRIPTION
Use front matter to specify the doc title for the Dockerfile reference
in order to make the title programmatically accessible with Hugo, making
it easier to properly render the title in templates.

Specifying the title in the document directly means we have no control
over the rendering of the top-level heading.

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>
