### PR TITLE
fix: create windows npipe with the right security descriptor

### DIFF
--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -639,6 +639,9 @@ func getListener(addr string, uid, gid int, tlsConfig *tls.Config) (net.Listener
 		if tlsConfig != nil {
 			bklog.L.Warnf("TLS is disabled for %s", addr)
 		}
+		if proto == "npipe" {
+			return getLocalListener(listenAddr)
+		}
 		return sys.GetLocalListener(listenAddr, uid, gid)
 	case "fd":
 		return listenFD(listenAddr, tlsConfig)


### PR DESCRIPTION
There was already code that was creating the npipe with the right descriptors, as it has been for other like docker[1].

This fix uses the main.getLocalListener instead of the generic one from `containerd/sys`.

__
[1] https://github.com/moby/moby/blob/master/daemon/listeners/listeners_windows.go#L25

fixes #4864

---

Before and After (running from non-Admin terminal):

![image](https://github.com/moby/buildkit/assets/261265/4e9b9824-e324-42f9-afdf-9f59539b2398)
