### PR TITLE
detect: remove extraneous check for detected exporters

### DIFF
--- a/util/tracing/detect/detect.go
+++ b/util/tracing/detect/detect.go
@@ -120,7 +120,7 @@ func detect() error {
 	mp = sdkmetric.NewMeterProvider()
 
 	texp, mexp, err := detectExporters()
-	if err != nil || (texp == nil && mexp == nil) {
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Checking for detected exporters doesn't really work properly because of implicit exporters like the recorder and the prometheus metrics. Removing that line because it interfered with the correct initialization of the tracer provider in moby.