### PR TITLE
align prune with disk usage (du) command behaviour

### DIFF
--- a/cache/manager.go
+++ b/cache/manager.go
@@ -1109,10 +1109,11 @@ func (cm *cacheManager) prune(ctx context.Context, ch chan client.UsageInfo, opt
 			}
 
 			c := &client.UsageInfo{
-				ID:         cr.ID(),
-				Mutable:    cr.mutable,
-				RecordType: recordType,
-				Shared:     shared,
+				ID:          cr.ID(),
+				Mutable:     cr.mutable,
+				RecordType:  recordType,
+				Shared:      shared,
+				Description: cr.GetDescription(),
 			}
 
 			usageCount, lastUsedAt := cr.getLastUsed()


### PR DESCRIPTION
The command `buildctl du—-filter=...` or the associated RPC supports a wider range of filters than the `prune` command.

```
> buildctl --addr unix:///var/lib/buildkit/buildkitd.sock du --filter='description~=".*go build.*"'
ID									RECLAIMABLE	SIZE	LAST ACCESSED
wt5gwgj5p8m7croouarjwp2vp*                                             	true       	1.49GB
k5ysmyy2eahyze4783hobeh3i*                                             	true       	1.49GB
kcae1sloyiibspvg0grlgukre*                                             	true       	1.48GB
> buildctl --addr unix:///var/lib/buildkit/buildkitd.sock prune --filter='description~=".*go build.*"'
Total:	0B
```

The expected behavior is that the `prune` command should match the same layers as the `du` command if they are reclaimable.

```
> buildctl --addr unix:///var/lib/buildkit/buildkitd.sock du --filter='description~=".*go build.*"'
ID									RECLAIMABLE	SIZE	LAST ACCESSED
wt5gwgj5p8m7croouarjwp2vp*                                             	true       	1.49GB
k5ysmyy2eahyze4783hobeh3i*                                             	true       	1.49GB
kcae1sloyiibspvg0grlgukre*                                             	true       	1.48GB
> buildctl --addr unix:///var/lib/buildkit/buildkitd.sock prune --filter='description~=".*go build.*"'
Total:	4.46GB
```

This would also allow finer GC control over the build cache when running buildkitd as a daemon.