### PR TITLE
linter: add lint rule for required json arguments

### DIFF
--- a/frontend/dockerfile/linter/ruleset.go
+++ b/frontend/dockerfile/linter/ruleset.go
@@ -55,6 +55,13 @@ var (
 			return fmt.Sprintf("Stage name should not use the same name as reserved stage %q", reservedStageName)
 		},
 	}
+	RuleJSONArgsRecommended = LinterRule[func(instructionName string) string]{
+		Name:        "JSONArgsRecommended",
+		Description: "JSON arguments recommended for ENTRYPOINT/CMD to prevent unintended behavior related to OS signals",
+		Format: func(instructionName string) string {
+			return fmt.Sprintf("JSON arguments recommended for %s to prevent unintended behavior related to OS signals", instructionName)
+		},
+	}
 	RuleMaintainerDeprecated = LinterRule[func() string]{
 		Name:        "MaintainerDeprecated",
 		Description: "The maintainer instruction is deprecated, use a label instead to define an image author",


### PR DESCRIPTION
This lint requires json arguments to be used when the `SHELL` command isn't used previously for `ENTRYPOINT` and `CMD`. This is because using non-json arguments can block signals from properly being handled when used in shell mode.

This uses the `Shell` attribute on the image configuration and therefore
requires the stage to be included in the build for it to properly run.
This is done because we don't want to force image config resolution on
every stage even if the stage isn't part of the build, but the only way
to definitively know if a custom shell is set is to look at the image
configuration.