### PR TITLE
Adds alpine:latest to mirrored images in dockerfile integration tests

### DIFF
--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -211,7 +211,7 @@ func init() {
 	frontends := map[string]interface{}{}
 
 	opts = []integration.TestOpt{
-		integration.WithMirroredImages(integration.OfficialImages("busybox:latest")),
+		integration.WithMirroredImages(integration.OfficialImages("busybox:latest", "alpine:latest")),
 		integration.WithMatrix("frontend", frontends),
 	}
 


### PR DESCRIPTION
Currently, several of the integration tests in `dockerfile_test` rely upon the `alpine:latest` image. This adds that image to the mirrored images to reduce the number of image pulls while running tests.