### PR TITLE
contenthash: implement proper Linux symlink semantics

### DIFF
--- a/cache/contenthash/checksum.go
+++ b/cache/contenthash/checksum.go
@@ -407,7 +407,7 @@ func (cc *cacheContext) Checksum(ctx context.Context, mountable cache.Mountable,
 	defer m.clean()
 
 	if !opts.Wildcard && len(opts.IncludePatterns) == 0 && len(opts.ExcludePatterns) == 0 {
-		return cc.checksumFollow(ctx, m, p, opts.FollowLinks)
+		return cc.lazyChecksum(ctx, m, p, opts.FollowLinks)
 	}
 
 	includedPaths, err := cc.includedPaths(ctx, m, p, opts)
@@ -418,7 +418,7 @@ func (cc *cacheContext) Checksum(ctx context.Context, mountable cache.Mountable,
 	if opts.FollowLinks {
 		for i, w := range includedPaths {
 			if w.record.Type == CacheRecordTypeSymlink {
-				dgst, err := cc.checksumFollow(ctx, m, w.path, opts.FollowLinks)
+				dgst, err := cc.lazyChecksum(ctx, m, w.path, opts.FollowLinks)
 				if err != nil {
 					return "", err
 				}
@@ -445,30 +445,6 @@ func (cc *cacheContext) Checksum(ctx context.Context, mountable cache.Mountable,
 	return digester.Digest(), nil
 }
 
-func (cc *cacheContext) checksumFollow(ctx context.Context, m *mount, p string, follow bool) (digest.Digest, error) {
-	const maxSymlinkLimit = 255
-	i := 0
-	for {
-		if i > maxSymlinkLimit {
-			return "", errors.Errorf("too many symlinks: %s", p)
-		}
-		cr, err := cc.checksumNoFollow(ctx, m, p)
-		if err != nil {
-			return "", err
-		}
-		if cr.Type == CacheRecordTypeSymlink && follow {
-			link := cr.Linkname
-			if !path.IsAbs(cr.Linkname) {
-				link = path.Join(path.Dir(p), link)
-			}
-			i++
-			p = link
-		} else {
-			return cr.Digest, nil
-		}
-	}
-}
-
 func (cc *cacheContext) includedPaths(ctx context.Context, m *mount, p string, opts ChecksumOpts) ([]*includedPath, error) {
 	cc.mu.Lock()
 	defer cc.mu.Unlock()
@@ -478,12 +454,12 @@ func (cc *cacheContext) includedPaths(ctx context.Context, m *mount, p string, o
 	}
 
 	root := cc.tree.Root()
-	scan, err := cc.needsScan(root, "")
+	scan, err := cc.needsScan(root, "", false)
 	if err != nil {
 		return nil, err
 	}
 	if scan {
-		if err := cc.scanPath(ctx, m, ""); err != nil {
+		if err := cc.scanPath(ctx, m, "", false); err != nil {
 			return nil, err
 		}
 	}
@@ -542,7 +518,7 @@ func (cc *cacheContext) includedPaths(ctx context.Context, m *mount, p string, o
 		// involves a symlink. That will match fsutil behavior of
 		// calling functions such as stat and walk.
 		var cr *CacheRecord
-		k, cr, err = getFollowParentLinks(root, k, true)
+		k, cr, err = getFollowLinks(root, k, false)
 		if err != nil {
 			return nil, err
 		}
@@ -753,11 +729,7 @@ func wildcardPrefix(root *iradix.Node, p string) (string, []byte, bool, error) {
 
 	// Only resolve the final symlink component if there are components in the
 	// wildcard segment.
-	resolveFn := getFollowParentLinks
-	if d2 != "" {
-		resolveFn = getFollowLinks
-	}
-	k, cr, err := resolveFn(root, convertPathToKey(d1), true)
+	k, cr, err := getFollowLinks(root, convertPathToKey(d1), d2 != "")
 	if err != nil {
 		return "", k, false, err
 	}
@@ -796,19 +768,22 @@ func containsWildcards(name string) bool {
 	return false
 }
 
-func (cc *cacheContext) checksumNoFollow(ctx context.Context, m *mount, p string) (*CacheRecord, error) {
+func (cc *cacheContext) lazyChecksum(ctx context.Context, m *mount, p string, followTrailing bool) (digest.Digest, error) {
 	p = keyPath(p)
+	k := convertPathToKey(p)
 
+	// Try to look up the path directly without doing a scan.
 	cc.mu.RLock()
 	if cc.txn == nil {
 		root := cc.tree.Root()
 		cc.mu.RUnlock()
-		v, ok := root.Get(convertPathToKey(p))
-		if ok {
-			cr := v.(*CacheRecord)
-			if cr.Digest != "" {
-				return cr, nil
-			}
+
+		_, cr, err := getFollowLinks(root, k, followTrailing)
+		if err != nil {
+			return "", err
+		}
+		if cr != nil && cr.Digest != "" {
+			return cr.Digest, nil
 		}
 	} else {
 		cc.mu.RUnlock()
@@ -828,7 +803,11 @@ func (cc *cacheContext) checksumNoFollow(ctx context.Context, m *mount, p string
 		}
 	}()
 
-	return cc.lazyChecksum(ctx, m, p)
+	cr, err := cc.scanChecksum(ctx, m, p, followTrailing)
+	if err != nil {
+		return "", err
+	}
+	return cr.Digest, nil
 }
 
 func (cc *cacheContext) commitActiveTransaction() {
@@ -847,21 +826,21 @@ func (cc *cacheContext) commitActiveTransaction() {
 	cc.txn = nil
 }
 
-func (cc *cacheContext) lazyChecksum(ctx context.Context, m *mount, p string) (*CacheRecord, error) {
+func (cc *cacheContext) scanChecksum(ctx context.Context, m *mount, p string, followTrailing bool) (*CacheRecord, error) {
 	root := cc.tree.Root()
-	scan, err := cc.needsScan(root, p)
+	scan, err := cc.needsScan(root, p, followTrailing)
 	if err != nil {
 		return nil, err
 	}
 	if scan {
-		if err := cc.scanPath(ctx, m, p); err != nil {
+		if err := cc.scanPath(ctx, m, p, followTrailing); err != nil {
 			return nil, err
 		}
 	}
 	k := convertPathToKey(p)
 	txn := cc.tree.Txn()
 	root = txn.Root()
-	cr, updated, err := cc.checksum(ctx, root, txn, m, k, true)
+	cr, updated, err := cc.checksum(ctx, root, txn, m, k, followTrailing)
 	if err != nil {
 		return nil, err
 	}
@@ -870,9 +849,9 @@ func (cc *cacheContext) lazyChecksum(ctx context.Context, m *mount, p string) (*
 	return cr, err
 }
 
-func (cc *cacheContext) checksum(ctx context.Context, root *iradix.Node, txn *iradix.Txn, m *mount, k []byte, follow bool) (*CacheRecord, bool, error) {
+func (cc *cacheContext) checksum(ctx context.Context, root *iradix.Node, txn *iradix.Txn, m *mount, k []byte, followTrailing bool) (*CacheRecord, bool, error) {
 	origk := k
-	k, cr, err := getFollowParentLinks(root, k, follow)
+	k, cr, err := getFollowLinks(root, k, followTrailing)
 	if err != nil {
 		return nil, false, err
 	}
@@ -898,7 +877,9 @@ func (cc *cacheContext) checksum(ctx context.Context, root *iradix.Node, txn *ir
 			}
 			h.Write(bytes.TrimPrefix(subk, k))
 
-			subcr, _, err := cc.checksum(ctx, root, txn, m, subk, true)
+			// We do not follow trailing links when checksumming a directory's
+			// contents.
+			subcr, _, err := cc.checksum(ctx, root, txn, m, subk, false)
 			if err != nil {
 				return nil, false, err
 			}
@@ -949,13 +930,13 @@ func (cc *cacheContext) checksum(ctx context.Context, root *iradix.Node, txn *ir
 
 // needsScan returns false if path is in the tree or a parent path is in tree
 // and subpath is missing.
-func (cc *cacheContext) needsScan(root *iradix.Node, path string) (bool, error) {
+func (cc *cacheContext) needsScan(root *iradix.Node, path string, followTrailing bool) (bool, error) {
 	var (
 		lastGoodPath    string
 		hasParentInTree bool
 	)
 	k := convertPathToKey(path)
-	_, cr, err := getFollowLinksCallback(root, k, true, func(subpath string, cr *CacheRecord) error {
+	_, cr, err := getFollowLinksCallback(root, k, followTrailing, func(subpath string, cr *CacheRecord) error {
 		if cr != nil {
 			// If the path is not a symlink, then for now we have a parent in
 			// the tree. Otherwise, we reset hasParentInTree because we
@@ -981,8 +962,8 @@ func (cc *cacheContext) needsScan(root *iradix.Node, path string) (bool, error) 
 	return cr == nil && !hasParentInTree, nil
 }
 
-func (cc *cacheContext) scanPath(ctx context.Context, m *mount, p string) (retErr error) {
-	d := path.Dir(path.Join("/", p))
+func (cc *cacheContext) scanPath(ctx context.Context, m *mount, p string, followTrailing bool) (retErr error) {
+	p = path.Join("/", p)
 
 	mp, err := m.mount(ctx)
 	if err != nil {
@@ -992,7 +973,7 @@ func (cc *cacheContext) scanPath(ctx context.Context, m *mount, p string) (retEr
 	n := cc.tree.Root()
 	txn := cc.tree.Txn()
 
-	parentPath, err := rootPath(mp, filepath.FromSlash(d), func(p, link string) error {
+	resolvedPath, err := rootPath(mp, filepath.FromSlash(p), followTrailing, func(p, link string) error {
 		cr := &CacheRecord{
 			Type:     CacheRecordTypeSymlink,
 			Linkname: filepath.ToSlash(link),
@@ -1005,7 +986,14 @@ func (cc *cacheContext) scanPath(ctx context.Context, m *mount, p string) (retEr
 		return err
 	}
 
-	err = filepath.Walk(parentPath, func(itemPath string, fi os.FileInfo, err error) error {
+	// Scan the parent directory of the path we resolved, unless we're at the
+	// root (in which case we scan the root).
+	scanPath := filepath.Dir(resolvedPath)
+	if !strings.HasPrefix(filepath.ToSlash(scanPath)+"/", filepath.ToSlash(mp)+"/") {
+		scanPath = resolvedPath
+	}
+
+	err = filepath.Walk(scanPath, func(itemPath string, fi os.FileInfo, err error) error {
 		if err != nil {
 			// If the root doesn't exist, ignore the error.
 			if itemPath == scanPath && errors.Is(err, os.ErrNotExist) {
@@ -1054,48 +1042,33 @@ func (cc *cacheContext) scanPath(ctx context.Context, m *mount, p string) (retEr
 	return nil
 }
 
-// getFollowParentLinks is effectively O_PATH|O_NOFOLLOW, where the final
-// component is looked up without doing any symlink resolution (if it is a
-// symlink).
-func getFollowParentLinks(root *iradix.Node, k []byte, follow bool) ([]byte, *CacheRecord, error) {
-	v, ok := root.Get(k)
-	if ok {
-		return k, v.(*CacheRecord), nil
-	}
-	if !follow || len(k) == 0 {
-		return k, nil, nil
-	}
-
-	// Only fully evaluate the parent path.
-	dir, file := splitKey(k)
-	dir, _, err := getFollowLinks(root, dir, follow)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Do a direct lookup of the final component.
-	k = append(dir, file...)
-	v, ok = root.Get(k)
-	if ok {
-		return k, v.(*CacheRecord), nil
-	}
-	return k, nil, nil
-}
-
 // followLinksCallback is called after we try to resolve each element. If the
 // path was not found, cr is nil.
 type followLinksCallback func(path string, cr *CacheRecord) error
 
-func getFollowLinks(root *iradix.Node, k []byte, follow bool) ([]byte, *CacheRecord, error) {
-	return getFollowLinksCallback(root, k, follow, nil)
+// getFollowLinks is shorthand for getFollowLinksCallback(..., nil).
+func getFollowLinks(root *iradix.Node, k []byte, followTrailing bool) ([]byte, *CacheRecord, error) {
+	return getFollowLinksCallback(root, k, followTrailing, nil)
 }
 
-func getFollowLinksCallback(root *iradix.Node, k []byte, follow bool, cb followLinksCallback) ([]byte, *CacheRecord, error) {
+// getFollowLinksCallback looks up the requested key, fully resolving any
+// symlink components encountered. The implementation is heavily based on
+// <https://github.com/cyphar/filepath-securejoin>.
+//
+// followTrailing indicates whether the *final component* of the path should be
+// resolved (effectively O_PATH|O_NOFOLLOW). Note that (in contrast to some
+// Linux APIs), followTrailing is obeyed even if the key has a trailing slash
+// (though paths like "foo/link/." will cause the link to be resolved).
+//
+// The callback cb is called after each cache lookup done by
+// getFollowLinksCallback, except for the first lookup where the verbatim key
+// is looked up in the cache.
+func getFollowLinksCallback(root *iradix.Node, k []byte, followTrailing bool, cb followLinksCallback) ([]byte, *CacheRecord, error) {
 	v, ok := root.Get(k)
-	if ok && v.(*CacheRecord).Type != CacheRecordTypeSymlink {
+	if ok && (!followTrailing || v.(*CacheRecord).Type != CacheRecordTypeSymlink) {
 		return k, v.(*CacheRecord), nil
 	}
-	if !follow || len(k) == 0 {
+	if len(k) == 0 {
 		return k, nil, nil
 	}
 
@@ -1144,6 +1117,10 @@ func getFollowLinksCallback(root *iradix.Node, k []byte, follow bool, cb followL
 		if !ok || cr.Type != CacheRecordTypeSymlink {
 			currentPath = nextPath
 			continue
+		}
+		if !followTrailing && remainingPath == "" {
+			currentPath = nextPath
+			break
 		}
 
 		linksWalked++
@@ -1235,19 +1212,4 @@ func convertPathToKey(p string) []byte {
 
 func convertKeyToPath(p []byte) string {
 	return string(bytes.ReplaceAll(p, []byte{0}, []byte("/")))
-}
-
-func splitKey(k []byte) ([]byte, []byte) {
-	foundBytes := false
-	i := len(k) - 1
-	for {
-		if i <= 0 || foundBytes && k[i] == 0 {
-			break
-		}
-		if k[i] != 0 {
-			foundBytes = true
-		}
-		i--
-	}
-	return append([]byte{}, k[:i]...), k[i:]
 }

--- a/cache/contenthash/path.go
+++ b/cache/contenthash/path.go
@@ -1,108 +1,102 @@
+// This code mostly comes from <https://github.com/cyphar/filepath-securejoin>.
+
+// Copyright (C) 2014-2015 Docker Inc & Go Authors. All rights reserved.
+// Copyright (C) 2017-2024 SUSE LLC. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package contenthash
 
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 )
 
-var (
-	errTooManyLinks = errors.New("too many links")
-)
+var errTooManyLinks = errors.New("too many links")
+
+const maxSymlinkLimit = 255
 
 type onSymlinkFunc func(string, string) error
 
-// rootPath joins a path with a root, evaluating and bounding any
-// symlink to the root directory.
-// This is containerd/continuity/fs RootPath implementation with a callback on
-// resolving the symlink.
-func rootPath(root, path string, cb onSymlinkFunc) (string, error) {
-	if path == "" {
+// rootPath joins a path with a root, evaluating and bounding any symlink to
+// the root directory. This is a slightly modified version of SecureJoin from
+// github.com/cyphar/filepath-securejoin, with a callback which we call after
+// each symlink resolution.
+func rootPath(root, unsafePath string, cb onSymlinkFunc) (string, error) {
+	if unsafePath == "" {
 		return root, nil
 	}
-	var linksWalked int // to protect against cycles
-	for {
-		i := linksWalked
-		newpath, err := walkLinks(root, path, &linksWalked, cb)
+
+	unsafePath = filepath.FromSlash(unsafePath)
+	var (
+		currentPath string
+		linksWalked int
+	)
+	for unsafePath != "" {
+		// Windows-specific: remove any drive letters from the path.
+		if v := filepath.VolumeName(unsafePath); v != "" {
+			unsafePath = unsafePath[len(v):]
+		}
+
+		// Get the next path component.
+		var part string
+		if i := strings.IndexRune(unsafePath, filepath.Separator); i == -1 {
+			part, unsafePath = unsafePath, ""
+		} else {
+			part, unsafePath = unsafePath[:i], unsafePath[i+1:]
+		}
+
+		// Apply the component lexically to the path we are building. path does
+		// not contain any symlinks, and we are lexically dealing with a single
+		// component, so it's okay to do filepath.Clean here.
+		nextPath := filepath.Join(string(filepath.Separator), currentPath, part)
+		if nextPath == string(filepath.Separator) {
+			// If we end up back at the root, we don't need to re-evaluate /.
+			currentPath = ""
+			continue
+		}
+		fullPath := root + string(filepath.Separator) + nextPath
+
+		// Figure out whether the path is a symlink.
+		fi, err := os.Lstat(fullPath)
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
+		// Treat non-existent path components the same as non-symlinks (we
+		// can't do any better here).
+		if errors.Is(err, os.ErrNotExist) || fi.Mode()&os.ModeSymlink == 0 {
+			currentPath = nextPath
+			continue
+		}
+
+		// It's a symlink, so get its contents and expand it by prepending it
+		// to the yet-unparsed path.
+		linksWalked++
+		if linksWalked > maxSymlinkLimit {
+			return "", errTooManyLinks
+		}
+
+		dest, err := os.Readlink(fullPath)
 		if err != nil {
 			return "", err
 		}
-		path = newpath
-		if i == linksWalked {
-			newpath = filepath.Join("/", newpath)
-			if path == newpath {
-				return filepath.Join(root, newpath), nil
+		if cb != nil {
+			if err := cb(nextPath, dest); err != nil {
+				return "", err
 			}
-			path = newpath
 		}
-	}
-}
-
-func walkLink(root, path string, linksWalked *int, cb onSymlinkFunc) (newpath string, islink bool, err error) {
-	if *linksWalked > 255 {
-		return "", false, errTooManyLinks
+		unsafePath = dest + string(filepath.Separator) + unsafePath
+		// Absolute symlinks reset any work we've already done.
+		if filepath.IsAbs(dest) {
+			currentPath = ""
+		}
 	}
 
-	path = filepath.Join("/", path)
-	if path == "/" {
-		return path, false, nil
-	}
-	realPath := filepath.Join(root, path)
-
-	fi, err := os.Lstat(realPath)
-	if err != nil {
-		// If path does not yet exist, treat as non-symlink
-		if errors.Is(err, os.ErrNotExist) {
-			return path, false, nil
-		}
-		return "", false, err
-	}
-	if fi.Mode()&os.ModeSymlink == 0 {
-		return path, false, nil
-	}
-	newpath, err = os.Readlink(realPath)
-	if err != nil {
-		return "", false, err
-	}
-	if cb != nil {
-		if err := cb(path, newpath); err != nil {
-			return "", false, err
-		}
-	}
-	*linksWalked++
-	return newpath, true, nil
-}
-
-func walkLinks(root, path string, linksWalked *int, cb onSymlinkFunc) (string, error) {
-	switch dir, file := filepath.Split(path); {
-	case dir == "":
-		newpath, _, err := walkLink(root, file, linksWalked, cb)
-		return newpath, err
-	case file == "":
-		if os.IsPathSeparator(dir[len(dir)-1]) {
-			if dir == "/" {
-				return dir, nil
-			}
-			return walkLinks(root, dir[:len(dir)-1], linksWalked, cb)
-		}
-		newpath, _, err := walkLink(root, dir, linksWalked, cb)
-		return newpath, err
-	default:
-		newdir, err := walkLinks(root, dir, linksWalked, cb)
-		if err != nil {
-			return "", err
-		}
-		newpath, islink, err := walkLink(root, filepath.Join(newdir, file), linksWalked, cb)
-		if err != nil {
-			return "", err
-		}
-		if !islink {
-			return newpath, nil
-		}
-		if filepath.IsAbs(newpath) {
-			return newpath, nil
-		}
-		return filepath.Join(newdir, newpath), nil
-	}
+	// There should be no lexical components left in path here, but just for
+	// safety do a filepath.Clean before the join.
+	finalPath := filepath.Join(string(filepath.Separator), currentPath)
+	return filepath.Join(root, finalPath), nil
 }

--- a/cache/contenthash/path_test.go
+++ b/cache/contenthash/path_test.go
@@ -1,0 +1,124 @@
+package contenthash
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRootPathSymlinks(t *testing.T) {
+	t.Parallel()
+	tmpdir := t.TempDir()
+
+	// Make the following tree:
+	//  /
+	//  |- target/
+	mkdirAll(t, tmpdir, "target")
+	//  |- link1
+	//     |- sub/
+	//     |- notaloop -> ../target
+	//     |- final -> /target
+	mkdirAll(t, tmpdir, "link1")
+	mkdirAll(t, tmpdir, "link1/sub")
+	symlink(t, tmpdir, "link1/notaloop", "../target")
+	symlink(t, tmpdir, "link1/final", "/target")
+	//  |- link2
+	//     |- link1 -> /link1/
+	//     |- link1sub -> /link1/sub/
+	//     |- notaloop -> ./link1sub/../notaloop
+	//     |- notaloop_abs -> /link2/link1sub/../notaloop
+	//     |- notaloop2 -> ./link1/../link1/notaloop
+	//     |- notaloop2_abs -> /link2/link1/../link1/notaloop
+	//     |- target -> ./link1sub/../final
+	//     |- target_abs -> /link2/link1sub/../final
+	//     |- target2 -> ./link1/../link1/final
+	//     |- target2_abs -> /link2/link1/../link1/final
+	mkdirAll(t, tmpdir, "link2")
+	symlink(t, tmpdir, "link2/link1", "/link1/")
+	symlink(t, tmpdir, "link2/link1sub", "/link1/sub/")
+	symlink(t, tmpdir, "link2/notaloop", "./link1sub/../notaloop")
+	symlink(t, tmpdir, "link2/notaloop_abs", "/link2/link1sub/../notaloop")
+	symlink(t, tmpdir, "link2/notaloop2", "./link1/../link1/notaloop")
+	symlink(t, tmpdir, "link2/notaloop2_abs", "/link2/link1/../link1/notaloop")
+	symlink(t, tmpdir, "link2/target", "./link1sub/../final")
+	symlink(t, tmpdir, "link2/target_abs", "/link2/link1sub/../final")
+	symlink(t, tmpdir, "link2/target2", "./link1/../link1/final")
+	symlink(t, tmpdir, "link2/target2_abs", "/link2/link1/../link1/final")
+
+	// All of the symlinks in the tree should lead to /target.
+	expected := filepath.Join(tmpdir, "target")
+
+	for _, link := range []string{
+		"target",
+		"link1/notaloop",
+		"link1/final",
+		"link2/notaloop",
+		"link2/notaloop_abs",
+		"link2/notaloop2",
+		"link2/notaloop2_abs",
+		"link2/target",
+		"link2/target_abs",
+		"link2/target2",
+		"link2/target2_abs",
+		"link2/link1sub/../notaloop",    // link2/notaloop
+		"link2/link1/../link1/notaloop", // link2/notaloop2
+		"link2/link1sub/../final",       // link2/target
+		"link2/link1/../link1/final",    // link2/target2
+	} {
+		link := link // capture range variable
+		t.Run(fmt.Sprintf("resolve(%q)", link), func(t *testing.T) {
+			t.Parallel()
+
+			resolvedPath, err := rootPath(tmpdir, link, nil)
+			require.NoError(t, err)
+			require.Equal(t, expected, resolvedPath)
+		})
+	}
+}
+
+func mkdirAll(t *testing.T, root, path string) {
+	path = filepath.FromSlash(path)
+
+	err := os.MkdirAll(filepath.Join(root, path), 0755)
+	require.NoError(t, err)
+}
+
+func symlink(t *testing.T, root, linkname, target string) {
+	linkname = filepath.FromSlash(linkname)
+
+	// We need to add a dummy drive letter to emulate absolute symlinks on
+	// Windows.
+	if runtime.GOOS == "windows" && path.IsAbs(target) {
+		target = "Z:" + filepath.FromSlash(target)
+	} else {
+		target = filepath.FromSlash(target)
+	}
+
+	dir, _ := filepath.Split(linkname)
+	mkdirAll(t, root, dir)
+
+	fullLinkname := filepath.Join(root, linkname)
+
+	err := os.Symlink(target, fullLinkname)
+	require.NoError(t, err)
+
+	// Windows seems to automatically change our /foo/../bar symlinks to /bar,
+	// causing some tests to fail. Technically we only care about this symlink
+	// behaviour on Linux (since we implemented it this way to keep Linux
+	// compatibility), so if our symlink has the wrong target we can just skip
+	// the test.
+	actualTarget, err := os.Readlink(fullLinkname)
+	require.NoError(t, err)
+	if actualTarget != target {
+		fn := t.Skipf
+		if runtime.GOOS != "windows" {
+			fn = t.Fatalf
+		}
+		fn("created link had the wrong contents -- %s -> %s", target, actualTarget)
+	}
+}


### PR DESCRIPTION
This series fixes the symlink following implementation of `cache/contenthash`. The primary issue with the previous implementation is that it assumed that `path.Join` is a reasonable way of implementing trailing symlink following -- this is not correct on Linux. `path.Clean` is a Plan9-ism, and while it is useful, on Linux symlinks are resolved left-to-right and thus lexically transforming `a/b/../c` to `a/c` is incorrect if `b` is a symlink. [The paper describing Plan9's `path_clean` makes reference to this Unix-ism they fixed by removing symlinks from Plan9.](https://9p.io/sys/doc/lexnames.html)

As the trailing symlink logic was written in quite a few places, all of the implementations needed to be fixed. The headline changes are:

 * All of the symlink following implementations are now iterative, based on https://github.com/cyphar/filepath-securejoin. Because of the requirement to apply each component in a symlink individually, recursive implementations end up with a lot of wasted work.
 * The `follow` flag now means `followTrailing` (`O_NOFOLLOW`) everywhere. Previously, `getFollowLinks` and `cc.checksum` used it to mean "don't follow any links" (a-la `RESOLVE_NO_SYMLINKS`) while `cc.Checksum` and `cc.checksumFollow` used it to mean `O_FOLLOW`. There was only one user of the `RESOLVE_NO_SYMLINKS` implementation (`cc.includedPaths`) and it appears it was only used as an optimisation (when in fact, since we are iterating over the keys in the cache, the key definitely exists, `cc.checksum` will just do a simple lookup regardless of `RESOLVE_NO_SYMLINKS`).
 * `cc.checksumFollow` is gone (now that `checksum` supports `followTrailing` directly), and `cc.checksumNoFollow` and `cc.lazyChecksum` have been renamed and reworked slightly. Removing the loop in `checksumFollow` also means we will detect symlink loops 255 times faster :smile_cat:, not to mention that we now don't do a bunch of unnecessary scanning and checksumming when dealing with trailing symlinks.
 * `needsScan` now just uses `getFollowLinksCallback` to track the status of a lookup to see if there is a non-symlink path component that has already been scanned in the cache. This removes one extra implementation of symlink lookups.
 * `scanPath` now does a scan of `path.Dir` of the resolved path, rather than resolving the lexical directory of the requested path (this means `scanPath`, `needsScan`, and thus `rootPath` now also take `followTrailing`). I suspect that always fully-resolving the path would be okay (because we fill in symlinks during resolution) but in the case of `followTrailing=false` it seems unclear to me which directory "should" be scanned. The old implementation would scan all of them (because `checksumFollow` would re-apply the trailing link and re-checksum everything).

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>