### PR TITLE
buildkitd: Frontend restriction support

### DIFF
--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -33,6 +33,11 @@ type Config struct {
 	DNS *DNSConfig `toml:"dns"`
 
 	History *HistoryConfig `toml:"history"`
+
+	Frontends struct {
+		Dockerfile DockerfileFrontendConfig `toml:"dockerfile.v0"`
+		Gateway    GatewayFrontendConfig    `toml:"gateway.v0"`
+	} `toml:"frontend"`
 }
 
 type LogConfig struct {
@@ -154,4 +159,13 @@ type DNSConfig struct {
 type HistoryConfig struct {
 	MaxAge     Duration `toml:"maxAge"`
 	MaxEntries int64    `toml:"maxEntries"`
+}
+
+type DockerfileFrontendConfig struct {
+	Enabled *bool `toml:"enabled"`
+}
+
+type GatewayFrontendConfig struct {
+	Enabled             *bool    `toml:"enabled"`
+	AllowedRepositories []string `toml:"allowedRepositories"`
 }

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -759,8 +759,17 @@ func newController(c *cli.Context, cfg *config.Config) (*control.Controller, err
 		return nil, err
 	}
 	frontends := map[string]frontend.Frontend{}
-	frontends["dockerfile.v0"] = forwarder.NewGatewayForwarder(wc.Infos(), dockerfile.Build)
-	frontends["gateway.v0"] = gateway.NewGatewayFrontend(wc.Infos())
+
+	if cfg.Frontends.Dockerfile.Enabled == nil || *cfg.Frontends.Dockerfile.Enabled {
+		frontends["dockerfile.v0"] = forwarder.NewGatewayForwarder(wc.Infos(), dockerfile.Build)
+	}
+	if cfg.Frontends.Gateway.Enabled == nil || *cfg.Frontends.Gateway.Enabled {
+		gwfe, err := gateway.NewGatewayFrontend(wc.Infos(), cfg.Frontends.Gateway.AllowedRepositories)
+		if err != nil {
+			return nil, err
+		}
+		frontends["gateway.v0"] = gwfe
+	}
 
 	cacheStorage, err := bboltcachestorage.NewStore(filepath.Join(cfg.Root, "cache.db"))
 	if err != nil {

--- a/docs/buildkitd.toml.md
+++ b/docs/buildkitd.toml.md
@@ -136,4 +136,21 @@ insecure-entitlements = [ "network.host", "security.insecure" ]
 # optionally mirror configuration can be done by defining it as a registry.
 [registry."yourmirror.local:5000"]
   http = true
+
+# Frontend control
+[frontend."dockerfile.v0"]
+ enabled = true
+
+[frontend."gateway.v0"]
+ enabled = true
+
+ # If allowedRepositories is empty, all gateway sources are allowed.
+ # Otherwise, only the listed repositories are allowed as a gateway source.
+ # 
+ # NOTE: Only the repository name (without tag) is compared.
+ #
+ # Example:
+ # allowedRepositories = [ "docker-registry.wikimedia.org/repos/releng/blubber/buildkit" ]
+ allowedRepositories = []
+
 ```

--- a/frontend/gateway/gateway_test.go
+++ b/frontend/gateway/gateway_test.go
@@ -1,0 +1,45 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckSourceIsAllowed(t *testing.T) {
+	makeGatewayFrontend := func(sources []string) (*gatewayFrontend, error) {
+		gw, err := NewGatewayFrontend(nil, sources)
+		if err != nil {
+			return nil, err
+		}
+		gw1 := gw.(*gatewayFrontend)
+		return gw1, nil
+	}
+
+	var gw *gatewayFrontend
+	var err error
+
+	// no restrictions
+	gw, err = makeGatewayFrontend([]string{})
+	assert.NoError(t, err)
+	err = gw.checkSourceIsAllowed("anything")
+	assert.NoError(t, err)
+
+	gw, err = makeGatewayFrontend([]string{"docker-registry.wikimedia.org/repos/releng/blubber/buildkit:9.9.9"})
+	assert.NoError(t, err)
+	err = gw.checkSourceIsAllowed("docker-registry.wikimedia.org/repos/releng/blubber/buildkit")
+	assert.NoError(t, err)
+	err = gw.checkSourceIsAllowed("docker-registry.wikimedia.org/repos/releng/blubber/buildkit:v1.2.3")
+	assert.NoError(t, err)
+	err = gw.checkSourceIsAllowed("docker-registry.wikimedia.org/something-else")
+	assert.Error(t, err)
+
+	gw, err = makeGatewayFrontend([]string{"alpine"})
+	assert.NoError(t, err)
+	err = gw.checkSourceIsAllowed("alpine")
+	assert.NoError(t, err)
+	err = gw.checkSourceIsAllowed("library/alpine")
+	assert.NoError(t, err)
+	err = gw.checkSourceIsAllowed("docker.io/library/alpine")
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
This commit adds buildkitd configuration options `allowed-frontends` and `allowed-gateway-source`.  These options enable restricting the allowed frontends or gateways sources to enforce local policy.

If allowed-frontends is empty (the default), all frontends (e.g, "dockerfile.v0" and "gateway.v0") are allowed.  Otherwise, only those listed are allowed

If allowed-gateway-sources is empty (the default), all gateway sources are allowed.  Otherwise, only sources that match the patterns in this list will be allowed.  Patterns are matched using
<https://pkg.go.dev/github.com/moby/buildkit/util/wildcard>.  Note that implicit references to docker.io should not be used in the patterns since matching occurs on a fully expanded image name (for example "docker/dockerfile" expands to "docker.io/docker/dockerfile").
