### PR TITLE
progress: fix leak of pipe goroutine from MultiReader

### DIFF
--- a/util/progress/multireader.go
+++ b/util/progress/multireader.go
@@ -95,6 +95,7 @@ func (mr *MultiReader) Reader(ctx context.Context) Reader {
 		mr.mu.Lock()
 		defer mr.mu.Unlock()
 		delete(mr.writers, w)
+		closeWriter(context.Cause(ctx))
 	}()
 
 	if !mr.initialized {


### PR DESCRIPTION
In the case where the context provided to MultiReader.Reader is cancelled, the writer will be deleted.

Before this, closeWriter was not called in that codepath, which meant that MultiReader.handle would never see the writer and never close it.
* I don't have an isolated repro, but when running a few hundred of Dagger's tests I was seeing several thousand goroutines blocked on waiting for the progress pipe's context to be done.

Now, we just call closeWriter when it gets deleted so that the pipe's goroutine doesn't leak.
* After this change, those thousands of leaked goroutines are entirely gone.