### PR TITLE
verifier: verify platforms of the build result

### DIFF
--- a/exporter/verifier/opts.go
+++ b/exporter/verifier/opts.go
@@ -1,0 +1,59 @@
+package verifier
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/containerd/containerd/platforms"
+	"github.com/moby/buildkit/solver/result"
+)
+
+const requestOptsKeys = "verifier.requestopts"
+
+const (
+	platformsKey = "platform"
+	labelsPrefix = "label:"
+	keyRequestID = "requestid"
+)
+
+type RequestOpts struct {
+	Platforms []string
+	Labels    map[string]string
+	Request   string
+}
+
+func CaptureFrontendOpts[T comparable](m map[string]string, res *result.Result[T]) error {
+	req := &RequestOpts{}
+	if v, ok := m[platformsKey]; ok {
+		req.Platforms = strings.Split(v, ",")
+	} else {
+		req.Platforms = []string{platforms.Format(platforms.Normalize(platforms.DefaultSpec()))}
+	}
+
+	req.Labels = map[string]string{}
+	for k, v := range m {
+		if strings.HasPrefix(k, labelsPrefix) {
+			req.Labels[strings.TrimPrefix(k, labelsPrefix)] = v
+		}
+	}
+	req.Request = m[keyRequestID]
+
+	dt, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+	res.AddMeta(requestOptsKeys, dt)
+	return nil
+}
+
+func getRequestOpts[T comparable](res *result.Result[T]) (*RequestOpts, error) {
+	dt, ok := res.Metadata[requestOptsKeys]
+	if !ok {
+		return nil, nil
+	}
+	req := &RequestOpts{}
+	if err := json.Unmarshal(dt, req); err != nil {
+		return nil, err
+	}
+	return req, nil
+}

--- a/exporter/verifier/platforms.go
+++ b/exporter/verifier/platforms.go
@@ -1,0 +1,107 @@
+package verifier
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/containerd/containerd/platforms"
+	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/exporter/containerimage/exptypes"
+	"github.com/moby/buildkit/solver/result"
+	"github.com/pkg/errors"
+)
+
+func CheckInvalidPlatforms[T comparable](ctx context.Context, res *result.Result[T]) ([]client.VertexWarning, error) {
+	req, err := getRequestOpts(res)
+	if err != nil {
+		return nil, err
+	}
+
+	if req.Request != "" {
+		return nil, nil
+	}
+
+	if _, ok := res.Metadata[exptypes.ExporterPlatformsKey]; len(res.Refs) > 0 && !ok {
+		return nil, errors.Errorf("build result contains multiple refs without platforms mapping")
+	}
+
+	isMap := len(res.Refs) > 0
+
+	ps, err := exptypes.ParsePlatforms(res.Metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	warnings := []client.VertexWarning{}
+	reqMap := map[string]struct{}{}
+	reqList := []exptypes.Platform{}
+
+	for _, v := range req.Platforms {
+		p, err := platforms.Parse(v)
+		if err != nil {
+			warnings = append(warnings, client.VertexWarning{
+				Short: []byte(fmt.Sprintf("Invalid platform result requested %q: %s", v, err.Error())),
+			})
+		}
+		p = platforms.Normalize(p)
+		_, ok := reqMap[platforms.Format(p)]
+		if ok {
+			warnings = append(warnings, client.VertexWarning{
+				Short: []byte(fmt.Sprintf("Duplicate platform result requested %q", v)),
+			})
+		}
+		reqMap[platforms.Format(p)] = struct{}{}
+		reqList = append(reqList, exptypes.Platform{Platform: p})
+	}
+
+	if len(warnings) > 0 {
+		return warnings, nil
+	}
+
+	if len(reqMap) == 1 && len(ps.Platforms) == 1 {
+		pp := platforms.Normalize(ps.Platforms[0].Platform)
+		if _, ok := reqMap[platforms.Format(pp)]; !ok {
+			return []client.VertexWarning{{
+				Short: []byte(fmt.Sprintf("Requested platform %q does not match result platform %q", req.Platforms[0], platforms.Format(pp))),
+			}}, nil
+		}
+		return nil, nil
+	}
+
+	if !isMap && len(reqMap) > 1 {
+		return []client.VertexWarning{{
+			Short: []byte("Multiple platforms requested but result is not multi-platform"),
+		}}, nil
+	}
+
+	mismatch := len(reqMap) != len(ps.Platforms)
+
+	if !mismatch {
+		for _, p := range ps.Platforms {
+			pp := platforms.Normalize(p.Platform)
+			if _, ok := reqMap[platforms.Format(pp)]; !ok {
+				mismatch = true
+				break
+			}
+		}
+	}
+
+	if mismatch {
+		return []client.VertexWarning{{
+			Short: []byte(fmt.Sprintf("Requested platforms %s do not match result platforms %s", platformsString(reqList), platformsString(ps.Platforms))),
+		}}, nil
+	}
+
+	return nil, nil
+}
+
+func platformsString(ps []exptypes.Platform) string {
+	var ss []string
+	for _, p := range ps {
+		ss = append(ss, platforms.Format(platforms.Normalize(p.Platform)))
+	}
+	sort.Strings(ss)
+	return strings.Join(ss, ",")
+}


### PR DESCRIPTION
Check that the result returned from the frontend
matches the user request conventions and show a
warning if it doesn't.

I'll be following up to this with verification on image metadata (if image is exported) as well. Currently, in some cases image platform gets reset even if using `FROM --platform` and a new metadata field would need to be passed from Dockerfile, so leaving this to future changes.