### PR TITLE
linter: add rule to catch multiple conflicting instructions used in the same stage

### DIFF
--- a/frontend/dockerfile/linter/ruleset.go
+++ b/frontend/dockerfile/linter/ruleset.go
@@ -98,4 +98,11 @@ var (
 			return fmt.Sprintf("Usage of undefined variable '$%s'", arg)
 		},
 	}
+	RuleMultipleInstructionsDisallowed = LinterRule[func(instructionName string) string]{
+		Name:        "MultipleInstructionsDisallowed",
+		Description: "Multiple instructions of the same type should not be used in the same stage",
+		Format: func(instructionName string) string {
+			return fmt.Sprintf("Multiple %s instructions should not be used in the same stage because only the last one will be used", instructionName)
+		},
+	}
 )


### PR DESCRIPTION
This linter rule catches when ENTRYPOINT, CMD, and HEALTHCHECK are used
multiple times in the same stage. This is because the last usage of each
of these overrides the other usages which makes it so the earlier usage
is ignored and unnecessary.