### PR TITLE
remotecache: remove cache manifest size limit check

### DIFF
--- a/cache/remotecache/import.go
+++ b/cache/remotecache/import.go
@@ -129,10 +129,6 @@ func (ci *contentCacheImporter) Resolve(ctx context.Context, desc ocispecs.Descr
 }
 
 func readBlob(ctx context.Context, provider content.Provider, desc ocispecs.Descriptor) ([]byte, error) {
-	maxBlobSize := int64(1 << 20)
-	if desc.Size > maxBlobSize {
-		return nil, errors.Errorf("blob %s is too large (%d > %d)", desc.Digest, desc.Size, maxBlobSize)
-	}
 	dt, err := content.ReadBlob(ctx, provider, desc)
 	if err != nil {
 		// NOTE: even if err == EOF, we might have got expected dt here.


### PR DESCRIPTION
Removes arbitrary remote cache manifest limit of 1 MB, which was added here: https://github.com/moby/buildkit/commit/80d2f820f936fe31a97564fd7f4dfbf6f3b28016#diff-43026ef44c9363551fae4714a9441a4fdc4e61ab4b315c07f29fd10f1199cfeaR80-R83

Resolves https://github.com/moby/buildkit/issues/4916