### PR TITLE
dockerfile: fix test mirror config bullseye-slim

### DIFF
--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -252,7 +252,7 @@ func TestIntegration(t *testing.T) {
 	integration.Run(t, reproTests, append(opts,
 		// Only use the amd64 digest,  regardless to the host platform
 		integration.WithMirroredImages(map[string]string{
-			"amd64/bullseye-20230109-slim": "docker.io/amd64/debian:bullseye-20230109-slim@sha256:1acb06a0c31fb467eb8327ad361f1091ab265e0bf26d452dea45dcb0c0ea5e75",
+			"amd64/bullseye-20230109-slim:latest": "docker.io/amd64/debian:bullseye-20230109-slim@sha256:1acb06a0c31fb467eb8327ad361f1091ab265e0bf26d452dea45dcb0c0ea5e75",
 		}),
 	)...)
 }


### PR DESCRIPTION
A tag needs to be set for the tag to be created on the mirror. Otherwise new registry access is needed to recreate the tag on repeated runs.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>