### PR TITLE
removes the extra build-arg in dockerfile lint tests

### DIFF
--- a/frontend/dockerfile/dockerfile_lint_test.go
+++ b/frontend/dockerfile/dockerfile_lint_test.go
@@ -527,7 +527,6 @@ func checkUnmarshal(t *testing.T, sb integration.Sandbox, lintTest *lintTestPara
 			FrontendOpt: map[string]string{
 				"frontend.caps": "moby.buildkit.frontend.subrequests",
 				"requestid":     "frontend.lint",
-				"build-arg:BAR": "678",
 			},
 			Frontend: "dockerfile.v0",
 		})


### PR DESCRIPTION
This removes the copy-pasta build-arg passed in as a frontend option in the dockerfile lint teste.