### PR TITLE
dockerfile: detect base image with wrong platform being used

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -539,6 +539,7 @@ func toDispatchState(ctx context.Context, dt []byte, opt ConvertOpt) (*dispatchS
 							llb.WithCustomName(prefixCommand(d, "FROM "+d.stage.BaseName, opt.MultiPlatformRequested, platform, nil)),
 							location(opt.SourceMap, d.stage.Location),
 						)
+						validateBaseImagePlatform(origName, *platform, d.image.Platform, d.stage.Location, opt.Warn)
 					}
 					d.platform = platform
 					return nil
@@ -2203,4 +2204,13 @@ func wrapSuggestAny(err error, keys map[string]struct{}, options []string) error
 		}
 	}
 	return err
+}
+
+func validateBaseImagePlatform(name string, expected, actual ocispecs.Platform, location []parser.Range, warn linter.LintWarnFunc) {
+	if expected.OS != actual.OS || expected.Architecture != actual.Architecture {
+		expectedStr := platforms.Format(platforms.Normalize(expected))
+		actualStr := platforms.Format(platforms.Normalize(actual))
+		msg := linter.RuleInvalidBaseImagePlatform.Format(name, expectedStr, actualStr)
+		linter.RuleInvalidBaseImagePlatform.Run(warn, location, msg)
+	}
 }

--- a/frontend/dockerfile/dockerfile_lint_test.go
+++ b/frontend/dockerfile/dockerfile_lint_test.go
@@ -37,6 +37,7 @@ var lintTests = integration.TestFuncs(
 	testUnmatchedVars,
 	testMultipleInstructionsDisallowed,
 	testLegacyKeyValueFormat,
+	testBaseImagePlatformMismatch,
 )
 
 func testStageName(t *testing.T, sb integration.Sandbox) {
@@ -800,10 +801,15 @@ func checkProgressStream(t *testing.T, sb integration.Sandbox, lintTest *lintTes
 
 	f := getFrontend(t, sb)
 
-	_, err := f.Solve(sb.Context(), lintTest.Client, client.SolveOpt{
-		FrontendAttrs: map[string]string{
+	attrs := lintTest.FrontendAttrs
+	if attrs == nil {
+		attrs = map[string]string{
 			"platform": "linux/amd64,linux/arm64",
-		},
+		}
+	}
+
+	_, err := f.Solve(sb.Context(), lintTest.Client, client.SolveOpt{
+		FrontendAttrs: attrs,
 		LocalMounts: map[string]fsutil.FS{
 			dockerui.DefaultLocalNameDockerfile: lintTest.TmpDir,
 			dockerui.DefaultLocalNameContext:    lintTest.TmpDir,
@@ -915,4 +921,5 @@ type lintTestParams struct {
 	StreamBuildErr    string
 	UnmarshalBuildErr string
 	BuildErrLocation  int32
+	FrontendAttrs     map[string]string
 }

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -7073,6 +7073,80 @@ func testSourcePolicyWithNamedContext(t *testing.T, sb integration.Sandbox) {
 	require.Equal(t, "foo", string(dt))
 }
 
+func testBaseImagePlatformMismatch(t *testing.T, sb integration.Sandbox) {
+	integration.SkipOnPlatform(t, "windows")
+	workers.CheckFeatureCompat(t, sb, workers.FeatureDirectPush)
+	ctx := sb.Context()
+
+	c, err := client.New(ctx, sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	registry, err := sb.NewRegistry()
+	if errors.Is(err, integration.ErrRequirements) {
+		t.Skip(err.Error())
+	}
+	require.NoError(t, err)
+
+	f := getFrontend(t, sb)
+
+	dockerfile := []byte(`
+FROM scratch
+COPY foo /foo
+`)
+	dir := integration.Tmpdir(
+		t,
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+		fstest.CreateFile("foo", []byte("test"), 0644),
+	)
+
+	// choose target platform that is different from the current platform
+	targetPlatform := runtime.GOOS + "/arm64"
+	if runtime.GOARCH == "arm64" {
+		targetPlatform = runtime.GOOS + "/amd64"
+	}
+
+	target := registry + "/buildkit/testbaseimageplatform:latest"
+	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
+		LocalMounts: map[string]fsutil.FS{
+			dockerui.DefaultLocalNameDockerfile: dir,
+			dockerui.DefaultLocalNameContext:    dir,
+		},
+		FrontendAttrs: map[string]string{
+			"platform": targetPlatform,
+		},
+		Exports: []client.ExportEntry{
+			{
+				Type: client.ExporterImage,
+				Attrs: map[string]string{
+					"name": target,
+					"push": "true",
+				},
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	dockerfile = []byte(fmt.Sprintf(`
+FROM %s
+ENV foo=bar
+	`, target))
+
+	checkLinterWarnings(t, sb, &lintTestParams{
+		Dockerfile: dockerfile,
+		Warnings: []expectedLintWarning{
+			{
+				RuleName:    "InvalidBaseImagePlatform",
+				Description: "Base image platform does not match expected target platform",
+				Detail:      fmt.Sprintf("Base image %s was pulled with platform %q, expected %q for current build", target, targetPlatform, runtime.GOOS+"/"+runtime.GOARCH),
+				Level:       1,
+				Line:        2,
+			},
+		},
+		FrontendAttrs: map[string]string{},
+	})
+}
+
 func runShell(dir string, cmds ...string) error {
 	for _, args := range cmds {
 		var cmd *exec.Cmd

--- a/frontend/dockerfile/linter/ruleset.go
+++ b/frontend/dockerfile/linter/ruleset.go
@@ -120,4 +120,11 @@ var (
 			return fmt.Sprintf("\"%s key=value\" should be used instead of legacy \"%s key value\" format", cmdName, cmdName)
 		},
 	}
+	RuleInvalidBaseImagePlatform = LinterRule[func(string, string, string) string]{
+		Name:        "InvalidBaseImagePlatform",
+		Description: "Base image platform does not match expected target platform",
+		Format: func(image, expected, actual string) string {
+			return fmt.Sprintf("Base image %s was pulled with platform %q, expected %q for current build", image, actual, expected)
+		},
+	}
 )


### PR DESCRIPTION
Detect the case where the resolved base image does not match the expected platform from request. This can happen in two main cases:
- Single arch image manifest for a wrong platform than expected by the build
- Wrong metadata info in the image config (common for cross-compiled images pre buildkit and `--platform` flag).

Fixes https://github.com/docker/buildx/issues/844

This isn't directly a linter issue as Dockerfile is not using a wrong command/flag but the base image is problematic. I still used the same naming schema but we probably don't want to include it in the rules docs.