### PR TITLE
dockerfile: improve error messages and add suggest to flag parsing

### DIFF
--- a/frontend/dockerfile/dockerfile_lint_test.go
+++ b/frontend/dockerfile/dockerfile_lint_test.go
@@ -467,9 +467,31 @@ COPY Dockerfile .
 				Line:        2,
 			},
 		},
-		StreamBuildErr:    "failed to solve: failed to parse platform : \"\" is an invalid component of \"\": platform specifier component must match \"^[A-Za-z0-9_-]+$\": invalid argument",
-		UnmarshalBuildErr: "failed to parse platform : \"\" is an invalid component of \"\": platform specifier component must match \"^[A-Za-z0-9_-]+$\": invalid argument",
+		StreamBuildErr:    "failed to solve: empty platform value from expression $BULIDPLATFORM (did you mean BUILDPLATFORM?)",
+		UnmarshalBuildErr: "empty platform value from expression $BULIDPLATFORM (did you mean BUILDPLATFORM?)",
 		BuildErrLocation:  2,
+	})
+
+	dockerfile = []byte(`
+ARG MY_OS=linux
+ARG MY_ARCH=amd64
+FROM --platform=linux/${MYARCH} busybox
+COPY Dockerfile .
+	`)
+	checkLinterWarnings(t, sb, &lintTestParams{
+		Dockerfile: dockerfile,
+		Warnings: []expectedLintWarning{
+			{
+				RuleName:    "UndeclaredArgInFrom",
+				Description: "FROM command must use declared ARGs",
+				Detail:      "FROM argument 'MYARCH' is not declared",
+				Level:       1,
+				Line:        4,
+			},
+		},
+		StreamBuildErr:    "failed to solve: failed to parse platform linux/${MYARCH}: \"\" is an invalid component of \"linux/\": platform specifier component must match \"^[A-Za-z0-9_-]+$\": invalid argument (did you mean MY_ARCH?)",
+		UnmarshalBuildErr: "failed to parse platform linux/${MYARCH}: \"\" is an invalid component of \"linux/\": platform specifier component must match \"^[A-Za-z0-9_-]+$\": invalid argument (did you mean MY_ARCH?)",
+		BuildErrLocation:  4,
 	})
 
 	dockerfile = []byte(`

--- a/frontend/dockerfile/dockerfile_lint_test.go
+++ b/frontend/dockerfile/dockerfile_lint_test.go
@@ -582,6 +582,43 @@ RUN echo $foo
 			},
 		},
 	})
+
+	dockerfile = []byte(`
+FROM alpine
+ARG DIR_BINARIES=binaries/
+ARG DIR_ASSETS=assets/
+ARG DIR_CONFIG=config/
+COPY $DIR_ASSET .
+	`)
+	checkLinterWarnings(t, sb, &lintTestParams{
+		Dockerfile: dockerfile,
+		Warnings: []expectedLintWarning{
+			{
+				RuleName:    "UndefinedVar",
+				Description: "Variables should be defined before their use",
+				Detail:      "Usage of undefined variable '$DIR_ASSET' (did you mean $DIR_ASSETS?)",
+				Level:       1,
+				Line:        6,
+			},
+		},
+	})
+
+	dockerfile = []byte(`
+FROM alpine
+ENV PATH=$PAHT:/tmp/bin
+		`)
+	checkLinterWarnings(t, sb, &lintTestParams{
+		Dockerfile: dockerfile,
+		Warnings: []expectedLintWarning{
+			{
+				RuleName:    "UndefinedVar",
+				Description: "Variables should be defined before their use",
+				Detail:      "Usage of undefined variable '$PAHT' (did you mean $PATH?)",
+				Level:       1,
+				Line:        3,
+			},
+		},
+	})
 }
 
 func testMultipleInstructionsDisallowed(t *testing.T, sb integration.Sandbox) {

--- a/frontend/dockerfile/dockerfile_lint_test.go
+++ b/frontend/dockerfile/dockerfile_lint_test.go
@@ -462,7 +462,7 @@ COPY Dockerfile .
 			{
 				RuleName:    "UndeclaredArgInFrom",
 				Description: "FROM command must use declared ARGs",
-				Detail:      "FROM argument 'BULIDPLATFORM' is not declared",
+				Detail:      "FROM argument 'BULIDPLATFORM' is not declared (did you mean BUILDPLATFORM?)",
 				Level:       1,
 				Line:        2,
 			},
@@ -484,7 +484,7 @@ COPY Dockerfile .
 			{
 				RuleName:    "UndeclaredArgInFrom",
 				Description: "FROM command must use declared ARGs",
-				Detail:      "FROM argument 'MYARCH' is not declared",
+				Detail:      "FROM argument 'MYARCH' is not declared (did you mean MY_ARCH?)",
 				Level:       1,
 				Line:        4,
 			},

--- a/frontend/dockerfile/linter/ruleset.go
+++ b/frontend/dockerfile/linter/ruleset.go
@@ -70,11 +70,15 @@ var (
 			return "Maintainer instruction is deprecated in favor of using label"
 		},
 	}
-	RuleUndeclaredArgInFrom = LinterRule[func(string) string]{
+	RuleUndeclaredArgInFrom = LinterRule[func(string, string) string]{
 		Name:        "UndeclaredArgInFrom",
 		Description: "FROM command must use declared ARGs",
-		Format: func(baseArg string) string {
-			return fmt.Sprintf("FROM argument '%s' is not declared", baseArg)
+		Format: func(baseArg, suggest string) string {
+			out := fmt.Sprintf("FROM argument '%s' is not declared", baseArg)
+			if suggest != "" {
+				out += fmt.Sprintf(" (did you mean %s?)", suggest)
+			}
+			return out
 		},
 	}
 	RuleWorkdirRelativePath = LinterRule[func(workdir string) string]{

--- a/frontend/dockerfile/linter/ruleset.go
+++ b/frontend/dockerfile/linter/ruleset.go
@@ -95,11 +95,15 @@ var (
 			return fmt.Sprintf("Usage of undefined variable '$%s'", arg)
 		},
 	}
-	RuleUndefinedVar = LinterRule[func(string) string]{
+	RuleUndefinedVar = LinterRule[func(string, string) string]{
 		Name:        "UndefinedVar",
 		Description: "Variables should be defined before their use",
-		Format: func(arg string) string {
-			return fmt.Sprintf("Usage of undefined variable '$%s'", arg)
+		Format: func(arg, suggest string) string {
+			out := fmt.Sprintf("Usage of undefined variable '$%s'", arg)
+			if suggest != "" {
+				out += fmt.Sprintf(" (did you mean $%s?)", suggest)
+			}
+			return out
 		},
 	}
 	RuleMultipleInstructionsDisallowed = LinterRule[func(instructionName string) string]{

--- a/util/suggest/error.go
+++ b/util/suggest/error.go
@@ -8,8 +8,13 @@ import (
 
 // WrapError wraps error with a suggestion for fixing it
 func WrapError(err error, val string, options []string, caseSensitive bool) error {
+	err, _ = WrapErrorMaybe(err, val, options, caseSensitive)
+	return err
+}
+
+func WrapErrorMaybe(err error, val string, options []string, caseSensitive bool) (error, bool) {
 	if err == nil {
-		return nil
+		return nil, false
 	}
 	orig := val
 	if !caseSensitive {
@@ -23,7 +28,7 @@ func WrapError(err error, val string, options []string, caseSensitive bool) erro
 		}
 		if val == opt {
 			// exact match means error was unrelated to the value
-			return err
+			return err, false
 		}
 		dist := levenshtein.Distance(val, opt, nil)
 		if dist < mindist {
@@ -37,13 +42,13 @@ func WrapError(err error, val string, options []string, caseSensitive bool) erro
 	}
 
 	if match == "" {
-		return err
+		return err, false
 	}
 
 	return &suggestError{
 		err:   err,
 		match: match,
-	}
+	}, true
 }
 
 type suggestError struct {


### PR DESCRIPTION
Improve the error messages for error messages if FROM flags if they are caused by mismatched variables.

Additional commits improve the messages for UndeclaredArgInFrom and UndefinedVar warnings.


Example:
```
Dockerfile:1
--------------------
   1 | >>> FROM --platform=$BULIDPLATFORM alpine
   2 |     RUN apk add git
   3 |
--------------------
ERROR: failed to solve: failed to parse platform : "" is an invalid component of "": platform specifier component must match "^[A-Za-z0-9_-]+$": invalid argument
```

```
Dockerfile:1
--------------------
   1 | >>> FROM --platform=$BULIDPLATFORM alpine
   2 |     RUN apk add git
   3 |     
--------------------
ERROR: failed to solve: empty platform value from expression $BULIDPLATFORM (did you mean BUILDPLATFORM?)
````
