### PR TITLE
lint: fix some testifylint warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,7 @@ linters:
     - nolintlint
     - revive
     - staticcheck
+    # - testifylint
     - typecheck
     - unused
     - whitespace
@@ -74,6 +75,12 @@ linters-settings:
       - G601  # Implicit memory aliasing in for loop (false positives)
     config:
       G306: "0644"
+  testifylint:
+    disable:
+      # disable rules that reduce the test condition
+      - "empty"
+      - "bool-compare"
+      - "len"
 
 issues:
   exclude-files:

--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -230,7 +230,7 @@ func TestManager(t *testing.T) {
 
 	fi, err := os.Stat(target)
 	require.NoError(t, err)
-	require.Equal(t, fi.IsDir(), true)
+	require.Equal(t, true, fi.IsDir())
 
 	err = lm.Unmount()
 	require.NoError(t, err)
@@ -315,7 +315,7 @@ func TestManager(t *testing.T) {
 
 	checkDiskUsage(ctx, t, cm, 0, 0)
 
-	require.Equal(t, len(buf.all), 2)
+	require.Equal(t, 2, len(buf.all))
 
 	err = cm.Close()
 	require.NoError(t, err)
@@ -506,7 +506,7 @@ func TestSnapshotExtract(t *testing.T) {
 
 	checkDiskUsage(ctx, t, cm, 2, 0)
 
-	require.Equal(t, len(buf.all), 0)
+	require.Equal(t, 0, len(buf.all))
 
 	dirs, err = os.ReadDir(filepath.Join(tmpdir, "snapshots/snapshots"))
 	require.NoError(t, err)
@@ -1823,7 +1823,7 @@ func TestGetRemotes(t *testing.T) {
 			eg.Go(func() error {
 				remotes, err := ir.GetRemotes(egctx, false, refCfg, true, nil)
 				require.NoError(t, err)
-				require.True(t, len(remotes) > 0, "for %s : %d", compressionType, len(remotes))
+				require.Greater(t, len(remotes), 0, "for %s : %d", compressionType, len(remotes))
 				gotMain, gotVariants := remotes[0], remotes[1:]
 
 				// Check the main blob is compatible with all == false

--- a/cache/metadata/metadata_test.go
+++ b/cache/metadata/metadata_test.go
@@ -146,14 +146,14 @@ func TestIndexes(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 2, len(sis))
 
-	require.Equal(t, sis[0].ID(), "foo1")
-	require.Equal(t, sis[1].ID(), "foo3")
+	require.Equal(t, "foo1", sis[0].ID())
+	require.Equal(t, "foo3", sis[1].ID())
 
 	sis, err = s.Search(ctx, "tag:bax")
 	require.NoError(t, err)
 	require.Equal(t, 1, len(sis))
 
-	require.Equal(t, sis[0].ID(), "foo2")
+	require.Equal(t, "foo2", sis[0].ID())
 
 	err = s.Clear("foo1")
 	require.NoError(t, err)
@@ -162,7 +162,7 @@ func TestIndexes(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(sis))
 
-	require.Equal(t, sis[0].ID(), "foo3")
+	require.Equal(t, "foo3", sis[0].ID())
 }
 
 func TestExternalData(t *testing.T) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1018,7 +1018,7 @@ func testPushByDigest(t *testing.T, sb integration.Sandbox) {
 
 	require.Equal(t, resp.ExporterResponse[exptypes.ExporterImageDigestKey], desc.Digest.String())
 	require.Equal(t, images.MediaTypeDockerSchema2Manifest, desc.MediaType)
-	require.True(t, desc.Size > 0)
+	require.Greater(t, desc.Size, int64(0))
 }
 
 func testSecurityMode(t *testing.T, sb integration.Sandbox) {
@@ -3354,7 +3354,7 @@ func testSourceDateEpochClamp(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 	busyboxTms := busyboxTmsX.FromImage
 
-	require.True(t, len(busyboxTms) > 1)
+	require.Greater(t, len(busyboxTms), 1)
 	bboxLayerLen := len(busyboxTms) - 1
 
 	tm, err := time.Parse(time.RFC3339Nano, busyboxTms[1])
@@ -4475,7 +4475,7 @@ func testBuildPushAndValidate(t *testing.T, sb integration.Sandbox) {
 	require.Equal(t, "layers", ociimg.RootFS.Type)
 	require.Equal(t, 3, len(ociimg.RootFS.DiffIDs))
 	require.NotNil(t, ociimg.Created)
-	require.True(t, time.Since(*ociimg.Created) < 2*time.Minute)
+	require.Less(t, time.Since(*ociimg.Created), 2*time.Minute)
 	require.Condition(t, func() bool {
 		for _, env := range ociimg.Config.Env {
 			if strings.HasPrefix(env, "PATH=") {
@@ -7766,7 +7766,7 @@ func checkAllReleasable(t *testing.T, c *Client, sb integration.Sandbox, checkCo
 	retries := 0
 loop0:
 	for {
-		require.True(t, 20 > retries)
+		require.Greater(t, 20, retries)
 		retries++
 		du, err := c.DiskUsage(sb.Context())
 		require.NoError(t, err)
@@ -7814,7 +7814,7 @@ loop0:
 		if count == 0 {
 			break
 		}
-		require.True(t, 20 > retries)
+		require.Less(t, retries, 20)
 		retries++
 		time.Sleep(500 * time.Millisecond)
 	}

--- a/client/llb/fileop_test.go
+++ b/client/llb/fileop_test.go
@@ -710,7 +710,7 @@ func parseDef(t *testing.T, def [][]byte) (map[digest.Digest]pb.Op, []pb.Op) {
 }
 
 func last(t *testing.T, arr []pb.Op) (digest.Digest, int) {
-	require.True(t, len(arr) > 1)
+	require.Greater(t, len(arr), 1)
 
 	op := arr[len(arr)-1]
 	require.Equal(t, 1, len(op.Inputs))

--- a/client/llb/llbbuild/llbbuild_test.go
+++ b/client/llb/llbbuild/llbbuild_test.go
@@ -24,7 +24,7 @@ func TestMarshal(t *testing.T) {
 	require.NoError(t, err)
 
 	buildop := op.GetBuild()
-	require.NotEqual(t, buildop, nil)
+	require.NotNil(t, buildop)
 
 	require.Equal(t, len(op.Inputs), 1)
 	require.Equal(t, buildop.Builder, pb.LLBBuilder)

--- a/client/llb/llbtest/platform_test.go
+++ b/client/llb/llbtest/platform_test.go
@@ -30,7 +30,7 @@ func TestCustomPlatform(t *testing.T) {
 	e, err := llbsolver.Load(context.TODO(), def.ToPB(), nil)
 	require.NoError(t, err)
 
-	require.Equal(t, depth(e), 5)
+	require.Equal(t, 5, depth(e))
 
 	expected := ocispecs.Platform{OS: "windows", Architecture: "amd64"}
 	require.Equal(t, expected, platform(e))
@@ -59,7 +59,7 @@ func TestDefaultPlatform(t *testing.T) {
 	e, err := llbsolver.Load(context.TODO(), def.ToPB(), nil)
 	require.NoError(t, err)
 
-	require.Equal(t, depth(e), 2)
+	require.Equal(t, 2, depth(e))
 
 	// needs extra normalize for default spec
 	// https://github.com/moby/buildkit/pull/2427#issuecomment-952301867
@@ -103,7 +103,7 @@ func TestPlatformMixed(t *testing.T) {
 	e, err := llbsolver.Load(context.TODO(), def.ToPB(), nil)
 	require.NoError(t, err)
 
-	require.Equal(t, depth(e), 4)
+	require.Equal(t, 4, depth(e))
 
 	expectedAmd := ocispecs.Platform{OS: "linux", Architecture: "amd64"}
 	require.Equal(t, []string{"cmd-main"}, args(e))

--- a/control/control_test.go
+++ b/control/control_test.go
@@ -140,9 +140,9 @@ func TestParseCacheExportIgnoreError(t *testing.T) {
 		t.Run(ignoreErrStr, func(t *testing.T) {
 			ignoreErr, supported := parseCacheExportIgnoreError(ignoreErrStr)
 			t.Log("checking expectedIgnoreError")
-			require.Equal(t, ignoreErr, test.expectedIgnoreError)
+			require.Equal(t, test.expectedIgnoreError, ignoreErr)
 			t.Log("checking expectedSupported")
-			require.Equal(t, supported, test.expectedSupported)
+			require.Equal(t, test.expectedSupported, supported)
 		})
 	}
 }

--- a/executor/oci/mounts_test.go
+++ b/executor/oci/mounts_test.go
@@ -153,7 +153,7 @@ func TestWithRemovedMounts(t *testing.T) {
 
 	oldLen := len(s.Mounts)
 	err := withRemovedMount("/run")(appcontext.Context(), nil, nil, &s)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, oldLen-1, len(s.Mounts))
 }
 

--- a/executor/resources/io_test.go
+++ b/executor/resources/io_test.go
@@ -7,6 +7,7 @@ import (
 
 	resourcestypes "github.com/moby/buildkit/executor/resources/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseIOStat(t *testing.T) {
@@ -15,15 +16,15 @@ func TestParseIOStat(t *testing.T) {
 	ioStatContents := `8:0 rbytes=1024 wbytes=2048 dbytes=4096 rios=16 wios=32 dios=64
 8:1 rbytes=512 wbytes=1024 dbytes=2048 rios=8 wios=16 dios=32`
 	err := os.WriteFile(filepath.Join(testDir, "io.stat"), []byte(ioStatContents), 0644)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	ioPressureContents := `some avg10=1.23 avg60=4.56 avg300=7.89 total=3031
 full avg10=0.12 avg60=0.34 avg300=0.56 total=9876`
 	err = os.WriteFile(filepath.Join(testDir, "io.pressure"), []byte(ioPressureContents), 0644)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	ioStat, err := getCgroupIOStat(testDir)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var expectedPressure = &resourcestypes.Pressure{
 		Some: &resourcestypes.PressureValues{

--- a/frontend/dockerfile/dockerfile2llb/convert_test.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/moby/buildkit/util/appcontext"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func toEnvMap(args []instructions.KeyValuePairOptional, env []string) map[string]string {
@@ -35,7 +36,7 @@ COPY f1 f2 /sub/
 RUN ls -l
 `
 	_, _, _, _, err := Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	df = `FROM scratch AS foo
 ENV FOO bar
@@ -44,7 +45,7 @@ COPY --from=foo f1 /
 COPY --from=0 f2 /
 	`
 	_, _, _, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	df = `FROM scratch AS foo
 ENV FOO bar
@@ -57,20 +58,20 @@ COPY --from=0 f2 /
 			Target: "Foo",
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, _, _, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{
 		Config: dockerui.Config{
 			Target: "nosuch",
 		},
 	})
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	df = `FROM scratch
 	ADD http://github.com/moby/buildkit/blob/master/README.md /
 		`
 	_, _, _, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	df = `FROM scratch
 	COPY http://github.com/moby/buildkit/blob/master/README.md /
@@ -80,11 +81,11 @@ COPY --from=0 f2 /
 
 	df = `FROM "" AS foo`
 	_, _, _, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	df = `FROM ${BLANK} AS foo`
 	_, _, _, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestDockerfileParsingMarshal(t *testing.T) {
@@ -219,7 +220,7 @@ FROM foo AS bar
 RUN echo bar
 `
 	_, _, baseImg, _, err := Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	t.Logf("baseImg=%+v", baseImg)
 	assert.Equal(t, []digest.Digest{"sha256:2e112031b4b923a873c8b3d685d48037e4d5ccd967b658743d93a6e56c3064b9"}, baseImg.RootFS.DiffIDs)
 	assert.Equal(t, "2024-01-17 21:49:12 +0000 UTC", baseImg.Created.String())

--- a/frontend/dockerfile/dockerfile_outline_test.go
+++ b/frontend/dockerfile/dockerfile_outline_test.go
@@ -267,7 +267,7 @@ COPY Dockerfile Dockerfile
 		reqs, err := subrequests.Describe(ctx, c)
 		require.NoError(t, err)
 
-		require.True(t, len(reqs) > 0)
+		require.Greater(t, len(reqs), 0)
 
 		hasOutline := false
 

--- a/frontend/dockerfile/dockerfile_provenance_test.go
+++ b/frontend/dockerfile/dockerfile_provenance_test.go
@@ -204,9 +204,9 @@ RUN echo "ok" > /foo
 			require.Equal(t, "dockerfile", pred.Invocation.Parameters.Locals[1].Name)
 
 			require.NotNil(t, pred.Metadata.BuildFinishedOn)
-			require.True(t, time.Since(*pred.Metadata.BuildFinishedOn) < 5*time.Minute)
+			require.Less(t, time.Since(*pred.Metadata.BuildFinishedOn), 5*time.Minute)
 			require.NotNil(t, pred.Metadata.BuildStartedOn)
-			require.True(t, time.Since(*pred.Metadata.BuildStartedOn) < 5*time.Minute)
+			require.Less(t, time.Since(*pred.Metadata.BuildStartedOn), 5*time.Minute)
 			require.True(t, pred.Metadata.BuildStartedOn.Before(*pred.Metadata.BuildFinishedOn))
 
 			require.True(t, pred.Metadata.Completeness.Environment)

--- a/frontend/dockerfile/dockerfile_targets_test.go
+++ b/frontend/dockerfile/dockerfile_targets_test.go
@@ -152,7 +152,7 @@ COPY Dockerfile Dockerfile
 		reqs, err := subrequests.Describe(ctx, c)
 		require.NoError(t, err)
 
-		require.True(t, len(reqs) > 0)
+		require.Greater(t, len(reqs), 0)
 
 		hasTargets := false
 

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -5075,7 +5075,7 @@ COPY Dockerfile Dockerfile
 		reqs, err := subrequests.Describe(ctx, c)
 		require.NoError(t, err)
 
-		require.True(t, len(reqs) > 0)
+		require.Greater(t, len(reqs), 0)
 
 		hasDescribe := false
 
@@ -5084,7 +5084,7 @@ COPY Dockerfile Dockerfile
 				hasDescribe = true
 				require.Equal(t, subrequests.RequestType("rpc"), req.Type)
 				require.NotEqual(t, req.Version, "")
-				require.True(t, len(req.Metadata) > 0)
+				require.Greater(t, len(req.Metadata), 0)
 				require.Equal(t, "result.json", req.Metadata[0].Name)
 			}
 		}

--- a/frontend/dockerfile/instructions/parse_test.go
+++ b/frontend/dockerfile/instructions/parse_test.go
@@ -245,7 +245,7 @@ func TestRunCmdFlagsUsed(t *testing.T) {
 	n := ast.AST.Children[0]
 	c, err := ParseInstruction(n)
 	require.NoError(t, err)
-	require.IsType(t, c, &RunCommand{})
+	require.IsType(t, &RunCommand{}, c)
 	require.Equal(t, []string{"mount"}, c.(*RunCommand).FlagsUsed)
 }
 

--- a/solver/llbsolver/mounts/mount_test.go
+++ b/solver/llbsolver/mounts/mount_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/moby/buildkit/util/leaseutil"
 	"github.com/moby/buildkit/util/winlayers"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	bolt "go.etcd.io/bbolt"
 	"golang.org/x/sync/errgroup"
@@ -288,8 +289,8 @@ func TestCacheMountLockedRefs(t *testing.T) {
 	gotRef4 := make(chan struct{})
 	go func() {
 		ref4, err := g2.getRefCacheDir(ctx, nil, "foo", pb.CacheSharingOpt_LOCKED)
-		require.NoError(t, err)
-		require.Equal(t, ref.ID(), ref4.ID())
+		assert.NoError(t, err)
+		assert.Equal(t, ref.ID(), ref4.ID())
 		close(gotRef4)
 	}()
 
@@ -359,7 +360,7 @@ func TestCacheMountSharedRefsDeadlock(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		err = eg.Wait()
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		close(done)
 	}()
 

--- a/source/git/source_test.go
+++ b/source/git/source_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/moby/buildkit/util/progress/logs"
 	"github.com/moby/buildkit/util/winlayers"
 	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	bolt "go.etcd.io/bbolt"
 )
@@ -93,10 +92,10 @@ func testRepeatedFetch(t *testing.T, keepGitDir bool) {
 	require.Equal(t, "bar\n", string(dt))
 
 	_, err = os.Lstat(filepath.Join(dir, "ghi"))
-	require.ErrorAs(t, err, &os.ErrNotExist)
+	require.ErrorIs(t, err, os.ErrNotExist)
 
 	_, err = os.Lstat(filepath.Join(dir, "sub/subfile"))
-	require.ErrorAs(t, err, &os.ErrNotExist)
+	require.ErrorIs(t, err, os.ErrNotExist)
 
 	// second fetch returns same dir
 	id = &GitIdentifier{Remote: repo.mainURL, Ref: "master", KeepGitDir: keepGitDir}
@@ -314,10 +313,10 @@ func testFetchByTag(t *testing.T, tag, expectedCommitSubject string, isAnnotated
 
 	dt, err = os.ReadFile(filepath.Join(dir, "foo13"))
 	if hasFoo13File {
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, "sbb\n", string(dt))
 	} else {
-		require.ErrorAs(t, err, &os.ErrNotExist)
+		require.ErrorIs(t, err, os.ErrNotExist)
 	}
 
 	if keepGitDir {
@@ -546,7 +545,7 @@ func testSubdir(t *testing.T, keepGitDir bool) {
 
 func setupGitSource(t *testing.T, tmpdir string) source.Source {
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	store, err := local.NewStore(tmpdir)
 	require.NoError(t, err)

--- a/sourcepolicy/engine_test.go
+++ b/sourcepolicy/engine_test.go
@@ -306,7 +306,7 @@ func testAllowConvertDeny(t *testing.T) {
 	mutated, err := e.Evaluate(ctx, op)
 	require.True(t, mutated)
 	require.ErrorIs(t, err, ErrSourceDenied)
-	require.Equal(t, op.Identifier, "docker-image://docker.io/library/alpine:latest")
+	require.Equal(t, "docker-image://docker.io/library/alpine:latest", op.Identifier)
 }
 
 func testConvertDeny(t *testing.T) {
@@ -340,7 +340,7 @@ func testConvertDeny(t *testing.T) {
 	mutated, err := e.Evaluate(ctx, op)
 	require.True(t, mutated)
 	require.ErrorIs(t, err, ErrSourceDenied)
-	require.Equal(t, op.Identifier, "docker-image://docker.io/library/alpine:latest")
+	require.Equal(t, "docker-image://docker.io/library/alpine:latest", op.Identifier)
 }
 
 func testConvert(t *testing.T) {

--- a/util/apicaps/caps_test.go
+++ b/util/apicaps/caps_test.go
@@ -5,6 +5,7 @@ import (
 
 	pb "github.com/moby/buildkit/util/apicaps/pb"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDisabledCap(t *testing.T) {
@@ -27,16 +28,16 @@ func TestDisabledCap(t *testing.T) {
 		{ID: "cap2", Enabled: true},
 	})
 	err := cs.Supports("cap1")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = cs.Supports("cap2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	cs = cl.CapSet([]pb.APICap{
 		{ID: "cap1", Enabled: true},
 		{ID: "cap2", Enabled: false},
 	})
 	err = cs.Supports("cap1")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = cs.Supports("cap2")
 	assert.EqualError(t, err, "requested experimental feature cap2 (a second test cap) has been disabled on the build server")
 

--- a/util/converter/tarconverter/tarconverter_test.go
+++ b/util/converter/tarconverter/tarconverter_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func createTar(t testing.TB, name string, b []byte) []byte {
@@ -20,10 +21,10 @@ func createTar(t testing.TB, name string, b []byte) []byte {
 		Mode:     0o644,
 		ModTime:  time.Now(),
 	}
-	assert.NoError(t, tw.WriteHeader(&hdr))
+	require.NoError(t, tw.WriteHeader(&hdr))
 	_, err := tw.Write(b)
-	assert.NoError(t, err)
-	assert.NoError(t, tw.Close())
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
 	return buf.Bytes()
 }
 

--- a/util/flightcontrol/flightcontrol_test.go
+++ b/util/flightcontrol/flightcontrol_test.go
@@ -40,7 +40,7 @@ func TestNoCancel(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "bar", r1)
 	assert.Equal(t, "bar", r2)
-	assert.Equal(t, counter, int64(1))
+	assert.Equal(t, int64(1), counter)
 }
 
 func TestCancelOne(t *testing.T) {
@@ -81,7 +81,7 @@ func TestCancelOne(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "", r1)
 	assert.Equal(t, "bar", r2)
-	assert.Equal(t, counter, int64(1))
+	assert.Equal(t, int64(1), counter)
 }
 
 func TestCancelRace(t *testing.T) {
@@ -130,7 +130,7 @@ func TestCancelRace(t *testing.T) {
 		cancel(errors.WithStack(context.Canceled))
 		time.Sleep(5 * time.Millisecond)
 		_, err := g.Do(context.Background(), "foo", f)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 
 	_, err := g.Do(ctx, "foo", f)
@@ -188,7 +188,7 @@ func TestCancelBoth(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "", r1)
 	assert.Equal(t, "", r2)
-	assert.Equal(t, counter, int64(1))
+	assert.Equal(t, int64(1), counter)
 	ret1, err := g.Do(context.TODO(), "foo", f)
 	assert.NoError(t, err)
 	assert.Equal(t, ret1, "bar")

--- a/util/progress/progress_test.go
+++ b/util/progress/progress_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -36,8 +37,8 @@ func TestProgress(t *testing.T) {
 	err = eg.Wait()
 	assert.NoError(t, err)
 
-	assert.True(t, len(trace.items) > 5)
-	assert.True(t, len(trace.items) <= 7)
+	assert.Greater(t, len(trace.items), 5)
+	assert.LessOrEqual(t, len(trace.items), 7)
 	for _, p := range trace.items {
 		v, ok := p.Meta("tag")
 		assert.True(t, ok)
@@ -54,16 +55,16 @@ func TestProgressNested(t *testing.T) {
 		return saveProgress(ctx, pr, &trace)
 	})
 	s, err := reduceCalc(ctx, 3)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 6, s)
 
 	cancelProgress(errors.WithStack(context.Canceled))
 
 	err = eg.Wait()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.True(t, len(trace.items) > 9) // usually 14
-	assert.True(t, len(trace.items) <= 15)
+	assert.Greater(t, len(trace.items), 9) // usually 14
+	assert.LessOrEqual(t, len(trace.items), 15)
 }
 
 func calc(ctx context.Context, total int, name string) (int, error) {

--- a/util/resolver/resolver_test.go
+++ b/util/resolver/resolver_test.go
@@ -60,7 +60,7 @@ mirrors = ["https://url/", "https://url/path/"]
 		for _, m := range registry.Mirrors {
 			test := tests[m]
 			h := newMirrorRegistryHost(m)
-			require.NotEqual(t, h, nil)
+			require.NotNil(t, h)
 			require.Equal(t, h.Host, test.host)
 			require.Equal(t, h.Path, test.path)
 		}

--- a/util/throttle/throttle_test.go
+++ b/util/throttle/throttle_test.go
@@ -26,7 +26,7 @@ func TestThrottle(t *testing.T) {
 	// test that i is never incremented twice and at least once in next 600ms
 	retries := 0
 	for {
-		require.True(t, retries < 10)
+		require.Less(t, retries, 10)
 		time.Sleep(60 * time.Millisecond)
 		v := atomic.LoadInt64(&i)
 		if v > 1 {
@@ -44,7 +44,7 @@ func TestThrottle(t *testing.T) {
 
 	retries = 0
 	for {
-		require.True(t, retries < 10)
+		require.Less(t, retries, 10)
 		time.Sleep(60 * time.Millisecond)
 		v := atomic.LoadInt64(&i)
 		if v == 2 {

--- a/worker/runc/runc_test.go
+++ b/worker/runc/runc_test.go
@@ -82,7 +82,7 @@ func TestRuncWorker(t *testing.T) {
 
 	names, err := f.Readdirnames(-1)
 	require.NoError(t, err)
-	require.True(t, len(names) > 5)
+	require.Greater(t, len(names), 5)
 
 	err = f.Close()
 	require.NoError(t, err)
@@ -98,7 +98,7 @@ func TestRuncWorker(t *testing.T) {
 	// }
 
 	for _, d := range du {
-		require.True(t, d.Size >= 8192)
+		require.GreaterOrEqual(t, d.Size, int64(8192))
 	}
 
 	meta := executor.Meta{


### PR DESCRIPTION
~depends on #4931 (only last commit new)~

This does not cover all warnings yet but split into chunks to ease review. There are quite a lot of updates needed so we can do them in multiple PRs so that there isn't a big review or bad rebase needed.