### PR TITLE
hack: add prometheus and grafana to hack/compose

### DIFF
--- a/hack/composefiles/compose.yaml
+++ b/hack/composefiles/compose.yaml
@@ -14,6 +14,7 @@ services:
     privileged: true
     environment:
       DELVE_PORT: 5000
+      OTEL_SERVICE_NAME: buildkitd
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
     configs:
       - source: buildkit_config
@@ -36,11 +37,38 @@ services:
         target: /etc/otelcol-contrib/config.yaml
     ports:
       - 127.0.0.1:4317:4317
+      - 127.0.0.1:8000:8000
     depends_on:
       - jaeger
 
+  prometheus:
+    image: prom/prometheus:v2.48.1
+    configs:
+      - source: prometheus_config
+        target: /etc/prometheus/prometheus.yml
+    volumes:
+      - prometheus:/prometheus
+    depends_on:
+      - buildkit
+
+  grafana:
+    image: grafana/grafana-oss:10.2.3
+    configs:
+      - source: grafana_config
+        target: /etc/grafana/grafana.ini
+      - source: grafana_datasources_config
+        target: /etc/grafana/provisioning/datasources/datasources.yaml
+    ports:
+      - 127.0.0.1:3000:3000
+    volumes:
+      - grafana:/var/lib/grafana
+    depends_on:
+      - prometheus
+
 volumes:
   buildkit:
+  prometheus:
+  grafana:
 
 configs:
   buildkit_config:
@@ -48,3 +76,12 @@ configs:
 
   otelcol_config:
     file: ./otelcol.yaml
+
+  prometheus_config:
+    file: ./prometheus.yml
+
+  grafana_config:
+    file: ./grafana.ini
+
+  grafana_datasources_config:
+    file: ./datasources.yaml

--- a/hack/composefiles/datasources.yaml
+++ b/hack/composefiles/datasources.yaml
@@ -1,0 +1,19 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    jsonData:
+      httpMethod: POST
+      manageAlerts: false
+      prometheusType: Prometheus
+      prometheusVersion: 2.48.1
+      # cacheLevel set to none because this is primarily used for development
+      # where caching is detrimental to the experience and there's not enough
+      # data where caching is helpful.
+      cacheLevel: 'None'
+      disableRecordingRules: false
+      incrementalQueryOverlapWindow: 10m
+      exemplarTraceIdDestinations: []

--- a/hack/composefiles/extensions/buildx.yaml
+++ b/hack/composefiles/extensions/buildx.yaml
@@ -15,6 +15,7 @@ configs:
           metrics::metric:
             - 'instrumentation_scope.name != "github.com/docker/buildx"'
       exporters::debug::verbosity: detailed
-      service::pipelines::metrics::receivers: [otlp]
-      service::pipelines::metrics::processors: [filter/buildx]
-      service::pipelines::metrics::exporters: [debug]
+      service::pipelines::metrics/buildx:
+        receivers: [otlp]
+        processors: [filter/buildx]
+        exporters: [debug]

--- a/hack/composefiles/grafana.ini
+++ b/hack/composefiles/grafana.ini
@@ -1,0 +1,3 @@
+[security]
+admin_user = moby
+admin_password = moby

--- a/hack/composefiles/prometheus.yml
+++ b/hack/composefiles/prometheus.yml
@@ -1,0 +1,6 @@
+scrape_configs:
+  - job_name: buildkit
+    scrape_interval: 1m
+    static_configs:
+      - targets:
+          - "buildkit:6060"


### PR DESCRIPTION
Starts a prometheus server that automatically scrapes buildkit for metrics using the `/metrics` endpoint. Also configures a grafana instance to use prometheus as the default connection.