### PR TITLE
Adds linter warning for using variables defined in parent stages

### DIFF
--- a/frontend/dockerfile/linter/ruleset.go
+++ b/frontend/dockerfile/linter/ruleset.go
@@ -105,4 +105,11 @@ var (
 			return fmt.Sprintf("Multiple %s instructions should not be used in the same stage because only the last one will be used", instructionName)
 		},
 	}
+	RuleOutOfScopeVar = LinterRule[func(string, string) string]{
+		Name:        "OutOfScopeVar",
+		Description: "Variables should be defined within the same stage",
+		Format: func(word, stageName string) string {
+			return fmt.Sprintf("Variable '%s' is out of scope for stage '%s', it should be defined within the same stage", word, stageName)
+		},
+	}
 )

--- a/frontend/dockerfile/shell/lex.go
+++ b/frontend/dockerfile/shell/lex.go
@@ -35,9 +35,9 @@ func NewLex(escapeToken rune) *Lex {
 // and replace any env var references in 'word'. It will also
 // return variables in word which were not found in the 'env' list,
 // which is useful in later linting.
-func (s *Lex) ProcessWord(word string, env []string) (string, map[string]struct{}, error) {
+func (s *Lex) ProcessWord(word string, env []string) (*ProcessWordResult, error) {
 	result, err := s.process(word, BuildEnvs(env))
-	return result.Result, result.Unmatched, err
+	return result, err
 }
 
 // ProcessWords will use the 'env' list of environment variables,

--- a/frontend/dockerfile/shell/lex_test.go
+++ b/frontend/dockerfile/shell/lex_test.go
@@ -50,7 +50,6 @@ func TestReversePattern(t *testing.T) {
 }
 
 func TestShellParserMandatoryEnvVars(t *testing.T) {
-	var newWord string
 	var err error
 	shlex := NewLex('\\')
 	setEnvs := []string{"VAR=plain", "ARG=x"}
@@ -61,26 +60,26 @@ func TestShellParserMandatoryEnvVars(t *testing.T) {
 	noUnset := "${VAR?message here$ARG}"
 
 	// disallow empty
-	newWord, _, err = shlex.ProcessWord(noEmpty, setEnvs)
+	result, err := shlex.ProcessWord(noEmpty, setEnvs)
 	require.NoError(t, err)
-	require.Equal(t, "plain", newWord)
+	require.Equal(t, "plain", result.Result)
 
-	_, _, err = shlex.ProcessWord(noEmpty, emptyEnvs)
+	_, err = shlex.ProcessWord(noEmpty, emptyEnvs)
 	require.ErrorContains(t, err, "message herex")
 
-	_, _, err = shlex.ProcessWord(noEmpty, unsetEnvs)
+	_, err = shlex.ProcessWord(noEmpty, unsetEnvs)
 	require.ErrorContains(t, err, "message herex")
 
 	// disallow unset
-	newWord, _, err = shlex.ProcessWord(noUnset, setEnvs)
+	result, err = shlex.ProcessWord(noUnset, setEnvs)
 	require.NoError(t, err)
-	require.Equal(t, "plain", newWord)
+	require.Equal(t, "plain", result.Result)
 
-	newWord, _, err = shlex.ProcessWord(noUnset, emptyEnvs)
+	result, err = shlex.ProcessWord(noUnset, emptyEnvs)
 	require.NoError(t, err)
-	require.Empty(t, newWord)
+	require.Empty(t, result.Result)
 
-	_, _, err = shlex.ProcessWord(noUnset, unsetEnvs)
+	_, err = shlex.ProcessWord(noUnset, unsetEnvs)
 	require.ErrorContains(t, err, "message herex")
 }
 
@@ -123,15 +122,15 @@ func TestShellParser4EnvVars(t *testing.T) {
 
 		if ((platform == "W" || platform == "A") && runtime.GOOS == "windows") ||
 			((platform == "U" || platform == "A") && runtime.GOOS != "windows") {
-			newWord, _, err := shlex.ProcessWord(source, envs)
+			result, err := shlex.ProcessWord(source, envs)
 			if expected == "error" {
-				require.Errorf(t, err, "input: %q, result: %q", source, newWord)
+				require.Errorf(t, err, "input: %q, result: %q", source, result.Result)
 			} else {
 				require.NoError(t, err, "at line %d of %s", lineCount, fn)
-				require.Equal(t, expected, newWord, "at line %d of %s", lineCount, fn)
+				require.Equal(t, expected, result.Result, "at line %d of %s", lineCount, fn)
 			}
 
-			newWord, err = shlex.ProcessWordWithMap(source, envsMap)
+			newWord, err := shlex.ProcessWordWithMap(source, envsMap)
 			if expected == "error" {
 				require.Errorf(t, err, "input: %q, result: %q", source, newWord)
 			} else {


### PR DESCRIPTION
This adds a linter warning for the case where a build arg is declared, and then later used in a child stage without being redeclared in that stage. For example:

```FROM busybox AS one
RUN echo "Building version"
ARG username=foo
RUN echo "declared username: $username"

FROM one AS two
# Causes the lint warning
RUN echo "out of scope arg username: $username, define ARG in current stage to use it"
```