### PR TITLE
[dnm] testing if FileMode is affected by umask

### DIFF
--- a/client/llb/fileop_test.go
+++ b/client/llb/fileop_test.go
@@ -13,7 +13,7 @@ import (
 func TestFileMkdir(t *testing.T) {
 	t.Parallel()
 
-	st := Image("foo").File(Mkdir("/foo", 0700))
+	st := Image("foo").File(Mkdir("/foo", 0770))
 	def, err := st.Marshal(context.TODO())
 
 	require.NoError(t, err)
@@ -40,7 +40,7 @@ func TestFileMkdir(t *testing.T) {
 	mkdir := action.Action.(*pb.FileAction_Mkdir).Mkdir
 
 	require.Equal(t, "/foo", mkdir.Path)
-	require.Equal(t, 0700, int(mkdir.Mode))
+	require.Equal(t, 0770, int(mkdir.Mode))
 	require.Equal(t, int64(-1), mkdir.Timestamp)
 }
 


### PR DESCRIPTION
I was trying to run a build stage as non-root user, but it uses some cache mounts. So I tried to mount the cache-mount with a specific group (gid), and set permissions to 0775 (instead of the default 0755) to allow the stage to write, but it looks like it still ends up with 0755 permissions.

Most minimal reproducer;

    docker build --progress=plain --no-cache -<<'EOF'
    # syntax=docker/dockerfile:1

    FROM alpine
    RUN --mount=type=cache,target=/hello/.cache,mode=0775 ls -la /hello/.cache/

Which shows that the target has 0755 permissions;

    #6 [stage-0 1/2] FROM docker.io/library/alpine:latest
    #6 DONE 0.0s

    #7 [internal] settings cache mount permissions
    #7 DONE 0.1s

    #8 [stage-0 2/2] RUN --mount=type=cache,target=/hello/.cache,mode=0775  ls -la /hello/.cache/
    #8 0.641 total 8
    #8 0.641 drwxr-xr-x    2 root     root          4096 May 17 12:04 .
    #8 0.641 drwxr-xr-x    3 root     root          4096 May 17 12:04 ..
    #8 DONE 0.7s

Looking at that `settings cache mount permissions` message brings me to this code, which uses `llb.Mkdir`;
https://github.com/moby/buildkit/blob/4b5bf7ef9b3cd0a2485c173f0700dce21e83d964/frontend/dockerfile/dockerfile2llb/convert_runmount.go#L60

My initial assumption is that possibly the given filemode still gets an umask applied, causing the effective permissions to be different.

It's a bit hard to find where the actual `Mkdir` happens, because that function returns a `FileOp` (which only contains the options), but looking through tests I see that there's various tests setting a mode, but all of them seem to use a mode that's not affected by umask (assuming default `022` umask); most (if not "all") of them seem to be using (e.g.) `0700` or `0600`.

Let's change a test to see if it fails, which may confirm my suspicion.