### PR TITLE
Adjusts syscall.Statfs_t for OpenBSD

### DIFF
--- a/cmd/buildkitd/config/gcpolicy_openbsd.go
+++ b/cmd/buildkitd/config/gcpolicy_openbsd.go
@@ -1,5 +1,5 @@
-//go:build !windows && !openbsd
-// +build !windows,!openbsd
+//go:build openbsd
+// +build openbsd
 
 package config
 
@@ -14,6 +14,6 @@ func getDiskSize(root string) (int64, error) {
 	if err := syscall.Statfs(root, &st); err != nil {
 		return 0, err
 	}
-	diskSize := int64(st.Bsize) * int64(st.Blocks)
+	diskSize := int64(st.F_bsize) * int64(st.F_blocks)
 	return diskSize, nil
 }


### PR DESCRIPTION
Here a small adjustmend for OpenBSD's syscall.Statfs_t which is backport of https://github.com/openbsd/ports/blob/9c2aaca13bf333ac228677736b42f31cba441edd/sysutils/docker-buildx/patches/patch-vendor_github_com_moby_buildkit_cmd_buildkitd_config_gcpolicy_unix_go