### PR TITLE
fix: 20 sec timeout for write to disc too short

### DIFF
--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -198,7 +198,7 @@ func (s *Solver) recordBuildHistory(ctx context.Context, id string, req frontend
 		}
 
 		ctx, cancel := context.WithCancelCause(context.Background())
-		ctx, _ = context.WithTimeoutCause(ctx, 20*time.Second, errors.WithStack(context.DeadlineExceeded))
+		ctx, _ = context.WithTimeoutCause(ctx, 300*time.Second, errors.WithStack(context.DeadlineExceeded))
 		defer cancel(errors.WithStack(context.Canceled))
 
 		var mu sync.Mutex


### PR DESCRIPTION
20 sec stall on an platter old hdd is not unexpected. Nor is 20s write on a low-tier cloud environment drive unexpected.

300s should however be enough to tell the difference between crappy hardware/environment and actual failure.

fixes #4327