### PR TITLE
llbsolver: create single temp lease for exports for performance

### DIFF
--- a/cache/remote.go
+++ b/cache/remote.go
@@ -52,7 +52,7 @@ func (sr *immutableRef) GetRemotes(ctx context.Context, createIfNeeded bool, ref
 	}
 
 	// Search all available remotes that has the topmost blob with the specified
-	// compression with all combination of copmressions
+	// compression with all combination of compressions
 	res := []*solver.Remote{remote}
 	topmost, parentChain := remote.Descriptors[len(remote.Descriptors)-1], remote.Descriptors[:len(remote.Descriptors)-1]
 	vDesc, err := getBlobWithCompression(ctx, sr.cm.ContentStore, topmost, refCfg.Compression.Type)

--- a/solver/llbsolver/history.go
+++ b/solver/llbsolver/history.go
@@ -366,11 +366,11 @@ func (h *HistoryQueue) addResource(ctx context.Context, l leases.Lease, desc *co
 	}
 	if _, err := h.hContentStore.Info(ctx, desc.Digest); err != nil {
 		if errdefs.IsNotFound(err) {
-			ctx, release, err := leaseutil.WithLease(ctx, h.hLeaseManager, leases.WithID("history_migration_"+identity.NewID()), leaseutil.MakeTemporary)
+			lr, ctx, err := leaseutil.NewLease(ctx, h.hLeaseManager, leases.WithID("history_migration_"+identity.NewID()), leaseutil.MakeTemporary)
 			if err != nil {
 				return err
 			}
-			defer release(ctx)
+			defer lr.Discard()
 			ok, err := h.migrateBlobV2(ctx, string(desc.Digest), detectSkipLayers)
 			if err != nil {
 				return err


### PR DESCRIPTION
Currently there is a temp lease creation in `GetRemotes()` called from exporters, cache-exporting, and provenance creation and gets called for every cache result when walking the graph. 99% time it returns nil or reference to blob that already existed but temp lease is needed for the odd case where it needs to create new blobs to make sure the code does not go to race against containerd GC. Although it looks like creating a lease is just `context.WithValue` it is actually quite expensive as it is written into containerd boltdb. This improves performance in this case by creating a single temp lease for the whole export phase of a single job so calls inside `GetRemotes()` don't need to create their own one for safety.