### PR TITLE
allow controlling detected platforms cache timeout

### DIFF
--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -38,6 +38,14 @@ type Config struct {
 		Dockerfile DockerfileFrontendConfig `toml:"dockerfile.v0"`
 		Gateway    GatewayFrontendConfig    `toml:"gateway.v0"`
 	} `toml:"frontend"`
+
+	System *SystemConfig `toml:"system"`
+}
+
+type SystemConfig struct {
+	// PlatformCacheMaxAge controls how often supported platforms
+	// are refreshed by rescanning the system.
+	PlatformsCacheMaxAge *Duration `toml:"platformsCacheMaxAge"`
 }
 
 type LogConfig struct {

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -262,6 +262,12 @@ func main() {
 			logrus.SetLevel(logrus.TraceLevel)
 		}
 
+		if sc := cfg.System; sc != nil {
+			if v := sc.PlatformsCacheMaxAge; v != nil {
+				archutil.CacheMaxAge = v.Duration
+			}
+		}
+
 		if cfg.GRPC.DebugAddress != "" {
 			if err := setupDebugHandlers(cfg.GRPC.DebugAddress); err != nil {
 				return err

--- a/docs/buildkitd.toml.md
+++ b/docs/buildkitd.toml.md
@@ -139,18 +139,22 @@ insecure-entitlements = [ "network.host", "security.insecure" ]
 
 # Frontend control
 [frontend."dockerfile.v0"]
- enabled = true
+  enabled = true
 
 [frontend."gateway.v0"]
- enabled = true
+  enabled = true
 
- # If allowedRepositories is empty, all gateway sources are allowed.
- # Otherwise, only the listed repositories are allowed as a gateway source.
- # 
- # NOTE: Only the repository name (without tag) is compared.
- #
- # Example:
- # allowedRepositories = [ "docker-registry.wikimedia.org/repos/releng/blubber/buildkit" ]
- allowedRepositories = []
+  # If allowedRepositories is empty, all gateway sources are allowed.
+  # Otherwise, only the listed repositories are allowed as a gateway source.
+  # 
+  # NOTE: Only the repository name (without tag) is compared.
+  #
+  # Example:
+  # allowedRepositories = [ "docker-registry.wikimedia.org/repos/releng/blubber/buildkit" ]
+  allowedRepositories = []
+
+[system]
+  # how often buildkit scans for changes in the supported emulated platforms
+  platformsCacheMaxAge = "1h"
 
 ```

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -245,10 +245,14 @@ func (w *Worker) Labels() map[string]string {
 
 func (w *Worker) Platforms(noCache bool) []ocispecs.Platform {
 	if noCache {
+		matchers := make([]platforms.MatchComparer, len(w.WorkerOpt.Platforms))
+		for i, p := range w.WorkerOpt.Platforms {
+			matchers[i] = platforms.Only(p)
+		}
 		for _, p := range archutil.SupportedPlatforms(noCache) {
 			exists := false
-			for _, pp := range w.WorkerOpt.Platforms {
-				if platforms.Only(pp).Match(p) {
+			for _, m := range matchers {
+				if m.Match(p) {
 					exists = true
 					break
 				}


### PR DESCRIPTION
Because detecting emulator changes can be relatively expensive, avoid doing it very frequently. A new config parameter allows controlling if users prefer more or less frequent updates or want to disable detecting changes completely and only rely on emultor configuration at boot time.