### PR TITLE
ensure correct grpc max sizes for control API and frontends

### DIFF
--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/pkg/seed" //nolint:staticcheck // SA1019 deprecated
 	"github.com/containerd/containerd/pkg/userns"
 	"github.com/containerd/containerd/platforms"
@@ -289,6 +290,8 @@ func main() {
 			grpc.StatsHandler(statsHandler),
 			grpc.ChainUnaryInterceptor(unaryInterceptor, grpcerrors.UnaryServerInterceptor),
 			grpc.StreamInterceptor(grpcerrors.StreamServerInterceptor),
+			grpc.MaxRecvMsgSize(defaults.DefaultMaxRecvMsgSize),
+			grpc.MaxSendMsgSize(defaults.DefaultMaxSendMsgSize),
 		}
 		server := grpc.NewServer(opts...)
 


### PR DESCRIPTION
fixes #4948

Correct app default should be 16MB but were control API and frontends used library defaults.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>