### PR TITLE
allow skipping backlinks where walking cache chains for provenance

### DIFF
--- a/solver/exporter.go
+++ b/solver/exporter.go
@@ -199,9 +199,11 @@ func (e *exporter) ExportTo(ctx context.Context, t CacheExporterTarget, opt Cach
 			}
 		}
 
-		for cm, id := range k.ids {
-			if _, err := addBacklinks(t, rec, cm, id, bkm); err != nil {
-				return nil, err
+		if !opt.IgnoreBacklinks {
+			for cm, id := range k.ids {
+				if _, err := addBacklinks(t, rec, cm, id, bkm); err != nil {
+					return nil, err
+				}
 			}
 		}
 	}

--- a/solver/llbsolver/provenance.go
+++ b/solver/llbsolver/provenance.go
@@ -411,9 +411,10 @@ func NewProvenanceCreator(ctx context.Context, cp *provenance.Capture, res solve
 			}
 
 			if _, err := r.CacheKeys()[0].Exporter.ExportTo(ctx, e, solver.CacheExportOpt{
-				ResolveRemotes: resolveRemotes,
-				Mode:           solver.CacheExportModeRemoteOnly,
-				ExportRoots:    true,
+				ResolveRemotes:  resolveRemotes,
+				Mode:            solver.CacheExportModeRemoteOnly,
+				ExportRoots:     true,
+				IgnoreBacklinks: true,
 			}); err != nil {
 				return err
 			}

--- a/solver/types.go
+++ b/solver/types.go
@@ -112,6 +112,9 @@ type CacheExportOpt struct {
 	CompressionOpt *compression.Config
 	// ExportRoots defines if records for root vertexes should be exported.
 	ExportRoots bool
+	// IgnoreBacklinks defines if other cache chains for same result that did not
+	// participate in the current build should be exported.
+	IgnoreBacklinks bool
 }
 
 // CacheExporter can export the artifacts of the build chain


### PR DESCRIPTION
closes #4942

Backlink walking should not be needed to determine layers for current build and should be safe to skip. This improves performance of provenance creation for certain builds.

I consider this only a quick mitigation. It seems likely that there is an issue with walking all cache chains on export that shows up on specific builds that needs further investigation.