### PR TITLE
dockerfile/parse: Fix nil dereference of a linter

### DIFF
--- a/frontend/dockerfile/instructions/parse.go
+++ b/frontend/dockerfile/instructions/parse.go
@@ -209,7 +209,7 @@ func parseKvps(args []string, cmdName string, location []parser.Range, lint *lin
 			return nil, errBlankCommandNames(cmdName)
 		}
 		name, value, sep := args[j], args[j+1], args[j+2]
-		if sep == "" {
+		if lint != nil && sep == "" {
 			msg := linter.RuleLegacyKeyValueFormat.Format(cmdName)
 			lint.Run(&linter.RuleLegacyKeyValueFormat, location, msg)
 		}

--- a/frontend/dockerfile/instructions/parse_test.go
+++ b/frontend/dockerfile/instructions/parse_test.go
@@ -151,6 +151,30 @@ func TestParseOptInterval(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestNilLinter(t *testing.T) {
+	for cmd := range command.Commands {
+		cmd := cmd
+		t.Run(cmd, func(t *testing.T) {
+			t.Parallel()
+
+			for _, tc := range []string{
+				cmd + " foo=bar",
+				cmd + " a",
+				cmd + " a b",
+				cmd + " a b c",
+				cmd + " 0 0",
+			} {
+				t.Run(tc, func(t *testing.T) {
+					ast, err := parser.Parse(strings.NewReader("FROM busybox\n" + tc))
+					if err == nil {
+						_, _, _ = Parse(ast.AST, nil)
+					}
+				})
+			}
+		})
+	}
+}
+
 func TestCommentsDetection(t *testing.T) {
 	dt := `# foo sets foo
 ARG foo=bar


### PR DESCRIPTION
- related to: https://github.com/moby/buildkit/pull/4923

Fix a nil dereference panic happening when parsing `ENV` and `LABEL` commands without a linter introduced by 6cfa4599029db7f2e6e83feaaa33984785ddd147.

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>