### PR TITLE
dockerfile: make sure stage is reachable before validating base

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -601,7 +601,9 @@ func toDispatchState(ctx context.Context, dt []byte, opt ConvertOpt) (*dispatchS
 							llb.WithCustomName(prefixCommand(d, "FROM "+d.stage.BaseName, opt.MultiPlatformRequested, platform, nil)),
 							location(opt.SourceMap, d.stage.Location),
 						)
-						validateBaseImagePlatform(origName, *platform, d.image.Platform, d.stage.Location, lint)
+						if reachable {
+							validateBaseImagePlatform(origName, *platform, d.image.Platform, d.stage.Location, lint)
+						}
 					}
 					d.platform = platform
 					return nil


### PR DESCRIPTION
If base was not reachable then the config was not loaded in and the platform to compare with is not correct.