### PR TITLE
Update PrintLintViolations output

### DIFF
--- a/frontend/subrequests/lint/lint.go
+++ b/frontend/subrequests/lint/lint.go
@@ -169,10 +169,12 @@ func PrintLintViolations(dt []byte, w io.Writer) error {
 	})
 
 	for _, warning := range results.Warnings {
-		fmt.Fprintf(w, "\n- %s\n%s\n", warning.Detail, warning.Description)
+		fmt.Fprintf(w, "%s", warning.RuleName)
 		if warning.URL != "" {
-			fmt.Fprintf(w, "URL: %s\n", warning.URL)
+			fmt.Fprintf(w, " - %s", warning.URL)
 		}
+		fmt.Fprintf(w, "\n%s\n", warning.Description)
+
 		if warning.Location.SourceIndex < 0 {
 			continue
 		}
@@ -185,6 +187,7 @@ func PrintLintViolations(dt []byte, w io.Writer) error {
 		if err != nil {
 			return err
 		}
+		fmt.Fprintln(w)
 	}
 	return nil
 }


### PR DESCRIPTION
Updates the output of the `PrintLintViolations` to begin with the violation rule name, print the ULR inline to the name if it exists, and remove the printing of the `Detail` field, which is redundant when printing the `Description`.


Old:
```
- 'as' and 'FROM' keywords' casing do not match
The 'as' keyword should match the case of the 'from' keyword
Dockerfile:1
--------------------
   1 | >>> FROM scratch as base
   2 |     copy Dockerfile .
   3 |
--------------------

- Command 'copy' should match the case of the command majority (uppercase)
All commands within the Dockerfile should use the same casing (either upper or lower)
Dockerfile:2
--------------------
   1 |     FROM scratch as base
   2 | >>> copy Dockerfile .
   3 |
   4 |
--------------------

```

Updated:
```
FromAsCasing
The 'as' keyword should match the case of the 'from' keyword
Dockerfile:1
--------------------
   1 | >>> FROM scratch as base
   2 |     copy Dockerfile \
   3 |
--------------------

NoEmptyContinuations - https://github.com/moby/moby/pull/33719
Empty continuation lines will become errors in a future release
Dockerfile:4
--------------------
   2 |     copy Dockerfile \
   3 |
   4 | >>> .
   5 |     copy .dockerignore .
   6 |
--------------------
```