### PR TITLE
fix: acquire privileges to access special files on windows

### DIFF
--- a/exporter/tar/export.go
+++ b/exporter/tar/export.go
@@ -166,7 +166,7 @@ func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source
 		return nil, nil, err
 	}
 	report := progress.OneOff(ctx, "sending tarball")
-	if err := fsutil.WriteTar(ctx, fs, w); err != nil {
+	if err := writeTar(ctx, fs, w); err != nil {
 		w.Close()
 		return nil, nil, report(err)
 	}

--- a/exporter/tar/export_unix.go
+++ b/exporter/tar/export_unix.go
@@ -1,0 +1,15 @@
+//go:build !windows
+// +build !windows
+
+package local
+
+import (
+	"context"
+	"io"
+
+	"github.com/tonistiigi/fsutil"
+)
+
+func writeTar(ctx context.Context, fs fsutil.FS, w io.WriteCloser) error {
+	return fsutil.WriteTar(ctx, fs, w)
+}

--- a/exporter/tar/export_windows.go
+++ b/exporter/tar/export_windows.go
@@ -1,0 +1,18 @@
+package local
+
+import (
+	"context"
+	"io"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/tonistiigi/fsutil"
+)
+
+func writeTar(ctx context.Context, fs fsutil.FS, w io.WriteCloser) error {
+	// Windows rootfs has a few special metadata files that
+	// require extra privileges to be accessed.
+	privileges := []string{winio.SeBackupPrivilege}
+	return winio.RunWithPrivileges(privileges, func() error {
+		return fsutil.WriteTar(ctx, fs, w)
+	})
+}

--- a/session/filesync/diffcopy.go
+++ b/session/filesync/diffcopy.go
@@ -21,10 +21,6 @@ type Stream interface {
 	RecvMsg(m interface{}) error
 }
 
-func sendDiffCopy(stream Stream, fs fsutil.FS, progress progressCb) error {
-	return errors.WithStack(fsutil.Send(stream.Context(), stream, fs, progress))
-}
-
 func newStreamWriter(stream grpc.ClientStream) io.WriteCloser {
 	wc := &streamWriterCloser{ClientStream: stream}
 	return &bufferedWriteCloser{Writer: bufio.NewWriter(wc), Closer: wc}

--- a/session/filesync/diffcopy_unix.go
+++ b/session/filesync/diffcopy_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+// +build !windows
+
+package filesync
+
+import (
+	"github.com/pkg/errors"
+	"github.com/tonistiigi/fsutil"
+)
+
+func sendDiffCopy(stream Stream, fs fsutil.FS, progress progressCb) error {
+	return errors.WithStack(fsutil.Send(stream.Context(), stream, fs, progress))
+}

--- a/session/filesync/diffcopy_windows.go
+++ b/session/filesync/diffcopy_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+// +build windows
+
+package filesync
+
+import (
+	"github.com/Microsoft/go-winio"
+	"github.com/pkg/errors"
+	"github.com/tonistiigi/fsutil"
+)
+
+func sendDiffCopy(stream Stream, fs fsutil.FS, progress progressCb) error {
+	// adding one SeBackupPrivilege to the process so as to be able
+	// to run the subsequent goroutines in fsutil.Send that need
+	// to copy over special Windows metadata files.
+	// TODO(profnandaa): need to cross-check that this cannot be
+	// exploited in any way.
+	winio.EnableProcessPrivileges([]string{winio.SeBackupPrivilege})
+	defer winio.DisableProcessPrivileges([]string{winio.SeBackupPrivilege})
+	return errors.WithStack(fsutil.Send(stream.Context(), stream, fs, progress))
+}


### PR DESCRIPTION
fixes #4985 

Windows has some special / metadata files that [need special privileges to access](https://learn.microsoft.com/en-us/windows-hardware/drivers/ifs/privileges), even if the process is running as Admin.
Some of those files (across `nanoserver` and `servercore`) currently are:

```
\\Program Files\\Windows Defender Advanced Threat Protection\\Classification\\Configuration
\\ProgramData\\Microsoft\\Windows Defender Advanced Threat Protection\\Cache
\\ProgramData\\Microsoft\\Windows Defender Advanced Threat Protection\\Cyber
\\ProgramData\\Microsoft\\Windows Defender Advanced Threat Protection\\DLP
\\ProgramData\\Microsoft\\Windows Defender Advanced Threat Protection\\DataCollection
\\ProgramData\\Microsoft\\Windows Defender Advanced Threat Protection\\Downloads
\\ProgramData\\Microsoft\\Windows Defender Advanced Threat Protection\\Platform
\\ProgramData\\Microsoft\\Windows Defender Advanced Threat Protection\\SenseCM
\\ProgramData\\Microsoft\\Windows Defender Advanced Threat Protection\\SenseNDR
\\ProgramData\\Microsoft\\Windows Defender Advanced Threat Protection\\Temp\\PSScriptOutputs
\\ProgramData\\Microsoft\\Windows Defender Advanced Threat Protection\\Trace
\\System Volume Information
\\WcSandboxState
\\Windows\\System32\\LogFiles\\WMI\\RtBackup
\\Windows\Globalization\\ICU\\icudtl.dat
```

Additionally, we have directories that don't need to be exported, I have separated that work in a separate issue here #5011 

Also, I'm currently working on enabling the skipped integration tests on Windows, and most of them are using local exporter, therefore will be depending on this change e.g.:
https://github.com/moby/buildkit/blob/eed17a45c62b2d6e26273e4ead7e177fb7022338/frontend/dockerfile/dockerfile_test.go#L348-L359

--

### Sample Test
```
buildctl build `
--frontend=dockerfile.v0 `
--local context=C:\dev\play\dockerfiles\export_local `
--local dockerfile=C:\dev\play\dockerfiles\export_local `
--output type=tar,dest=C:\dev\tmp\exp-2.tar `
--progress plain --no-cache
```

Before:

```
#7 exporting to client tarball
#7 sending tarball
#7 sending tarball 0.1s done
#7 ERROR: open C:\Users\nandaa\AppData\Local\Temp\buildkit-mount91402518\System Volume Information: Access is denied.
```

After fix:

```
#7 exporting to client tarball
#7 sending tarball
#7 sending tarball 30.6s done
#7 DONE 32.1s
```
