### PR TITLE
llbsolver: add more otel spans for export and history

### DIFF
--- a/solver/llbsolver/proc/provenance.go
+++ b/solver/llbsolver/proc/provenance.go
@@ -12,11 +12,15 @@ import (
 	"github.com/moby/buildkit/solver"
 	"github.com/moby/buildkit/solver/llbsolver"
 	"github.com/moby/buildkit/solver/result"
+	"github.com/moby/buildkit/util/tracing"
 	"github.com/pkg/errors"
 )
 
 func ProvenanceProcessor(attrs map[string]string) llbsolver.Processor {
 	return func(ctx context.Context, res *llbsolver.Result, s *llbsolver.Solver, j *solver.Job, usage *resources.SysSampler) (*llbsolver.Result, error) {
+		span, ctx := tracing.StartSpan(ctx, "create provenance attestation")
+		defer span.End()
+
 		ps, err := exptypes.ParsePlatforms(res.Metadata)
 		if err != nil {
 			return nil, err

--- a/solver/llbsolver/proc/sbom.go
+++ b/solver/llbsolver/proc/sbom.go
@@ -12,6 +12,7 @@ import (
 	"github.com/moby/buildkit/solver"
 	"github.com/moby/buildkit/solver/llbsolver"
 	"github.com/moby/buildkit/solver/result"
+	"github.com/moby/buildkit/util/tracing"
 	"github.com/pkg/errors"
 )
 
@@ -21,6 +22,9 @@ func SBOMProcessor(scannerRef string, useCache bool, resolveMode string) llbsolv
 		if sbom.HasSBOM(res.Result) {
 			return res, nil
 		}
+
+		span, ctx := tracing.StartSpan(ctx, "create sbom attestation")
+		defer span.End()
 
 		ps, err := exptypes.ParsePlatforms(res.Metadata)
 		if err != nil {


### PR DESCRIPTION
Add more OpenTelemetry spans to track the time for exporters, attestations and history record creation.