### PR TITLE
dockerfile: only report legacy key/value format when stage is reachable

### DIFF
--- a/frontend/dockerfile/instructions/commands.go
+++ b/frontend/dockerfile/instructions/commands.go
@@ -13,8 +13,9 @@ import (
 // This is useful for commands containing key-value maps that want to preserve
 // the order of insertion, instead of map[string]string which does not.
 type KeyValuePair struct {
-	Key   string
-	Value string
+	Key     string
+	Value   string
+	NoDelim bool
 }
 
 func (kvp *KeyValuePair) String() string {
@@ -108,8 +109,9 @@ func expandKvp(kvp KeyValuePair, expander SingleWordExpander) (KeyValuePair, err
 	if err != nil {
 		return KeyValuePair{}, err
 	}
-	return KeyValuePair{Key: key, Value: value}, nil
+	return KeyValuePair{Key: key, Value: value, NoDelim: kvp.NoDelim}, nil
 }
+
 func expandKvpsInPlace(kvps KeyValuePairs, expander SingleWordExpander) error {
 	for i, kvp := range kvps {
 		newKvp, err := expandKvp(kvp, expander)


### PR DESCRIPTION
This modifies the linter to only report the legacy key/value format if the stage is reachable to be more compatible with the other lints that operate this way.

Instead of reporting the warning in the parser, it records whether a delimiter is present in the KeyValuePair and this gets checked when the dispatch happens.