### PR TITLE
flightcontrol: protect contention timeouts

### DIFF
--- a/util/flightcontrol/flightcontrol.go
+++ b/util/flightcontrol/flightcontrol.go
@@ -3,7 +3,7 @@ package flightcontrol
 import (
 	"context"
 	"io"
-	"runtime"
+	"math/rand"
 	"sort"
 	"sync"
 	"time"
@@ -43,13 +43,14 @@ func (g *Group[T]) Do(ctx context.Context, key string, fn func(ctx context.Conte
 			err = errors.Wrapf(errRetryTimeout, "flightcontrol")
 			return v, err
 		}
-		runtime.Gosched()
 		if backoff > 0 {
-			time.Sleep(backoff)
-			backoff *= 2
+			backoff = time.Duration(float64(backoff) * 1.2)
 		} else {
-			backoff = time.Millisecond
+			// randomize initial backoff to avoid all goroutines retrying at once
+			//nolint:gosec // using math/rand pseudo-randomness is acceptable here
+			backoff = time.Millisecond + time.Duration(rand.Intn(1e7))*time.Nanosecond
 		}
+		time.Sleep(backoff)
 	}
 }
 


### PR DESCRIPTION
We had a report of https://github.com/moby/buildkit/issues/1822 error showing up in some logs.

Possibly important aspect of this race seems to be that callbacks returning errors are handled differently and retry happens right away when previous callback has errored in the beginning of `wait()`. This was not handled by previous contention test. With the new test it is easy to reach timeout with ~100 goroutines (and smaller with reduced probability).

This patch reduces the backoff factor so it does not increase too quickly and adds a random factor to initial timeout so that when lots of goroutines hit the error at the same time, they do not all retry at the same time as well. This seems to dramatically reduce the maximum backoff that can be reached by generating contention with the new testcase. 