### PR TITLE
test: missing GOBUILDFLAGS build arg when building itg test image

### DIFF
--- a/hack/test
+++ b/hack/test
@@ -98,6 +98,7 @@ if [ "$TEST_IMAGE_BUILD" = "1" ]; then
     --build-arg GOBUILDFLAGS \
     --build-arg VERIFYFLAGS \
     --build-arg CGO_ENABLED \
+    --build-arg GOBUILDFLAGS \
     --target "integration-tests" \
     --output "type=docker,name=$TEST_IMAGE_ID" \
     $currentcontext


### PR DESCRIPTION
Exported `GOBUILDFLAGS` var in https://github.com/moby/buildkit/pull/4938/commits/54b247406392ea8192ecfe1c029d95ae70922dd0#diff-ecedb817abdf33fd9ee7bb0c35c9cfcedfb39d8f3b261d92a6254066578aff08R86 is not set as `build-arg` when building. Only impacts local testing as we are building the image with bake on ci.