### PR TITLE
ci: enable disable_file_fixes in codecov action

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -181,7 +181,7 @@ jobs:
         with:
           directory: ./bin/testreports
           flags: ${{ matrix.codecov_flags }}
-          disable_file_fixes: false
+          disable_file_fixes: true
           token: ${{ secrets.CODECOV_TOKEN }}  # used to upload coverage reports: https://github.com/moby/buildkit/pull/4660#issue-2142122533
       -
         name: Generate annotations

--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -146,7 +146,7 @@ jobs:
           directory: ./bin/testreports
           env_vars: RUNNER_OS
           flags: unit
-          disable_file_fixes: false
+          disable_file_fixes: true
           token: ${{ secrets.CODECOV_TOKEN }}  # used to upload coverage reports: https://github.com/moby/buildkit/pull/4660#issue-2142122533
       -
         name: Generate annotations


### PR DESCRIPTION
related to https://github.com/moby/buildkit/pull/4938#discussion_r1621031729

this is actually the other way around, we need to "enable" the `disable_file_fixes` opt: https://docs.codecov.com/docs/cli-options#do-upload

![image](https://github.com/moby/buildkit/assets/1951866/a5d0057a-6857-48b8-a1dd-669e774ae7a0)

Example:

![image](https://github.com/moby/buildkit/assets/1951866/86b21b05-e9cc-4da0-b77d-8f780a0db5bc)
