### PR TITLE
history: fix empty Exporters attribute

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2940,6 +2940,7 @@ func testMultipleExporters(t *testing.T, sb integration.Sandbox) {
 
 		if workers.IsTestDockerd() {
 			require.Len(t, ev.Record.Result.Results, 1)
+			require.Len(t, ev.Record.Exporters, 5)
 			if workers.IsTestDockerdMoby(sb) {
 				require.Equal(t, images.MediaTypeDockerSchema2Config, ev.Record.Result.Results[0].MediaType)
 			} else {
@@ -2947,6 +2948,7 @@ func testMultipleExporters(t *testing.T, sb integration.Sandbox) {
 			}
 		} else {
 			require.Len(t, ev.Record.Result.Results, 2)
+			require.Len(t, ev.Record.Exporters, 6)
 			require.Equal(t, images.MediaTypeDockerSchema2Manifest, ev.Record.Result.Results[0].MediaType)
 			require.Equal(t, ocispecs.MediaTypeImageManifest, ev.Record.Result.Results[1].MediaType)
 		}

--- a/control/control.go
+++ b/control/control.go
@@ -372,6 +372,7 @@ func (c *Controller) Solve(ctx context.Context, req *controlapi.SolveRequest) (*
 		if err != nil {
 			return nil, err
 		}
+		bklog.G(ctx).Debugf("resolve exporter %s with %v", ex.Type, ex.Attrs)
 		expi, err := exp.Resolve(ctx, i, ex.Attrs)
 		if err != nil {
 			return nil, err

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -20,6 +20,7 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/buildkit/cache"
 	cacheconfig "github.com/moby/buildkit/cache/config"
+	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/exporter"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/session"
@@ -68,6 +69,7 @@ func (e *imageExporter) Resolve(ctx context.Context, id int, opt map[string]stri
 	i := &imageExporterInstance{
 		imageExporter: e,
 		id:            id,
+		attrs:         opt,
 		opts: ImageCommitOpts{
 			RefCfg: cacheconfig.RefConfig{
 				Compression: compression.New(compression.Default),
@@ -168,7 +170,8 @@ func (e *imageExporter) Resolve(ctx context.Context, id int, opt map[string]stri
 
 type imageExporterInstance struct {
 	*imageExporter
-	id int
+	id    int
+	attrs map[string]string
 
 	opts                 ImageCommitOpts
 	push                 bool
@@ -192,6 +195,14 @@ func (e *imageExporterInstance) Name() string {
 
 func (e *imageExporterInstance) Config() *exporter.Config {
 	return exporter.NewConfigWithCompression(e.opts.RefCfg.Compression)
+}
+
+func (e *imageExporterInstance) Type() string {
+	return client.ExporterImage
+}
+
+func (e *imageExporterInstance) Attrs() map[string]string {
+	return e.attrs
 }
 
 func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source, inlineCache exptypes.InlineCache, sessionID string) (_ map[string]string, descref exporter.DescriptorReference, err error) {

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -22,6 +22,8 @@ type ExporterInstance interface {
 	ID() int
 	Name() string
 	Config() *Config
+	Type() string
+	Attrs() map[string]string
 	Export(ctx context.Context, src *Source, inlineCache exptypes.InlineCache, sessionID string) (map[string]string, DescriptorReference, error)
 }
 

--- a/exporter/local/export.go
+++ b/exporter/local/export.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/moby/buildkit/cache"
+	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/exporter"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/exporter/util/epoch"
@@ -38,6 +39,7 @@ func New(opt Opt) (exporter.Exporter, error) {
 func (e *localExporter) Resolve(ctx context.Context, id int, opt map[string]string) (exporter.ExporterInstance, error) {
 	i := &localExporterInstance{
 		id:            id,
+		attrs:         opt,
 		localExporter: e,
 	}
 	_, err := i.opts.Load(opt)
@@ -50,7 +52,8 @@ func (e *localExporter) Resolve(ctx context.Context, id int, opt map[string]stri
 
 type localExporterInstance struct {
 	*localExporter
-	id int
+	id    int
+	attrs map[string]string
 
 	opts CreateFSOpts
 }
@@ -61,6 +64,14 @@ func (e *localExporterInstance) ID() int {
 
 func (e *localExporterInstance) Name() string {
 	return "exporting to client directory"
+}
+
+func (e *localExporterInstance) Type() string {
+	return client.ExporterLocal
+}
+
+func (e *localExporterInstance) Attrs() map[string]string {
+	return e.attrs
 }
 
 func (e *localExporter) Config() *exporter.Config {

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -14,6 +14,7 @@ import (
 	"github.com/distribution/reference"
 	"github.com/moby/buildkit/cache"
 	cacheconfig "github.com/moby/buildkit/cache/config"
+	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/exporter"
 	"github.com/moby/buildkit/exporter/containerimage"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
@@ -34,8 +35,8 @@ import (
 type ExporterVariant string
 
 const (
-	VariantOCI    = "oci"
-	VariantDocker = "docker"
+	VariantOCI    = client.ExporterOCI
+	VariantDocker = client.ExporterDocker
 )
 
 const (
@@ -62,6 +63,7 @@ func (e *imageExporter) Resolve(ctx context.Context, id int, opt map[string]stri
 	i := &imageExporterInstance{
 		imageExporter: e,
 		id:            id,
+		attrs:         opt,
 		tar:           true,
 		opts: containerimage.ImageCommitOpts{
 			RefCfg: cacheconfig.RefConfig{
@@ -100,7 +102,8 @@ func (e *imageExporter) Resolve(ctx context.Context, id int, opt map[string]stri
 
 type imageExporterInstance struct {
 	*imageExporter
-	id int
+	id    int
+	attrs map[string]string
 
 	opts containerimage.ImageCommitOpts
 	tar  bool
@@ -113,6 +116,14 @@ func (e *imageExporterInstance) ID() int {
 
 func (e *imageExporterInstance) Name() string {
 	return fmt.Sprintf("exporting to %s image format", e.opt.Variant)
+}
+
+func (e *imageExporterInstance) Type() string {
+	return string(e.opt.Variant)
+}
+
+func (e *imageExporterInstance) Attrs() map[string]string {
+	return e.attrs
 }
 
 func (e *imageExporterInstance) Config() *exporter.Config {

--- a/exporter/tar/export.go
+++ b/exporter/tar/export.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/moby/buildkit/cache"
+	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/exporter"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/exporter/local"
@@ -37,6 +38,7 @@ func (e *localExporter) Resolve(ctx context.Context, id int, opt map[string]stri
 	li := &localExporterInstance{
 		localExporter: e,
 		id:            id,
+		attrs:         opt,
 	}
 	_, err := li.opts.Load(opt)
 	if err != nil {
@@ -49,7 +51,8 @@ func (e *localExporter) Resolve(ctx context.Context, id int, opt map[string]stri
 
 type localExporterInstance struct {
 	*localExporter
-	id int
+	id    int
+	attrs map[string]string
 
 	opts local.CreateFSOpts
 }
@@ -60,6 +63,14 @@ func (e *localExporterInstance) ID() int {
 
 func (e *localExporterInstance) Name() string {
 	return "exporting to client tarball"
+}
+
+func (e *localExporterInstance) Type() string {
+	return client.ExporterTar
+}
+
+func (e *localExporterInstance) Attrs() map[string]string {
+	return e.attrs
 }
 
 func (e *localExporterInstance) Config() *exporter.Config {

--- a/frontend/dockerfile/dockerfile_provenance_test.go
+++ b/frontend/dockerfile/dockerfile_provenance_test.go
@@ -1369,6 +1369,7 @@ COPY bar bar2
 			break
 		}
 		require.Equal(t, ref, ev.Record.Ref)
+		require.Len(t, ev.Record.Exporters, 1)
 
 		for _, prov := range ev.Record.Result.Attestations {
 			if len(prov.Annotations) == 0 || prov.Annotations["in-toto.io/predicate-type"] != "https://slsa.dev/provenance/v0.2" {

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -53,8 +53,6 @@ const (
 )
 
 type ExporterRequest struct {
-	Type           string
-	Attrs          map[string]string
 	Exporters      []exporter.ExporterInstance
 	CacheExporters []RemoteCacheExporter
 }
@@ -173,11 +171,11 @@ func (s *Solver) recordBuildHistory(ctx context.Context, id string, req frontend
 		CreatedAt:     &st,
 	}
 
-	if exp.Type != "" {
-		rec.Exporters = []*controlapi.Exporter{{
-			Type:  exp.Type,
-			Attrs: exp.Attrs,
-		}}
+	for _, e := range exp.Exporters {
+		rec.Exporters = append(rec.Exporters, &controlapi.Exporter{
+			Type:  e.Type(),
+			Attrs: e.Attrs(),
+		})
 	}
 
 	if err := s.history.Update(ctx, &controlapi.BuildHistoryEvent{


### PR DESCRIPTION
Since multiple exporters support https://github.com/moby/buildkit/pull/4134 in BuildKit 0.13, `Record.Exporters` is not set anymore.

This is related to the `Type` and `Attrs` fields not being set in the `llbsolver.ExporterRequest`: https://github.com/moby/buildkit/pull/4134/files#diff-0397d42d692ad676389ccf4b5a1126a3976ef69d4342b8423a6bbb51d21a9181L458-L459

But this is used when we want to set the `Exporters` for the build history: https://github.com/moby/buildkit/blob/eed17a45c62b2d6e26273e4ead7e177fb7022338/solver/llbsolver/solver.go#L176

To fix this, I have updated the `exporter.ExporterInstance` interface to expose attributes and name of the exporter. Also removes `Type` and `Attrs` fields `ExporterRequest` that don't seem used anymore.