### PR TITLE
flightcontrol: add cachedgroup struct

### DIFF
--- a/frontend/dockerui/config.go
+++ b/frontend/dockerui/config.go
@@ -78,8 +78,7 @@ type Client struct {
 	Config
 	client      client.Client
 	ignoreCache []string
-	bctx        *buildContext
-	g           flightcontrol.Group[*buildContext]
+	g           flightcontrol.CachedGroup[*buildContext]
 	bopts       client.BuildOpts
 
 	dockerignore     []byte
@@ -288,14 +287,7 @@ func (bc *Client) init() error {
 
 func (bc *Client) buildContext(ctx context.Context) (*buildContext, error) {
 	return bc.g.Do(ctx, "initcontext", func(ctx context.Context) (*buildContext, error) {
-		if bc.bctx != nil {
-			return bc.bctx, nil
-		}
-		bctx, err := bc.initContext(ctx)
-		if err == nil {
-			bc.bctx = bctx
-		}
-		return bctx, err
+		return bc.initContext(ctx)
 	})
 }
 

--- a/util/flightcontrol/cached.go
+++ b/util/flightcontrol/cached.go
@@ -1,0 +1,63 @@
+package flightcontrol
+
+import (
+	"context"
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+// Group is a flightcontrol synchronization group that memoizes the results of a function
+// and returns the cached result if the function is called with the same key.
+// Don't use with long-running groups as the results are cached indefinitely.
+type CachedGroup[T any] struct {
+	// CacheError defines if error results should also be cached.
+	// It is not safe to change this value after the first call to Do.
+	// Context cancellation errors are never cached.
+	CacheError bool
+	g          Group[T]
+	mu         sync.Mutex
+	cache      map[string]result[T]
+}
+
+type result[T any] struct {
+	v   T
+	err error
+}
+
+// Do executes a context function syncronized by the key or returns the cached result for the key.
+func (g *CachedGroup[T]) Do(ctx context.Context, key string, fn func(ctx context.Context) (T, error)) (T, error) {
+	return g.g.Do(ctx, key, func(ctx context.Context) (T, error) {
+		g.mu.Lock()
+		if v, ok := g.cache[key]; ok {
+			g.mu.Unlock()
+			if v.err != nil {
+				if g.CacheError {
+					return v.v, v.err
+				}
+			} else {
+				return v.v, nil
+			}
+		}
+		g.mu.Unlock()
+		v, err := fn(ctx)
+		if err != nil {
+			select {
+			case <-ctx.Done():
+				if errors.Is(err, context.Cause(ctx)) {
+					return v, err
+				}
+			default:
+			}
+		}
+		if err == nil || g.CacheError {
+			g.mu.Lock()
+			if g.cache == nil {
+				g.cache = make(map[string]result[T])
+			}
+			g.cache[key] = result[T]{v: v, err: err}
+			g.mu.Unlock()
+		}
+		return v, err
+	})
+}

--- a/util/flightcontrol/cached_test.go
+++ b/util/flightcontrol/cached_test.go
@@ -1,0 +1,97 @@
+package flightcontrol
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCached(t *testing.T) {
+	var g CachedGroup[int]
+
+	ctx := context.TODO()
+
+	v, err := g.Do(ctx, "11", func(ctx context.Context) (int, error) {
+		return 1, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, v)
+
+	v, err = g.Do(ctx, "22", func(ctx context.Context) (int, error) {
+		return 2, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, v)
+
+	didCall := false
+	v, err = g.Do(ctx, "11", func(ctx context.Context) (int, error) {
+		didCall = true
+		return 3, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, v)
+	require.Equal(t, false, didCall)
+
+	// by default, errors are not cached
+	_, err = g.Do(ctx, "33", func(ctx context.Context) (int, error) {
+		return 0, errors.Errorf("some error")
+	})
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "some error")
+
+	v, err = g.Do(ctx, "33", func(ctx context.Context) (int, error) {
+		return 3, nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 3, v)
+}
+
+func TestCachedError(t *testing.T) {
+	var g CachedGroup[string]
+	g.CacheError = true
+
+	ctx := context.TODO()
+
+	_, err := g.Do(ctx, "11", func(ctx context.Context) (string, error) {
+		return "", errors.Errorf("first error")
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "first error")
+
+	_, err = g.Do(ctx, "11", func(ctx context.Context) (string, error) {
+		return "never-ran", nil
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "first error")
+
+	// context errors are never cached
+	ctx, cancel := context.WithTimeoutCause(context.TODO(), 10*time.Millisecond, nil)
+	defer cancel()
+	_, err = g.Do(ctx, "22", func(ctx context.Context) (string, error) {
+		select {
+		case <-ctx.Done():
+			return "", context.Cause(ctx)
+		case <-time.After(10 * time.Second):
+			return "", errors.Errorf("unexpected error")
+		}
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "context deadline exceeded")
+
+	select {
+	case <-ctx.Done():
+	default:
+		require.Fail(t, "expected context to be done")
+	}
+
+	v, err := g.Do(ctx, "22", func(ctx context.Context) (string, error) {
+		return "did-run", nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, "did-run", v)
+}


### PR DESCRIPTION
This adds an additional version of `flightcontrol.Group` that caches previous results and returns earlier result if callback was already called for the same key.

Also refactor `llb.Async` and `dockerui` to use the new group. There are more cases that can be updated in follow-ups, for example in solver and puller, when implementing https://github.com/moby/buildkit/issues/4971 and rewriting https://github.com/docker/buildx/blob/v0.15.0/build/driver.go#L50-L60 .

Initially, this version was not used because without generics, it would have been quite hacky to do the `interace{}` type casts everywhere.