### PR TITLE
remove some redundant imports of github.com/sirupsen/logrus

### DIFF
--- a/cache/refs.go
+++ b/cache/refs.go
@@ -36,7 +36,6 @@ import (
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -482,7 +481,7 @@ type immutableRef struct {
 }
 
 // hold ref lock before calling
-func (sr *immutableRef) traceLogFields() logrus.Fields {
+func (sr *immutableRef) traceLogFields() map[string]any {
 	m := map[string]any{
 		"id":          sr.ID(),
 		"refID":       fmt.Sprintf("%p", sr),
@@ -622,7 +621,7 @@ type mutableRef struct {
 }
 
 // hold ref lock before calling
-func (sr *mutableRef) traceLogFields() logrus.Fields {
+func (sr *mutableRef) traceLogFields() map[string]any {
 	m := map[string]any{
 		"id":          sr.ID(),
 		"refID":       fmt.Sprintf("%p", sr),

--- a/examples/build-using-dockerfile/main.go
+++ b/examples/build-using-dockerfile/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,7 +16,6 @@ import (
 	"github.com/moby/buildkit/util/appdefaults"
 	"github.com/moby/buildkit/util/progress/progressui"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/tonistiigi/fsutil"
 	"github.com/urfave/cli"
 	"golang.org/x/sync/errgroup"
@@ -121,7 +121,7 @@ func action(clicontext *cli.Context) error {
 	if err := eg.Wait(); err != nil {
 		return err
 	}
-	logrus.Infof("Loaded the image %q to Docker.", clicontext.String("tag"))
+	log.Printf("Loaded the image %q to Docker.", clicontext.String("tag"))
 	return nil
 }
 

--- a/examples/dockerfile2llb/main.go
+++ b/examples/dockerfile2llb/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"io"
+	"log"
 	"os"
 
 	"github.com/moby/buildkit/client/llb"
@@ -13,7 +14,6 @@ import (
 	"github.com/moby/buildkit/frontend/dockerui"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/appcontext"
-	"github.com/sirupsen/logrus"
 )
 
 type buildOpt struct {
@@ -24,7 +24,7 @@ type buildOpt struct {
 
 func main() {
 	if err := xmain(); err != nil {
-		logrus.Fatal(err)
+		log.Fatal(err)
 	}
 }
 

--- a/examples/kubernetes/consistenthash/main.go
+++ b/examples/kubernetes/consistenthash/main.go
@@ -17,17 +17,17 @@ package main
 import (
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/serialx/hashring"
-	"github.com/sirupsen/logrus"
 )
 
 func main() {
 	if err := xmain(); err != nil {
-		logrus.Fatal(err)
+		log.Fatal(err)
 	}
 }
 

--- a/session/grpc.go
+++ b/session/grpc.go
@@ -12,7 +12,6 @@ import (
 	"github.com/moby/buildkit/util/grpcerrors"
 	"github.com/moby/buildkit/util/tracing"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/net/http2"
@@ -98,7 +97,7 @@ func monitorHealth(ctx context.Context, cc *grpc.ClientConn, cancelConn func(err
 			cancel(errors.WithStack(context.Canceled))
 
 			lastHealthcheckDuration = time.Since(healthcheckStart)
-			logFields := logrus.Fields{
+			logFields := map[string]any{
 				"timeout":        timeout,
 				"actualDuration": lastHealthcheckDuration,
 			}

--- a/solver/cachemanager.go
+++ b/solver/cachemanager.go
@@ -10,7 +10,6 @@ import (
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/util/bklog"
 	digest "github.com/opencontainers/go-digest"
-	"github.com/sirupsen/logrus"
 )
 
 // NewInMemoryCacheManager creates a new in-memory cache manager
@@ -61,7 +60,7 @@ func (c *cacheManager) Query(deps []CacheKeyWithSelector, input Index, dgst dige
 	for i, dep := range deps {
 		depsField[i] = dep.TraceFields()
 	}
-	lg := bklog.G(context.TODO()).WithFields(logrus.Fields{
+	lg := bklog.G(context.TODO()).WithFields(map[string]any{
 		"cache_manager": c.id,
 		"op":            "query",
 		"deps":          depsField,
@@ -135,7 +134,7 @@ func (c *cacheManager) Query(deps []CacheKeyWithSelector, input Index, dgst dige
 }
 
 func (c *cacheManager) Records(ctx context.Context, ck *CacheKey) (rrecs []*CacheRecord, rerr error) {
-	lg := bklog.G(context.TODO()).WithFields(logrus.Fields{
+	lg := bklog.G(context.TODO()).WithFields(map[string]any{
 		"cache_manager": c.id,
 		"op":            "records",
 		"cachekey":      ck.TraceFields(),
@@ -169,7 +168,7 @@ func (c *cacheManager) Records(ctx context.Context, ck *CacheKey) (rrecs []*Cach
 }
 
 func (c *cacheManager) Load(ctx context.Context, rec *CacheRecord) (rres Result, rerr error) {
-	lg := bklog.G(context.TODO()).WithFields(logrus.Fields{
+	lg := bklog.G(context.TODO()).WithFields(map[string]any{
 		"cache_manager": c.id,
 		"op":            "load",
 		"record":        rec.TraceFields(),
@@ -246,7 +245,7 @@ func (c *cacheManager) filterResults(m map[string]Result, ck *CacheKey, visited 
 }
 
 func (c *cacheManager) LoadWithParents(ctx context.Context, rec *CacheRecord) (rres []LoadedResult, rerr error) {
-	lg := bklog.G(context.TODO()).WithFields(logrus.Fields{
+	lg := bklog.G(context.TODO()).WithFields(map[string]any{
 		"cache_manager": c.id,
 		"op":            "load_with_parents",
 		"record":        rec.TraceFields(),
@@ -299,7 +298,7 @@ func (c *cacheManager) LoadWithParents(ctx context.Context, rec *CacheRecord) (r
 }
 
 func (c *cacheManager) Save(k *CacheKey, r Result, createdAt time.Time) (rck *ExportableCacheKey, rerr error) {
-	lg := bklog.G(context.TODO()).WithFields(logrus.Fields{
+	lg := bklog.G(context.TODO()).WithFields(map[string]any{
 		"cache_manager": c.id,
 		"op":            "save",
 		"result":        r.ID(),

--- a/sourcepolicy/engine.go
+++ b/sourcepolicy/engine.go
@@ -7,7 +7,6 @@ import (
 	spb "github.com/moby/buildkit/sourcepolicy/pb"
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -117,12 +116,11 @@ func (e *Engine) evaluatePolicy(ctx context.Context, pol *spb.Policy, srcOp *pb.
 	ctx = bklog.WithLogger(ctx, bklog.G(ctx).WithField("ref", ident))
 	defer func() {
 		if retMut || retErr != nil {
-			bklog.G(ctx).WithFields(
-				logrus.Fields{
-					"mutated":       retMut,
-					"updated":       srcOp.GetIdentifier(),
-					logrus.ErrorKey: retErr,
-				}).Debug("Evaluated source policy")
+			bklog.G(ctx).WithFields(map[string]any{
+				"mutated": retMut,
+				"updated": srcOp.GetIdentifier(),
+				"error":   retErr,
+			}).Debug("Evaluated source policy")
 		}
 	}()
 

--- a/util/bklog/log.go
+++ b/util/bklog/log.go
@@ -53,7 +53,7 @@ func GetLogger(ctx context.Context) (l *logrus.Entry) {
 
 	if logWithTraceID {
 		if spanContext := trace.SpanFromContext(ctx).SpanContext(); spanContext.IsValid() {
-			return l.WithFields(logrus.Fields{
+			return l.WithFields(map[string]any{
 				"traceID": spanContext.TraceID(),
 				"spanID":  spanContext.SpanID(),
 			})

--- a/util/resolver/authorizer.go
+++ b/util/resolver/authorizer.go
@@ -20,7 +20,6 @@ import (
 	"github.com/moby/buildkit/util/flightcontrol"
 	"github.com/moby/buildkit/version"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 const defaultExpiration = 60
@@ -393,7 +392,7 @@ func (ah *authHandler) fetchToken(ctx context.Context, sm *session.Manager, g se
 					token = resp.AccessToken
 					return nil, nil
 				}
-				log.G(ctx).WithFields(logrus.Fields{
+				log.G(ctx).WithFields(map[string]any{
 					"status": errStatus.Status,
 					"body":   string(errStatus.Body),
 				}).Debugf("token request failed")

--- a/util/resolver/pool.go
+++ b/util/resolver/pool.go
@@ -19,7 +19,6 @@ import (
 	"github.com/moby/buildkit/version"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 // DefaultPool is the default shared resolver pool instance
@@ -108,7 +107,7 @@ func (p *Pool) GetResolver(hosts docker.RegistryHosts, ref, scope string, sm *se
 		p.m[key] = h
 	}
 
-	log.G(context.TODO()).WithFields(logrus.Fields{
+	log.G(context.TODO()).WithFields(map[string]any{
 		"name":   name,
 		"scope":  scope,
 		"key":    key,


### PR DESCRIPTION
### remove uses of logrus.Fields

logrus.Fields is a map[string]any, so we don't need the logrus
import in these places.

containerd/log aliases the type, which could be an alternative, but
the containerd/log module is not used in many places, so would be
a bit redundant just for this type.

### examples: remove uses of logrus

These are very basic examples, so stdlib's "log" package should be
fine for purpose of illustration.
