### PR TITLE
tests: enabling integration tests on windows

### DIFF
--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -77,7 +77,7 @@ jobs:
     needs:
       - build
     env:
-      TESTFLAGS: "-v --parallel=6 --timeout=30m"
+      TESTFLAGS: "-v --timeout=60m"
       GOTESTSUM_FORMAT: "standard-verbose"
     strategy:
       fail-fast: false
@@ -102,7 +102,7 @@ jobs:
           echo "TEST_REPORT_NAME=${{ github.job }}-$(echo "${{ matrix.pkg }}-${{ matrix.skip-integration-tests }}-${{ matrix.worker }}" | tr -dc '[:alnum:]-\n\r' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
           testFlags="${{ env.TESTFLAGS }}"
           if [ -n "${{ matrix.worker }}" ]; then
-            testFlags="${testFlags} --run=//worker=${{ matrix.worker }}$"
+            testFlags="${testFlags} --run=TestIntegration/.*/worker=${{ matrix.worker }}"
           fi
           echo "TESTFLAGS=${testFlags}" >> $GITHUB_ENV
         shell: bash

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -6297,6 +6297,7 @@ func testExportLocalNoPlatformSplit(t *testing.T, sb integration.Sandbox) {
 }
 
 func testExportLocalNoPlatformSplitOverwrite(t *testing.T, sb integration.Sandbox) {
+	integration.SkipOnPlatform(t, "windows")
 	workers.CheckFeatureCompat(t, sb, workers.FeatureOCIExporter, workers.FeatureMultiPlatform)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -8131,6 +8132,7 @@ func testPullWithLayerLimit(t *testing.T, sb integration.Sandbox) {
 }
 
 func testCallInfo(t *testing.T, sb integration.Sandbox) {
+	integration.SkipOnPlatform(t, "windows")
 	workers.CheckFeatureCompat(t, sb, workers.FeatureInfo)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -10568,6 +10570,7 @@ func testLayerLimitOnMounts(t *testing.T, sb integration.Sandbox) {
 }
 
 func testClientCustomGRPCOpts(t *testing.T, sb integration.Sandbox) {
+	integration.SkipOnPlatform(t, "windows")
 	var interceptedMethods []string
 	intercept := func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		interceptedMethods = append(interceptedMethods, method)

--- a/util/testutil/integration/pins.go
+++ b/util/testutil/integration/pins.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 package integration
 
 var pins = map[string]map[string]string{

--- a/util/testutil/integration/run_unix.go
+++ b/util/testutil/integration/run_unix.go
@@ -1,0 +1,26 @@
+//go:build !windows
+// +build !windows
+
+package integration
+
+import "runtime"
+
+func officialImages(names ...string) map[string]string {
+	ns := runtime.GOARCH
+	if ns == "arm64" {
+		ns = "arm64v8"
+	} else if ns != "amd64" {
+		ns = "library"
+	}
+	m := map[string]string{}
+	for _, name := range names {
+		ref := "docker.io/" + ns + "/" + name
+		if pns, ok := pins[name]; ok {
+			if dgst, ok := pns[ns]; ok {
+				ref += "@" + dgst
+			}
+		}
+		m["library/"+name] = ref
+	}
+	return m
+}

--- a/util/testutil/integration/run_windows.go
+++ b/util/testutil/integration/run_windows.go
@@ -1,0 +1,13 @@
+package integration
+
+func officialImages(names ...string) map[string]string {
+	m := map[string]string{}
+	for _, name := range names {
+		// select available refs from the mirror map
+		// so that we mirror only those needed for the tests
+		if ref, ok := windowsImagesMirrorMap[name]; ok {
+			m["library/"+name] = ref
+		}
+	}
+	return m
+}

--- a/util/testutil/integration/util.go
+++ b/util/testutil/integration/util.go
@@ -94,8 +94,12 @@ func StartCmd(cmd *exec.Cmd, logs map[string]*bytes.Buffer) (func() error, error
 		case <-ctx.Done():
 		case <-stopped:
 		case <-stop:
+			// windows processes not responding to SIGTERM
+			signal := UnixOrWindows(syscall.SIGTERM, syscall.SIGKILL)
+			signalStr := UnixOrWindows("SIGTERM", "SIGKILL")
 			fmt.Fprintf(cmd.Stderr, "> sending sigterm %v\n", time.Now())
-			cmd.Process.Signal(syscall.SIGTERM)
+			fmt.Fprintf(cmd.Stderr, "> sending %s %v\n", signalStr, time.Now())
+			cmd.Process.Signal(signal)
 			go func() {
 				select {
 				case <-stopped:

--- a/util/testutil/integration/util_windows.go
+++ b/util/testutil/integration/util_windows.go
@@ -11,6 +11,13 @@ import (
 
 var socketScheme = "npipe://"
 
+var windowsImagesMirrorMap = map[string]string{
+	// TODO(profnandaa): currently, amd64 only, to revisit for other archs.
+	"nanoserver:latest": "mcr.microsoft.com/windows/nanoserver:ltsc2022",
+	"servercore:latest": "mcr.microsoft.com/windows/servercore:ltsc2022",
+	"busybox:latest":    "registry.k8s.io/e2e-test-images/busybox@sha256:6d854ffad9666d2041b879a1c128c9922d77faced7745ad676639b07111ab650",
+}
+
 // abstracted function to handle pipe dialing on windows.
 // some simplification has been made to discard timeout param.
 func dialPipe(address string) (net.Conn, error) {


### PR DESCRIPTION
Depends on #4994
Started addressing #4485

Starting off with this one as a POC on the approach, before we proceed to complete the rest under `/frontend/dockerfile`.

Tests covered so far:

- [x] `/frontend/dockerfile: testEnvEmptyFormatting`
- [x] `/frontend/dockerfile: testDockerignoreOverride`
- [x] `/frontend/dockerfile: caseEmptyDestDir`