### PR TITLE
Adds 'WARNING' prefix to the rule check output

### DIFF
--- a/frontend/subrequests/lint/lint.go
+++ b/frontend/subrequests/lint/lint.go
@@ -108,7 +108,7 @@ func (results *LintResults) ToResult() (*client.Result, error) {
 	res.AddMeta("result.txt", b.Bytes())
 
 	status := 0
-	if len(results.Warnings) > 0 {
+	if len(results.Warnings) > 0 || results.Error != nil {
 		status = 1
 	}
 	res.AddMeta("result.statuscode", []byte(fmt.Sprintf("%d", status)))
@@ -169,7 +169,7 @@ func PrintLintViolations(dt []byte, w io.Writer) error {
 	})
 
 	for _, warning := range results.Warnings {
-		fmt.Fprintf(w, "%s", warning.RuleName)
+		fmt.Fprintf(w, "\nWARNING: %s", warning.RuleName)
 		if warning.URL != "" {
 			fmt.Fprintf(w, " - %s", warning.URL)
 		}
@@ -187,8 +187,8 @@ func PrintLintViolations(dt []byte, w io.Writer) error {
 		if err != nil {
 			return err
 		}
-		fmt.Fprintln(w)
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
Old Output
```
[+] Building 0.1s (2/2) FINISHED                                                                                                         docker-container:dev
 => [internal] connecting to local controller                                                                                                            0.0s
 => [internal] load build definition from Dockerfile                                                                                                     0.0s
 => => transferring dockerfile: 171B                                                                                                                     0.0s
FromAsCasing - https://docs.docker.com/go/dockerfile/rule/from-as-casing/
The 'as' keyword should match the case of the 'from' keyword
Dockerfile:1
--------------------
   1 | >>> FROM scratch as first
   2 |     COPY $app .
   3 |
--------------------

FromAsCasing - https://docs.docker.com/go/dockerfile/rule/from-as-casing/
The 'as' keyword should match the case of the 'from' keyword
Dockerfile:7
--------------------
   5 |     COPY $app .
   6 |
   7 | >>> FROM scratch asgard third
   8 |
--------------------
```

New Output
```
[+] Building 0.1s (2/2) FINISHED                                                                                                         docker-container:dev
 => [internal] connecting to local controller                                                                                                            0.0s
 => [internal] load build definition from Dockerfile                                                                                                     0.0s
 => => transferring dockerfile: 171B                                                                                                                     0.0s

WARNING: FromAsCasing - https://docs.docker.com/go/dockerfile/rule/from-as-casing/
The 'as' keyword should match the case of the 'from' keyword
Dockerfile:1
--------------------
   1 | >>> FROM scratch as first
   2 |     COPY $app .
   3 |
--------------------

WARNING: FromAsCasing - https://docs.docker.com/go/dockerfile/rule/from-as-casing/
The 'as' keyword should match the case of the 'from' keyword
Dockerfile:7
--------------------
   5 |     COPY $app .
   6 |
   7 | >>> FROM scratch asgard third
   8 |
--------------------
```