### PR TITLE
Spelling correction

### DIFF
--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -79,7 +79,7 @@ func Build(ctx context.Context, c client.Client) (_ *client.Result, err error) {
 
 	if res, ok, err := bc.HandleSubrequest(ctx, dockerui.RequestHandler{
 		Outline: func(ctx context.Context) (*outline.Outline, error) {
-			return dockerfile2llb.Dockefile2Outline(ctx, src.Data, convertOpt)
+			return dockerfile2llb.Dockerfile2Outline(ctx, src.Data, convertOpt)
 		},
 		ListTargets: func(ctx context.Context) (*targets.List, error) {
 			return dockerfile2llb.ListTargets(ctx, src.Data)

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -99,7 +99,7 @@ func Dockerfile2LLB(ctx context.Context, dt []byte, opt ConvertOpt) (*llb.State,
 	return &ds.state, &ds.image, &sbom, nil
 }
 
-func Dockefile2Outline(ctx context.Context, dt []byte, opt ConvertOpt) (*outline.Outline, error) {
+func Dockerfile2Outline(ctx context.Context, dt []byte, opt ConvertOpt) (*outline.Outline, error) {
 	ds, err := toDispatchState(ctx, dt, opt)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
During code maintenance, I realized that the function `Dockefile2Outline` seems to be misspelled, it should be `Dockerfile2Outline`