### PR TITLE
Updates lint output to print detail instead of description

### DIFF
--- a/frontend/dockerfile/linter/linter.go
+++ b/frontend/dockerfile/linter/linter.go
@@ -91,8 +91,12 @@ func (rule *LinterRule[F]) Run(warn LintWarnFunc, location []parser.Range, txt .
 	warn(rule.Name, rule.Description, rule.URL, short, location)
 }
 
-func LintFormatShort(rulename, msg string, startLine int) string {
-	return fmt.Sprintf("%s: %s (line %d)", rulename, msg, startLine)
+func LintFormatShort(rulename, msg string, line int) string {
+	msg = fmt.Sprintf("%s: %s", rulename, msg)
+	if line > 0 {
+		msg = fmt.Sprintf("%s (line %d)", msg, line)
+	}
+	return msg
 }
 
 type LintWarnFunc func(rulename, description, url, fmtmsg string, location []parser.Range)

--- a/frontend/subrequests/lint/lint.go
+++ b/frontend/subrequests/lint/lint.go
@@ -173,7 +173,7 @@ func PrintLintViolations(dt []byte, w io.Writer) error {
 		if warning.URL != "" {
 			fmt.Fprintf(w, " - %s", warning.URL)
 		}
-		fmt.Fprintf(w, "\n%s\n", warning.Description)
+		fmt.Fprintf(w, "\n%s\n", warning.Detail)
 
 		if warning.Location.SourceIndex < 0 {
 			continue


### PR DESCRIPTION
Currently, the `PrintLintViolations` output warning text includes the static description of the lint rule, rather than the formatted text message that often includes context specific to a given instance of rule violation.

This updates `PrintLintViolations` to print out the formatted lint message instead. Below is an instance where you can see the difference in the types of output.

Current:
```
UndefinedVar - https://docs.docker.com/go/dockerfile/rule/undefined-var/
Variables should be defined before their use
Dockerfile:3
--------------------
   1 |     FROM alpine
   2 | >>> ENV PATH=$PAHT:/foo
   3 |
--------------------
```

New:
```
UndefinedVar - https://docs.docker.com/go/dockerfile/rule/undefined-var/
Usage of undefined variable '$PAHT' (did you mean $PATH?)
Dockerfile:3
--------------------
   1 |     FROM alpine
   2 | >>> ENV PATH=$PAHT:/foo
   3 |
--------------------
```