### PR TITLE
Initialize build args from stage base

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -2210,7 +2210,9 @@ func reportUnmatchedVariables(cmd instructions.Command, buildArgs []instructions
 		return
 	}
 	for _, buildArg := range buildArgs {
-		delete(unmatched, buildArg.Key)
+		if buildArg.Value != nil {
+			delete(unmatched, buildArg.Key)
+		}
 	}
 	if len(unmatched) == 0 {
 		return

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -1034,6 +1034,7 @@ func (ds *dispatchState) init() {
 	// the paths we use back to the base image.
 	ds.paths = ds.base.paths
 	ds.workdirSet = ds.base.workdirSet
+	ds.buildArgs = append(ds.buildArgs, ds.base.buildArgs...)
 }
 
 type dispatchStates struct {
@@ -2210,9 +2211,7 @@ func reportUnmatchedVariables(cmd instructions.Command, buildArgs []instructions
 		return
 	}
 	for _, buildArg := range buildArgs {
-		if buildArg.Value != nil {
-			delete(unmatched, buildArg.Key)
-		}
+		delete(unmatched, buildArg.Key)
 	}
 	if len(unmatched) == 0 {
 		return


### PR DESCRIPTION
Currently, when we initialize a new `dispatchState`, `buildArgs` are not carried forward from the `base`.
This causes a subtle issue while linting where a Dockerfile such as

```
FROM alpine AS declared
ARG foo
COPY $foo .

FROM declared AS dependent
COPY $foo .
```

Will erroneously emit a `UndeclaredVariable` linting warning for the occurrence of `$foo` in the `dependent` stage.

This updates `dispatchState` to initialize `buildArgs` from its base.