### PR TITLE
shell: handle empty string for var replacements

### DIFF
--- a/frontend/dockerfile/shell/lex.go
+++ b/frontend/dockerfile/shell/lex.go
@@ -430,7 +430,8 @@ func (sw *shellWord) processDollar() (string, error) {
 		case '%', '#':
 			// %/# matches the shortest pattern expansion, %%/## the longest
 			greedy := false
-			if word[0] == byte(ch) {
+
+			if len(word) > 0 && word[0] == byte(ch) {
 				greedy = true
 				word = word[1:]
 			}


### PR DESCRIPTION
Avoid nil dereference when variable replacements/trims are used with empty string argument.