### PR TITLE
refactor: split containerd runtime options definions by OS

### DIFF
--- a/cmd/buildkitd/main_containerd_worker.go
+++ b/cmd/buildkitd/main_containerd_worker.go
@@ -12,13 +12,9 @@ import (
 	"strings"
 	"time"
 
-	runhcsoptions "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
 	ctd "github.com/containerd/containerd"
 	"github.com/containerd/containerd/defaults"
-	runtimeoptions "github.com/containerd/containerd/pkg/runtimeoptions/v1"
 	"github.com/containerd/containerd/pkg/userns"
-	"github.com/containerd/containerd/plugin"
-	runcoptions "github.com/containerd/containerd/runtime/v2/runc/options"
 	"github.com/moby/buildkit/cmd/buildkitd/config"
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/network/cniprovider"
@@ -34,9 +30,6 @@ import (
 
 const (
 	defaultContainerdNamespace = "buildkit"
-
-	// runtimeRunhcsV1 is the runtime type for runhcs.
-	runtimeRunhcsV1 = "io.containerd.runhcs.v1"
 )
 
 func init() {
@@ -372,16 +365,4 @@ func validContainerdSocket(cfg config.ContainerdConfig) bool {
 		return false
 	}
 	return true
-}
-
-// getRuntimeOptionsType gets empty runtime options by the runtime type name.
-func getRuntimeOptionsType(t string) interface{} {
-	switch t {
-	case plugin.RuntimeRuncV2:
-		return &runcoptions.Options{}
-	case runtimeRunhcsV1:
-		return &runhcsoptions.Options{}
-	default:
-		return &runtimeoptions.Options{}
-	}
 }

--- a/cmd/buildkitd/main_containerd_worker_unix.go
+++ b/cmd/buildkitd/main_containerd_worker_unix.go
@@ -1,0 +1,18 @@
+//go:build !windows
+// +build !windows
+
+package main
+
+import (
+	runtimeoptions "github.com/containerd/containerd/pkg/runtimeoptions/v1"
+	"github.com/containerd/containerd/plugin"
+	runcoptions "github.com/containerd/containerd/runtime/v2/runc/options"
+)
+
+// getRuntimeOptionsType gets empty runtime options by the runtime type name.
+func getRuntimeOptionsType(t string) interface{} {
+	if t == plugin.RuntimeRuncV2 {
+		return &runcoptions.Options{}
+	}
+	return &runtimeoptions.Options{}
+}

--- a/cmd/buildkitd/main_containerd_worker_windows.go
+++ b/cmd/buildkitd/main_containerd_worker_windows.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	runhcsoptions "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
+	runtimeoptions "github.com/containerd/containerd/pkg/runtimeoptions/v1"
+)
+
+const runtimeRunhcsV1 = "io.containerd.runhcs.v1"
+
+// getRuntimeOptionsType gets empty runtime options by the runtime type name.
+func getRuntimeOptionsType(t string) interface{} {
+	if t == runtimeRunhcsV1 {
+		return &runhcsoptions.Options{}
+	}
+	return &runtimeoptions.Options{}
+}


### PR DESCRIPTION
address #5056

Split out the code for `getRuntimeOptionsType` so as to reduce the unnecessary imports, hence binary size.