### PR TITLE
dockerfile: clarify that checksum works with HTTPS

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -1349,7 +1349,7 @@ func dispatchCopy(d *dispatchState, cfg copyConfig) error {
 			return errors.New("checksum can't be specified for multiple sources")
 		}
 		if !isHTTPSource(cfg.params.SourcePaths[0]) {
-			return errors.New("checksum can't be specified for non-HTTP sources")
+			return errors.New("checksum can't be specified for non-HTTP(S) sources")
 		}
 	}
 

--- a/frontend/dockerfile/dockerfile_addchecksum_test.go
+++ b/frontend/dockerfile/dockerfile_addchecksum_test.go
@@ -162,6 +162,6 @@ ADD --checksum=%s foo /tmp/foo
 				dockerui.DefaultLocalNameContext:    dir,
 			},
 		}, nil)
-		require.Error(t, err, "checksum can't be specified for non-HTTP sources")
+		require.Error(t, err, "checksum can't be specified for non-HTTP(S) sources")
 	})
 }

--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -1339,7 +1339,7 @@ The `--checksum` flag lets you verify the checksum of a remote resource:
 ADD --checksum=sha256:24454f830cdb571e2c4ad15481119c43b3cafd48dd869a9b2945d1036d1dc68d https://mirrors.edge.kernel.org/pub/linux/kernel/Historic/linux-0.01.tar.gz /
 ```
 
-The `--checksum` flag only supports HTTP sources currently.
+The `--checksum` flag only supports HTTP(S) sources.
 
 ### ADD --chown --chmod
 


### PR DESCRIPTION
Docs and error message didn't indicate whether checksum was supported for HTTPS.

- Addresses docker/docs#20159
