### PR TITLE
dockerfile: cleanup of memory allocations

### DIFF
--- a/client/llb/meta.go
+++ b/client/llb/meta.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net"
 	"path"
+	"slices"
+	"sync"
 
 	"github.com/containerd/containerd/platforms"
 	"github.com/google/shlex"
@@ -111,16 +113,16 @@ func Reset(other State) StateOption {
 	}
 }
 
-func getEnv(s State) func(context.Context, *Constraints) (EnvList, error) {
-	return func(ctx context.Context, c *Constraints) (EnvList, error) {
+func getEnv(s State) func(context.Context, *Constraints) (*EnvList, error) {
+	return func(ctx context.Context, c *Constraints) (*EnvList, error) {
 		v, err := s.getValue(keyEnv)(ctx, c)
 		if err != nil {
 			return nil, err
 		}
 		if v != nil {
-			return v.(EnvList), nil
+			return v.(*EnvList), nil
 		}
-		return EnvList{}, nil
+		return &EnvList{}, nil
 	}
 }
 
@@ -346,54 +348,83 @@ func getSecurity(s State) func(context.Context, *Constraints) (pb.SecurityMode, 
 	}
 }
 
-type EnvList []KeyValue
-
-type KeyValue struct {
-	key   string
-	value string
+type EnvList struct {
+	parent *EnvList
+	key    string
+	value  string
+	del    bool
+	once   sync.Once
+	l      int
+	values map[string]string
+	keys   []string
 }
 
-func (e EnvList) AddOrReplace(k, v string) EnvList {
-	e = e.Delete(k)
-	e = append(e, KeyValue{key: k, value: v})
-	return e
+func (e *EnvList) AddOrReplace(k, v string) *EnvList {
+	return &EnvList{
+		parent: e,
+		key:    k,
+		value:  v,
+		l:      e.l + 1,
+	}
 }
 
-func (e EnvList) SetDefault(k, v string) EnvList {
+func (e *EnvList) SetDefault(k, v string) *EnvList {
 	if _, ok := e.Get(k); !ok {
-		e = append(e, KeyValue{key: k, value: v})
+		return e.AddOrReplace(k, v)
 	}
 	return e
 }
 
-func (e EnvList) Delete(k string) EnvList {
-	e = append([]KeyValue(nil), e...)
-	if i, ok := e.Index(k); ok {
-		return append(e[:i], e[i+1:]...)
+func (e *EnvList) Delete(k string) EnvList {
+	return EnvList{
+		parent: e,
+		key:    k,
+		del:    true,
+		l:      e.l + 1,
 	}
-	return e
 }
 
-func (e EnvList) Get(k string) (string, bool) {
-	if index, ok := e.Index(k); ok {
-		return e[index].value, true
-	}
-	return "", false
+func (e *EnvList) makeValues() {
+	m := make(map[string]string, e.l)
+	seen := make(map[string]struct{}, e.l)
+	keys := make([]string, 0, e.l)
+	e.keys = e.addValue(keys, m, seen)
+	e.values = m
+	slices.Reverse(e.keys)
 }
 
-func (e EnvList) Index(k string) (int, bool) {
-	for i, kv := range e {
-		if kv.key == k {
-			return i, true
-		}
+func (e *EnvList) addValue(keys []string, vals map[string]string, seen map[string]struct{}) []string {
+	if e.parent == nil {
+		return keys
 	}
-	return -1, false
+	if _, ok := seen[e.key]; !e.del && !ok {
+		vals[e.key] = e.value
+		keys = append(keys, e.key)
+	}
+	seen[e.key] = struct{}{}
+	if e.parent != nil {
+		keys = e.parent.addValue(keys, vals, seen)
+	}
+	return keys
 }
 
-func (e EnvList) ToArray() []string {
-	out := make([]string, 0, len(e))
-	for _, kv := range e {
-		out = append(out, kv.key+"="+kv.value)
+func (e *EnvList) Get(k string) (string, bool) {
+	e.once.Do(e.makeValues)
+	v, ok := e.values[k]
+	return v, ok
+}
+
+func (e *EnvList) Keys() []string {
+	e.once.Do(e.makeValues)
+	return e.keys
+}
+
+func (e *EnvList) ToArray() []string {
+	keys := e.Keys()
+	out := make([]string, 0, len(keys))
+	for _, k := range keys {
+		v, _ := e.Get(k)
+		out = append(out, k+"="+v)
 	}
 	return out
 }

--- a/client/llb/state.go
+++ b/client/llb/state.go
@@ -351,16 +351,12 @@ func (s State) GetEnv(ctx context.Context, key string, co ...ConstraintsOpt) (st
 
 // Env returns a new [State] with the provided environment variable set.
 // See [Env]
-func (s State) Env(ctx context.Context, co ...ConstraintsOpt) ([]string, error) {
+func (s State) Env(ctx context.Context, co ...ConstraintsOpt) (*EnvList, error) {
 	c := &Constraints{}
 	for _, f := range co {
 		f.SetConstraintsOption(c)
 	}
-	env, err := getEnv(s)(ctx, c)
-	if err != nil {
-		return nil, err
-	}
-	return env.ToArray(), nil
+	return getEnv(s)(ctx, c)
 }
 
 // GetDir returns the current working directory for the state.

--- a/cmd/buildctl/build/exportcache.go
+++ b/cmd/buildctl/build/exportcache.go
@@ -1,12 +1,12 @@
 package build
 
 import (
-	"encoding/csv"
 	"strings"
 
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/pkg/errors"
+	"github.com/tonistiigi/go-csvvalue"
 )
 
 func parseExportCacheCSV(s string) (client.CacheOptionsEntry, error) {
@@ -14,8 +14,7 @@ func parseExportCacheCSV(s string) (client.CacheOptionsEntry, error) {
 		Type:  "",
 		Attrs: map[string]string{},
 	}
-	csvReader := csv.NewReader(strings.NewReader(s))
-	fields, err := csvReader.Read()
+	fields, err := csvvalue.Fields(s, nil)
 	if err != nil {
 		return ex, err
 	}

--- a/cmd/buildctl/build/importcache.go
+++ b/cmd/buildctl/build/importcache.go
@@ -1,12 +1,12 @@
 package build
 
 import (
-	"encoding/csv"
 	"strings"
 
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/pkg/errors"
+	"github.com/tonistiigi/go-csvvalue"
 )
 
 func parseImportCacheCSV(s string) (client.CacheOptionsEntry, error) {
@@ -14,8 +14,7 @@ func parseImportCacheCSV(s string) (client.CacheOptionsEntry, error) {
 		Type:  "",
 		Attrs: map[string]string{},
 	}
-	csvReader := csv.NewReader(strings.NewReader(s))
-	fields, err := csvReader.Read()
+	fields, err := csvvalue.Fields(s, nil)
 	if err != nil {
 		return im, err
 	}

--- a/cmd/buildctl/build/output.go
+++ b/cmd/buildctl/build/output.go
@@ -1,7 +1,6 @@
 package build
 
 import (
-	"encoding/csv"
 	"io"
 	"os"
 	"strconv"
@@ -11,6 +10,7 @@ import (
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/session/filesync"
 	"github.com/pkg/errors"
+	"github.com/tonistiigi/go-csvvalue"
 )
 
 // parseOutputCSV parses a single --output CSV string
@@ -19,8 +19,7 @@ func parseOutputCSV(s string) (client.ExportEntry, error) {
 		Type:  "",
 		Attrs: map[string]string{},
 	}
-	csvReader := csv.NewReader(strings.NewReader(s))
-	fields, err := csvReader.Read()
+	fields, err := csvvalue.Fields(s, nil)
 	if err != nil {
 		return ex, err
 	}

--- a/cmd/buildctl/build/registryauthtlscontext.go
+++ b/cmd/buildctl/build/registryauthtlscontext.go
@@ -1,12 +1,12 @@
 package build
 
 import (
-	"encoding/csv"
 	"strconv"
 	"strings"
 
 	"github.com/moby/buildkit/session/auth/authprovider"
 	"github.com/pkg/errors"
+	"github.com/tonistiigi/go-csvvalue"
 )
 
 type authTLSContextEntry struct {
@@ -19,8 +19,7 @@ type authTLSContextEntry struct {
 
 func parseRegistryAuthTLSContextCSV(s string) (authTLSContextEntry, error) {
 	authTLSContext := authTLSContextEntry{}
-	csvReader := csv.NewReader(strings.NewReader(s))
-	fields, err := csvReader.Read()
+	fields, err := csvvalue.Fields(s, nil)
 	if err != nil {
 		return authTLSContext, err
 	}

--- a/cmd/buildctl/build/secret.go
+++ b/cmd/buildctl/build/secret.go
@@ -1,12 +1,12 @@
 package build
 
 import (
-	"encoding/csv"
 	"strings"
 
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/secrets/secretsprovider"
 	"github.com/pkg/errors"
+	"github.com/tonistiigi/go-csvvalue"
 )
 
 // ParseSecret parses --secret
@@ -27,8 +27,7 @@ func ParseSecret(sl []string) (session.Attachable, error) {
 }
 
 func parseSecret(val string) (*secretsprovider.Source, error) {
-	csvReader := csv.NewReader(strings.NewReader(val))
-	fields, err := csvReader.Read()
+	fields, err := csvvalue.Fields(val, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse csv secret")
 	}

--- a/frontend/attestations/parse.go
+++ b/frontend/attestations/parse.go
@@ -1,10 +1,10 @@
 package attestations
 
 import (
-	"encoding/csv"
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/tonistiigi/go-csvvalue"
 )
 
 const (
@@ -63,8 +63,7 @@ func Parse(values map[string]string) (map[string]map[string]string, error) {
 		if v == "" {
 			continue
 		}
-		csvReader := csv.NewReader(strings.NewReader(v))
-		fields, err := csvReader.Read()
+		fields, err := csvvalue.Fields(v, nil)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to parse %s", k)
 		}

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -613,7 +613,7 @@ func toDispatchState(ctx context.Context, dt []byte, opt ConvertOpt) (*dispatchS
 							dfCmd(d.stage.SourceCode),
 							llb.Platform(*platform),
 							opt.ImageResolveMode,
-							llb.WithCustomName(prefixCommand(d, "FROM "+d.stage.BaseName, opt.MultiPlatformRequested, platform, nil)),
+							llb.WithCustomName(prefixCommand(d, "FROM "+d.stage.BaseName, opt.MultiPlatformRequested, platform, emptyEnvs{})),
 							location(opt.SourceMap, d.stage.Location),
 						)
 						if reachable {
@@ -884,7 +884,7 @@ func (e *envsFromState) init() {
 	if err != nil {
 		return
 	}
-	e.env = shell.EnvsFromSlice(env)
+	e.env = env
 }
 
 func (e *envsFromState) Get(key string) (string, bool) {
@@ -2351,4 +2351,14 @@ func validateBaseImagePlatform(name string, expected, actual ocispecs.Platform, 
 		msg := linter.RuleInvalidBaseImagePlatform.Format(name, expectedStr, actualStr)
 		lint.Run(&linter.RuleInvalidBaseImagePlatform, location, msg)
 	}
+}
+
+type emptyEnvs struct{}
+
+func (emptyEnvs) Get(string) (string, bool) {
+	return "", false
+}
+
+func (emptyEnvs) Keys() []string {
+	return nil
 }

--- a/frontend/dockerfile/dockerfile2llb/convert_test.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_test.go
@@ -14,7 +14,12 @@ import (
 )
 
 func toEnvMap(args []instructions.KeyValuePairOptional, env []string) map[string]string {
-	m := shell.BuildEnvs(env)
+	envs := shell.EnvsFromSlice(env)
+	m := make(map[string]string)
+
+	for _, k := range envs.Keys() {
+		m[k], _ = envs.Get(k)
+	}
 
 	for _, arg := range args {
 		// If key already exists, keep previous value.
@@ -147,48 +152,48 @@ func TestToEnvList(t *testing.T) {
 	v := "val2"
 	args := []instructions.KeyValuePairOptional{{Key: "key2", Value: &v}}
 	env := []string{"key1=val1"}
-	resutl := toEnvMap(args, env)
-	assert.Equal(t, map[string]string{"key1": "val1", "key2": "val2"}, resutl)
+	result := toEnvMap(args, env)
+	assert.Equal(t, map[string]string{"key1": "val1", "key2": "val2"}, result)
 
 	// value of args is nil
 	args = []instructions.KeyValuePairOptional{{Key: "key2", Value: nil}}
 	env = []string{"key1=val1"}
-	resutl = toEnvMap(args, env)
-	assert.Equal(t, map[string]string{"key1": "val1"}, resutl)
+	result = toEnvMap(args, env)
+	assert.Equal(t, map[string]string{"key1": "val1"}, result)
 
 	// args has duplicated key with env
 	v = "val2"
 	args = []instructions.KeyValuePairOptional{{Key: "key1", Value: &v}}
 	env = []string{"key1=val1"}
-	resutl = toEnvMap(args, env)
-	assert.Equal(t, map[string]string{"key1": "val1"}, resutl)
+	result = toEnvMap(args, env)
+	assert.Equal(t, map[string]string{"key1": "val1"}, result)
 
 	v = "val2"
 	args = []instructions.KeyValuePairOptional{{Key: "key1", Value: &v}}
 	env = []string{"key1="}
-	resutl = toEnvMap(args, env)
-	assert.Equal(t, map[string]string{"key1": ""}, resutl)
+	result = toEnvMap(args, env)
+	assert.Equal(t, map[string]string{"key1": ""}, result)
 
 	v = "val2"
 	args = []instructions.KeyValuePairOptional{{Key: "key1", Value: &v}}
 	env = []string{"key1"}
-	resutl = toEnvMap(args, env)
-	assert.Equal(t, map[string]string{"key1": ""}, resutl)
+	result = toEnvMap(args, env)
+	assert.Equal(t, map[string]string{"key1": ""}, result)
 
 	// env has duplicated keys
 	v = "val2"
 	args = []instructions.KeyValuePairOptional{{Key: "key2", Value: &v}}
 	env = []string{"key1=val1", "key1=val1_2"}
-	resutl = toEnvMap(args, env)
-	assert.Equal(t, map[string]string{"key1": "val1_2", "key2": "val2"}, resutl)
+	result = toEnvMap(args, env)
+	assert.Equal(t, map[string]string{"key1": "val1_2", "key2": "val2"}, result)
 
 	// args has duplicated keys
 	v1 := "v1"
 	v2 := "v2"
 	args = []instructions.KeyValuePairOptional{{Key: "key2", Value: &v1}, {Key: "key2", Value: &v2}}
 	env = []string{"key1=val1"}
-	resutl = toEnvMap(args, env)
-	assert.Equal(t, map[string]string{"key1": "val1", "key2": "v1"}, resutl)
+	result = toEnvMap(args, env)
+	assert.Equal(t, map[string]string{"key1": "val1", "key2": "v1"}, result)
 }
 
 func TestDockerfileCircularDependencies(t *testing.T) {

--- a/frontend/dockerfile/instructions/commands_runmount.go
+++ b/frontend/dockerfile/instructions/commands_runmount.go
@@ -2,7 +2,6 @@ package instructions
 
 import (
 	"encoding/csv"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -84,13 +83,13 @@ func setMountState(cmd *RunCommand, expander SingleWordExpander) error {
 	if st == nil {
 		return errors.Errorf("no mount state")
 	}
-	var mounts []*Mount
-	for _, str := range st.flag.StringValues {
+	mounts := make([]*Mount, len(st.flag.StringValues))
+	for i, str := range st.flag.StringValues {
 		m, err := parseMount(str, expander)
 		if err != nil {
 			return err
 		}
-		mounts = append(mounts, m)
+		mounts[i] = m
 	}
 	st.mounts = mounts
 	return nil
@@ -176,9 +175,7 @@ func parseMount(val string, expander SingleWordExpander) (*Mount, error) {
 				return nil, err
 			}
 		} else if key == "from" {
-			if matched, err := regexp.MatchString(`\$.`, value); err != nil { //nolint
-				return nil, err
-			} else if matched {
+			if idx := strings.IndexByte(value, '$'); idx != -1 && idx != len(value)-1 {
 				return nil, errors.Errorf("'%s' doesn't support variable expansion, define alias stage instead", key)
 			}
 		} else {

--- a/frontend/dockerfile/instructions/commands_runmount.go
+++ b/frontend/dockerfile/instructions/commands_runmount.go
@@ -1,13 +1,13 @@
 package instructions
 
 import (
-	"encoding/csv"
 	"strconv"
 	"strings"
 
 	"github.com/docker/go-units"
 	"github.com/moby/buildkit/util/suggest"
 	"github.com/pkg/errors"
+	"github.com/tonistiigi/go-csvvalue"
 )
 
 type MountType string
@@ -128,8 +128,7 @@ type Mount struct {
 }
 
 func parseMount(val string, expander SingleWordExpander) (*Mount, error) {
-	csvReader := csv.NewReader(strings.NewReader(val))
-	fields, err := csvReader.Read()
+	fields, err := csvvalue.Fields(val, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse csv mounts")
 	}

--- a/frontend/dockerfile/instructions/parse.go
+++ b/frontend/dockerfile/instructions/parse.go
@@ -73,7 +73,9 @@ func ParseInstruction(node *parser.Node) (v interface{}, err error) {
 // ParseInstruction converts an AST to a typed instruction (either a command or a build stage beginning when encountering a `FROM` statement)
 func ParseInstructionWithLinter(node *parser.Node, lint *linter.Linter) (v interface{}, err error) {
 	defer func() {
-		err = parser.WithLocation(err, node.Location())
+		if err != nil {
+			err = parser.WithLocation(err, node.Location())
+		}
 	}()
 	req := newParseRequestFromNode(node)
 	switch strings.ToLower(node.Value) {

--- a/frontend/dockerfile/parser/line_parsers.go
+++ b/frontend/dockerfile/parser/line_parsers.go
@@ -59,11 +59,11 @@ func parseWords(rest string, d *directives) []string {
 
 	words := []string{}
 	phase := inSpaces
-	word := ""
 	quote := '\000'
 	blankOK := false
 	var ch rune
 	var chWidth int
+	var sbuilder strings.Builder
 
 	for pos := 0; pos <= len(rest); pos += chWidth {
 		if pos != len(rest) {
@@ -80,18 +80,18 @@ func parseWords(rest string, d *directives) []string {
 			phase = inWord // found it, fall through
 		}
 		if (phase == inWord || phase == inQuote) && (pos == len(rest)) {
-			if blankOK || len(word) > 0 {
-				words = append(words, word)
+			if blankOK || sbuilder.Len() > 0 {
+				words = append(words, sbuilder.String())
 			}
 			break
 		}
 		if phase == inWord {
 			if unicode.IsSpace(ch) {
 				phase = inSpaces
-				if blankOK || len(word) > 0 {
-					words = append(words, word)
+				if blankOK || sbuilder.Len() > 0 {
+					words = append(words, sbuilder.String())
 				}
-				word = ""
+				sbuilder.Reset()
 				blankOK = false
 				continue
 			}
@@ -107,11 +107,11 @@ func parseWords(rest string, d *directives) []string {
 				// If we're not quoted and we see an escape token, then always just
 				// add the escape token plus the char to the word, even if the char
 				// is a quote.
-				word += string(ch)
+				sbuilder.WriteRune(ch)
 				pos += chWidth
 				ch, chWidth = utf8.DecodeRuneInString(rest[pos:])
 			}
-			word += string(ch)
+			sbuilder.WriteRune(ch)
 			continue
 		}
 		if phase == inQuote {
@@ -125,10 +125,10 @@ func parseWords(rest string, d *directives) []string {
 					continue // just skip the escape token at end
 				}
 				pos += chWidth
-				word += string(ch)
+				sbuilder.WriteRune(ch)
 				ch, chWidth = utf8.DecodeRuneInString(rest[pos:])
 			}
-			word += string(ch)
+			sbuilder.WriteRune(ch)
 		}
 	}
 

--- a/frontend/dockerfile/parser/line_parsers.go
+++ b/frontend/dockerfile/parser/line_parsers.go
@@ -17,6 +17,7 @@ import (
 
 var (
 	errDockerfileNotStringArray = errors.New("when using JSON array syntax, arrays must be comprised of strings only")
+	errDockerfileNotJSONArray   = errors.New("not a JSON array")
 )
 
 const (
@@ -277,7 +278,7 @@ func parseString(rest string, d *directives) (*Node, map[string]bool, error) {
 func parseJSON(rest string) (*Node, map[string]bool, error) {
 	rest = strings.TrimLeftFunc(rest, unicode.IsSpace)
 	if !strings.HasPrefix(rest, "[") {
-		return nil, nil, errors.Errorf("Error parsing %q as a JSON array", rest)
+		return nil, nil, errDockerfileNotJSONArray
 	}
 
 	var myJSON []interface{}

--- a/frontend/dockerfile/parser/parser.go
+++ b/frontend/dockerfile/parser/parser.go
@@ -168,8 +168,8 @@ func (d *directives) setEscapeToken(s string) error {
 // possibleParserDirective looks for parser directives, eg '# escapeToken=<char>'.
 // Parser directives must precede any builder instruction or other comments,
 // and cannot be repeated.
-func (d *directives) possibleParserDirective(line string) error {
-	directive, err := d.parser.ParseLine([]byte(line))
+func (d *directives) possibleParserDirective(line []byte) error {
+	directive, err := d.parser.ParseLine(line)
 	if err != nil {
 		return err
 	}
@@ -528,7 +528,7 @@ func processLine(d *directives, token []byte, stripLeftWhitespace bool) ([]byte,
 	if stripLeftWhitespace {
 		token = trimLeadingWhitespace(token)
 	}
-	return trimComments(token), d.possibleParserDirective(string(token))
+	return trimComments(token), d.possibleParserDirective(token)
 }
 
 // Variation of bufio.ScanLines that preserves the line endings

--- a/frontend/dockerfile/parser/parser.go
+++ b/frontend/dockerfile/parser/parser.go
@@ -418,7 +418,7 @@ func heredocFromMatch(match []string) (*Heredoc, error) {
 	// If there are quotes in one but not the other, then we know that some
 	// part of the heredoc word is quoted, so we shouldn't expand the content.
 	shlex.RawQuotes = false
-	words, err := shlex.ProcessWords(rest, []string{})
+	words, err := shlex.ProcessWords(rest, emptyEnvs{})
 	if err != nil {
 		return nil, err
 	}
@@ -428,7 +428,7 @@ func heredocFromMatch(match []string) (*Heredoc, error) {
 	}
 
 	shlex.RawQuotes = true
-	wordsRaw, err := shlex.ProcessWords(rest, []string{})
+	wordsRaw, err := shlex.ProcessWords(rest, emptyEnvs{})
 	if err != nil {
 		return nil, err
 	}
@@ -469,7 +469,7 @@ func heredocsFromLine(line string) ([]Heredoc, error) {
 	shlex.RawQuotes = true
 	shlex.RawEscapes = true
 	shlex.SkipUnsetEnv = true
-	words, _ := shlex.ProcessWords(line, []string{})
+	words, _ := shlex.ProcessWords(line, emptyEnvs{})
 
 	var docs []Heredoc
 	for _, word := range words {
@@ -556,4 +556,14 @@ func handleScannerError(err error) error {
 	default:
 		return err
 	}
+}
+
+type emptyEnvs struct{}
+
+func (emptyEnvs) Get(string) (string, bool) {
+	return "", false
+}
+
+func (emptyEnvs) Keys() []string {
+	return nil
 }

--- a/frontend/dockerfile/parser/parser.go
+++ b/frontend/dockerfile/parser/parser.go
@@ -347,7 +347,7 @@ func Parse(rwc io.Reader) (*Result, error) {
 			return nil, withLocation(err, startLine, currentLine)
 		}
 
-		if child.canContainHeredoc() {
+		if child.canContainHeredoc() && strings.Contains(line, "<<") {
 			heredocs, err := heredocsFromLine(line)
 			if err != nil {
 				return nil, withLocation(err, startLine, currentLine)

--- a/frontend/dockerfile/parser/parser.go
+++ b/frontend/dockerfile/parser/parser.go
@@ -114,7 +114,6 @@ type Heredoc struct {
 var (
 	dispatch      map[string]func(string, *directives) (*Node, map[string]bool, error)
 	reWhitespace  = regexp.MustCompile(`[\t\v\f\r ]+`)
-	reComment     = regexp.MustCompile(`^#.*$`)
 	reHeredoc     = regexp.MustCompile(`^(\d*)<<(-?)([^<]*)$`)
 	reLeadingTabs = regexp.MustCompile(`(?m)^\t+`)
 )
@@ -487,7 +486,10 @@ func ChompHeredocContent(src string) string {
 }
 
 func trimComments(src []byte) []byte {
-	return reComment.ReplaceAll(src, []byte{})
+	if !isComment(src) {
+		return src
+	}
+	return nil
 }
 
 func trimLeadingWhitespace(src []byte) []byte {
@@ -501,7 +503,8 @@ func trimNewline(src []byte) []byte {
 }
 
 func isComment(line []byte) bool {
-	return reComment.Match(trimLeadingWhitespace(trimNewline(line)))
+	line = trimLeadingWhitespace(line)
+	return len(line) > 0 && line[0] == '#'
 }
 
 func isEmptyContinuationLine(line []byte) bool {

--- a/frontend/dockerfile/shell/equal_env_unix.go
+++ b/frontend/dockerfile/shell/equal_env_unix.go
@@ -9,3 +9,10 @@ package shell
 func EqualEnvKeys(from, to string) bool {
 	return from == to
 }
+
+// NormalizeEnvKey returns the key in a normalized form that can be used
+// for comparison. On Unix this is a no-op. On Windows this converts the
+// key to uppercase.
+func NormalizeEnvKey(key string) string {
+	return key
+}

--- a/frontend/dockerfile/shell/equal_env_windows.go
+++ b/frontend/dockerfile/shell/equal_env_windows.go
@@ -8,3 +8,10 @@ import "strings"
 func EqualEnvKeys(from, to string) bool {
 	return strings.EqualFold(from, to)
 }
+
+// NormalizeEnvKey returns the key in a normalized form that can be used
+// for comparison. On Unix this is a no-op. On Windows this converts the
+// key to uppercase.
+func NormalizeEnvKey(key string) string {
+	return strings.ToUpper(key)
+}

--- a/frontend/dockerui/attr.go
+++ b/frontend/dockerui/attr.go
@@ -1,7 +1,6 @@
 package dockerui
 
 import (
-	"encoding/csv"
 	"net"
 	"strconv"
 	"strings"
@@ -13,6 +12,7 @@ import (
 	"github.com/moby/buildkit/solver/pb"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+	"github.com/tonistiigi/go-csvvalue"
 )
 
 func parsePlatforms(v string) ([]ocispecs.Platform, error) {
@@ -45,8 +45,7 @@ func parseExtraHosts(v string) ([]llb.HostIP, error) {
 		return nil, nil
 	}
 	out := make([]llb.HostIP, 0)
-	csvReader := csv.NewReader(strings.NewReader(v))
-	fields, err := csvReader.Read()
+	fields, err := csvvalue.Fields(v, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -80,8 +79,7 @@ func parseUlimits(v string) ([]pb.Ulimit, error) {
 		return nil, nil
 	}
 	out := make([]pb.Ulimit, 0)
-	csvReader := csv.NewReader(strings.NewReader(v))
-	fields, err := csvReader.Read()
+	fields, err := csvvalue.Fields(v, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 	github.com/tonistiigi/fsutil v0.0.0-20240424095704-91a3fc46842c
 	github.com/tonistiigi/go-actions-cache v0.0.0-20240320205438-9794bdbb2fb4
 	github.com/tonistiigi/go-archvariant v1.0.0
+	github.com/tonistiigi/go-csvvalue v0.0.0-20240619222358-bb8dd5cba3c2
 	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea
 	github.com/tonistiigi/vt100 v0.0.0-20240514184818-90bafcd6abab
 	github.com/urfave/cli v1.22.14

--- a/go.sum
+++ b/go.sum
@@ -403,6 +403,8 @@ github.com/tonistiigi/go-actions-cache v0.0.0-20240320205438-9794bdbb2fb4 h1:R0l
 github.com/tonistiigi/go-actions-cache v0.0.0-20240320205438-9794bdbb2fb4/go.mod h1:anhKd3mnC1shAbQj1Q4IJ+w6xqezxnyDYlx/yKa7IXM=
 github.com/tonistiigi/go-archvariant v1.0.0 h1:5LC1eDWiBNflnTF1prCiX09yfNHIxDC/aukdhCdTyb0=
 github.com/tonistiigi/go-archvariant v1.0.0/go.mod h1:TxFmO5VS6vMq2kvs3ht04iPXtu2rUT/erOnGFYfk5Ho=
+github.com/tonistiigi/go-csvvalue v0.0.0-20240619222358-bb8dd5cba3c2 h1:4dXTcm/McJMoXXFhqr+4rNL4WkLqMoHkdMhT4nU0Z28=
+github.com/tonistiigi/go-csvvalue v0.0.0-20240619222358-bb8dd5cba3c2/go.mod h1:278M4p8WsNh3n4a1eqiFcV2FGk7wE5fwUpUom9mK9lE=
 github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea h1:SXhTLE6pb6eld/v/cCndK0AMpt1wiVFb/YYmqB3/QG0=
 github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea/go.mod h1:WPnis/6cRcDZSUvVmezrxJPkiO87ThFYsoUiMwWNDJk=
 github.com/tonistiigi/vt100 v0.0.0-20240514184818-90bafcd6abab h1:H6aJ0yKQ0gF49Qb2z5hI1UHxSQt4JMyxebFR15KnApw=

--- a/solver/scheduler.go
+++ b/solver/scheduler.go
@@ -2,15 +2,14 @@ package solver
 
 import (
 	"context"
-	"encoding/csv"
 	"os"
-	"strings"
 	"sync"
 
 	"github.com/moby/buildkit/solver/internal/pipe"
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/cond"
 	"github.com/pkg/errors"
+	"github.com/tonistiigi/go-csvvalue"
 )
 
 var debugScheduler = false // TODO: replace with logs in build trace
@@ -74,7 +73,7 @@ func (s *scheduler) Stop() {
 func (s *scheduler) loop() {
 	debugSchedulerStepsParseOnce.Do(func() {
 		if s := os.Getenv("BUILDKIT_SCHEDULER_DEBUG_STEPS"); s != "" {
-			fields, err := csv.NewReader(strings.NewReader(s)).Read()
+			fields, err := csvvalue.Fields(s, nil)
 			if err != nil {
 				return
 			}

--- a/util/progress/progressui/colors.go
+++ b/util/progress/progressui/colors.go
@@ -1,13 +1,13 @@
 package progressui
 
 import (
-	"encoding/csv"
 	"errors"
 	"strconv"
 	"strings"
 
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/morikuni/aec"
+	"github.com/tonistiigi/go-csvvalue"
 )
 
 var termColorMap = map[string]aec.ANSI{
@@ -59,9 +59,9 @@ func setUserDefinedTermColors(colorsEnv string) {
 }
 
 func readBuildkitColorsEnv(colorsEnv string) []string {
-	csvReader := csv.NewReader(strings.NewReader(colorsEnv))
+	csvReader := csvvalue.NewParser()
 	csvReader.Comma = ':'
-	fields, err := csvReader.Read()
+	fields, err := csvReader.Fields(colorsEnv, nil)
 	if err != nil {
 		bklog.L.WithError(err).Warnf("Could not parse BUILDKIT_COLORS. Falling back to defaults.")
 		return nil
@@ -70,8 +70,7 @@ func readBuildkitColorsEnv(colorsEnv string) []string {
 }
 
 func readRGB(v string) aec.ANSI {
-	csvReader := csv.NewReader(strings.NewReader(v))
-	fields, err := csvReader.Read()
+	fields, err := csvvalue.Fields(v, nil)
 	if err != nil {
 		bklog.L.WithError(err).Warnf("Could not parse value %s as valid comma-separated RGB color. Ignoring.", v)
 		return nil

--- a/vendor/github.com/tonistiigi/go-csvvalue/.golangci.yml
+++ b/vendor/github.com/tonistiigi/go-csvvalue/.golangci.yml
@@ -1,0 +1,30 @@
+run:
+  timeout: 10m
+
+linters:
+  enable:
+    - bodyclose
+    - depguard
+    - errname
+    - forbidigo
+    - gocritic
+    - gofmt
+    - goimports
+    - gosec
+    - gosimple
+    - govet
+    - importas
+    - ineffassign
+    - makezero
+    - misspell
+    - noctx
+    - nolintlint
+    - revive
+    - staticcheck
+    - typecheck
+    - unused
+    - whitespace
+  disable-all: true
+
+issues:
+  exclude-use-default: false

--- a/vendor/github.com/tonistiigi/go-csvvalue/.yamllint.yml
+++ b/vendor/github.com/tonistiigi/go-csvvalue/.yamllint.yml
@@ -1,0 +1,13 @@
+ignore: |
+  /vendor
+
+extends: default
+
+yaml-files:
+  - '*.yaml'
+  - '*.yml'
+
+rules:
+  truthy: disable
+  line-length: disable
+  document-start: disable

--- a/vendor/github.com/tonistiigi/go-csvvalue/Dockerfile
+++ b/vendor/github.com/tonistiigi/go-csvvalue/Dockerfile
@@ -1,0 +1,42 @@
+#syntax=docker/dockerfile:1.8
+#check=error=true
+
+ARG GO_VERSION=1.22
+ARG XX_VERSION=1.4.0
+
+ARG COVER_FILENAME="cover.out"
+ARG BENCH_FILENAME="bench.txt"
+
+FROM --platform=${BUILDPLATFORM} tonistiigi/xx:${XX_VERSION} AS xx
+
+FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION}-alpine AS golang
+COPY --link --from=xx / /
+WORKDIR /src
+ARG TARGETPLATFORM
+
+FROM golang AS build
+RUN --mount=target=/root/.cache,type=cache \
+    --mount=type=bind xx-go build .
+
+FROM golang AS runbench
+ARG BENCH_FILENAME
+RUN --mount=target=/root/.cache,type=cache \
+    --mount=type=bind \
+    xx-go test -v --run skip --bench . | tee /tmp/${BENCH_FILENAME}
+
+FROM scratch AS bench
+ARG BENCH_FILENAME
+COPY --from=runbench /tmp/${BENCH_FILENAME} /
+
+FROM golang AS runtest
+ARG TESTFLAGS="-v"
+ARG COVER_FILENAME
+RUN --mount=target=/root/.cache,type=cache \
+    --mount=type=bind \
+    xx-go test -coverprofile=/tmp/${COVER_FILENAME} $TESTFLAGS .
+
+FROM scratch AS test
+ARG COVER_FILENAME
+COPY --from=runtest /tmp/${COVER_FILENAME} /
+
+FROM build

--- a/vendor/github.com/tonistiigi/go-csvvalue/LICENSE
+++ b/vendor/github.com/tonistiigi/go-csvvalue/LICENSE
@@ -1,0 +1,22 @@
+MIT
+
+Copyright 2024 Tõnis Tiigi <tonistiigi@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/tonistiigi/go-csvvalue/codecov.yml
+++ b/vendor/github.com/tonistiigi/go-csvvalue/codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/vendor/github.com/tonistiigi/go-csvvalue/csvvalue.go
+++ b/vendor/github.com/tonistiigi/go-csvvalue/csvvalue.go
@@ -1,0 +1,172 @@
+// Package csvvalue provides an efficient parser for a single line CSV value.
+// It is more efficient than the standard library csv package for parsing many
+// small values. For multi-line CSV parsing, the standard library is recommended.
+package csvvalue
+
+import (
+	"encoding/csv"
+	"errors"
+	"io"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+var errInvalidDelim = errors.New("csv: invalid field or comment delimiter")
+
+var defaultParser = NewParser()
+
+// Fields parses the line with default parser and returns
+// slice of fields for the record. If dst is nil, a new slice is allocated.
+func Fields(inp string, dst []string) ([]string, error) {
+	return defaultParser.Fields(inp, dst)
+}
+
+// Parser is a CSV parser for a single line value.
+type Parser struct {
+	Comma            rune
+	LazyQuotes       bool
+	TrimLeadingSpace bool
+}
+
+// NewParser returns a new Parser with default settings.
+func NewParser() *Parser {
+	return &Parser{Comma: ','}
+}
+
+// Fields parses the line and returns slice of fields for the record.
+// If dst is nil, a new slice is allocated.
+// For backward compatibility, a trailing newline is allowed.
+func (r *Parser) Fields(line string, dst []string) ([]string, error) {
+	if !validDelim(r.Comma) {
+		return nil, errInvalidDelim
+	}
+
+	if cap(dst) == 0 {
+		// imprecise estimate, strings.Count is fast
+		dst = make([]string, 0, 1+strings.Count(line, string(r.Comma)))
+	} else {
+		dst = dst[:0]
+	}
+
+	const quoteLen = len(`"`)
+	var (
+		pos      int
+		commaLen = utf8.RuneLen(r.Comma)
+		trim     = r.TrimLeadingSpace
+	)
+
+	// allow trailing newline for compatibility
+	if n := len(line); n > 0 && line[n-1] == '\n' {
+		if n > 1 && line[n-2] == '\r' {
+			line = line[:n-2]
+		} else {
+			line = line[:n-1]
+		}
+	}
+
+	if len(line) == 0 {
+		return nil, io.EOF
+	}
+
+parseField:
+	for {
+		if trim {
+			i := strings.IndexFunc(line, func(r rune) bool {
+				return !unicode.IsSpace(r)
+			})
+			if i < 0 {
+				i = len(line)
+			}
+			line = line[i:]
+			pos += i
+		}
+		if len(line) == 0 || line[0] != '"' {
+			// Non-quoted string field
+			i := strings.IndexRune(line, r.Comma)
+			var field string
+			if i >= 0 {
+				field = line[:i]
+			} else {
+				field = line
+			}
+			// Check to make sure a quote does not appear in field.
+			if !r.LazyQuotes {
+				if j := strings.IndexRune(field, '"'); j >= 0 {
+					return nil, parseErr(pos+j, csv.ErrBareQuote)
+				}
+			}
+			dst = append(dst, field)
+			if i >= 0 {
+				line = line[i+commaLen:]
+				pos += i + commaLen
+				continue
+			}
+			break
+		}
+		// Quoted string field
+		line = line[quoteLen:]
+		pos += quoteLen
+		halfOpen := false
+		for {
+			i := strings.IndexRune(line, '"')
+			if i >= 0 {
+				// Hit next quote.
+				if !halfOpen {
+					dst = append(dst, line[:i])
+				} else {
+					appendToLast(dst, line[:i])
+				}
+				halfOpen = false
+				line = line[i+quoteLen:]
+				pos += i + quoteLen
+				switch rn := nextRune(line); {
+				case rn == '"':
+					// `""` sequence (append quote).
+					appendToLast(dst, "\"")
+					line = line[quoteLen:]
+					pos += quoteLen
+				case rn == r.Comma:
+					// `",` sequence (end of field).
+					line = line[commaLen:]
+					pos += commaLen
+					continue parseField
+				case len(line) == 0:
+					break parseField
+				case r.LazyQuotes:
+					// `"` sequence (bare quote).
+					appendToLast(dst, "\"")
+					halfOpen = true
+				default:
+					// `"*` sequence (invalid non-escaped quote).
+					return nil, parseErr(pos-quoteLen, csv.ErrQuote)
+				}
+			} else {
+				if !r.LazyQuotes {
+					return nil, parseErr(pos, csv.ErrQuote)
+				}
+				// Hit end of line (copy all data so far).
+				dst = append(dst, line)
+				break parseField
+			}
+		}
+	}
+	return dst, nil
+}
+
+func validDelim(r rune) bool {
+	return r != 0 && r != '"' && r != '\r' && r != '\n' && utf8.ValidRune(r) && r != utf8.RuneError
+}
+
+func appendToLast(dst []string, s string) {
+	dst[len(dst)-1] += s
+}
+
+func nextRune(b string) rune {
+	r, _ := utf8.DecodeRuneInString(b)
+	return r
+}
+
+func parseErr(pos int, err error) error {
+	return &csv.ParseError{StartLine: 1, Line: 1, Column: pos + 1, Err: err}
+}

--- a/vendor/github.com/tonistiigi/go-csvvalue/docker-bake.hcl
+++ b/vendor/github.com/tonistiigi/go-csvvalue/docker-bake.hcl
@@ -1,0 +1,68 @@
+variable "COVER_FILENAME" {
+    default = null
+}
+
+variable "BENCH_FILENAME" {
+    default = null
+}
+
+variable "GO_VERSION" {
+    default = null
+}
+
+target "default" {
+    targets = ["build"]
+}
+
+target "_all_platforms" {
+    platforms = [
+        "linux/amd64",
+        "linux/arm64",
+        "linux/arm/v7",
+        "linux/arm/v6",
+        "linux/386",
+        "linux/ppc64le",
+        "linux/s390x",
+        "darwin/amd64",
+        "darwin/arm64",
+        "windows/amd64",
+    ]
+}
+
+target "build" {
+    output = ["type=cacheonly"]
+    args = {
+        GO_VERSION = GO_VERSION
+    }
+}
+
+target "build-all" {
+    inherits = ["build", "_all_platforms"]
+}
+
+target "test" {
+    target = "test"
+    args = {
+        COVER_FILENAME = COVER_FILENAME
+        GO_VERSION = GO_VERSION
+    }
+    output = [COVER_FILENAME!=null?".":"type=cacheonly"]
+}
+
+target "bench" {
+    target = "bench"
+    args = {
+        BENCH_FILENAME = BENCH_FILENAME
+        GO_VERSION = GO_VERSION
+    }
+    output = [BENCH_FILENAME!=null?".":"type=cacheonly"]
+}
+
+target "lint" {
+    dockerfile = "hack/dockerfiles/lint.Dockerfile"
+    output = ["type=cacheonly"]
+}
+
+target "lint-all" {
+    inherits = ["lint", "_all_platforms"]
+}

--- a/vendor/github.com/tonistiigi/go-csvvalue/readme.md
+++ b/vendor/github.com/tonistiigi/go-csvvalue/readme.md
@@ -1,0 +1,44 @@
+### go-csvvalue
+
+![GitHub Release](https://img.shields.io/github/v/release/tonistiigi/go-csvvalue)
+[![Go Reference](https://pkg.go.dev/badge/github.com/tonistiigi/go-csvvalue.svg)](https://pkg.go.dev/github.com/tonistiigi/go-csvvalue)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/tonistiigi/go-csvvalue/ci.yml)
+![Codecov](https://img.shields.io/codecov/c/github/tonistiigi/go-csvvalue)
+![GitHub License](https://img.shields.io/github/license/tonistiigi/go-csvvalue)
+
+
+`go-csvvalue` provides an efficient parser for a single-line CSV value.
+
+It is more efficient than the standard library `encoding/csv` package for parsing many small values. The main problem with stdlib implementation is that it calls `bufio.NewReader` internally, allocating 4KB of memory on each invocation. For multi-line CSV parsing, the standard library is still recommended. If you wish to optimize memory usage for `encoding/csv`, call `csv.NewReader` with an instance of `*bufio.Reader` that already has a 4KB buffer allocated and then reuse that buffer for all reads.
+
+For further memory optimization, an existing string slice can be optionally passed to be reused for returning the parsed fields.
+
+For backwards compatibility with stdlib record parser, the input may contain a trailing newline character.
+
+### Benchmark
+
+```
+goos: linux
+goarch: amd64
+pkg: github.com/tonistiigi/go-csvvalue
+cpu: AMD EPYC 7763 64-Core Processor                
+BenchmarkFields/stdlib/withcache-4         	 1109917	      1103 ns/op	    4520 B/op	      14 allocs/op
+BenchmarkFields/stdlib/nocache-4           	 1082838	      1125 ns/op	    4520 B/op	      14 allocs/op
+BenchmarkFields/csvvalue/withcache-4       	28554976	        42.12 ns/op	       0 B/op	       0 allocs/op
+BenchmarkFields/csvvalue/nocache-4         	13666134	        83.77 ns/op	      48 B/op	       1 allocs/op
+```
+```
+goos: darwin
+goarch: arm64
+pkg: github.com/tonistiigi/go-csvvalue
+BenchmarkFields/stdlib/nocache-10                1679923               784.9 ns/op          4520 B/op         14 allocs/op
+BenchmarkFields/stdlib/withcache-10              1641891               826.9 ns/op          4520 B/op         14 allocs/op
+BenchmarkFields/csvvalue/withcache-10           34399642                33.93 ns/op            0 B/op          0 allocs/op
+BenchmarkFields/csvvalue/nocache-10             17441373                67.21 ns/op           48 B/op          1 allocs/op
+PASS
+```
+
+### Credits
+
+This package is mostly based on `encoding/csv` implementation and also uses that package for compatibility testing.
+

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -774,6 +774,9 @@ github.com/tonistiigi/go-actions-cache
 # github.com/tonistiigi/go-archvariant v1.0.0
 ## explicit; go 1.17
 github.com/tonistiigi/go-archvariant
+# github.com/tonistiigi/go-csvvalue v0.0.0-20240619222358-bb8dd5cba3c2
+## explicit; go 1.16
+github.com/tonistiigi/go-csvvalue
 # github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea
 ## explicit
 github.com/tonistiigi/units


### PR DESCRIPTION
This adds many updates to reduce memory allocations in Dockerfile frontend when dealing with huge inputs, improving performance and reducing GC pressure for other component.

Most of the issues are in dockerfile parser code and have been there forever (pre-buildkit). There was issue with excessive env reads in variable expansion as well. I also switched the `llb.Env()` datatype although performance impact of that was not very significant and it should be considered more as a cleanup of unneeded conversions. CSV parsers have also been switched as we used them for parsing small single-line values while stdlib parser is optimized for big documents.

Profile of allocations with giant Dockerfile from https://github.com/moby/buildkit/issues/4948 (5x)

Before:
```
(pprof) top20
Showing nodes accounting for 2.92GB, 76.90% of 3.79GB total
Dropped 2584 nodes (cum <= 0.02GB)
Showing top 20 nodes out of 198
      flat  flat%   sum%        cum   cum%
    0.65GB 17.18% 17.18%     1.13GB 29.74%  github.com/moby/buildkit/client/llb.EnvList.AddOrReplace (inline)
    0.57GB 14.93% 32.11%     0.57GB 14.93%  github.com/moby/buildkit/frontend/dockerfile/shell.(*wordsStruct).addRawChar (inline)
    0.48GB 12.57% 44.68%     0.48GB 12.57%  github.com/moby/buildkit/client/llb.EnvList.Delete (inline)
    0.24GB  6.22% 50.89%     0.24GB  6.22%  github.com/moby/buildkit/frontend/dockerfile/parser.extractBuilderFlags
    0.15GB  4.00% 54.90%     0.16GB  4.10%  github.com/moby/buildkit/frontend/dockerfile/shell.(*Lex).init
    0.14GB  3.75% 58.64%     0.14GB  3.75%  github.com/moby/buildkit/frontend/dockerfile/shell.BuildEnvs
    0.14GB  3.62% 62.26%     0.14GB  3.62%  bufio.NewReaderSize
    0.11GB  2.95% 65.21%     0.69GB 18.21%  github.com/moby/buildkit/frontend/dockerfile/parser.Parse
    0.08GB  2.16% 67.37%     0.08GB  2.16%  github.com/moby/buildkit/client/llb.EnvList.ToArray
    0.05GB  1.41% 68.79%     0.05GB  1.41%  bytes.growSlice
    0.05GB  1.19% 69.98%     0.05GB  1.25%  go.etcd.io/bbolt.(*DB).allocate
    0.04GB  1.11% 71.08%     1.20GB 31.58%  github.com/moby/buildkit/client/llb.addEnvf.func1.1
    0.04GB  1.03% 72.11%     0.04GB  1.03%  golang.org/x/net/http2/hpack.AppendHuffmanString
    0.03GB  0.82% 72.93%     0.03GB  0.82%  google.golang.org/grpc.nopBufferPool.Get
    0.03GB  0.74% 73.67%     1.15GB 30.25%  github.com/moby/buildkit/client/llb.addEnvf.func1.1.getEnv.func1
    0.03GB  0.71% 74.38%     0.03GB  0.71%  github.com/gogo/protobuf/types.(*Any).Unmarshal
    0.03GB  0.68% 75.06%     0.03GB  0.68%  google.golang.org/protobuf/internal/impl.mergeBytesNoZero
    0.02GB  0.65% 75.71%     0.02GB  0.65%  io.ReadAll
    0.02GB   0.6% 76.30%     0.02GB   0.6%  github.com/moby/buildkit/frontend/dockerfile/parser.parseWords
    0.02GB   0.6% 76.90%     0.02GB   0.6%  encoding/csv.(*Reader).readRecord
(pprof)
(pprof) top20 -cum
Showing nodes accounting for 901.51MB, 23.21% of 3883.95MB total
Dropped 2584 nodes (cum <= 19.42MB)
Showing top 20 nodes out of 198
      flat  flat%   sum%        cum   cum%
         0     0%     0%  2768.01MB 71.27%  golang.org/x/sync/errgroup.(*Group).Go.func1
    7.35MB  0.19%  0.19%  2672.03MB 68.80%  github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb.toDispatchState
         0     0%  0.19%  2661.26MB 68.52%  github.com/moby/buildkit/frontend/dockerfile/builder.Build.func6
         0     0%  0.19%  2634.52MB 67.83%  github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb.Dockerfile2LLB
         0     0%  0.19%  2620.18MB 67.46%  github.com/moby/buildkit/frontend/dockerui.(*Client).Build.func1
    2.77MB 0.071%  0.26%  1834.50MB 47.23%  github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb.dispatch
    4.58MB  0.12%  0.38%  1488.46MB 38.32%  github.com/moby/buildkit/frontend/dockerfile/instructions.parseMount
    4.85MB  0.12%   0.5%  1473.75MB 37.94%  github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb.dispatch.func1
    0.79MB  0.02%  0.52%  1459.55MB 37.58%  github.com/moby/buildkit/frontend/dockerfile/instructions.setMountState
         0     0%  0.52%  1339.45MB 34.49%  github.com/moby/buildkit/frontend/dockerfile/instructions.(*RunCommand).Expand
   42.94MB  1.11%  1.63%  1226.72MB 31.58%  github.com/moby/buildkit/client/llb.addEnvf.func1.1
   28.61MB  0.74%  2.37%  1174.74MB 30.25%  github.com/moby/buildkit/client/llb.addEnvf.func1.1.getEnv.func1
  667.12MB 17.18% 19.54%  1155.17MB 29.74%  github.com/moby/buildkit/client/llb.EnvList.AddOrReplace (inline)
   13.88MB  0.36% 19.90%  1122.60MB 28.90%  github.com/moby/buildkit/client/llb.State.Env
    1.58MB 0.041% 19.94%  1040.14MB 26.78%  github.com/moby/buildkit/client/llb.State.Env.getEnv.func1
    6.94MB  0.18% 20.12%   804.23MB 20.71%  github.com/moby/buildkit/frontend/dockerfile/shell.(*Lex).process
  114.52MB  2.95% 23.07%   707.38MB 18.21%  github.com/moby/buildkit/frontend/dockerfile/parser.Parse
         0     0% 23.07%   671.93MB 17.30%  github.com/moby/buildkit/frontend/dockerfile/shell.(*Lex).ProcessWord
         0     0% 23.07%   642.40MB 16.54%  github.com/moby/buildkit/frontend/dockerfile/shell.(*shellWord).process
    5.57MB  0.14% 23.21%   642.40MB 16.54%  github.com/moby/buildkit/frontend/dockerfile/shell.(*shellWord).processStopOn
```

After:
```
(pprof) top20
Showing nodes accounting for 468.47MB, 42.97% of 1090.19MB total
Dropped 2432 nodes (cum <= 5.45MB)
Showing top 20 nodes out of 341
      flat  flat%   sum%        cum   cum%
   46.23MB  4.24%  4.24%    47.94MB  4.40%  go.etcd.io/bbolt.(*DB).allocate
   44.21MB  4.06%  8.30%    44.21MB  4.06%  unicode/utf8.AppendRune (inline)
   40.04MB  3.67% 11.97%    40.04MB  3.67%  golang.org/x/net/http2/hpack.AppendHuffmanString
   30.99MB  2.84% 14.81%    30.99MB  2.84%  google.golang.org/grpc.nopBufferPool.Get
   28.87MB  2.65% 17.46%    28.87MB  2.65%  bytes.growSlice
   26.31MB  2.41% 19.87%    26.31MB  2.41%  google.golang.org/protobuf/internal/impl.mergeBytesNoZero
   25.05MB  2.30% 22.17%    25.06MB  2.30%  io.ReadAll
   21.55MB  1.98% 24.15%    21.55MB  1.98%  github.com/sirupsen/logrus.(*Entry).WithFields
   21.47MB  1.97% 26.12%    34.33MB  3.15%  encoding/json.Marshal
   21.07MB  1.93% 28.05%    21.07MB  1.93%  github.com/gogo/protobuf/types.(*Any).Unmarshal
   20.42MB  1.87% 29.92%    35.05MB  3.22%  encoding/json.(*decodeState).literalStore
   19.30MB  1.77% 31.69%    19.97MB  1.83%  github.com/moby/buildkit/frontend/gateway/pb.(*SolveResponse).Marshal
   19.08MB  1.75% 33.44%   126.33MB 11.59%  github.com/moby/buildkit/solver.(*scheduler).dispatch
   17.50MB  1.61% 35.05%    17.50MB  1.61%  encoding/base64.(*Encoding).EncodeToString
   16.75MB  1.54% 36.58%    16.75MB  1.54%  go.etcd.io/bbolt.(*node).read
   15.53MB  1.42% 38.01%    15.53MB  1.42%  github.com/moby/buildkit/solver/internal/pipe.New
   14.18MB  1.30% 39.31%    14.69MB  1.35%  fmt.Sprintf
   13.63MB  1.25% 40.56%    13.63MB  1.25%  go.etcd.io/bbolt.(*Tx).writeMeta
   13.17MB  1.21% 41.77%    44.24MB  4.06%  github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb.dispatch.func1
   13.12MB  1.20% 42.97%    13.12MB  1.20%  github.com/moby/buildkit/api/services/control.(*BuildHistoryRecord).Marshal
(pprof)
(pprof) top20 -cum
Showing nodes accounting for 29.41MB, 2.70% of 1090.19MB total
Dropped 2432 nodes (cum <= 5.45MB)
Showing top 20 nodes out of 341
      flat  flat%   sum%        cum   cum%
         0     0%     0%   438.28MB 40.20%  golang.org/x/sync/errgroup.(*Group).Go.func1
         0     0%     0%   275.03MB 25.23%  github.com/moby/buildkit/frontend/dockerfile/builder.Build.func6
         0     0%     0%   274.94MB 25.22%  github.com/moby/buildkit/frontend/dockerui.(*Client).Build.func1
         0     0%     0%   236.46MB 21.69%  github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb.Dockerfile2LLB
    7.46MB  0.68%  0.68%   236.24MB 21.67%  github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb.toDispatchState
         0     0%  0.68%   198.40MB 18.20%  google.golang.org/grpc.(*Server).handleStream
         0     0%  0.68%   198.39MB 18.20%  google.golang.org/grpc.(*Server).serveStreams.func1.1
    0.01MB 0.0011%  0.69%   197.76MB 18.14%  google.golang.org/grpc.(*Server).processUnaryRPC
    2.71MB  0.25%  0.93%   150.28MB 13.78%  github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb.dispatch
   19.08MB  1.75%  2.68%   126.33MB 11.59%  github.com/moby/buildkit/solver.(*scheduler).dispatch
         0     0%  2.68%   126.33MB 11.59%  github.com/moby/buildkit/solver.(*scheduler).loop
         0     0%  2.68%   113.19MB 10.38%  go.etcd.io/bbolt.(*DB).Update
         0     0%  2.68%   100.89MB  9.25%  github.com/moby/buildkit/util/grpcerrors.UnaryServerInterceptor
         0     0%  2.68%   100.89MB  9.25%  google.golang.org/grpc.NewServer.chainUnaryServerInterceptors.chainUnaryInterceptors.func1
         0     0%  2.68%   100.89MB  9.25%  main.unaryInterceptor
         0     0%  2.68%   100.89MB  9.25%  google.golang.org/grpc.getChainUnaryHandler.func1
         0     0%  2.68%   100.75MB  9.24%  sync.(*Once).doSlow
         0     0%  2.68%   100.57MB  9.23%  sync.(*Once).Do (inline)
    0.08MB 0.0072%  2.69%    95.27MB  8.74%  github.com/moby/buildkit/solver.(*edge).unpark
    0.08MB 0.0072%  2.70%    85.74MB  7.86%  github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb.toDispatchState.toDispatchState.func2.func3
```

There are many unrelated updates in here so definitely review per-commit. I can also start to split it to more reasonable smaller PRs. I did it all together as only then the profiler result is reasonable.
