### PR TITLE
git: fix pulling commit SHA only referenced from a tag

### DIFF
--- a/source/git/source.go
+++ b/source/git/source.go
@@ -470,6 +470,7 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context, g session.Group) (out 
 		if !isCommitSHA(ref) { // TODO: find a branch from ls-remote?
 			args = append(args, "--depth=1", "--no-tags")
 		} else {
+			args = append(args, "--tags")
 			if _, err := os.Lstat(filepath.Join(gitDir, "shallow")); err == nil {
 				args = append(args, "--unshallow")
 			}


### PR DESCRIPTION
On commit SHA input we currently do a full fetch of remote so we can pick up the commit by SHA later. This only pulls in tags that are also part of branches. Extra flag is needed to also get the tags that are not part of branches.