### PR TITLE
fix: dot and empty paths normalized correctly for COPY to WORKDIR

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -1763,9 +1763,6 @@ func pathRelativeToWorkingDir(s llb.State, p string, platform ocispecs.Platform)
 		return "", err
 	}
 
-	if len(p) == 0 {
-		return dir, nil
-	}
 	p, err = system.CheckSystemDriveAndRemoveDriveLetter(p, platform.OS)
 	if err != nil {
 		return "", errors.Wrap(err, "removing drive letter")
@@ -1773,6 +1770,12 @@ func pathRelativeToWorkingDir(s llb.State, p string, platform ocispecs.Platform)
 
 	if system.IsAbs(p, platform.OS) {
 		return system.NormalizePath("/", p, platform.OS, true)
+	}
+
+	// add slashes for "" and "." paths
+	// "" is treated as current directory and not necessariy root
+	if p == "." || p == "" {
+		p = "./"
 	}
 	return system.NormalizePath(dir, p, platform.OS, true)
 }


### PR DESCRIPTION
In my previous fix on #4825, I had removed this line knowing that all that had been addressed in `pahtRelativeToWorkingDir`:

```go
	if cfg.params.DestPath == "." // <-- this one
		|| cfg.params.DestPath == ""
                || cfg.params.DestPath[len(cfg.params.DestPath)-1] == filepath.Separator {
		dest += string(filepath.Separator)
	}
```

However, I had overlooked the `"."` and `""` scenarios. `""`. The  `"/"`case is handled correctly in `system.NormalizePath()`.

This change therefore undoes this, to make sure "." is transformed correctly to "./" during COPY operation, same to "" -> "./". This is important especially for WORKDIR that are not `/`, so that `COPY --link` operations are handled properly.

fixes #5070