### PR TITLE
docs: use json args in multiple instructions example

### DIFF
--- a/frontend/dockerfile/docs/rules/multiple-instructions-disallowed.md
+++ b/frontend/dockerfile/docs/rules/multiple-instructions-disallowed.md
@@ -23,16 +23,16 @@ Dockerfile, only the last occurrence is used. An image can only ever have one
 
 ```dockerfile
 FROM alpine
-CMD echo "Hello, Norway!"
-CMD echo "Hello, Sweden!"
+ENTRYPOINT ["echo", "Hello, Norway!"]
+ENTRYPOINT ["echo", "Hello, Sweden!"]
 # Only "Hello, Sweden!" will be printed
 ```
 
-✅ Good: only one `CMD` instruction.
+✅ Good: only one `ENTRYPOINT` instruction.
 
 ```dockerfile
 FROM alpine
-CMD echo "Hello, Norway!"; echo "Hello, Sweden!"
+ENTRYPOINT ["echo", "Hello, Norway!\nHello, Sweden!"]
 ```
 
 You can have both a regular, top-level `CMD`
@@ -44,7 +44,7 @@ and a separate `CMD` for a `HEALTHCHECK` instruction.
 FROM python:alpine
 RUN apk add curl
 HEALTHCHECK --interval=1s --timeout=3s \
-  CMD curl -f http://localhost:8080 || exit 1
-CMD python -m http.server 8080
+  CMD ["curl", "-f", "http://localhost:8080"]
+CMD ["python", "-m", "http.server", "8080"]
 ```
 

--- a/frontend/dockerfile/linter/docs/MultipleInstructionsDisallowed.md
+++ b/frontend/dockerfile/linter/docs/MultipleInstructionsDisallowed.md
@@ -16,16 +16,16 @@ Dockerfile, only the last occurrence is used. An image can only ever have one
 
 ```dockerfile
 FROM alpine
-CMD echo "Hello, Norway!"
-CMD echo "Hello, Sweden!"
+ENTRYPOINT ["echo", "Hello, Norway!"]
+ENTRYPOINT ["echo", "Hello, Sweden!"]
 # Only "Hello, Sweden!" will be printed
 ```
 
-✅ Good: only one `CMD` instruction.
+✅ Good: only one `ENTRYPOINT` instruction.
 
 ```dockerfile
 FROM alpine
-CMD echo "Hello, Norway!"; echo "Hello, Sweden!"
+ENTRYPOINT ["echo", "Hello, Norway!\nHello, Sweden!"]
 ```
 
 You can have both a regular, top-level `CMD`
@@ -37,6 +37,6 @@ and a separate `CMD` for a `HEALTHCHECK` instruction.
 FROM python:alpine
 RUN apk add curl
 HEALTHCHECK --interval=1s --timeout=3s \
-  CMD curl -f http://localhost:8080 || exit 1
-CMD python -m http.server 8080
+  CMD ["curl", "-f", "http://localhost:8080"]
+CMD ["python", "-m", "http.server", "8080"]
 ```


### PR DESCRIPTION
The example for the multiple instructions rule used shell form, changed it to exec form.

