### PR TITLE
ociLayoutResolver.info: remove use of reference.SplitObject

### DIFF
--- a/source/containerimage/ocilayout.go
+++ b/source/containerimage/ocilayout.go
@@ -105,7 +105,7 @@ func (r *ociLayoutResolver) info(ctx context.Context, ref reference.Spec) (conte
 	err := r.withCaller(ctx, func(ctx context.Context, caller session.Caller) error {
 		store := sessioncontent.NewCallerStore(caller, "oci:"+r.store.StoreID)
 
-		_, dgst := reference.SplitObject(ref.Object)
+		dgst := ref.Digest()
 		if dgst == "" {
 			return errors.Errorf("reference %q does not contain a digest", ref.String())
 		}


### PR DESCRIPTION
- relates to https://github.com/containerd/containerd/pull/10394
- relates to https://github.com/containerd/containerd/pull/10393


We already have a `reference.Spec` and `reference.Spec.Digest()` does exactly this. In addition, buildkit was the only external consumer of the `reference.SplitObject` function, and it may be deprecated and removed for containerd 2.0.