### PR TITLE
git: ensure exec option is propagated to child git clis

### DIFF
--- a/source/git/source_test.go
+++ b/source/git/source_test.go
@@ -373,9 +373,20 @@ func testFetchByTag(t *testing.T, tag, expectedCommitSubject string, isAnnotated
 	require.NoError(t, err)
 	defer lm.Unmount()
 
+	st, err := os.Lstat(filepath.Join(dir, "subdir"))
+	require.NoError(t, err)
+
+	require.True(t, st.IsDir())
+	require.Equal(t, strconv.FormatInt(0755, 8), strconv.FormatInt(int64(st.Mode()&os.ModePerm), 8))
+
 	dt, err := os.ReadFile(filepath.Join(dir, "def"))
 	require.NoError(t, err)
 	require.Equal(t, "bar\n", string(dt))
+
+	st, err = os.Lstat(filepath.Join(dir, "def"))
+	require.NoError(t, err)
+
+	require.Equal(t, strconv.FormatInt(0644, 8), strconv.FormatInt(int64(st.Mode()&os.ModePerm), 8))
 
 	dt, err = os.ReadFile(filepath.Join(dir, "foo13"))
 	if hasFoo13File {
@@ -692,7 +703,9 @@ func setupGitRepo(t *testing.T) gitRepoFixture {
 		"git commit -m initial",
 		"git tag --no-sign a/v1.2.3",
 		"echo bar > def",
-		"git add def",
+		"mkdir subdir",
+		"echo subcontents > subdir/subfile",
+		"git add def subdir",
 		"git commit -m second",
 		"git tag -a -m \"this is an annotated tag\" v1.2.3",
 		"echo foo > bar",

--- a/source/git/source_unix_test.go
+++ b/source/git/source_unix_test.go
@@ -1,0 +1,11 @@
+//go:build !windows
+// +build !windows
+
+package git
+
+import "syscall"
+
+func init() {
+	// Reset umask to zero to match buildkitd and to make sure the tests do not rely on standard umask from the host.
+	syscall.Umask(0)
+}

--- a/util/gitutil/git_cli.go
+++ b/util/gitutil/git_cli.go
@@ -119,20 +119,13 @@ func NewGitCLI(opts ...Option) *GitCLI {
 // New returns a new git client with the same config as the current one, but
 // with the given options applied on top.
 func (cli *GitCLI) New(opts ...Option) *GitCLI {
-	c := &GitCLI{
-		git:           cli.git,
-		dir:           cli.dir,
-		workTree:      cli.workTree,
-		gitDir:        cli.gitDir,
-		args:          append([]string{}, cli.args...),
-		streams:       cli.streams,
-		sshAuthSock:   cli.sshAuthSock,
-		sshKnownHosts: cli.sshKnownHosts,
-	}
+	clone := *cli
+	clone.args = append([]string{}, cli.args...)
+
 	for _, opt := range opts {
-		opt(c)
+		opt(&clone)
 	}
-	return c
+	return &clone
 }
 
 // Run executes a git command with the given args.


### PR DESCRIPTION
Alternative to #5092, fixes #5066.

This option is already correctly specified in `gitCLI`, the call chain looks like:
- `gitutil.NewCLI(..., gitutil.WithExec(runWithStandardUmask))` called in `gitCLI`
- `gitCLI` called in `mountRemote`
- `git.New` called in `mountRemote`

The `exec` field specified by `WithExec` from the first `NewCLI` call should propagate down to `git.New` - but this wasn't being done, I clearly missed this somehow.