### PR TITLE
Adds a deprecated flag to linter rules

### DIFF
--- a/frontend/dockerfile/linter/linter.go
+++ b/frontend/dockerfile/linter/linter.go
@@ -39,7 +39,7 @@ func New(config *Config) *Linter {
 }
 
 func (lc *Linter) Run(rule LinterRuleI, location []parser.Range, txt ...string) {
-	if lc == nil || lc.Warn == nil || lc.SkipAll {
+	if lc == nil || lc.Warn == nil || lc.SkipAll || rule.IsDeprecated() {
 		return
 	}
 	rulename := rule.RuleName()
@@ -71,11 +71,13 @@ func (lc *Linter) Error() error {
 type LinterRuleI interface {
 	RuleName() string
 	Run(warn LintWarnFunc, location []parser.Range, txt ...string)
+	IsDeprecated() bool
 }
 
 type LinterRule[F any] struct {
 	Name        string
 	Description string
+	Deprecated  bool
 	URL         string
 	Format      F
 }
@@ -90,6 +92,10 @@ func (rule *LinterRule[F]) Run(warn LintWarnFunc, location []parser.Range, txt .
 	}
 	short := strings.Join(txt, " ")
 	warn(rule.Name, rule.Description, rule.URL, short, location)
+}
+
+func (rule *LinterRule[F]) IsDeprecated() bool {
+	return rule.Deprecated
 }
 
 func LintFormatShort(rulename, msg string, line int) string {


### PR DESCRIPTION
Implements: https://github.com/moby/buildkit/issues/5082

This adds a `IsDeprecated` function to the `LinterRuleI` interface, and skips running a rule if `IsDeprecated` returns true. It also implements this function for the `LinterRule` type.