### PR TITLE
checks: warning for an invalid default arg in from

### DIFF
--- a/frontend/dockerfile/docs/rules/_index.md
+++ b/frontend/dockerfile/docs/rules/_index.md
@@ -80,5 +80,9 @@ $ docker build --check .
       <td><a href="./legacy-key-value-format/">LegacyKeyValueFormat</a></td>
       <td>Legacy key/value format with whitespace separator should not be used</td>
     </tr>
+    <tr>
+      <td><a href="./invalid-default-arg-in-from/">InvalidDefaultArgInFrom</a></td>
+      <td>Using ARG with default value results in an empty or invalid base image name</td>
+    </tr>
   </tbody>
 </table>

--- a/frontend/dockerfile/docs/rules/invalid-default-arg-in-from.md
+++ b/frontend/dockerfile/docs/rules/invalid-default-arg-in-from.md
@@ -1,0 +1,40 @@
+---
+title: InvalidDefaultArgInFrom
+description: Using ARG with default value results in an empty or invalid base image name
+aliases:
+  - /go/dockerfile/rule/invalid-default-arg-in-from/
+---
+
+## Output
+
+```text
+Using ARG for FROM busybox:${TAG} with default value results in an empty or invalid base image name
+```
+
+## Description
+
+An `ARG` used in an image reference should be valid when no build arguments are used. An image build should not require `--build-arg` to be used to produce a valid build.
+
+## Examples
+
+❌ Bad: don't rely on an ARG being set for an image reference to be valid
+
+```dockerfile
+ARG TAG
+FROM busybox:${TAG}
+```
+
+✅ Good: include a default for the ARG
+
+```dockerfile
+ARG TAG=latest
+FROM busybox:${TAG}
+```
+
+✅ Good: ARG can be empty if the image would be valid with it empty
+
+```dockerfile
+ARG VARIANT
+FROM busybox:stable${VARIANT}
+```
+

--- a/frontend/dockerfile/linter/docs/InvalidDefaultArgInFrom.md
+++ b/frontend/dockerfile/linter/docs/InvalidDefaultArgInFrom.md
@@ -1,0 +1,32 @@
+## Output
+
+```text
+Using ARG for FROM busybox:${TAG} with default value results in an empty or invalid base image name
+```
+
+## Description
+
+An `ARG` used in an image reference should be valid when no build arguments are used. An image build should not require `--build-arg` to be used to produce a valid build.
+
+## Examples
+
+❌ Bad: don't rely on an ARG being set for an image reference to be valid
+
+```dockerfile
+ARG TAG
+FROM busybox:${TAG}
+```
+
+✅ Good: include a default for the ARG
+
+```dockerfile
+ARG TAG=latest
+FROM busybox:${TAG}
+```
+
+✅ Good: ARG can be empty if the image would be valid with it empty
+
+```dockerfile
+ARG VARIANT
+FROM busybox:stable${VARIANT}
+```

--- a/frontend/dockerfile/linter/ruleset.go
+++ b/frontend/dockerfile/linter/ruleset.go
@@ -124,4 +124,12 @@ var (
 			return fmt.Sprintf("Base image %s was pulled with platform %q, expected %q for current build", image, actual, expected)
 		},
 	}
+	RuleInvalidDefaultArgInFrom = LinterRule[func(string) string]{
+		Name:        "InvalidDefaultArgInFrom",
+		Description: "Using ARG with default value results in an empty or invalid base image name",
+		URL:         "https://docs.docker.com/go/dockerfile/rule/invalid-default-arg-in-from/",
+		Format: func(baseName string) string {
+			return fmt.Sprintf("Using ARG for %v with default values results in empty or invalid base image name", baseName)
+		},
+	}
 )


### PR DESCRIPTION
A dockerfile should be valid when used with the default values for `ARG` and not require the use of `--build-arg` to function correctly. This checks that using the default values causes the images in `FROM` to be valid names.