### PR TITLE
executor: fix cancellation before start signal

### DIFF
--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -610,9 +610,14 @@ func runcProcessHandle(ctx context.Context, killer procKiller) (*procHandle, con
 	go func() {
 		// Wait for pid
 		select {
-		case <-ctx.Done():
+		case <-p.ended:
 			return // nothing to kill
 		case <-p.ready:
+			select {
+			case <-p.ended:
+				return
+			default:
+			}
 		}
 
 		for {


### PR DESCRIPTION
If context is canceled before the process is ready then kill goroutine returns early because there is nothing to kill. But the process may still start after this and in that case remain running without cancellation. Fix is to skip cancellation only if the run goroutine is ended, as then the process will not be started.