### PR TITLE
fix incorrect usage of json.NewDecoder

### DIFF
--- a/cache/remotecache/s3/s3.go
+++ b/cache/remotecache/s3/s3.go
@@ -408,6 +408,9 @@ func (s3Client *s3Client) getManifest(ctx context.Context, key string, config *v
 	if err := decoder.Decode(config); err != nil {
 		return false, errors.WithStack(err)
 	}
+	if _, err := decoder.Token(); !errors.Is(err, io.EOF) {
+		return false, errors.Errorf("unexpected data after JSON object")
+	}
 
 	return true, nil
 }

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -422,8 +422,12 @@ func (w *runcExecutor) Exec(ctx context.Context, id string, process executor.Pro
 	defer f.Close()
 
 	spec := &specs.Spec{}
-	if err := json.NewDecoder(f).Decode(spec); err != nil {
+	dec := json.NewDecoder(f)
+	if err := dec.Decode(spec); err != nil {
 		return err
+	}
+	if _, err := dec.Token(); !errors.Is(err, io.EOF) {
+		return errors.Errorf("unexpected data after JSON spec object")
 	}
 
 	if process.Meta.User != "" {

--- a/exporter/attestation/unbundle.go
+++ b/exporter/attestation/unbundle.go
@@ -3,6 +3,7 @@ package attestation
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"os"
 	"path"
 	"strings"
@@ -140,6 +141,9 @@ func unbundle(root string, bundle exporter.Attestation) ([]exporter.Attestation,
 		var stmt intoto.Statement
 		if err := dec.Decode(&stmt); err != nil {
 			return nil, errors.Wrap(err, "cannot decode in-toto statement")
+		}
+		if _, err := dec.Token(); !errors.Is(err, io.EOF) {
+			return nil, errors.New("in-toto statement is not a single JSON object")
 		}
 		if bundle.InToto.PredicateType != "" && stmt.PredicateType != bundle.InToto.PredicateType {
 			return nil, errors.Errorf("bundle entry %s does not match required predicate type %s", stmt.PredicateType, bundle.InToto.PredicateType)

--- a/frontend/dockerfile/parser/line_parsers.go
+++ b/frontend/dockerfile/parser/line_parsers.go
@@ -282,7 +282,7 @@ func parseJSON(rest string) (*Node, map[string]bool, error) {
 	}
 
 	var myJSON []interface{}
-	if err := json.NewDecoder(strings.NewReader(rest)).Decode(&myJSON); err != nil {
+	if err := json.Unmarshal([]byte(rest), &myJSON); err != nil {
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
Fixes cases where `json.Decoder` was improperly used for parsing JSON values. `Decode()` only parses the next object and does not check if there is additional content after it (unlike `Unmarshal()`).

In Dockerfile it meant that currently invalid commands like this would cause no error and skip over the invalid bytes:

```
RUN ["ls"]random symbols in here
ENTRYPOINT []<-this is JSON array
```