### PR TITLE
Always return non-nil contexts

### DIFF
--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -328,11 +328,8 @@ func (gf *gatewayFrontend) Solve(ctx context.Context, llbBridge frontend.Fronten
 		}
 	}
 
-	lbf, ctx, err := serveLLBBridgeForwarder(ctx, llbBridge, exec, gf.workers, inputs, sid, sm)
-	defer lbf.conn.Close() //nolint
-	if err != nil {
-		return nil, err
-	}
+	lbf, ctx := serveLLBBridgeForwarder(ctx, llbBridge, exec, gf.workers, inputs, sid, sm)
+	defer lbf.conn.Close()
 	defer lbf.Discard()
 
 	mdmnt, release, err := metadataMount(frontendDef)
@@ -498,7 +495,7 @@ func newBridgeForwarder(ctx context.Context, llbBridge frontend.FrontendLLBBridg
 	return lbf
 }
 
-func serveLLBBridgeForwarder(ctx context.Context, llbBridge frontend.FrontendLLBBridge, exec executor.Executor, workers worker.Infos, inputs map[string]*opspb.Definition, sid string, sm *session.Manager) (*llbBridgeForwarder, context.Context, error) {
+func serveLLBBridgeForwarder(ctx context.Context, llbBridge frontend.FrontendLLBBridge, exec executor.Executor, workers worker.Infos, inputs map[string]*opspb.Definition, sid string, sm *session.Manager) (*llbBridgeForwarder, context.Context) {
 	ctx, cancel := context.WithCancelCause(ctx)
 	lbf := newBridgeForwarder(ctx, llbBridge, exec, workers, inputs, sid, sm)
 	serverOpt := []grpc.ServerOption{
@@ -521,7 +518,7 @@ func serveLLBBridgeForwarder(ctx context.Context, llbBridge frontend.FrontendLLB
 		cancel(errors.WithStack(context.Canceled))
 	}()
 
-	return lbf, ctx, nil
+	return lbf, ctx
 }
 
 type pipe struct {

--- a/frontend/gateway/grpcclient/client.go
+++ b/frontend/gateway/grpcclient/client.go
@@ -1262,7 +1262,7 @@ func grpcClientConn(ctx context.Context) (context.Context, *grpc.ClientConn, err
 
 	cc, err := grpc.DialContext(ctx, "localhost", dialOpts...)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to create grpc client")
+		return ctx, nil, errors.Wrap(err, "failed to create grpc client")
 	}
 
 	ctx, cancel := context.WithCancelCause(ctx)

--- a/session/grpc.go
+++ b/session/grpc.go
@@ -58,7 +58,7 @@ func grpcClientConn(ctx context.Context, conn net.Conn) (context.Context, *grpc.
 
 	cc, err := grpc.DialContext(ctx, "localhost", dialOpts...)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to create grpc client")
+		return ctx, nil, errors.Wrap(err, "failed to create grpc client")
 	}
 
 	ctx, cancel := context.WithCancelCause(ctx)

--- a/util/leaseutil/manager.go
+++ b/util/leaseutil/manager.go
@@ -20,7 +20,7 @@ func WithLease(ctx context.Context, ls leases.Manager, opts ...leases.Opt) (cont
 
 	lr, ctx, err := NewLease(ctx, ls, opts...)
 	if err != nil {
-		return nil, nil, err
+		return ctx, nil, err
 	}
 
 	return ctx, func(ctx context.Context) error {
@@ -31,7 +31,7 @@ func WithLease(ctx context.Context, ls leases.Manager, opts ...leases.Opt) (cont
 func NewLease(ctx context.Context, lm leases.Manager, opts ...leases.Opt) (*LeaseRef, context.Context, error) {
 	l, err := lm.Create(ctx, append([]leases.Opt{leases.WithRandomID(), leases.WithExpiration(time.Hour)}, opts...)...)
 	if err != nil {
-		return nil, nil, err
+		return nil, ctx, err
 	}
 
 	ctx = leases.WithLease(ctx, l.ID)


### PR DESCRIPTION
This prevents cases where the returned nil context ends up overwriting another context in the caller which can mess up defers.

Ex:

```go
ctx := context.Background()

defer func() {
  cleanup(ctx)
}()

ctx, done, err := leaseutil.WithLease(...)
```

In this cae when `leaseutil.WithLease` has an error, before this change the returned context is nil.
The solver this can trigger a panic when the context is cancelled because leaseutil will error out and then a prior defer function will call `context.WithoutCancel(ctx)` triggering the panic because context should never be nil.

leaseutil seems like the only place this was problematic but changed a couple of other places I found to make sure they don't cause problems if the caller changes in the future.