### PR TITLE
update containerd binary to v1.7.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile-upstream:master
 
 ARG RUNC_VERSION=v1.1.13
-ARG CONTAINERD_VERSION=v1.7.18
+ARG CONTAINERD_VERSION=v1.7.19
 # containerd v1.6 for integration tests
 ARG CONTAINERD_ALT_VERSION_16=v1.6.33
 ARG REGISTRY_VERSION=v2.8.3


### PR DESCRIPTION
Update the containerd binary that's used in CI.

- release notes: https://github.com/containerd/containerd/releases/tag/v1.7.19
- full diff: https://github.com/containerd/containerd/compare/v1.7.18...v1.7.19

Welcome to the v1.7.19 release of containerd!

The nineteenth patch release for containerd 1.7 contains various updates and splits the main module from the api module in preparation for the same change in containerd 2.0. Splitting the modules will allow 1.7 and 2.x to both exist as transitive dependencies without running into API registration errors. Projects should use this version as the minimum 1.7 version in preparing to use containerd 2.0 or to be imported alongside it.

Highlights

- Fix support for OTLP config
- Add API go module
- Remove overlayfs volatile option on temp mounts
- Update runc binary to v1.1.13
- Migrate platforms package to github.com/containerd/platforms
- Migrate reference/docker package to github.com/distribution/reference

Container Runtime Interface (CRI)

- Fix panic in NRI from nil CRI reference
- Fix Windows HPC working directory