### PR TITLE
bboltcachestorage: only delete link after releasing result

### DIFF
--- a/solver/bboltcachestorage/storage.go
+++ b/solver/bboltcachestorage/storage.go
@@ -278,8 +278,10 @@ func (s *Store) emptyBranchWithParents(tx *bolt.Tx, id []byte) error {
 				}
 
 				if isEmptyBucket(subLinks) {
-					if err := tx.Bucket([]byte(linksBucket)).DeleteBucket(k); err != nil {
-						return err
+					if subResult := tx.Bucket([]byte(resultBucket)).Bucket(k); isEmptyBucket(subResult) {
+						if err := tx.Bucket([]byte(linksBucket)).DeleteBucket(k); err != nil {
+							return err
+						}
 					}
 				}
 			}


### PR DESCRIPTION
If the result exists but the link has been deleted, it will cause the result to never be released, ultimately leading to data leakage. 