### PR TITLE
docs: fix broken link in lint docs after rule rename

### DIFF
--- a/frontend/dockerfile/docs/rules/from-as-casing.md
+++ b/frontend/dockerfile/docs/rules/from-as-casing.md
@@ -40,5 +40,5 @@ from debian:latest as deb-builder
 
 ## Related errors
 
-- [`FileConsistentCommandCasing`](./file-consistent-command-casing.md)
+- [`FileConsistentCommandCasing`](./consistent-instruction-casing.md)
 

--- a/frontend/dockerfile/linter/docs/FromAsCasing.md
+++ b/frontend/dockerfile/linter/docs/FromAsCasing.md
@@ -33,4 +33,4 @@ from debian:latest as deb-builder
 
 ## Related errors
 
-- [`FileConsistentCommandCasing`](./file-consistent-command-casing.md)
+- [`FileConsistentCommandCasing`](./consistent-instruction-casing.md)


### PR DESCRIPTION
The ConsistentInstructionCasing rule was renamed but there was still a link pointing to the old filename, causing docs build to fail:

```
0.133 Start building sites … 
0.133 hugo v0.127.0-74e0f3bd63c51f3c7a0f07a7c779eec9e922957e+extended linux/arm64 BuildDate=2024-06-05T10:27:59Z VendorInfo=gohugoio
0.133 
4.479 WARN  [introduced] version below threshold: buildx 0.9.0 "/src/content/build/building/variables.md:351:1"
7.442 ERROR [en] REF_NOT_FOUND: Ref "./file-consistent-command-casing.md" from page "/reference/build-checks/from-as-casing": page not found
9.221 Total in 9093 ms
9.221 Error: error building site: logged 1 error(s)
```

Updated the link to the new filename.

## Notes

- We should probably have tests for this (e.g. docs validate) or have a way to generate "related" links. Or just remove those links. The links are hard to get right because the filenames are different in the source .md files than what they are in the generated md - source filenames use pascal case and generated files are kebab case.
- We currently don't have a way of handling redirects for old rules. The old rulename is still used in older releases, we don't keep an alias around for the old rulename. In this case, that means the documentation link for FileConsistentCommandCasing would be broken. Maybe for backwards compatibility, we should include old rulenames as aliases in `ruleset.go`.