### PR TITLE
docs: add a multi-line ENV example

### DIFF
--- a/frontend/dockerfile/docs/rules/legacy-key-value-format.md
+++ b/frontend/dockerfile/docs/rules/legacy-key-value-format.md
@@ -36,3 +36,21 @@ FROM alpine
 ARG foo=bar
 ```
 
+❌ Bad: multi-line variable declaration with a space separator.
+
+```dockerfile
+ENV DEPS \
+    curl \
+    git \
+    make
+```
+
+✅ Good: use an equals sign and wrap the value in quotes.
+
+```dockerfile
+ENV DEPS="\
+    curl \
+    git \
+    make"
+```
+

--- a/frontend/dockerfile/linter/docs/LegacyKeyValueFormat.md
+++ b/frontend/dockerfile/linter/docs/LegacyKeyValueFormat.md
@@ -28,3 +28,21 @@ ARG foo bar
 FROM alpine
 ARG foo=bar
 ```
+
+❌ Bad: multi-line variable declaration with a space separator.
+
+```dockerfile
+ENV DEPS \
+    curl \
+    git \
+    make
+```
+
+✅ Good: use an equals sign and wrap the value in quotes.
+
+```dockerfile
+ENV DEPS="\
+    curl \
+    git \
+    make"
+```


### PR DESCRIPTION
Adds an example of a multiline ENV declaration, with and without a `=` separator.

- resolves docker/docs#20355
