### PR TITLE
ci(docs-upstream): missing path for frontend rules docs

### DIFF
--- a/.github/workflows/docs-upstream.yml
+++ b/.github/workflows/docs-upstream.yml
@@ -18,6 +18,7 @@ on:
       - 'docs/attestations/slsa-definitions.md'
       - 'docs/attestations/attestation-storage.md'
       - 'frontend/dockerfile/docs/reference.md'
+      - 'frontend/dockerfile/docs/rules/**'
   pull_request:
     paths:
       - '.github/workflows/docs-upstream.yml'
@@ -25,6 +26,7 @@ on:
       - 'docs/attestations/slsa-definitions.md'
       - 'docs/attestations/attestation-storage.md'
       - 'frontend/dockerfile/docs/reference.md'
+      - 'frontend/dockerfile/docs/rules/**'
 
 jobs:
   validate:


### PR DESCRIPTION
relates to https://github.com/moby/buildkit/pull/5124#issuecomment-2209250809