### PR TITLE
llbsolver: make sure stoptrace called on bolt error

### DIFF
--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -180,6 +180,9 @@ func (s *Solver) recordBuildHistory(ctx context.Context, id string, req frontend
 		Type:   controlapi.BuildHistoryEventType_STARTED,
 		Record: rec,
 	}); err != nil {
+		if stopTrace != nil {
+			stopTrace()
+		}
 		return nil, err
 	}
 
@@ -377,9 +380,10 @@ func (s *Solver) recordBuildHistory(ctx context.Context, id string, req frontend
 		}()
 
 		if err != nil {
-			status, desc, release, err := s.history.ImportError(ctx, err)
-			if err != nil {
-				return err
+			status, desc, release, err1 := s.history.ImportError(ctx, err)
+			if err1 != nil {
+				// don't replace the build error with this import error
+				bklog.G(ctx).Errorf("failed to import error to build record: %+v", err1)
 			}
 			rec.ExternalError = desc
 			releasers = append(releasers, release)


### PR DESCRIPTION
These cases could cause early exit without calling `stopTrace`.

@cpuguy83 Related to https://github.com/moby/moby/issues/48144 but I don't think this is actual issue(build would fail without starting in this case). Also the `ImportStatus` is unreleased new code.