### PR TITLE
checks: add check for constant in from platform flag

### DIFF
--- a/frontend/dockerfile/docs/rules/_index.md
+++ b/frontend/dockerfile/docs/rules/_index.md
@@ -92,5 +92,9 @@ $ docker build --check .
       <td><a href="./invalid-default-arg-in-from/">InvalidDefaultArgInFrom</a></td>
       <td>Default value for global ARG results in an empty or invalid base image name</td>
     </tr>
+    <tr>
+      <td><a href="./from-platform-flag-const-disallowed/">FromPlatformFlagConstDisallowed</a></td>
+      <td>FROM --platform flag should not use a constant value</td>
+    </tr>
   </tbody>
 </table>

--- a/frontend/dockerfile/docs/rules/from-platform-flag-const-disallowed.md
+++ b/frontend/dockerfile/docs/rules/from-platform-flag-const-disallowed.md
@@ -1,0 +1,59 @@
+---
+title: FromPlatformFlagConstDisallowed
+description: FROM --platform flag should not use a constant value
+aliases:
+  - /go/dockerfile/rule/from-platform-flag-const-disallowed/
+---
+
+## Output
+
+```text
+FROM --platform flag should not use constant value "linux/amd64"
+```
+
+## Description
+
+Specifying `--platform` in the Dockerfile `FROM` instruction forces the image to build on only one target platform. This prevents building a multi-platform image from this Dockerfile and you must build on the same platform as specified in `--platform`.
+
+The recommended approach is to:
+
+* Omit `FROM --platform` in the Dockerfile and use the `--platform` argument on the command line.
+* Use `$BUILDPLATFORM` or some other combination of variables for the `--platform` argument.
+* Stage name should include the platform, OS, or architecture name to indicate that it only contains platform-specific instructions.
+
+## Examples
+
+❌ Bad: using a constant argument for `--platform`
+
+```dockerfile
+FROM --platform=linux/amd64 alpine AS base
+RUN apk add --no-cache git
+```
+
+✅ Good: using the default platform
+
+```dockerfile
+FROM alpine AS base
+RUN apk add --no-cache git
+```
+
+✅ Good: using a meta variable
+
+```dockerfile
+FROM --platform=${BUILDPLATFORM} alpine AS base
+RUN apk add --no-cache git
+```
+
+✅ Good: used in a multi-stage build with a target architecture
+
+```dockerfile
+FROM --platform=linux/amd64 alpine AS build_amd64
+...
+
+FROM --platform=linux/arm64 alpine AS build_arm64
+...
+
+FROM build_${TARGETARCH} AS build
+...
+```
+

--- a/frontend/dockerfile/linter/docs/FromPlatformFlagConstDisallowed.md
+++ b/frontend/dockerfile/linter/docs/FromPlatformFlagConstDisallowed.md
@@ -1,0 +1,51 @@
+## Output
+
+```text
+FROM --platform flag should not use constant value "linux/amd64"
+```
+
+## Description
+
+Specifying `--platform` in the Dockerfile `FROM` instruction forces the image to build on only one target platform. This prevents building a multi-platform image from this Dockerfile and you must build on the same platform as specified in `--platform`.
+
+The recommended approach is to:
+
+* Omit `FROM --platform` in the Dockerfile and use the `--platform` argument on the command line.
+* Use `$BUILDPLATFORM` or some other combination of variables for the `--platform` argument.
+* Stage name should include the platform, OS, or architecture name to indicate that it only contains platform-specific instructions.
+
+## Examples
+
+❌ Bad: using a constant argument for `--platform`
+
+```dockerfile
+FROM --platform=linux/amd64 alpine AS base
+RUN apk add --no-cache git
+```
+
+✅ Good: using the default platform
+
+```dockerfile
+FROM alpine AS base
+RUN apk add --no-cache git
+```
+
+✅ Good: using a meta variable
+
+```dockerfile
+FROM --platform=${BUILDPLATFORM} alpine AS base
+RUN apk add --no-cache git
+```
+
+✅ Good: used in a multi-stage build with a target architecture
+
+```dockerfile
+FROM --platform=linux/amd64 alpine AS build_amd64
+...
+
+FROM --platform=linux/arm64 alpine AS build_arm64
+...
+
+FROM build_${TARGETARCH} AS build
+...
+```

--- a/frontend/dockerfile/linter/ruleset.go
+++ b/frontend/dockerfile/linter/ruleset.go
@@ -148,4 +148,12 @@ var (
 			return fmt.Sprintf("Default value for ARG %v results in empty or invalid base image name", baseName)
 		},
 	}
+	RuleFromPlatformFlagConstDisallowed = LinterRule[func(string) string]{
+		Name:        "FromPlatformFlagConstDisallowed",
+		Description: "FROM --platform flag should not use a constant value",
+		URL:         "https://docs.docker.com/go/dockerfile/rule/from-platform-flag-const-disallowed/",
+		Format: func(platform string) string {
+			return fmt.Sprintf("FROM --platform flag should not use constant value %q", platform)
+		},
+	}
 )


### PR DESCRIPTION
This linter rule triggers if a constant value has been used in the
`FROM --platform` flag and the stage name doesn't contain the OS or
architecture mentioned.

Fixes https://github.com/moby/buildkit/issues/5131.