### PR TITLE
testutil: optimization for mirror handling

### DIFF
--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -236,6 +236,11 @@ func copyImagesLocal(t *testing.T, host string, images map[string]string) error 
 		}
 		localImageCache[host][to] = struct{}{}
 
+		// already exists check
+		if _, _, err := docker.NewResolver(docker.ResolverOptions{}).Resolve(context.TODO(), host+"/"+to); err == nil {
+			continue
+		}
+
 		var desc ocispecs.Descriptor
 		var provider content.Provider
 		var err error
@@ -253,12 +258,6 @@ func copyImagesLocal(t *testing.T, host string, images map[string]string) error 
 			if err != nil {
 				return err
 			}
-		}
-
-		// already exists check
-		_, _, err = docker.NewResolver(docker.ResolverOptions{}).Resolve(context.TODO(), host+"/"+to)
-		if err == nil {
-			continue
 		}
 
 		ingester, err := contentutil.IngesterFromRef(host + "/" + to)


### PR DESCRIPTION
- Instead of running a mirror for each `integration.Run` call,
only run it if there is actual sandboxed test running. This speeds
up running tests with a filter as if all the tests from a given
suite are inactive, no time is spent running the mirror.
- ProviderFromRef call is already making the HEAD request
to upstream registry to get digest. Avoid doing that if
image already exists in mirror anyway.

Before:

```
--- PASS: TestIntegration (6.46s)
    --- PASS: TestIntegration/TestHistoryError/worker=containerd-1.6/frontend=builtin (0.40s)
PASS
ok      github.com/moby/buildkit/frontend/dockerfile    6.872s
```

After:
```
--- PASS: TestIntegration (0.39s)
    --- PASS: TestIntegration/TestHistoryError/worker=containerd-1.6/frontend=builtin (0.36s)
PASS
ok      github.com/moby/buildkit/frontend/dockerfile    0.406s
```


