### PR TITLE
llbsolver: fix possible early delete of external error

### DIFF
--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -7485,6 +7485,8 @@ COPY notexist /foo
 	}, nil)
 	require.Error(t, err)
 
+	expectedError := err
+
 	cl, err := c.ControlClient().ListenBuildHistory(sb.Context(), &controlapi.BuildHistoryRequest{
 		EarlyExit: true,
 		Ref:       ref,
@@ -7495,7 +7497,7 @@ COPY notexist /foo
 	for {
 		resp, err := cl.Recv()
 		if err == io.EOF {
-			require.Equal(t, true, got)
+			require.Equal(t, true, got, "expected error was %+v", expectedError)
 			break
 		}
 		require.NoError(t, err)


### PR DESCRIPTION
fixes #5122

Discard was called always, even if `Commit` had succeeded but it is not allowed as it removed the writer lease and blob could be deleted before it reaches the `AddResource` call of the history record.