### PR TITLE
Check invalid environment replacement form like ${VAR:%}

### DIFF
--- a/frontend/dockerfile/shell/lex.go
+++ b/frontend/dockerfile/shell/lex.go
@@ -378,6 +378,9 @@ func (sw *shellWord) processDollar() (string, error) {
 		fallthrough
 	case '+', '-', '?', '#', '%':
 		rawEscapes := ch == '#' || ch == '%'
+		if nullIsUnset && rawEscapes {
+			return "", errors.Errorf("unsupported modifier (%s) in substitution", chs)
+		}
 		word, _, err := sw.processStopOn('}', rawEscapes)
 		if err != nil {
 			if sw.scanner.Peek() == scanner.EOF {

--- a/frontend/dockerfile/shell/lex_test.go
+++ b/frontend/dockerfile/shell/lex_test.go
@@ -498,6 +498,26 @@ func TestProcessWithMatches(t *testing.T) {
 			matches:  map[string]struct{}{"FOO": {}, "BAR": {}},
 		},
 		{
+			input:       "${FOO:#}",
+			envs:        map[string]string{},
+			expectedErr: true,
+		},
+		{
+			input:       "${FOO:##}",
+			envs:        map[string]string{},
+			expectedErr: true,
+		},
+		{
+			input:       "${FOO:%}",
+			envs:        map[string]string{},
+			expectedErr: true,
+		},
+		{
+			input:       "${FOO:%%}",
+			envs:        map[string]string{},
+			expectedErr: true,
+		},
+		{
 			// test: wildcards
 			input:    "${FOO/$NEEDLE/.} - ${FOO//$NEEDLE/.}",
 			envs:     map[string]string{"FOO": "/foo*/*/*.txt", "NEEDLE": "\\*/"},


### PR DESCRIPTION
Environment replacement form like below are invalid, so they should cause error.

- `${VAR:#pattern}`
- `${VAR:##pattern}`
- `${VAR:%pattern}`
- `${VAR:%%pattern}`