### PR TITLE
Check the validity of the chmod option arguments for COPY and ADD

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -1363,10 +1363,11 @@ func dispatchCopy(d *dispatchState, cfg copyConfig) error {
 	var mode *os.FileMode
 	if cfg.chmod != "" {
 		p, err := strconv.ParseUint(cfg.chmod, 8, 32)
-		if err == nil {
-			perm := os.FileMode(p)
-			mode = &perm
+		if err != nil || p > 0o7777 {
+			return errors.Errorf("invalid chmod parameter: '%v'. it should be octal string and between 0 and 07777", cfg.chmod)
 		}
+		perm := os.FileMode(p)
+		mode = &perm
 	}
 
 	if cfg.checksum != "" {


### PR DESCRIPTION
The current implementation silently ignores the chmod option argument for COPY and ADD if it is invalid, so this PR change to check the validity of the argument.