### PR TITLE
dockerfile: avoid frontend panic when no stages defined

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -258,6 +258,9 @@ func toDispatchState(ctx context.Context, dt []byte, opt ConvertOpt) (*dispatchS
 	if err != nil {
 		return nil, err
 	}
+	if len(stages) == 0 {
+		return nil, errors.New("dockerfile contains no stages to build")
+	}
 	validateStageNames(stages, lint)
 
 	shlex := shell.NewLex(dockerfile.EscapeToken)


### PR DESCRIPTION
fixes #5147

Although #5147 does not list Dockerfile, this is the only case I see where this was possible. Build without stages is still error, but don't let the frontend panic. 