### PR TITLE
Restore env replacement process of ARG's variable names

### DIFF
--- a/frontend/dockerfile/instructions/commands.go
+++ b/frontend/dockerfile/instructions/commands.go
@@ -456,25 +456,6 @@ type ArgCommand struct {
 	Args []KeyValuePairOptional
 }
 
-func (c *ArgCommand) Expand(expander SingleWordExpander) error {
-	for i, v := range c.Args {
-		p, err := expander(v.Key)
-		if err != nil {
-			return err
-		}
-		v.Key = p
-		if v.Value != nil {
-			p, err = expander(*v.Value)
-			if err != nil {
-				return err
-			}
-			v.Value = &p
-		}
-		c.Args[i] = v
-	}
-	return nil
-}
-
 // ShellCommand sets a custom shell to use.
 //
 //	SHELL bash -e -c


### PR DESCRIPTION
Up to 1.7.1, variable names in `ARG` command could also use environment replacement, but in commit 47a52a17b remove the replacement process, so the replacement for variable names is no longer available in 1.8.0.
This PR restore this.
In addition, remove the `Expand` method of `ArgCommand` because it was no longer used.