### PR TITLE
Reduce clone size and time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -235,7 +235,7 @@ ARG CONTAINERD_VERSION
 RUN --mount=from=containerd-src,src=/usr/src/containerd,rw \
     --mount=target=/root/.cache,type=cache <<EOT
   set -ex
-  git switch -q -d "$CONTAINERD_VERSION"
+  git checkout -q "$CONTAINERD_VERSION"
   mkdir /out
   ext=""
   if [ "$(xx-info os)" = "windows" ]; then
@@ -257,7 +257,7 @@ ARG CONTAINERD_ALT_VERSION_16
 RUN --mount=from=containerd-src,src=/usr/src/containerd,rw \
     --mount=target=/root/.cache,type=cache <<EOT
   set -ex
-  git switch -q -d "$CONTAINERD_ALT_VERSION_16"
+  git checkout -q "$CONTAINERD_ALT_VERSION_16"
   mkdir /out
   ext=""
   if [ "$(xx-info os)" = "windows" ]; then


### PR DESCRIPTION
The clone executed in the Dockerfile is used only specific tags afterwards, so by cloning only the necessary tags, reduce the amount of data transfer and time required for the clone.

(In my poor environment, cloning the entire repository takes too long and often fails.)