### PR TITLE
solver: mark history and graph concistency errors as internal

### DIFF
--- a/errdefs/errdefs.go
+++ b/errdefs/errdefs.go
@@ -1,0 +1,31 @@
+package errdefs
+
+import "errors"
+
+type internalErr struct {
+	error
+}
+
+func (internalErr) System() {}
+
+func (err internalErr) Unwrap() error {
+	return err.error
+}
+
+type system interface {
+	System()
+}
+
+var _ system = internalErr{}
+
+func Internal(err error) error {
+	if err == nil {
+		return nil
+	}
+	return internalErr{err}
+}
+
+func IsInternal(err error) bool {
+	var s system
+	return errors.As(err, &s)
+}

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -18,6 +18,7 @@ import (
 	"github.com/moby/buildkit/cache/remotecache"
 	"github.com/moby/buildkit/client"
 	controlgateway "github.com/moby/buildkit/control/gateway"
+	"github.com/moby/buildkit/errdefs"
 	"github.com/moby/buildkit/executor/resources"
 	resourcestypes "github.com/moby/buildkit/executor/resources/types"
 	"github.com/moby/buildkit/exporter"
@@ -158,7 +159,7 @@ func (s *Solver) Bridge(b solver.Builder) frontend.FrontendLLBBridge {
 func (s *Solver) recordBuildHistory(ctx context.Context, id string, req frontend.SolveRequest, exp ExporterRequest, j *solver.Job, usage *resources.SysSampler) (func(context.Context, *Result, []exporter.DescriptorReference, error) error, error) {
 	stopTrace, err := detect.Recorder.Record(ctx)
 	if err != nil {
-		return nil, err
+		return nil, errdefs.Internal(err)
 	}
 
 	st := time.Now()
@@ -183,7 +184,7 @@ func (s *Solver) recordBuildHistory(ctx context.Context, id string, req frontend
 		if stopTrace != nil {
 			stopTrace()
 		}
-		return nil, err
+		return nil, errdefs.Internal(err)
 	}
 
 	return func(ctx context.Context, res *Result, descrefs []exporter.DescriptorReference, err error) error {
@@ -370,7 +371,8 @@ func (s *Solver) recordBuildHistory(ctx context.Context, id string, req frontend
 			})
 		}
 		if err1 := eg.Wait(); err == nil {
-			err = err1
+			// any error from exporting history record is internal
+			err = errdefs.Internal(err1)
 		}
 
 		defer func() {
@@ -397,7 +399,7 @@ func (s *Solver) recordBuildHistory(ctx context.Context, id string, req frontend
 			Record: rec,
 		}); err1 != nil {
 			if err == nil {
-				err = err1
+				err = errdefs.Internal(err1)
 			}
 		}
 

--- a/solver/scheduler.go
+++ b/solver/scheduler.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/moby/buildkit/errdefs"
 	"github.com/moby/buildkit/solver/internal/pipe"
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/cond"
@@ -403,7 +404,7 @@ func (pf *pipeFactory) NewInputRequest(ee Edge, req *edgeRequest) pipe.Receiver 
 			WithField("edge_index", ee.Index).
 			Error("failed to get edge: inconsistent graph state")
 		return pf.NewFuncRequest(func(_ context.Context) (interface{}, error) {
-			return nil, errors.Errorf("failed to get edge: inconsistent graph state in edge %s %s %d", ee.Vertex.Name(), ee.Vertex.Digest(), ee.Index)
+			return nil, errdefs.Internal(errors.Errorf("failed to get edge: inconsistent graph state in edge %s %s %d", ee.Vertex.Name(), ee.Vertex.Digest(), ee.Index))
 		})
 	}
 	p := pf.s.newPipe(target, pf.e, pipe.Request{Payload: req})

--- a/util/grpcerrors/grpcerrors.go
+++ b/util/grpcerrors/grpcerrors.go
@@ -10,6 +10,7 @@ import (
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/golang/protobuf/proto" //nolint:staticcheck
 	"github.com/golang/protobuf/ptypes/any"
+	"github.com/moby/buildkit/errdefs"
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/stack"
 	spb "google.golang.org/genproto/googleapis/rpc/status"
@@ -94,6 +95,10 @@ func withDetails(ctx context.Context, s *status.Status, details ...proto.Message
 }
 
 func Code(err error) codes.Code {
+	if errdefs.IsInternal(err) {
+		return codes.Internal
+	}
+
 	if se, ok := err.(interface {
 		Code() codes.Code
 	}); ok {


### PR DESCRIPTION
Error during creating history or failure in graph concistency checks are signs of either bugs or system configuration issue. This makes sure that gRPC error code in the API error based on these cases has correct value to signify it.

This doesn't of course cover all the possible cases where error return from BuildKit could be considered internal, but can be used as a proof of concept.