### PR TITLE
errors: remove usage of errors.Cause

### DIFF
--- a/cache/util/fsutil_test.go
+++ b/cache/util/fsutil_test.go
@@ -1,0 +1,31 @@
+package util
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tonistiigi/fsutil"
+)
+
+// TestSetErrorPath ensures that modifying the os.PathError from fsutil.Stat
+// modifies the error message appropriately.
+//
+// This method of modifying the path error is an implementation
+// detail of how the error is returned. It isn't necessarily the
+// case that this will always work if the underlying library changes.
+func TestSetErrorPath(t *testing.T) {
+	// Temporary directory to reduce the chance of using stat on a real file.
+	dir := t.TempDir()
+
+	// Random path that shouldn't exist.
+	fpath := path.Join(dir, "a/b/c")
+	_, err := fsutil.Stat(fpath)
+	require.Error(t, err)
+
+	require.ErrorContains(t, err, "a/b/c")
+	// Set the path in the error to a new path.
+	replaceErrorPath(err, "/my/new/path")
+	require.NotContains(t, err.Error(), "a/b/c")
+	require.Contains(t, err.Error(), "/my/new/path")
+}

--- a/util/resolver/retryhandler/retry.go
+++ b/util/resolver/retryhandler/retry.go
@@ -64,11 +64,7 @@ func retryError(err error) bool {
 		return true
 	}
 	// catches TLS timeout or other network-related temporary errors
-	if ne, ok := errors.Cause(err).(net.Error); ok && ne.Temporary() { //nolint:staticcheck // ignoring "SA1019: Temporary is deprecated", continue to propagate net.Error through the "temporary" status
-		return true
-	}
-	// https://github.com/containerd/containerd/pull/4724
-	if errors.Cause(err).Error() == "no response" {
+	if ne := net.Error(nil); errors.As(err, &ne) && ne.Temporary() { //nolint:staticcheck // ignoring "SA1019: Temporary is deprecated", continue to propagate net.Error through the "temporary" status
 		return true
 	}
 

--- a/util/system/path_test.go
+++ b/util/system/path_test.go
@@ -3,7 +3,6 @@ package system
 import (
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -77,7 +76,7 @@ func TestNormalizeWorkdir(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := NormalizeWorkdir(tc.currentWorkdir, tc.newWorkDir, "linux")
 			if tc.err != "" {
-				require.EqualError(t, errors.Cause(err), tc.err)
+				require.ErrorContains(t, err, tc.err)
 			} else {
 				require.NoError(t, err)
 			}
@@ -300,7 +299,7 @@ func TestNormalizeWorkdirWindows(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := NormalizeWorkdir(tc.currentWorkdir, tc.newWorkDir, "windows")
 			if tc.err != "" {
-				require.EqualError(t, errors.Cause(err), tc.err)
+				require.ErrorContains(t, err, tc.err)
 			} else {
 				require.NoError(t, err)
 			}
@@ -365,7 +364,7 @@ func TestNormalizeWorkdirUnix(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := NormalizeWorkdir(tc.currentWorkdir, tc.newWorkDir, "linux")
 			if tc.err != "" {
-				require.EqualError(t, errors.Cause(err), tc.err)
+				require.ErrorContains(t, err, tc.err)
 			} else {
 				require.NoError(t, err)
 			}


### PR DESCRIPTION
This removes usages of `errors.Cause` in favor of using `errors.As` which is the more standard way of handling error causes. `Cause` was not used frequently and `errors.As` is part of the standard library and is supported by `github.com/pkg/errors`.

For one usage of `errors.Cause`, the underlying implementation itself has a reliance on the internal implementation of the error being returned and this method isn't guaranteed to work. Since we are relying on an implementation detail and not an API, I've added a test to ensure the behavior continues working as designed.

This also removes a check for an error being returned from containerd that has since been fixed so the code is dead.