### PR TITLE
dockerui: allow passing sessionID for specific local source

### DIFF
--- a/frontend/dockerui/attr.go
+++ b/frontend/dockerui/attr.go
@@ -125,6 +125,16 @@ func parseSourceDateEpoch(v string) (*time.Time, error) {
 	return &tm, nil
 }
 
+func parseLocalSessionIDs(opt map[string]string) map[string]string {
+	m := map[string]string{}
+	for k, v := range opt {
+		if strings.HasPrefix(k, localSessionIDPrefix) {
+			m[strings.TrimPrefix(k, localSessionIDPrefix)] = v
+		}
+	}
+	return m
+}
+
 func filter(opt map[string]string, key string) map[string]string {
 	m := map[string]string{}
 	for k, v := range opt {

--- a/frontend/dockerui/namedcontext.go
+++ b/frontend/dockerui/namedcontext.go
@@ -187,8 +187,12 @@ func (bc *Client) namedContextRecursive(ctx context.Context, name string, nameWi
 		}
 		return &st, &img, nil
 	case "local":
+		sessionID := bc.bopts.SessionID
+		if v, ok := bc.localsSessionIDs[vv[1]]; ok {
+			sessionID = v
+		}
 		st := llb.Local(vv[1],
-			llb.SessionID(bc.bopts.SessionID),
+			llb.SessionID(sessionID),
 			llb.FollowPaths([]string{DefaultDockerignoreName}),
 			llb.SharedKeyHint("context:"+nameWithPlatform+"-"+DefaultDockerignoreName),
 			llb.WithCustomName("[context "+nameWithPlatform+"] load "+DefaultDockerignoreName),
@@ -226,7 +230,7 @@ func (bc *Client) namedContextRecursive(ctx context.Context, name string, nameWi
 		localOutput := &asyncLocalOutput{
 			name:             vv[1],
 			nameWithPlatform: nameWithPlatform,
-			sessionID:        bc.bopts.SessionID,
+			sessionID:        sessionID,
 			excludes:         excludes,
 			extraOpts:        opt.AsyncLocalOpts,
 		}


### PR DESCRIPTION
This allows frontend to associate a specific local to specific session when it is assembling LLB. It can be used to create builds using files from multiple sessions or multiple builds to use the same session that is different from default session for the build request.