### PR TITLE
session: remove session name property

### DIFF
--- a/client/solve.go
+++ b/client/solve.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"maps"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -120,7 +119,7 @@ func (c *Client) solve(ctx context.Context, def *llb.Definition, runGateway runG
 		if opt.SessionPreInitialized {
 			return nil, errors.Errorf("no session provided for preinitialized option")
 		}
-		s, err = session.NewSession(statusContext, defaultSessionName(), opt.SharedKey)
+		s, err = session.NewSession(statusContext, opt.SharedKey)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create session")
 		}
@@ -417,14 +416,6 @@ func prepareSyncedFiles(def *llb.Definition, localMounts map[string]fsutil.FS) (
 		}
 	}
 	return result, nil
-}
-
-func defaultSessionName() string {
-	wd, err := os.Getwd()
-	if err != nil {
-		return "unknown"
-	}
-	return filepath.Base(wd)
 }
 
 type cacheOptions struct {

--- a/session/content/content_test.go
+++ b/session/content/content_test.go
@@ -40,7 +40,7 @@ func TestContentAttachable(t *testing.T) {
 		}
 	}
 
-	s, err := session.NewSession(ctx, "foo", "bar")
+	s, err := session.NewSession(ctx, "bar")
 	require.NoError(t, err)
 
 	m, err := session.NewManager()

--- a/session/filesync/filesync_test.go
+++ b/session/filesync/filesync_test.go
@@ -30,7 +30,7 @@ func TestFileSyncIncludePatterns(t *testing.T) {
 	err = os.WriteFile(filepath.Join(tmpDir, "bar"), []byte("content2"), 0600)
 	require.NoError(t, err)
 
-	s, err := session.NewSession(ctx, "foo", "bar")
+	s, err := session.NewSession(ctx, "bar")
 	require.NoError(t, err)
 
 	m, err := session.NewManager()

--- a/session/manager.go
+++ b/session/manager.go
@@ -16,7 +16,6 @@ type Caller interface {
 	Context() context.Context
 	Supports(method string) bool
 	Conn() *grpc.ClientConn
-	Name() string
 	SharedKey() string
 }
 
@@ -106,7 +105,6 @@ func (sm *Manager) handleConn(ctx context.Context, conn net.Conn, opts map[strin
 
 	h := http.Header(opts)
 	id := h.Get(headerSessionID)
-	name := h.Get(headerSessionName)
 	sharedKey := h.Get(headerSessionSharedKey)
 
 	ctx, cc, err := grpcClientConn(ctx, conn)
@@ -118,7 +116,6 @@ func (sm *Manager) handleConn(ctx context.Context, conn net.Conn, opts map[strin
 	c := &client{
 		Session: Session{
 			id:        id,
-			name:      name,
 			sharedKey: sharedKey,
 			ctx:       ctx,
 			cancelCtx: cancel,
@@ -195,10 +192,6 @@ func (sm *Manager) Get(ctx context.Context, id string, noWait bool) (Caller, err
 
 func (c *client) Context() context.Context {
 	return c.context()
-}
-
-func (c *client) Name() string {
-	return c.name
 }
 
 func (c *client) SharedKey() string {

--- a/session/session.go
+++ b/session/session.go
@@ -38,7 +38,6 @@ type Attachable interface {
 type Session struct {
 	mu          sync.Mutex // synchronizes conn run and close
 	id          string
-	name        string
 	sharedKey   string
 	ctx         context.Context
 	cancelCtx   func(error)
@@ -49,7 +48,7 @@ type Session struct {
 }
 
 // NewSession returns a new long running session
-func NewSession(ctx context.Context, name, sharedKey string) (*Session, error) {
+func NewSession(ctx context.Context, sharedKey string) (*Session, error) {
 	id := identity.NewID()
 
 	serverOpts := []grpc.ServerOption{
@@ -67,7 +66,6 @@ func NewSession(ctx context.Context, name, sharedKey string) (*Session, error) {
 
 	s := &Session{
 		id:         id,
-		name:       name,
 		sharedKey:  sharedKey,
 		grpcServer: grpc.NewServer(serverOpts...),
 	}
@@ -103,7 +101,6 @@ func (s *Session) Run(ctx context.Context, dialer Dialer) error {
 
 	meta := make(map[string][]string)
 	meta[headerSessionID] = []string{s.id}
-	meta[headerSessionName] = []string{s.name}
 	meta[headerSessionSharedKey] = []string{s.sharedKey}
 
 	for name, svc := range s.grpcServer.GetServiceInfo() {


### PR DESCRIPTION
This seems to be completely unused.

I believe it is remnant of pre-buildkit session implementation and was used for either logging of some transfer reuse.