### PR TITLE
llbsolver: avoid nil releaser on error

### DIFF
--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -385,9 +385,10 @@ func (s *Solver) recordBuildHistory(ctx context.Context, id string, req frontend
 			if err1 != nil {
 				// don't replace the build error with this import error
 				bklog.G(ctx).Errorf("failed to import error to build record: %+v", err1)
+			} else {
+				releasers = append(releasers, release)
 			}
 			rec.ExternalError = desc
-			releasers = append(releasers, release)
 			rec.Error = status
 		}
 


### PR DESCRIPTION
Theoretically this can result in panic so adding to v0.15 milestone