### PR TITLE
db: move DB dependencies to transactor interface

### DIFF
--- a/cache/metadata/metadata.go
+++ b/cache/metadata/metadata.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 
 	"github.com/moby/buildkit/util/bklog"
+	"github.com/moby/buildkit/util/db"
+	"github.com/moby/buildkit/util/db/boltutil"
 	"github.com/pkg/errors"
 	bolt "go.etcd.io/bbolt"
 )
@@ -21,18 +23,18 @@ const (
 var errNotFound = errors.Errorf("not found")
 
 type Store struct {
-	db *bolt.DB
+	db db.DB
 }
 
 func NewStore(dbPath string) (*Store, error) {
-	db, err := bolt.Open(dbPath, 0600, nil)
+	db, err := boltutil.Open(dbPath, 0600, nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to open database file %s", dbPath)
 	}
 	return &Store{db: db}, nil
 }
 
-func (s *Store) DB() *bolt.DB {
+func (s *Store) DB() db.Transactor {
 	return s.db
 }
 
@@ -183,21 +185,28 @@ func (s *Store) Get(id string) (*StorageItem, bool) {
 		si, _ := newStorageItem(id, nil, s)
 		return si
 	}
-	tx, err := s.db.Begin(false)
-	if err != nil {
+
+	var si *StorageItem
+	if err := s.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(mainBucket))
+		if b == nil {
+			return nil
+		}
+		b = b.Bucket([]byte(id))
+		if b == nil {
+			return nil
+		}
+		si, _ = newStorageItem(id, b, s)
+		return nil
+	}); err != nil {
 		return empty(), false
 	}
-	defer tx.Rollback()
-	b := tx.Bucket([]byte(mainBucket))
-	if b == nil {
-		return empty(), false
+
+	if si != nil {
+		return si, true
 	}
-	b = b.Bucket([]byte(id))
-	if b == nil {
-		return empty(), false
-	}
-	si, _ := newStorageItem(id, b, s)
-	return si, true
+
+	return empty(), false
 }
 
 func (s *Store) Close() error {

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -46,6 +46,7 @@ import (
 	"github.com/moby/buildkit/util/appdefaults"
 	"github.com/moby/buildkit/util/archutil"
 	"github.com/moby/buildkit/util/bklog"
+	"github.com/moby/buildkit/util/db/boltutil"
 	"github.com/moby/buildkit/util/grpcerrors"
 	"github.com/moby/buildkit/util/profiler"
 	"github.com/moby/buildkit/util/resolver"
@@ -62,7 +63,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
-	"go.etcd.io/bbolt"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/exporters/prometheus"
 	"go.opentelemetry.io/otel/propagation"
@@ -804,7 +804,7 @@ func newController(c *cli.Context, cfg *config.Config) (*control.Controller, err
 		return nil, err
 	}
 
-	historyDB, err := bbolt.Open(filepath.Join(cfg.Root, "history.db"), 0600, nil)
+	historyDB, err := boltutil.Open(filepath.Join(cfg.Root, "history.db"), 0600, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/control/control.go
+++ b/control/control.go
@@ -35,6 +35,7 @@ import (
 	"github.com/moby/buildkit/solver/llbsolver/proc"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/bklog"
+	"github.com/moby/buildkit/util/db"
 	"github.com/moby/buildkit/util/imageutil"
 	"github.com/moby/buildkit/util/leaseutil"
 	"github.com/moby/buildkit/util/throttle"
@@ -43,7 +44,6 @@ import (
 	"github.com/moby/buildkit/worker"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
-	"go.etcd.io/bbolt"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	tracev1 "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	"golang.org/x/sync/errgroup"
@@ -62,7 +62,7 @@ type Opt struct {
 	ResolveCacheImporterFuncs map[string]remotecache.ResolveCacheImporterFunc
 	Entitlements              []string
 	TraceCollector            sdktrace.SpanExporter
-	HistoryDB                 *bbolt.DB
+	HistoryDB                 db.DB
 	CacheStore                *bboltcachestorage.Store
 	LeaseManager              *leaseutil.Manager
 	ContentStore              *containerdsnapshot.Store

--- a/solver/bboltcachestorage/storage_test.go
+++ b/solver/bboltcachestorage/storage_test.go
@@ -16,7 +16,7 @@ func TestBoltCacheStorage(t *testing.T) {
 		st, err := NewStore(filepath.Join(tmpDir, "cache.db"))
 		require.NoError(t, err)
 		t.Cleanup(func() {
-			require.NoError(t, st.db.Close())
+			require.NoError(t, st.Close())
 		})
 
 		return st

--- a/solver/llbsolver/history.go
+++ b/solver/llbsolver/history.go
@@ -22,6 +22,7 @@ import (
 	"github.com/moby/buildkit/cmd/buildkitd/config"
 	"github.com/moby/buildkit/identity"
 	containerdsnapshot "github.com/moby/buildkit/snapshot/containerd"
+	"github.com/moby/buildkit/util/db"
 	"github.com/moby/buildkit/util/grpcerrors"
 	"github.com/moby/buildkit/util/iohelper"
 	"github.com/moby/buildkit/util/leaseutil"
@@ -39,7 +40,7 @@ const (
 )
 
 type HistoryQueueOpt struct {
-	DB           *bolt.DB
+	DB           db.Transactor
 	LeaseManager *leaseutil.Manager
 	ContentStore *containerdsnapshot.Store
 	CleanConfig  *config.HistoryConfig

--- a/util/db/boltutil/db.go
+++ b/util/db/boltutil/db.go
@@ -1,0 +1,16 @@
+package boltutil
+
+import (
+	"io/fs"
+
+	"github.com/moby/buildkit/util/db"
+	bolt "go.etcd.io/bbolt"
+)
+
+func Open(p string, mode fs.FileMode, options *bolt.Options) (db.DB, error) {
+	bdb, err := bolt.Open(p, mode, options)
+	if err != nil {
+		return nil, err
+	}
+	return bdb, nil
+}

--- a/util/db/db.go
+++ b/util/db/db.go
@@ -1,0 +1,8 @@
+package db
+
+import "io"
+
+type DB interface {
+	io.Closer
+	Transactor
+}

--- a/util/db/transactor.go
+++ b/util/db/transactor.go
@@ -1,0 +1,11 @@
+package db
+
+import (
+	bolt "go.etcd.io/bbolt"
+)
+
+// Transactor is the database interface for running transactions
+type Transactor interface {
+	View(fn func(*bolt.Tx) error) error
+	Update(fn func(*bolt.Tx) error) error
+}


### PR DESCRIPTION
This allows more flexible control over DB transactions and compaction.

Similar change for containerd's boltdb is coming in containerd v2 https://github.com/containerd/containerd/pull/10385