### PR TITLE
ci: sync labels when files are reverted or no longer changed with labeler

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -17,3 +17,5 @@ jobs:
       -
         name: Run
         uses: actions/labeler@v5
+        with:
+          sync-labels: true


### PR DESCRIPTION
relates to https://github.com/moby/buildkit/pull/515

When someone opens a PR and push new changes where files are reverted or no longer changed, the labels are not synced: https://github.com/moby/buildkit/pull/5139

![image](https://github.com/user-attachments/assets/bff86cb3-4548-4f68-8889-340654182d29)

![image](https://github.com/user-attachments/assets/f8e5ecc4-e562-4768-b4c6-f6f07a7c2377)

I think we should use the `sync-labels` opt: https://github.com/actions/labeler?tab=readme-ov-file#inputs

I just wonder what this will do if we set a label manually so I'm going to test that in this one.