### PR TITLE
fix: check network mode when choosing resolv.conf

### DIFF
--- a/executor/oci/resolvconf_test.go
+++ b/executor/oci/resolvconf_test.go
@@ -111,15 +111,16 @@ func TestResolvConf(t *testing.T) {
 			t.Cleanup(func() {
 				resolvconfPath = oldResolvconfPath
 			})
-			resolvconfPath = func() string {
-				if tt.dt == nil {
-					return "no-such-file"
-				}
-				rpath := path.Join(t.TempDir(), "resolv.conf")
-				require.NoError(t, os.WriteFile(rpath, tt.dt, 0600))
-				return rpath
-			}
 			for i := 0; i < tt.execution; i++ {
+				resolvconfPath = func(netMode pb.NetMode) string {
+					if tt.dt == nil {
+						return "no-such-file"
+					}
+					rpath := path.Join(t.TempDir(), "resolv.conf")
+					require.NoError(t, os.WriteFile(rpath, tt.dt, 0600))
+					require.Equal(t, tt.networkMode[i], netMode)
+					return rpath
+				}
 				if i > 0 {
 					time.Sleep(100 * time.Millisecond)
 				}


### PR DESCRIPTION
Hi,

this fixes #2404 . Instead of always checking for systemd-resolved it's sufficient to do so only if the run does not happen within the host networking mode.

I was a bit unsure what happens [here](https://github.com/moby/buildkit/blob/bc92b63b98aa0968614240082997483f6bf68cbe/executor/oci/resolvconf.go#L38) and if it might get problematic in consecutive builds with different networking modes. Maybe someone can explain this to me.

BR Kai