### PR TITLE
docs: emphasize the fact that secrets aren't saved in cache

### DIFF
--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -669,13 +669,13 @@ This can be used to:
 
 The supported mount types are:
 
-| Type                                     | Description                                                                                               |
-| ---------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| [`bind`](#run---mounttypebind) (default) | Bind-mount context directories (read-only).                                                               |
-| [`cache`](#run---mounttypecache)         | Mount a temporary directory to cache directories for compilers and package managers.                      |
-| [`tmpfs`](#run---mounttypetmpfs)         | Mount a `tmpfs` in the build container.                                                                   |
-| [`secret`](#run---mounttypesecret)       | Allow the build container to access secure files such as private keys without baking them into the image. |
-| [`ssh`](#run---mounttypessh)             | Allow the build container to access SSH keys via SSH agents, with support for passphrases.                |
+| Type                                     | Description                                                                                                               |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------                 |
+| [`bind`](#run---mounttypebind) (default) | Bind-mount context directories (read-only).                                                                               |
+| [`cache`](#run---mounttypecache)         | Mount a temporary directory to cache directories for compilers and package managers.                                      |
+| [`tmpfs`](#run---mounttypetmpfs)         | Mount a `tmpfs` in the build container.                                                                                   |
+| [`secret`](#run---mounttypesecret)       | Allow the build container to access secure files such as private keys without baking them into the image and build cache. |
+| [`ssh`](#run---mounttypessh)             | Allow the build container to access SSH keys via SSH agents, with support for passphrases.                                |
 
 ### RUN --mount=type=bind
 

--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -669,13 +669,13 @@ This can be used to:
 
 The supported mount types are:
 
-| Type                                     | Description                                                                                                               |
-| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------                 |
-| [`bind`](#run---mounttypebind) (default) | Bind-mount context directories (read-only).                                                                               |
-| [`cache`](#run---mounttypecache)         | Mount a temporary directory to cache directories for compilers and package managers.                                      |
-| [`tmpfs`](#run---mounttypetmpfs)         | Mount a `tmpfs` in the build container.                                                                                   |
-| [`secret`](#run---mounttypesecret)       | Allow the build container to access secure files such as private keys without baking them into the image and build cache. |
-| [`ssh`](#run---mounttypessh)             | Allow the build container to access SSH keys via SSH agents, with support for passphrases.                                |
+| Type                                     | Description                                                                                                              |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------                |
+| [`bind`](#run---mounttypebind) (default) | Bind-mount context directories (read-only).                                                                              |
+| [`cache`](#run---mounttypecache)         | Mount a temporary directory to cache directories for compilers and package managers.                                     |
+| [`tmpfs`](#run---mounttypetmpfs)         | Mount a `tmpfs` in the build container.                                                                                  |
+| [`secret`](#run---mounttypesecret)       | Allow the build container to access secure files such as private keys without baking them into the image or build cache. |
+| [`ssh`](#run---mounttypessh)             | Allow the build container to access SSH keys via SSH agents, with support for passphrases.                               |
 
 ### RUN --mount=type=bind
 


### PR DESCRIPTION
I was reading through the documentation trying to understand what's so
special about secret type mount except for extra options it takes as I
found that contents of bind mount doesn't get baked into the image too
but it can be found in /var/lib/docker in contrary to secret type
mount. I've learned that secret type mount uses tmpfs under the hood
and my findings were confirmed by
https://docs.docker.com/build/cache/invalidation/#general-rules: 'The
contents of build secrets are not part of the build cache.'. I think
it's worth emphasizing in the documentation.

Fixes https://github.com/docker/docs/issues/20436.

Signed-off-by: Arkadiusz Drabczyk <arkadiusz@drabczyk.org>
