### PR TITLE
feat: support lfs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -195,7 +195,7 @@ FROM scratch AS release
 COPY --link --from=releaser /out/ /
 
 FROM alpine:${ALPINE_VERSION} AS buildkit-export
-RUN apk add --no-cache fuse3 git openssh pigz xz iptables ip6tables \
+RUN apk add --no-cache fuse3 git git-lfs openssh pigz xz iptables ip6tables \
   && ln -s fusermount3 /usr/bin/fusermount
 COPY --link examples/buildctl-daemonless/buildctl-daemonless.sh /usr/bin/
 VOLUME /var/lib/buildkit

--- a/source/git/source.go
+++ b/source/git/source.go
@@ -539,6 +539,14 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context, g session.Group) (out 
 		if err != nil {
 			return nil, err
 		}
+		_, err = checkoutGit.Run(ctx, "lfs", "install", "--local")
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to install lfs for repo at %s", checkoutDir)
+		}
+		_, err = checkoutGit.Run(ctx, "config", "lfs.url", gs.src.Remote+"/info/lfs")
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to set lfs.url for remote %s", urlutil.RedactCredentials(gs.src.Remote))
+		}
 
 		gitCatFileBuf, err := git.Run(ctx, "cat-file", "-t", ref)
 		if err != nil {
@@ -587,6 +595,10 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context, g session.Group) (out 
 			}
 		}
 		checkoutGit := git.New(gitutil.WithWorkTree(cd), gitutil.WithGitDir(gitDir))
+		_, err = checkoutGit.Run(ctx, "lfs", "install", "--local")
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to install lfs for repo at %s", cd)
+		}
 		_, err = checkoutGit.Run(ctx, "checkout", ref, "--", ".")
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to checkout remote %s", urlutil.RedactCredentials(gs.src.Remote))


### PR DESCRIPTION
With the development of AI, more and more Git repositories use LFS to store model weights. The `ADD` command already supports pulling from Git URLs, https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/reference.md#adding-files-from-a-url. This PR intends to support the `ADD` command to pull content managed by Git LFS.