### PR TITLE
frontend: allow mounting secret environment variables

### DIFF
--- a/client/llb/exec.go
+++ b/client/llb/exec.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"sort"
+	"strings"
 
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/system"
@@ -290,7 +291,7 @@ func (e *ExecOp) Marshal(ctx context.Context, c *Constraints) (digest.Digest, []
 	if len(e.secrets) > 0 {
 		addCap(&e.constraints, pb.CapExecMountSecret)
 		for _, s := range e.secrets {
-			if s.IsEnv {
+			if s.Env != nil {
 				addCap(&e.constraints, pb.CapExecSecretEnv)
 				break
 			}
@@ -388,16 +389,17 @@ func (e *ExecOp) Marshal(ctx context.Context, c *Constraints) (digest.Digest, []
 	}
 
 	for _, s := range e.secrets {
-		if s.IsEnv {
+		if s.Env != nil {
 			peo.Secretenv = append(peo.Secretenv, &pb.SecretEnv{
 				ID:       s.ID,
-				Name:     s.Target,
+				Name:     *s.Env,
 				Optional: s.Optional,
 			})
-		} else {
+		}
+		if s.Target != nil {
 			pm := &pb.Mount{
 				Input:     pb.Empty,
-				Dest:      s.Target,
+				Dest:      *s.Target,
 				MountType: pb.MountType_SECRET,
 				SecretOpt: &pb.SecretOpt{
 					ID:       s.ID,
@@ -680,7 +682,19 @@ type SSHInfo struct {
 // AddSecret is a RunOption that adds a secret to the exec.
 func AddSecret(dest string, opts ...SecretOption) RunOption {
 	return runOptionFunc(func(ei *ExecInfo) {
-		s := &SecretInfo{ID: dest, Target: dest, Mode: 0400}
+		s := &SecretInfo{ID: dest, Target: &dest, Mode: 0400}
+		for _, opt := range opts {
+			opt.SetSecretOption(s)
+		}
+		ei.Secrets = append(ei.Secrets, *s)
+	})
+}
+
+// AddSecretWithDest is a RunOption that adds a secret to the exec
+// with an optional destination.
+func AddSecretWithDest(src string, dest *string, opts ...SecretOption) RunOption {
+	return runOptionFunc(func(ei *ExecInfo) {
+		s := &SecretInfo{ID: src, Target: dest, Mode: 0400}
 		for _, opt := range opts {
 			opt.SetSecretOption(s)
 		}
@@ -699,13 +713,15 @@ func (fn secretOptionFunc) SetSecretOption(si *SecretInfo) {
 }
 
 type SecretInfo struct {
-	ID       string
-	Target   string
+	ID string
+	// Target optionally specifies the target for the secret mount
+	Target *string
+	// Env optionally names the environment variable for the secret
+	Env      *string
 	Mode     int
 	UID      int
 	GID      int
 	Optional bool
-	IsEnv    bool
 }
 
 var SecretOptional = secretOptionFunc(func(si *SecretInfo) {
@@ -721,7 +737,24 @@ func SecretID(id string) SecretOption {
 // SecretAsEnv defines if the secret should be added as an environment variable
 func SecretAsEnv(v bool) SecretOption {
 	return secretOptionFunc(func(si *SecretInfo) {
-		si.IsEnv = v
+		if !v {
+			si.Env = nil
+			return
+		}
+		if si.Target == nil {
+			return
+		}
+		target := strings.Clone(*si.Target)
+		si.Env = &target
+		si.Target = nil
+	})
+}
+
+// SecretAsEnvName defines if the secret should be added as an environment variable
+// with the specified name
+func SecretAsEnvName(v string) SecretOption {
+	return secretOptionFunc(func(si *SecretInfo) {
+		si.Env = &v
 	})
 }
 

--- a/frontend/dockerfile/instructions/commands_runmount.go
+++ b/frontend/dockerfile/instructions/commands_runmount.go
@@ -122,9 +122,12 @@ type Mount struct {
 	CacheID      string
 	CacheSharing ShareMode
 	Required     bool
-	Mode         *uint64
-	UID          *uint64
-	GID          *uint64
+	// Env optionally specifies the name of the environment variable for a secret.
+	// A pointer to an empty value uses the default
+	Env  *string
+	Mode *uint64
+	UID  *uint64
+	GID  *uint64
 }
 
 func parseMount(val string, expander SingleWordExpander) (*Mount, error) {
@@ -252,9 +255,11 @@ func parseMount(val string, expander SingleWordExpander) (*Mount, error) {
 				return nil, errors.Errorf("invalid value %s for gid", value)
 			}
 			m.GID = &gid
+		case "env":
+			m.Env = &value
 		default:
 			allKeys := []string{
-				"type", "from", "source", "target", "readonly", "id", "sharing", "required", "size", "mode", "uid", "gid", "src", "dst", "destination", "ro", "rw", "readwrite",
+				"type", "from", "source", "target", "readonly", "id", "sharing", "required", "size", "mode", "uid", "gid", "src", "dst", "destination", "ro", "rw", "readwrite", "env",
 			}
 			return nil, suggest.WrapError(errors.Errorf("unexpected key '%s' in '%s'", key, field), key, allKeys, true)
 		}


### PR DESCRIPTION
Implements frontend side of #2122.

This adds the syntax to Dockerfile frontend.
I purposefully chose to use a simple format for this as it's likely going to be debated. As implemented, the following format is supported:

```dockerfile
RUN --mount=type=secret,id=MYSECRET,env
```
or, more explicitly:

```dockerfile
RUN --mount=type=secret,id=mysecret,env=MYSECRET
```

will mount the secret with id `mysecret` as a new environment variable with the name `MYSECRET`).

Either way, the secret will be mounted as a file (existing behavior).
Note, that this already implements a suggestion from the PR comments.

Any suggestions on making it even more ergonomic or straightforward are welcome.