### PR TITLE
tests: frontend/dockerfile: add dockerfile lint tests for WCOW

### DIFF
--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -236,7 +236,7 @@ func init() {
 
 	images := integration.UnixOrWindows(
 		[]string{"busybox:latest", "alpine:latest"},
-		[]string{"nanoserver:latest", "nanoserver:plus"})
+		[]string{"nanoserver:latest", "nanoserver:plus", "nanoserver:plus-busybox"})
 	opts = []integration.TestOpt{
 		integration.WithMirroredImages(integration.OfficialImages(images...)),
 		integration.WithMatrix("frontend", frontends),

--- a/util/testutil/integration/util_windows.go
+++ b/util/testutil/integration/util_windows.go
@@ -19,7 +19,8 @@ var windowsImagesMirrorMap = map[string]string{
 	// nanoserver with extra binaries, like fc.exe
 	// TODO(profnandaa): get an approved/compliant repo, placeholder for now
 	// see dockerfile here - https://github.com/microsoft/windows-container-tools/pull/178
-	"nanoserver:plus": "docker.io/wintools/nanoserver:ltsc2022",
+	"nanoserver:plus":         "docker.io/wintools/nanoserver:ltsc2022",
+	"nanoserver:plus-busybox": "docker.io/wintools/nanoserver:ltsc2022",
 }
 
 // abstracted function to handle pipe dialing on windows.


### PR DESCRIPTION
A number of integration tests were initially skipped on Windows, waiting for their platform-specific translations. See #4485.

This commit enables all the dockerfile linter tests that had been skipped before. Some of the tests did not need any platform specific change since the lint warning were being generated before actual image pull.