### PR TITLE
ci: missing tags to be scanned with scout

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -216,7 +216,7 @@ jobs:
         run: |
           ./hack/images "${{ needs.prepare.outputs.tag }}" "$IMAGE_NAME" "${{ needs.prepare.outputs.push }}"
         env:
-          RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
+          RELEASE: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
           TARGET: ${{ matrix.target-stage }}
           CACHE_FROM: type=gha,scope=image${{ matrix.target-stage }}
           CACHE_TO: type=gha,scope=image${{ matrix.target-stage }}

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -230,6 +230,12 @@ jobs:
       security-events: write
     needs:
       - image
+    strategy:
+      fail-fast: false
+      matrix:
+        tag:
+          - master
+          - master-rootless
     steps:
       -
         name: Checkout
@@ -247,7 +253,7 @@ jobs:
         with:
           version: ${{ env.SCOUT_VERSION }}
           format: sarif
-          image: registry://${{ env.IMAGE_NAME }}:master
+          image: registry://${{ env.IMAGE_NAME }}:${{ matrix.tag }}
       -
         name: Upload SARIF report
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -121,7 +121,7 @@ jobs:
         run: |
           ./frontend/dockerfile/cmd/dockerfile-frontend/hack/release "${{ needs.prepare.outputs.typ }}" "${{ matrix.tag }}" "$IMAGE_NAME" "${{ needs.prepare.outputs.push }}"
         env:
-          RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
+          RELEASE: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
           CACHE_FROM: type=gha,scope=${{ env.CACHE_SCOPE }}
           CACHE_TO: type=gha,scope=${{ env.CACHE_SCOPE }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -134,6 +134,12 @@ jobs:
       security-events: write
     needs:
       - image
+    strategy:
+      fail-fast: false
+      matrix:
+        tag:
+          - master
+          - master-labs
     steps:
       -
         name: Checkout
@@ -151,7 +157,7 @@ jobs:
         with:
           version: ${{ env.SCOUT_VERSION }}
           format: sarif
-          image: registry://${{ env.IMAGE_NAME }}:master
+          image: registry://${{ env.IMAGE_NAME }}:${{ matrix.tag }}
       -
         name: Upload SARIF report
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
Scan `master-rootless` tag for buildkit image and `master-labs` tag for dockerfile frontend with Scout.

Last commit make sure no-cache-filter is applied when master images are being built so we are aligned with release workflow to avoid Scout reporting false positives like https://github.com/moby/buildkit/security/code-scanning/6 that is already fixed in Alpine packages: https://pkgs.alpinelinux.org/package/v3.20/main/x86_64/libcurl