### PR TITLE
ci: print scout result

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -255,6 +255,10 @@ jobs:
           format: sarif
           image: registry://${{ env.IMAGE_NAME }}:${{ matrix.tag }}
       -
+        name: Result output
+        run: |
+          jq . ${{ steps.scout.outputs.result-file }}
+      -
         name: Upload SARIF report
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -24,7 +24,7 @@ env:
   GO_VERSION: "1.22"
   SETUP_BUILDX_VERSION: "latest"
   SETUP_BUILDKIT_IMAGE: "moby/buildkit:latest"
-  SCOUT_VERSION: "1.11.0"
+  SCOUT_VERSION: "1.13.0"
   IMAGE_NAME: "moby/buildkit"
   PLATFORMS: "linux/amd64,linux/arm/v7,linux/arm64,linux/s390x,linux/ppc64le,linux/riscv64"
   DESTDIR: "./bin"

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -22,7 +22,7 @@ env:
   GO_VERSION: "1.22"
   SETUP_BUILDX_VERSION: "latest"
   SETUP_BUILDKIT_TAG: "moby/buildkit:latest"
-  SCOUT_VERSION: "1.11.0"
+  SCOUT_VERSION: "1.13.0"
   IMAGE_NAME: "docker/dockerfile-upstream"
   PLATFORMS: "linux/386,linux/amd64,linux/arm/v7,linux/arm64,linux/mips,linux/mipsle,linux/mips64,linux/mips64le,linux/s390x,linux/ppc64le,linux/riscv64"
 

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -159,6 +159,10 @@ jobs:
           format: sarif
           image: registry://${{ env.IMAGE_NAME }}:${{ matrix.tag }}
       -
+        name: Result output
+        run: |
+          jq . ${{ steps.scout.outputs.result-file }}
+      -
         name: Upload SARIF report
         uses: github/codeql-action/upload-sarif@v3
         with:


### PR DESCRIPTION
I'm a bit confused by what is reported by scout scan for https://github.com/moby/buildkit/security/code-scanning/9

![image](https://github.com/user-attachments/assets/d65ef196-c296-4087-ae29-51976c18d4c6)

It says we have libcurl 8.8.0 but looking at build logs it's 8.9.0: https://github.com/moby/buildkit/actions/runs/10302220041/job/28516403157#step:7:403

```
#49 6.078 (11/33) Installing zstd-libs (1.5.6-r0)
#49 6.153 (12/33) Installing libcurl (8.9.0-r0)
#49 6.220 (13/33) Installing libexpat (2.6.2-r0)
```

I can't repro locally so maybe there is an issue with Scout or our pipeline so adds an extra step to figure this out.
