### PR TITLE
Update area/project to PR auto labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -119,6 +119,16 @@ area/hack:
           - 'hack/**'
           - 'frontend/dockerfile/cmd/dockerfile-frontend/hack/**'
 
+# area:project
+area/project:
+  - changed-files:
+      - any-glob-to-any-file: 
+        - '.dockerignore'
+        - 'codecov.yml'
+        - 'docker-bake.hcl'
+        - 'Dockerfile'
+        - 'Makefile'
+
 # area:session
 area/session:
   - changed-files:


### PR DESCRIPTION
Adds support for auto-labeling of Pull Requests with `area/project` when they match the list of changed files.