### PR TITLE
docs: clarify valid from targets for run --mount

### DIFF
--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -682,12 +682,12 @@ The supported mount types are:
 This mount type allows binding files or directories to the build container. A
 bind mount is read-only by default.
 
-| Option                             | Description                                                                          |
-| ----------------                   | ------------------------------------------------------------------------------------ |
-| `target`, `dst`, `destination`[^1] | Mount path.                                                                          |
-| `source`                           | Source path in the `from`. Defaults to the root of the `from`.                       |
-| `from`                             | Build stage or image name for the root of the source. Defaults to the build context. |
-| `rw`,`readwrite`                   | Allow writes on the mount. Written data will be discarded.                           |
+| Option                             | Description                                                                                    |
+| ----------------                   | ---------------------------------------------------------------------------------------------- |
+| `target`, `dst`, `destination`[^1] | Mount path.                                                                                    |
+| `source`                           | Source path in the `from`. Defaults to the root of the `from`.                                 |
+| `from`                             | Build stage, context, or image name for the root of the source. Defaults to the build context. |
+| `rw`,`readwrite`                   | Allow writes on the mount. Written data will be discarded.                                     |
 
 ### RUN --mount=type=cache
 
@@ -700,7 +700,7 @@ and package managers.
 | `target`, `dst`, `destination`[^1] | Mount path.                                                                                                                                                                                                                                                                |
 | `ro`,`readonly`                    | Read-only if set.                                                                                                                                                                                                                                                          |
 | `sharing`                          | One of `shared`, `private`, or `locked`. Defaults to `shared`. A `shared` cache mount can be used concurrently by multiple writers. `private` creates a new mount if there are multiple writers. `locked` pauses the second writer until the first one releases the mount. |
-| `from`                             | Build stage to use as a base of the cache mount. Defaults to empty directory.                                                                                                                                                                                              |
+| `from`                             | Build stage, context, or image name to use as a base of the cache mount. Defaults to empty directory.                                                                                                                                                                      |
 | `source`                           | Subpath in the `from` to mount. Defaults to the root of the `from`.                                                                                                                                                                                                        |
 | `mode`                             | File mode for new cache directory in octal. Default `0755`.                                                                                                                                                                                                                |
 | `uid`                              | User ID for new cache directory. Default `0`.                                                                                                                                                                                                                              |


### PR DESCRIPTION
Closes #4912
