### PR TITLE
exec: fix incorrect deps computation for special mounts

### DIFF
--- a/solver/llbsolver/ops/exec.go
+++ b/solver/llbsolver/ops/exec.go
@@ -285,6 +285,11 @@ type dep struct {
 func (e *ExecOp) getMountDeps() ([]dep, error) {
 	deps := make([]dep, e.numInputs)
 	for _, m := range e.op.Mounts {
+		switch m.MountType {
+		case pb.MountType_SECRET, pb.MountType_SSH, pb.MountType_TMPFS:
+			continue
+		}
+
 		if m.Input == pb.Empty {
 			continue
 		}


### PR DESCRIPTION
fixes https://github.com/docker/buildx/issues/2479
regression from #4624 (v0.13)

Secret, SSH and Tmpfs mounts never have an input vertex and zero value for input should not be considered an input at index 0 .

Currently, if for example secret mount had a input=0, it caused content based checksum from first input(rootfs), that could take quite a lot of time when image was big and had lots of files. The computation result was cached but if there was a cache invalidation in previous commands it caused checksum to recomputed again for the command with the secret mount.
