### PR TITLE
chore: set `pb.Empty` on ssh and secret mounts

### DIFF
--- a/client/llb/exec.go
+++ b/client/llb/exec.go
@@ -396,6 +396,7 @@ func (e *ExecOp) Marshal(ctx context.Context, c *Constraints) (digest.Digest, []
 			})
 		} else {
 			pm := &pb.Mount{
+				Input:     pb.Empty,
 				Dest:      s.Target,
 				MountType: pb.MountType_SECRET,
 				SecretOpt: &pb.SecretOpt{
@@ -412,6 +413,7 @@ func (e *ExecOp) Marshal(ctx context.Context, c *Constraints) (digest.Digest, []
 
 	for _, s := range e.ssh {
 		pm := &pb.Mount{
+			Input:     pb.Empty,
 			Dest:      s.Target,
 			MountType: pb.MountType_SSH,
 			SSHOpt: &pb.SSHOpt{


### PR DESCRIPTION
See https://github.com/moby/buildkit/pull/5251#issuecomment-2286100909.

These mounts have no vertex inputs, and so should be *explicitly* marshaled as such.

I think this is the "root cause" of https://github.com/docker/buildx/issues/2479, but since marshaling is done on the client, https://github.com/moby/buildkit/pull/5251 is still required. However, the client should explicitly indicate that there is no vertex input on these special mount types.