### PR TITLE
tests: frontend/dockerfile: update integration tests for windows/wcow (part 4)

### DIFF
--- a/frontend/dockerfile/dockerfile_outline_test.go
+++ b/frontend/dockerfile/dockerfile_outline_test.go
@@ -240,7 +240,6 @@ FROM second
 }
 
 func testOutlineDescribeDefinition(t *testing.T, sb integration.Sandbox) {
-	integration.SkipOnPlatform(t, "windows")
 	workers.CheckFeatureCompat(t, sb, workers.FeatureFrontendOutline)
 	f := getFrontend(t, sb)
 	if _, ok := f.(*clientFrontend); !ok {
@@ -251,10 +250,16 @@ func testOutlineDescribeDefinition(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 	defer c.Close()
 
-	dockerfile := []byte(`
+	dockerfile := []byte(integration.UnixOrWindows(
+		`
 FROM scratch
 COPY Dockerfile Dockerfile
-`)
+`,
+		`
+FROM nanoserver
+COPY Dockerfile Dockerfile
+`,
+	))
 
 	dir := integration.Tmpdir(
 		t,

--- a/frontend/dockerfile/dockerfile_targets_test.go
+++ b/frontend/dockerfile/dockerfile_targets_test.go
@@ -125,7 +125,6 @@ FROM second AS binary
 }
 
 func testTargetsDescribeDefinition(t *testing.T, sb integration.Sandbox) {
-	integration.SkipOnPlatform(t, "windows")
 	workers.CheckFeatureCompat(t, sb, workers.FeatureFrontendTargets)
 	f := getFrontend(t, sb)
 	if _, ok := f.(*clientFrontend); !ok {
@@ -136,10 +135,16 @@ func testTargetsDescribeDefinition(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 	defer c.Close()
 
-	dockerfile := []byte(`
+	dockerfile := []byte(integration.UnixOrWindows(
+		`
 FROM scratch
 COPY Dockerfile Dockerfile
-`)
+`,
+		`
+FROM nanoserver
+COPY Dockerfile Dockerfile
+`,
+	))
 
 	dir := integration.Tmpdir(
 		t,

--- a/util/testutil/integration/sandbox.go
+++ b/util/testutil/integration/sandbox.go
@@ -59,6 +59,8 @@ func (sb *sandbox) NewRegistry() (string, error) {
 
 func (sb *sandbox) Cmd(args ...string) *exec.Cmd {
 	if len(args) == 1 {
+		// \\ being stripped off for Windows paths, convert to unix style
+		args[0] = strings.ReplaceAll(args[0], "\\", "/")
 		if split, err := shlex.Split(args[0]); err == nil {
 			args = split
 		}

--- a/util/testutil/integration/util_windows.go
+++ b/util/testutil/integration/util_windows.go
@@ -16,6 +16,10 @@ var windowsImagesMirrorMap = map[string]string{
 	"nanoserver:latest": "mcr.microsoft.com/windows/nanoserver:ltsc2022",
 	"servercore:latest": "mcr.microsoft.com/windows/servercore:ltsc2022",
 	"busybox:latest":    "registry.k8s.io/e2e-test-images/busybox@sha256:6d854ffad9666d2041b879a1c128c9922d77faced7745ad676639b07111ab650",
+	// nanoserver with extra binaries, like fc.exe
+	// TODO(profnandaa): get an approved/compliant repo, placeholder for now
+	// see dockerfile here - https://github.com/microsoft/windows-container-tools/pull/178
+	"nanoserver:plus": "docker.io/wintools/nanoserver:ltsc2022",
 }
 
 // abstracted function to handle pipe dialing on windows.


### PR DESCRIPTION
> We have split the tests in batches across a number of PRs with the same title + suffix `(part X)`

Additional translated tests for Windows in frontend/dockerfile.

- [x] `testDockerfileDirs`
- [x] `testDockerfileInvalidCommand`
- [x] `testCopyUnicodePath`
- [x] `testHistoryError`
- [x] `testTargetsDescribeDefinition`
- [x] `testHistoryFinalizeTrace`
- [x] `testOutlineDescribeDefinition`
- [x] `testCopyRelative`
- [x] `testNamedLocalContext`
- [x] `testLocalCustomSessionID`
- [x] `testNamedOCILayoutContextExport`
- [x] `testSourcePolicyWithNamedContext`
- [x] `testSourcePolicyWithNamedContext`

Partially addresses https://github.com/moby/buildkit/issues/4485