### PR TITLE
ci: update golangci-lint to v1.60.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,6 +30,9 @@ linters:
   disable-all: true
 
 linters-settings:
+  staticcheck:
+    checks:
+      - "all"
   gocritic:
     disabled-checks:
       - "ifElseChain"
@@ -98,6 +101,7 @@ linters-settings:
       - "empty"
       - "bool-compare"
       - "len"
+      - "negative-positive"
 
 issues:
   exclude-files:

--- a/cache/contenthash/tarsum.go
+++ b/cache/contenthash/tarsum.go
@@ -37,10 +37,10 @@ func v0TarHeaderSelect(h *tar.Header) (orderedHeaders [][2]string) {
 
 func v1TarHeaderSelect(h *tar.Header) (orderedHeaders [][2]string) {
 	pax := h.PAXRecords
-	if len(h.Xattrs) > 0 { //nolint:staticcheck // field deprecated in stdlib
+	if len(h.Xattrs) > 0 { // field deprecated in stdlib
 		if pax == nil {
 			pax = map[string]string{}
-			for k, v := range h.Xattrs { //nolint:staticcheck // field deprecated in stdlib
+			for k, v := range h.Xattrs { // field deprecated in stdlib
 				pax["SCHILY.xattr."+k] = v
 			}
 		}

--- a/executor/resources/cpu_test.go
+++ b/executor/resources/cpu_test.go
@@ -57,7 +57,7 @@ func TestReadPressureFile(t *testing.T) {
 full avg10=0.12 avg60=0.34 avg300=0.56 total=9876`
 
 	tmpFile := filepath.Join(t.TempDir(), "pressure_test")
-	err := os.WriteFile(tmpFile, []byte(pressureContents), os.ModePerm)
+	err := os.WriteFile(tmpFile, []byte(pressureContents), os.ModePerm) //nolint:gosec
 	require.NoError(t, err)
 
 	pressure, err := parsePressureFile(tmpFile)

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -371,7 +371,7 @@ func exitError(ctx context.Context, err error) error {
 		)
 		select {
 		case <-ctx.Done():
-			exitErr.Err = errors.Wrapf(context.Cause(ctx), exitErr.Error())
+			exitErr.Err = errors.Wrap(context.Cause(ctx), exitErr.Error())
 			return exitErr
 		default:
 			return stack.Enable(exitErr)

--- a/hack/dockerfiles/lint.Dockerfile
+++ b/hack/dockerfiles/lint.Dockerfile
@@ -4,7 +4,7 @@ ARG GO_VERSION=1.22
 ARG ALPINE_VERSION=3.20
 ARG XX_VERSION=1.4.0
 ARG PROTOLINT_VERSION=0.45.0
-ARG GOLANGCI_LINT_VERSION=1.57.1
+ARG GOLANGCI_LINT_VERSION=1.60.1
 ARG GOPLS_VERSION=v0.20.0
 # disabled: deprecated unusedvariable simplifyrange
 ARG GOPLS_ANALYZERS="embeddirective fillreturns infertypeargs nonewvars noresultvalues simplifycompositelit simplifyslice stubmethods undeclaredname unusedparams useany"

--- a/session/secrets/secretsprovider/secretsprovider.go
+++ b/session/secrets/secretsprovider/secretsprovider.go
@@ -32,7 +32,7 @@ func (sp *secretProvider) GetSecret(ctx context.Context, req *secrets.GetSecretR
 	dt, err := sp.store.GetSecret(ctx, req.ID)
 	if err != nil {
 		if errors.Is(err, secrets.ErrNotFound) {
-			return nil, status.Errorf(codes.NotFound, err.Error())
+			return nil, status.Error(codes.NotFound, err.Error())
 		}
 		return nil, err
 	}

--- a/solver/testutil/cachestorage_testsuite.go
+++ b/solver/testutil/cachestorage_testsuite.go
@@ -385,7 +385,7 @@ func testWalkIDsByResult(t *testing.T, st solver.CacheKeyStorage) {
 func getFunctionName(i interface{}) string {
 	fullname := runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
 	dot := strings.LastIndex(fullname, ".") + 1
-	return strings.Title(fullname[dot:]) //nolint:staticcheck // ignoring "SA1019: strings.Title is deprecated", as for our use we don't need full unicode support
+	return strings.Title(fullname[dot:]) // ignoring "SA1019: strings.Title is deprecated", as for our use we don't need full unicode support
 }
 
 func rootKey(dgst digest.Digest, output solver.Index) digest.Digest {

--- a/util/appcontext/appcontext.go
+++ b/util/appcontext/appcontext.go
@@ -38,7 +38,7 @@ func Context() context.Context {
 				err := errors.Errorf("got %d SIGTERM/SIGINTs, forcing shutdown", retries)
 				cancel(err)
 				if retries >= exitLimit {
-					bklog.G(ctx).Errorf(err.Error())
+					bklog.G(ctx).Error(err.Error())
 					os.Exit(1)
 				}
 			}

--- a/util/resolver/retryhandler/retry.go
+++ b/util/resolver/retryhandler/retry.go
@@ -64,7 +64,7 @@ func retryError(err error) bool {
 		return true
 	}
 	// catches TLS timeout or other network-related temporary errors
-	if ne := net.Error(nil); errors.As(err, &ne) && ne.Temporary() { //nolint:staticcheck // ignoring "SA1019: Temporary is deprecated", continue to propagate net.Error through the "temporary" status
+	if ne := net.Error(nil); errors.As(err, &ne) && ne.Temporary() { // ignoring "SA1019: Temporary is deprecated", continue to propagate net.Error through the "temporary" status
 		return true
 	}
 

--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -220,7 +220,7 @@ func Run(t *testing.T, testCases []Test, opt ...TestOpt) {
 func getFunctionName(i interface{}) string {
 	fullname := runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
 	dot := strings.LastIndex(fullname, ".") + 1
-	return strings.Title(fullname[dot:]) //nolint:staticcheck // ignoring "SA1019: strings.Title is deprecated", as for our use we don't need full unicode support
+	return strings.Title(fullname[dot:]) // ignoring "SA1019: strings.Title is deprecated", as for our use we don't need full unicode support
 }
 
 var localImageCache map[string]map[string]struct{}

--- a/util/testutil/integration/sandbox.go
+++ b/util/testutil/integration/sandbox.go
@@ -151,7 +151,7 @@ func FormatLogs(m map[string]*bytes.Buffer) string {
 func CheckFeatureCompat(t *testing.T, sb Sandbox, features map[string]struct{}, reason ...string) {
 	t.Helper()
 	if err := HasFeatureCompat(t, sb, features, reason...); err != nil {
-		t.Skipf(err.Error())
+		t.Skip(err.Error())
 	}
 }
 


### PR DESCRIPTION
Previous version runs out of memory on go1.23