### PR TITLE
remotecache: handle not implemented error for Info()

### DIFF
--- a/cache/remotecache/v1/utils.go
+++ b/cache/remotecache/v1/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/buildkit/solver"
 	"github.com/moby/buildkit/util/bklog"
 	digest "github.com/opencontainers/go-digest"
@@ -281,7 +282,9 @@ func marshalRemote(ctx context.Context, r *solver.Remote, state *marshalState) s
 	if r.Provider != nil {
 		for _, d := range r.Descriptors {
 			if _, err := r.Provider.Info(ctx, d.Digest); err != nil {
-				return ""
+				if !cerrdefs.IsNotImplemented(err) {
+					return ""
+				}
 			}
 		}
 	}


### PR DESCRIPTION
fixes https://github.com/moby/buildkit/issues/5242

Moby graphdriver backend does not implement Info() and such case should not be used as a signal for
blob needed to be skipped as it is unavailable.

This requires a change in Moby side as well to return a typed error instead of string.