### PR TITLE
docs: use gh alert syntax for callouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,12 @@ Introductory blog post https://blog.mobyproject.org/introducing-buildkit-17e056c
 
 Join `#buildkit` channel on [Docker Community Slack](https://dockr.ly/comm-slack)
 
-> **Note**
->
+> [!NOTE]
 > If you are visiting this repo for the usage of BuildKit-only Dockerfile features
 > like `RUN --mount=type=(bind|cache|tmpfs|secret|ssh)`, please refer to the
 > [Dockerfile reference](https://docs.docker.com/engine/reference/builder/).
 
-> **Note**
->
+> [!NOTE]
 > `docker build` [uses Buildx and BuildKit by default](https://docs.docker.com/build/architecture/) since Docker Engine 23.0.
 > You don't need to read this document unless you want to use the full-featured
 > standalone version of BuildKit.
@@ -614,8 +612,7 @@ There are 2 options supported for Azure Blob Storage authentication:
 * Any system using environment variables supported by the [Azure SDK for Go](https://docs.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication). The configuration must be available for the buildkit daemon, not for the client.
 * Secret Access Key, using the `secret_access_key` attribute to specify the primary or secondary account key for your Azure Blob Storage account. [Azure Blob Storage account keys](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage)
 
-> **Note**
->
+> [!NOTE]
 > Account name can also be specified with `account_name` attribute (or `$BUILDKIT_AZURE_STORAGE_ACCOUNT_NAME`)
 > if it is not part of the account URL host.
 

--- a/docs/attestations/sbom-protocol.md
+++ b/docs/attestations/sbom-protocol.md
@@ -10,8 +10,7 @@ mount, writes its SBOM scan data to a specified directory.
 The SBOM generator image is expected to follow the rules of the BuildKit SBOM
 generator protocol, defined in this document.
 
-> **Note**
->
+> [!NOTE]
 > Currently, only SBOMs in the [SPDX](https://spdx.dev) JSON format are
 > supported.
 >

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -3,8 +3,7 @@
 These are the BuildKit developer docs, designed to be read by technical users
 interested in contributing to or integrating with BuildKit.
 
-> **Warning**
->
+> [!WARNING]
 > While these docs attempt to keep up with the current state of our `master`
 > development branch, the code is constantly changing and updating, as bugs are
 > fixed, and features are added. Remember, the ultimate source of truth is

--- a/docs/dev/solver.md
+++ b/docs/dev/solver.md
@@ -151,8 +151,7 @@ for its inputs.
   after it has completed. In LLB this is used for calculating a cache key based
   on the checksum of file contents of the input snapshots.
   
-> **Note**
->
+> [!NOTE]
 > For example, in the case of LLB, if a vertex is a FileOp that copies a file
 > from one snapshot to another, the selector can be set to the path of the
 > source file in the input snapshot, while the content-based cache function can

--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -80,6 +80,7 @@ world
 
 Comments don't support line continuation characters.
 
+> [!NOTE]
 > **Note on whitespace**
 >
 > For backward compatibility, leading whitespace before comments (`#`) and
@@ -857,8 +858,7 @@ can be controlled by an earlier build stage.
 The command is run in the host's network environment (similar to
 `docker build --network=host`, but on a per-instruction basis)
 
-> **Warning**
->
+> [!WARNING]
 > The use of `--network=host` is protected by the `network.host` entitlement,
 > which needs to be enabled when starting the buildkitd daemon with
 > `--allow-insecure-entitlement network.host` flag or in [buildkitd config](https://github.com/moby/buildkit/blob/master/docs/buildkitd.toml.md),
@@ -867,8 +867,7 @@ The command is run in the host's network environment (similar to
 
 ### RUN --security
 
-> **Note**
->
+> [!NOTE]
 > Not yet available in stable syntax, use [`docker/dockerfile:1-labs`](#syntax) version.
 
 ```dockerfile
@@ -880,8 +879,7 @@ With `--security=insecure`, the builder runs the command without sandbox in inse
 mode, which allows to run flows requiring elevated privileges (e.g. containerd).
 This is equivalent to running `docker run --privileged`.
 
-> **Warning**
->
+> [!WARNING]
 > In order to access this feature, entitlement `security.insecure` should be
 > enabled when starting the buildkitd daemon with
 > `--allow-insecure-entitlement security.insecure` flag or in [buildkitd config](https://github.com/moby/buildkit/blob/master/docs/buildkitd.toml.md),
@@ -931,8 +929,7 @@ If `CMD` is used to provide default arguments for the `ENTRYPOINT` instruction,
 both the `CMD` and `ENTRYPOINT` instructions should be specified in the
 [exec form](#exec-form).
 
-> **Note**
->
+> [!NOTE]
 > Don't confuse `RUN` with `CMD`. `RUN` actually runs a command and commits
 > the result; `CMD` doesn't execute anything at build time, but specifies
 > the intended command for the image.
@@ -970,8 +967,7 @@ LABEL multi.label1="value1" \
       other="value3"
 ```
 
-> **Note**
->
+> [!NOTE]
 > Be sure to use double quotes and not single quotes. Particularly when you are
 > using string interpolation (e.g. `LABEL example="foo-$ENV_VAR"`), single
 > quotes will take the string as is without unpacking the variable's value.
@@ -1121,6 +1117,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y ...
 ```
 
+> [!NOTE]
 > **Alternative syntax**
 >
 > The `ENV` instruction also allows an alternative syntax `ENV <key> <value>`,
@@ -1275,8 +1272,7 @@ The result is the union of:
 2. The contents of the source tree, with conflicts resolved in favor of the
    content being added, on a file-by-file basis.
 
-> **Note**
->
+> [!NOTE]
 > Whether a file is identified as a recognized compression format or not is
 > done solely based on the contents of the file, not the name of the file. For
 > example, if an empty file happens to end with `.tar.gz` this isn't recognized
@@ -1609,8 +1605,7 @@ image or stage that you specify.
 
 ### COPY --chown --chmod
 
-> **Note**
->
+> [!NOTE]
 > Only octal notation is currently supported. Non-octal support is tracked in
 > [moby/buildkit#1951](https://github.com/moby/buildkit/issues/1951).
 
@@ -1731,8 +1726,7 @@ conditions for cache reuse.
 
 ### COPY --parents
 
-> **Note**
->
+> [!NOTE]
 > Not yet available in stable syntax, use [`docker/dockerfile:1.7-labs`](#syntax) version.
 
 ```dockerfile
@@ -1789,8 +1783,7 @@ with the `--parents` flag, the Buildkit is capable of packing multiple
 
 ### COPY --exclude
 
-> **Note**
->
+> [!NOTE]
 > Not yet available in stable syntax, use [`docker/dockerfile:1.7-labs`](#syntax) version.
 
 ```dockerfile
@@ -1987,8 +1980,7 @@ user	0m 0.03s
 sys	0m 0.03s
 ```
 
-> **Note**
->
+> [!NOTE]
 > You can override the `ENTRYPOINT` setting using `--entrypoint`,
 > but this can only set the binary to exec (no `sh -c` will be used).
 
@@ -2095,8 +2087,7 @@ The table below shows what command is executed for different `ENTRYPOINT` / `CMD
 | **CMD ["exec_cmd", "p1_cmd"]** | exec_cmd p1_cmd            | /bin/sh -c exec_entry p1_entry | exec_entry p1_entry exec_cmd p1_cmd            |
 | **CMD exec_cmd p1_cmd**        | /bin/sh -c exec_cmd p1_cmd | /bin/sh -c exec_entry p1_entry | exec_entry p1_entry /bin/sh -c exec_cmd p1_cmd |
 
-> **Note**
->
+> [!NOTE]
 > If `CMD` is defined from the base image, setting `ENTRYPOINT` will
 > reset `CMD` to an empty value. In this scenario, `CMD` must be defined in the
 > current image to have a value.
@@ -2174,8 +2165,7 @@ runtime, runs the relevant `ENTRYPOINT` and `CMD` commands.
 > Note that when specifying a group for the user, the user will have _only_ the
 > specified group membership. Any other configured group memberships will be ignored.
 
-> **Warning**
->
+> [!WARNING]
 > When the user doesn't have a primary group then the image (or the next
 > instructions) will be run with the `root` group.
 >
@@ -2243,8 +2233,7 @@ The `ARG` instruction defines a variable that users can pass at build-time to
 the builder with the `docker build` command using the `--build-arg <varname>=<value>`
 flag.
 
-> **Warning**
->
+> [!WARNING]
 > It isn't recommended to use build arguments for passing secrets such as
 > user credentials, API tokens, etc. Build arguments are visible in the
 > `docker history` command and in `max` mode provenance attestations,

--- a/frontend/dockerfile/docs/rules/copy-ignored-file.md
+++ b/frontend/dockerfile/docs/rules/copy-ignored-file.md
@@ -5,8 +5,7 @@ aliases:
   - /go/dockerfile/rule/copy-ignored-file/
 ---
 
-> **Note**
->
+> [!NOTE]
 > This check is experimental and is not enabled by default. To enable it, see
 > [Experimental checks](https://docs.docker.com/go/build-checks-experimental/).
 

--- a/frontend/dockerfile/linter/generate.go
+++ b/frontend/dockerfile/linter/generate.go
@@ -38,8 +38,7 @@ aliases:
 ---
 {{- if .Rule.Experimental }}
 
-> **Note**
->
+> [!NOTE]
 > This check is experimental and is not enabled by default. To enable it, see
 > [Experimental checks](https://docs.docker.com/go/build-checks-experimental/).
 {{- end }}


### PR DESCRIPTION
GitHub markdown supports an extension for rendering notes, warnings, and tips.
This extension is now also supported by the Docker documentation site.
This PR updates the Markdown files to use the new syntax.

Example:

```
> [!NOTE]
> This is a note
```

Rendered version:

> [!NOTE]
> This is a note

- related pr: docker/docs#20608
