### PR TITLE
S3 Cache: Use multipart upload instead of CopyObject for touching file > 5GB

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,7 @@ Other options are:
 * `name=<manifest>`: specify name of the manifest to use (default `buildkit`)
   * Multiple manifest names can be specified at the same time, separated by `;`. The standard use case is to use the git sha1 as name, and the branch name as duplicate, and load both with 2 `import-cache` commands.
 * `ignore-error=<false|true>`: specify if error is ignored in case cache export fails (default: `false`)
+* `touch_refresh=24h`: Instead of being uploaded again when not changed, blobs files will be "touched" on s3 every `touch_refresh`, default is 24h. Due to this, an expiration policy can be set on the S3 bucket to cleanup useless files automatically. Manifests files are systematically rewritten, there is no need to touch them.
 
 `--import-cache` options:
 * `type=s3`


### PR DESCRIPTION
Fix #4885

Tested locally with this Dockerfile

```
FROM python:3.11

RUN pip install torch

ARG x
RUN echo $x
```

And with the `touch_refresh` option set to 10s.