### PR TITLE
docs: clarify in #shell-form that heredocs apply to supported commands

### DIFF
--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -514,7 +514,7 @@ They're equivalent to the following line:
 RUN source $HOME/.bashrc && echo $HOME
 ```
 
-You can also use heredocs with the shell form to break up a command:
+You can also use heredocs with the shell form to break up supported commands.
 
 ```dockerfile
 RUN <<EOF


### PR DESCRIPTION
Updates documentation ( in response to https://github.com/moby/buildkit/issues/5240 😄 ) to provide clarification that not all commands support `heredoc`. It leaves to the user to click through the follow-up link to learn more about heredocs.