### PR TITLE
README.md: Add DevZero as consuming project

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ BuildKit is used by the following projects:
 -   [Depot](https://depot.dev)
 -   [Namespace](https://namespace.so)
 -   [Unikraft](https://unikraft.org)
+-   [DevZero](https://devzero.io)
 
 ## Quick start
 


### PR DESCRIPTION
DevZero uses Buildkit for building all of workspaces.
Looking forward to being listed as a Buildkit user. 

Documentation: https://www.devzero.io/docs/recipes/build-process