### PR TITLE
fix: dockerfile2llb: handle escaping of backslashes correctly

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -2052,6 +2052,8 @@ func uppercaseCmd(str string) string {
 }
 
 func processCmdEnv(shlex *shell.Lex, cmd string, env shell.EnvGetter) string {
+	// since shlex is tripping off backslashes
+	cmd = strings.ReplaceAll(cmd, "\\", "\\\\")
 	w, _, err := shlex.ProcessWord(cmd, env)
 	if err != nil {
 		return cmd


### PR DESCRIPTION
`shlex` in was treating single backslash "\\" in string as escape sequence, hence stripping them off. Modify `processCmdEnv` to double escape `\\`.

This was in turn affecting the vertex `Name`, and mostly pronounced on Windows where backslashes are prevalent in path names. For example `C:\hello\world\path` was being rendered as `C:helloworldpath`, hence confusing users.

Fixes #5250

Build progress before fix:
```
    #5 [2/4] RUN echo C:helloworldpath
    #5 1.359 C:\hello\world\path
    #5 DONE 1.7s

    #6 [3/4] RUN echo C:\hello\escaped\path
    #6 1.734 C:\\hello\\escaped\\path
    #6 DONE 2.1s

    #7 [4/4] RUN echo "C:\hello\quoted\path"
    #7 1.765 "C:\hello\quoted\path"
    #7 DONE 2.1s
```

Build progress after fix:
```
    #5 [2/4] RUN echo C:\hello\world\path
    #5 1.458 C:\hello\world\path
    #5 DONE 1.8s
    
    #6 [3/4] RUN echo C:\\hello\\escaped\\path
    #6 1.730 C:\\hello\\escaped\\path
    #6 DONE 2.1s
    
    #7 [4/4] RUN echo "C:\hello\quoted\path"
    #7 1.702 "C:\hello\quoted\path"
    #7 DONE 2.1s
```

You can also see that now paths in the step/vertex names now match those in the log lines right after the name.