### PR TITLE
frontend: rule check print to include path to dockerfile

### DIFF
--- a/frontend/dockerui/requests.go
+++ b/frontend/dockerui/requests.go
@@ -66,7 +66,7 @@ func (bc *Client) HandleSubrequest(ctx context.Context, h RequestHandler) (*clie
 			if warnings == nil {
 				return nil, true, nil
 			}
-			res, err := warnings.ToResult()
+			res, err := warnings.ToResult(nil)
 			return res, true, err
 		}
 	}


### PR DESCRIPTION
Currently, when displaying lint check warnings, the warning only displays the name of the source file and does not include any path information for disambiguating Dockerfiles which may be named the same within a context but exist at different paths. This PR updates the functions around printing these warnings to accept an additional parameter which allows for specifying a different path to print, which allows the caller to provide path context rather than being limited to the source name.

(frontend work to address: https://github.com/docker/buildx/issues/2542)