### PR TITLE
chore: annotate every cancel cause with message

### DIFF
--- a/cache/remotecache/azblob/exporter.go
+++ b/cache/remotecache/azblob/exporter.go
@@ -152,7 +152,7 @@ func (ce *exporter) uploadManifest(ctx context.Context, manifestKey string, read
 
 	ctx, cnclFn := context.WithCancelCause(ctx)
 	ctx, _ = context.WithTimeoutCause(ctx, time.Minute*5, errors.WithStack(context.DeadlineExceeded))
-	defer cnclFn(errors.WithStack(context.Canceled))
+	defer cnclFn(errors.Wrap(context.Canceled, "upload manifest done"))
 
 	_, err = blobClient.Upload(ctx, reader, &azblob.BlockBlobUploadOptions{})
 	if err != nil {
@@ -173,7 +173,7 @@ func (ce *exporter) uploadBlobIfNotExists(ctx context.Context, blobKey string, r
 
 	uploadCtx, cnclFn := context.WithCancelCause(ctx)
 	uploadCtx, _ = context.WithTimeoutCause(uploadCtx, time.Minute*5, errors.WithStack(context.DeadlineExceeded))
-	defer cnclFn(errors.WithStack(context.Canceled))
+	defer cnclFn(errors.Wrap(context.Canceled, "upload blob done"))
 
 	// Only upload if the blob doesn't exist
 	eTagAny := azblob.ETagAny

--- a/cache/remotecache/azblob/utils.go
+++ b/cache/remotecache/azblob/utils.go
@@ -135,7 +135,7 @@ func createContainerClient(ctx context.Context, config *Config) (*azblob.Contain
 
 	ctx, cnclFn := context.WithCancelCause(ctx)
 	ctx, _ = context.WithTimeoutCause(ctx, time.Second*60, errors.WithStack(context.DeadlineExceeded))
-	defer cnclFn(errors.WithStack(context.Canceled))
+	defer cnclFn(errors.Wrap(context.Canceled, "init new container client done"))
 
 	containerClient, err := serviceClient.NewContainerClient(config.Container)
 	if err != nil {
@@ -151,7 +151,7 @@ func createContainerClient(ctx context.Context, config *Config) (*azblob.Contain
 	if errors.As(err, &se) && se.ErrorCode == azblob.StorageErrorCodeContainerNotFound {
 		ctx, cnclFn := context.WithCancelCause(ctx)
 		ctx, _ = context.WithTimeoutCause(ctx, time.Minute*5, errors.WithStack(context.DeadlineExceeded))
-		defer cnclFn(errors.WithStack(context.Canceled))
+		defer cnclFn(errors.Wrap(context.Canceled, "create container client done"))
 		_, err := containerClient.Create(ctx, &azblob.ContainerCreateOptions{})
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to create cache container %s", config.Container)
@@ -181,7 +181,7 @@ func blobExists(ctx context.Context, containerClient *azblob.ContainerClient, bl
 
 	ctx, cnclFn := context.WithCancelCause(ctx)
 	ctx, _ = context.WithTimeoutCause(ctx, time.Second*60, errors.WithStack(context.DeadlineExceeded))
-	defer cnclFn(errors.WithStack(context.Canceled))
+	defer cnclFn(errors.Wrap(context.Canceled, "check blob existence done"))
 	_, err = blobClient.GetProperties(ctx, &azblob.BlobGetPropertiesOptions{})
 	if err == nil {
 		return true, nil

--- a/cache/remotecache/local/local.go
+++ b/cache/remotecache/local/local.go
@@ -107,7 +107,7 @@ func getContentStore(ctx context.Context, sm *session.Manager, g session.Group, 
 	}
 	timeoutCtx, cancel := context.WithCancelCause(ctx)
 	timeoutCtx, _ = context.WithTimeoutCause(timeoutCtx, 5*time.Second, errors.WithStack(context.DeadlineExceeded))
-	defer cancel(errors.WithStack(context.Canceled))
+	defer cancel(errors.Wrap(context.Canceled, "local cache import/export get content store done"))
 
 	caller, err := sm.Get(timeoutCtx, sessionID, false)
 	if err != nil {

--- a/cmd/buildctl/common/common.go
+++ b/cmd/buildctl/common/common.go
@@ -86,7 +86,7 @@ func ResolveClient(c *cli.Context) (*client.Client, error) {
 		ctx2, cancel := context.WithCancelCause(ctx)
 		ctx2, _ = context.WithTimeoutCause(ctx2, timeout*time.Second, errors.WithStack(context.DeadlineExceeded))
 		ctx = ctx2
-		defer cancel(errors.WithStack(context.Canceled))
+		defer cancel(errors.Wrap(context.Canceled, "init client done"))
 	}
 
 	cl, err := client.New(ctx, c.GlobalString("addr"), opts...)

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -231,7 +231,7 @@ func main() {
 			return errors.New("rootless mode requires to be executed as the mapped root in a user namespace; you may use RootlessKit for setting up the namespace")
 		}
 		ctx, cancel := context.WithCancelCause(appcontext.Context())
-		defer cancel(errors.WithStack(context.Canceled))
+		defer cancel(errors.Wrap(context.Canceled, "main done"))
 
 		cfg, err := config.LoadFile(c.GlobalString("config"))
 		if err != nil {
@@ -377,7 +377,7 @@ func main() {
 		select {
 		case serverErr := <-errCh:
 			err = serverErr
-			cancel(err)
+			cancel(errors.Wrap(err, "server error"))
 		case <-ctx.Done():
 			err = context.Cause(ctx)
 		}

--- a/control/control.go
+++ b/control/control.go
@@ -530,7 +530,7 @@ func (c *Controller) Session(stream controlapi.Control_SessionServer) error {
 	ctx, cancel := context.WithCancelCause(stream.Context())
 	go func() {
 		<-closeCh
-		cancel(errors.WithStack(context.Canceled))
+		cancel(errors.Wrap(context.Canceled, "controller session conn closed"))
 	}()
 
 	err := c.opt.SessionManager.HandleConn(ctx, conn, opts)

--- a/control/gateway/gateway.go
+++ b/control/gateway/gateway.go
@@ -61,7 +61,7 @@ func (gwf *GatewayForwarder) lookupForwarder(ctx context.Context) (gateway.LLBBr
 
 	ctx, cancel := context.WithCancelCause(ctx)
 	ctx, _ = context.WithTimeoutCause(ctx, 3*time.Second, errors.WithStack(context.DeadlineExceeded))
-	defer cancel(errors.WithStack(context.Canceled))
+	defer cancel(errors.Wrap(context.Canceled, "lookupForwarder done"))
 
 	go func() {
 		<-ctx.Done()

--- a/executor/containerdexecutor/executor.go
+++ b/executor/containerdexecutor/executor.go
@@ -351,7 +351,7 @@ func (w *containerdExecutor) runProcess(ctx context.Context, p containerd.Proces
 	// handle signals (and resize) in separate go loop so it does not
 	// potentially block the container cancel/exit status loop below.
 	eventCtx, eventCancel := context.WithCancelCause(ctx)
-	defer eventCancel(errors.WithStack(context.Canceled))
+	defer eventCancel(errors.Wrap(context.Canceled, "containerd process event loop done"))
 	go func() {
 		for {
 			select {
@@ -400,7 +400,7 @@ func (w *containerdExecutor) runProcess(ctx context.Context, p containerd.Proces
 			io.Cancel()
 		case status := <-statusCh:
 			if cancel != nil {
-				cancel(errors.WithStack(context.Canceled))
+				cancel(errors.Wrap(context.Canceled, "containerd process exited"))
 			}
 			trace.SpanFromContext(ctx).AddEvent(
 				"Container exited",
@@ -426,7 +426,7 @@ func (w *containerdExecutor) runProcess(ctx context.Context, p containerd.Proces
 			return nil
 		case <-killCtxDone:
 			if cancel != nil {
-				cancel(errors.WithStack(context.Canceled))
+				cancel(errors.Wrap(context.Canceled, "containerd process killed"))
 			}
 			io.Cancel()
 			return errors.Errorf("failed to kill process on cancel")

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -543,7 +543,7 @@ func (k procKiller) Kill(ctx context.Context) (err error) {
 	// shorter timeout but here as a fail-safe for future refactoring.
 	ctx, cancel := context.WithCancelCause(ctx)
 	ctx, _ = context.WithTimeoutCause(ctx, 10*time.Second, errors.WithStack(context.DeadlineExceeded))
-	defer cancel(errors.WithStack(context.Canceled))
+	defer cancel(errors.Wrap(context.Canceled, "runc kill process done"))
 
 	if k.pidfile == "" {
 		// for `runc run` process we use `runc kill` to terminate the process
@@ -640,7 +640,7 @@ func runcProcessHandle(ctx context.Context, killer procKiller) (*procHandle, con
 					default:
 					}
 				}
-				timeout(errors.WithStack(context.Canceled))
+				timeout(errors.Wrap(context.Canceled, "killing process done"))
 				select {
 				case <-time.After(50 * time.Millisecond):
 				case <-p.ended:
@@ -668,7 +668,7 @@ func (p *procHandle) Release() {
 // goroutines.
 func (p *procHandle) Shutdown() {
 	if p.shutdown != nil {
-		p.shutdown(errors.WithStack(context.Canceled))
+		p.shutdown(errors.Wrap(context.Canceled, "runc process shutdown"))
 	}
 }
 
@@ -690,7 +690,7 @@ func (p *procHandle) WaitForReady(ctx context.Context) error {
 func (p *procHandle) WaitForStart(ctx context.Context, startedCh <-chan int, started func()) error {
 	ctx, cancel := context.WithCancelCause(ctx)
 	ctx, _ = context.WithTimeoutCause(ctx, 10*time.Second, errors.WithStack(context.DeadlineExceeded))
-	defer cancel(errors.WithStack(context.Canceled))
+	defer cancel(errors.Wrap(context.Canceled, "runc process wait for start done"))
 	select {
 	case <-ctx.Done():
 		return errors.New("go-runc started message never received")

--- a/exporter/local/export.go
+++ b/exporter/local/export.go
@@ -81,7 +81,7 @@ func (e *localExporter) Config() *exporter.Config {
 func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source, _ exptypes.InlineCache, sessionID string) (map[string]string, exporter.DescriptorReference, error) {
 	timeoutCtx, cancel := context.WithCancelCause(ctx)
 	timeoutCtx, _ = context.WithTimeoutCause(timeoutCtx, 5*time.Second, errors.WithStack(context.DeadlineExceeded))
-	defer cancel(errors.WithStack(context.Canceled))
+	defer cancel(errors.Wrap(context.Canceled, "local export done"))
 
 	if e.opts.Epoch == nil {
 		if tm, ok, err := epoch.ParseSource(inp); err != nil {

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -218,7 +218,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 
 	timeoutCtx, cancel := context.WithCancelCause(ctx)
 	timeoutCtx, _ = context.WithTimeoutCause(timeoutCtx, 5*time.Second, errors.WithStack(context.DeadlineExceeded))
-	defer cancel(errors.WithStack(context.Canceled))
+	defer cancel(errors.Wrap(context.Canceled, "image export done"))
 
 	caller, err := e.opt.SessionManager.Get(timeoutCtx, sessionID, false)
 	if err != nil {

--- a/exporter/tar/export.go
+++ b/exporter/tar/export.go
@@ -165,7 +165,7 @@ func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source
 
 	timeoutCtx, cancel := context.WithCancelCause(ctx)
 	timeoutCtx, _ = context.WithTimeoutCause(timeoutCtx, 5*time.Second, errors.WithStack(context.DeadlineExceeded))
-	defer cancel(errors.WithStack(context.Canceled))
+	defer cancel(errors.Wrap(context.Canceled, "local tar export done"))
 
 	caller, err := e.opt.SessionManager.Get(timeoutCtx, sessionID, false)
 	if err != nil {

--- a/frontend/gateway/container/container.go
+++ b/frontend/gateway/container/container.go
@@ -407,7 +407,7 @@ func (gwCtr *gatewayContainer) loadSecretEnv(ctx context.Context, secretEnv []*p
 func (gwCtr *gatewayContainer) Release(ctx context.Context) error {
 	gwCtr.mu.Lock()
 	defer gwCtr.mu.Unlock()
-	gwCtr.cancel(errors.WithStack(context.Canceled))
+	gwCtr.cancel(errors.Wrap(context.Canceled, "container released"))
 	err1 := gwCtr.errGroup.Wait()
 
 	var err2 error

--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -515,7 +515,7 @@ func serveLLBBridgeForwarder(ctx context.Context, llbBridge frontend.FrontendLLB
 		default:
 			lbf.isErrServerClosed = true
 		}
-		cancel(errors.WithStack(context.Canceled))
+		cancel(errors.Wrap(context.Canceled, "llb bridge forwarder grpc server done"))
 	}()
 
 	return lbf, ctx
@@ -1444,7 +1444,7 @@ func (lbf *llbBridgeForwarder) ExecProcess(srv pb.LLBBridge_ExecProcessServer) e
 				}
 
 				initCtx, initCancel := context.WithCancelCause(context.Background())
-				defer initCancel(errors.WithStack(context.Canceled))
+				defer initCancel(errors.Wrap(context.Canceled, "llb bridge exec process init done"))
 
 				pio := newProcessIO(pid, init.Fds)
 				pios[pid] = pio

--- a/frontend/gateway/grpcclient/client.go
+++ b/frontend/gateway/grpcclient/client.go
@@ -48,7 +48,7 @@ type GrpcClient interface {
 func New(ctx context.Context, opts map[string]string, session, product string, c pb.LLBBridgeClient, w []client.WorkerInfo) (GrpcClient, error) {
 	pingCtx, pingCancel := context.WithCancelCause(ctx)
 	pingCtx, _ = context.WithTimeoutCause(pingCtx, 15*time.Second, errors.WithStack(context.DeadlineExceeded))
-	defer pingCancel(errors.WithStack(context.Canceled))
+	defer pingCancel(errors.Wrap(context.Canceled, "new grpc client ping done"))
 	resp, err := c.Ping(pingCtx, &pb.PingRequest{})
 	if err != nil {
 		return nil, err
@@ -832,7 +832,7 @@ func (m *messageForwarder) Send(msg *pb.ExecMessage) error {
 }
 
 func (m *messageForwarder) Release() error {
-	m.cancel(errors.WithStack(context.Canceled))
+	m.cancel(errors.Wrap(context.Canceled, "message forwarder released"))
 	return m.eg.Wait()
 }
 

--- a/session/filesync/filesync.go
+++ b/session/filesync/filesync.go
@@ -205,7 +205,7 @@ func FSSync(ctx context.Context, c session.Caller, opt FSSendRequestOpt) error {
 	opts[keyDirName] = []string{opt.Name}
 
 	ctx, cancel := context.WithCancelCause(ctx)
-	defer cancel(errors.WithStack(context.Canceled))
+	defer cancel(errors.Wrap(context.Canceled, "FSSync done"))
 
 	client := NewFileSyncClient(c.Conn())
 

--- a/session/group.go
+++ b/session/group.go
@@ -74,7 +74,7 @@ func (sm *Manager) Any(ctx context.Context, g Group, f func(context.Context, str
 
 		timeoutCtx, cancel := context.WithCancelCause(ctx)
 		timeoutCtx, _ = context.WithTimeoutCause(timeoutCtx, 5*time.Second, errors.WithStack(context.DeadlineExceeded))
-		defer cancel(errors.WithStack(context.Canceled))
+		defer cancel(errors.Wrapf(context.Canceled, "session manager get %s done", id))
 		c, err := sm.Get(timeoutCtx, id, false)
 		if err != nil {
 			lastErr = err

--- a/session/grpc.go
+++ b/session/grpc.go
@@ -68,7 +68,7 @@ func grpcClientConn(ctx context.Context, conn net.Conn) (context.Context, *grpc.
 }
 
 func monitorHealth(ctx context.Context, cc *grpc.ClientConn, cancelConn func(error)) {
-	defer cancelConn(errors.WithStack(context.Canceled))
+	defer cancelConn(errors.Wrap(context.Canceled, "monitorHealth done"))
 	defer cc.Close()
 
 	ticker := time.NewTicker(5 * time.Second)
@@ -95,7 +95,7 @@ func monitorHealth(ctx context.Context, cc *grpc.ClientConn, cancelConn func(err
 			ctx, cancel := context.WithCancelCause(ctx)
 			ctx, _ = context.WithTimeoutCause(ctx, timeout, errors.WithStack(context.DeadlineExceeded))
 			_, err := healthClient.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
-			cancel(errors.WithStack(context.Canceled))
+			cancel(errors.Wrap(context.Canceled, "healthcheck done"))
 
 			lastHealthcheckDuration = time.Since(healthcheckStart)
 			logFields := logrus.Fields{

--- a/session/manager.go
+++ b/session/manager.go
@@ -99,7 +99,7 @@ func (sm *Manager) HandleConn(ctx context.Context, conn net.Conn, opts map[strin
 // caller needs to take lock, this function will release it
 func (sm *Manager) handleConn(ctx context.Context, conn net.Conn, opts map[string][]string) error {
 	ctx, cancel := context.WithCancelCause(ctx)
-	defer cancel(errors.WithStack(context.Canceled))
+	defer cancel(errors.Wrap(context.Canceled, "session manager handleConn done"))
 
 	opts = canonicalHeaders(opts)
 
@@ -154,7 +154,7 @@ func (sm *Manager) Get(ctx context.Context, id string, noWait bool) (Caller, err
 	}
 
 	ctx, cancel := context.WithCancelCause(ctx)
-	defer cancel(errors.WithStack(context.Canceled))
+	defer cancel(errors.Wrapf(context.Canceled, "session manager get %s done", id))
 
 	go func() {
 		<-ctx.Done()

--- a/session/session.go
+++ b/session/session.go
@@ -96,7 +96,7 @@ func (s *Session) Run(ctx context.Context, dialer Dialer) error {
 	s.cancelCtx = cancel
 	s.done = make(chan struct{})
 
-	defer cancel(errors.WithStack(context.Canceled))
+	defer cancel(errors.Wrap(context.Canceled, "session run done"))
 	defer close(s.done)
 
 	meta := make(map[string][]string)

--- a/solver/internal/pipe/pipe.go
+++ b/solver/internal/pipe/pipe.go
@@ -74,7 +74,7 @@ func NewWithFunction(f func(context.Context) (interface{}, error)) (*Pipe, func(
 
 	p.OnReceiveCompletion = func() {
 		if req := p.Sender.Request(); req.Canceled {
-			cancel(errors.WithStack(context.Canceled))
+			cancel(errors.Wrap(context.Canceled, "pipe sender request canceled"))
 		}
 	}
 

--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -626,7 +626,7 @@ func (jl *Solver) NewJob(id string) (*Job, error) {
 func (jl *Solver) Get(id string) (*Job, error) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	ctx, _ = context.WithTimeoutCause(ctx, 6*time.Second, errors.WithStack(context.DeadlineExceeded))
-	defer cancel(errors.WithStack(context.Canceled))
+	defer cancel(errors.Wrap(context.Canceled, "solver get job done"))
 
 	go func() {
 		<-ctx.Done()
@@ -751,7 +751,7 @@ func (j *Job) walkProvenance(ctx context.Context, e Edge, f func(ProvenanceProvi
 }
 
 func (j *Job) CloseProgress() {
-	j.progressCloser(errors.WithStack(context.Canceled))
+	j.progressCloser(errors.WithStack(errors.Wrap(context.Canceled, "job progress closed")))
 	j.pw.Close()
 }
 

--- a/solver/llbsolver/mounts/mount.go
+++ b/solver/llbsolver/mounts/mount.go
@@ -210,6 +210,7 @@ func (sm *sshMountInstance) Mount() ([]mount.Mount, func() error, error) {
 			GID: gid,
 		})
 		if err != nil {
+			err = errors.Wrap(err, "ssh mount failed to map identity")
 			cancel(err)
 			return nil, nil, err
 		}
@@ -224,6 +225,7 @@ func (sm *sshMountInstance) Mount() ([]mount.Mount, func() error, error) {
 		Mode: int(sm.sm.mount.SSHOpt.Mode & 0777),
 	})
 	if err != nil {
+		err = errors.Wrap(err, "ssh mount failed to mount socket")
 		cancel(err)
 		return nil, nil, err
 	}
@@ -232,7 +234,7 @@ func (sm *sshMountInstance) Mount() ([]mount.Mount, func() error, error) {
 		if cleanup != nil {
 			err = cleanup()
 		}
-		cancel(err)
+		cancel(errors.Wrap(err, "ssh mount cleanup"))
 		return err
 	}
 

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -205,7 +205,7 @@ func (s *Solver) recordBuildHistory(ctx context.Context, id string, req frontend
 
 		ctx, cancel := context.WithCancelCause(ctx)
 		ctx, _ = context.WithTimeoutCause(ctx, 300*time.Second, errors.WithStack(context.DeadlineExceeded))
-		defer cancel(errors.WithStack(context.Canceled))
+		defer cancel(errors.Wrap(context.Canceled, "create history record done"))
 
 		var mu sync.Mutex
 		ch := make(chan *client.SolveStatus)

--- a/solver/scheduler.go
+++ b/solver/scheduler.go
@@ -282,7 +282,7 @@ func (s *scheduler) build(ctx context.Context, edge Edge) (CachedResult, error) 
 	s.mu.Unlock()
 
 	ctx, cancel := context.WithCancelCause(ctx)
-	defer cancel(errors.WithStack(context.Canceled))
+	defer cancel(errors.Wrap(context.Canceled, "scheduler build done"))
 
 	go func() {
 		<-ctx.Done()

--- a/source/containerimage/ocilayout.go
+++ b/source/containerimage/ocilayout.go
@@ -126,7 +126,7 @@ func (r *ociLayoutResolver) withCaller(ctx context.Context, f func(context.Conte
 	if r.store.SessionID != "" {
 		timeoutCtx, cancel := context.WithCancelCause(ctx)
 		timeoutCtx, _ = context.WithTimeoutCause(timeoutCtx, 5*time.Second, errors.WithStack(context.DeadlineExceeded))
-		defer cancel(errors.WithStack(context.Canceled))
+		defer cancel(errors.Wrap(context.Canceled, "oci layout resolver withCaller done"))
 
 		caller, err := r.sm.Get(timeoutCtx, r.store.SessionID, false)
 		if err != nil {

--- a/source/local/source.go
+++ b/source/local/source.go
@@ -143,7 +143,7 @@ func (ls *localSourceHandler) Snapshot(ctx context.Context, g session.Group) (ca
 
 	timeoutCtx, cancel := context.WithCancelCause(ctx)
 	timeoutCtx, _ = context.WithTimeoutCause(timeoutCtx, 5*time.Second, errors.WithStack(context.DeadlineExceeded))
-	defer cancel(errors.WithStack(context.Canceled))
+	defer cancel(errors.Wrap(context.Canceled, "local source handler snapshot done"))
 
 	caller, err := ls.sm.Get(timeoutCtx, sessionID, false)
 	if err != nil {

--- a/util/flightcontrol/flightcontrol.go
+++ b/util/flightcontrol/flightcontrol.go
@@ -116,9 +116,9 @@ func newCall[T any](fn func(ctx context.Context) (T, error)) *call[T] {
 }
 
 func (c *call[T]) run() {
-	defer c.closeProgressWriter(errors.WithStack(context.Canceled))
+	defer c.closeProgressWriter(errors.Wrap(context.Canceled, "flightcontrol call run progress done"))
 	ctx, cancel := context.WithCancelCause(c.ctx)
-	defer cancel(errors.WithStack(context.Canceled))
+	defer cancel(errors.Wrap(context.Canceled, "flightcontrol call run done"))
 	v, err := c.fn(ctx)
 	c.mu.Lock()
 	c.result = v
@@ -157,7 +157,7 @@ func (c *call[T]) wait(ctx context.Context) (v T, err error) {
 	}
 
 	ctx, cancel := context.WithCancelCause(ctx)
-	defer cancel(errors.WithStack(context.Canceled))
+	defer cancel(errors.Wrap(context.Canceled, "flightcontrol wait done"))
 
 	c.ctxs = append(c.ctxs, ctx)
 

--- a/util/pull/pullprogress/progress.go
+++ b/util/pull/pullprogress/progress.go
@@ -45,7 +45,7 @@ type readerAtWithCancel struct {
 }
 
 func (ra readerAtWithCancel) Close() error {
-	ra.cancel(errors.WithStack(context.Canceled))
+	ra.cancel(errors.Wrap(context.Canceled, "readerAtWithCancel closed"))
 	select {
 	case <-ra.doneCh:
 	case <-time.After(time.Second):
@@ -79,7 +79,7 @@ type readerWithCancel struct {
 }
 
 func (r readerWithCancel) Close() error {
-	r.cancel(errors.WithStack(context.Canceled))
+	r.cancel(errors.Wrap(context.Canceled, "readerWithCancel closed"))
 	select {
 	case <-r.doneCh:
 	case <-time.After(time.Second):

--- a/util/tracing/detect/recorder.go
+++ b/util/tracing/detect/recorder.go
@@ -152,7 +152,7 @@ func (r *TraceRecorder) ExportSpans(ctx context.Context, spans []sdktrace.ReadOn
 
 func (r *TraceRecorder) Shutdown(ctx context.Context) error {
 	// Initiate the shutdown of the gc loop.
-	r.shutdownGC(errors.WithStack(context.Canceled))
+	r.shutdownGC(errors.Wrap(context.Canceled, "trace recorder shutdown"))
 
 	// Wait for it to be done or the context is canceled.
 	select {

--- a/util/tracing/otlptracegrpc/client.go
+++ b/util/tracing/otlptracegrpc/client.go
@@ -70,10 +70,10 @@ func (c *client) UploadTraces(ctx context.Context, protoSpans []*tracepb.Resourc
 	}
 
 	ctx, cancel := c.connection.ContextWithStop(ctx)
-	defer cancel(errors.WithStack(context.Canceled))
+	defer cancel(errors.Wrap(context.Canceled, "upload traces done"))
 	ctx, tCancel := context.WithCancelCause(ctx)
 	ctx, _ = context.WithTimeoutCause(ctx, 30*time.Second, errors.WithStack(context.DeadlineExceeded))
-	defer tCancel(errors.WithStack(context.Canceled))
+	defer tCancel(errors.Wrap(context.Canceled, "upload traces timeout"))
 
 	ctx = c.connection.ContextWithMetadata(ctx)
 	err := func() error {

--- a/util/tracing/otlptracegrpc/connection.go
+++ b/util/tracing/otlptracegrpc/connection.go
@@ -211,7 +211,7 @@ func (c *Connection) ContextWithStop(ctx context.Context) (context.Context, cont
 			// Nothing to do, either cancelled or deadline
 			// happened.
 		case <-c.stopCh:
-			cancel(errors.WithStack(context.Canceled))
+			cancel(errors.Wrap(context.Canceled, "connection stopped"))
 		}
 	}(ctx, cancel)
 	return ctx, cancel


### PR DESCRIPTION
We've been hitting some random ephemeral `failed to compute cache key: context canceled` errors for a while now, which have been very hard to track down.

Buildkit does use ContextCause everywhere, but only wraps the error using `github.com/pkg/errors.WithStack` so unless I'm missing something obvious the error messages don't actually contain any extra useful information.

This changes everywhere to use `errors.Wrap`, which includes the stack trace same as before but also includes a message so error messages here will have actual context on the cause.

I just went ahead and updated the entire codebase rather than those most likely to be a culprit for this bug since it seemed worth squashing this everywhere, but can be more selective if there's objections for any reason.

Also happy to be told I'm missing something obvious and there's a better way of going about this.