### PR TITLE
fix(WCOW): fix file access failure for multistage builds

### DIFF
--- a/cache/contenthash/checksum.go
+++ b/cache/contenthash/checksum.go
@@ -1034,7 +1034,7 @@ func (cc *cacheContext) scanPath(ctx context.Context, m *mount, p string, follow
 		scanPath = resolvedPath
 	}
 
-	err = filepath.Walk(scanPath, func(itemPath string, fi os.FileInfo, err error) error {
+	walkFunc := func(itemPath string, fi os.FileInfo, err error) error {
 		if scanCounterEnable {
 			scanCounter.Add(1)
 		}
@@ -1073,7 +1073,10 @@ func (cc *cacheContext) scanPath(ctx context.Context, m *mount, p string, follow
 			txn.Insert(k, cr)
 		}
 		return nil
-	})
+	}
+
+	err = cc.walk(scanPath, walkFunc)
+
 	if err != nil {
 		return err
 	}

--- a/cache/contenthash/checksum_unix.go
+++ b/cache/contenthash/checksum_unix.go
@@ -1,0 +1,10 @@
+//go:build !windows
+// +build !windows
+
+package contenthash
+
+import "path/filepath"
+
+func (cc *cacheContext) walk(scanPath string, walkFunc filepath.WalkFunc) error {
+	return filepath.Walk(scanPath, walkFunc)
+}

--- a/cache/contenthash/checksum_windows.go
+++ b/cache/contenthash/checksum_windows.go
@@ -1,0 +1,16 @@
+package contenthash
+
+import (
+	"path/filepath"
+
+	"github.com/Microsoft/go-winio"
+)
+
+func (cc *cacheContext) walk(scanPath string, walkFunc filepath.WalkFunc) error {
+	// elevating the admin privileges to walk special files/directory
+	// like `System Volume Information`, etc. See similar in #4994
+	privileges := []string{winio.SeBackupPrivilege}
+	return winio.RunWithPrivileges(privileges, func() error {
+		return filepath.Walk(scanPath, walkFunc)
+	})
+}


### PR DESCRIPTION
fix (WCOW) file access failure for multistage builds
Fixes: #5193

The failure occurs on Windows Client SKUs (e.g., Windows 11) but generally works on server SKUs like WS2022, although similar failures can also occur on WS2022 in some cases.
