### PR TITLE
docs: use front matter title in buildkitd.toml doc

### DIFF
--- a/docs/buildkitd.toml.md
+++ b/docs/buildkitd.toml.md
@@ -1,4 +1,6 @@
-# buildkitd.toml
+---
+title: buildkitd.toml
+---
 
 The TOML file used to configure the buildkitd daemon settings has a short
 list of global settings followed by a series of sections for specific areas


### PR DESCRIPTION
Use a front matter key for the title, instead of an in-line heading. This makes it possible to use the title in templates for docs.docker.com
