### PR TITLE
hack: do not cache rootless stage on release

### DIFF
--- a/hack/images
+++ b/hack/images
@@ -109,7 +109,7 @@ done
 
 nocacheFilterFlag=""
 if [[ "$RELEASE" = "true" ]] && [[ "$GITHUB_ACTIONS" = "true" ]]; then
-  nocacheFilterFlag="--no-cache-filter=buildkit-export,gobuild-base"
+  nocacheFilterFlag="--no-cache-filter=buildkit-export,gobuild-base,rootless"
 fi
 
 buildxCmd build --build-arg BUILDKIT_DEBUG $platformFlag $targetFlag $importCacheFlags $exportCacheFlags $tagFlags $outputFlag $nocacheFilterFlag $attestFlags \


### PR DESCRIPTION
similar to https://github.com/moby/buildkit/pull/3543
fixes https://github.com/moby/buildkit/issues/5279

We got some false-positive reported in security tab when rootless image is analyzed by Docker Scout because alpine packages are cached. With this change we make sure this stage is not cached on release.

cc @cdupuis 