### PR TITLE
exclude vendor directory from windows label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -159,3 +159,4 @@ area/worker:
 area/windows:
   - changed-files:
       - any-glob-to-any-file: "**/*_windows.go"
+      - all-globs-to-all-files: "!vendor/**/*_windows.go"


### PR DESCRIPTION
This issue updates the `area/windows` auto-labeling to exclude any files ending in `_windows.go` under the `vendor/` folder.