### PR TITLE
hack: update golangci-lint to 1.61

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -93,6 +93,7 @@ linters-settings:
       - G402  # TLS MinVersion too low
       - G504  # Import blocklist: net/http/cgi
       - G601  # Implicit memory aliasing in for loop (false positives)
+      - G115  # integer overflow conversion (TODO: verify these)
     config:
       G306: "0644"
   testifylint:

--- a/cache/contenthash/tarsum.go
+++ b/cache/contenthash/tarsum.go
@@ -37,10 +37,10 @@ func v0TarHeaderSelect(h *tar.Header) (orderedHeaders [][2]string) {
 
 func v1TarHeaderSelect(h *tar.Header) (orderedHeaders [][2]string) {
 	pax := h.PAXRecords
-	if len(h.Xattrs) > 0 { // field deprecated in stdlib
+	if len(h.Xattrs) > 0 { //nolint:staticcheck // field deprecated in stdlib
 		if pax == nil {
 			pax = map[string]string{}
-			for k, v := range h.Xattrs { // field deprecated in stdlib
+			for k, v := range h.Xattrs { //nolint:staticcheck // field deprecated in stdlib
 				pax["SCHILY.xattr."+k] = v
 			}
 		}

--- a/hack/dockerfiles/lint.Dockerfile
+++ b/hack/dockerfiles/lint.Dockerfile
@@ -4,7 +4,7 @@ ARG GO_VERSION=1.22
 ARG ALPINE_VERSION=3.20
 ARG XX_VERSION=1.4.0
 ARG PROTOLINT_VERSION=0.45.0
-ARG GOLANGCI_LINT_VERSION=1.60.1
+ARG GOLANGCI_LINT_VERSION=1.61.0
 ARG GOPLS_VERSION=v0.20.0
 # disabled: deprecated unusedvariable simplifyrange
 ARG GOPLS_ANALYZERS="embeddirective fillreturns infertypeargs nonewvars noresultvalues simplifycompositelit simplifyslice stubmethods undeclaredname unusedparams useany"

--- a/solver/testutil/cachestorage_testsuite.go
+++ b/solver/testutil/cachestorage_testsuite.go
@@ -385,7 +385,7 @@ func testWalkIDsByResult(t *testing.T, st solver.CacheKeyStorage) {
 func getFunctionName(i interface{}) string {
 	fullname := runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
 	dot := strings.LastIndex(fullname, ".") + 1
-	return strings.Title(fullname[dot:]) // ignoring "SA1019: strings.Title is deprecated", as for our use we don't need full unicode support
+	return strings.Title(fullname[dot:]) //nolint:staticcheck // ignoring "SA1019: strings.Title is deprecated", as for our use we don't need full unicode support
 }
 
 func rootKey(dgst digest.Digest, output solver.Index) digest.Digest {

--- a/util/resolver/retryhandler/retry.go
+++ b/util/resolver/retryhandler/retry.go
@@ -64,7 +64,7 @@ func retryError(err error) bool {
 		return true
 	}
 	// catches TLS timeout or other network-related temporary errors
-	if ne := net.Error(nil); errors.As(err, &ne) && ne.Temporary() { // ignoring "SA1019: Temporary is deprecated", continue to propagate net.Error through the "temporary" status
+	if ne := net.Error(nil); errors.As(err, &ne) && ne.Temporary() { //nolint:staticcheck // ignoring "SA1019: Temporary is deprecated", continue to propagate net.Error through the "temporary" status
 		return true
 	}
 

--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -220,7 +220,7 @@ func Run(t *testing.T, testCases []Test, opt ...TestOpt) {
 func getFunctionName(i interface{}) string {
 	fullname := runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
 	dot := strings.LastIndex(fullname, ".") + 1
-	return strings.Title(fullname[dot:]) // ignoring "SA1019: strings.Title is deprecated", as for our use we don't need full unicode support
+	return strings.Title(fullname[dot:]) //nolint:staticcheck // ignoring "SA1019: strings.Title is deprecated", as for our use we don't need full unicode support
 }
 
 var localImageCache map[string]map[string]struct{}


### PR DESCRIPTION
Unblock CI with the schema verify error in 1.60 https://github.com/golangci/golangci-lint/issues/5003