### PR TITLE
bklog: always enable trace id if it exists

### DIFF
--- a/util/bklog/log.go
+++ b/util/bklog/log.go
@@ -20,14 +20,6 @@ var (
 	L = logrus.NewEntry(logrus.StandardLogger())
 )
 
-var (
-	logWithTraceID = false
-)
-
-func EnableLogWithTraceID(b bool) {
-	logWithTraceID = b
-}
-
 type (
 	loggerKey struct{}
 )
@@ -51,13 +43,11 @@ func GetLogger(ctx context.Context) (l *logrus.Entry) {
 		l = L
 	}
 
-	if logWithTraceID {
-		if spanContext := trace.SpanFromContext(ctx).SpanContext(); spanContext.IsValid() {
-			return l.WithFields(logrus.Fields{
-				"traceID": spanContext.TraceID(),
-				"spanID":  spanContext.SpanID(),
-			})
-		}
+	if spanContext := trace.SpanFromContext(ctx).SpanContext(); spanContext.IsValid() {
+		return l.WithFields(logrus.Fields{
+			"traceID": spanContext.TraceID(),
+			"spanID":  spanContext.SpanID(),
+		})
 	}
 
 	return l


### PR DESCRIPTION
Previous version of the detect package would only enable trace ids in the build log if tracing was in use. For practical purposes, there was always a tracer in use (either the recorder which was always enabled or one of the detected tracers).

When this package was refactored, the call to enable the trace id was accidentally removed.

This removes the option to enable or disable the trace id from the log and instead just always enables it since this was the behavior previously.

Fixes #5310.