### PR TITLE
util/resolver: ignore invalid (empty) scope

### DIFF
--- a/util/resolver/authorizer.go
+++ b/util/resolver/authorizer.go
@@ -450,6 +450,9 @@ func parseScopes(s []string) scopes {
 	// https://docs.docker.com/registry/spec/auth/scope/
 	m := map[string]map[string]struct{}{}
 	for _, scopeStr := range s {
+		if scopeStr == "" {
+			return nil
+		}
 		// The scopeStr may have strings that contain multiple scopes separated by a space.
 		for _, scope := range strings.Split(scopeStr, " ") {
 			parts := strings.SplitN(scope, ":", 3)

--- a/util/resolver/authorizer_test.go
+++ b/util/resolver/authorizer_test.go
@@ -12,6 +12,11 @@ func TestParseScopes(t *testing.T) {
 		expected scopes
 	}{
 		{
+			name:     "InvalidScope",
+			input:    []string{""},
+			expected: nil,
+		},
+		{
 			name: "SeparateStrings",
 			input: []string{
 				"repository:foo/bar:pull",


### PR DESCRIPTION
This PR solves a problem specific for OCI registry. 

When starting auth process hitting `/v2` route, registry returns an empty scope which leads to a subsequent request as follow:

```
$ curl -v https://sa-saopaulo-1.ocir.io/v2/ 2>&1 | grep -i www
< WWW-Authenticate: Bearer realm="https://sa-saopaulo-1.ocir.io/20180419/docker/token",service="sa-saopaulo-1.ocir.io",scope=""
```

And them when hitting url `https://sa-saopaulo-1.ocir.io/20180419/docker/token`, buildkit try to send a invalid query string `scope=::`

This PR ignores empty scopes