### PR TITLE
solver: pipe implementation utilizes generics for better typing

### DIFF
--- a/solver/internal/pipe/pipe.go
+++ b/solver/internal/pipe/pipe.go
@@ -8,67 +8,63 @@ import (
 	"github.com/pkg/errors"
 )
 
-type channel struct {
+type channel[V any] struct {
 	OnSendCompletion func()
-	value            atomic.Value
-	lastValue        *wrappedValue
+	value            atomic.Pointer[V]
+	lastValue        *V
 }
 
-type wrappedValue struct {
-	value interface{}
-}
-
-func (c *channel) Send(v interface{}) {
-	c.value.Store(&wrappedValue{value: v})
+func (c *channel[V]) Send(v V) {
+	c.value.Store(&v)
 	if c.OnSendCompletion != nil {
 		c.OnSendCompletion()
 	}
 }
 
-func (c *channel) Receive() (interface{}, bool) {
+func (c *channel[V]) Receive() (V, bool) {
 	v := c.value.Load()
-	if v == nil || v.(*wrappedValue) == c.lastValue {
-		return nil, false
+	if v == nil || v == c.lastValue {
+		return *new(V), false
 	}
-	c.lastValue = v.(*wrappedValue)
-	return v.(*wrappedValue).value, true
+	c.lastValue = v
+	return *v, true
 }
 
-type Pipe struct {
-	Sender              Sender
-	Receiver            Receiver
+type Pipe[Payload, Value any] struct {
+	Sender              Sender[Payload, Value]
+	Receiver            Receiver[Payload, Value]
 	OnReceiveCompletion func()
 	OnSendCompletion    func()
 }
 
-type Request struct {
-	Payload  interface{}
+type Request[Payload any] struct {
+	Payload  Payload
 	Canceled bool
 }
 
-type Sender interface {
-	Request() Request
-	Update(v interface{})
-	Finalize(v interface{}, err error)
-	Status() Status
+type Sender[Payload, Value any] interface {
+	Request() Request[Payload]
+	Update(v Value)
+	Finalize(v Value, err error)
+	Status() Status[Value]
 }
 
-type Receiver interface {
+type Receiver[Payload, Value any] interface {
 	Receive() bool
 	Cancel()
-	Status() Status
-	Request() interface{}
+	Status() Status[Value]
+	Request() Payload
 }
 
-type Status struct {
+type Status[Value any] struct {
 	Canceled  bool
 	Completed bool
 	Err       error
-	Value     interface{}
+	Value     Value
 }
 
-func NewWithFunction(f func(context.Context) (interface{}, error)) (*Pipe, func()) {
-	p := New(Request{})
+func NewWithFunction[Payload, Value any](f func(context.Context) (Value, error)) (*Pipe[Payload, Value], func()) {
+	p := New[Payload, Value](Request[Payload]{})
 
 	ctx, cancel := context.WithCancelCause(context.TODO())
 
@@ -81,27 +77,27 @@ func NewWithFunction(f func(context.Context) (interface{}, error)) (*Pipe, func(
 	return p, func() {
 		res, err := f(ctx)
 		if err != nil {
-			p.Sender.Finalize(nil, err)
+			p.Sender.Finalize(*new(Value), err)
 			return
 		}
 		p.Sender.Finalize(res, nil)
 	}
 }
 
-func New(req Request) *Pipe {
-	cancelCh := &channel{}
-	roundTripCh := &channel{}
-	pw := &sender{
+func New[Payload, Value any](req Request[Payload]) *Pipe[Payload, Value] {
+	cancelCh := &channel[Request[Payload]]{}
+	roundTripCh := &channel[Status[Value]]{}
+	pw := &sender[Payload, Value]{
 		req:         req,
 		sendChannel: roundTripCh,
 	}
-	pr := &receiver{
+	pr := &receiver[Payload, Value]{
 		req:         req,
 		recvChannel: roundTripCh,
 		sendChannel: cancelCh,
 	}
 
-	p := &Pipe{
+	p := &Pipe[Payload, Value]{
 		Sender:   pw,
 		Receiver: pr,
 	}
@@ -109,7 +105,7 @@ func New(req Request) *Pipe {
 	cancelCh.OnSendCompletion = func() {
 		v, ok := cancelCh.Receive()
 		if ok {
-			pw.setRequest(v.(Request))
+			pw.setRequest(v)
 		}
 		if p.OnReceiveCompletion != nil {
 			p.OnReceiveCompletion()
@@ -125,38 +121,36 @@ func New(req Request) *Pipe {
 	return p
 }
 
-type sender struct {
-	status      Status
-	req         Request
-	sendChannel *channel
+type sender[Payload, Value any] struct {
+	status      Status[Value]
+	req         Request[Payload]
+	sendChannel *channel[Status[Value]]
 	mu          sync.Mutex
 }
 
-func (pw *sender) Status() Status {
+func (pw *sender[Payload, Value]) Status() Status[Value] {
 	return pw.status
 }
 
-func (pw *sender) Request() Request {
+func (pw *sender[Payload, Value]) Request() Request[Payload] {
 	pw.mu.Lock()
 	defer pw.mu.Unlock()
 	return pw.req
 }
 
-func (pw *sender) setRequest(req Request) {
+func (pw *sender[Payload, Value]) setRequest(req Request[Payload]) {
 	pw.mu.Lock()
 	defer pw.mu.Unlock()
 	pw.req = req
 }
 
-func (pw *sender) Update(v interface{}) {
+func (pw *sender[Payload, Value]) Update(v Value) {
 	pw.status.Value = v
 	pw.sendChannel.Send(pw.status)
 }
 
-func (pw *sender) Finalize(v interface{}, err error) {
-	if v != nil {
-		pw.status.Value = v
-	}
+func (pw *sender[Payload, Value]) Finalize(v Value, err error) {
+	pw.status.Value = v
 	pw.status.Err = err
 	pw.status.Completed = true
 	if errors.Is(err, context.Canceled) && pw.req.Canceled {
@@ -165,27 +159,27 @@ func (pw *sender) Finalize(v interface{}, err error) {
 	pw.sendChannel.Send(pw.status)
 }
 
-type receiver struct {
-	status      Status
-	req         Request
-	recvChannel *channel
-	sendChannel *channel
+type receiver[Payload, Value any] struct {
+	status      Status[Value]
+	req         Request[Payload]
+	recvChannel *channel[Status[Value]]
+	sendChannel *channel[Request[Payload]]
 }
 
-func (pr *receiver) Request() interface{} {
+func (pr *receiver[Payload, Value]) Request() Payload {
 	return pr.req.Payload
 }
 
-func (pr *receiver) Receive() bool {
+func (pr *receiver[Payload, Value]) Receive() bool {
 	v, ok := pr.recvChannel.Receive()
 	if !ok {
 		return false
 	}
-	pr.status = v.(Status)
+	pr.status = v
 	return true
 }
 
-func (pr *receiver) Cancel() {
+func (pr *receiver[Payload, Value]) Cancel() {
 	req := pr.req
 	if req.Canceled {
 		return
@@ -194,6 +188,6 @@ func (pr *receiver) Cancel() {
 	pr.sendChannel.Send(req)
 }
 
-func (pr *receiver) Status() Status {
+func (pr *receiver[Payload, Value]) Status() Status[Value] {
 	return pr.status
 }


### PR DESCRIPTION
This updates the pipe library to use generics for the request payload and the status value. This allows the solver to put in explicit types rather than rely on type casting from interfaces which helps with type safety and understandability.

The status value used by the solver uses the `any` type instead of an explicit type because the `unpark` method takes a generic list of pipes and the different pipes have different result types. We can likely change this in the future or create a discriminated union for the types that can be used in this package. That is left for future work because at least the request payload is typed now.