### PR TITLE
readme: add r2d4/llb frontend and dacc project

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ BuildKit is used by the following projects:
 -   [Namespace](https://namespace.so)
 -   [Unikraft](https://unikraft.org)
 -   [DevZero](https://devzero.io)
+-   [dacc](https://github.com/r2d4/dacc)
 
 ## Quick start
 
@@ -203,6 +204,7 @@ Currently, the following high-level languages have been implemented for LLB:
 -   [Blubber](https://gitlab.wikimedia.org/repos/releng/blubber)
 -   [Bass](https://github.com/vito/bass)
 -   [kraft.yaml (Unikraft)](https://github.com/unikraft/kraftkit/tree/staging/tools/dockerfile-llb-frontend)
+-   [r2d4/llb (JSON Gateway)](https://github.com/r2d4/llb)
 -   (open a PR to add your own language)
 
 ### Exploring Dockerfiles


### PR DESCRIPTION
Thanks again for a great project.

r2d4/llb is a frontend that exposes the Solve rpc and the image config via JSON. The idea is that I found it difficult to generate the full gRPC stubs for languages other than Go. Additionally, some runtimes (like connect/grpc node/web) can't listen on a unix socket. Instead, you only have to compile ops.proto and build the graph. It takes in a JSON file with the schema: imageConfig (OCI image config) and definition (the base64-encoded binary-encoded protobuf)

The dacc project is a TypeScript project that uses the r2d4/llb frontend. It is similar to llb.State, but in TypeScript and calls the frontend to solve the graph.

