### PR TITLE
ci: Fix govulncheck permissions

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -149,6 +149,8 @@ jobs:
     permissions:
       # required to write sarif report
       security-events: write
+      # required to check out the repository
+      contents: read
     steps:
       -
         name: Checkout


### PR DESCRIPTION
It needs at least content read to be able to checkout the repository.