### PR TITLE
 frontend/dockerfile/docs: add $ in mount env example

### DIFF
--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -842,7 +842,7 @@ environment variable with the same name.
 # syntax=docker/dockerfile:1
 FROM alpine
 RUN --mount=type=secret,id=API_KEY,env=API_KEY \
-    some-command --token-from-env API_KEY
+    some-command --token-from-env $API_KEY
 ```
 
 Assuming that the `API_KEY` environment variable is set in the build


### PR DESCRIPTION
I added $ in 'Example: Mount as environment variable' sample command because it is needed to refer to env.