### PR TITLE
frontend tests: add secondary sort on errors for more consistent rule check tests

### DIFF
--- a/frontend/dockerfile/dockerfile_lint_test.go
+++ b/frontend/dockerfile/dockerfile_lint_test.go
@@ -191,7 +191,7 @@ ENV git_key=
 			{
 				RuleName:    "SecretsUsedInArgOrEnv",
 				Description: "Sensitive data should not be used in the ARG or ENV commands",
-				Detail:      `Do not use ARG or ENV instructions for sensitive data (ARG "super_duper_secret_token")`,
+				Detail:      `Do not use ARG or ENV instructions for sensitive data (ARG "auth")`,
 				URL:         "https://docs.docker.com/go/dockerfile/rule/secrets-used-in-arg-or-env/",
 				Level:       1,
 				Line:        6,
@@ -199,7 +199,7 @@ ENV git_key=
 			{
 				RuleName:    "SecretsUsedInArgOrEnv",
 				Description: "Sensitive data should not be used in the ARG or ENV commands",
-				Detail:      `Do not use ARG or ENV instructions for sensitive data (ARG "auth")`,
+				Detail:      `Do not use ARG or ENV instructions for sensitive data (ARG "super_duper_secret_token")`,
 				URL:         "https://docs.docker.com/go/dockerfile/rule/secrets-used-in-arg-or-env/",
 				Level:       1,
 				Line:        6,
@@ -1388,6 +1388,9 @@ func checkUnmarshal(t *testing.T, sb integration.Sandbox, lintTest *lintTestPara
 			// sort by line number in ascending order
 			firstRange := lintResults.Warnings[i].Location.Ranges[0]
 			secondRange := lintResults.Warnings[j].Location.Ranges[0]
+			if firstRange.Start.Line == secondRange.Start.Line {
+				return lintResults.Warnings[i].Detail < lintResults.Warnings[j].Detail
+			}
 			return firstRange.Start.Line < secondRange.Start.Line
 		})
 		// Compare expectedLintWarning with actual lint results
@@ -1477,6 +1480,9 @@ func checkProgressStream(t *testing.T, sb integration.Sandbox, lintTest *lintTes
 		} else if len(w2.Range) == 0 {
 			return false
 		}
+		if w1.Range[0].Start.Line == w2.Range[0].Start.Line {
+			return string(w1.Short) < string(w2.Short)
+		}
 		return w1.Range[0].Start.Line < w2.Range[0].Start.Line
 	})
 	for i, w := range warnings {
@@ -1487,6 +1493,9 @@ func checkProgressStream(t *testing.T, sb integration.Sandbox, lintTest *lintTes
 func checkLinterWarnings(t *testing.T, sb integration.Sandbox, lintTest *lintTestParams) {
 	t.Helper()
 	sort.Slice(lintTest.Warnings, func(i, j int) bool {
+		if lintTest.Warnings[i].Line == lintTest.Warnings[j].Line {
+			return lintTest.Warnings[i].Detail < lintTest.Warnings[j].Detail
+		}
 		return lintTest.Warnings[i].Line < lintTest.Warnings[j].Line
 	})
 


### PR DESCRIPTION
fixes https://github.com/moby/buildkit/issues/5338

Currently when we run tests for the rule checks, we sort by line number so that we can make sure the warnings are being compared in a easily predictable order (as opposed to whichever order the linter happens to run the checks). In the case where multiple warnings were present on a single line, the tests could fail. This adds a secondary sort on the `Detail` (or `Short` field when checking `VertexWarning`s) field so that warnings within the same line are presented in a similarly predictable order.