### PR TITLE
docs: windows: add a note about ContainerUser limited permissions

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -154,6 +154,10 @@ Now that everything is setup, let's build a [simple _hello world_ image](https:/
     This message shows that your installation appears to be working correctly.
     "@
     ```
+
+    > **NOTE:** Writing to a file directly under `C:\` needs extra permissions that are `ContainerAdministrator`.
+    > The `ContainerUser` is default user for `nanoserver` image. See more details at [#4731](https://github.com/moby/buildkit/issues/4731).
+
 1. Build and push to your registry (or set to `push=false`). For Docker Hub, make sure you've done `docker login`. See more details on registry configuration [here](../README.md#imageregistry)
 
     ```powershell


### PR DESCRIPTION
`ContainerUser` is not permitted to write to `C:\` because of their limited permissions, `(WD)` at best.

Add a note explaining why we are using `USER ContainerAdministrator` in our dockerfile for us to be able to run:
```
RUN echo "Goodbye!" >> hello.txt
```

On client SKUs like Win11, there will be no issues since `ContainerUser` has `(M)` permissions on `C:\`

Fixes #4731 as by-design.