### PR TITLE
solver: make digest computation for ops deterministic again

### DIFF
--- a/solver/pb/ops.go
+++ b/solver/pb/ops.go
@@ -7,7 +7,7 @@ func (m *Definition) IsNil() bool {
 }
 
 func (m *Definition) Marshal() ([]byte, error) {
-	return proto.Marshal(m)
+	return proto.MarshalOptions{Deterministic: true}.Marshal(m)
 }
 
 func (m *Definition) Unmarshal(dAtA []byte) error {
@@ -15,7 +15,7 @@ func (m *Definition) Unmarshal(dAtA []byte) error {
 }
 
 func (m *Op) Marshal() ([]byte, error) {
-	return proto.Marshal(m)
+	return proto.MarshalOptions{Deterministic: true}.Marshal(m)
 }
 
 func (m *Op) Unmarshal(dAtA []byte) error {


### PR DESCRIPTION
The solver relied on protobuf marshaling to compute a digest. There's no guarantee of the byte order, especially for maps, with marshaling. As an implementation detail, gogo would sort the keys for a map and `Deterministic: true` causes the standard marshaler to sort the keys, but this isn't a reliable method.

In the future, we likely want to either remove the maps from the protobuf messages or not rely on protobuf serialization for this function.