### PR TITLE
allows setting volatile overlay mount option

### DIFF
--- a/util/overlay/overlay_linux.go
+++ b/util/overlay/overlay_linux.go
@@ -95,7 +95,7 @@ func GetOverlayLayers(m mount.Mount) ([]string, error) {
 			for i, j := 0, len(l)-1; i < j; i, j = i+1, j-1 {
 				l[i], l[j] = l[j], l[i] // make l[0] = bottommost
 			}
-		} else if strings.HasPrefix(o, "workdir=") || o == "index=off" || o == "userxattr" || strings.HasPrefix(o, "redirect_dir=") {
+		} else if strings.HasPrefix(o, "workdir=") || o == "index=off" || o == "userxattr" || strings.HasPrefix(o, "redirect_dir=") || o == "volatile" {
 			// these options are possible to specfied by the snapshotter but not indicate dir locations.
 			continue
 		} else {


### PR DESCRIPTION
given that buildkit is generally very IO intensive, some preliminary
tests have shown that adding the volatile option could yield up to
a 15% performance improvements in some cases.

ref: https://docs.kernel.org/filesystems/overlayfs.html#volatile-mount

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
