### PR TITLE
frontend: handle multiple platforms when using the lint rule check functionality

### DIFF
--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -94,6 +94,8 @@ func Build(ctx context.Context, c client.Client) (_ *client.Result, err error) {
 			return dockerfile2llb.ListTargets(ctx, src.Data)
 		},
 		Lint: func(ctx context.Context) (*lint.LintResults, error) {
+			convertOpt.TargetPlatform, _ = ctx.Value(dockerui.PlatformCtxKey{}).(*ocispecs.Platform)
+
 			return dockerfile2llb.DockerfileLint(ctx, src.Data, convertOpt)
 		},
 	}); err != nil {


### PR DESCRIPTION
fixes issue identified in [buildx#2708](https://github.com/docker/buildx/issues/2708)

Currently, using the rule check functionality doesn't respect `--platform` flags, which causes issues when trying to check images which rely on images not machine the host machine architecture. This update runs the check for each platform requested, and merges duplicate check warnings.