### PR TITLE
Added way to configure SBOM scanner

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -9213,7 +9213,13 @@ cat <<EOF > $BUILDKIT_SCAN_DESTINATION/spdx.json
 {
   "_type": "https://in-toto.io/Statement/v0.1",
   "predicateType": "https://spdx.dev/Document",
-  "predicate": {"name": "fallback"}
+  "predicate": {
+	"name": "fallback",
+	"extraParams": {
+	  "ARG1": "$BUILDKIT_SCAN_ARG1",
+	  "ARG2": "$BUILDKIT_SCAN_ARG2"
+	}
+  }
 }
 EOF
 `
@@ -9436,6 +9442,74 @@ EOF
 	require.Equal(t, "https://in-toto.io/Statement/v0.1", attest.Type)
 	require.Equal(t, intoto.PredicateSPDX, attest.PredicateType)
 	require.Subset(t, attest.Predicate, map[string]interface{}{"name": "frontend"})
+
+	// test configuring the scanner (simple)
+	target = registry + "/buildkit/testsbom4:latest"
+	_, err = c.Build(sb.Context(), SolveOpt{
+		FrontendAttrs: map[string]string{
+			"attest:sbom": "generator=" + scannerTarget + ",ARG1=foo,ARG2=bar",
+		},
+		Exports: []ExportEntry{
+			{
+				Type: ExporterImage,
+				Attrs: map[string]string{
+					"name": target,
+					"push": "true",
+				},
+			},
+		},
+	}, "", makeTargetFrontend(false), nil)
+	require.NoError(t, err)
+
+	desc, provider, err = contentutil.ProviderFromRef(target)
+	require.NoError(t, err)
+
+	imgs, err = testutil.ReadImages(sb.Context(), provider, desc)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(imgs.Images))
+
+	att = imgs.Find("unknown/unknown")
+	attest = intoto.Statement{}
+	require.NoError(t, json.Unmarshal(att.LayersRaw[0], &attest))
+	require.Equal(t, "https://in-toto.io/Statement/v0.1", attest.Type)
+	require.Equal(t, intoto.PredicateSPDX, attest.PredicateType)
+	require.Subset(t, attest.Predicate, map[string]interface{}{
+		"extraParams": map[string]interface{}{"ARG1": "foo", "ARG2": "bar"},
+	})
+
+	// test configuring the scanner (complex)
+	target = registry + "/buildkit/testsbom4:latest"
+	_, err = c.Build(sb.Context(), SolveOpt{
+		FrontendAttrs: map[string]string{
+			"attest:sbom": "\"generator=" + scannerTarget + "\",\"ARG1=foo\",\"ARG2=hello,world\"",
+		},
+		Exports: []ExportEntry{
+			{
+				Type: ExporterImage,
+				Attrs: map[string]string{
+					"name": target,
+					"push": "true",
+				},
+			},
+		},
+	}, "", makeTargetFrontend(false), nil)
+	require.NoError(t, err)
+
+	desc, provider, err = contentutil.ProviderFromRef(target)
+	require.NoError(t, err)
+
+	imgs, err = testutil.ReadImages(sb.Context(), provider, desc)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(imgs.Images))
+
+	att = imgs.Find("unknown/unknown")
+	attest = intoto.Statement{}
+	require.NoError(t, json.Unmarshal(att.LayersRaw[0], &attest))
+	require.Equal(t, "https://in-toto.io/Statement/v0.1", attest.Type)
+	require.Equal(t, intoto.PredicateSPDX, attest.PredicateType)
+	require.Subset(t, attest.Predicate, map[string]interface{}{
+		"extraParams": map[string]interface{}{"ARG1": "foo", "ARG2": "hello,world"},
+	})
 }
 
 func testSBOMScanSingleRef(t *testing.T, sb integration.Sandbox) {

--- a/frontend/attestations/parse_test.go
+++ b/frontend/attestations/parse_test.go
@@ -1,0 +1,66 @@
+package attestations
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		values   map[string]string
+		expected map[string]map[string]string
+	}{
+		{
+			name: "simple",
+			values: map[string]string{
+				"attest:sbom":       "generator=docker.io/foo/bar",
+				"attest:provenance": "mode=max",
+			},
+			expected: map[string]map[string]string{
+				"sbom": {
+					"generator": "docker.io/foo/bar",
+				},
+				"provenance": {
+					"mode": "max",
+				},
+			},
+		},
+		{
+			name: "extra params",
+			values: map[string]string{
+				"attest:sbom": "generator=docker.io/foo/bar,param1=foo,param2=bar",
+			},
+			expected: map[string]map[string]string{
+				"sbom": {
+					"generator": "docker.io/foo/bar",
+					"param1":    "foo",
+					"param2":    "bar",
+				},
+			},
+		},
+		{
+			name: "extra params (complex)",
+			values: map[string]string{
+				"attest:sbom": "\"generator=docker.io/foo/bar\",\"param1=foo\",\"param2=bar\",\"param3=abc,def\"",
+			},
+			expected: map[string]map[string]string{
+				"sbom": {
+					"generator": "docker.io/foo/bar",
+					"param1":    "foo",
+					"param2":    "bar",
+					"param3":    "abc,def",
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			attests, err := Parse(tc.values)
+			require.NoError(t, err)
+			_ = attests
+			assert.Equal(t, tc.expected, attests)
+		})
+	}
+}

--- a/frontend/attestations/sbom/sbom.go
+++ b/frontend/attestations/sbom/sbom.go
@@ -34,7 +34,7 @@ const (
 // attestation.
 type Scanner func(ctx context.Context, name string, ref llb.State, extras map[string]llb.State, opts ...llb.ConstraintsOpt) (result.Attestation[*llb.State], error)
 
-func CreateSBOMScanner(ctx context.Context, resolver sourceresolver.MetaResolver, scanner string, resolveOpt sourceresolver.Opt) (Scanner, error) {
+func CreateSBOMScanner(ctx context.Context, resolver sourceresolver.MetaResolver, scanner string, resolveOpt sourceresolver.Opt, params map[string]string) (Scanner, error) {
 	if scanner == "" {
 		return nil, nil
 	}
@@ -64,6 +64,10 @@ func CreateSBOMScanner(ctx context.Context, resolver sourceresolver.MetaResolver
 		env = append(env, "BUILDKIT_SCAN_SOURCE="+path.Join(srcDir, "core", CoreSBOMName))
 		if len(extras) > 0 {
 			env = append(env, "BUILDKIT_SCAN_SOURCE_EXTRAS="+path.Join(srcDir, "extras/"))
+		}
+
+		for k, v := range params {
+			env = append(env, "BUILDKIT_SCAN_"+k+"="+v)
 		}
 
 		runOpts := []llb.RunOption{

--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -118,7 +118,7 @@ func Build(ctx context.Context, c client.Client) (_ *client.Result, err error) {
 			ImageOpt: &sourceresolver.ResolveImageOpt{
 				ResolveMode: opts["image-resolve-mode"],
 			},
-		})
+		}, bc.SBOM.Parameters)
 		if err != nil {
 			return nil, err
 		}

--- a/solver/llbsolver/proc/sbom.go
+++ b/solver/llbsolver/proc/sbom.go
@@ -16,7 +16,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func SBOMProcessor(scannerRef string, useCache bool, resolveMode string) llbsolver.Processor {
+func SBOMProcessor(scannerRef string, useCache bool, resolveMode string, params map[string]string) llbsolver.Processor {
 	return func(ctx context.Context, res *llbsolver.Result, s *llbsolver.Solver, j *solver.Job, usage *resources.SysSampler) (*llbsolver.Result, error) {
 		// skip sbom generation if we already have an sbom
 		if sbom.HasSBOM(res.Result) {
@@ -35,7 +35,7 @@ func SBOMProcessor(scannerRef string, useCache bool, resolveMode string) llbsolv
 			ImageOpt: &sourceresolver.ResolveImageOpt{
 				ResolveMode: resolveMode,
 			},
-		})
+		}, params)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This addresses #3791.

Using the following scanner image

```Dockerfile
FROM alpine

CMD [ "printenv" ]
```

With the following command:

```
echo "FROM alpine" | docker buildx b . --progress=plain --no-cache -f - --sbom=generator=laurentgoderre689/mock-scanner,EXTRA_SCANNERS=test
```

Yields

```
#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 49B done
#1 DONE 0.0s

[...]

#8 DONE 0.7s

#9 [linux/arm64] generating sbom using docker.io/laurentgoderre689/mock-scanner:latest
#9 0.037 BUILDKIT_SCAN_DESTINATION=/run/out/
#9 0.037 BUILDKIT_SCAN_SOURCE=/run/src/core/sbom
#9 0.037 BUILDKIT_SCAN_type=sbom
#9 0.037 BUILDKIT_SCAN_EXTRA_SCANNERS=test
#9 DONE 0.1s
```

This also addresses the concerns about comma in values.

Running

```
echo "FROM alpine" | docker buildx b . --progress=plain --no-cache -f - --sbom="\"generator=laurentgoderre689/mock-scanner\",\"EXTRA_SCANNERS=test1,test2\""
```

Yields

```
#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 49B done
#1 DONE 0.0s

[...]

#7 [linux/arm64] generating sbom using docker.io/laurentgoderre689/mock-scanner:latest
#7 0.053 BUILDKIT_SCAN_DESTINATION=/run/out/
#7 0.053 BUILDKIT_SCAN_SOURCE=/run/src/core/sbom
#7 0.053 BUILDKIT_SCAN_type=sbom
#7 0.053 BUILDKIT_SCAN_EXTRA_SCANNERS=test1,test2
#7 DONE 0.1s
```