### PR TITLE
tests: skip TestContextChangeDirToFile on Windows

### DIFF
--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -1928,6 +1928,8 @@ COPY arch-$TARGETARCH whoami
 
 // tonistiigi/fsutil#46
 func testContextChangeDirToFile(t *testing.T, sb integration.Sandbox) {
+	// TODO(profnandaa): investigating flakyness on Windows CI
+	integration.SkipOnPlatform(t, "windows")
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(integration.UnixOrWindows(


### PR DESCRIPTION
This test has been flaky, see #5384

Skip on Windows for now as investigations go on. This is to allow the rest of the pipeline to remain
unpoisoned.