### PR TITLE
Multiple fixes for ONBUILD behavior

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -1134,6 +1134,7 @@ func initOnBuildTriggers(d *dispatchState, triggers []string, allDispatchStates 
 		}
 	}
 	d.commands = append(commands, d.commands...)
+	d.cmdTotal += len(commands)
 
 	return hasNewDeps, nil
 }

--- a/frontend/dockerfile/parser/errors.go
+++ b/frontend/dockerfile/parser/errors.go
@@ -34,12 +34,24 @@ func withLocation(err error, start, end int) error {
 
 // WithLocation extends an error with a source code location
 func WithLocation(err error, location []Range) error {
+	return setLocation(err, location, true)
+}
+
+func SetLocation(err error, location []Range) error {
+	return setLocation(err, location, false)
+}
+
+func setLocation(err error, location []Range, add bool) error {
 	if err == nil {
 		return nil
 	}
 	var el *ErrorLocation
 	if errors.As(err, &el) {
-		el.Locations = append(el.Locations, location)
+		if add {
+			el.Locations = append(el.Locations, location)
+		} else {
+			el.Locations = [][]Range{location}
+		}
 		return err
 	}
 	return stack.Enable(&ErrorLocation{


### PR DESCRIPTION
#### dockerfile: fix command count after new commands from ONBUILD

Fix progress lines like `[6/4] step`

#### dockerfile: mark commands invoked from ONBUILD with prefix

#### dockerfile: set error location for ONBUILD errors

Set error location for ONBUILD errors to the command
that pulled in the image with ONBUILD definitions.

Currently location was incorrectly set to the first
line as ONBUILD was parsed as a separate source code.

Location is handled both at parse time (for invalid
ONBUILD definition) and run time (when command set
via ONBUILD errors).
