### PR TITLE
worker/containerd: NewWorkerOpt: remove workaround for named pipes

### DIFF
--- a/worker/containerd/containerd.go
+++ b/worker/containerd/containerd.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	goRuntime "runtime"
 	"strconv"
 	"strings"
 
@@ -48,28 +47,13 @@ type WorkerOptions struct {
 }
 
 // NewWorkerOpt creates a WorkerOpt.
-func NewWorkerOpt(
-	workerOpts WorkerOptions,
-	opts ...containerd.ClientOpt,
-) (base.WorkerOpt, error) {
+func NewWorkerOpt(workerOpts WorkerOptions, opts ...containerd.ClientOpt) (base.WorkerOpt, error) {
 	opts = append(opts, containerd.WithDefaultNamespace(workerOpts.Namespace))
-
-	address := workerOpts.Address
-
-	if goRuntime.GOOS == "windows" {
-		// TODO(profnandaa): once the upstream PR[1] is merged and
-		// vendored in buildkit, we will remove this block.
-		// [1] https://github.com/containerd/containerd/pull/9412
-		address = strings.TrimPrefix(address, "npipe://")
-	}
-	client, err := containerd.New(address, opts...)
+	client, err := containerd.New(workerOpts.Address, opts...)
 	if err != nil {
-		return base.WorkerOpt{}, errors.Wrapf(err, "failed to connect client to %q . make sure containerd is running", address)
+		return base.WorkerOpt{}, errors.Wrapf(err, "failed to connect client to %q . make sure containerd is running", workerOpts.Address)
 	}
-	return newContainerd(
-		client,
-		workerOpts,
-	)
+	return newContainerd(client, workerOpts)
 }
 
 func newContainerd(client *containerd.Client, workerOpts WorkerOptions) (base.WorkerOpt, error) {


### PR DESCRIPTION
relates to;

- https://github.com/moby/buildkit/pull/4432
- https://github.com/containerd/containerd/pull/9412
- https://github.com/moby/buildkit/pull/4530



This workaround was added in 414edfaa7d20ed5d22876fdaa82eff212944a233, pending changes in containerd. Those changes were included in containerd 1.7.12, which was vendored in bce2f79f8333275426a1560b7dce18067476d720, so the workaround should no longer be needed.

I also reformatted the code, as there's no longer a need to wrap this function since the list of arguments has been reduced.