### PR TITLE
grpcclient: return proper nil reference from grpcclient

### DIFF
--- a/frontend/gateway/grpcclient/client.go
+++ b/frontend/gateway/grpcclient/client.go
@@ -429,28 +429,21 @@ func (c *grpcClient) Solve(ctx context.Context, creq client.SolveRequest) (res *
 			}
 		case *pb.Result_RefsDeprecated:
 			for k, v := range pbRes.RefsDeprecated.Refs {
-				ref := &reference{id: v, c: c}
-				if v == "" {
-					ref = nil
+				var ref client.Reference
+				if v != "" {
+					ref = &reference{id: v, c: c}
 				}
 				res.AddRef(k, ref)
 			}
 		case *pb.Result_Ref:
 			if pbRes.Ref.Id != "" {
-				ref, err := newReference(c, pbRes.Ref)
-				if err != nil {
-					return nil, err
-				}
-				res.SetRef(ref)
+				res.SetRef(newReference(c, pbRes.Ref))
 			}
 		case *pb.Result_Refs:
 			for k, v := range pbRes.Refs.Refs {
-				var ref *reference
+				var ref client.Reference
 				if v.Id != "" {
-					ref, err = newReference(c, v)
-					if err != nil {
-						return nil, err
-					}
+					ref = newReference(c, v)
 				}
 				res.AddRef(k, ref)
 			}
@@ -464,11 +457,7 @@ func (c *grpcClient) Solve(ctx context.Context, creq client.SolveRequest) (res *
 						return nil, err
 					}
 					if a.Ref.Id != "" {
-						ref, err := newReference(c, a.Ref)
-						if err != nil {
-							return nil, err
-						}
-						att.Ref = ref
+						att.Ref = newReference(c, a.Ref)
 					}
 					res.AddAttestation(p, *att)
 				}
@@ -1168,8 +1157,8 @@ type reference struct {
 	def *opspb.Definition
 }
 
-func newReference(c *grpcClient, ref *pb.Ref) (*reference, error) {
-	return &reference{c: c, id: ref.Id, def: ref.Def}, nil
+func newReference(c *grpcClient, ref *pb.Ref) *reference {
+	return &reference{c: c, id: ref.Id, def: ref.Def}
 }
 
 func (r *reference) ToState() (st llb.State, err error) {


### PR DESCRIPTION
The grpcclient would take an empty reference and convert it into a `(*reference)(nil)` and then store that in a `client.Reference`. This caused the `nil` check in `convertRef` to return false because it wasn't `nil` but then it panicked because it was `nil`.

`newReference` has been minorly refactored to not return an error. The method is not exported, the error value is not used, and it obscured the functionality which made it harder to use correctly.

Fixes https://github.com/moby/buildkit/issues/5379.