### PR TITLE
frontend: add an allow list for secret lint check and add public to said list

### DIFF
--- a/frontend/dockerfile/dockerfile_lint_test.go
+++ b/frontend/dockerfile/dockerfile_lint_test.go
@@ -152,6 +152,8 @@ ENV password=bar secret=baz
 ARG super_duper_secret_token=foo auth=bar
 ENV apikey=bar sunflower=foo
 ENV git_key=
+ENV PUBLIC_KEY=
+ARG public_token
 `)
 	checkLinterWarnings(t, sb, &lintTestParams{
 		Dockerfile: dockerfile,


### PR DESCRIPTION
fixes #5403

Adds the ability to add allowed tokens to the `SecretsUsedInArgOrEnv` check, which allows for `ARG` / `ENV` keys which might otherwise be considered a secret - such as `PUBLIC_KEY`.
