### PR TITLE
fix: set h2 protocol identifier to comply with TLS-ALPN

### DIFF
--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -740,6 +740,7 @@ func serverCredentials(cfg config.TLSConfig) (*tls.Config, error) {
 	}
 	tlsConf := &tls.Config{
 		Certificates: []tls.Certificate{certificate},
+		NextProtos:   []string{"h2"},
 	}
 	if caFile != "" {
 		certPool := x509.NewCertPool()


### PR DESCRIPTION
In order to bump `grpc-go` (in this repo or in external clients) we need to specify `h2` as the application protocol in buildkitd's TLS config.

The enforcement was introduced in `grpc-go v1.67.0`. 

`buildkit` and `buildx` are currently on `v1.66.2` so this patch is needed for the next update. I didn't update `grpc-go` in this patch, but can do if you prefer.

Testing with `buildctl` on `v1.67.1`

```
◊ cat go.mod | grep "google.golang.org/grpc\ "
        google.golang.org/grpc v1.67.1
```

Before this patch
```
◊ ./buildctl --addr tcp://localhost:1234 --tlsdir /tmp/certs/client/ build --local context=. --local dockerfile=. --frontend dockerfile.v0
[+] Building 0.0s (0/0)
error: listing workers for Build: failed to list workers: Unavailable: connection error: desc = "transport: authentication handshake failed: credentials: cannot check peer: missing selected ALPN property"
```

After patch
```
◊ ./buildctl --addr tcp://localhost:1234 --tlsdir /tmp/certs/client/ build --local context=. --local dockerfile=. --frontend dockerfile.v0
[+] Building 44.3s (71/71) FINISHED
```

Context
- https://github.com/grpc/grpc-go/releases/tag/v1.67.0
- TLS does not enforce ALPN protocol  grpc/grpc-go#434
- https://github.com/grpc/grpc-go/pull/7184