### PR TITLE
frontend: sets the InvalidDefinitionDescription check to be experimental

### DIFF
--- a/frontend/dockerfile/dockerfile_lint_test.go
+++ b/frontend/dockerfile/dockerfile_lint_test.go
@@ -50,7 +50,7 @@ var lintTests = integration.TestFuncs(
 )
 
 func testDefinitionDescription(t *testing.T, sb integration.Sandbox) {
-	dockerfile := []byte(`
+	dockerfile := []byte(`# check=experimental=InvalidDefinitionDescription
 # foo this is the foo
 ARG foo=bar
 
@@ -70,7 +70,7 @@ COPY Dockerfile .
 `)
 	checkLinterWarnings(t, sb, &lintTestParams{Dockerfile: dockerfile})
 
-	dockerfile = []byte(`
+	dockerfile = []byte(`# check=experimental=InvalidDefinitionDescription
 # bar this is the bar
 ARG foo=bar
 # BasE this is the BasE image

--- a/frontend/dockerfile/docs/rules/_index.md
+++ b/frontend/dockerfile/docs/rules/_index.md
@@ -104,7 +104,7 @@ To learn more about how to use build checks, see
       <td>Attempting to Copy file that is excluded by .dockerignore</td>
     </tr>
     <tr>
-      <td><a href="./invalid-definition-description/">InvalidDefinitionDescription</a></td>
+      <td><a href="./invalid-definition-description/">InvalidDefinitionDescription (experimental)</a></td>
       <td>Comment for build stage or argument should follow the format: `# <arg/stage name> <description>`. If this is not intended to be a description comment, add an empty line or comment between the instruction and the comment.</td>
     </tr>
   </tbody>

--- a/frontend/dockerfile/docs/rules/invalid-definition-description.md
+++ b/frontend/dockerfile/docs/rules/invalid-definition-description.md
@@ -5,6 +5,10 @@ aliases:
   - /go/dockerfile/rule/invalid-definition-description/
 ---
 
+> [!NOTE]
+> This check is experimental and is not enabled by default. To enable it, see
+> [Experimental checks](https://docs.docker.com/go/build-checks-experimental/).
+
 ## Output
 
 ```text

--- a/frontend/dockerfile/linter/ruleset.go
+++ b/frontend/dockerfile/linter/ruleset.go
@@ -172,5 +172,6 @@ var (
 		Format: func(instruction, defName string) string {
 			return fmt.Sprintf("Comment for %s should follow the format: `# %s <description>`", instruction, defName)
 		},
+		Experimental: true,
 	}
 )


### PR DESCRIPTION
Currently, the `InvalidDefinitionDescription` check generates a lot of noise. This PR marks this check as experimental in order to make it opt-in.