### PR TITLE
Dockerfile: update runc binary to 1.1.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:master
 
-ARG RUNC_VERSION=v1.1.14
+ARG RUNC_VERSION=v1.1.15
 ARG CONTAINERD_VERSION=v1.7.22
 # CONTAINERD_ALT_VERSION_16 defines fallback containerd version for integration tests
 ARG CONTAINERD_ALT_VERSION_16=v1.6.36


### PR DESCRIPTION
diff: https://github.com/opencontainers/runc/compare/v1.1.14...v1.1.15

Release Notes:
- The -ENOSYS seccomp stub is now always generated for the native
architecture that runc is running on. This is needed to work around some
arguably specification-incompliant behaviour from Docker on architectures
such as ppc64le, where the allowed architecture list is set to null. This
ensures that we always generate at least one -ENOSYS stub for the native
architecture even with these weird configs.
- On a system with older kernel, reading /proc/self/mountinfo may skip some
entries, as a consequence runc may not properly set mount propagation,
causing container mounts leak onto the host mount namespace.
- In order to fix performance issues in the "lightweight" bindfd protection
against [https://github.com/advisories/GHSA-gxmr-w5mj-v8hh], the temporary ro bind-mount of /proc/self/exe
has been removed. runc now creates a binary copy in all cases.