### PR TITLE
Update ARG sytnax definition in dockerfile reference

### DIFF
--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -728,7 +728,7 @@ This can be used to:
 The supported mount types are:
 
 | Type                                     | Description                                                                                                              |
-| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------                |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | [`bind`](#run---mounttypebind) (default) | Bind-mount context directories (read-only).                                                                              |
 | [`cache`](#run---mounttypecache)         | Mount a temporary directory to cache directories for compilers and package managers.                                     |
 | [`tmpfs`](#run---mounttypetmpfs)         | Mount a `tmpfs` in the build container.                                                                                  |
@@ -741,7 +741,7 @@ This mount type allows binding files or directories to the build container. A
 bind mount is read-only by default.
 
 | Option                             | Description                                                                                    |
-| ----------------                   | ---------------------------------------------------------------------------------------------- |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------- |
 | `target`, `dst`, `destination`[^1] | Mount path.                                                                                    |
 | `source`                           | Source path in the `from`. Defaults to the root of the `from`.                                 |
 | `from`                             | Build stage, context, or image name for the root of the source. Defaults to the build context. |
@@ -753,7 +753,7 @@ This mount type allows the build container to cache directories for compilers
 and package managers.
 
 | Option                             | Description                                                                                                                                                                                                                                                                |
-| ---------------                    | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `id`                               | Optional ID to identify separate/different caches. Defaults to value of `target`.                                                                                                                                                                                          |
 | `target`, `dst`, `destination`[^1] | Mount path.                                                                                                                                                                                                                                                                |
 | `ro`,`readonly`                    | Read-only if set.                                                                                                                                                                                                                                                          |
@@ -802,7 +802,7 @@ case.
 This mount type allows mounting `tmpfs` in the build container.
 
 | Option                             | Description                                           |
-| ------------                       | ----------------------------------------------------- |
+| ---------------------------------- | ----------------------------------------------------- |
 | `target`, `dst`, `destination`[^1] | Mount path.                                           |
 | `size`                             | Specify an upper limit on the size of the filesystem. |
 
@@ -863,7 +863,7 @@ This mount type allows the build container to access SSH keys via SSH agents,
 with support for passphrases.
 
 | Option                         | Description                                                                                    |
-| ----------                     | ---------------------------------------------------------------------------------------------- |
+| ------------------------------ | ---------------------------------------------------------------------------------------------- |
 | `id`                           | ID of SSH agent socket or key. Defaults to "default".                                          |
 | `target`, `dst`, `destination` | SSH agent socket path. Defaults to `/run/buildkit/ssh_agent.${N}`.                             |
 | `required`                     | If set to `true`, the instruction errors out when the key is unavailable. Defaults to `false`. |
@@ -2310,7 +2310,7 @@ Therefore, to avoid unintended operations in unknown directories, it's best prac
 ## ARG
 
 ```dockerfile
-ARG <name>[=<default value>]
+ARG <name>[=<default value>] ...
 ```
 
 The `ARG` instruction defines a variable that users can pass at build-time to


### PR DESCRIPTION
Small update to the `ARG` syntax definition in the reference document. It should now reflect the ability to have multiple `ARG`s declared on a single line.