### PR TITLE
docs: add front matter title to attestation docs

### DIFF
--- a/docs/attestations/attestation-storage.md
+++ b/docs/attestations/attestation-storage.md
@@ -1,4 +1,6 @@
-# Image Attestation Storage
+---
+title: Image attestation storage
+---
 
 Buildkit supports creating and attaching attestations to build artifacts. These
 attestations can provide valuable information from the build process,

--- a/docs/attestations/sbom-protocol.md
+++ b/docs/attestations/sbom-protocol.md
@@ -1,4 +1,6 @@
-# SBOM Scanning Protocol
+---
+title: SBOM scanning protocol
+---
 
 BuildKit supports automatic creation of [SBOMs](https://en.wikipedia.org/wiki/Software_supply_chain)
 for builds, attaching them as [image attestations](./attestation-storage.md).

--- a/docs/attestations/sbom.md
+++ b/docs/attestations/sbom.md
@@ -1,4 +1,6 @@
-# SBOMs
+---
+title: SBOMs
+---
 
 BuildKit supports automatic creation of [SBOMs](https://en.wikipedia.org/wiki/Software_supply_chain)
 to record the software components that make up the final image. These consist

--- a/docs/attestations/slsa-definitions.md
+++ b/docs/attestations/slsa-definitions.md
@@ -1,4 +1,6 @@
-# SLSA definitions
+---
+title: SLSA definitions
+---
 
 BuildKit supports the [creation of SLSA Provenance](./slsa-provenance.md) for builds that
 it runs.

--- a/docs/attestations/slsa-provenance.md
+++ b/docs/attestations/slsa-provenance.md
@@ -1,4 +1,6 @@
-# SLSA provenance
+---
+title: SLSA provenance
+---
 
 BuildKit supports automatic creation of provenance attestations for the build
 process. Provenance attestations record information describing how a build was


### PR DESCRIPTION
When republish these on docs.docker.com, having the title in front
matter means we can access it programmatically in templates.

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>
