### PR TITLE
dockerfile: expose TARGETSTAGE as builtin argument

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -227,10 +227,6 @@ func toDispatchState(ctx context.Context, dt []byte, opt ConvertOpt) (*dispatchS
 		opt.LLBCaps = &caps
 	}
 
-	platformOpt := buildPlatformOpt(&opt)
-
-	globalArgs := platformArgs(platformOpt, opt.BuildArgs)
-
 	dockerfile, err := parser.Parse(bytes.NewReader(dt))
 	if err != nil {
 		return nil, err
@@ -260,6 +256,13 @@ func toDispatchState(ctx context.Context, dt []byte, opt ConvertOpt) (*dispatchS
 	}
 	validateStageNames(stages, lint)
 	validateCommandCasing(stages, lint)
+
+	platformOpt := buildPlatformOpt(&opt)
+	targetName := opt.Target
+	if targetName == "" {
+		targetName = stages[len(stages)-1].Name
+	}
+	globalArgs := defaultArgs(platformOpt, opt.BuildArgs, targetName)
 
 	shlex := shell.NewLex(dockerfile.EscapeToken)
 	outline := newOutlineCapture()

--- a/frontend/dockerfile/dockerfile2llb/platform.go
+++ b/frontend/dockerfile/dockerfile2llb/platform.go
@@ -36,9 +36,12 @@ func buildPlatformOpt(opt *ConvertOpt) *platformOpt {
 	}
 }
 
-func platformArgs(po *platformOpt, overrides map[string]string) *llb.EnvList {
+func defaultArgs(po *platformOpt, overrides map[string]string, target string) *llb.EnvList {
 	bp := po.buildPlatforms[0]
 	tp := po.targetPlatform
+	if target == "" {
+		target = "default"
+	}
 	s := [...][2]string{
 		{"BUILDPLATFORM", platforms.Format(bp)},
 		{"BUILDOS", bp.OS},
@@ -48,6 +51,7 @@ func platformArgs(po *platformOpt, overrides map[string]string) *llb.EnvList {
 		{"TARGETOS", tp.OS},
 		{"TARGETARCH", tp.Architecture},
 		{"TARGETVARIANT", tp.Variant},
+		{"TARGETSTAGE", target},
 	}
 	env := &llb.EnvList{}
 	for _, kv := range s {


### PR DESCRIPTION
closes https://github.com/docker/buildx/issues/2646

Allows capturing what build stage is currently being built for patterns with better base stage reuse.