### PR TITLE
chore: add disk stat error wrapping

### DIFF
--- a/util/disk/disk_openbsd.go
+++ b/util/disk/disk_openbsd.go
@@ -5,12 +5,14 @@ package disk
 
 import (
 	"syscall"
+
+	"github.com/pkg/errors"
 )
 
 func GetDiskStat(root string) (DiskStat, error) {
 	var st syscall.Statfs_t
 	if err := syscall.Statfs(root, &st); err != nil {
-		return DiskStat{}, err
+		return DiskStat{}, errors.Wrapf(err, "could not stat fs at %s", root)
 	}
 
 	return DiskStat{

--- a/util/disk/disk_unix.go
+++ b/util/disk/disk_unix.go
@@ -5,12 +5,14 @@ package disk
 
 import (
 	"syscall"
+
+	"github.com/pkg/errors"
 )
 
 func GetDiskStat(root string) (DiskStat, error) {
 	var st syscall.Statfs_t
 	if err := syscall.Statfs(root, &st); err != nil {
-		return DiskStat{}, err
+		return DiskStat{}, errors.Wrapf(err, "could not stat fs at %s", root)
 	}
 
 	return DiskStat{

--- a/util/disk/disk_windows.go
+++ b/util/disk/disk_windows.go
@@ -4,13 +4,14 @@
 package disk
 
 import (
+	"github.com/pkg/errors"
 	"golang.org/x/sys/windows"
 )
 
 func GetDiskStat(root string) (DiskStat, error) {
 	rootUTF16, err := windows.UTF16FromString(root)
 	if err != nil {
-		return DiskStat{}, err
+		return DiskStat{}, errors.Wrapf(err, "could not encode %s", root)
 	}
 	var (
 		totalBytes         uint64
@@ -22,7 +23,7 @@ func GetDiskStat(root string) (DiskStat, error) {
 		&freeAvailableBytes,
 		&totalBytes,
 		&totalFreeBytes); err != nil {
-		return DiskStat{}, err
+		return DiskStat{}, errors.Wrapf(err, "could not stat fs at %s", root)
 	}
 
 	return DiskStat{


### PR DESCRIPTION
While doing some debugging, realized we weren't doing any disk wrapping so it was difficult to work out *which* file on disk didn't exist.