### PR TITLE
git: allow cloning commit shas not referenced by branch/tag

### DIFF
--- a/source/git/source.go
+++ b/source/git/source.go
@@ -36,7 +36,6 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-var validHex = regexp.MustCompile(`^[a-f0-9]{40}$`)
 var defaultBranch = regexp.MustCompile(`refs/heads/(\S+)`)
 
 type Opt struct {
@@ -341,7 +340,7 @@ func (gs *gitSourceHandler) CacheKey(ctx context.Context, g session.Group, index
 	gs.locker.Lock(remote)
 	defer gs.locker.Unlock(remote)
 
-	if ref := gs.src.Ref; ref != "" && isCommitSHA(ref) {
+	if ref := gs.src.Ref; ref != "" && gitutil.IsCommitSHA(ref) {
 		cacheKey := gs.shaToCacheKey(ref)
 		gs.cacheKey = cacheKey
 		return cacheKey, ref, nil, true, nil
@@ -400,7 +399,7 @@ func (gs *gitSourceHandler) CacheKey(ctx context.Context, g session.Group, index
 	if sha == "" {
 		return "", "", nil, false, errors.Errorf("repository does not contain ref %s, output: %q", ref, string(buf))
 	}
-	if !isCommitSHA(sha) {
+	if !gitutil.IsCommitSHA(sha) {
 		return "", "", nil, false, errors.Errorf("invalid commit sha %q", sha)
 	}
 
@@ -455,7 +454,7 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context, g session.Group) (out 
 	}
 
 	doFetch := true
-	if isCommitSHA(ref) {
+	if gitutil.IsCommitSHA(ref) {
 		// skip fetch if commit already exists
 		if _, err := git.Run(ctx, "cat-file", "-e", ref+"^{commit}"); err == nil {
 			doFetch = false
@@ -467,7 +466,7 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context, g session.Group) (out 
 		os.RemoveAll(filepath.Join(gitDir, "shallow.lock"))
 
 		args := []string{"fetch"}
-		if !isCommitSHA(ref) { // TODO: find a branch from ls-remote?
+		if !gitutil.IsCommitSHA(ref) { // TODO: find a branch from ls-remote?
 			args = append(args, "--depth=1", "--no-tags")
 		} else {
 			args = append(args, "--tags")
@@ -476,11 +475,11 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context, g session.Group) (out 
 			}
 		}
 		args = append(args, "origin")
-		if !isCommitSHA(ref) {
-			args = append(args, "--force", ref+":tags/"+ref)
+		if !gitutil.IsCommitSHA(ref) {
 			// local refs are needed so they would be advertised on next fetches. Force is used
 			// in case the ref is a branch and it now points to a different commit sha
 			// TODO: is there a better way to do this?
+			args = append(args, "--force", ref+":tags/"+ref)
 		}
 		if _, err := git.Run(ctx, args...); err != nil {
 			return nil, errors.Wrapf(err, "failed to fetch remote %s", urlutil.RedactCredentials(gs.src.Remote))
@@ -549,7 +548,7 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context, g session.Group) (out 
 		pullref := ref
 		if isAnnotatedTag {
 			pullref += ":refs/tags/" + pullref
-		} else if isCommitSHA(ref) {
+		} else if gitutil.IsCommitSHA(ref) {
 			pullref = "refs/buildkit/" + identity.NewID()
 			_, err = git.Run(ctx, "update-ref", pullref, ref)
 			if err != nil {
@@ -708,10 +707,6 @@ func (gs *gitSourceHandler) gitCli(ctx context.Context, g session.Group, opts ..
 		gitutil.WithSSHKnownHosts(knownHosts),
 	}, opts...)
 	return gitCLI(opts...), cleanup, err
-}
-
-func isCommitSHA(str string) bool {
-	return validHex.MatchString(str)
 }
 
 func tokenScope(remote string) string {

--- a/source/git/source.go
+++ b/source/git/source.go
@@ -475,7 +475,9 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context, g session.Group) (out 
 			}
 		}
 		args = append(args, "origin")
-		if !gitutil.IsCommitSHA(ref) {
+		if gitutil.IsCommitSHA(ref) {
+			args = append(args, ref)
+		} else {
 			// local refs are needed so they would be advertised on next fetches. Force is used
 			// in case the ref is a branch and it now points to a different commit sha
 			// TODO: is there a better way to do this?

--- a/util/gitutil/git_commit.go
+++ b/util/gitutil/git_commit.go
@@ -1,9 +1,19 @@
 package gitutil
 
-import "regexp"
-
-var validHex = regexp.MustCompile(`^[a-f0-9]{40}$`)
-
 func IsCommitSHA(str string) bool {
-	return validHex.MatchString(str)
+	if len(str) != 40 {
+		return false
+	}
+
+	for _, ch := range str {
+		if ch >= '0' && ch <= '9' {
+			continue
+		}
+		if ch >= 'a' && ch <= 'f' {
+			continue
+		}
+		return false
+	}
+
+	return true
 }

--- a/util/gitutil/git_commit.go
+++ b/util/gitutil/git_commit.go
@@ -1,0 +1,9 @@
+package gitutil
+
+import "regexp"
+
+var validHex = regexp.MustCompile(`^[a-f0-9]{40}$`)
+
+func IsCommitSHA(str string) bool {
+	return validHex.MatchString(str)
+}


### PR DESCRIPTION
https://github.com/moby/buildkit/pull/5072 is only half the fix - it's still possible for a commit to not be tagged or part of a branch.

For a practical example, see `refs/pull/.../merge` - the commit referenced by this ref is not tagged or part of any branch, and so isn't advertised by `upload-pack`, and so won't be part of clone.

Modern git servers should support this though - https://git-scm.com/docs/protocol-capabilities#_allow_reachable_sha1_in_want - we should be able to specify a specific commit when `fetch`ing. We can include a fallback for if the server *doesn't* support this capability (not 100% sure about the logic here though :thinking: - can we assume everyone is using `upload-pack`?)

This might feel a little edge-casey - but they're still important! The main reason is - `git fetch` supports this, so we should do as well. Another is that it's possible to break cache consistency without this fix, e.g.:
- Running these in order:
- `Snapshot(<commit at refs/pull/.../merge>)` - fails
- `Snapshot(refs/pull/.../merge)` - succeeds
- `Snapshot(<commit at refs/pull/.../merge>)` - succeeds, since this commit is now in the cloned repo
This doesn't really make much sense, and can break reproducibility.

(Originally reported in https://github.com/dagger/dagger/issues/8584)