### PR TITLE
filesync: reuse data buffer for diffcopy

### DIFF
--- a/session/filesync/diffcopy.go
+++ b/session/filesync/diffcopy.go
@@ -129,8 +129,9 @@ func syncTargetDiffCopy(ds grpc.ServerStream, dest string) error {
 }
 
 func writeTargetFile(ds grpc.ServerStream, wc io.WriteCloser) error {
+	var bm BytesMessage
 	for {
-		bm := BytesMessage{}
+		bm.Data = bm.Data[:0]
 		if err := ds.RecvMsg(&bm); err != nil {
 			if errors.Is(err, io.EOF) {
 				return nil


### PR DESCRIPTION
Reuse the bytes message data buffer for diffcopy to allow memory to be reused when unmarshaling the bytes.