### PR TITLE
Dockerfile: update runc binary to 1.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:master
 
-ARG RUNC_VERSION=v1.1.15
+ARG RUNC_VERSION=v1.2.1
 ARG CONTAINERD_VERSION=v1.7.23
 # CONTAINERD_ALT_VERSION_16 defines fallback containerd version for integration tests
 ARG CONTAINERD_ALT_VERSION_16=v1.6.36


### PR DESCRIPTION
https://github.com/opencontainers/runc/releases/tag/v1.2.0
https://github.com/opencontainers/runc/releases/tag/v1.2.1