### PR TITLE
fix: WCOW: add powershell.exe dir to default PATH for backward compatibiliy

### DIFF
--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -212,6 +212,7 @@ var allTests = integration.TestFuncs(
 	testLocalCustomSessionID,
 	testTargetStageNameArg,
 	testStepNames,
+	testPowershellInDefaultPathOnWindows,
 )
 
 // Tests that depend on the `security.*` entitlements
@@ -1812,7 +1813,7 @@ COPY Dockerfile .
 		entrypoint []string
 		env        []string
 	}{
-		{p: "windows/amd64", entrypoint: []string{"cmd", "/S", "/C", "foo bar"}, env: []string{"PATH=c:\\Windows\\System32;c:\\Windows"}},
+		{p: "windows/amd64", entrypoint: []string{"cmd", "/S", "/C", "foo bar"}, env: []string{"PATH=c:\\Windows\\System32;c:\\Windows;C:\\Windows\\System32\\WindowsPowerShell\\v1.0"}},
 		{p: "linux/amd64", entrypoint: []string{"/bin/sh", "-c", "foo bar"}, env: []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}},
 	} {
 		t.Run(exp.p, func(t *testing.T) {
@@ -1947,6 +1948,49 @@ COPY --from=base /out/ /
 	dt, err = os.ReadFile(filepath.Join(destDir, "second"))
 	require.NoError(t, err)
 	require.Equal(t, "value:final", string(dt))
+}
+
+func testPowershellInDefaultPathOnWindows(t *testing.T, sb integration.Sandbox) {
+	integration.SkipOnPlatform(t, "!windows")
+
+	f := getFrontend(t, sb)
+
+	// just testing that the powershell path is in PATH
+	// but not testing powershell itself since it will need
+	// servercore image that is too bulky for just one single test.
+	dockerfile := []byte(`
+FROM nanoserver
+USER ContainerAdministrator
+RUN echo %PATH% > env_path.txt
+`)
+	dir := integration.Tmpdir(
+		t,
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+	)
+	c, err := client.New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	destDir := t.TempDir()
+	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
+		Exports: []client.ExportEntry{
+			{
+				Type:      client.ExporterLocal,
+				OutputDir: destDir,
+			},
+		},
+		LocalMounts: map[string]fsutil.FS{
+			dockerui.DefaultLocalNameDockerfile: dir,
+			dockerui.DefaultLocalNameContext:    dir,
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	dt, err := os.ReadFile(filepath.Join(destDir, "env_path.txt"))
+	require.NoError(t, err)
+
+	envPath := string(dt)
+	require.Contains(t, envPath, "C:\\Windows\\System32\\WindowsPowerShell\\v1.0")
 }
 
 func testExportMultiPlatform(t *testing.T, sb integration.Sandbox) {

--- a/util/system/path.go
+++ b/util/system/path.go
@@ -16,7 +16,7 @@ const DefaultPathEnvUnix = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/s
 // DefaultPathEnvWindows is windows style list of directories to search for
 // executables. Each directory is separated from the next by a colon
 // ';' character .
-const DefaultPathEnvWindows = "c:\\Windows\\System32;c:\\Windows"
+const DefaultPathEnvWindows = "c:\\Windows\\System32;c:\\Windows;C:\\Windows\\System32\\WindowsPowerShell\\v1.0"
 
 func DefaultPathEnv(os string) string {
 	if os == "windows" {


### PR DESCRIPTION
The current default `PATH` has been set to the most basic subset for both `nanoserver` and `servercore`.

```go
const DefaultPathEnvWindows = "c:\\Windows\\System32;c:\\Windows;
```

The path to `powershell.exe` is conspicuously missing hence breaking the developer experience for most workloads that depend on PS.

This fix proposes to append `;C:\\Windows\\System32\\WindowsPowerShell\\v1.0` to that list to support PS scenarios, that make a big chunk of workloads, especially legacy ones, migrating from on-prem to cloud.

Fixes #4901, https://github.com/microsoft/Windows-Containers/issues/500
Ref #3158

### Basic Test

```dockerfile
# note, only servercore+ has powershell
FROM mcr.microsoft.com/windows/servercore:ltsc2022
RUN powershell -C Write-Host "hello powershell!!"
```

On classic docker build:

```
Step 2/2 : RUN powershell -C Write-Host "hello powershell!!"
 ---> Running in e06539ef3f11
hello powershell!!
```

Buildkit before fix:

```
> [2/2] RUN powershell -C Write-Host "hello powershell!!":
1.684 'powershell' is not recognized as an internal or external command,
1.684 operable program or batch file.
------
Dockerfile:2
--------------------
   1 |     FROM mcr.microsoft.com/windows/servercore:ltsc2022
   2 | >>> RUN powershell -C Write-Host "hello powershell!!"
   3 |
```

Buildkit after fix:

```
#5 [2/2] RUN powershell -C Write-Host "hello powershell!!"
#5 5.916 hello powershell!!
#5 DONE 7.1s
```

### Implication for nanoserver:

This does not any way break the experiences for those using `nanoserver` base image, as much as PS and the `C:\\Windows\\System32\\WindowsPowerShell\\v1.0` path is not present on `nanoserver`.

### Transition users to using `ENV`:

Users coming from classic `docker build` will need to transition from using `RUN setx /M` to `ENV` as a way of persisting environment variables in the images.

We can take a hit on not supporting backward compatibility for `RUN setx /M`, as opposed to not supporting both `RUN setx /M` and `RUN powershell` as it is the case right now.

### Alternative considered:

We thought of an option to ask the Windows platform team to add a default `Config.Env.PATH` in the config file for the base image. However, this causes a regression for `RUN setx /M` on the classic `docker build`. There could be a couple of more people too that might be depending on `Config.Env = null` as it is currently. See:

```
PS> docker inspect mcr.microsoft.com/windows/servercore:ltsc2022
```

Here is the regression details when we set `ENV` in the base image.

```dockerfile
FROM mcr.microsoft.com/windows/servercore:ltsc2022 AS newbase
ENV PATH="C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Users\ContainerAdministrator\AppData\Local\Microsoft\WindowsApps"

FROM newbase
RUN setx /M PATH "C:\my\path;%PATH%"
RUN echo %PATH%
```

```
PS> docker build --no-cache -t profnandaa/servercore-path-tests .

<snip>
Step 5/5 : RUN echo %PATH%
---> Running in 785633e2a31c
C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Users\ContainerAdministrator\AppData\Local\Microsoft\WindowsApps
   ^
   | ~~~~~~~~~ notice "C:\my\path" is missing, meaning `setx /M` is not persisting as before.

```

Current `RUN setx /M` behavior:

```dockerfile
FROM mcr.microsoft.com/windows/servercore:ltsc2022
RUN setx /M PATH "C:\my\path;%PATH%"
RUN echo %PATH%
```

```
PS> docker build --no-cache -t profnandaa/servercore-path-tests .

<snip>

Step 3/3 : RUN echo %PATH%
---> Running in 3bacb0b27bad
C:\my\path;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Users\ContainerAdministrator\AppData\Local\Microsoft\WindowsApps;
   ^
   |~~~~ `setx /M` persists.
```

`setx` vs. `ENV` has been discussed in details in #5445