### PR TITLE
Metadata descriptors

### DIFF
--- a/cmd/buildctl/build.go
+++ b/cmd/buildctl/build.go
@@ -439,8 +439,11 @@ func writeMetadataFile(filename string, exporterResponse map[string]string) erro
 		}
 		var raw map[string]interface{}
 		if err = json.Unmarshal(dt, &raw); err != nil || len(raw) == 0 {
-			out[k] = v
-			continue
+			var rawList []map[string]interface{}
+			if err = json.Unmarshal(dt, &rawList); err != nil || len(rawList) == 0 {
+				out[k] = v
+				continue
+			}
 		}
 		out[k] = json.RawMessage(dt)
 	}

--- a/cmd/buildctl/build_test.go
+++ b/cmd/buildctl/build_test.go
@@ -140,7 +140,7 @@ func testBuildMetadataFile(t *testing.T, sb integration.Sandbox) {
 	metadataBytes, err := os.ReadFile(metadataFile)
 	require.NoError(t, err)
 
-	var metadata map[string]interface{}
+	var metadata map[string]json.RawMessage
 	err = json.Unmarshal(metadataBytes, &metadata)
 	require.NoError(t, err)
 
@@ -153,12 +153,16 @@ func testBuildMetadataFile(t *testing.T, sb integration.Sandbox) {
 
 	require.Contains(t, metadata, exptypes.ExporterImageDescriptorKey)
 	var desc *ocispecs.Descriptor
-	dtdesc, err := json.Marshal(metadata[exptypes.ExporterImageDescriptorKey])
-	require.NoError(t, err)
-	err = json.Unmarshal(dtdesc, &desc)
+	err = json.Unmarshal(metadata[exptypes.ExporterImageDescriptorKey], &desc)
 	require.NoError(t, err)
 	require.NotEmpty(t, desc.MediaType)
 	require.NotEmpty(t, desc.Digest.String())
+
+	require.Contains(t, metadata, exptypes.ExporterImageDescriptorsKey)
+	var descList []*ocispecs.Descriptor
+	require.NoError(t, err)
+	err = json.Unmarshal(metadata[exptypes.ExporterImageDescriptorsKey], &descList)
+	require.NoError(t, err)
 
 	cdAddress := sb.ContainerdAddress()
 	if cdAddress == "" {

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -230,10 +230,11 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 		}
 	}()
 
-	desc, err := e.opt.ImageWriter.Commit(ctx, src, sessionID, inlineCache, &opts)
+	descriptors, err := e.opt.ImageWriter.Commit(ctx, src, sessionID, inlineCache, &opts)
 	if err != nil {
 		return nil, nil, err
 	}
+	desc := descriptors[0]
 	defer func() {
 		if err == nil {
 			descref = NewDescriptorReference(*desc, done)
@@ -358,6 +359,12 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 		return nil, nil, err
 	}
 	resp[exptypes.ExporterImageDescriptorKey] = base64.StdEncoding.EncodeToString(dtdesc)
+
+	dtdesclist, err := json.Marshal(descriptors)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp[exptypes.ExporterImageDescriptorsKey] = base64.StdEncoding.EncodeToString(dtdesclist)
 
 	return resp, nil, nil
 }

--- a/exporter/containerimage/exptypes/types.go
+++ b/exporter/containerimage/exptypes/types.go
@@ -13,6 +13,7 @@ const (
 	ExporterImageConfigKey       = "containerimage.config"
 	ExporterImageConfigDigestKey = "containerimage.config.digest"
 	ExporterImageDescriptorKey   = "containerimage.descriptor"
+	ExporterImageDescriptorsKey  = "containerimage.descriptors"
 	ExporterImageBaseConfigKey   = "containerimage.base.config"
 	ExporterPlatformsKey         = "refs.platforms"
 )

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -159,10 +159,11 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 		}
 	}()
 
-	desc, err := e.opt.ImageWriter.Commit(ctx, src, sessionID, inlineCache, &opts)
+	descriptors, err := e.opt.ImageWriter.Commit(ctx, src, sessionID, inlineCache, &opts)
 	if err != nil {
 		return nil, nil, err
 	}
+	desc := descriptors[0]
 	defer func() {
 		if err == nil {
 			descref = containerimage.NewDescriptorReference(*desc, done)
@@ -193,6 +194,12 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 		return nil, nil, err
 	}
 	resp[exptypes.ExporterImageDescriptorKey] = base64.StdEncoding.EncodeToString(dtdesc)
+
+	dtdesclist, err := json.Marshal(descriptors)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp[exptypes.ExporterImageDescriptorsKey] = base64.StdEncoding.EncodeToString(dtdesclist)
 
 	if n, ok := src.Metadata["image.name"]; e.opts.ImageName == "*" && ok {
 		e.opts.ImageName = string(n)


### PR DESCRIPTION
This PR allows outputting all the descriptors in the metadata file. This is how it would look:

```json
"containerimage.descriptors": [
    {
      "mediaType": "application/vnd.oci.image.index.v1+json",
      "digest": "sha256:09ebf864af696306655197662bac5fc5d249e273223bf0c02df053c5b969e723",
      "size": 1607,
      "annotations": {
        "org.opencontainers.image.created": "2024-10-28T13:41:56Z"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:465f515dfba9a241c3af16b4154e4161db1e8de1055b753434874158e7ae05d9",
      "size": 480,
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.config.v1+json",
      "digest": "sha256:e75ff1d806b99c41ff0f797f6800a85546d5ebf447d69796ec1db166809a41a2",
      "size": 585
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:6769e746bda352f77bbc473606b8e55bed52a2e091d7bba0d953aba8915410ac",
      "size": 480,
      "platform": {
        "architecture": "arm64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.config.v1+json",
      "digest": "sha256:1c1104847de44646826edc258cfc23c4955f05ab2110d6aa1944ee283f993bb2",
      "size": 585
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:a8287ced569f2ab73e293791fcab87478106a5b87eda2567ada9341c675f52c2",
      "size": 838,
      "annotations": {
        "vnd.docker.reference.digest": "sha256:465f515dfba9a241c3af16b4154e4161db1e8de1055b753434874158e7ae05d9",
        "vnd.docker.reference.type": "attestation-manifest"
      },
      "platform": {
        "architecture": "unknown",
        "os": "unknown"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:c844cf966bdfe7d63e4b87f69b66238fe0e8e42539faa3240258b07f3e85d45d",
      "size": 838,
      "annotations": {
        "vnd.docker.reference.digest": "sha256:6769e746bda352f77bbc473606b8e55bed52a2e091d7bba0d953aba8915410ac",
        "vnd.docker.reference.type": "attestation-manifest"
      },
      "platform": {
        "architecture": "unknown",
        "os": "unknown"
      }
    }
]
```