### PR TITLE
util/tracing: switch to semconv v0.21.0

### DIFF
--- a/util/tracing/tracing.go
+++ b/util/tracing/tracing.go
@@ -11,7 +11,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
-	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
 


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/48757#issuecomment-2437558426

Align the package to use the same version of semconv we use elsewhere. Worth noting that some modules still use v0.17;

- go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
- go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace
- go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp

Git grep on buildkit;

    util/tracing/detect/resource.go:                                                                                      semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
    util/tracing/tracing.go:                                                                                              semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
    vendor/github.com/containerd/containerd/tracing/tracing.go:                                                           semconv "go.opentelemetry.io/otel/semconv/v1.21.0"

    vendor/go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/config.go:                         semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
    vendor/go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go:                    semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
    vendor/go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/internal/parse.go:                 semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
    vendor/go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/semconv.go:                        semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
    vendor/go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/stats_handler.go:                  semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
    vendor/go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace/clienttrace.go:                   semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
    vendor/go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace/httptrace.go:                     semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
    vendor/go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace/internal/semconvutil/httpconv.go: semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
    vendor/go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace/internal/semconvutil/netconv.go:  semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
    vendor/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/handler.go:                                      semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
    vendor/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/internal/semconvutil/httpconv.go:                semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
    vendor/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/internal/semconvutil/netconv.go:                 semconv "go.opentelemetry.io/otel/semconv/v1.17.0"

    vendor/go.opentelemetry.io/otel/exporters/jaeger/jaeger.go:                                                           semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
    vendor/go.opentelemetry.io/otel/sdk/resource/builtin.go:                                                              semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
    vendor/go.opentelemetry.io/otel/sdk/resource/container.go:                                                            semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
    vendor/go.opentelemetry.io/otel/sdk/resource/env.go:                                                                  semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
    vendor/go.opentelemetry.io/otel/sdk/resource/host_id.go:                                                              semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
    vendor/go.opentelemetry.io/otel/sdk/resource/os.go:                                                                   semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
    vendor/go.opentelemetry.io/otel/sdk/resource/process.go:                                                              semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
    vendor/go.opentelemetry.io/otel/sdk/trace/span.go:                                                                    semconv "go.opentelemetry.io/otel/semconv/v1.21.0"