### PR TITLE
Add support for SHA-256 Git commit IDs

### DIFF
--- a/source/git/source_test.go
+++ b/source/git/source_test.go
@@ -150,14 +150,20 @@ func testRepeatedFetch(t *testing.T, keepGitDir bool) {
 	require.Equal(t, "subcontents\n", string(dt))
 }
 
-func TestFetchBySHA(t *testing.T) {
-	testFetchBySHA(t, false)
+func TestFetchBySHA1(t *testing.T) {
+	testFetchBySHA(t, "sha1", false)
 }
-func TestFetchBySHAKeepGitDir(t *testing.T) {
-	testFetchBySHA(t, true)
+func TestFetchBySHA1KeepGitDir(t *testing.T) {
+	testFetchBySHA(t, "sha1", true)
+}
+func TestFetchBySHA256(t *testing.T) {
+	testFetchBySHA(t, "sha256", false)
+}
+func TestFetchBySHA256KeepGitDir(t *testing.T) {
+	testFetchBySHA(t, "sha256", true)
 }
 
-func testFetchBySHA(t *testing.T, keepGitDir bool) {
+func testFetchBySHA(t *testing.T, format string, keepGitDir bool) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Depends on unimplemented containerd bind-mount support on Windows")
 	}
@@ -168,7 +174,7 @@ func testFetchBySHA(t *testing.T, keepGitDir bool) {
 
 	gs := setupGitSource(t, t.TempDir())
 
-	repo := setupGitRepo(t)
+	repo := setupGitRepoFormat(t, format)
 
 	cmd := exec.Command("git", "rev-parse", "feature")
 	cmd.Dir = repo.mainPath
@@ -176,8 +182,18 @@ func testFetchBySHA(t *testing.T, keepGitDir bool) {
 	out, err := cmd.Output()
 	require.NoError(t, err)
 
+	var shaLen int
+	switch format {
+	case "sha1":
+		shaLen = 40
+	case "sha256":
+		shaLen = 64
+	default:
+		t.Fatalf("unexpected format: %q", format)
+	}
+
 	sha := strings.TrimSpace(string(out))
-	require.Equal(t, 40, len(sha))
+	require.Equal(t, shaLen, len(sha))
 
 	id := &GitIdentifier{Remote: repo.mainURL, Ref: sha, KeepGitDir: keepGitDir}
 
@@ -188,14 +204,14 @@ func testFetchBySHA(t *testing.T, keepGitDir bool) {
 	require.NoError(t, err)
 	require.True(t, done)
 
-	expLen := 40
+	expLen := shaLen
 	if keepGitDir {
 		expLen += 4
 		require.GreaterOrEqual(t, len(key1), expLen)
 	} else {
 		require.Equal(t, expLen, len(key1))
 	}
-	require.Equal(t, 40, len(pin1))
+	require.Equal(t, shaLen, len(pin1))
 
 	ref1, err := g.Snapshot(ctx, nil)
 	require.NoError(t, err)
@@ -796,7 +812,13 @@ type gitRepoFixture struct {
 	mainURL, subURL   string // HTTP URLs for the respective repos
 }
 
+// small helper for the common case
 func setupGitRepo(t *testing.T) gitRepoFixture {
+	t.Helper()
+	return setupGitRepoFormat(t, "sha1")
+}
+
+func setupGitRepoFormat(t *testing.T, format string) gitRepoFixture {
 	t.Helper()
 	dir := t.TempDir()
 	srv := serveGitRepo(t, dir)
@@ -810,7 +832,7 @@ func setupGitRepo(t *testing.T) gitRepoFixture {
 	require.NoError(t, os.MkdirAll(fixture.mainPath, 0700))
 
 	runShell(t, fixture.subPath,
-		"git -c init.defaultBranch=master init",
+		"git -c init.defaultBranch=master init --object-format="+format,
 		"git config --local user.email test",
 		"git config --local user.name test",
 		"echo subcontents > subfile",
@@ -827,7 +849,7 @@ func setupGitRepo(t *testing.T) gitRepoFixture {
 	// * (tag: refs/tags/v1.2.3) second
 	// * (tag: refs/tags/a/v1.2.3, refs/tags/a/v1.2.3-same) initial
 	runShell(t, fixture.mainPath,
-		"git -c init.defaultBranch=master init",
+		"git -c init.defaultBranch=master init --object-format="+format,
 		"git config --local user.email test",
 		"git config --local user.name test",
 

--- a/util/gitutil/git_commit.go
+++ b/util/gitutil/git_commit.go
@@ -1,7 +1,7 @@
 package gitutil
 
 func IsCommitSHA(str string) bool {
-	if len(str) != 40 {
+	if l := len(str); l != 40 && l != 64 {
 		return false
 	}
 

--- a/util/gitutil/git_commit_test.go
+++ b/util/gitutil/git_commit_test.go
@@ -10,7 +10,8 @@ import (
 func TestIsCommitSHA(t *testing.T) {
 	for truthy, commits := range map[bool][]string{
 		true: {
-			"01234567890abcdef01234567890abcdef012345", // 40 valid characters (SHA-1)
+			"01234567890abcdef01234567890abcdef012345",                         // 40 valid characters (SHA-1)
+			"01234567890abcdef01234567890abcdef01234567890abcdef01234567890ab", // 64 valid characters (SHA-256)
 		},
 		false: {
 			"",       // empty string
@@ -23,9 +24,6 @@ func TestIsCommitSHA(t *testing.T) {
 			"01234567890abcdef01234567890abcdef01234567890abcdef01234567890a",   // 63 valid characters
 			"zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",  // 64 invalid characters
 			"01234567890abcdef01234567890abcdef01234567890abcdef01234567890abc", // 65 valid characters
-
-			// TODO: add SHA-256 support and move this up to the "true" section
-			"01234567890abcdef01234567890abcdef01234567890abcdef01234567890ab", // 64 valid characters (SHA-256)
 		},
 	} {
 		for _, commit := range commits {


### PR DESCRIPTION
This also adds a few (mostly edge-case) tests for the `gitutil.IsCommitSHA` function.

(This is a follow-up to https://github.com/moby/buildkit/pull/5441#discussion_r1823560038)