### PR TITLE
docs: remove older warning format

### DIFF
--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -943,7 +943,6 @@ The command is run in the host's network environment (similar to
 > which needs to be enabled when starting the buildkitd daemon with
 > `--allow-insecure-entitlement network.host` flag or in [buildkitd config](https://github.com/moby/buildkit/blob/master/docs/buildkitd.toml.md),
 > and for a build request with [`--allow network.host` flag](https://docs.docker.com/engine/reference/commandline/buildx_build/#allow).
-{ .warning }
 
 ### RUN --security
 
@@ -964,7 +963,6 @@ This is equivalent to running `docker run --privileged`.
 > enabled when starting the buildkitd daemon with
 > `--allow-insecure-entitlement security.insecure` flag or in [buildkitd config](https://github.com/moby/buildkit/blob/master/docs/buildkitd.toml.md),
 > and for a build request with [`--allow security.insecure` flag](https://docs.docker.com/engine/reference/commandline/buildx_build/#allow).
-{ .warning }
 
 Default sandbox mode can be activated via `--security=sandbox`, but that is no-op.
 
@@ -2255,7 +2253,6 @@ runtime, runs the relevant `ENTRYPOINT` and `CMD` commands.
 >
 > On Windows, the user must be created first if it's not a built-in account.
 > This can be done with the `net user` command called as part of a Dockerfile.
-{ .warning }
 
 ```dockerfile
 FROM microsoft/windowsservercore
@@ -2326,7 +2323,6 @@ flag.
 >
 > Refer to the [`RUN --mount=type=secret`](#run---mounttypesecret) section to
 > learn about secure ways to use secrets when building images.
-{ .warning }
 
 A Dockerfile may include one or more `ARG` instructions. For example,
 the following is a valid Dockerfile:


### PR DESCRIPTION
This change removes some older warning formatting.