### PR TITLE
tests: client: set up for wcow integration tests

### DIFF
--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -427,7 +427,16 @@ func prepareValueMatrix(tc testConf) []matrixValue {
 
 // Skips tests on platform
 func SkipOnPlatform(t *testing.T, goos string) {
-	if runtime.GOOS == goos {
+	skip := false
+	// support for negation
+	if strings.HasPrefix(goos, "!") {
+		goos = strings.TrimPrefix(goos, "!")
+		skip = runtime.GOOS != goos
+	} else {
+		skip = runtime.GOOS == goos
+	}
+
+	if skip {
 		t.Skipf("Skipped on %s", goos)
 	}
 }


### PR DESCRIPTION
Make some minor modification to allow running integration tests for `./client`.

Added tests for `testExportedImageLabels` as a sample.

Ref: #4485