### PR TITLE
ci: enable archutil-arm64 job

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -67,9 +67,6 @@ jobs:
 
   archutil-arm64:
     runs-on: ubuntu-24.04
-    # TODO: enable when binutils-loongarch64-linux-gnu pkg is available for aarch64 arch
-    # https://github.com/moby/buildkit/pull/4392#issuecomment-1938223235
-    if: false
     steps:
       -
         name: Checkout


### PR DESCRIPTION
follow-up https://github.com/moby/buildkit/pull/4392#issuecomment-1938223235

package now available on trixie: https://packages.debian.org/trixie/binutils-loongarch64-linux-gnu