### PR TITLE
detect: use newer semconv for resource and add unit test

### DIFF
--- a/util/tracing/detect/resource.go
+++ b/util/tracing/detect/resource.go
@@ -8,7 +8,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
 var (

--- a/util/tracing/detect/resource_test.go
+++ b/util/tracing/detect/resource_test.go
@@ -1,0 +1,29 @@
+package detect
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+)
+
+func TestResource(t *testing.T) {
+	prevHandler := otel.GetErrorHandler()
+	t.Cleanup(func() {
+		otel.SetErrorHandler(prevHandler)
+	})
+
+	var resourceErr error
+	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
+		resourceErr = err
+	}))
+
+	res := Resource()
+
+	// Should not have an empty schema url. Only happens when
+	// there is a schema conflict.
+	require.NotEqual(t, "", res.SchemaURL())
+
+	// No error should have been invoked.
+	require.NoError(t, resourceErr)
+}

--- a/util/tracing/tracing.go
+++ b/util/tracing/tracing.go
@@ -11,7 +11,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
-	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
 


### PR DESCRIPTION
We upgraded a dependency that upgraded otel and also changed the semconv schema for us to a newer version. We forgot to upgrade our own semconv.

In the future, we may want to find a way to have a detector that doesn't require us to manually specify a semconv so we don't have to remember this. For now, I've added a test to catch when this happens so it doesn't happen again.