### PR TITLE
detect: sever semconv relationship to otel sdk

### DIFF
--- a/util/tracing/detect/resource.go
+++ b/util/tracing/detect/resource.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package detect
 
 import (
@@ -7,6 +10,7 @@ import (
 	"sync"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/sdk"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 )
@@ -23,7 +27,7 @@ func Resource() *resource.Resource {
 		res, err := resource.New(context.Background(),
 			resource.WithDetectors(serviceNameDetector{}),
 			resource.WithFromEnv(),
-			resource.WithTelemetrySDK(),
+			resource.WithDetectors(telemetrySDK{}),
 		)
 		if err != nil {
 			otel.Handle(err)
@@ -42,7 +46,15 @@ func OverrideResource(res *resource.Resource) {
 	})
 }
 
-type serviceNameDetector struct{}
+type (
+	telemetrySDK        struct{}
+	serviceNameDetector struct{}
+)
+
+var (
+	_ resource.Detector = telemetrySDK{}
+	_ resource.Detector = serviceNameDetector{}
+)
 
 func (serviceNameDetector) Detect(ctx context.Context) (*resource.Resource, error) {
 	return resource.StringDetector(
@@ -55,4 +67,14 @@ func (serviceNameDetector) Detect(ctx context.Context) (*resource.Resource, erro
 			return filepath.Base(os.Args[0]), nil
 		},
 	).Detect(ctx)
+}
+
+// Detect returns a *Resource that describes the OpenTelemetry SDK used.
+func (telemetrySDK) Detect(context.Context) (*resource.Resource, error) {
+	return resource.NewWithAttributes(
+		semconv.SchemaURL,
+		semconv.TelemetrySDKName("opentelemetry"),
+		semconv.TelemetrySDKLanguageGo,
+		semconv.TelemetrySDKVersion(sdk.Version()),
+	), nil
 }

--- a/util/tracing/detect/resource_test.go
+++ b/util/tracing/detect/resource_test.go
@@ -1,0 +1,29 @@
+package detect
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+)
+
+func TestResource(t *testing.T) {
+	prevHandler := otel.GetErrorHandler()
+	t.Cleanup(func() {
+		otel.SetErrorHandler(prevHandler)
+	})
+
+	var resourceErr error
+	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
+		resourceErr = err
+	}))
+
+	res := Resource()
+
+	// Should not have an empty schema url. Only happens when
+	// there is a schema conflict.
+	require.NotEqual(t, "", res.SchemaURL())
+
+	// No error should have been invoked.
+	require.NoError(t, resourceErr)
+}


### PR DESCRIPTION
Copies over the telemetry sdk detection to utilize our own version of semconv rather than mix the versions between different packages. This will keep a consistent schema url instead of constantly chasing whichever one the otel sdk is using.

The only thing left from the otel sdk is `WithFromEnv` which is schemaless and won't conflict for that reason so we can continue to use it.