### PR TITLE
docs: update `consistent-instruction-casing.md` reference

### DIFF
--- a/frontend/dockerfile/linter/docs/FromAsCasing.md
+++ b/frontend/dockerfile/linter/docs/FromAsCasing.md
@@ -33,4 +33,4 @@ from debian:latest as deb-builder
 
 ## Related errors
 
-- [`FileConsistentCommandCasing`](./consistent-instruction-casing.md)
+- [`FileConsistentCommandCasing`](../../docs/rules/consistent-instruction-casing.md)


### PR DESCRIPTION
# PR Summary
Small PR - fixes link to `consistent-instruction-casing.md` in `frontend/dockerfile/linter/docs/FromAsCasing.md`.