### PR TITLE
contenthash: don't delete records when a directory is only modified

### DIFF
--- a/cache/contenthash/checksum.go
+++ b/cache/contenthash/checksum.go
@@ -352,9 +352,12 @@ func (cc *cacheContext) HandleChange(kind fsutil.ChangeKind, p string, fi os.Fil
 		return errors.Errorf("invalid fileinfo: %s", p)
 	}
 
+	// if we are replacing a directory with a non-directory, rm -rf the tree under the existing dir
 	v, ok := cc.node.Get(k)
 	if ok {
-		deleteDir(v)
+		if v.Type == CacheRecordTypeDir && !fi.IsDir() {
+			deleteDir(v)
+		}
 	}
 
 	cr := &CacheRecord{


### PR DESCRIPTION
Before this commit, HandleChange would always recursively remove records whenever any Modify change was applied to a directory path.

This was wasteful in the case where HandleChange was called only due to a metadata modification to a directory. In that case, it makes sense to *update* the directory's node but no existing entries under the directory need to be thrown away.

Now, we only recursively remove records under a directory for the Delete case and when a Modify change replaces a directory with a non-directory.