### PR TITLE
tests: add `testDockerfileFromHTTP` for WCOW

### DIFF
--- a/client/llb/fileop.go
+++ b/client/llb/fileop.go
@@ -5,6 +5,7 @@ import (
 	_ "crypto/sha256" // for opencontainers/go-digest
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -563,7 +564,7 @@ func (a *fileActionCopy) toProtoAction(ctx context.Context, parent string, base 
 }
 
 func (a *fileActionCopy) sourcePath(ctx context.Context) (string, error) {
-	p := path.Clean(a.src)
+	p := filepath.ToSlash(path.Clean(a.src))
 	dir := "/"
 	var err error
 	if !path.IsAbs(p) {

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -4491,7 +4491,6 @@ COPY --from=build foo bar2
 }
 
 func testDockerfileFromHTTP(t *testing.T, sb integration.Sandbox) {
-	integration.SkipOnPlatform(t, "windows")
 	f := getFrontend(t, sb)
 
 	buf := bytes.NewBuffer(nil)
@@ -4509,9 +4508,10 @@ func testDockerfileFromHTTP(t *testing.T, sb integration.Sandbox) {
 		require.NoError(t, err)
 	}
 
-	writeFile("mydockerfile", `FROM scratch
+	dockerfile := fmt.Sprintf(`FROM %s
 COPY foo bar
-`)
+`, integration.UnixOrWindows("scratch", "nanoserver"))
+	writeFile("mydockerfile", dockerfile)
 
 	writeFile("foo", "foo-contents")
 


### PR DESCRIPTION
Enables `testDockerfileFromHTTP` integration test
for Windows.

Also fixes a bug where paths were being joined wrongly, for example:

```go
path.Join("/", "\\context") // would be "/\\context"
```

Addressing tests marked as Revisit for #4485