### PR TITLE
protobuf: fix casing of json attributes with the switch from gogo

### DIFF
--- a/solver/pb/json.go
+++ b/solver/pb/json.go
@@ -2,58 +2,100 @@ package pb
 
 import "encoding/json"
 
-func (m *Op) UnmarshalJSON(data []byte) error {
-	var v struct {
-		Inputs []*Input `json:"inputs,omitempty"`
-		Op     struct {
-			*Op_Exec
-			*Op_Source
-			*Op_File
-			*Op_Build
-			*Op_Merge
-			*Op_Diff
-		}
-		Platform    *Platform          `json:"platform,omitempty"`
-		Constraints *WorkerConstraints `json:"constraints,omitempty"`
+type jsonOp struct {
+	Inputs []*Input `json:"inputs,omitempty"`
+	Op     struct {
+		Exec   *ExecOp   `json:"exec,omitempty"`
+		Source *SourceOp `json:"source,omitempty"`
+		File   *FileOp   `json:"file,omitempty"`
+		Build  *BuildOp  `json:"build,omitempty"`
+		Merge  *MergeOp  `json:"merge,omitempty"`
+		Diff   *DiffOp   `json:"diff,omitempty"`
 	}
+	Platform    *Platform          `json:"platform,omitempty"`
+	Constraints *WorkerConstraints `json:"constraints,omitempty"`
+}
 
+func (m *Op) MarshalJSON() ([]byte, error) {
+	var v jsonOp
+	v.Inputs = m.Inputs
+	switch op := m.Op.(type) {
+	case *Op_Exec:
+		v.Op.Exec = op.Exec
+	case *Op_Source:
+		v.Op.Source = op.Source
+	case *Op_File:
+		v.Op.File = op.File
+	case *Op_Build:
+		v.Op.Build = op.Build
+	case *Op_Merge:
+		v.Op.Merge = op.Merge
+	case *Op_Diff:
+		v.Op.Diff = op.Diff
+	}
+	v.Platform = m.Platform
+	v.Constraints = m.Constraints
+	return json.Marshal(v)
+}
+
+func (m *Op) UnmarshalJSON(data []byte) error {
+	var v jsonOp
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
 	m.Inputs = v.Inputs
 	switch {
-	case v.Op.Op_Exec != nil:
-		m.Op = v.Op.Op_Exec
-	case v.Op.Op_Source != nil:
-		m.Op = v.Op.Op_Source
-	case v.Op.Op_File != nil:
-		m.Op = v.Op.Op_File
-	case v.Op.Op_Build != nil:
-		m.Op = v.Op.Op_Build
-	case v.Op.Op_Merge != nil:
-		m.Op = v.Op.Op_Merge
-	case v.Op.Op_Diff != nil:
-		m.Op = v.Op.Op_Diff
+	case v.Op.Exec != nil:
+		m.Op = &Op_Exec{v.Op.Exec}
+	case v.Op.Source != nil:
+		m.Op = &Op_Source{v.Op.Source}
+	case v.Op.File != nil:
+		m.Op = &Op_File{v.Op.File}
+	case v.Op.Build != nil:
+		m.Op = &Op_Build{v.Op.Build}
+	case v.Op.Merge != nil:
+		m.Op = &Op_Merge{v.Op.Merge}
+	case v.Op.Diff != nil:
+		m.Op = &Op_Diff{v.Op.Diff}
 	}
 	m.Platform = v.Platform
 	m.Constraints = v.Constraints
 	return nil
 }
 
-func (m *FileAction) UnmarshalJSON(data []byte) error {
-	var v struct {
-		Input          InputIndex  `json:"input"`
-		SecondaryInput InputIndex  `json:"secondaryInput"`
-		Output         OutputIndex `json:"output"`
-		Action         struct {
-			*FileAction_Copy
-			*FileAction_Mkfile
-			*FileAction_Mkdir
-			*FileAction_Rm
-		}
+type jsonFileAction struct {
+	Input          InputIndex  `json:"input"`
+	SecondaryInput InputIndex  `json:"secondaryInput"`
+	Output         OutputIndex `json:"output"`
+	Action         struct {
+		Copy   *FileActionCopy   `json:"copy,omitempty"`
+		Mkfile *FileActionMkFile `json:"mkfile,omitempty"`
+		Mkdir  *FileActionMkDir  `json:"mkdir,omitempty"`
+		Rm     *FileActionRm     `json:"rm,omitempty"`
 	}
+}
 
+func (m *FileAction) MarshalJSON() ([]byte, error) {
+	var v jsonFileAction
+	v.Input = InputIndex(m.Input)
+	v.SecondaryInput = InputIndex(m.SecondaryInput)
+	v.Output = OutputIndex(m.Output)
+	switch action := m.Action.(type) {
+	case *FileAction_Copy:
+		v.Action.Copy = action.Copy
+	case *FileAction_Mkfile:
+		v.Action.Mkfile = action.Mkfile
+	case *FileAction_Mkdir:
+		v.Action.Mkdir = action.Mkdir
+	case *FileAction_Rm:
+		v.Action.Rm = action.Rm
+	}
+	return json.Marshal(v)
+}
+
+func (m *FileAction) UnmarshalJSON(data []byte) error {
+	var v jsonFileAction
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
@@ -62,35 +104,47 @@ func (m *FileAction) UnmarshalJSON(data []byte) error {
 	m.SecondaryInput = int64(v.SecondaryInput)
 	m.Output = int64(v.Output)
 	switch {
-	case v.Action.FileAction_Copy != nil:
-		m.Action = v.Action.FileAction_Copy
-	case v.Action.FileAction_Mkfile != nil:
-		m.Action = v.Action.FileAction_Mkfile
-	case v.Action.FileAction_Mkdir != nil:
-		m.Action = v.Action.FileAction_Mkdir
-	case v.Action.FileAction_Rm != nil:
-		m.Action = v.Action.FileAction_Rm
+	case v.Action.Copy != nil:
+		m.Action = &FileAction_Copy{v.Action.Copy}
+	case v.Action.Mkfile != nil:
+		m.Action = &FileAction_Mkfile{v.Action.Mkfile}
+	case v.Action.Mkdir != nil:
+		m.Action = &FileAction_Mkdir{v.Action.Mkdir}
+	case v.Action.Rm != nil:
+		m.Action = &FileAction_Rm{v.Action.Rm}
 	}
 	return nil
 }
 
-func (m *UserOpt) UnmarshalJSON(data []byte) error {
-	var v struct {
-		User struct {
-			*UserOpt_ByName
-			*UserOpt_ByID
-		}
+type jsonUserOpt struct {
+	User struct {
+		ByName *NamedUserOpt `json:"byName,omitempty"`
+		ByID   uint32        `json:"byId,omitempty"`
 	}
+}
 
+func (m *UserOpt) MarshalJSON() ([]byte, error) {
+	var v jsonUserOpt
+	switch userOpt := m.User.(type) {
+	case *UserOpt_ByName:
+		v.User.ByName = userOpt.ByName
+	case *UserOpt_ByID:
+		v.User.ByID = userOpt.ByID
+	}
+	return json.Marshal(v)
+}
+
+func (m *UserOpt) UnmarshalJSON(data []byte) error {
+	var v jsonUserOpt
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
 	switch {
-	case v.User.UserOpt_ByName != nil:
-		m.User = v.User.UserOpt_ByName
-	case v.User.UserOpt_ByID != nil:
-		m.User = v.User.UserOpt_ByID
+	case v.User.ByName != nil:
+		m.User = &UserOpt_ByName{v.User.ByName}
+	default:
+		m.User = &UserOpt_ByID{v.User.ByID}
 	}
 	return nil
 }


### PR DESCRIPTION
With the switch from gogo, the `oneof` fields no longer have their `json:"name"` fields emitted. Protobuf doesn't formally support these fields and tells users to use the `protojson` package, but we didn't and the official format is incompatible with the current format we use.

This adds some custom marshaling code to the already existant custom unmarshaling code to ensure these fields are marshaled with the correct casing.