### PR TITLE
Revert "Dockerfile: update containerd binary to v2.0.0"

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -112,7 +112,6 @@ jobs:
           - containerd
           - containerd-rootless
           - containerd-1.6
-          - containerd-1.7
           - containerd-snapshotter-stargz
           - oci
           - oci-rootless


### PR DESCRIPTION
This reverts commit b1adeed5caf1003ed565a7a89a9174c171a3e247.

Building for arm64 fails. 

```
 docker buildx build --target containerd --platform linux/arm64 .

=> ERROR [containerd 3/3] RUN /build.sh                                                                                                  12.9s
------
 > [containerd 3/3] RUN /build.sh:
0.096 + mkdir /out
0.097 + xx-info os
0.099 + '[' linux '=' linux ]
0.099 + make bin/containerd
0.649 + bin/containerd
0.649 go build  -gcflags=-trimpath=/go/src -buildmode=pie  -o bin/containerd -ldflags '-X github.com/containerd/containerd/v2/version.Version=v2.0.0 -X github.com/containerd/containerd/v2/version.Revision=207ad711eabd375a01713109a8a197d197ff6542 -X github.com/containerd/containerd/v2/version.Package=github.com/containerd/containerd/v2 -s -w ' -tags "no_btrfs urfave_cli_no_docs"  ./cmd/containerd
12.74 # github.com/containerd/containerd/cmd/containerd
12.74 /usr/local/go/pkg/tool/linux_arm64/link: running aarch64-alpine-linux-musl-clang failed: exit status 1
12.74 /usr/bin/aarch64-alpine-linux-musl-clang -s -Wl,-z,relro -pie -Wl,-z,now -Wl,-z,nocopyreloc -fuse-ld=gold -o $WORK/b001/exe/a.out -rdynamic /tmp/go-link-585608912/go.o /tmp/go-link-585608912/000000.o /tmp/go-link-585608912/000001.o /tmp/go-link-585608912/000002.o /tmp/go-link-585608912/000003.o /tmp/go-link-585608912/000004.o /tmp/go-link-585608912/000005.o /tmp/go-link-585608912/000006.o /tmp/go-link-585608912/000007.o /tmp/go-link-585608912/000008.o /tmp/go-link-585608912/000009.o /tmp/go-link-585608912/000010.o /tmp/go-link-585608912/000011.o /tmp/go-link-585608912/000012.o /tmp/go-link-585608912/000013.o /tmp/go-link-585608912/000014.o /tmp/go-link-585608912/000015.o /tmp/go-link-585608912/000016.o /tmp/go-link-585608912/000017.o /tmp/go-link-585608912/000018.o /tmp/go-link-585608912/000019.o /tmp/go-link-585608912/000020.o /tmp/go-link-585608912/000021.o /tmp/go-link-585608912/000022.o /tmp/go-link-585608912/000023.o /tmp/go-link-585608912/000024.o /tmp/go-link-585608912/000025.o /tmp/go-link-585608912/000026.o /tmp/go-link-585608912/000027.o /tmp/go-link-585608912/000028.o -O2 -g -lresolv -O2 -g -lpthread -O2 -g -ldl -O2 -g -O2 -g -ldl
12.74 clang: error: invalid linker name in argument '-fuse-ld=gold'
12.74
12.82 make: *** [Makefile:264: bin/containerd] Error 1
------
Dockerfile:234
--------------------
 232 |     ARG CONTAINERD_VERSION
 233 |     ADD --keep-git-dir=true "https://github.com/containerd/containerd.git#$CONTAINERD_VERSION" .
 234 | >>> RUN /build.sh
 235 |
 236 |     # containerd-alt-17 builds containerd v1.7 for integration tests
--------------------
```

`--platform=linux/amd64` is ok and this is why CI is ok. We might need to make sure that integration tests stage is tested on arm64 as well (even if tests actually don't run this way).

@AkihiroSuda If you can provide immediate fix then this can be closed. Otherwise revert and then reenable later.