### PR TITLE
Use view transaction for metadata read

### DIFF
--- a/cache/metadata/metadata.go
+++ b/cache/metadata/metadata.go
@@ -193,7 +193,7 @@ func (s *Store) Get(id string) (*StorageItem, bool) {
 	}
 
 	var si *StorageItem
-	if err := s.db.Update(func(tx *bolt.Tx) error {
+	if err := s.db.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(mainBucket))
 		if b == nil {
 			return nil


### PR DESCRIPTION
Found this while trying to dig into some other issues.
I don't think `store.Get` should need a write transaction here.