### PR TITLE
docs: add --checksum only supports sha256

### DIFF
--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -1476,8 +1476,8 @@ ADD [--checksum=<hash>] <src> ... <dir>
 ```
 
 The `--checksum` flag lets you verify the checksum of a remote resource. The
-checksum is formatted as `<algorithm>:<hash>`. The supported algorithms are
-`sha256`, `sha384`, and `sha512`.
+checksum is formatted as `sha256:<hash>`. SHA-256 is the only supported hash
+algorithm.
 
 ```dockerfile
 ADD --checksum=sha256:24454f830cdb571e2c4ad15481119c43b3cafd48dd869a9b2945d1036d1dc68d https://mirrors.edge.kernel.org/pub/linux/kernel/Historic/linux-0.01.tar.gz /


### PR DESCRIPTION
- relates to docker/buildx#2816