### PR TITLE
add OCI artifact version of attestation manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ Keys supported by image output:
 * `push-by-digest=true`: push unnamed image
 * `registry.insecure=true`: push to insecure HTTP registry
 * `oci-mediatypes=true`: use OCI mediatypes in configuration JSON instead of Docker's
+* `oci-artifact=false`: use OCI artifact format for attestations
 * `unpack=true`: unpack image after creation (for use with containerd)
 * `dangling-name-prefix=<value>`: name image with `prefix@<digest>`, used for anonymous images
 * `name-canonical=true`: add additional canonical name `name@<digest>`

--- a/exporter/containerimage/exptypes/keys.go
+++ b/exporter/containerimage/exptypes/keys.go
@@ -44,6 +44,9 @@ var (
 	// Value: bool <true|false>
 	OptKeyOCITypes ImageExporterOptKey = "oci-mediatypes"
 
+	// Use OCI artifact format for the attestation manifest.
+	OptKeyOCIArtifact ImageExporterOptKey = "oci-artifact"
+
 	// Force attestation to be attached.
 	// Value: bool <true|false>
 	OptKeyForceInlineAttestations ImageExporterOptKey = "attestation-inline"

--- a/exporter/containerimage/opts.go
+++ b/exporter/containerimage/opts.go
@@ -17,6 +17,7 @@ type ImageCommitOpts struct {
 	ImageName   string
 	RefCfg      cacheconfig.RefConfig
 	OCITypes    bool
+	OCIArtifact bool
 	Annotations AnnotationsGroup
 	Epoch       *time.Time
 
@@ -49,6 +50,8 @@ func (c *ImageCommitOpts) Load(ctx context.Context, opt map[string]string) (map[
 			c.ImageName = v
 		case exptypes.OptKeyOCITypes:
 			err = parseBoolWithDefault(&c.OCITypes, k, v, true)
+		case exptypes.OptKeyOCIArtifact:
+			err = parseBool(&c.OCIArtifact, k, v)
 		case exptypes.OptKeyForceInlineAttestations:
 			err = parseBool(&c.ForceInlineAttestations, k, v)
 		case exptypes.OptKeyPreferNondistLayers:
@@ -66,6 +69,9 @@ func (c *ImageCommitOpts) Load(ctx context.Context, opt map[string]string) (map[
 
 	if c.RefCfg.Compression.Type.OnlySupportOCITypes() {
 		c.EnableOCITypes(ctx, c.RefCfg.Compression.Type.String())
+	}
+	if c.OCIArtifact && !c.OCITypes {
+		c.EnableOCITypes(ctx, "oci-artifact")
 	}
 
 	c.Annotations = c.Annotations.Merge(as)

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -46,6 +46,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+const attestationManifestArtifactType = "application/vnd.docker.attestation.manifest.v1+json"
+
 type WriterOpt struct {
 	Snapshotter  snapshot.Snapshotter
 	ContentStore content.Store
@@ -312,7 +314,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 				return nil, err
 			}
 
-			desc, err := ic.commitAttestationsManifest(ctx, opts, desc.Digest.String(), stmts)
+			desc, err := ic.commitAttestationsManifest(ctx, opts, *desc, stmts, opts.OCIArtifact)
 			if err != nil {
 				return nil, err
 			}
@@ -553,7 +555,7 @@ func (ic *ImageWriter) commitDistributionManifest(ctx context.Context, opts *Ima
 	}, &configDesc, nil
 }
 
-func (ic *ImageWriter) commitAttestationsManifest(ctx context.Context, opts *ImageCommitOpts, target string, statements []intoto.Statement) (*ocispecs.Descriptor, error) {
+func (ic *ImageWriter) commitAttestationsManifest(ctx context.Context, opts *ImageCommitOpts, target ocispecs.Descriptor, statements []intoto.Statement, ociArtifact bool) (*ocispecs.Descriptor, error) {
 	var (
 		manifestType = ocispecs.MediaTypeImageManifest
 		configType   = ocispecs.MediaTypeImageConfig
@@ -588,15 +590,21 @@ func (ic *ImageWriter) commitAttestationsManifest(ctx context.Context, opts *Ima
 		layers[i] = desc
 	}
 
-	config, err := attestationsConfig(layers)
-	if err != nil {
-		return nil, err
-	}
-	configDigest := digest.FromBytes(config)
-	configDesc := ocispecs.Descriptor{
-		Digest:    configDigest,
-		Size:      int64(len(config)),
-		MediaType: configType,
+	configDesc := ocispecs.DescriptorEmptyJSON
+	config := configDesc.Data
+
+	if !ociArtifact {
+		var err error
+		config, err = attestationsConfig(layers)
+		if err != nil {
+			return nil, err
+		}
+		configDigest := digest.FromBytes(config)
+		configDesc = ocispecs.Descriptor{
+			Digest:    configDigest,
+			Size:      int64(len(config)),
+			MediaType: configType,
+		}
 	}
 
 	mfst := ocispecs.Manifest{
@@ -604,15 +612,16 @@ func (ic *ImageWriter) commitAttestationsManifest(ctx context.Context, opts *Ima
 		Versioned: specs.Versioned{
 			SchemaVersion: 2,
 		},
-		Config: ocispecs.Descriptor{
-			Digest:    configDigest,
-			Size:      int64(len(config)),
-			MediaType: configType,
-		},
+		Config: configDesc,
+	}
+
+	if ociArtifact {
+		mfst.ArtifactType = attestationManifestArtifactType
+		mfst.Subject = &target
 	}
 
 	labels := map[string]string{
-		"containerd.io/gc.ref.content.0": configDigest.String(),
+		"containerd.io/gc.ref.content.0": configDesc.Digest.String(),
 	}
 	for i, desc := range layers {
 		desc.Annotations = RemoveInternalLayerAnnotations(desc.Annotations, opts.OCITypes)
@@ -635,7 +644,7 @@ func (ic *ImageWriter) commitAttestationsManifest(ctx context.Context, opts *Ima
 	if err := content.WriteBlob(ctx, ic.opt.ContentStore, mfstDigest.String(), bytes.NewReader(mfstJSON), mfstDesc, content.WithLabels((labels))); err != nil {
 		return nil, done(errors.Wrapf(err, "error writing manifest blob %s", mfstDigest))
 	}
-	if err := content.WriteBlob(ctx, ic.opt.ContentStore, configDigest.String(), bytes.NewReader(config), configDesc); err != nil {
+	if err := content.WriteBlob(ctx, ic.opt.ContentStore, configDesc.Digest.String(), bytes.NewReader(config), configDesc); err != nil {
 		return nil, done(errors.Wrap(err, "error writing config blob"))
 	}
 	done(nil)
@@ -646,7 +655,7 @@ func (ic *ImageWriter) commitAttestationsManifest(ctx context.Context, opts *Ima
 		MediaType: manifestType,
 		Annotations: map[string]string{
 			attestationTypes.DockerAnnotationReferenceType:   attestationTypes.DockerAnnotationReferenceTypeDefault,
-			attestationTypes.DockerAnnotationReferenceDigest: target,
+			attestationTypes.DockerAnnotationReferenceDigest: string(target.Digest),
 		},
 	}, nil
 }


### PR DESCRIPTION
fixes #5561

This adds a new exporter option oci-artifact. If set then it changes the attestation manifest to be exported with following changes:
- subject field is added to attestation manifest
- config uses empty descriptor instead of fake image config
- artifactType property is set

The intention is to change this behavior from opt-in to opt-out in some future release when target is OCI image.

Example https://explore.ggcr.dev/?image=docker.io/tonistiigi/buildkit@sha256:bf8355824354aee83a9874f7178ea91a17752603a949e89f00f9e3ca5404db35&mt=application%2Fvnd.oci.image.manifest.v1%2Bjson&size=915

Quick test:
```
docker buildx create --bootstrap --name=dev --driver-opt image=tonistiigi/buildkit:artifact-mfst
```