### PR TITLE
integration: increase timeout to mitigate TestBasicGhaCacheImportExport flakiness

### DIFF
--- a/util/testutil/integration/sandbox.go
+++ b/util/testutil/integration/sandbox.go
@@ -121,7 +121,7 @@ func newSandbox(ctx context.Context, t *testing.T, w Worker, mirror string, mv m
 	go func() {
 		timeout := maxSandboxTimeout
 		if strings.Contains(t.Name(), "ExtraTimeout") {
-			timeout *= 3
+			timeout *= 6
 		}
 		timeoutContext, cancelTimeout := context.WithTimeoutCause(ctx, timeout, errors.WithStack(context.DeadlineExceeded))
 		defer cancelTimeout()


### PR DESCRIPTION
This PR adds an increased timeout to the `TestBasicGhaCacheImportExport` integration test in an effort to mitigate flakiness highlighted in the linked issue. Instead of an `"ExtraTimeout"` of just `15 minutes (3 * maxTimeout where maxTimeout equals 5 minutes)`, this now goes as high as 30 minutes by updating the multiplier to `6`. This should theoretically be more than enough time to allow the test to complete successfully if the flake is truly rate-limited/time based `(i.e. "We encounter this one when a bunch of jobs are running on CI and therefore we got rate-limited in GHA cache backend with this test.")`.

Any more time would likely require deeper investigation into figuring out how to more adequately handle the rate limiting issue.

Related to #5494 