### PR TITLE
Multiple exporter responses

### DIFF
--- a/api/services/control/control.pb.go
+++ b/api/services/control/control.pb.go
@@ -692,10 +692,16 @@ func (x *CacheOptionsEntry) GetAttrs() map[string]string {
 }
 
 type SolveResponse struct {
-	state            protoimpl.MessageState `protogen:"open.v1"`
-	ExporterResponse map[string]string      `protobuf:"bytes,1,rep,name=ExporterResponse,proto3" json:"ExporterResponse,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// ExporterResponseDeprecated is a combined exporter response - it aggregates
+	// responses from all exporters (including cache exporters) running in parallel.
+	// It is deprecated in favor of the structured exporter responses but will be
+	// populated as long as it is supported.
+	ExporterResponseDeprecated map[string]string   `protobuf:"bytes,1,rep,name=ExporterResponseDeprecated,proto3" json:"ExporterResponseDeprecated,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	ExporterResponses          []*ExporterResponse `protobuf:"bytes,2,rep,name=exporterResponses,proto3" json:"exporterResponses,omitempty"`
+	CacheExporterResponses     []*ExporterResponse `protobuf:"bytes,3,rep,name=cacheExporterResponses,proto3" json:"cacheExporterResponses,omitempty"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
 }
 
 func (x *SolveResponse) Reset() {
@@ -728,9 +734,23 @@ func (*SolveResponse) Descriptor() ([]byte, []int) {
 	return file_github_com_moby_buildkit_api_services_control_control_proto_rawDescGZIP(), []int{7}
 }
 
-func (x *SolveResponse) GetExporterResponse() map[string]string {
+func (x *SolveResponse) GetExporterResponseDeprecated() map[string]string {
 	if x != nil {
-		return x.ExporterResponse
+		return x.ExporterResponseDeprecated
+	}
+	return nil
+}
+
+func (x *SolveResponse) GetExporterResponses() []*ExporterResponse {
+	if x != nil {
+		return x.ExporterResponses
+	}
+	return nil
+}
+
+func (x *SolveResponse) GetCacheExporterResponses() []*ExporterResponse {
+	if x != nil {
+		return x.CacheExporterResponses
 	}
 	return nil
 }
@@ -2022,6 +2042,107 @@ func (x *Exporter) GetAttrs() map[string]string {
 	return nil
 }
 
+// ExporterResponse describes the output of an exporter
+type ExporterResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Metadata describes the exporter
+	Metadata *ExporterMetadata `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	// Data is the exporter's output
+	Data          map[string]string `protobuf:"bytes,2,rep,name=data,proto3" json:"data,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ExporterResponse) Reset() {
+	*x = ExporterResponse{}
+	mi := &file_github_com_moby_buildkit_api_services_control_control_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExporterResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExporterResponse) ProtoMessage() {}
+
+func (x *ExporterResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_github_com_moby_buildkit_api_services_control_control_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExporterResponse.ProtoReflect.Descriptor instead.
+func (*ExporterResponse) Descriptor() ([]byte, []int) {
+	return file_github_com_moby_buildkit_api_services_control_control_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *ExporterResponse) GetMetadata() *ExporterMetadata {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+func (x *ExporterResponse) GetData() map[string]string {
+	if x != nil {
+		return x.Data
+	}
+	return nil
+}
+
+// ExporterMetadata describes the output exporter
+type ExporterMetadata struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Type identifies the exporter type
+	Type          string `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ExporterMetadata) Reset() {
+	*x = ExporterMetadata{}
+	mi := &file_github_com_moby_buildkit_api_services_control_control_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExporterMetadata) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExporterMetadata) ProtoMessage() {}
+
+func (x *ExporterMetadata) ProtoReflect() protoreflect.Message {
+	mi := &file_github_com_moby_buildkit_api_services_control_control_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExporterMetadata.ProtoReflect.Descriptor instead.
+func (*ExporterMetadata) Descriptor() ([]byte, []int) {
+	return file_github_com_moby_buildkit_api_services_control_control_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *ExporterMetadata) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
 var File_github_com_moby_buildkit_api_services_control_control_proto protoreflect.FileDescriptor
 
 const file_github_com_moby_buildkit_api_services_control_control_proto_rawDesc = "" +
@@ -2102,10 +2223,12 @@ const file_github_com_moby_buildkit_api_services_control_control_proto_rawDesc =
 	"\n" +
 	"AttrsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xb7\x01\n" +
-	"\rSolveResponse\x12a\n" +
-	"\x10ExporterResponse\x18\x01 \x03(\v25.moby.buildkit.v1.SolveResponse.ExporterResponseEntryR\x10ExporterResponse\x1aC\n" +
-	"\x15ExporterResponseEntry\x12\x10\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x8d\x03\n" +
+	"\rSolveResponse\x12\x7f\n" +
+	"\x1aExporterResponseDeprecated\x18\x01 \x03(\v2?.moby.buildkit.v1.SolveResponse.ExporterResponseDeprecatedEntryR\x1aExporterResponseDeprecated\x12P\n" +
+	"\x11exporterResponses\x18\x02 \x03(\v2\".moby.buildkit.v1.ExporterResponseR\x11exporterResponses\x12Z\n" +
+	"\x16cacheExporterResponses\x18\x03 \x03(\v2\".moby.buildkit.v1.ExporterResponseR\x16cacheExporterResponses\x1aM\n" +
+	"\x1fExporterResponseDeprecatedEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"!\n" +
 	"\rStatusRequest\x12\x10\n" +
@@ -2227,7 +2350,15 @@ const file_github_com_moby_buildkit_api_services_control_control_proto_rawDesc =
 	"\n" +
 	"AttrsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01*?\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xcd\x01\n" +
+	"\x10ExporterResponse\x12>\n" +
+	"\bmetadata\x18\x01 \x01(\v2\".moby.buildkit.v1.ExporterMetadataR\bmetadata\x12@\n" +
+	"\x04data\x18\x02 \x03(\v2,.moby.buildkit.v1.ExporterResponse.DataEntryR\x04data\x1a7\n" +
+	"\tDataEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"&\n" +
+	"\x10ExporterMetadata\x12\x12\n" +
+	"\x04type\x18\x02 \x01(\tR\x04type*?\n" +
 	"\x15BuildHistoryEventType\x12\v\n" +
 	"\aSTARTED\x10\x00\x12\f\n" +
 	"\bCOMPLETE\x10\x01\x12\v\n" +
@@ -2256,7 +2387,7 @@ func file_github_com_moby_buildkit_api_services_control_control_proto_rawDescGZI
 }
 
 var file_github_com_moby_buildkit_api_services_control_control_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_github_com_moby_buildkit_api_services_control_control_proto_msgTypes = make([]protoimpl.MessageInfo, 39)
+var file_github_com_moby_buildkit_api_services_control_control_proto_msgTypes = make([]protoimpl.MessageInfo, 42)
 var file_github_com_moby_buildkit_api_services_control_control_proto_goTypes = []any{
 	(BuildHistoryEventType)(0),         // 0: moby.buildkit.v1.BuildHistoryEventType
 	(*PruneRequest)(nil),               // 1: moby.buildkit.v1.PruneRequest
@@ -2286,103 +2417,110 @@ var file_github_com_moby_buildkit_api_services_control_control_proto_goTypes = [
 	(*Descriptor)(nil),                 // 25: moby.buildkit.v1.Descriptor
 	(*BuildResultInfo)(nil),            // 26: moby.buildkit.v1.BuildResultInfo
 	(*Exporter)(nil),                   // 27: moby.buildkit.v1.Exporter
-	nil,                                // 28: moby.buildkit.v1.SolveRequest.ExporterAttrsDeprecatedEntry
-	nil,                                // 29: moby.buildkit.v1.SolveRequest.FrontendAttrsEntry
-	nil,                                // 30: moby.buildkit.v1.SolveRequest.FrontendInputsEntry
-	nil,                                // 31: moby.buildkit.v1.CacheOptions.ExportAttrsDeprecatedEntry
-	nil,                                // 32: moby.buildkit.v1.CacheOptionsEntry.AttrsEntry
-	nil,                                // 33: moby.buildkit.v1.SolveResponse.ExporterResponseEntry
-	nil,                                // 34: moby.buildkit.v1.BuildHistoryRecord.FrontendAttrsEntry
-	nil,                                // 35: moby.buildkit.v1.BuildHistoryRecord.ExporterResponseEntry
-	nil,                                // 36: moby.buildkit.v1.BuildHistoryRecord.ResultsEntry
-	nil,                                // 37: moby.buildkit.v1.Descriptor.AnnotationsEntry
-	nil,                                // 38: moby.buildkit.v1.BuildResultInfo.ResultsEntry
-	nil,                                // 39: moby.buildkit.v1.Exporter.AttrsEntry
-	(*timestamp.Timestamp)(nil),        // 40: google.protobuf.Timestamp
-	(*pb.Definition)(nil),              // 41: pb.Definition
-	(*pb1.Policy)(nil),                 // 42: moby.buildkit.v1.sourcepolicy.Policy
-	(*pb.ProgressGroup)(nil),           // 43: pb.ProgressGroup
-	(*pb.SourceInfo)(nil),              // 44: pb.SourceInfo
-	(*pb.Range)(nil),                   // 45: pb.Range
-	(*types.WorkerRecord)(nil),         // 46: moby.buildkit.v1.types.WorkerRecord
-	(*types.BuildkitVersion)(nil),      // 47: moby.buildkit.v1.types.BuildkitVersion
-	(*status.Status)(nil),              // 48: google.rpc.Status
+	(*ExporterResponse)(nil),           // 28: moby.buildkit.v1.ExporterResponse
+	(*ExporterMetadata)(nil),           // 29: moby.buildkit.v1.ExporterMetadata
+	nil,                                // 30: moby.buildkit.v1.SolveRequest.ExporterAttrsDeprecatedEntry
+	nil,                                // 31: moby.buildkit.v1.SolveRequest.FrontendAttrsEntry
+	nil,                                // 32: moby.buildkit.v1.SolveRequest.FrontendInputsEntry
+	nil,                                // 33: moby.buildkit.v1.CacheOptions.ExportAttrsDeprecatedEntry
+	nil,                                // 34: moby.buildkit.v1.CacheOptionsEntry.AttrsEntry
+	nil,                                // 35: moby.buildkit.v1.SolveResponse.ExporterResponseDeprecatedEntry
+	nil,                                // 36: moby.buildkit.v1.BuildHistoryRecord.FrontendAttrsEntry
+	nil,                                // 37: moby.buildkit.v1.BuildHistoryRecord.ExporterResponseEntry
+	nil,                                // 38: moby.buildkit.v1.BuildHistoryRecord.ResultsEntry
+	nil,                                // 39: moby.buildkit.v1.Descriptor.AnnotationsEntry
+	nil,                                // 40: moby.buildkit.v1.BuildResultInfo.ResultsEntry
+	nil,                                // 41: moby.buildkit.v1.Exporter.AttrsEntry
+	nil,                                // 42: moby.buildkit.v1.ExporterResponse.DataEntry
+	(*timestamp.Timestamp)(nil),        // 43: google.protobuf.Timestamp
+	(*pb.Definition)(nil),              // 44: pb.Definition
+	(*pb1.Policy)(nil),                 // 45: moby.buildkit.v1.sourcepolicy.Policy
+	(*pb.ProgressGroup)(nil),           // 46: pb.ProgressGroup
+	(*pb.SourceInfo)(nil),              // 47: pb.SourceInfo
+	(*pb.Range)(nil),                   // 48: pb.Range
+	(*types.WorkerRecord)(nil),         // 49: moby.buildkit.v1.types.WorkerRecord
+	(*types.BuildkitVersion)(nil),      // 50: moby.buildkit.v1.types.BuildkitVersion
+	(*status.Status)(nil),              // 51: google.rpc.Status
 }
 var file_github_com_moby_buildkit_api_services_control_control_proto_depIdxs = []int32{
 	4,  // 0: moby.buildkit.v1.DiskUsageResponse.record:type_name -> moby.buildkit.v1.UsageRecord
-	40, // 1: moby.buildkit.v1.UsageRecord.CreatedAt:type_name -> google.protobuf.Timestamp
-	40, // 2: moby.buildkit.v1.UsageRecord.LastUsedAt:type_name -> google.protobuf.Timestamp
-	41, // 3: moby.buildkit.v1.SolveRequest.Definition:type_name -> pb.Definition
-	28, // 4: moby.buildkit.v1.SolveRequest.ExporterAttrsDeprecated:type_name -> moby.buildkit.v1.SolveRequest.ExporterAttrsDeprecatedEntry
-	29, // 5: moby.buildkit.v1.SolveRequest.FrontendAttrs:type_name -> moby.buildkit.v1.SolveRequest.FrontendAttrsEntry
+	43, // 1: moby.buildkit.v1.UsageRecord.CreatedAt:type_name -> google.protobuf.Timestamp
+	43, // 2: moby.buildkit.v1.UsageRecord.LastUsedAt:type_name -> google.protobuf.Timestamp
+	44, // 3: moby.buildkit.v1.SolveRequest.Definition:type_name -> pb.Definition
+	30, // 4: moby.buildkit.v1.SolveRequest.ExporterAttrsDeprecated:type_name -> moby.buildkit.v1.SolveRequest.ExporterAttrsDeprecatedEntry
+	31, // 5: moby.buildkit.v1.SolveRequest.FrontendAttrs:type_name -> moby.buildkit.v1.SolveRequest.FrontendAttrsEntry
 	6,  // 6: moby.buildkit.v1.SolveRequest.Cache:type_name -> moby.buildkit.v1.CacheOptions
-	30, // 7: moby.buildkit.v1.SolveRequest.FrontendInputs:type_name -> moby.buildkit.v1.SolveRequest.FrontendInputsEntry
-	42, // 8: moby.buildkit.v1.SolveRequest.SourcePolicy:type_name -> moby.buildkit.v1.sourcepolicy.Policy
+	32, // 7: moby.buildkit.v1.SolveRequest.FrontendInputs:type_name -> moby.buildkit.v1.SolveRequest.FrontendInputsEntry
+	45, // 8: moby.buildkit.v1.SolveRequest.SourcePolicy:type_name -> moby.buildkit.v1.sourcepolicy.Policy
 	27, // 9: moby.buildkit.v1.SolveRequest.Exporters:type_name -> moby.buildkit.v1.Exporter
-	31, // 10: moby.buildkit.v1.CacheOptions.ExportAttrsDeprecated:type_name -> moby.buildkit.v1.CacheOptions.ExportAttrsDeprecatedEntry
+	33, // 10: moby.buildkit.v1.CacheOptions.ExportAttrsDeprecated:type_name -> moby.buildkit.v1.CacheOptions.ExportAttrsDeprecatedEntry
 	7,  // 11: moby.buildkit.v1.CacheOptions.Exports:type_name -> moby.buildkit.v1.CacheOptionsEntry
 	7,  // 12: moby.buildkit.v1.CacheOptions.Imports:type_name -> moby.buildkit.v1.CacheOptionsEntry
-	32, // 13: moby.buildkit.v1.CacheOptionsEntry.Attrs:type_name -> moby.buildkit.v1.CacheOptionsEntry.AttrsEntry
-	33, // 14: moby.buildkit.v1.SolveResponse.ExporterResponse:type_name -> moby.buildkit.v1.SolveResponse.ExporterResponseEntry
-	11, // 15: moby.buildkit.v1.StatusResponse.vertexes:type_name -> moby.buildkit.v1.Vertex
-	12, // 16: moby.buildkit.v1.StatusResponse.statuses:type_name -> moby.buildkit.v1.VertexStatus
-	13, // 17: moby.buildkit.v1.StatusResponse.logs:type_name -> moby.buildkit.v1.VertexLog
-	14, // 18: moby.buildkit.v1.StatusResponse.warnings:type_name -> moby.buildkit.v1.VertexWarning
-	40, // 19: moby.buildkit.v1.Vertex.started:type_name -> google.protobuf.Timestamp
-	40, // 20: moby.buildkit.v1.Vertex.completed:type_name -> google.protobuf.Timestamp
-	43, // 21: moby.buildkit.v1.Vertex.progressGroup:type_name -> pb.ProgressGroup
-	40, // 22: moby.buildkit.v1.VertexStatus.timestamp:type_name -> google.protobuf.Timestamp
-	40, // 23: moby.buildkit.v1.VertexStatus.started:type_name -> google.protobuf.Timestamp
-	40, // 24: moby.buildkit.v1.VertexStatus.completed:type_name -> google.protobuf.Timestamp
-	40, // 25: moby.buildkit.v1.VertexLog.timestamp:type_name -> google.protobuf.Timestamp
-	44, // 26: moby.buildkit.v1.VertexWarning.info:type_name -> pb.SourceInfo
-	45, // 27: moby.buildkit.v1.VertexWarning.ranges:type_name -> pb.Range
-	46, // 28: moby.buildkit.v1.ListWorkersResponse.record:type_name -> moby.buildkit.v1.types.WorkerRecord
-	47, // 29: moby.buildkit.v1.InfoResponse.buildkitVersion:type_name -> moby.buildkit.v1.types.BuildkitVersion
-	0,  // 30: moby.buildkit.v1.BuildHistoryEvent.type:type_name -> moby.buildkit.v1.BuildHistoryEventType
-	22, // 31: moby.buildkit.v1.BuildHistoryEvent.record:type_name -> moby.buildkit.v1.BuildHistoryRecord
-	34, // 32: moby.buildkit.v1.BuildHistoryRecord.FrontendAttrs:type_name -> moby.buildkit.v1.BuildHistoryRecord.FrontendAttrsEntry
-	27, // 33: moby.buildkit.v1.BuildHistoryRecord.Exporters:type_name -> moby.buildkit.v1.Exporter
-	48, // 34: moby.buildkit.v1.BuildHistoryRecord.error:type_name -> google.rpc.Status
-	40, // 35: moby.buildkit.v1.BuildHistoryRecord.CreatedAt:type_name -> google.protobuf.Timestamp
-	40, // 36: moby.buildkit.v1.BuildHistoryRecord.CompletedAt:type_name -> google.protobuf.Timestamp
-	25, // 37: moby.buildkit.v1.BuildHistoryRecord.logs:type_name -> moby.buildkit.v1.Descriptor
-	35, // 38: moby.buildkit.v1.BuildHistoryRecord.ExporterResponse:type_name -> moby.buildkit.v1.BuildHistoryRecord.ExporterResponseEntry
-	26, // 39: moby.buildkit.v1.BuildHistoryRecord.Result:type_name -> moby.buildkit.v1.BuildResultInfo
-	36, // 40: moby.buildkit.v1.BuildHistoryRecord.Results:type_name -> moby.buildkit.v1.BuildHistoryRecord.ResultsEntry
-	25, // 41: moby.buildkit.v1.BuildHistoryRecord.trace:type_name -> moby.buildkit.v1.Descriptor
-	25, // 42: moby.buildkit.v1.BuildHistoryRecord.externalError:type_name -> moby.buildkit.v1.Descriptor
-	37, // 43: moby.buildkit.v1.Descriptor.annotations:type_name -> moby.buildkit.v1.Descriptor.AnnotationsEntry
-	25, // 44: moby.buildkit.v1.BuildResultInfo.ResultDeprecated:type_name -> moby.buildkit.v1.Descriptor
-	25, // 45: moby.buildkit.v1.BuildResultInfo.Attestations:type_name -> moby.buildkit.v1.Descriptor
-	38, // 46: moby.buildkit.v1.BuildResultInfo.Results:type_name -> moby.buildkit.v1.BuildResultInfo.ResultsEntry
-	39, // 47: moby.buildkit.v1.Exporter.Attrs:type_name -> moby.buildkit.v1.Exporter.AttrsEntry
-	41, // 48: moby.buildkit.v1.SolveRequest.FrontendInputsEntry.value:type_name -> pb.Definition
-	26, // 49: moby.buildkit.v1.BuildHistoryRecord.ResultsEntry.value:type_name -> moby.buildkit.v1.BuildResultInfo
-	25, // 50: moby.buildkit.v1.BuildResultInfo.ResultsEntry.value:type_name -> moby.buildkit.v1.Descriptor
-	2,  // 51: moby.buildkit.v1.Control.DiskUsage:input_type -> moby.buildkit.v1.DiskUsageRequest
-	1,  // 52: moby.buildkit.v1.Control.Prune:input_type -> moby.buildkit.v1.PruneRequest
-	5,  // 53: moby.buildkit.v1.Control.Solve:input_type -> moby.buildkit.v1.SolveRequest
-	9,  // 54: moby.buildkit.v1.Control.Status:input_type -> moby.buildkit.v1.StatusRequest
-	15, // 55: moby.buildkit.v1.Control.Session:input_type -> moby.buildkit.v1.BytesMessage
-	16, // 56: moby.buildkit.v1.Control.ListWorkers:input_type -> moby.buildkit.v1.ListWorkersRequest
-	18, // 57: moby.buildkit.v1.Control.Info:input_type -> moby.buildkit.v1.InfoRequest
-	20, // 58: moby.buildkit.v1.Control.ListenBuildHistory:input_type -> moby.buildkit.v1.BuildHistoryRequest
-	23, // 59: moby.buildkit.v1.Control.UpdateBuildHistory:input_type -> moby.buildkit.v1.UpdateBuildHistoryRequest
-	3,  // 60: moby.buildkit.v1.Control.DiskUsage:output_type -> moby.buildkit.v1.DiskUsageResponse
-	4,  // 61: moby.buildkit.v1.Control.Prune:output_type -> moby.buildkit.v1.UsageRecord
-	8,  // 62: moby.buildkit.v1.Control.Solve:output_type -> moby.buildkit.v1.SolveResponse
-	10, // 63: moby.buildkit.v1.Control.Status:output_type -> moby.buildkit.v1.StatusResponse
-	15, // 64: moby.buildkit.v1.Control.Session:output_type -> moby.buildkit.v1.BytesMessage
-	17, // 65: moby.buildkit.v1.Control.ListWorkers:output_type -> moby.buildkit.v1.ListWorkersResponse
-	19, // 66: moby.buildkit.v1.Control.Info:output_type -> moby.buildkit.v1.InfoResponse
-	21, // 67: moby.buildkit.v1.Control.ListenBuildHistory:output_type -> moby.buildkit.v1.BuildHistoryEvent
-	24, // 68: moby.buildkit.v1.Control.UpdateBuildHistory:output_type -> moby.buildkit.v1.UpdateBuildHistoryResponse
-	60, // [60:69] is the sub-list for method output_type
-	51, // [51:60] is the sub-list for method input_type
-	51, // [51:51] is the sub-list for extension type_name
-	51, // [51:51] is the sub-list for extension extendee
-	0,  // [0:51] is the sub-list for field type_name
+	34, // 13: moby.buildkit.v1.CacheOptionsEntry.Attrs:type_name -> moby.buildkit.v1.CacheOptionsEntry.AttrsEntry
+	35, // 14: moby.buildkit.v1.SolveResponse.ExporterResponseDeprecated:type_name -> moby.buildkit.v1.SolveResponse.ExporterResponseDeprecatedEntry
+	28, // 15: moby.buildkit.v1.SolveResponse.exporterResponses:type_name -> moby.buildkit.v1.ExporterResponse
+	28, // 16: moby.buildkit.v1.SolveResponse.cacheExporterResponses:type_name -> moby.buildkit.v1.ExporterResponse
+	11, // 17: moby.buildkit.v1.StatusResponse.vertexes:type_name -> moby.buildkit.v1.Vertex
+	12, // 18: moby.buildkit.v1.StatusResponse.statuses:type_name -> moby.buildkit.v1.VertexStatus
+	13, // 19: moby.buildkit.v1.StatusResponse.logs:type_name -> moby.buildkit.v1.VertexLog
+	14, // 20: moby.buildkit.v1.StatusResponse.warnings:type_name -> moby.buildkit.v1.VertexWarning
+	43, // 21: moby.buildkit.v1.Vertex.started:type_name -> google.protobuf.Timestamp
+	43, // 22: moby.buildkit.v1.Vertex.completed:type_name -> google.protobuf.Timestamp
+	46, // 23: moby.buildkit.v1.Vertex.progressGroup:type_name -> pb.ProgressGroup
+	43, // 24: moby.buildkit.v1.VertexStatus.timestamp:type_name -> google.protobuf.Timestamp
+	43, // 25: moby.buildkit.v1.VertexStatus.started:type_name -> google.protobuf.Timestamp
+	43, // 26: moby.buildkit.v1.VertexStatus.completed:type_name -> google.protobuf.Timestamp
+	43, // 27: moby.buildkit.v1.VertexLog.timestamp:type_name -> google.protobuf.Timestamp
+	47, // 28: moby.buildkit.v1.VertexWarning.info:type_name -> pb.SourceInfo
+	48, // 29: moby.buildkit.v1.VertexWarning.ranges:type_name -> pb.Range
+	49, // 30: moby.buildkit.v1.ListWorkersResponse.record:type_name -> moby.buildkit.v1.types.WorkerRecord
+	50, // 31: moby.buildkit.v1.InfoResponse.buildkitVersion:type_name -> moby.buildkit.v1.types.BuildkitVersion
+	0,  // 32: moby.buildkit.v1.BuildHistoryEvent.type:type_name -> moby.buildkit.v1.BuildHistoryEventType
+	22, // 33: moby.buildkit.v1.BuildHistoryEvent.record:type_name -> moby.buildkit.v1.BuildHistoryRecord
+	36, // 34: moby.buildkit.v1.BuildHistoryRecord.FrontendAttrs:type_name -> moby.buildkit.v1.BuildHistoryRecord.FrontendAttrsEntry
+	27, // 35: moby.buildkit.v1.BuildHistoryRecord.Exporters:type_name -> moby.buildkit.v1.Exporter
+	51, // 36: moby.buildkit.v1.BuildHistoryRecord.error:type_name -> google.rpc.Status
+	43, // 37: moby.buildkit.v1.BuildHistoryRecord.CreatedAt:type_name -> google.protobuf.Timestamp
+	43, // 38: moby.buildkit.v1.BuildHistoryRecord.CompletedAt:type_name -> google.protobuf.Timestamp
+	25, // 39: moby.buildkit.v1.BuildHistoryRecord.logs:type_name -> moby.buildkit.v1.Descriptor
+	37, // 40: moby.buildkit.v1.BuildHistoryRecord.ExporterResponse:type_name -> moby.buildkit.v1.BuildHistoryRecord.ExporterResponseEntry
+	26, // 41: moby.buildkit.v1.BuildHistoryRecord.Result:type_name -> moby.buildkit.v1.BuildResultInfo
+	38, // 42: moby.buildkit.v1.BuildHistoryRecord.Results:type_name -> moby.buildkit.v1.BuildHistoryRecord.ResultsEntry
+	25, // 43: moby.buildkit.v1.BuildHistoryRecord.trace:type_name -> moby.buildkit.v1.Descriptor
+	25, // 44: moby.buildkit.v1.BuildHistoryRecord.externalError:type_name -> moby.buildkit.v1.Descriptor
+	39, // 45: moby.buildkit.v1.Descriptor.annotations:type_name -> moby.buildkit.v1.Descriptor.AnnotationsEntry
+	25, // 46: moby.buildkit.v1.BuildResultInfo.ResultDeprecated:type_name -> moby.buildkit.v1.Descriptor
+	25, // 47: moby.buildkit.v1.BuildResultInfo.Attestations:type_name -> moby.buildkit.v1.Descriptor
+	40, // 48: moby.buildkit.v1.BuildResultInfo.Results:type_name -> moby.buildkit.v1.BuildResultInfo.ResultsEntry
+	41, // 49: moby.buildkit.v1.Exporter.Attrs:type_name -> moby.buildkit.v1.Exporter.AttrsEntry
+	29, // 50: moby.buildkit.v1.ExporterResponse.metadata:type_name -> moby.buildkit.v1.ExporterMetadata
+	42, // 51: moby.buildkit.v1.ExporterResponse.data:type_name -> moby.buildkit.v1.ExporterResponse.DataEntry
+	44, // 52: moby.buildkit.v1.SolveRequest.FrontendInputsEntry.value:type_name -> pb.Definition
+	26, // 53: moby.buildkit.v1.BuildHistoryRecord.ResultsEntry.value:type_name -> moby.buildkit.v1.BuildResultInfo
+	25, // 54: moby.buildkit.v1.BuildResultInfo.ResultsEntry.value:type_name -> moby.buildkit.v1.Descriptor
+	2,  // 55: moby.buildkit.v1.Control.DiskUsage:input_type -> moby.buildkit.v1.DiskUsageRequest
+	1,  // 56: moby.buildkit.v1.Control.Prune:input_type -> moby.buildkit.v1.PruneRequest
+	5,  // 57: moby.buildkit.v1.Control.Solve:input_type -> moby.buildkit.v1.SolveRequest
+	9,  // 58: moby.buildkit.v1.Control.Status:input_type -> moby.buildkit.v1.StatusRequest
+	15, // 59: moby.buildkit.v1.Control.Session:input_type -> moby.buildkit.v1.BytesMessage
+	16, // 60: moby.buildkit.v1.Control.ListWorkers:input_type -> moby.buildkit.v1.ListWorkersRequest
+	18, // 61: moby.buildkit.v1.Control.Info:input_type -> moby.buildkit.v1.InfoRequest
+	20, // 62: moby.buildkit.v1.Control.ListenBuildHistory:input_type -> moby.buildkit.v1.BuildHistoryRequest
+	23, // 63: moby.buildkit.v1.Control.UpdateBuildHistory:input_type -> moby.buildkit.v1.UpdateBuildHistoryRequest
+	3,  // 64: moby.buildkit.v1.Control.DiskUsage:output_type -> moby.buildkit.v1.DiskUsageResponse
+	4,  // 65: moby.buildkit.v1.Control.Prune:output_type -> moby.buildkit.v1.UsageRecord
+	8,  // 66: moby.buildkit.v1.Control.Solve:output_type -> moby.buildkit.v1.SolveResponse
+	10, // 67: moby.buildkit.v1.Control.Status:output_type -> moby.buildkit.v1.StatusResponse
+	15, // 68: moby.buildkit.v1.Control.Session:output_type -> moby.buildkit.v1.BytesMessage
+	17, // 69: moby.buildkit.v1.Control.ListWorkers:output_type -> moby.buildkit.v1.ListWorkersResponse
+	19, // 70: moby.buildkit.v1.Control.Info:output_type -> moby.buildkit.v1.InfoResponse
+	21, // 71: moby.buildkit.v1.Control.ListenBuildHistory:output_type -> moby.buildkit.v1.BuildHistoryEvent
+	24, // 72: moby.buildkit.v1.Control.UpdateBuildHistory:output_type -> moby.buildkit.v1.UpdateBuildHistoryResponse
+	64, // [64:73] is the sub-list for method output_type
+	55, // [55:64] is the sub-list for method input_type
+	55, // [55:55] is the sub-list for extension type_name
+	55, // [55:55] is the sub-list for extension extendee
+	0,  // [0:55] is the sub-list for field type_name
 }
 
 func init() { file_github_com_moby_buildkit_api_services_control_control_proto_init() }
@@ -2396,7 +2534,7 @@ func file_github_com_moby_buildkit_api_services_control_control_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_moby_buildkit_api_services_control_control_proto_rawDesc), len(file_github_com_moby_buildkit_api_services_control_control_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   39,
+			NumMessages:   42,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/services/control/control.proto
+++ b/api/services/control/control.proto
@@ -35,7 +35,7 @@ message PruneRequest {
 }
 
 message DiskUsageRequest {
-	repeated string filter = 1; 
+	repeated string filter = 1;
 	int64 ageLimit = 2;
 }
 
@@ -108,7 +108,13 @@ message CacheOptionsEntry {
 }
 
 message SolveResponse {
-	map<string, string> ExporterResponse = 1;
+	// ExporterResponseDeprecated is a combined exporter response - it aggregates
+	// responses from all exporters (including cache exporters) running in parallel.
+	// It is deprecated in favor of the structured exporter responses but will be
+	// populated as long as it is supported.
+	map<string, string> ExporterResponseDeprecated = 1;
+	repeated ExporterResponse exporterResponses = 2;
+	repeated ExporterResponse cacheExporterResponses = 3;
 }
 
 message StatusRequest {
@@ -250,4 +256,18 @@ message Exporter {
 	string Type = 1;
 	// Attrs specifies exporter configuration
 	map<string, string> Attrs = 2;
+}
+
+// ExporterResponse describes the output of an exporter
+message ExporterResponse {
+	// Metadata describes the exporter
+	ExporterMetadata metadata = 1;
+	// Data is the exporter's output
+	map<string, string> data = 2;
+}
+
+// ExporterMetadata describes the output exporter
+message ExporterMetadata {
+	// Type identifies the exporter type
+	string type = 2;
 }

--- a/api/services/control/control_vtproto.pb.go
+++ b/api/services/control/control_vtproto.pb.go
@@ -259,12 +259,26 @@ func (m *SolveResponse) CloneVT() *SolveResponse {
 		return (*SolveResponse)(nil)
 	}
 	r := new(SolveResponse)
-	if rhs := m.ExporterResponse; rhs != nil {
+	if rhs := m.ExporterResponseDeprecated; rhs != nil {
 		tmpContainer := make(map[string]string, len(rhs))
 		for k, v := range rhs {
 			tmpContainer[k] = v
 		}
-		r.ExporterResponse = tmpContainer
+		r.ExporterResponseDeprecated = tmpContainer
+	}
+	if rhs := m.ExporterResponses; rhs != nil {
+		tmpContainer := make([]*ExporterResponse, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.ExporterResponses = tmpContainer
+	}
+	if rhs := m.CacheExporterResponses; rhs != nil {
+		tmpContainer := make([]*ExporterResponse, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.CacheExporterResponses = tmpContainer
 	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
@@ -778,6 +792,47 @@ func (m *Exporter) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (m *ExporterResponse) CloneVT() *ExporterResponse {
+	if m == nil {
+		return (*ExporterResponse)(nil)
+	}
+	r := new(ExporterResponse)
+	r.Metadata = m.Metadata.CloneVT()
+	if rhs := m.Data; rhs != nil {
+		tmpContainer := make(map[string]string, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.Data = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *ExporterResponse) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *ExporterMetadata) CloneVT() *ExporterMetadata {
+	if m == nil {
+		return (*ExporterMetadata)(nil)
+	}
+	r := new(ExporterMetadata)
+	r.Type = m.Type
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *ExporterMetadata) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (this *PruneRequest) EqualVT(that *PruneRequest) bool {
 	if this == that {
 		return true
@@ -1164,16 +1219,50 @@ func (this *SolveResponse) EqualVT(that *SolveResponse) bool {
 	} else if this == nil || that == nil {
 		return false
 	}
-	if len(this.ExporterResponse) != len(that.ExporterResponse) {
+	if len(this.ExporterResponseDeprecated) != len(that.ExporterResponseDeprecated) {
 		return false
 	}
-	for i, vx := range this.ExporterResponse {
-		vy, ok := that.ExporterResponse[i]
+	for i, vx := range this.ExporterResponseDeprecated {
+		vy, ok := that.ExporterResponseDeprecated[i]
 		if !ok {
 			return false
 		}
 		if vx != vy {
 			return false
+		}
+	}
+	if len(this.ExporterResponses) != len(that.ExporterResponses) {
+		return false
+	}
+	for i, vx := range this.ExporterResponses {
+		vy := that.ExporterResponses[i]
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &ExporterResponse{}
+			}
+			if q == nil {
+				q = &ExporterResponse{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
+		}
+	}
+	if len(this.CacheExporterResponses) != len(that.CacheExporterResponses) {
+		return false
+	}
+	for i, vx := range this.CacheExporterResponses {
+		vy := that.CacheExporterResponses[i]
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &ExporterResponse{}
+			}
+			if q == nil {
+				q = &ExporterResponse{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
 		}
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -1925,6 +2014,56 @@ func (this *Exporter) EqualMessageVT(thatMsg proto.Message) bool {
 	}
 	return this.EqualVT(that)
 }
+func (this *ExporterResponse) EqualVT(that *ExporterResponse) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !this.Metadata.EqualVT(that.Metadata) {
+		return false
+	}
+	if len(this.Data) != len(that.Data) {
+		return false
+	}
+	for i, vx := range this.Data {
+		vy, ok := that.Data[i]
+		if !ok {
+			return false
+		}
+		if vx != vy {
+			return false
+		}
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *ExporterResponse) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*ExporterResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *ExporterMetadata) EqualVT(that *ExporterMetadata) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.Type != that.Type {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *ExporterMetadata) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*ExporterMetadata)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (m *PruneRequest) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -2599,9 +2738,33 @@ func (m *SolveResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
-	if len(m.ExporterResponse) > 0 {
-		for k := range m.ExporterResponse {
-			v := m.ExporterResponse[k]
+	if len(m.CacheExporterResponses) > 0 {
+		for iNdEx := len(m.CacheExporterResponses) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.CacheExporterResponses[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if len(m.ExporterResponses) > 0 {
+		for iNdEx := len(m.ExporterResponses) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.ExporterResponses[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if len(m.ExporterResponseDeprecated) > 0 {
+		for k := range m.ExporterResponseDeprecated {
+			v := m.ExporterResponseDeprecated[k]
 			baseI := i
 			i -= len(v)
 			copy(dAtA[i:], v)
@@ -3968,6 +4131,108 @@ func (m *Exporter) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *ExporterResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ExporterResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *ExporterResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Data) > 0 {
+		for k := range m.Data {
+			v := m.Data[k]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if m.Metadata != nil {
+		size, err := m.Metadata.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *ExporterMetadata) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ExporterMetadata) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *ExporterMetadata) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Type) > 0 {
+		i -= len(m.Type)
+		copy(dAtA[i:], m.Type)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Type)))
+		i--
+		dAtA[i] = 0x12
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *PruneRequest) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -4246,12 +4511,24 @@ func (m *SolveResponse) SizeVT() (n int) {
 	}
 	var l int
 	_ = l
-	if len(m.ExporterResponse) > 0 {
-		for k, v := range m.ExporterResponse {
+	if len(m.ExporterResponseDeprecated) > 0 {
+		for k, v := range m.ExporterResponseDeprecated {
 			_ = k
 			_ = v
 			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + 1 + len(v) + protohelpers.SizeOfVarint(uint64(len(v)))
 			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
+		}
+	}
+	if len(m.ExporterResponses) > 0 {
+		for _, e := range m.ExporterResponses {
+			l = e.SizeVT()
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	if len(m.CacheExporterResponses) > 0 {
+		for _, e := range m.CacheExporterResponses {
+			l = e.SizeVT()
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
 	}
 	n += len(m.unknownFields)
@@ -4788,6 +5065,42 @@ func (m *Exporter) SizeVT() (n int) {
 			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + 1 + len(v) + protohelpers.SizeOfVarint(uint64(len(v)))
 			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
 		}
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *ExporterResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Metadata != nil {
+		l = m.Metadata.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.Data) > 0 {
+		for k, v := range m.Data {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + 1 + len(v) + protohelpers.SizeOfVarint(uint64(len(v)))
+			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
+		}
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *ExporterMetadata) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Type)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -6899,7 +7212,7 @@ func (m *SolveResponse) UnmarshalVT(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field ExporterResponse", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field ExporterResponseDeprecated", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -6926,8 +7239,8 @@ func (m *SolveResponse) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.ExporterResponse == nil {
-				m.ExporterResponse = make(map[string]string)
+			if m.ExporterResponseDeprecated == nil {
+				m.ExporterResponseDeprecated = make(map[string]string)
 			}
 			var mapkey string
 			var mapvalue string
@@ -7022,7 +7335,75 @@ func (m *SolveResponse) UnmarshalVT(dAtA []byte) error {
 					iNdEx += skippy
 				}
 			}
-			m.ExporterResponse[mapkey] = mapvalue
+			m.ExporterResponseDeprecated[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ExporterResponses", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ExporterResponses = append(m.ExporterResponses, &ExporterResponse{})
+			if err := m.ExporterResponses[len(m.ExporterResponses)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CacheExporterResponses", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.CacheExporterResponses = append(m.CacheExporterResponses, &ExporterResponse{})
+			if err := m.CacheExporterResponses[len(m.CacheExporterResponses)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -10814,6 +11195,303 @@ func (m *Exporter) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.Attrs[mapkey] = mapvalue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ExporterResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ExporterResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ExporterResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Metadata", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Metadata == nil {
+				m.Metadata = &ExporterMetadata{}
+			}
+			if err := m.Metadata.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Data", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Data == nil {
+				m.Data = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Data[mapkey] = mapvalue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ExporterMetadata) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ExporterMetadata: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ExporterMetadata: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Type", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Type = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/cache/remotecache/azblob/exporter.go
+++ b/cache/remotecache/azblob/exporter.go
@@ -64,6 +64,10 @@ func (ce *exporter) Name() string {
 	return "exporting cache to Azure Blob Storage"
 }
 
+func (ce *exporter) Type() string {
+	return remotecache.ExporterAzureBlob
+}
+
 func (ce *exporter) Finalize(ctx context.Context) (map[string]string, error) {
 	config, descs, err := ce.chains.Marshal(ctx)
 	if err != nil {

--- a/cache/remotecache/export.go
+++ b/cache/remotecache/export.go
@@ -31,6 +31,8 @@ type Exporter interface {
 	solver.CacheExporterTarget
 	// Name uniquely identifies the exporter
 	Name() string
+	// Type identifies the exporter's type
+	Type() string
 	// Finalize finalizes and return metadata that are returned to the client
 	// e.g. ExporterResponseManifestDesc
 	Finalize(ctx context.Context) (map[string]string, error)
@@ -55,6 +57,15 @@ const (
 	ImageManifest
 )
 
+const (
+	ExporterRegistry      = "registry"
+	ExporterGithubActions = "gha"
+	ExporterS3            = "s3"
+	ExporterAzureBlob     = "azblob"
+	ExporterLocal         = "local"
+	ExporterInline        = "inline"
+)
+
 func (data CacheType) String() string {
 	switch data {
 	case ManifestList:
@@ -66,9 +77,9 @@ func (data CacheType) String() string {
 	}
 }
 
-func NewExporter(ingester content.Ingester, ref string, oci bool, imageManifest bool, compressionConfig compression.Config) Exporter {
+func NewExporter(ingester content.Ingester, ref string, oci bool, imageManifest bool, compressionConfig compression.Config, typ string) Exporter {
 	cc := v1.NewCacheChains()
-	return &contentCacheExporter{CacheExporterTarget: cc, chains: cc, ingester: ingester, oci: oci, imageManifest: imageManifest, ref: ref, comp: compressionConfig}
+	return &contentCacheExporter{CacheExporterTarget: cc, chains: cc, ingester: ingester, oci: oci, imageManifest: imageManifest, ref: ref, comp: compressionConfig, typ: typ}
 }
 
 type ExportableCache struct {
@@ -170,10 +181,15 @@ type contentCacheExporter struct {
 	imageManifest bool
 	ref           string
 	comp          compression.Config
+	typ           string
 }
 
 func (ce *contentCacheExporter) Name() string {
 	return "exporting content cache"
+}
+
+func (ce *contentCacheExporter) Type() string {
+	return ce.typ
 }
 
 func (ce *contentCacheExporter) Config() Config {

--- a/cache/remotecache/gha/gha.go
+++ b/cache/remotecache/gha/gha.go
@@ -173,6 +173,10 @@ func (*exporter) Name() string {
 	return "exporting to GitHub Actions Cache"
 }
 
+func (*exporter) Type() string {
+	return remotecache.ExporterGithubActions
+}
+
 func (ce *exporter) Config() remotecache.Config {
 	return remotecache.Config{
 		Compression: compression.New(compression.Default),

--- a/cache/remotecache/inline/inline.go
+++ b/cache/remotecache/inline/inline.go
@@ -37,6 +37,10 @@ func (*exporter) Name() string {
 	return "exporting inline cache"
 }
 
+func (*exporter) Type() string {
+	return remotecache.ExporterInline
+}
+
 func (ce *exporter) Config() remotecache.Config {
 	return remotecache.Config{
 		Compression: compression.New(compression.Default),

--- a/cache/remotecache/local/local.go
+++ b/cache/remotecache/local/local.go
@@ -67,7 +67,7 @@ func ResolveCacheExporterFunc(sm *session.Manager) remotecache.ResolveCacheExpor
 		if err != nil {
 			return nil, err
 		}
-		return &exporter{remotecache.NewExporter(cs, "", ociMediatypes, imageManifest, compressionConfig)}, nil
+		return &exporter{remotecache.NewExporter(cs, "", ociMediatypes, imageManifest, compressionConfig, remotecache.ExporterLocal)}, nil
 	}
 }
 

--- a/cache/remotecache/registry/registry.go
+++ b/cache/remotecache/registry/registry.go
@@ -96,7 +96,7 @@ func ResolveCacheExporterFunc(sm *session.Manager, hosts docker.RegistryHosts) r
 		if err != nil {
 			return nil, err
 		}
-		return &exporter{remotecache.NewExporter(contentutil.FromPusher(pusher), refString, ociMediatypes, imageManifest, compressionConfig)}, nil
+		return &exporter{remotecache.NewExporter(contentutil.FromPusher(pusher), refString, ociMediatypes, imageManifest, compressionConfig, remotecache.ExporterRegistry)}, nil
 	}
 }
 

--- a/cache/remotecache/s3/s3.go
+++ b/cache/remotecache/s3/s3.go
@@ -228,6 +228,10 @@ func (*exporter) Name() string {
 	return "exporting cache to Amazon S3"
 }
 
+func (*exporter) Type() string {
+	return remotecache.ExporterS3
+}
+
 func (e *exporter) Config() remotecache.Config {
 	return remotecache.Config{
 		Compression: compression.New(compression.Default),

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -178,6 +178,8 @@ var allTests = []func(t *testing.T, sb integration.Sandbox){
 	testTarExporterSymlink,
 	testMultipleRegistryCacheImportExport,
 	testMultipleExporters,
+	testMultipleImageExporters,
+	testExporterResponses,
 	testSourceMap,
 	testSourceMapFromRef,
 	testLazyImagePush,
@@ -3011,7 +3013,7 @@ func testSessionExporter(t *testing.T, sb integration.Sandbox) {
 		require.Equal(t, "foo", resp.Entries[1].Path)
 
 		exporterCalled = true
-		target.Add(filesync.WithFSSync(0, fixedWriteCloser(&iohelper.NopWriteCloser{Writer: outW})))
+		target.Add(filesync.WithFSSync("0", fixedWriteCloser(&iohelper.NopWriteCloser{Writer: outW})))
 		return []*exporter.ExporterRequest{
 			{
 				Type: ExporterOCI,
@@ -4238,6 +4240,157 @@ func testMultipleExporters(t *testing.T, sb integration.Sandbox) {
 		}
 		require.Equal(t, ev.Record.Result.Results[0], ev.Record.Result.ResultDeprecated)
 	}
+
+	require.Len(t, resp.ExporterResponses, len(exporters))
+	for i, exporterResp := range resp.ExporterResponses {
+		require.NotEmpty(t, exporterResp.Type, "exporter %d should have Type", i)
+		require.Equal(t, exporters[i].Type, exporterResp.Type,
+			"ExporterResponses[%d].Type should match Exports[%d].Type", i, i)
+	}
+}
+
+func testMultipleImageExporters(t *testing.T, sb integration.Sandbox) {
+	workers.CheckFeatureCompat(t, sb, workers.FeatureOCIExporter)
+	requiresLinux(t)
+
+	c, err := New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	def, err := llb.Scratch().Marshal(context.TODO())
+	require.NoError(t, err)
+
+	destDir := t.TempDir()
+	ociTar := filepath.Join(destDir, "oci.tar")
+	ociOut, err := os.Create(ociTar)
+	require.NoError(t, err)
+	defer ociOut.Close()
+
+	dockerTar := filepath.Join(destDir, "docker.tar")
+	dockerOut, err := os.Create(dockerTar)
+	require.NoError(t, err)
+	defer dockerOut.Close()
+
+	exporters := []ExportEntry{
+		{
+			Type: ExporterOCI,
+			Attrs: map[string]string{
+				"dest": ociTar,
+			},
+			Output: fixedWriteCloser(ociOut),
+		},
+		{
+			Type: ExporterDocker,
+			Attrs: map[string]string{
+				"dest": dockerTar,
+			},
+			Output: fixedWriteCloser(dockerOut),
+		},
+	}
+
+	ref := identity.NewID()
+	_, err = c.Solve(sb.Context(), def, SolveOpt{
+		Ref:     ref,
+		Exports: exporters,
+	}, nil)
+	require.NoError(t, err)
+
+	require.FileExists(t, filepath.Join(destDir, "oci.tar"))
+	require.FileExists(t, filepath.Join(destDir, "docker.tar"))
+
+	ociConfig := extractImageConfig(t, ociTar)
+	dockerConfig := extractImageConfig(t, dockerTar)
+	// Validate that the image configurtion is not empty
+	require.NotEmpty(t, ociConfig.Architecture, "architecture is missing")
+	require.NotEmpty(t, dockerConfig.Architecture, "architecture is missing")
+}
+
+func extractImageConfig(t *testing.T, path string) ocispecs.Image {
+	t.Helper()
+
+	dt, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	m, err := testutil.ReadTarToMap(dt, false)
+	require.NoError(t, err)
+
+	var index ocispecs.Index
+	err = json.Unmarshal(m["index.json"].Data, &index)
+	require.NoError(t, err)
+	require.NotEmpty(t, index.Manifests, "index is missing platform manifests")
+
+	var manifest ocispecs.Manifest
+	err = json.Unmarshal(m[filepath.Join("blobs", "sha256", index.Manifests[0].Digest.Encoded())].Data, &manifest)
+	require.NoError(t, err)
+
+	var config ocispecs.Image
+	err = json.Unmarshal(m[filepath.Join("blobs", "sha256", manifest.Config.Digest.Encoded())].Data, &config)
+	require.NoError(t, err)
+
+	return config
+}
+
+func testExporterResponses(t *testing.T, sb integration.Sandbox) {
+	workers.CheckFeatureCompat(t, sb, workers.FeatureOCIExporter)
+	requiresLinux(t)
+
+	c, err := New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	def, err := llb.Scratch().File(llb.Mkfile("foo.txt", 0o755, nil)).Marshal(context.TODO())
+	require.NoError(t, err)
+
+	destDir := t.TempDir()
+	ociTar := filepath.Join(destDir, "oci.tar")
+	dockerTar := filepath.Join(destDir, "docker.tar")
+	localDir := filepath.Join(destDir, "local")
+
+	ociOut, err := os.Create(ociTar)
+	require.NoError(t, err)
+	defer ociOut.Close()
+	dockerOut, err := os.Create(dockerTar)
+	require.NoError(t, err)
+	defer dockerOut.Close()
+
+	exporters := []ExportEntry{
+		{
+			Type:   ExporterOCI,
+			Attrs:  map[string]string{"dest": ociTar},
+			Output: fixedWriteCloser(ociOut),
+		},
+		{
+			Type:   ExporterDocker,
+			Attrs:  map[string]string{"dest": dockerTar},
+			Output: fixedWriteCloser(dockerOut),
+		},
+		{
+			Type:      ExporterLocal,
+			OutputDir: localDir,
+		},
+		{
+			Type:  ExporterImage,
+			Attrs: map[string]string{"name": "test:0.0.1"},
+		},
+	}
+
+	// exercise
+	resp, err := c.Solve(sb.Context(), def, SolveOpt{
+		Exports: exporters,
+	}, nil)
+	require.NoError(t, err)
+
+	// verify
+	require.Len(t, resp.ExporterResponses, 4)
+	require.Equal(t, ExporterOCI, resp.ExporterResponses[0].Type)
+	require.Equal(t, ExporterDocker, resp.ExporterResponses[1].Type)
+	require.Equal(t, ExporterLocal, resp.ExporterResponses[2].Type)
+	require.Equal(t, ExporterImage, resp.ExporterResponses[3].Type)
+
+	require.Contains(t, resp.ExporterResponses[0].Data, exptypes.ExporterImageDescriptorKey, "expected descriptor in OCI export response")
+	require.Contains(t, resp.ExporterResponses[0].Data, exptypes.ExporterImageDigestKey, "expected descriptor in OCI export response")
+	require.Contains(t, resp.ExporterResponses[3].Data, exptypes.ExporterImageNameKey, "expected image name in image export response")
+	require.NotContains(t, resp.ExporterResponses[2].Data, exptypes.ExporterImageDigestKey, "did not expect image-specific data in local export response")
 }
 
 func testOCIExporter(t *testing.T, sb integration.Sandbox) {
@@ -11625,25 +11778,25 @@ func testMultipleCacheExports(t *testing.T, sb integration.Sandbox) {
 		},
 		CacheExports: []CacheOptionsEntry{
 			{
-				Type: "local",
+				Type: CacheExporterLocal,
 				Attrs: map[string]string{
 					"dest": cacheOutDir,
 				},
 			},
 			{
-				Type: "local",
+				Type: CacheExporterLocal,
 				Attrs: map[string]string{
 					"dest": cacheOutDir2,
 				},
 			},
 			{
-				Type: "registry",
+				Type: CacheExporterRegistry,
 				Attrs: map[string]string{
 					"ref": cacheRef,
 				},
 			},
 			{
-				Type: "inline",
+				Type: CacheExporterInline,
 			},
 		},
 	}, nil)
@@ -11651,6 +11804,18 @@ func testMultipleCacheExports(t *testing.T, sb integration.Sandbox) {
 
 	ensureFile(t, filepath.Join(cacheOutDir, ocispecs.ImageIndexFile))
 	ensureFile(t, filepath.Join(cacheOutDir2, ocispecs.ImageIndexFile))
+
+	require.NotEmpty(t, res.CacheExporterResponses, "should have cache exporter responses")
+	contentCacheResponses := 0
+	for i, cacheResp := range res.CacheExporterResponses {
+		require.NotEmpty(t, cacheResp.Type, "cache exporter %d should have Type", i)
+		require.NotNil(t, cacheResp.Data, "cache exporter %d should have Data", i)
+		if _, ok := cacheResp.Data[exporterResponseManifestDesc]; ok {
+			contentCacheResponses++
+		}
+	}
+	// 2 local + 1 registry
+	require.Equal(t, 3, contentCacheResponses, "should have 3 responses from content cache exporters")
 
 	dgst := res.ExporterResponse[exptypes.ExporterImageDigestKey]
 

--- a/client/exporters.go
+++ b/client/exporters.go
@@ -6,4 +6,11 @@ const (
 	ExporterTar    = "tar"
 	ExporterOCI    = "oci"
 	ExporterDocker = "docker"
+
+	CacheExporterRegistry      = "registry"
+	CacheExporterGithubActions = "gha"
+	CacheExporterS3            = "s3"
+	CacheExporterAzureBlob     = "azblob"
+	CacheExporterLocal         = "local"
+	CacheExporterInline        = "inline"
 )

--- a/client/graph.go
+++ b/client/graph.go
@@ -55,6 +55,13 @@ type SolveStatus struct {
 }
 
 type SolveResponse struct {
-	// ExporterResponse is also used for CacheExporter
-	ExporterResponse map[string]string
+	// ExporterResponse is the deprecated combined exporter response.
+	ExporterResponse       map[string]string
+	ExporterResponses      []ExporterResponse
+	CacheExporterResponses []ExporterResponse
+}
+
+type ExporterResponse struct {
+	Type string
+	Data map[string]string
 }

--- a/client/solve.go
+++ b/client/solve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"maps"
 	"os"
@@ -13,6 +14,14 @@ import (
 
 	"github.com/containerd/containerd/v2/core/content"
 	contentlocal "github.com/containerd/containerd/v2/plugins/content/local"
+	digest "github.com/opencontainers/go-digest"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"github.com/tonistiigi/fsutil"
+	fstypes "github.com/tonistiigi/fsutil/types"
+	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/errgroup"
+
 	controlapi "github.com/moby/buildkit/api/services/control"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/client/ociindex"
@@ -25,13 +34,6 @@ import (
 	"github.com/moby/buildkit/solver/pb"
 	spb "github.com/moby/buildkit/sourcepolicy/pb"
 	"github.com/moby/buildkit/util/bklog"
-	digest "github.com/opencontainers/go-digest"
-	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
-	"github.com/tonistiigi/fsutil"
-	fstypes "github.com/tonistiigi/fsutil/types"
-	"go.opentelemetry.io/otel/trace"
-	"golang.org/x/sync/errgroup"
 )
 
 type SolveOpt struct {
@@ -53,6 +55,11 @@ type SolveOpt struct {
 	SourcePolicy          *spb.Policy
 	SourcePolicyProvider  session.Attachable
 	Ref                   string
+}
+
+type ociStore struct {
+	path string
+	tag  string
 }
 
 type ExportEntry struct {
@@ -129,7 +136,7 @@ func (c *Client) solve(ctx context.Context, def *llb.Definition, runGateway runG
 		return nil, err
 	}
 
-	storesToUpdate := []string{}
+	var storesToUpdate map[int]ociStore // exporter index -> store config
 
 	if !opt.SessionPreInitialized {
 		if len(syncedDirs) > 0 {
@@ -174,17 +181,18 @@ func (c *Client) solve(ctx context.Context, def *llb.Definition, runGateway runG
 			if !supportStore && ex.OutputStore != nil {
 				return nil, errors.Errorf("output store is not supported by %s exporter", ex.Type)
 			}
+			id := fmt.Sprint(exID)
 			if supportFile {
 				if ex.Output == nil {
 					return nil, errors.Errorf("output file writer is required for %s exporter", ex.Type)
 				}
-				syncTargets = append(syncTargets, filesync.WithFSSync(exID, ex.Output))
+				syncTargets = append(syncTargets, filesync.WithFSSync(id, ex.Output))
 			}
 			if supportDir {
 				if ex.OutputDir == "" {
 					return nil, errors.Errorf("output directory is required for %s exporter", ex.Type)
 				}
-				syncTargets = append(syncTargets, filesync.WithFSSyncDir(exID, ex.OutputDir))
+				syncTargets = append(syncTargets, filesync.WithFSSyncDir(id, ex.OutputDir))
 			}
 			if supportStore {
 				store := ex.OutputStore
@@ -196,7 +204,10 @@ func (c *Client) solve(ctx context.Context, def *llb.Definition, runGateway runG
 					if err != nil {
 						return nil, err
 					}
-					storesToUpdate = append(storesToUpdate, ex.OutputDir)
+					if storesToUpdate == nil {
+						storesToUpdate = make(map[int]ociStore)
+					}
+					storesToUpdate[exID] = ociStore{path: ex.OutputDir}
 				}
 
 				// TODO: this should be dependent on the exporter id (to allow multiple oci exporters)
@@ -317,7 +328,21 @@ func (c *Client) solve(ctx context.Context, def *llb.Definition, runGateway runG
 			return errors.Wrap(err, "failed to solve")
 		}
 		res = &SolveResponse{
-			ExporterResponse: resp.ExporterResponse,
+			ExporterResponse:       resp.ExporterResponseDeprecated,
+			ExporterResponses:      make([]ExporterResponse, 0, len(resp.ExporterResponses)),
+			CacheExporterResponses: make([]ExporterResponse, 0, len(resp.CacheExporterResponses)),
+		}
+		for _, resp := range resp.ExporterResponses {
+			res.ExporterResponses = append(res.ExporterResponses, ExporterResponse{
+				Type: resp.Metadata.Type,
+				Data: resp.Data,
+			})
+		}
+		for _, resp := range resp.CacheExporterResponses {
+			res.CacheExporterResponses = append(res.CacheExporterResponses, ExporterResponse{
+				Type: resp.Metadata.Type,
+				Data: resp.Data,
+			})
 		}
 		return nil
 	})
@@ -377,45 +402,91 @@ func (c *Client) solve(ctx context.Context, def *llb.Definition, runGateway runG
 	if err := eg.Wait(); err != nil {
 		return nil, err
 	}
-	// Update index.json of exported cache content store
-	// FIXME(AkihiroSuda): dedupe const definition of cache/remotecache.ExporterResponseManifestDesc = "cache.manifest"
-	if manifestDescJSON := res.ExporterResponse["cache.manifest"]; manifestDescJSON != "" {
-		var manifestDesc ocispecs.Descriptor
-		if err = json.Unmarshal([]byte(manifestDescJSON), &manifestDesc); err != nil {
-			return nil, err
-		}
-		for storePath, tag := range cacheOpt.storesToUpdate {
-			idx := ociindex.NewStoreIndex(storePath)
-			if err := idx.Put(manifestDesc, ociindex.Tag(tag)); err != nil {
-				return nil, err
-			}
-		}
-	}
-	if manifestDescDt := res.ExporterResponse[exptypes.ExporterImageDescriptorKey]; manifestDescDt != "" {
-		manifestDescDt, err := base64.StdEncoding.DecodeString(manifestDescDt)
+
+	for id, store := range cacheOpt.storesToUpdate {
+		// Update index.json of exported cache content store
+		manifestDesc, err := getCacheManifestDescriptor(id, res)
 		if err != nil {
 			return nil, err
 		}
-		var manifestDesc ocispecs.Descriptor
-		if err = json.Unmarshal(manifestDescDt, &manifestDesc); err != nil {
+		if manifestDesc == nil {
+			continue
+		}
+		idxStore := ociindex.NewStoreIndex(store.path)
+		if err := idxStore.Put(*manifestDesc, ociindex.Tag(store.tag)); err != nil {
 			return nil, err
 		}
-		for _, storePath := range storesToUpdate {
-			names := []ociindex.NameOrTag{ociindex.Tag("latest")}
-			if t, ok := res.ExporterResponse[exptypes.ExporterImageNameKey]; ok {
+	}
+
+	if len(storesToUpdate) == 0 {
+		return res, nil
+	}
+
+	for id, store := range storesToUpdate {
+		manifestDesc, err := getImageManifestDescriptor(id, res)
+		if err != nil {
+			return nil, err
+		}
+		if manifestDesc == nil {
+			continue
+		}
+		names := []ociindex.NameOrTag{ociindex.Tag("latest")}
+		if id < len(res.ExporterResponses) {
+			resp := res.ExporterResponses[id]
+			if t, ok := resp.Data[exptypes.ExporterImageNameKey]; ok {
 				inp := strings.Split(t, ",")
 				names = make([]ociindex.NameOrTag, len(inp))
 				for i, n := range inp {
 					names[i] = ociindex.Name(n)
 				}
 			}
-			idx := ociindex.NewStoreIndex(storePath)
-			if err := idx.Put(manifestDesc, names...); err != nil {
-				return nil, err
-			}
+		}
+		idxStore := ociindex.NewStoreIndex(store.path)
+		if err := idxStore.Put(*manifestDesc, names...); err != nil {
+			return nil, err
 		}
 	}
 	return res, nil
+}
+
+func getCacheManifestDescriptor(exporterIdx int, resp *SolveResponse) (*ocispecs.Descriptor, error) {
+	if exporterIdx < len(resp.CacheExporterResponses) {
+		if manifestDescDt := resp.CacheExporterResponses[exporterIdx].Data[exporterResponseManifestDesc]; manifestDescDt != "" {
+			return unmarshalManifestDescriptor(manifestDescDt)
+		}
+	}
+	if manifestDescDt := resp.ExporterResponse[exporterResponseManifestDesc]; manifestDescDt != "" {
+		return unmarshalManifestDescriptor(manifestDescDt)
+	}
+	return nil, nil
+}
+
+func getImageManifestDescriptor(exporterIdx int, resp *SolveResponse) (*ocispecs.Descriptor, error) {
+	if exporterIdx < len(resp.ExporterResponses) {
+		if manifestDescDt := resp.ExporterResponses[exporterIdx].Data[exptypes.ExporterImageDescriptorKey]; manifestDescDt != "" {
+			return unmarshalEncodedManifestDescriptor(manifestDescDt)
+		}
+	}
+	if manifestDescDt := resp.ExporterResponse[exptypes.ExporterImageDescriptorKey]; manifestDescDt != "" {
+		return unmarshalEncodedManifestDescriptor(manifestDescDt)
+	}
+	return nil, nil
+}
+
+func unmarshalEncodedManifestDescriptor(base64Payload string) (*ocispecs.Descriptor, error) {
+	manifestDescDt, err := base64.StdEncoding.DecodeString(base64Payload)
+	if err != nil {
+		return nil, err
+	}
+	return unmarshalManifestDescriptor(string(manifestDescDt))
+}
+
+func unmarshalManifestDescriptor(manifestDescJSON string) (*ocispecs.Descriptor, error) {
+	var desc ocispecs.Descriptor
+	if err := json.Unmarshal([]byte(manifestDescJSON), &desc); err != nil {
+		return nil, err
+	}
+	return &desc, nil
 }
 
 func prepareSyncedFiles(def *llb.Definition, localMounts map[string]fsutil.FS) (filesync.StaticDirSource, error) {
@@ -465,7 +536,7 @@ func prepareSyncedFiles(def *llb.Definition, localMounts map[string]fsutil.FS) (
 type cacheOptions struct {
 	options        controlapi.CacheOptions
 	contentStores  map[string]content.Store // key: ID of content store ("local:" + csDir)
-	storesToUpdate map[string]string        // key: path to content store, value: tag
+	storesToUpdate map[int]ociStore         // key: exporter index
 	frontendAttrs  map[string]string
 }
 
@@ -475,10 +546,10 @@ func parseCacheOptions(ctx context.Context, isGateway bool, opt SolveOpt) (*cach
 		cacheImports []*controlapi.CacheOptionsEntry
 	)
 	contentStores := make(map[string]content.Store)
-	storesToUpdate := make(map[string]string)
+	storesToUpdate := make(map[int]ociStore, len(opt.CacheExports))
 	frontendAttrs := make(map[string]string)
-	for _, ex := range opt.CacheExports {
-		if ex.Type == "local" {
+	for exID, ex := range opt.CacheExports {
+		if ex.Type == CacheExporterLocal {
 			csDir := ex.Attrs["dest"]
 			if csDir == "" {
 				return nil, errors.New("local cache exporter requires dest")
@@ -496,10 +567,9 @@ func parseCacheOptions(ctx context.Context, isGateway bool, opt SolveOpt) (*cach
 			if t, ok := ex.Attrs["tag"]; ok {
 				tag = t
 			}
-			// TODO(AkihiroSuda): support custom index JSON path and tag
-			storesToUpdate[csDir] = tag
+			storesToUpdate[exID] = ociStore{path: csDir, tag: tag}
 		}
-		if ex.Type == "registry" {
+		if ex.Type == CacheExporterRegistry {
 			regRef := ex.Attrs["ref"]
 			if regRef == "" {
 				return nil, errors.New("registry cache exporter requires ref")
@@ -511,7 +581,7 @@ func parseCacheOptions(ctx context.Context, isGateway bool, opt SolveOpt) (*cach
 		})
 	}
 	for _, im := range opt.CacheImports {
-		if im.Type == "local" {
+		if im.Type == CacheExporterLocal {
 			csDir := im.Attrs["src"]
 			if csDir == "" {
 				return nil, errors.New("local cache importer requires src")
@@ -550,7 +620,7 @@ func parseCacheOptions(ctx context.Context, isGateway bool, opt SolveOpt) (*cach
 			}
 			contentStores["local:"+csDir] = cs
 		}
-		if im.Type == "registry" {
+		if im.Type == CacheExporterRegistry {
 			regRef := im.Attrs["ref"]
 			if regRef == "" {
 				return nil, errors.New("registry cache importer requires ref")
@@ -570,7 +640,7 @@ func parseCacheOptions(ctx context.Context, isGateway bool, opt SolveOpt) (*cach
 			frontendAttrs["cache-imports"] = string(s)
 		}
 	}
-	res := cacheOptions{
+	return &cacheOptions{
 		options: controlapi.CacheOptions{
 			Exports: cacheExports,
 			Imports: cacheImports,
@@ -578,6 +648,7 @@ func parseCacheOptions(ctx context.Context, isGateway bool, opt SolveOpt) (*cach
 		contentStores:  contentStores,
 		storesToUpdate: storesToUpdate,
 		frontendAttrs:  frontendAttrs,
-	}
-	return &res, nil
+	}, nil
 }
+
+const exporterResponseManifestDesc = "cache.manifest"

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -849,19 +849,19 @@ func newController(ctx context.Context, c *cli.Context, cfg *config.Config) (*co
 	}
 
 	remoteCacheExporterFuncs := map[string]remotecache.ResolveCacheExporterFunc{
-		"registry": registryremotecache.ResolveCacheExporterFunc(sessionManager, resolverFn),
-		"local":    localremotecache.ResolveCacheExporterFunc(sessionManager),
-		"inline":   inlineremotecache.ResolveCacheExporterFunc(),
-		"gha":      gha.ResolveCacheExporterFunc(cfg.Cache.GHA, verifierProvider),
-		"s3":       s3remotecache.ResolveCacheExporterFunc(),
-		"azblob":   azblob.ResolveCacheExporterFunc(),
+		remotecache.ExporterRegistry:      registryremotecache.ResolveCacheExporterFunc(sessionManager, resolverFn),
+		remotecache.ExporterLocal:         localremotecache.ResolveCacheExporterFunc(sessionManager),
+		remotecache.ExporterInline:        inlineremotecache.ResolveCacheExporterFunc(),
+		remotecache.ExporterGithubActions: gha.ResolveCacheExporterFunc(cfg.Cache.GHA, verifierProvider),
+		remotecache.ExporterS3:            s3remotecache.ResolveCacheExporterFunc(),
+		remotecache.ExporterAzureBlob:     azblob.ResolveCacheExporterFunc(),
 	}
 	remoteCacheImporterFuncs := map[string]remotecache.ResolveCacheImporterFunc{
-		"registry": registryremotecache.ResolveCacheImporterFunc(sessionManager, w.ContentStore(), resolverFn),
-		"local":    localremotecache.ResolveCacheImporterFunc(sessionManager),
-		"gha":      gha.ResolveCacheImporterFunc(cfg.Cache.GHA, verifierProvider),
-		"s3":       s3remotecache.ResolveCacheImporterFunc(),
-		"azblob":   azblob.ResolveCacheImporterFunc(),
+		remotecache.ExporterRegistry:      registryremotecache.ResolveCacheImporterFunc(sessionManager, w.ContentStore(), resolverFn),
+		remotecache.ExporterLocal:         localremotecache.ResolveCacheImporterFunc(sessionManager),
+		remotecache.ExporterGithubActions: gha.ResolveCacheImporterFunc(cfg.Cache.GHA, verifierProvider),
+		remotecache.ExporterS3:            s3remotecache.ResolveCacheImporterFunc(),
+		remotecache.ExporterAzureBlob:     azblob.ResolveCacheImporterFunc(),
 	}
 
 	if cfg.CDI.Disabled == nil || !*cfg.CDI.Disabled {

--- a/control/control.go
+++ b/control/control.go
@@ -22,7 +22,6 @@ import (
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/cmd/buildkitd/config"
 	controlgateway "github.com/moby/buildkit/control/gateway"
-	"github.com/moby/buildkit/exporter"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/exporter/util/epoch"
 	"github.com/moby/buildkit/frontend"
@@ -343,7 +342,7 @@ func translateLegacySolveRequest(req *controlapi.SolveRequest) {
 	// translates ExportRef and ExportAttrs to new Exports (v0.4.0)
 	if legacyExportRef := req.Cache.ExportRefDeprecated; legacyExportRef != "" {
 		ex := &controlapi.CacheOptionsEntry{
-			Type:  "registry",
+			Type:  remotecache.ExporterRegistry,
 			Attrs: req.Cache.ExportAttrsDeprecated,
 		}
 		if ex.Attrs == nil {
@@ -359,7 +358,7 @@ func translateLegacySolveRequest(req *controlapi.SolveRequest) {
 	// translates ImportRefs to new Imports (v0.4.0)
 	for _, legacyImportRef := range req.Cache.ImportRefsDeprecated {
 		im := &controlapi.CacheOptionsEntry{
-			Type:  "registry",
+			Type:  remotecache.ExporterRegistry,
 			Attrs: map[string]string{"ref": legacyImportRef},
 		}
 		// FIXME(AkihiroSuda): skip append if already exists
@@ -412,18 +411,21 @@ func (c *Controller) Solve(ctx context.Context, req *controlapi.SolveRequest) (*
 		}
 	}
 
-	var expis []exporter.ExporterInstance
-	for i, ex := range req.Exporters {
+	var expis []llbsolver.Exporter
+	for exID, ex := range req.Exporters {
 		exp, err := w.Exporter(ex.Type, c.opt.SessionManager)
 		if err != nil {
 			return nil, err
 		}
 		bklog.G(ctx).Debugf("resolve exporter %s with %v", ex.Type, ex.Attrs)
-		expi, err := exp.Resolve(ctx, i, ex.Attrs)
+		expi, err := exp.Resolve(ctx, ex.Attrs)
 		if err != nil {
 			return nil, err
 		}
-		expis = append(expis, expi)
+		expis = append(expis, llbsolver.Exporter{
+			ExporterIO:       llbsolver.NewIO(fmt.Sprint(exID)),
+			ExporterInstance: expi,
+		})
 	}
 
 	rest, dupes, err := findDuplicateCacheOptions(req.Cache.Exports)
@@ -546,9 +548,7 @@ func (c *Controller) Solve(ctx context.Context, req *controlapi.SolveRequest) (*
 	if err != nil {
 		return nil, err
 	}
-	return &controlapi.SolveResponse{
-		ExporterResponse: resp.ExporterResponse,
-	}, nil
+	return resp, nil
 }
 
 func (c *Controller) Status(req *controlapi.StatusRequest, stream controlapi.Control_StatusServer) error {

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -68,10 +68,9 @@ func New(opt Opt) (exporter.Exporter, error) {
 	return im, nil
 }
 
-func (e *imageExporter) Resolve(ctx context.Context, id int, opt map[string]string) (exporter.ExporterInstance, error) {
+func (e *imageExporter) Resolve(ctx context.Context, opt map[string]string) (exporter.ExporterInstance, error) {
 	i := &imageExporterInstance{
 		imageExporter: e,
-		id:            id,
 		attrs:         opt,
 		opts: ImageCommitOpts{
 			RefCfg: cacheconfig.RefConfig{
@@ -183,7 +182,6 @@ func (e *imageExporter) Resolve(ctx context.Context, id int, opt map[string]stri
 
 type imageExporterInstance struct {
 	*imageExporter
-	id    int
 	attrs map[string]string
 
 	opts                 ImageCommitOpts
@@ -197,10 +195,6 @@ type imageExporterInstance struct {
 	danglingPrefix       string
 	danglingEmptyOnly    bool
 	meta                 map[string][]byte
-}
-
-func (e *imageExporterInstance) ID() int {
-	return e.id
 }
 
 func (e *imageExporterInstance) Name() string {

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -2,12 +2,15 @@ package exporter
 
 import (
 	"context"
+	"io"
 
 	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
+	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver/result"
 	"github.com/moby/buildkit/util/compression"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/tonistiigi/fsutil"
 )
 
 type Source = result.Result[cache.ImmutableRef]
@@ -15,7 +18,7 @@ type Source = result.Result[cache.ImmutableRef]
 type Attestation = result.Attestation[cache.ImmutableRef]
 
 type Exporter interface {
-	Resolve(context.Context, int, map[string]string) (ExporterInstance, error)
+	Resolve(context.Context, map[string]string) (ExporterInstance, error)
 }
 
 // FinalizeFunc completes an export operation after all exports have created
@@ -29,7 +32,6 @@ type Exporter interface {
 type FinalizeFunc func(ctx context.Context) error
 
 type ExporterInstance interface {
-	ID() int
 	Name() string
 	Config() *Config
 	Type() string
@@ -53,6 +55,13 @@ type ExportBuildInfo struct {
 	Ref         string
 	InlineCache exptypes.InlineCache
 	SessionID   string
+	IO          ExporterIO
+}
+
+// ExporterIO encapsulates the streaming APIs.
+type ExporterIO struct {
+	CopyFileWriter func(context.Context, map[string]string /*metadata*/, session.Caller) (io.WriteCloser, error)
+	CopyToCaller   func(context.Context, fsutil.FS, session.Caller, func(int, bool) /*progress*/) error
 }
 
 type DescriptorReference interface {

--- a/exporter/exptypes/keys.go
+++ b/exporter/exptypes/keys.go
@@ -7,7 +7,7 @@ const (
 type ExporterOptKey string
 
 // Options keys supported by all exporters.
-var (
+const (
 	// Clamp produced timestamps. For more information see the
 	// SOURCE_DATE_EPOCH specification.
 	// Value: int (number of seconds since Unix epoch)

--- a/exporter/local/export.go
+++ b/exporter/local/export.go
@@ -13,7 +13,6 @@ import (
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/exporter/util/epoch"
 	"github.com/moby/buildkit/session"
-	"github.com/moby/buildkit/session/filesync"
 	"github.com/moby/buildkit/util/progress"
 	"github.com/pkg/errors"
 	"github.com/tonistiigi/fsutil"
@@ -36,9 +35,8 @@ func New(opt Opt) (exporter.Exporter, error) {
 	return le, nil
 }
 
-func (e *localExporter) Resolve(ctx context.Context, id int, opt map[string]string) (exporter.ExporterInstance, error) {
+func (e *localExporter) Resolve(ctx context.Context, opt map[string]string) (exporter.ExporterInstance, error) {
 	i := &localExporterInstance{
-		id:            id,
 		attrs:         opt,
 		localExporter: e,
 	}
@@ -52,14 +50,9 @@ func (e *localExporter) Resolve(ctx context.Context, id int, opt map[string]stri
 
 type localExporterInstance struct {
 	*localExporter
-	id    int
 	attrs map[string]string
 
 	opts CreateFSOpts
-}
-
-func (e *localExporterInstance) ID() int {
-	return e.id
 }
 
 func (e *localExporterInstance) Name() string {
@@ -162,7 +155,7 @@ func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source
 			}
 
 			progress := NewProgressHandler(ctx, lbl)
-			if err := filesync.CopyToCaller(ctx, outputFS, e.id, caller, progress); err != nil {
+			if err := buildInfo.IO.CopyToCaller(ctx, outputFS, caller, progress); err != nil {
 				return err
 			}
 			return nil

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -21,7 +21,6 @@ import (
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/session"
 	sessioncontent "github.com/moby/buildkit/session/content"
-	"github.com/moby/buildkit/session/filesync"
 	"github.com/moby/buildkit/util/compression"
 	"github.com/moby/buildkit/util/contentutil"
 	"github.com/moby/buildkit/util/grpcerrors"
@@ -60,10 +59,9 @@ func New(opt Opt) (exporter.Exporter, error) {
 	return im, nil
 }
 
-func (e *imageExporter) Resolve(ctx context.Context, id int, opt map[string]string) (exporter.ExporterInstance, error) {
+func (e *imageExporter) Resolve(ctx context.Context, opt map[string]string) (exporter.ExporterInstance, error) {
 	i := &imageExporterInstance{
 		imageExporter: e,
-		id:            id,
 		attrs:         opt,
 		tar:           true,
 		opts: containerimage.ImageCommitOpts{
@@ -103,16 +101,11 @@ func (e *imageExporter) Resolve(ctx context.Context, id int, opt map[string]stri
 
 type imageExporterInstance struct {
 	*imageExporter
-	id    int
 	attrs map[string]string
 
 	opts containerimage.ImageCommitOpts
 	tar  bool
 	meta map[string][]byte
-}
-
-func (e *imageExporterInstance) ID() int {
-	return e.id
 }
 
 func (e *imageExporterInstance) Name() string {
@@ -260,7 +253,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 	}
 
 	if e.tar {
-		w, err := filesync.CopyFileWriter(ctx, resp, e.id, caller)
+		w, err := buildInfo.IO.CopyFileWriter(ctx, resp, caller)
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/exporter/tar/export.go
+++ b/exporter/tar/export.go
@@ -13,7 +13,6 @@ import (
 	"github.com/moby/buildkit/exporter/local"
 	"github.com/moby/buildkit/exporter/util/epoch"
 	"github.com/moby/buildkit/session"
-	"github.com/moby/buildkit/session/filesync"
 	"github.com/moby/buildkit/util/progress"
 	"github.com/pkg/errors"
 	"github.com/tonistiigi/fsutil"
@@ -34,31 +33,24 @@ func New(opt Opt) (exporter.Exporter, error) {
 	return le, nil
 }
 
-func (e *localExporter) Resolve(ctx context.Context, id int, opt map[string]string) (exporter.ExporterInstance, error) {
+func (e *localExporter) Resolve(ctx context.Context, opt map[string]string) (exporter.ExporterInstance, error) {
 	li := &localExporterInstance{
 		localExporter: e,
-		id:            id,
 		attrs:         opt,
 	}
 	_, err := li.opts.Load(opt)
 	if err != nil {
 		return nil, err
 	}
-	_ = opt
 
 	return li, nil
 }
 
 type localExporterInstance struct {
 	*localExporter
-	id    int
 	attrs map[string]string
 
 	opts local.CreateFSOpts
-}
-
-func (e *localExporterInstance) ID() int {
-	return e.id
 }
 
 func (e *localExporterInstance) Name() string {
@@ -180,7 +172,7 @@ func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source
 		return nil, nil, nil, err
 	}
 
-	w, err := filesync.CopyFileWriter(ctx, nil, e.id, caller)
+	w, err := buildInfo.IO.CopyFileWriter(ctx, nil, caller)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/session/filesync/filesync.go
+++ b/session/filesync/filesync.go
@@ -253,7 +253,7 @@ type FSSyncTarget interface {
 }
 
 type fsSyncTarget struct {
-	id     int
+	id     string
 	outdir string
 	f      FileOutputFunc
 }
@@ -262,14 +262,14 @@ func (target *fsSyncTarget) target() *fsSyncTarget {
 	return target
 }
 
-func WithFSSync(id int, f FileOutputFunc) FSSyncTarget {
+func WithFSSync(id string, f FileOutputFunc) FSSyncTarget {
 	return &fsSyncTarget{
 		id: id,
 		f:  f,
 	}
 }
 
-func WithFSSyncDir(id int, outdir string) FSSyncTarget {
+func WithFSSyncDir(id, outdir string) FSSyncTarget {
 	return &fsSyncTarget{
 		id:     id,
 		outdir: outdir,
@@ -278,16 +278,18 @@ func WithFSSyncDir(id int, outdir string) FSSyncTarget {
 
 func NewFSSyncTarget(targets ...FSSyncTarget) *SyncTarget {
 	st := &SyncTarget{
-		fs:      make(map[int]FileOutputFunc),
-		outdirs: make(map[int]string),
+		fs:      make(map[string]FileOutputFunc),
+		outdirs: make(map[string]string),
 	}
 	st.Add(targets...)
 	return st
 }
 
 type SyncTarget struct {
-	fs      map[int]FileOutputFunc
-	outdirs map[int]string
+	// maps exporter id -> file output handler
+	fs map[string]FileOutputFunc
+	// maps exporter id -> output directory
+	outdirs map[string]string
 }
 
 var _ session.Attachable = &SyncTarget{}
@@ -308,20 +310,16 @@ func (sp *SyncTarget) Register(server *grpc.Server) {
 	RegisterFileSendServer(server, sp)
 }
 
-func (sp *SyncTarget) chooser(ctx context.Context) int {
+func (sp *SyncTarget) chooser(ctx context.Context) string {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return 0
+		return ""
 	}
 	values := md[keyExporterID]
 	if len(values) == 0 {
-		return 0
+		return ""
 	}
-	id, err := strconv.ParseInt(values[0], 10, 64)
-	if err != nil {
-		return 0
-	}
-	return int(id)
+	return values[0]
 }
 
 func (sp *SyncTarget) DiffCopy(stream FileSend_DiffCopyServer) (err error) {
@@ -331,7 +329,7 @@ func (sp *SyncTarget) DiffCopy(stream FileSend_DiffCopyServer) (err error) {
 	}
 	f, ok := sp.fs[id]
 	if !ok {
-		return errors.Errorf("exporter %d not found", id)
+		return errors.Errorf("exporter %s not found", id)
 	}
 
 	opts, _ := metadata.FromIncomingContext(stream.Context()) // if no metadata continue with empty object
@@ -357,7 +355,7 @@ func (sp *SyncTarget) DiffCopy(stream FileSend_DiffCopyServer) (err error) {
 	return writeTargetFile(stream, wc)
 }
 
-func CopyToCaller(ctx context.Context, fs fsutil.FS, id int, c session.Caller, progress func(int, bool)) error {
+func CopyToCaller(ctx context.Context, fs fsutil.FS, id string, c session.Caller, progress func(int, bool)) error {
 	method := session.MethodURL(FileSend_ServiceDesc.ServiceName, "diffcopy")
 	if !c.Supports(method) {
 		return errors.Errorf("method %s not supported by the client", method)
@@ -374,7 +372,7 @@ func CopyToCaller(ctx context.Context, fs fsutil.FS, id int, c session.Caller, p
 	if existingVal, ok := opts[keyExporterID]; ok {
 		bklog.G(ctx).Warnf("overwriting grpc metadata key %q from value %+v to %+v", keyExporterID, existingVal, id)
 	}
-	opts[keyExporterID] = []string{fmt.Sprint(id)}
+	opts[keyExporterID] = []string{id}
 	ctx = metadata.NewOutgoingContext(ctx, opts)
 
 	cc, err := client.DiffCopy(ctx)
@@ -385,7 +383,7 @@ func CopyToCaller(ctx context.Context, fs fsutil.FS, id int, c session.Caller, p
 	return sendDiffCopy(cc, fs, progress)
 }
 
-func CopyFileWriter(ctx context.Context, md map[string]string, id int, c session.Caller) (io.WriteCloser, error) {
+func CopyFileWriter(ctx context.Context, md map[string]string, id string, c session.Caller) (io.WriteCloser, error) {
 	method := session.MethodURL(FileSend_ServiceDesc.ServiceName, "diffcopy")
 	if !c.Supports(method) {
 		return nil, errors.Errorf("method %s not supported by the client", method)
@@ -408,7 +406,7 @@ func CopyFileWriter(ctx context.Context, md map[string]string, id int, c session
 	if existingVal, ok := opts[keyExporterID]; ok {
 		bklog.G(ctx).Warnf("overwriting grpc metadata key %q from value %+v to %+v", keyExporterID, existingVal, id)
 	}
-	opts[keyExporterID] = []string{fmt.Sprint(id)}
+	opts[keyExporterID] = []string{id}
 	ctx = metadata.NewOutgoingContext(ctx, opts)
 
 	cc, err := client.DiffCopy(ctx)

--- a/solver/llbsolver/export.go
+++ b/solver/llbsolver/export.go
@@ -3,10 +3,17 @@ package llbsolver
 import (
 	"context"
 	"fmt"
-	"maps"
+	"io"
 	"sync"
 	"time"
 
+	digest "github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
+	"github.com/tonistiigi/fsutil"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc/codes"
+
+	controlapi "github.com/moby/buildkit/api/services/control"
 	"github.com/moby/buildkit/cache"
 	cacheconfig "github.com/moby/buildkit/cache/config"
 	"github.com/moby/buildkit/cache/remotecache"
@@ -16,6 +23,7 @@ import (
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/session"
 	sessionexporter "github.com/moby/buildkit/session/exporter"
+	"github.com/moby/buildkit/session/filesync"
 	"github.com/moby/buildkit/solver"
 	"github.com/moby/buildkit/solver/result"
 	"github.com/moby/buildkit/util/compression"
@@ -23,13 +31,9 @@ import (
 	"github.com/moby/buildkit/util/progress"
 	"github.com/moby/buildkit/util/tracing"
 	"github.com/moby/buildkit/worker"
-	digest "github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
-	"golang.org/x/sync/errgroup"
-	"google.golang.org/grpc/codes"
 )
 
-func (s *Solver) getSessionExporters(ctx context.Context, sessionID string, id int, inp *exporter.Source) ([]exporter.ExporterInstance, error) {
+func (s *Solver) getSessionExporters(ctx context.Context, sessionID string, id int, inp *exporter.Source) ([]Exporter, error) {
 	timeoutCtx, cancel := context.WithCancelCause(ctx)
 	timeoutCtx, _ = context.WithTimeoutCause(timeoutCtx, 5*time.Second, errors.WithStack(context.DeadlineExceeded)) //nolint:govet
 	defer func() { cancel(errors.WithStack(context.Canceled)) }()
@@ -67,27 +71,31 @@ func (s *Solver) getSessionExporters(ctx context.Context, sessionID string, id i
 		return nil, err
 	}
 
-	var out []exporter.ExporterInstance
+	var out []Exporter
 	for i, req := range res.Exporters {
 		exp, err := w.Exporter(req.Type, s.sm)
 		if err != nil {
 			return nil, err
 		}
-		expi, err := exp.Resolve(ctx, id+i, req.Attrs)
+		expi, err := exp.Resolve(ctx, req.Attrs)
 		if err != nil {
 			return nil, err
 		}
-		out = append(out, expi)
+		id := fmt.Sprint(id + i)
+		out = append(out, Exporter{
+			ExporterInstance: expi,
+			ExporterIO:       NewIO(id),
+		})
 	}
 	return out, nil
 }
 
-func runCacheExporters(ctx context.Context, exporters []RemoteCacheExporter, j *solver.Job, cached *result.Result[solver.CachedResult], inp *result.Result[cache.ImmutableRef]) (map[string]string, error) {
+func runCacheExporters(ctx context.Context, exporters []RemoteCacheExporter, j *solver.Job, cached *result.Result[solver.CachedResult], inp *result.Result[cache.ImmutableRef]) (exporterResponses []*controlapi.ExporterResponse, err error) {
 	eg, ctx := errgroup.WithContext(ctx)
 	g := session.NewGroup(j.SessionID)
-	resps := make([]map[string]string, len(exporters))
-	for i, exp := range exporters {
-		id := fmt.Sprint(j.SessionID, "-cache-", i)
+	exporterResponses = make([]*controlapi.ExporterResponse, len(exporters))
+	for exID, exp := range exporters {
+		id := fmt.Sprint(j.SessionID, "-cache-", exID)
 		eg.Go(func() (err error) {
 			err = inBuilderContext(ctx, j, exp.Name(), id, func(ctx context.Context, _ solver.JobContext) error {
 				prepareDone := progress.OneOff(ctx, "preparing build cache for export")
@@ -110,7 +118,13 @@ func runCacheExporters(ctx context.Context, exporters []RemoteCacheExporter, j *
 				}
 				prepareDone(nil)
 				finalizeDone := progress.OneOff(ctx, "sending cache export")
-				resps[i], err = exp.Finalize(ctx)
+				resp, err := exp.Finalize(ctx)
+				exporterResponses[exID] = &controlapi.ExporterResponse{
+					Metadata: &controlapi.ExporterMetadata{
+						Type: exp.Type(),
+					},
+					Data: resp,
+				}
 				return finalizeDone(err)
 			})
 			if exp.IgnoreError {
@@ -123,14 +137,7 @@ func runCacheExporters(ctx context.Context, exporters []RemoteCacheExporter, j *
 		return nil, err
 	}
 
-	var cacheExporterResponse map[string]string
-	for _, resp := range resps {
-		if cacheExporterResponse == nil {
-			cacheExporterResponse = make(map[string]string)
-		}
-		maps.Copy(cacheExporterResponse, resp)
-	}
-	return cacheExporterResponse, nil
+	return exporterResponses, nil
 }
 
 func runInlineCacheExporter(ctx context.Context, e exporter.ExporterInstance, inlineExporter inlineCacheExporter, j *solver.Job, cached *result.Result[solver.CachedResult]) (*result.Result[*exptypes.InlineCacheEntry], error) {
@@ -156,25 +163,25 @@ func exporterVertexID(sessionID string, exporterIndex int) string {
 	return fmt.Sprint(sessionID, "-export-", exporterIndex)
 }
 
-func (s *Solver) runExporters(ctx context.Context, ref string, exporters []exporter.ExporterInstance, inlineCacheExporter inlineCacheExporter, job *solver.Job, cached *result.Result[solver.CachedResult], inp *exporter.Source) (exporterResponse map[string]string, finalizers []exporter.FinalizeFunc, descrefs []exporter.DescriptorReference, err error) {
+func (s *Solver) runExporters(ctx context.Context, ref string, exporters []Exporter, inlineCacheExporter inlineCacheExporter, job *solver.Job, cached *result.Result[solver.CachedResult], inp *exporter.Source) (exporterResponses []*controlapi.ExporterResponse, finalizers []exporter.FinalizeFunc, descrefs []exporter.DescriptorReference, err error) {
 	warnings, err := verifier.CheckInvalidPlatforms(ctx, inp)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
 	eg, ctx := errgroup.WithContext(ctx)
-	resps := make([]map[string]string, len(exporters))
+	exporterResponses = make([]*controlapi.ExporterResponse, len(exporters))
 	finalizeFuncs := make([]exporter.FinalizeFunc, len(exporters))
 	descs := make([]exporter.DescriptorReference, len(exporters))
 	var inlineCacheMu sync.Mutex
-	for i, exp := range exporters {
-		id := exporterVertexID(job.SessionID, i)
+	for exID, exp := range exporters {
+		id := exporterVertexID(job.SessionID, exID)
 		eg.Go(func() error {
 			return inBuilderContext(ctx, job, exp.Name(), id, func(ctx context.Context, _ solver.JobContext) error {
 				span, ctx := tracing.StartSpan(ctx, exp.Name())
 				defer span.End()
 
-				if i == 0 && len(warnings) > 0 {
+				if exID == 0 && len(warnings) > 0 {
 					pw, _, _ := progress.NewFromContext(ctx)
 					for _, w := range warnings {
 						pw.Write(identity.NewID(), w)
@@ -189,14 +196,21 @@ func (s *Solver) runExporters(ctx context.Context, ref string, exporters []expor
 					return runInlineCacheExporter(ctx, exp, inlineCacheExporter, job, cached)
 				})
 
-				resp, finalize, desc, expErr := exp.Export(ctx, inp, exporter.ExportBuildInfo{
+				var md map[string]string
+				md, finalizeFuncs[exID], descs[exID], err = exp.Export(ctx, inp, exporter.ExportBuildInfo{
 					Ref:         ref,
 					SessionID:   job.SessionID,
 					InlineCache: inlineCache,
+					IO:          exp.ExporterIO,
 				})
-				resps[i], finalizeFuncs[i], descs[i] = resp, finalize, desc
-				if expErr != nil {
-					return expErr
+				exporterResponses[exID] = &controlapi.ExporterResponse{
+					Metadata: &controlapi.ExporterMetadata{
+						Type: exp.Type(),
+					},
+					Data: md,
+				}
+				if err != nil {
+					return err
 				}
 				return nil
 			})
@@ -219,18 +233,7 @@ func (s *Solver) runExporters(ctx context.Context, ref string, exporters []expor
 		}
 	}
 
-	// TODO: separate these out, and return multiple exporter responses to the
-	// client
-	for _, resp := range resps {
-		for k, v := range resp {
-			if exporterResponse == nil {
-				exporterResponse = make(map[string]string)
-			}
-			exporterResponse[k] = v
-		}
-	}
-
-	return exporterResponse, finalizeFuncs, descs, nil
+	return exporterResponses, finalizeFuncs, descs, nil
 }
 
 func splitCacheExporters(exporters []RemoteCacheExporter) (rest []RemoteCacheExporter, inline inlineCacheExporter) {
@@ -297,4 +300,25 @@ func withDescHandlerCacheOpts(ctx context.Context, ref cache.ImmutableRef) conte
 		}
 		return vals
 	})
+}
+
+// NewIO creates a new exporter API for the specified id
+func NewIO(id string) exporter.ExporterIO {
+	apis := exporterAPIs{exporterID: id}
+	return exporter.ExporterIO{
+		CopyToCaller:   apis.CopyToCaller,
+		CopyFileWriter: apis.CopyFileWriter,
+	}
+}
+
+func (r exporterAPIs) CopyToCaller(ctx context.Context, fs fsutil.FS, c session.Caller, progress func(int, bool)) error {
+	return filesync.CopyToCaller(ctx, fs, r.exporterID, c, progress)
+}
+
+func (r exporterAPIs) CopyFileWriter(ctx context.Context, md map[string]string, c session.Caller) (io.WriteCloser, error) {
+	return filesync.CopyFileWriter(ctx, md, r.exporterID, c)
+}
+
+type exporterAPIs struct {
+	exporterID string
 }

--- a/solver/llbsolver/history.go
+++ b/solver/llbsolver/history.go
@@ -26,7 +26,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func (s *Solver) recordBuildHistory(ctx context.Context, id string, req frontend.SolveRequest, exp ExporterRequest, j *solver.Job, usage *resources.SysSampler) (func(context.Context, *Result, []exporter.DescriptorReference, error) error, error) {
+func (s *Solver) recordBuildHistory(ctx context.Context, id string, req frontend.SolveRequest, exps []Exporter, j *solver.Job, usage *resources.SysSampler) (func(context.Context, *Result, []exporter.DescriptorReference, error) error, error) {
 	stopTrace, err := detect.Recorder.Record(ctx)
 	if err != nil {
 		return nil, errdefs.Internal(err)
@@ -39,7 +39,7 @@ func (s *Solver) recordBuildHistory(ctx context.Context, id string, req frontend
 		CreatedAt:     timestamppb.Now(),
 	}
 
-	for _, e := range exp.Exporters {
+	for _, e := range exps {
 		rec.Exporters = append(rec.Exporters, &controlapi.Exporter{
 			Type:  e.Type(),
 			Attrs: e.Attrs(),

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -7,6 +7,11 @@ import (
 	"strings"
 	"time"
 
+	digest "github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
+
+	controlapi "github.com/moby/buildkit/api/services/control"
 	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/cache/remotecache"
 	"github.com/moby/buildkit/client"
@@ -27,15 +32,17 @@ import (
 	"github.com/moby/buildkit/util/leaseutil"
 	"github.com/moby/buildkit/util/progress"
 	"github.com/moby/buildkit/worker"
-	digest "github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
-	"golang.org/x/sync/errgroup"
 )
 
 type ExporterRequest struct {
-	Exporters             []exporter.ExporterInstance
+	Exporters             []Exporter
 	CacheExporters        []RemoteCacheExporter
 	EnableSessionExporter bool
+}
+
+type Exporter struct {
+	exporter.ExporterIO
+	exporter.ExporterInstance
 }
 
 type RemoteCacheExporter struct {
@@ -153,7 +160,7 @@ func (s *Solver) Bridge(b solver.Builder) frontend.FrontendLLBBridge {
 	return s.bridge(b)
 }
 
-func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req frontend.SolveRequest, exp ExporterRequest, ent []entitlements.Entitlement, post []Processor, internal bool, srcPol *spb.Policy, policySession string) (_ *client.SolveResponse, err error) {
+func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req frontend.SolveRequest, exp ExporterRequest, ent []entitlements.Entitlement, post []Processor, internal bool, srcPol *spb.Policy, policySession string) (_ *controlapi.SolveResponse, err error) {
 	hasNamedDockerfileContext := false
 	for k := range req.FrontendOpt {
 		if k == "context:dockerfile.v0" || strings.HasPrefix(k, "context:dockerfile.v0::") {
@@ -235,7 +242,7 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 	}
 
 	if !internal {
-		rec, err1 := s.recordBuildHistory(ctx, id, req, exp, j, usage)
+		rec, err1 := s.recordBuildHistory(ctx, id, req, exp.Exporters, j, usage)
 		if err1 != nil {
 			defer j.CloseProgress()
 			return nil, err1
@@ -349,9 +356,9 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 		exp.Exporters = append(exp.Exporters, exporters...)
 	}
 
-	var exporterResponse map[string]string
+	var exporterResponses []*controlapi.ExporterResponse
 	var finalizers []exporter.FinalizeFunc
-	exporterResponse, finalizers, descrefs, err = s.runExporters(ctx, id, exp.Exporters, inlineCacheExporter, j, cached, inp)
+	exporterResponses, finalizers, descrefs, err = s.runExporters(ctx, id, exp.Exporters, inlineCacheExporter, j, cached, inp)
 	if err != nil {
 		return nil, err
 	}
@@ -372,34 +379,40 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 			})
 		})
 	}
-	var cacheExporterResponse map[string]string
+	var cacheExporterResponses []*controlapi.ExporterResponse
 	eg.Go(func() error {
 		var err error
-		cacheExporterResponse, err = runCacheExporters(egCtx, cacheExporters, j, cached, inp)
+		cacheExporterResponses, err = runCacheExporters(egCtx, cacheExporters, j, cached, inp)
 		return err
 	})
 	if err := eg.Wait(); err != nil {
 		return nil, err
 	}
 
-	if exporterResponse == nil {
-		exporterResponse = make(map[string]string)
+	exporterResponse := &controlapi.SolveResponse{
+		ExporterResponseDeprecated: make(map[string]string),
+		ExporterResponses:          exporterResponses,
+		CacheExporterResponses:     cacheExporterResponses,
 	}
 
 	for k, v := range res.Metadata {
 		if strings.HasPrefix(k, "frontend.") {
-			exporterResponse[k] = string(v)
-		}
-	}
-	for k, v := range cacheExporterResponse {
-		if strings.HasPrefix(k, "cache.") {
-			exporterResponse[k] = v
+			exporterResponse.ExporterResponseDeprecated[k] = string(v)
 		}
 	}
 
-	return &client.SolveResponse{
-		ExporterResponse: exporterResponse,
-	}, nil
+	for _, resp := range exporterResponses {
+		maps.Copy(exporterResponse.ExporterResponseDeprecated, resp.Data)
+	}
+	for _, resp := range cacheExporterResponses {
+		for k, v := range resp.Data {
+			if strings.HasPrefix(k, "cache.") {
+				exporterResponse.ExporterResponseDeprecated[k] = v
+			}
+		}
+	}
+
+	return exporterResponse, nil
 }
 
 func (s *Solver) leaseManager() (*leaseutil.Manager, error) {


### PR DESCRIPTION
This is an attempt to fix #5556 by implementing support for separate exporter responses.

While working on this, I realized that I don't quite understand the preinitialized sessions and how custom-initialized sessions play with the exporter configuration:
https://github.com/moby/buildkit/blob/7d7a9196a378477271cf44c8638e546c37d1bf83/client/solve.go#L49-L50

I've moved some code that sets up exporter configuration in the session to a public API but this is definitely something I'd like more feedback and context on. Basically, I was thinking along the lines of allowing users setting up sessions on their own to reuse some work that buildkit does internally.

Otherwise, on to the actual issue: I'm trying to re-introduce explicit exporter IDs as I believe it's hard to avoid this at this point. And unless there's going to be major architectural changes around exports soon, I think this should lay some ground for further improvements with the cache exports.
By re-introducing IDs, I also removed them from actual exporter implementations as I think they carry little weight there and were introducing a point of inconsistency with the assumption that they are indices in some array. Instead - these are completely under control of the client for now.

I'm still working on tests.

Let me know if this is the direction to go or there are other options to explore.

@tonistiigi @jedevc @crazy-max @LaurentGoderre 
