### PR TITLE
Dockerfile: update runc binary to v1.2.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:master
 
-ARG RUNC_VERSION=v1.2.2
+ARG RUNC_VERSION=v1.2.3
 ARG CONTAINERD_VERSION=v2.0.0
 # CONTAINERD_ALT_VERSION_... defines fallback containerd version for integration tests
 ARG CONTAINERD_ALT_VERSION_17=v1.7.23


### PR DESCRIPTION
- relates to https://github.com/opencontainers/runc/issues/4543
- relates to / fixes https://github.com/moby/buildkit/issues/5566


This is the third patch release of the 1.2.z release branch of runc. It primarily fixes some minor regressions introduced in 1.2.0.

- Fixed a regression in use of securejoin.MkdirAll, where multiple runc processes racing to create the same mountpoint in a shared rootfs would result in spurious EEXIST errors. In particular, this regression caused issues with BuildKit.
- Fixed a regression in eBPF support for pre-5.6 kernels after upgrading Cilium's eBPF library version to 0.16 in runc.

full diff: https://github.com/opencontainers/runc/compare/v1.2.2...v1.2.3
release notes: https://github.com/opencontainers/runc/releases/tag/v1.2.3