### PR TITLE
cache: Fix walkBlbo to call callback only for unlazied contents 

### DIFF
--- a/cache/manager.go
+++ b/cache/manager.go
@@ -143,7 +143,7 @@ func (cm *cacheManager) GetByBlob(ctx context.Context, desc ocispecs.Descriptor,
 	descHandlers := descHandlersOf(opts...)
 	if desc.Digest != "" && (descHandlers == nil || descHandlers[desc.Digest] == nil) {
 		if _, err := cm.ContentStore.Info(ctx, desc.Digest); errors.Is(err, cerrdefs.ErrNotFound) {
-			return nil, NeedsRemoteProviderError([]digest.Digest{desc.Digest})
+			return nil, NeedsRemoteProviderError([]DigestDescriptionPair{{Digest: desc.Digest}})
 		} else if err != nil {
 			return nil, err
 		}
@@ -396,7 +396,7 @@ func (cm *cacheManager) getRecord(ctx context.Context, id string, opts ...RefOpt
 			if isLazy, err := cr.isLazy(ctx); err != nil {
 				return err
 			} else if isLazy && dhs[blob] == nil {
-				missing = append(missing, blob)
+				missing = append(missing, DigestDescriptionPair{Digest: blob, Description: cr.GetDescription()})
 			}
 			return nil
 		}); err != nil {

--- a/cache/opts.go
+++ b/cache/opts.go
@@ -30,10 +30,19 @@ func descHandlersOf(opts ...RefOption) DescHandlers {
 
 type DescHandlerKey digest.Digest
 
-type NeedsRemoteProviderError []digest.Digest //nolint:errname
+type NeedsRemoteProviderError []DigestDescriptionPair //nolint:errname
+
+type DigestDescriptionPair struct {
+	Digest      digest.Digest
+	Description string
+}
+
+func (d DigestDescriptionPair) String() string {
+	return fmt.Sprintf("%s: %s", d.Digest, d.Description)
+}
 
 func (m NeedsRemoteProviderError) Error() string {
-	return fmt.Sprintf("missing descriptor handlers for lazy blobs %+v", []digest.Digest(m))
+	return fmt.Sprintf("missing descriptor handlers for lazy blobs %+v", []DigestDescriptionPair(m))
 }
 
 type Unlazy session.Group

--- a/cache/refs.go
+++ b/cache/refs.go
@@ -848,6 +848,11 @@ func getBlobWithCompression(ctx context.Context, cs content.Store, desc ocispecs
 }
 
 func walkBlob(ctx context.Context, cs content.Store, desc ocispecs.Descriptor, f func(ocispecs.Descriptor) bool) error {
+	if _, err := cs.Info(ctx, desc.Digest); errors.Is(err, cerrdefs.ErrNotFound) {
+		return nil // this blob doesn't exist in the content store. Don't call the callback.
+	} else if err != nil {
+		return err
+	}
 	if !f(desc) {
 		return nil
 	}

--- a/cache/refs.go
+++ b/cache/refs.go
@@ -49,6 +49,7 @@ type Ref interface {
 	RefMetadata
 	Release(context.Context) error
 	IdentityMapping() *idtools.IdentityMapping
+	DescHandlers() DescHandlers
 	DescHandler(digest.Digest) *DescHandler
 }
 
@@ -612,6 +613,13 @@ func (sr *immutableRef) LayerChain() RefList {
 	return l
 }
 
+func (sr *immutableRef) DescHandlers() DescHandlers {
+	// clone to prevent mutation of internal state
+	dhs := make(DescHandlers)
+	maps.Copy(dhs, sr.descHandlers)
+	return dhs
+}
+
 func (sr *immutableRef) DescHandler(dgst digest.Digest) *DescHandler {
 	return sr.descHandlers[dgst]
 }
@@ -638,6 +646,13 @@ func (sr *mutableRef) traceLogFields() logrus.Fields {
 		m["equalImmutableID"] = sr.equalImmutable.ID()
 	}
 	return m
+}
+
+func (sr *mutableRef) DescHandlers() DescHandlers {
+	// clone to prevent mutation of internal state
+	dhs := make(DescHandlers)
+	maps.Copy(dhs, sr.descHandlers)
+	return dhs
 }
 
 func (sr *mutableRef) DescHandler(dgst digest.Digest) *DescHandler {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -10899,6 +10899,7 @@ func testRunValidExitCodes(t *testing.T, sb integration.Sandbox) {
 }
 
 func testSameChainIDWithLazyBlobsCacheExport(t *testing.T, sb integration.Sandbox) {
+	requiresLinux(t)
 	workers.CheckFeatureCompat(t, sb,
 		workers.FeatureCacheExport,
 		workers.FeatureCacheImport,
@@ -11040,6 +11041,7 @@ func testSameChainIDWithLazyBlobsCacheExport(t *testing.T, sb integration.Sandbo
 }
 
 func testSameChainIDWithLazyBlobsCacheMountBase(t *testing.T, sb integration.Sandbox) {
+	requiresLinux(t)
 	workers.CheckFeatureCompat(t, sb,
 		workers.FeatureCacheExport,
 		workers.FeatureCacheImport,
@@ -11123,7 +11125,7 @@ func testSameChainIDWithLazyBlobsCacheMountBase(t *testing.T, sb integration.San
 	require.NoError(t, err)
 
 	// try to re-use the cache mount from before, ensure we successfully get
-	// the same one writen to in previous step
+	// the same one written to in previous step
 	def, err = llb.Image(busyboxZstdRef).Run(
 		llb.Shlex(`stat /mnt/bar`),
 		llb.AddMount("/mnt",

--- a/solver/cacheopts.go
+++ b/solver/cacheopts.go
@@ -28,69 +28,85 @@ func WithCacheOptGetter(ctx context.Context, getter func(includeAncestors bool, 
 	return context.WithValue(ctx, cacheOptGetterKey{}, getter)
 }
 
-func withAncestorCacheOpts(ctx context.Context, start *state) context.Context {
+func withAncestorCacheOpts(ctx context.Context, start *sharedOp) context.Context {
 	return WithCacheOptGetter(ctx, func(includeAncestors bool, keys ...interface{}) map[interface{}]interface{} {
 		keySet := make(map[interface{}]struct{})
 		for _, k := range keys {
 			keySet[k] = struct{}{}
 		}
 		values := make(map[interface{}]interface{})
-		walkAncestors(ctx, start, func(st *state) bool {
-			if st.clientVertex.Error != "" {
+		walkAncestors(ctx, start, func(op *sharedOp) bool {
+			if op.st.clientVertex.Error != "" {
 				// don't use values from cancelled or otherwise error'd vertexes
 				return false
 			}
-			for _, res := range st.op.cacheRes {
-				if res.Opts == nil {
-					continue
+
+			for k := range keySet {
+				var v any
+				var ok bool
+
+				// check opts set from CacheMap operation
+				for _, res := range op.cacheRes {
+					if res.Opts == nil {
+						continue
+					}
+					v, ok = res.Opts[k]
+					if ok {
+						break
+					}
 				}
-				for k := range keySet {
-					if v, ok := res.Opts[k]; ok {
-						values[k] = v
-						delete(keySet, k)
-						if len(keySet) == 0 {
-							return true
-						}
+
+				// check opts set during cache load
+				if !ok && op.loadCacheOpts != nil {
+					v, ok = op.loadCacheOpts[k]
+				}
+
+				if ok {
+					values[k] = v
+					delete(keySet, k)
+					if len(keySet) == 0 {
+						return true
 					}
 				}
 			}
-			return !includeAncestors // stop after the first state unless includeAncestors is true
+
+			return !includeAncestors // stop after the first op unless includeAncestors is true
 		})
 		return values
 	})
 }
 
-func walkAncestors(ctx context.Context, start *state, f func(*state) bool) {
-	stack := [][]*state{{start}}
+func walkAncestors(ctx context.Context, start *sharedOp, f func(*sharedOp) bool) {
+	stack := [][]*sharedOp{{start}}
 	cache := make(map[digest.Digest]struct{})
 	for len(stack) > 0 {
-		sts := stack[len(stack)-1]
-		if len(sts) == 0 {
+		ops := stack[len(stack)-1]
+		if len(ops) == 0 {
 			stack = stack[:len(stack)-1]
 			continue
 		}
-		st := sts[len(sts)-1]
-		stack[len(stack)-1] = sts[:len(sts)-1]
-		if st == nil {
+		op := ops[len(ops)-1]
+		stack[len(stack)-1] = ops[:len(ops)-1]
+		if op == nil {
 			continue
 		}
-		if _, ok := cache[st.origDigest]; ok {
+		if _, ok := cache[op.st.origDigest]; ok {
 			continue
 		}
-		cache[st.origDigest] = struct{}{}
-		if shouldStop := f(st); shouldStop {
+		cache[op.st.origDigest] = struct{}{}
+		if shouldStop := f(op); shouldStop {
 			return
 		}
-		stack = append(stack, []*state{})
-		for _, parentDgst := range st.clientVertex.Inputs {
-			st.solver.mu.RLock()
-			parent := st.solver.actives[parentDgst]
-			st.solver.mu.RUnlock()
+		stack = append(stack, []*sharedOp{})
+		for _, parentDgst := range op.st.clientVertex.Inputs {
+			op.st.solver.mu.RLock()
+			parent := op.st.solver.actives[parentDgst]
+			op.st.solver.mu.RUnlock()
 			if parent == nil {
 				bklog.G(ctx).Warnf("parent %q not found in active job list during cache opt search", parentDgst)
 				continue
 			}
-			stack[len(stack)-1] = append(stack[len(stack)-1], parent)
+			stack[len(stack)-1] = append(stack[len(stack)-1], parent.op)
 		}
 	}
 }

--- a/solver/edge.go
+++ b/solver/edge.go
@@ -24,7 +24,7 @@ func (t edgeStatusType) String() string {
 	return []string{"initial", "cache-fast", "cache-slow", "complete"}[t]
 }
 
-func newEdge(ed Edge, op activeOp, index *edgeIndex) *edge {
+func newEdge(ed Edge, op *sharedOp, index *edgeIndex) *edge {
 	e := &edge{
 		edge:               ed,
 		op:                 op,
@@ -40,7 +40,7 @@ func newEdge(ed Edge, op activeOp, index *edgeIndex) *edge {
 
 type edge struct {
 	edge Edge
-	op   activeOp
+	op   *sharedOp
 
 	edgeState
 	depRequests map[pipeReceiver]*dep

--- a/solver/exporter.go
+++ b/solver/exporter.go
@@ -118,8 +118,7 @@ func (e *exporter) ExportTo(ctx context.Context, t CacheExporterTarget, opt Cach
 		}
 
 		if e.edge != nil {
-			op, ok := e.edge.op.(*sharedOp)
-			if ok && op != nil && op.st != nil {
+			if op := e.edge.op; op != nil && op.st != nil {
 				ctx = withAncestorCacheOpts(ctx, op)
 			}
 		}

--- a/solver/exporter.go
+++ b/solver/exporter.go
@@ -172,7 +172,7 @@ func (e *exporter) ExportTo(ctx context.Context, t CacheExporterTarget, opt Cach
 		for _, dep := range deps {
 			recs, err := dep.CacheKey.Exporter.ExportTo(ctx, t, opt)
 			if err != nil {
-				return nil, nil
+				return nil, err
 			}
 			for _, r := range recs {
 				srcs[i] = append(srcs[i], expr{r: r, selector: dep.Selector})
@@ -184,7 +184,7 @@ func (e *exporter) ExportTo(ctx context.Context, t CacheExporterTarget, opt Cach
 		for _, de := range e.edge.secondaryExporters {
 			recs, err := de.cacheKey.CacheKey.Exporter.ExportTo(ctx, t, opt)
 			if err != nil {
-				return nil, nil
+				return nil, err
 			}
 			for _, r := range recs {
 				srcs[de.index] = append(srcs[de.index], expr{r: r, selector: de.cacheKey.Selector})

--- a/solver/exporter.go
+++ b/solver/exporter.go
@@ -120,7 +120,7 @@ func (e *exporter) ExportTo(ctx context.Context, t CacheExporterTarget, opt Cach
 		if e.edge != nil {
 			op, ok := e.edge.op.(*sharedOp)
 			if ok && op != nil && op.st != nil {
-				ctx = withAncestorCacheOpts(ctx, op.st)
+				ctx = withAncestorCacheOpts(ctx, op)
 			}
 		}
 

--- a/solver/exporter.go
+++ b/solver/exporter.go
@@ -117,6 +117,13 @@ func (e *exporter) ExportTo(ctx context.Context, t CacheExporterTarget, opt Cach
 			return nil, err
 		}
 
+		if e.edge != nil {
+			op, ok := e.edge.op.(*sharedOp)
+			if ok && op != nil && op.st != nil {
+				ctx = withAncestorCacheOpts(ctx, op.st)
+			}
+		}
+
 		remotes, err := cm.results.LoadRemotes(ctx, res, opt.CompressionOpt, opt.Session)
 		if err != nil {
 			return nil, err

--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -825,15 +825,6 @@ type cacheMapResp struct {
 	complete bool
 }
 
-type activeOp interface {
-	CacheMap(context.Context, int) (*cacheMapResp, error)
-	LoadCache(ctx context.Context, rec *CacheRecord) (Result, error)
-	Exec(ctx context.Context, inputs []Result) (outputs []Result, exporters []ExportableCacheKey, err error)
-	IgnoreCache() bool
-	Cache() CacheManager
-	CalcSlowCache(context.Context, Index, PreprocessFunc, ResultBasedCacheFunc, Result) (digest.Digest, error)
-}
-
 func newSharedOp(resolver ResolveOpFunc, st *state) *sharedOp {
 	so := &sharedOp{
 		resolver:     resolver,

--- a/solver/llbsolver/mounts/mount.go
+++ b/solver/llbsolver/mounts/mount.go
@@ -128,9 +128,9 @@ func (g *cacheRefGetter) getRefCacheDirNoCache(ctx context.Context, key string, 
 			var needsRemoteProviders cache.NeedsRemoteProviderError
 			if errors.As(err, &needsRemoteProviders) && ref != nil {
 				descHandlers := cache.DescHandlers(make(map[digest.Digest]*cache.DescHandler))
-				for _, dgst := range needsRemoteProviders {
-					if handler := ref.DescHandler(dgst); handler != nil {
-						descHandlers[dgst] = handler
+				for _, dgstDescPair := range needsRemoteProviders {
+					if handler := ref.DescHandler(dgstDescPair.Digest); handler != nil {
+						descHandlers[dgstDescPair.Digest] = handler
 					}
 				}
 				mRef, err = g.cm.GetMutable(ctx, si.ID(), descHandlers)

--- a/solver/llbsolver/provenance.go
+++ b/solver/llbsolver/provenance.go
@@ -398,17 +398,8 @@ func NewProvenanceCreator(ctx context.Context, cp *provenance.Capture, res solve
 			return nil, err
 		}
 
-		wref, ok := r.Sys().(*worker.WorkerRef)
-		if !ok {
-			return nil, errors.Errorf("invalid worker ref %T", r.Sys())
-		}
-
 		addLayers = func() error {
 			e := newCacheExporter()
-
-			if wref.ImmutableRef != nil {
-				ctx = withDescHandlerCacheOpts(ctx, wref.ImmutableRef)
-			}
 
 			if _, err := r.CacheKeys()[0].Exporter.ExportTo(ctx, e, solver.CacheExportOpt{
 				ResolveRemotes:  resolveRemotes,

--- a/solver/scheduler_test.go
+++ b/solver/scheduler_test.go
@@ -3947,6 +3947,7 @@ func (r *dummyResult) ID() string                    { return r.id }
 func (r *dummyResult) Release(context.Context) error { return nil }
 func (r *dummyResult) Sys() interface{}              { return r }
 func (r *dummyResult) Clone() Result                 { return r }
+func (r *dummyResult) CacheOpts() CacheOpts          { return nil }
 
 func testOpResolver(v Vertex, b Builder) (Op, error) {
 	if op, ok := v.Sys().(Op); ok {

--- a/solver/types.go
+++ b/solver/types.go
@@ -64,6 +64,7 @@ type Result interface {
 	Release(context.Context) error
 	Sys() interface{}
 	Clone() Result
+	CacheOpts() CacheOpts
 }
 
 // CachedResult is a result connected with its cache key

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -300,8 +300,8 @@ func (w *Worker) LoadRef(ctx context.Context, id string, hidden bool) (cache.Imm
 	if errors.As(err, &needsRemoteProviders) {
 		if optGetter := solver.CacheOptGetterOf(ctx); optGetter != nil {
 			var keys []interface{}
-			for _, dgst := range needsRemoteProviders {
-				keys = append(keys, cache.DescHandlerKey(dgst))
+			for _, dgstDescPair := range needsRemoteProviders {
+				keys = append(keys, cache.DescHandlerKey(dgstDescPair.Digest))
 			}
 			descHandlers := cache.DescHandlers(make(map[digest.Digest]*cache.DescHandler))
 			for k, v := range optGetter(true, keys...) {

--- a/worker/result.go
+++ b/worker/result.go
@@ -33,6 +33,16 @@ func (wr *WorkerRef) Release(ctx context.Context) error {
 	return wr.ImmutableRef.Release(ctx)
 }
 
+func (wr *WorkerRef) CacheOpts() solver.CacheOpts {
+	opts := solver.CacheOpts{}
+	if wr.ImmutableRef != nil {
+		for k, v := range wr.ImmutableRef.DescHandlers() {
+			opts[cache.DescHandlerKey(k)] = v
+		}
+	}
+	return opts
+}
+
 // GetRemotes method abstracts ImmutableRef's GetRemotes to allow a Worker to override.
 // This is needed for moby integration.
 // Use this method instead of calling ImmutableRef.GetRemotes() directly.


### PR DESCRIPTION
Testing c00304fd39b2fa444cd67bad3f3ddf05c363644f as a following-up patch for https://github.com/moby/buildkit/pull/5560#issuecomment-2522236139 This PR contains patches from #5560 so this should be rebased after that PR is merged. OR, this should be cherry-picked to that PR.

`walkBlob` walks compression variants in the content store with calling a callback for the found content. The current implementation doesn't check the existence of the specified content and this resulted in a test failure described in https://github.com/moby/buildkit/pull/5560#issuecomment-2522236139 . This commit fixes this issue.
