### PR TITLE
hack: remove loong64 validation in archutil

### DIFF
--- a/hack/dockerfiles/archutil.Dockerfile
+++ b/hack/dockerfiles/archutil.Dockerfile
@@ -120,6 +120,8 @@ RUN --mount=type=bind,target=.,rw \
   if [ "$(ls -A /generated-files)" ]; then
     cp -rf /generated-files/* ./util/archutil
   fi
+  # loong64 is not stable atm
+  git checkout -- util/archutil/loong64_binary.go
   diff=$(git status --porcelain -- util/archutil)
   if [ -n "$diff" ]; then
     echo >&2 'ERROR: The result of archutil differs. Please update with "make archutil"'


### PR DESCRIPTION
Unbreak CI. Later we can change to run this only if archutil changes but even then we would also need to validate that amd64 and arm64 can both pass validation. Debian packages do not seem to be stable.