### PR TITLE
fix git http_proxy ignored

### DIFF
--- a/util/gitutil/git_cli.go
+++ b/util/gitutil/git_cli.go
@@ -134,6 +134,10 @@ func (cli *GitCLI) Run(ctx context.Context, args ...string) (_ []byte, err error
 	if cli.git != "" {
 		gitBinary = cli.git
 	}
+	proxyEnvVars := [...]string{
+		"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "ALL_PROXY",
+		"http_proxy", "https_proxy", "no_proxy", "all_proxy",
+	}
 
 	for {
 		var cmd *exec.Cmd
@@ -189,6 +193,11 @@ func (cli *GitCLI) Run(ctx context.Context, args ...string) (_ []byte, err error
 			"GIT_CONFIG_NOSYSTEM=1", // Disable reading from system gitconfig.
 			"HOME=/dev/null",        // Disable reading from user gitconfig.
 			"LC_ALL=C",              // Ensure consistent output.
+		}
+		for _, ev := range proxyEnvVars {
+			if v, ok := os.LookupEnv(ev); ok {
+				cmd.Env = append(cmd.Env, ev+"="+v)
+			}
 		}
 		if cli.sshAuthSock != "" {
 			cmd.Env = append(cmd.Env, "SSH_AUTH_SOCK="+cli.sshAuthSock)


### PR DESCRIPTION
fix #5329

Git commands are executed using [os/exec](https://pkg.go.dev/os/exec) package and therefore do not share environment variables with the main process, That's why `ADD` doesn't honor proxy related environment variables in this context.

That said, in a pure HTTP context, like:
```dockerfile
ADD https://example.com/archive.zip /usr/src/things/
```
`ADD` already respects proxy-related environment variables because it uses [net/http](https://pkg.go.dev/net/http) package internally.