### PR TITLE
Support OS version in platform string

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -10419,7 +10419,7 @@ func testFrontendVerifyPlatforms(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 
 	warnings = wc.wait()
-	require.Len(t, warnings, 0)
+	require.Len(t, warnings, 0, warningsListOutput(warnings))
 
 	frontend = func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
 		res := gateway.NewResult()
@@ -11015,4 +11015,18 @@ func testRunValidExitCodes(t *testing.T, sb integration.Sandbox) {
 	_, err = c.Solve(sb.Context(), def, SolveOpt{}, nil)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "exit code: 0")
+}
+
+type warningsListOutput []*VertexWarning
+
+func (w warningsListOutput) String() string {
+	if len(w) == 0 {
+		return ""
+	}
+	var b strings.Builder
+
+	for _, warn := range w {
+		_, _ = b.Write(warn.Short)
+	}
+	return b.String()
 }

--- a/client/llb/imagemetaresolver/resolver.go
+++ b/client/llb/imagemetaresolver/resolver.go
@@ -107,7 +107,7 @@ func (imr *imageMetaResolver) ResolveImageConfig(ctx context.Context, ref string
 
 func (imr *imageMetaResolver) key(ref string, platform *ocispecs.Platform) string {
 	if platform != nil {
-		ref += platforms.Format(*platform)
+		ref += platforms.FormatAll(*platform)
 	}
 	return ref
 }

--- a/exporter/containerimage/annotations.go
+++ b/exporter/containerimage/annotations.go
@@ -71,7 +71,7 @@ func (ag AnnotationsGroup) Platform(p *ocispecs.Platform) *Annotations {
 
 	ps := []string{""}
 	if p != nil {
-		ps = append(ps, platforms.Format(*p))
+		ps = append(ps, platforms.FormatAll(*p))
 	}
 
 	for _, a := range ag {

--- a/exporter/containerimage/exptypes/annotations.go
+++ b/exporter/containerimage/exptypes/annotations.go
@@ -49,7 +49,7 @@ func (k AnnotationKey) PlatformString() string {
 	if k.Platform == nil {
 		return ""
 	}
-	return platforms.Format(*k.Platform)
+	return platforms.FormatAll(*k.Platform)
 }
 
 func AnnotationIndexKey(key string) string {

--- a/exporter/containerimage/exptypes/parse.go
+++ b/exporter/containerimage/exptypes/parse.go
@@ -53,7 +53,7 @@ func ParsePlatforms(meta map[string][]byte) (Platforms, error) {
 		}
 	}
 	p = platforms.Normalize(p)
-	pk := platforms.Format(p)
+	pk := platforms.FormatAll(p)
 	ps := Platforms{
 		Platforms: []Platform{{ID: pk, Platform: p}},
 	}

--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -160,7 +160,7 @@ func Build(ctx context.Context, c client.Client) (_ *client.Result, err error) {
 		if platform != nil {
 			p = *platform
 		}
-		scanTargets.Store(platforms.Format(platforms.Normalize(p)), scanTarget)
+		scanTargets.Store(platforms.FormatAll(platforms.Normalize(p)), scanTarget)
 
 		return ref, img, baseImg, nil
 	})

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -520,7 +520,7 @@ func toDispatchState(ctx context.Context, dt []byte, opt ConvertOpt) (*dispatchS
 						if reachable {
 							prefix := "["
 							if opt.MultiPlatformRequested && platform != nil {
-								prefix += platforms.Format(*platform) + " "
+								prefix += platforms.FormatAll(*platform) + " "
 							}
 							prefix += "internal]"
 							mutRef, dgst, dt, err := metaResolver.ResolveImageConfig(ctx, d.stage.BaseName, sourceresolver.Opt{
@@ -2110,7 +2110,7 @@ func prefixCommand(ds *dispatchState, str string, prefixPlatform bool, platform 
 	}
 	out := "["
 	if prefixPlatform && platform != nil {
-		out += platforms.Format(*platform) + formatTargetPlatform(*platform, platformFromEnv(env)) + " "
+		out += platforms.FormatAll(*platform) + formatTargetPlatform(*platform, platformFromEnv(env)) + " "
 	}
 	if ds.stageName != "" {
 		out += ds.stageName + " "
@@ -2144,7 +2144,7 @@ func formatTargetPlatform(base ocispecs.Platform, target *ocispecs.Platform) str
 		return "->" + archVariant
 	}
 	if p.OS != base.OS {
-		return "->" + platforms.Format(p)
+		return "->" + platforms.FormatAll(p)
 	}
 	return ""
 }
@@ -2491,8 +2491,8 @@ func wrapSuggestAny(err error, keys map[string]struct{}, options []string) error
 
 func validateBaseImagePlatform(name string, expected, actual ocispecs.Platform, location []parser.Range, lint *linter.Linter) {
 	if expected.OS != actual.OS || expected.Architecture != actual.Architecture {
-		expectedStr := platforms.Format(platforms.Normalize(expected))
-		actualStr := platforms.Format(platforms.Normalize(actual))
+		expectedStr := platforms.FormatAll(platforms.Normalize(expected))
+		actualStr := platforms.FormatAll(platforms.Normalize(actual))
 		msg := linter.RuleInvalidBaseImagePlatform.Format(name, expectedStr, actualStr)
 		lint.Run(&linter.RuleInvalidBaseImagePlatform, location, msg)
 	}

--- a/frontend/dockerfile/dockerfile2llb/platform.go
+++ b/frontend/dockerfile/dockerfile2llb/platform.go
@@ -45,10 +45,12 @@ func defaultArgs(po *platformOpt, overrides map[string]string, target string) *l
 	s := [...][2]string{
 		{"BUILDPLATFORM", platforms.Format(bp)},
 		{"BUILDOS", bp.OS},
+		{"BUILDOSVERSION", bp.OSVersion},
 		{"BUILDARCH", bp.Architecture},
 		{"BUILDVARIANT", bp.Variant},
-		{"TARGETPLATFORM", platforms.Format(tp)},
+		{"TARGETPLATFORM", platforms.FormatAll(tp)},
 		{"TARGETOS", tp.OS},
+		{"TARGETOSVERSION", tp.OSVersion},
 		{"TARGETARCH", tp.Architecture},
 		{"TARGETVARIANT", tp.Variant},
 		{"TARGETSTAGE", target},

--- a/frontend/dockerui/build.go
+++ b/frontend/dockerui/build.go
@@ -70,7 +70,7 @@ func (bc *Client) Build(ctx context.Context, fn BuildFunc) (*ResultBuilder, erro
 			}
 
 			p = platforms.Normalize(p)
-			k := platforms.Format(p)
+			k := platforms.FormatAll(p)
 
 			if bc.MultiPlatformRequested {
 				res.AddRef(k, ref)

--- a/frontend/dockerui/config.go
+++ b/frontend/dockerui/config.go
@@ -463,7 +463,7 @@ func (bc *Client) NamedContext(ctx context.Context, name string, opt ContextOpt)
 	if opt.Platform != nil {
 		pp = *opt.Platform
 	}
-	pname := name + "::" + platforms.Format(platforms.Normalize(pp))
+	pname := name + "::" + platforms.FormatAll(platforms.Normalize(pp))
 	st, img, err := bc.namedContext(ctx, name, pname, opt)
 	if err != nil || st != nil {
 		return st, img, err

--- a/solver/llbsolver/bridge.go
+++ b/solver/llbsolver/bridge.go
@@ -354,9 +354,9 @@ func (b *llbBridge) ResolveSourceMetadata(ctx context.Context, op *pb.SourceOp, 
 	}
 	id := op.Identifier
 	if opt.Platform != nil {
-		id += platforms.Format(*opt.Platform)
+		id += platforms.FormatAll(*opt.Platform)
 	} else {
-		id += platforms.Format(platforms.DefaultSpec())
+		id += platforms.FormatAll(platforms.DefaultSpec())
 	}
 	pol, err := loadSourcePolicy(b.builder)
 	if err != nil {

--- a/source/containerimage/source.go
+++ b/source/containerimage/source.go
@@ -162,7 +162,7 @@ func (is *Source) ResolveImageConfig(ctx context.Context, ref string, opt source
 		err   error
 	)
 	if platform := opt.Platform; platform != nil {
-		key += platforms.Format(*platform)
+		key += platforms.FormatAll(*platform)
 	}
 
 	switch is.ResolverType {


### PR DESCRIPTION
This allows platforms following the new `platforms.FormatAll` function, which allows for setting the `OSVersion` field of the platform with `<os>(<ver>)/<arch>`.

Closes #5115 

---

*Note*: In order to make `FROM <img>` match the correct OS version with the new platform format some changes need to be made to containerd/platforms (see vendor/ changes).