### PR TITLE
vendor: github.com/docker/docker, github.com/docker/cli v27.4.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/containernetworking/plugins v1.4.0
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/distribution/reference v0.6.0
-	github.com/docker/cli v27.4.0+incompatible
+	github.com/docker/cli v27.4.1+incompatible
 	github.com/docker/docker v27.4.1+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/docker/go-units v0.5.0

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/distribution/reference v0.6.0
 	github.com/docker/cli v27.4.0+incompatible
-	github.com/docker/docker v27.4.0+incompatible
+	github.com/docker/docker v27.4.1+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/docker/go-units v0.5.0
 	github.com/gofrs/flock v0.12.1

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/cli v27.4.0+incompatible h1:/nJzWkcI1MDMN+U+px/YXnQWJqnu4J+QKGTfD6ptiTc=
 github.com/docker/cli v27.4.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
-github.com/docker/docker v27.4.0+incompatible h1:I9z7sQ5qyzO0BfAb9IMOawRkAGxhYsidKiTMcm0DU+A=
-github.com/docker/docker v27.4.0+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v27.4.1+incompatible h1:ZJvcY7gfwHn1JF48PfbyXg7Jyt9ZCWDW+GGXOIxEwp4=
+github.com/docker/docker v27.4.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.8.2 h1:bX3YxiGzFP5sOXWc3bTPEXdEaZSeVMrFgOr3T+zrFAo=
 github.com/docker/docker-credential-helpers v0.8.2/go.mod h1:P3ci7E3lwkZg6XiHdRKft1KckHiO9a2rNtyFbZ/ry9M=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/docker/cli v27.4.0+incompatible h1:/nJzWkcI1MDMN+U+px/YXnQWJqnu4J+QKGTfD6ptiTc=
-github.com/docker/cli v27.4.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v27.4.1+incompatible h1:VzPiUlRJ/xh+otB75gva3r05isHMo5wXDfPRi5/b4hI=
+github.com/docker/cli v27.4.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker v27.4.1+incompatible h1:ZJvcY7gfwHn1JF48PfbyXg7Jyt9ZCWDW+GGXOIxEwp4=
 github.com/docker/docker v27.4.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.8.2 h1:bX3YxiGzFP5sOXWc3bTPEXdEaZSeVMrFgOr3T+zrFAo=

--- a/vendor/github.com/docker/docker/api/swagger.yaml
+++ b/vendor/github.com/docker/docker/api/swagger.yaml
@@ -5820,8 +5820,6 @@ definitions:
           type: "string"
         example:
           - "WARNING: No memory limit support"
-          - "WARNING: bridge-nf-call-iptables is disabled"
-          - "WARNING: bridge-nf-call-ip6tables is disabled"
       CDISpecDirs:
         description: |
           List of directories where (Container Device Interface) CDI
@@ -9563,7 +9561,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:
@@ -9619,7 +9617,7 @@ paths:
             type: "string"
             example: "(empty)"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:

--- a/vendor/github.com/docker/docker/client/ping.go
+++ b/vendor/github.com/docker/docker/client/ping.go
@@ -56,8 +56,8 @@ func parsePingResponse(cli *Client, resp serverResponse) (types.Ping, error) {
 		err := cli.checkResponseErr(resp)
 		return ping, errdefs.FromStatusCode(err, resp.statusCode)
 	}
-	ping.APIVersion = resp.header.Get("API-Version")
-	ping.OSType = resp.header.Get("OSType")
+	ping.APIVersion = resp.header.Get("Api-Version")
+	ping.OSType = resp.header.Get("Ostype")
 	if resp.header.Get("Docker-Experimental") == "true" {
 		ping.Experimental = true
 	}

--- a/vendor/github.com/docker/docker/pkg/system/lstat_unix.go
+++ b/vendor/github.com/docker/docker/pkg/system/lstat_unix.go
@@ -10,7 +10,9 @@ import (
 // Lstat takes a path to a file and returns
 // a system.StatT type pertaining to that file.
 //
-// Throws an error if the file does not exist
+// Throws an error if the file does not exist.
+//
+// Deprecated: this function is only used internally, and will be removed in the next release.
 func Lstat(path string) (*StatT, error) {
 	s := &syscall.Stat_t{}
 	if err := syscall.Lstat(path, s); err != nil {

--- a/vendor/github.com/docker/docker/pkg/system/lstat_windows.go
+++ b/vendor/github.com/docker/docker/pkg/system/lstat_windows.go
@@ -4,6 +4,8 @@ import "os"
 
 // Lstat calls os.Lstat to get a fileinfo interface back.
 // This is then copied into our own locally defined structure.
+//
+// Deprecated: this function is only used internally, and will be removed in the next release.
 func Lstat(path string) (*StatT, error) {
 	fi, err := os.Lstat(path)
 	if err != nil {

--- a/vendor/github.com/docker/docker/pkg/system/mknod.go
+++ b/vendor/github.com/docker/docker/pkg/system/mknod.go
@@ -11,6 +11,8 @@ import (
 // Linux device nodes are a bit weird due to backwards compat with 16 bit device nodes.
 // They are, from low to high: the lower 8 bits of the minor, then 12 bits of the major,
 // then the top 12 bits of the minor.
+//
+// Deprecated: this function is only used internally, and will be removed in the next release.
 func Mkdev(major int64, minor int64) uint32 {
 	return uint32(unix.Mkdev(uint32(major), uint32(minor)))
 }

--- a/vendor/github.com/docker/docker/pkg/system/mknod_freebsd.go
+++ b/vendor/github.com/docker/docker/pkg/system/mknod_freebsd.go
@@ -8,6 +8,8 @@ import (
 
 // Mknod creates a filesystem node (file, device special file or named pipe) named path
 // with attributes specified by mode and dev.
+//
+// Deprecated: this function is only used internally, and will be removed in the next release.
 func Mknod(path string, mode uint32, dev int) error {
 	return unix.Mknod(path, mode, uint64(dev))
 }

--- a/vendor/github.com/docker/docker/pkg/system/mknod_unix.go
+++ b/vendor/github.com/docker/docker/pkg/system/mknod_unix.go
@@ -8,6 +8,8 @@ import (
 
 // Mknod creates a filesystem node (file, device special file or named pipe) named path
 // with attributes specified by mode and dev.
+//
+// Deprecated: this function is only used internally, and will be removed in the next release.
 func Mknod(path string, mode uint32, dev int) error {
 	return unix.Mknod(path, mode, dev)
 }

--- a/vendor/github.com/docker/docker/pkg/system/stat_linux.go
+++ b/vendor/github.com/docker/docker/pkg/system/stat_linux.go
@@ -17,6 +17,8 @@ func fromStatT(s *syscall.Stat_t) (*StatT, error) {
 
 // FromStatT converts a syscall.Stat_t type to a system.Stat_t type
 // This is exposed on Linux as pkg/archive/changes uses it.
+//
+// Deprecated: this function is only used internally, and will be removed in the next release.
 func FromStatT(s *syscall.Stat_t) (*StatT, error) {
 	return fromStatT(s)
 }

--- a/vendor/github.com/docker/docker/pkg/system/stat_unix.go
+++ b/vendor/github.com/docker/docker/pkg/system/stat_unix.go
@@ -9,6 +9,8 @@ import (
 
 // StatT type contains status of a file. It contains metadata
 // like permission, owner, group, size, etc about a file.
+//
+// Deprecated: this type is only used internally, and will be removed in the next release.
 type StatT struct {
 	mode uint32
 	uid  uint32
@@ -56,7 +58,9 @@ func (s StatT) IsDir() bool {
 // Stat takes a path to a file and returns
 // a system.StatT type pertaining to that file.
 //
-// Throws an error if the file does not exist
+// Throws an error if the file does not exist.
+//
+// Deprecated: this function is only used internally, and will be removed in the next release.
 func Stat(path string) (*StatT, error) {
 	s := &syscall.Stat_t{}
 	if err := syscall.Stat(path, s); err != nil {

--- a/vendor/github.com/docker/docker/pkg/system/stat_windows.go
+++ b/vendor/github.com/docker/docker/pkg/system/stat_windows.go
@@ -7,6 +7,8 @@ import (
 
 // StatT type contains status of a file. It contains metadata
 // like permission, size, etc about a file.
+//
+// Deprecated: this type is only used internally, and will be removed in the next release.
 type StatT struct {
 	mode os.FileMode
 	size int64
@@ -31,7 +33,9 @@ func (s StatT) Mtim() time.Time {
 // Stat takes a path to a file and returns
 // a system.StatT type pertaining to that file.
 //
-// Throws an error if the file does not exist
+// Throws an error if the file does not exist.
+//
+// Deprecated: this function is only used internally, and will be removed in the next release.
 func Stat(path string) (*StatT, error) {
 	fi, err := os.Stat(path)
 	if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -459,7 +459,7 @@ github.com/dimchansky/utfbom
 # github.com/distribution/reference v0.6.0
 ## explicit; go 1.20
 github.com/distribution/reference
-# github.com/docker/cli v27.4.0+incompatible
+# github.com/docker/cli v27.4.1+incompatible
 ## explicit
 github.com/docker/cli/cli/config
 github.com/docker/cli/cli/config/configfile

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -466,7 +466,7 @@ github.com/docker/cli/cli/config/configfile
 github.com/docker/cli/cli/config/credentials
 github.com/docker/cli/cli/config/types
 github.com/docker/cli/cli/connhelper/commandconn
-# github.com/docker/docker v27.4.0+incompatible
+# github.com/docker/docker v27.4.1+incompatible
 ## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types


### PR DESCRIPTION
- related: https://github.com/docker/buildx/pull/2874

### vendor: github.com/docker/docker v27.4.1

full diff: https://github.com/docker/docker/compare/v27.4.0...v27.4.1


### vendor: github.com/docker/cli v27.4.1

no changes in vendored code

full diff: https://github.com/docker/cli/compare/v27.4.0...v27.4.1