### PR TITLE
dockerfile: fix copy non-octal build tag

### DIFF
--- a/frontend/dockerfile/release/labs/tags
+++ b/frontend/dockerfile/release/labs/tags
@@ -1,1 +1,1 @@
-dfrunsecurity dfparents dfexcludepatterns dfchmodnonoctal
+dfrunsecurity dfparents dfexcludepatterns dfcopychmodnonoctal

--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spdx/tools-golang v0.5.3
 	github.com/stretchr/testify v1.9.0
+	github.com/tonistiigi/dchapes-mode v0.0.0-20241001053921-ca0759fec205
 	github.com/tonistiigi/fsutil v0.0.0-20241121093142-31cf1f437184
 	github.com/tonistiigi/go-actions-cache v0.0.0-20241108014124-394979b8119e
 	github.com/tonistiigi/go-archvariant v1.0.0
@@ -168,7 +169,6 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.4.0 // indirect
 	github.com/shibumi/go-pathspec v1.3.0 // indirect
-	github.com/tonistiigi/dchapes-mode v0.0.0-20241001053921-ca0759fec205 // indirect
 	github.com/vbatts/tar-split v0.11.5 // indirect
 	github.com/vishvananda/netns v0.0.4 // indirect
 	go.opencensus.io v0.24.0 // indirect


### PR DESCRIPTION
fix #5611

It looks like there was some switch in build tags, resulting in the feature not being enabled in the release and the test being skipped.