### PR TITLE
cache: add tracing to prune

### DIFF
--- a/cache/manager.go
+++ b/cache/manager.go
@@ -25,10 +25,13 @@ import (
 	"github.com/moby/buildkit/util/disk"
 	"github.com/moby/buildkit/util/flightcontrol"
 	"github.com/moby/buildkit/util/progress"
+	"github.com/moby/buildkit/util/tracing"
 	digest "github.com/opencontainers/go-digest"
 	imagespecidentity "github.com/opencontainers/image-spec/identity"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -36,6 +39,17 @@ var (
 	ErrLocked   = errors.New("locked")
 	errNotFound = errors.New("not found")
 	errInvalid  = errors.New("invalid")
+)
+
+var (
+	PruneFilterAttribute       = attribute.Key("moby.buildkit.prune.filter")
+	PruneAllAttribute          = attribute.Key("moby.buildkit.prune.all")
+	PruneGCPolicyKeepDuration  = attribute.Key("moby.buildkit.prune.gcpolicy.keepduration")
+	PruneGCPolicyReservedSpace = attribute.Key("moby.buildkit.prune.gcpolicy.reservedspace")
+	PruneGCPolicyMaxUsedSpace  = attribute.Key("moby.buildkit.prune.gcpolicy.maxusedspace")
+	PruneGCPolicyMinFreeSpace  = attribute.Key("moby.buildkit.prune.gcpolicy.minfreespace")
+	PruneDeleteSizeAttribute   = attribute.Key("moby.buildkit.prune.delete.size")
+	PruneDeleteCountAttribute  = attribute.Key("moby.buildkit.prune.delete.count")
 )
 
 const maxPruneBatch = 10 // maximum number of refs to prune while holding the manager lock
@@ -51,6 +65,7 @@ type ManagerOpt struct {
 	MetadataStore   *metadata.Store
 	Root            string
 	MountPoolRoot   string
+	TracerProvider  trace.TracerProvider
 }
 
 type Accessor interface {
@@ -95,7 +110,8 @@ type cacheManager struct {
 	Differ          diff.Comparer
 	MetadataStore   *metadata.Store
 
-	root string
+	root   string
+	tracer trace.Tracer
 
 	mountPool sharableMountPool
 
@@ -114,6 +130,7 @@ func NewManager(opt ManagerOpt) (Manager, error) {
 		Differ:          opt.Differ,
 		MetadataStore:   opt.MetadataStore,
 		root:            opt.Root,
+		tracer:          tracing.Tracer(opt.TracerProvider),
 		records:         make(map[string]*cacheRecord),
 	}
 
@@ -1009,10 +1026,13 @@ func (cm *cacheManager) createDiffRef(ctx context.Context, parents parentRefs, d
 }
 
 func (cm *cacheManager) Prune(ctx context.Context, ch chan client.UsageInfo, opts ...client.PruneInfo) error {
+	ctx, span := cm.tracer.Start(ctx, "cacheManager.Prune")
+	defer span.End()
+
 	cm.muPrune.Lock()
 
 	for _, opt := range opts {
-		if err := cm.pruneOnce(ctx, ch, opt); err != nil {
+		if err := cm.prune(ctx, ch, opt); err != nil {
 			cm.muPrune.Unlock()
 			return err
 		}
@@ -1029,7 +1049,19 @@ func (cm *cacheManager) Prune(ctx context.Context, ch chan client.UsageInfo, opt
 	return nil
 }
 
-func (cm *cacheManager) pruneOnce(ctx context.Context, ch chan client.UsageInfo, opt client.PruneInfo) error {
+func (cm *cacheManager) prune(ctx context.Context, ch chan client.UsageInfo, opt client.PruneInfo) error {
+	ctx, span := cm.tracer.Start(ctx, "cacheManager.prune",
+		trace.WithAttributes(
+			PruneFilterAttribute.StringSlice(opt.Filter),
+			PruneAllAttribute.Bool(opt.All),
+			PruneGCPolicyKeepDuration.Int64(int64(opt.KeepDuration)),
+			PruneGCPolicyReservedSpace.Int64(opt.ReservedSpace),
+			PruneGCPolicyMaxUsedSpace.Int64(opt.MaxUsedSpace),
+			PruneGCPolicyMinFreeSpace.Int64(opt.MinFreeSpace),
+		),
+	)
+	defer span.End()
+
 	filter, err := filters.ParseAll(opt.Filter...)
 	if err != nil {
 		return errors.Wrapf(err, "failed to parse prune filters %v", opt.Filter)
@@ -1066,14 +1098,38 @@ func (cm *cacheManager) pruneOnce(ctx context.Context, ch chan client.UsageInfo,
 		}
 	}
 
-	return cm.prune(ctx, ch, pruneOpt{
+	var (
+		totalReleasedSize  int64
+		totalReleasedCount int64
+	)
+	defer func() {
+		span.SetAttributes(
+			PruneDeleteSizeAttribute.Int64(totalReleasedSize),
+			PruneDeleteCountAttribute.Int64(totalReleasedCount),
+		)
+	}()
+
+	popt := pruneOpt{
 		filter:       filter,
 		all:          opt.All,
 		checkShared:  check,
 		keepDuration: opt.KeepDuration,
 		keepBytes:    calculateKeepBytes(totalSize, dstat, opt),
 		totalSize:    totalSize,
-	})
+	}
+	for {
+		releasedSize, releasedCount, err := cm.pruneOnce(ctx, ch, popt)
+		if err != nil {
+			return err
+		}
+		totalReleasedSize += releasedSize
+		totalReleasedCount += releasedCount
+
+		if releasedCount == 0 {
+			return nil
+		}
+		popt.totalSize -= releasedSize
+	}
 }
 
 func calculateKeepBytes(totalSize int64, dstat disk.DiskStat, opt client.PruneInfo) int64 {
@@ -1100,9 +1156,9 @@ func calculateKeepBytes(totalSize int64, dstat disk.DiskStat, opt client.PruneIn
 	return keepBytes
 }
 
-func (cm *cacheManager) prune(ctx context.Context, ch chan client.UsageInfo, opt pruneOpt) (err error) {
+func (cm *cacheManager) pruneOnce(ctx context.Context, ch chan client.UsageInfo, opt pruneOpt) (releasedSize, releasedCount int64, err error) {
 	if opt.keepBytes != 0 && opt.totalSize < opt.keepBytes {
-		return nil
+		return
 	}
 
 	var toDelete []*deleteRecord
@@ -1206,11 +1262,11 @@ func (cm *cacheManager) prune(ctx context.Context, ch chan client.UsageInfo, opt
 			// mark metadata as deleted in case we crash before cleanup finished
 			if err := cr.queueDeleted(); err != nil {
 				releaseLocks()
-				return err
+				return 0, 0, err
 			}
 			if err := cr.commitMetadata(); err != nil {
 				releaseLocks()
-				return err
+				return 0, 0, err
 			}
 		}
 		cr.mu.Unlock()
@@ -1221,7 +1277,7 @@ func (cm *cacheManager) prune(ctx context.Context, ch chan client.UsageInfo, opt
 	cm.mu.Unlock()
 
 	if len(toDelete) == 0 {
-		return nil
+		return 0, 0, nil
 	}
 
 	// calculate sizes here so that lock does not need to be held for slow process
@@ -1234,7 +1290,7 @@ func (cm *cacheManager) prune(ctx context.Context, ch chan client.UsageInfo, opt
 		if size == sizeUnknown {
 			// calling size will warm cache for next call
 			if _, err := cr.size(ctx); err != nil {
-				return err
+				return 0, 0, err
 			}
 		}
 	}
@@ -1277,15 +1333,18 @@ func (cm *cacheManager) prune(ctx context.Context, ch chan client.UsageInfo, opt
 			c.Size = cr.equalImmutable.getSize() // benefit from DiskUsage calc
 		}
 
-		opt.totalSize -= c.Size
+		releasedSize += c.Size
 
 		if cr.equalImmutable != nil {
 			if err1 := cr.equalImmutable.remove(ctx, false); err == nil {
 				err = err1
 			}
 		}
-		if err1 := cr.remove(ctx, true); err == nil {
+
+		if err1 := cr.remove(ctx, true); err1 != nil && err == nil {
 			err = err1
+		} else if err1 == nil {
+			releasedCount++
 		}
 
 		if err == nil && ch != nil {
@@ -1294,16 +1353,17 @@ func (cm *cacheManager) prune(ctx context.Context, ch chan client.UsageInfo, opt
 		cr.mu.Unlock()
 	}
 	cm.mu.Unlock()
+
 	if err != nil {
-		return err
+		return releasedSize, releasedCount, err
 	}
 
 	select {
 	case <-ctx.Done():
-		return context.Cause(ctx)
+		err = context.Cause(ctx)
 	default:
-		return cm.prune(ctx, ch, opt)
 	}
+	return releasedSize, releasedCount, err
 }
 
 func (cm *cacheManager) markShared(m map[string]*cacheUsageInfo) error {

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -70,6 +70,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
 	tracev1 "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
@@ -96,6 +97,7 @@ type workerInitializerOpt struct {
 	config         *config.Config
 	sessionManager *session.Manager
 	traceSocket    string
+	tracerProvider trace.TracerProvider
 }
 
 type workerInitializer struct {
@@ -341,7 +343,7 @@ func main() {
 			return err
 		}
 
-		controller, err := newController(ctx, c, &cfg)
+		controller, err := newController(ctx, c, &cfg, tp)
 		if err != nil {
 			return err
 		}
@@ -760,7 +762,7 @@ func serverCredentials(cfg config.TLSConfig) (*tls.Config, error) {
 	return tlsConf, nil
 }
 
-func newController(ctx context.Context, c *cli.Context, cfg *config.Config) (*control.Controller, error) {
+func newController(ctx context.Context, c *cli.Context, cfg *config.Config, tp trace.TracerProvider) (*control.Controller, error) {
 	sessionManager, err := session.NewManager()
 	if err != nil {
 		return nil, err
@@ -789,6 +791,7 @@ func newController(ctx context.Context, c *cli.Context, cfg *config.Config) (*co
 		config:         cfg,
 		sessionManager: sessionManager,
 		traceSocket:    traceSocket,
+		tracerProvider: tp,
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/buildkitd/main_containerd_worker.go
+++ b/cmd/buildkitd/main_containerd_worker.go
@@ -348,6 +348,7 @@ func containerdWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([
 	opt.GCPolicy = getGCPolicy(cfg.GCConfig, common.config.Root)
 	opt.BuildkitVersion = getBuildkitVersion()
 	opt.RegistryHosts = resolverFunc(common.config)
+	opt.TracerProvider = common.tracerProvider
 
 	if platformsStr := cfg.Platforms; len(platformsStr) != 0 {
 		platforms, err := parsePlatforms(platformsStr)

--- a/cmd/buildkitd/main_oci_worker.go
+++ b/cmd/buildkitd/main_oci_worker.go
@@ -322,6 +322,7 @@ func ociWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([]worker
 	opt.GCPolicy = getGCPolicy(cfg.GCConfig, common.config.Root)
 	opt.BuildkitVersion = getBuildkitVersion()
 	opt.RegistryHosts = hosts
+	opt.TracerProvider = common.tracerProvider
 
 	if platformsStr := cfg.Platforms; len(platformsStr) != 0 {
 		platforms, err := parsePlatforms(platformsStr)

--- a/control/control.go
+++ b/control/control.go
@@ -623,14 +623,12 @@ func (c *Controller) gc() {
 	}()
 
 	for _, w := range workers {
-		func(w worker.Worker) {
-			eg.Go(func() error {
-				if policy := w.GCPolicy(); len(policy) > 0 {
-					return w.Prune(ctx, ch, policy...)
-				}
-				return nil
-			})
-		}(w)
+		eg.Go(func() error {
+			if policy := w.GCPolicy(); len(policy) > 0 {
+				return w.Prune(ctx, ch, policy...)
+			}
+			return nil
+		})
 	}
 
 	err = eg.Wait()

--- a/hack/composefiles/compose.yaml
+++ b/hack/composefiles/compose.yaml
@@ -4,8 +4,6 @@ services:
     container_name: buildkit-dev
     build:
       context: ../..
-      args:
-        BUILDKIT_DEBUG: 1
     image: moby/buildkit:local
     ports:
       - 127.0.0.1:5000:5000
@@ -13,7 +11,6 @@ services:
     restart: always
     privileged: true
     environment:
-      DELVE_PORT: 5000
       OTEL_SERVICE_NAME: buildkitd
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
     configs:

--- a/util/tracing/tracing.go
+++ b/util/tracing/tracing.go
@@ -5,7 +5,13 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptrace"
+	"runtime"
+	"strings"
+	"sync"
 
+	"github.com/moby/buildkit/util/bklog"
+	"github.com/moby/buildkit/util/stack"
+	"github.com/pkg/errors"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
@@ -14,18 +20,57 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
-
-	"github.com/pkg/errors"
-
-	"github.com/moby/buildkit/util/bklog"
-	"github.com/moby/buildkit/util/stack"
 )
+
+var noopTracer = sync.OnceValue(func() trace.TracerProvider {
+	return noop.NewTracerProvider()
+})
+
+// Tracer is a utility function for creating a tracer. It will create
+// a tracer with the name matching the package of the caller with the given options.
+//
+// This function isn't meant to be called in a tight loop. It is intended to be
+// called on initialization and the tracer is supposed to be retained for future use.
+func Tracer(tp trace.TracerProvider, options ...trace.TracerOption) trace.Tracer {
+	if tp == nil {
+		// Potentially consider using otel.GetTracerProvider here, but
+		// we know of some issues where the default tracer provider can cause
+		// memory leaks if it is never initialized so just being cautious
+		// and using the noop tracer because buildkit itself doesn't use the global
+		// tracer provider.
+		return noopTracer().Tracer("", options...)
+	}
+
+	var (
+		name    string
+		callers [1]uintptr
+	)
+
+	if runtime.Callers(2, callers[:]) > 0 {
+		frames := runtime.CallersFrames(callers[:])
+		frame, _ := frames.Next()
+
+		if frame.Function != "" {
+			lastSlash := strings.LastIndex(frame.Function, "/")
+			if lastSlash < 0 {
+				lastSlash = 0
+			}
+
+			if funcStart := strings.Index(frame.Function[lastSlash:], "."); funcStart >= 0 {
+				name = frame.Function[:lastSlash+funcStart]
+			} else {
+				name = frame.Function
+			}
+		}
+	}
+	return tp.Tracer(name, options...)
+}
 
 // StartSpan starts a new span as a child of the span in context.
 // If there is no span in context then this is a no-op.
 func StartSpan(ctx context.Context, operationName string, opts ...trace.SpanStartOption) (trace.Span, context.Context) {
 	parent := trace.SpanFromContext(ctx)
-	tracer := noop.NewTracerProvider().Tracer("")
+	tracer := noopTracer().Tracer("")
 	if parent != nil && parent.SpanContext().IsValid() {
 		tracer = parent.TracerProvider().Tracer("")
 	}

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -50,6 +50,7 @@ import (
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 )
@@ -82,6 +83,7 @@ type WorkerOpt struct {
 	MetadataStore    *metadata.Store
 	MountPoolRoot    string
 	ResourceMonitor  *resources.Monitor
+	TracerProvider   trace.TracerProvider
 }
 
 // Worker is a local worker instance with dedicated snapshotter, cache, and so on.
@@ -113,6 +115,7 @@ func NewWorker(ctx context.Context, opt WorkerOpt) (*Worker, error) {
 		MetadataStore:   opt.MetadataStore,
 		Root:            opt.Root,
 		MountPoolRoot:   opt.MountPoolRoot,
+		TracerProvider:  opt.TracerProvider,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Adds tracing to the cache manager prune operation. The attribute will show both explicit prunes from a user and background prunes initiated after solve requests are processed.

The prune code has also been refactored a bit to remove a recursive call to prune. It has now been unrolled and the functions have been renamed so `prune` stands for the entire prune process and `pruneOnce` is a single cycle. Previously, `prune` was a single cycle and `pruneOnce` would run the entire prune cycle with a set of options.

This also disabled the delve component of the `hack/compose` script. It appears to be broken at the moment.