### PR TITLE
util(disk): freebsd and netbsd support

### DIFF
--- a/util/disk/disk_freebsd.go
+++ b/util/disk/disk_freebsd.go
@@ -1,4 +1,4 @@
-//go:build !windows && !freebsd && !netbsd && !openbsd
+//go:build freebsd
 
 package disk
 

--- a/util/disk/disk_netbsd.go
+++ b/util/disk/disk_netbsd.go
@@ -1,0 +1,21 @@
+//go:build netbsd
+
+package disk
+
+import (
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+func GetDiskStat(root string) (DiskStat, error) {
+	var st unix.Statvfs_t
+	if err := unix.Statvfs(root, &st); err != nil {
+		return DiskStat{}, errors.Wrapf(err, "could not stat fs at %s", root)
+	}
+
+	return DiskStat{
+		Total:     int64(st.Frsize) * int64(st.Blocks),
+		Free:      int64(st.Frsize) * int64(st.Bfree),
+		Available: int64(st.Frsize) * int64(st.Bavail),
+	}, nil
+}

--- a/util/disk/disk_test.go
+++ b/util/disk/disk_test.go
@@ -1,0 +1,15 @@
+package disk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDiskStat(t *testing.T) {
+	diskStat, err := GetDiskStat("/")
+	require.NoError(t, err)
+	require.Greater(t, diskStat.Total, int64(0))
+	require.GreaterOrEqual(t, diskStat.Free, int64(0))
+	require.GreaterOrEqual(t, diskStat.Available, int64(0))
+}


### PR DESCRIPTION
Was looking at netbsd support in buildx and it fails to build the `util/disk` package:

```
#18 [buildx-build 1/1] RUN --mount=type=bind,target=.   --mount=type=cache,target=/root/.cache   --mount=type=cache,target=/go/pkg/mod   --mount=type=bind,from=buildx-version,source=/buildx-version,target=/buildx-version <<EOT (set -e...)
#18 0.322 + CGO_ENABLED=0 go build -mod vendor -trimpath -ldflags '-X github.com/docker/buildx/version.Version=v0.19.0-49-g3e1a0982 -X github.com/docker/buildx/version.Revision=3e1a0982b6216e234e5576a5a30c30bf05ed4a6e -X github.com/docker/buildx/version.Package=github.com/docker/buildx -s -w' -o /usr/bin/docker-buildx ./cmd/buildx
#18 1.142 # github.com/moby/buildkit/util/disk
#18 1.142 vendor/github.com/moby/buildkit/util/disk/disk_unix.go:13:20: undefined: syscall.Statfs
#18 1.142 vendor/github.com/moby/buildkit/util/disk/disk_unix.go:18:23: st.Bsize undefined (type syscall.Statfs_t has no field or method Bsize)
#18 1.142 vendor/github.com/moby/buildkit/util/disk/disk_unix.go:18:41: st.Blocks undefined (type syscall.Statfs_t has no field or method Blocks)
#18 1.142 vendor/github.com/moby/buildkit/util/disk/disk_unix.go:19:23: st.Bsize undefined (type syscall.Statfs_t has no field or method Bsize)
#18 1.142 vendor/github.com/moby/buildkit/util/disk/disk_unix.go:19:41: st.Bfree undefined (type syscall.Statfs_t has no field or method Bfree)
#18 1.142 vendor/github.com/moby/buildkit/util/disk/disk_unix.go:20:23: st.Bsize undefined (type syscall.Statfs_t has no field or method Bsize)
#18 1.142 vendor/github.com/moby/buildkit/util/disk/disk_unix.go:20:41: st.Bavail undefined (type syscall.Statfs_t has no field or method Bavail)
```

cc @akhramov @catap