### PR TITLE
cache: convert prune loop from recursive invocation to iterative

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -623,14 +623,12 @@ func (c *Controller) gc() {
 	}()
 
 	for _, w := range workers {
-		func(w worker.Worker) {
-			eg.Go(func() error {
-				if policy := w.GCPolicy(); len(policy) > 0 {
-					return w.Prune(ctx, ch, policy...)
-				}
-				return nil
-			})
-		}(w)
+		eg.Go(func() error {
+			if policy := w.GCPolicy(); len(policy) > 0 {
+				return w.Prune(ctx, ch, policy...)
+			}
+			return nil
+		})
 	}
 
 	err = eg.Wait()

--- a/hack/composefiles/compose.yaml
+++ b/hack/composefiles/compose.yaml
@@ -4,8 +4,6 @@ services:
     container_name: buildkit-dev
     build:
       context: ../..
-      args:
-        BUILDKIT_DEBUG: 1
     image: moby/buildkit:local
     ports:
       - 127.0.0.1:5000:5000
@@ -13,7 +11,6 @@ services:
     restart: always
     privileged: true
     environment:
-      DELVE_PORT: 5000
       OTEL_SERVICE_NAME: buildkitd
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
     configs:


### PR DESCRIPTION
The prune logic would prune multiple times because one prune could cause more things to be capable of pruning and change the logic. This was done through a recursive invocation.

Since go doesn't have support for function tail calls, this would result in a new stack entry for each loop. This unrolls the logic so the prune function is invoked iteratively rather than recursively.

`prune` and `pruneOnce` have also had their names swapped. In general, `pruneOnce` implies that it runs a single prune while `prune` sounds like the top level function. The current code had this reversed and `pruneOnce` would call `prune` and `prune` would call itself recursively.

I've also updated a section in the controller that invoked prune on each worker. In older versions of Go, the current version was correct because those versions of Go would reuse the location for each loop which would cause goroutines to all reference the same worker instead of different workers.

Recent versions of Go have changed the behavior so this is no longer needed.