### PR TITLE
dockerfile: don't allow non-Dockerfile syntax for directives

### DIFF
--- a/frontend/dockerfile/parser/directives.go
+++ b/frontend/dockerfile/parser/directives.go
@@ -112,10 +112,14 @@ func (d *DirectiveParser) ParseAll(data []byte) ([]*Directive, error) {
 // This allows for a flexible range of input formats, and appropriate syntax
 // selection.
 func DetectSyntax(dt []byte) (string, string, []Range, bool) {
-	return ParseDirective(keySyntax, dt)
+	return parseDirective(keySyntax, dt, true)
 }
 
 func ParseDirective(key string, dt []byte) (string, string, []Range, bool) {
+	return parseDirective(key, dt, false)
+}
+
+func parseDirective(key string, dt []byte, anyFormat bool) (string, string, []Range, bool) {
 	dt = discardBOM(dt)
 	dt, hadShebang, err := discardShebang(dt)
 	if err != nil {
@@ -130,6 +134,10 @@ func ParseDirective(key string, dt []byte) (string, string, []Range, bool) {
 	directiveParser := DirectiveParser{line: line}
 	if syntax, cmdline, loc, ok := detectDirectiveFromParser(key, dt, directiveParser); ok {
 		return syntax, cmdline, loc, true
+	}
+
+	if !anyFormat {
+		return "", "", nil, false
 	}
 
 	// use directive with different comment prefix, and search for //key=

--- a/frontend/dockerfile/parser/directives_test.go
+++ b/frontend/dockerfile/parser/directives_test.go
@@ -158,27 +158,6 @@ RUN ls
 
 	dt = `//check=skip=all
 //key=value`
-	ref, _, _, ok = ParseDirective("check", []byte(dt))
-	require.True(t, ok)
-	require.Equal(t, "skip=all", ref)
-
-	dt = `#!/bin/sh
-//check=skip=all`
-	ref, _, _, ok = ParseDirective("check", []byte(dt))
-	require.True(t, ok)
-	require.Equal(t, "skip=all", ref)
-
-	dt = `{"check": "skip=all"}`
-	ref, _, _, ok = ParseDirective("check", []byte(dt))
-	require.True(t, ok)
-	require.Equal(t, "skip=all", ref)
-
-	dt = `{"check": "foo"`
-	_, _, _, ok = ParseDirective("check", []byte(dt))
-	require.False(t, ok)
-
-	dt = `{"check": "foo"}
-# syntax=bar`
 	_, _, _, ok = ParseDirective("check", []byte(dt))
 	require.False(t, ok)
 }


### PR DESCRIPTION
regression from https://github.com/moby/buildkit/pull/4962

ParseDirectives code was changed when "check" directive was added and copied over logic from DetectSyntax function. This does not look correct as the only allowed formatting for Dockerfile directives is with a Dockerfile comment. "#syntax" is a special case because we want to allow frontend forwarding capability also in non-Dockerfile sources that use different style of comments or using config files with JSON as frontend entrypoints.