### PR TITLE
ci: ignore error if gha cache export fails

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -88,7 +88,7 @@ jobs:
           targets: integration-tests-base
           set: |
             *.cache-from=type=gha,scope=${{ inputs.cache_scope }}
-            *.cache-to=type=gha,scope=${{ inputs.cache_scope }},repository=${{ github.repository }},ghtoken=${{ secrets.GITHUB_TOKEN }}
+            *.cache-to=type=gha,scope=${{ inputs.cache_scope }},ignore-error=true,repository=${{ github.repository }},ghtoken=${{ secrets.GITHUB_TOKEN }}
 
   run:
     runs-on: ubuntu-24.04

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -106,7 +106,7 @@ jobs:
           RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
           PLATFORMS: ${{ matrix.platform }}
           CACHE_FROM: type=gha,scope=binaries-${{ env.PLATFORM_PAIR }}
-          CACHE_TO: type=gha,scope=binaries-${{ env.PLATFORM_PAIR }}
+          CACHE_TO: type=gha,scope=binaries-${{ env.PLATFORM_PAIR }},ignore-error=true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Upload artifacts
@@ -216,7 +216,7 @@ jobs:
           RELEASE: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
           TARGET: ${{ matrix.target-stage }}
           CACHE_FROM: type=gha,scope=image${{ matrix.target-stage }}
-          CACHE_TO: type=gha,scope=image${{ matrix.target-stage }}
+          CACHE_TO: type=gha,scope=image${{ matrix.target-stage }},ignore-error=true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   scout:

--- a/.github/workflows/dockerd.yml
+++ b/.github/workflows/dockerd.yml
@@ -128,7 +128,7 @@ jobs:
           TESTPKGS: "${{ matrix.pkg }}"
           TESTFLAGS: "${{ env.TESTFLAGS }} --run=//worker=${{ matrix.worker }}$"
           SKIP_INTEGRATION_TESTS: "${{ matrix.skip-integration-tests }}"
-          CACHE_FROM: "type=gha,scope=build-integration-tests"
+          CACHE_FROM: "type=gha,scope=build-integration-tests,ignore-error=true"
           BUILDKIT_INTEGRATION_DOCKERD_FLAGS: |
             --bip=10.66.66.1/24
             --default-address-pool=base=10.66.66.0/16,size=24

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -123,7 +123,7 @@ jobs:
         env:
           RELEASE: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
           CACHE_FROM: type=gha,scope=${{ env.CACHE_SCOPE }}
-          CACHE_TO: type=gha,scope=${{ env.CACHE_SCOPE }}
+          CACHE_TO: type=gha,scope=${{ env.CACHE_SCOPE }},ignore-error=true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   scout:

--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -55,7 +55,7 @@ jobs:
           set: |
             *.platform=${{ matrix.platform }}
             *.cache-from=type=gha,scope=binaries-for-test-${{ env.PLATFORM_PAIR }}
-            *.cache-to=type=gha,scope=binaries-for-test-${{ env.PLATFORM_PAIR }},repository=${{ github.repository }},ghtoken=${{ secrets.GITHUB_TOKEN }}
+            *.cache-to=type=gha,scope=binaries-for-test-${{ env.PLATFORM_PAIR }},ignore-error=true,repository=${{ github.repository }},ghtoken=${{ secrets.GITHUB_TOKEN }}
       -
         name: List artifacts
         run: |


### PR DESCRIPTION
We often encounter rate limits when trying to export the GHA cache on this repo:
* https://github.com/moby/buildkit/actions/runs/12761713702/job/35574523031?pr=5649#step:7:1948
* https://github.com/moby/buildkit/actions/runs/12763721138/job/35575847332?pr=5638#step:8:1551
* https://github.com/moby/buildkit/actions/runs/12763721107/job/35574441704#step:4:854

```
#41 exporting to GitHub Actions Cache
#41 preparing build cache for export
#41 writing layer sha256:4dfab37fddd981de09c236979ac9e012419dc3b5abc78e9b416e5ac243838826
#41 writing layer sha256:4dfab37fddd981de09c236979ac9e012419dc3b5abc78e9b416e5ac243838826 0.1s done
#41 writing layer sha256:bcf9cb26c40f8c5b74030342ac94a99169912038ab09dc3d727e1c7452c6ac7a
#41 writing layer sha256:bcf9cb26c40f8c5b74030342ac94a99169912038ab09dc3d727e1c7452c6ac7a 0.1s done
#41 preparing build cache for export 607.5s done
#41 ERROR: maximum timeout reached
```

We can use the `ignore-error` attribute to avoid jobs to fail. We also have the `testBasicGhaCacheImportExportExtraTimeout` integration test for such case so I'm not that concerned that we could miss actual issues with GHA cache backend.