### PR TITLE
tests: add validation that config has OSVersion set

### DIFF
--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -9510,6 +9510,15 @@ EOF
 
 	require.NoError(t, err)
 
+	desc, provider, err := contentutil.ProviderFromRef(target)
+	require.NoError(t, err)
+
+	info, err := testutil.ReadImages(ctx, provider, desc)
+	require.NoError(t, err)
+	require.Len(t, info.Images, 2)
+	require.Equal(t, info.Images[0].Img.Platform.OSVersion, p1.OSVersion)
+	require.Equal(t, info.Images[1].Img.Platform.OSVersion, p2.OSVersion)
+
 	dt, err := os.ReadFile(filepath.Join(destDir, strings.Replace(p1Str, "/", "_", 1), "osversion"))
 	require.NoError(t, err)
 	require.Equal(t, p1.OSVersion+"\n", string(dt))


### PR DESCRIPTION
This is a follow-up from 94ddeb7dbe427ef6a39dbdbf0d5096b6752da296 to ensure that the expected OSVersion is set on the respective image configs.