### PR TITLE
testing: use env var for configuring debugaddress for tests

### DIFF
--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -193,9 +193,10 @@ func main() {
 			Value: groupValue(defaultConf.GRPC.GID),
 		},
 		cli.StringFlag{
-			Name:  "debugaddr",
-			Usage: "debugging address (eg. 0.0.0.0:6060)",
-			Value: defaultConf.GRPC.DebugAddress,
+			Name:   "debugaddr",
+			Usage:  "debugging address (eg. 0.0.0.0:6060)",
+			Value:  defaultConf.GRPC.DebugAddress,
+			EnvVar: "BUILDKITD_DEBUGADDR",
 		},
 		cli.StringFlag{
 			Name:  "tlscert",

--- a/util/testutil/workers/util.go
+++ b/util/testutil/workers/util.go
@@ -73,12 +73,13 @@ func runBuildkitd(
 	address := getBuildkitdAddr(tmpdir)
 	debugAddress := getBuildkitdDebugAddr(tmpdir)
 
-	args = append(args, "--root", tmpdir, "--addr", address, "--debugaddr", debugAddress, "--debug")
+	args = append(args, "--root", tmpdir, "--addr", address, "--debug")
 	cmd := exec.Command(args[0], args[1:]...) //nolint:gosec // test utility
 	cmd.Env = append(
 		os.Environ(),
 		"BUILDKIT_DEBUG_EXEC_OUTPUT=1",
 		"BUILDKIT_DEBUG_PANIC_ON_ERROR=1",
+		"BUILDKITD_DEBUGADDR="+debugAddress,
 		"TMPDIR="+filepath.Join(tmpdir, "tmp"))
 	if v := os.Getenv("GO_TEST_COVERPROFILE"); v != "" {
 		coverDir := filepath.Join(filepath.Dir(v), "helpers")


### PR DESCRIPTION
Unix socket support for --debugaddr was added later what means the test suite can not be used to test old versions of releases anymore. This makes debug address configurable via env variable so that old versions can just ignore it without crashing.

This resolves the need for extra patch in https://github.com/docker/buildx/pull/2914 to make full buildx test matrix run.