### PR TITLE
test: missing direct push check feature compat

### DIFF
--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -9430,6 +9430,7 @@ func testPlatformWithOSVersion(t *testing.T, sb integration.Sandbox) {
 	// This test cannot be run on Windows currently due to `FROM scratch` and
 	// layer formatting not being supported on Windows.
 	integration.SkipOnPlatform(t, "windows")
+	workers.CheckFeatureCompat(t, sb, workers.FeatureDirectPush)
 
 	ctx := sb.Context()
 


### PR DESCRIPTION
we forgot to check feature compat in https://github.com/moby/buildkit/pull/5614

relates to: https://github.com/moby/moby/actions/runs/12778000243/job/35622992353?pr=49279#step:13:4311

```
=== FAIL: frontend/dockerfile TestIntegration/TestPlatformWithOSVersion/worker=dockerd/frontend=client (4.82s)
    dockerfile_test.go:9511: 
        	Error Trace:	/src/frontend/dockerfile/dockerfile_test.go:9511
        	            				/src/util/testutil/integration/run.go:98
        	            				/src/util/testutil/integration/run.go:212
        	Error:      	Received unexpected error:
        	            	exporter "image" could not be found
        	            	github.com/moby/buildkit/util/stack.Enable
        	            		/src/util/stack/stack.go:82
        	            	github.com/moby/buildkit/util/grpcerrors.FromGRPC
        	            		/src/util/grpcerrors/grpcerrors.go:204
        	            	github.com/moby/buildkit/util/grpcerrors.UnaryClientInterceptor
        	            		/src/util/grpcerrors/intercept.go:41
        	            	google.golang.org/grpc.(*ClientConn).Invoke
        	            		/src/vendor/google.golang.org/grpc/call.go:35
        	            	github.com/moby/buildkit/api/services/control.(*controlClient).Solve
        	            		/src/api/services/control/control_grpc.pb.go:88
        	            	github.com/moby/buildkit/client.(*Client).solve.func2
        	            		/src/client/solve.go:269
        	            	golang.org/x/sync/errgroup.(*Group).Go.func1
        	            		/src/vendor/golang.org/x/sync/errgroup/errgroup.go:78
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1700
        	            	failed to solve
        	            	github.com/moby/buildkit/client.(*Client).solve.func2
        	            		/src/client/solve.go:285
        	            	golang.org/x/sync/errgroup.(*Group).Go.func1
        	            		/src/vendor/golang.org/x/sync/errgroup/errgroup.go:78
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1700
```