### PR TITLE
contenthash: clear ModeIrregular before sending to archive/tar

### DIFF
--- a/cache/contenthash/filehash.go
+++ b/cache/contenthash/filehash.go
@@ -41,6 +41,15 @@ func NewFileHash(path string, fi os.FileInfo) (hash.Hash, error) {
 }
 
 func NewFromStat(stat *fstypes.Stat) (hash.Hash, error) {
+	// Clear the irregular file bit if this is some kind of special
+	// file. Pre-Go 1.23 behavior would only add the irregular file
+	// bit to regular files with non-handled reparse points.
+	// Current versions of Go now apply them to directories too.
+	// archive/tar.FileInfoHeader does not handle the irregular bit.
+	if stat.Mode&uint32(os.ModeType&^os.ModeIrregular) != 0 {
+		stat.Mode &^= uint32(os.ModeIrregular)
+	}
+
 	// Clear the socket bit since archive/tar.FileInfoHeader does not handle it
 	stat.Mode &^= uint32(os.ModeSocket)
 


### PR DESCRIPTION
Clears ModeIrregular from the checksum generation. This may be sent by the client when the version of Go used is post Go 1.23. The behavior of `os.Stat` was modified in Go 1.23 to set `ModeIrregular` on reparse points in Windows. This clears `ModeIrregular` when any mode is set which was the previous behavior of `os.Stat`.

Fixes https://github.com/docker/for-win/issues/14083.