### PR TITLE
llbsolver: take copy of history record to avoid marshal race

### DIFF
--- a/solver/llbsolver/history.go
+++ b/solver/llbsolver/history.go
@@ -680,6 +680,8 @@ func (h *HistoryQueue) Update(ctx context.Context, e *controlapi.BuildHistoryEve
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
+	e = e.CloneVT()
+
 	if e.Type == controlapi.BuildHistoryEventType_STARTED {
 		h.active[e.Record.Ref] = e.Record
 		h.ps.Send(e)


### PR DESCRIPTION
For active builds these records get stored in the memory and marshalled on user request. This leads to possibility that the original record may be updated while the marshalling is happening, leading to a crash.