### PR TITLE
Replace legacy issue template with revised issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,76 @@
+name: Bug Report
+description: File a bug report.
+type: "bug"
+labels:
+  - status/triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Thank you for taking the time to report a bug!**
+        If this is a security issue please report it to the [Docker Security team](mailto:security@docker.com), see [SECURITY.md](https://github.com/moby/buildkit/blob/master/.github/SECURITY.md) for more information.
+
+  - type: checkboxes
+    attributes:
+      label: Contributing guidelines and issue reporting guide
+      description: |
+        Please read the contributing guidelines and issue reporting guide before proceeding.
+      options:
+        - label: I've read the [contributing guidelines](https://github.com/moby/buildkit/blob/master/.github/CONTRIBUTING.md) and wholeheartedly agree. I've also read the [issue reporting guide](https://github.com/moby/buildkit/blob/master/.github/issue_reporting_guide.md).
+          required: true
+
+  - type: checkboxes
+    attributes:
+      label: Well-formed report checklist
+      description: |
+        Make sure that your request fulfills all of the following requirements.
+        If one requirement cannot be satisfied, explain in detail why.
+      options:
+        - label: I have found a bug that the documentation does not mention anything about my problem
+          required: true
+        - label: I have found a bug that there are no open or closed issues that are related to my problem
+          required: true
+        - label: I have provided version/information about my environment and done my best to provide a reproducer
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Description of bug
+      description: |
+        Please provide a description of the bug, reproduction steps and version information.
+
+        <details>
+        <summary>How to collect version information</summary>
+
+        Using `buildctl` and `buildkitd` to get version information
+        ```bash
+        buildctl --version && buildkitd version
+        ```
+
+        Using `docker` to get BuildKit information
+        ```bash
+        docker buildx version && docker buildx inspect
+        ```
+
+        Add Docker Engine information (if available)
+        ```bash
+        docker version && docker info
+        ```
+
+        </details>
+      value: |
+        ## Bug description
+
+        A description of the bug, observed, and expected behaviour.
+
+        ## Reproduction
+
+        Steps to reproduce the problem. If you are using `docker build` or `docker buildx build` providing the command as well as any input files will help analysis.
+
+        ## Version information
+
+        ```bash
+        terminal_output
+        ```
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,15 @@
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+blank_issues_enabled: true
+contact_links:
+  - name: Security and Vulnerabilities
+    url: https://github.com/moby/buildkit/blob/master/.github/SECURITY.md
+    about: Please report any security issues or vulnerabilities responsibly to the Docker security team. Please do not use the public issue tracker.
+  - name: Questions and Discussions
+    url: https://github.com/moby/buildkit/discussions/new
+    about: Use Github Discussions to ask questions and/or open discussion topics.
+  - name: Documentation
+    url: https://github.com/moby/buildkit/tree/master/docs
+    about: Read the documentation.
+  - name: Join the Docker Community on Slack
+    url: http://dockr.ly/comm-slack
+    about: Join the Docker Community on Slack and head to the buildkit channel.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,14 @@
+name: Feature or enhancement request
+description: Missing functionality? Come tell us about it!
+type: "enhancement"
+labels:
+  - status/triage
+
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What is the feature you want to see?
+    validations:
+      required: true

--- a/.github/issue_reporting_guide.md
+++ b/.github/issue_reporting_guide.md
@@ -1,17 +1,17 @@
 # Issue reporting guide
 
-* [Security issues](#security-issues)
-* [Search for an existing issue](#search-for-an-existing-issue)
-* [Reproducible test case](#reproducible-test-case)
-* [Describe your environment](#describe-your-environment)
-* [Reporting deadlock](#reporting-deadlock)
-* [Reporting panics/error returns](#reporting-panicserror-returns)
-* [Gathering more debugging data](#gathering-more-debugging-data)
-* [Regressions](#regressions)
-* [Debugging issues that only reproduce in the live environment](#debugging-issues-that-only-reproduce-in-the-live-environment)
-* [Follow the progress of your issue](#follow-the-progress-of-your-issue)
-* [Try fixing your issue yourself](#try-fixing-your-issue-yourself)
-* [Additional reading](#additional-reading)
+- [Security issues](#security-issues)
+- [Search for an existing issue](#search-for-an-existing-issue)
+- [Reproducible test case](#reproducible-test-case)
+- [Describe your environment](#describe-your-environment)
+- [Reporting deadlock](#reporting-deadlock)
+- [Reporting panics/error returns](#reporting-panicserror-returns)
+- [Gathering more debugging data](#gathering-more-debugging-data)
+- [Regressions](#regressions)
+- [Debugging issues that only reproduce in the live environment](#debugging-issues-that-only-reproduce-in-the-live-environment)
+- [Follow the progress of your issue](#follow-the-progress-of-your-issue)
+- [Try fixing your issue yourself](#try-fixing-your-issue-yourself)
+- [Additional reading](#additional-reading)
 
 ## Security issues
 
@@ -57,7 +57,7 @@ Sometimes it is not completely clear if the issue belongs in `moby/buildkit` , `
 
 Provide versions of the tools you used:
 
-- Using Buildkitd/Buildctl  `buildctl --version` `buildkitd version`
+- Using Buildkitd/Buildctl  `buildctl --version` and `buildkitd version`
 - Using Docker Buildx `docker buildx version` and `docker buildx inspect` to return info about your current builder instance. If you run `docker build` then also report this.
 - If the issue is specific to Docker Engine embedded BuildKit or `docker buildx` Docker driver then report `docker version` and `docker info`
 

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,5 +1,0 @@
-<!---
-Thank you for contributing to BuildKit through issue submission! If you're new to this repository, we encourage you to review our issue reporting guide https://github.com/moby/buildkit/blob/master/.github/issue_reporting_guide.md which outlines the key information you should provide for the process to go smoothly.
-
-Feel free to report bugs, suggest features, or submit proposals here. For general questions about using BuildKit, consider joining the #buildkit channel on the Docker Community Slack, where a broader community can provide support and insights.
---->


### PR DESCRIPTION
Closes #5587 

This PR replaces the deprecated legacy markdown template at `.github/issue_template.md` with new YAML-based forms for bug reports and feature requests. Blank issues are still allowed under this PR's configuration. An issue type is also added when available.

Note that for the forms most fields are required.

## Additions
- [Issue template chooser](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) added with links to discussions, slack and documentation
- Bug report form
- Feature request form

## Reference
- [GitHub form schema](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema)
- [Issue types in GitHub forms](https://github.com/orgs/community/discussions/112806)