### PR TITLE
authprovider: Add support for expiring auth cache

### DIFF
--- a/cmd/buildctl/build.go
+++ b/cmd/buildctl/build.go
@@ -187,7 +187,11 @@ func buildAction(clicontext *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	attachable := []session.Attachable{authprovider.NewDockerAuthProvider(dockerConfig, tlsConfigs)}
+
+	attachable := []session.Attachable{authprovider.NewDockerAuthProvider(authprovider.DockerAuthProviderConfig{
+		ConfigFile: dockerConfig,
+		TLSConfigs: tlsConfigs,
+	})}
 
 	if ssh := clicontext.StringSlice("ssh"); len(ssh) > 0 {
 		configs, err := build.ParseSSH(ssh)

--- a/session/auth/authprovider/authprovider_test.go
+++ b/session/auth/authprovider/authprovider_test.go
@@ -3,6 +3,7 @@ package authprovider
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/config/types"
@@ -12,12 +13,18 @@ import (
 )
 
 func TestFetchTokenCaching(t *testing.T) {
-	cfg := &configfile.ConfigFile{
-		AuthConfigs: map[string]types.AuthConfig{
-			dockerHubConfigfileKey: {Username: "user", RegistryToken: "hunter2"},
-		},
+	newCfg := func() *configfile.ConfigFile {
+		return &configfile.ConfigFile{
+			AuthConfigs: map[string]types.AuthConfig{
+				dockerHubConfigfileKey: {Username: "user", RegistryToken: "hunter2"},
+			},
+		}
 	}
-	p := NewDockerAuthProvider(cfg, nil).(*authProvider)
+
+	cfg := newCfg()
+	p := NewDockerAuthProvider(DockerAuthProviderConfig{
+		ConfigFile: cfg,
+	}).(*authProvider)
 	res, err := p.FetchToken(context.Background(), &auth.FetchTokenRequest{Host: dockerHubRegistryHost})
 	require.NoError(t, err)
 	assert.Equal(t, "hunter2", res.Token)
@@ -28,4 +35,26 @@ func TestFetchTokenCaching(t *testing.T) {
 
 	// Verify that we cached the result instead of returning hunter3.
 	assert.Equal(t, "hunter2", res.Token)
+
+	// Now again but this time expire the auth.
+
+	cfg = newCfg()
+	p = NewDockerAuthProvider(DockerAuthProviderConfig{
+		ConfigFile: cfg,
+		ExpireCachedAuth: func(_ time.Time, host string) bool {
+			require.Equal(t, dockerHubConfigfileKey, host)
+			return true
+		},
+	}).(*authProvider)
+
+	res, err = p.FetchToken(context.Background(), &auth.FetchTokenRequest{Host: dockerHubRegistryHost})
+	require.NoError(t, err)
+	assert.Equal(t, "hunter2", res.Token)
+
+	cfg.AuthConfigs[dockerHubConfigfileKey] = types.AuthConfig{Username: "user", RegistryToken: "hunter3"}
+	res, err = p.FetchToken(context.Background(), &auth.FetchTokenRequest{Host: dockerHubRegistryHost})
+	require.NoError(t, err)
+
+	// Verify that we re-fetched the token after it expired.
+	assert.Equal(t, "hunter3", res.Token)
 }


### PR DESCRIPTION
This exposes a mechanism to expire cached auth configs.