### PR TITLE
dockerfile: avoid too eager loading of unreachable named contextes

### DIFF
--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -191,14 +191,22 @@ func (gf *gatewayFrontend) Solve(ctx context.Context, llbBridge frontend.Fronten
 		if err != nil {
 			return nil, err
 		}
-		st, dockerImage, err := dc.NamedContext(ctx, source, dockerui.ContextOpt{
+		nc, err := dc.NamedContext(source, dockerui.ContextOpt{
 			CaptureDigest: &mfstDigest,
 		})
 		if err != nil {
 			return nil, err
 		}
-		if dockerImage != nil {
-			img = *dockerImage
+		var st *llb.State
+		if nc != nil {
+			var dockerImage *dockerspec.DockerOCIImage
+			st, dockerImage, err = nc.Load(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if dockerImage != nil {
+				img = *dockerImage
+			}
 		}
 		if st == nil {
 			sourceRef, err := reference.ParseNormalizedNamed(source)


### PR DESCRIPTION
fixes https://github.com/docker/buildx/issues/2939

Avoids pulling in a named context if the build dependencies are not actually using it. The main case where this issue appears is when image is used as a named context and image config would be resolved. In addition to wasting resources, the image could also be invalid for the current build configuration and cause the build to fail.