### PR TITLE
ci: use main branch for docs upstream validation workflow

### DIFF
--- a/.github/workflows/docs-upstream.yml
+++ b/.github/workflows/docs-upstream.yml
@@ -30,6 +30,6 @@ on:
 
 jobs:
   validate:
-    uses: docker/docs/.github/workflows/validate-upstream.yml@919a9b9104a34a40b30d116529bcce589a544d1c  # pin for artifact v4 support: https://github.com/docker/docs/pull/19220
+    uses: docker/docs/.github/workflows/validate-upstream.yml@main
     with:
       module-name: moby/buildkit


### PR DESCRIPTION
relates to https://github.com/moby/buildkit/actions/runs/13117267129/job/36594495990#step:6:20
similar to https://github.com/docker/buildx/pull/2941