### PR TITLE
 feat: wcow: add support for bind and cache mounts

### DIFF
--- a/cache/contenthash/checksum.go
+++ b/cache/contenthash/checksum.go
@@ -110,6 +110,9 @@ func (cm *cacheManager) Checksum(ctx context.Context, ref cache.ImmutableRef, p 
 	if err != nil {
 		return "", nil
 	}
+	// only applies for Windows, it's a no-op on non-Windows.
+	enableProcessPrivileges()
+	defer disableProcessPrivileges()
 	return cc.Checksum(ctx, ref, p, opts, s)
 }
 

--- a/cache/contenthash/checksum_unix.go
+++ b/cache/contenthash/checksum_unix.go
@@ -7,3 +7,9 @@ import "path/filepath"
 func (cc *cacheContext) walk(scanPath string, walkFunc filepath.WalkFunc) error {
 	return filepath.Walk(scanPath, walkFunc)
 }
+
+// This is a no-op on non-Windows
+func enableProcessPrivileges() {}
+
+// This is a no-op on non-Windows
+func disableProcessPrivileges() {}

--- a/cache/contenthash/checksum_windows.go
+++ b/cache/contenthash/checksum_windows.go
@@ -6,11 +6,24 @@ import (
 	"github.com/Microsoft/go-winio"
 )
 
+var privileges = []string{winio.SeBackupPrivilege}
+
 func (cc *cacheContext) walk(scanPath string, walkFunc filepath.WalkFunc) error {
 	// elevating the admin privileges to walk special files/directory
 	// like `System Volume Information`, etc. See similar in #4994
-	privileges := []string{winio.SeBackupPrivilege}
 	return winio.RunWithPrivileges(privileges, func() error {
 		return filepath.Walk(scanPath, walkFunc)
 	})
+}
+
+// Adds the SeBackupPrivilege to the process
+// to be able to access some special files and directories.
+func enableProcessPrivileges() {
+	_ = winio.EnableProcessPrivileges(privileges)
+}
+
+// Disables the SeBackupPrivilege on the process
+// once the group of functions that needed it is complete.
+func disableProcessPrivileges() {
+	_ = winio.DisableProcessPrivileges(privileges)
 }

--- a/executor/oci/spec_unix.go
+++ b/executor/oci/spec_unix.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package oci
+
+// no effect for non-Windows
+func normalizeMountType(mType string) string {
+	return mType
+}

--- a/executor/oci/spec_windows.go
+++ b/executor/oci/spec_windows.go
@@ -119,3 +119,9 @@ func generateCDIOpts(_ *cdidevices.Manager, devices []*pb.CDIDevice) ([]oci.Spec
 	// https://github.com/cncf-tags/container-device-interface/issues/28
 	return nil, errors.New("no support for CDI on Windows")
 }
+
+func normalizeMountType(_ string) string {
+	// HCS shim doesn't expect a named type
+	// for the mount.
+	return ""
+}

--- a/frontend/dockerfile/dockerfile2llb/convert_runmount.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_runmount.go
@@ -9,6 +9,7 @@ import (
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/util/system"
 	"github.com/pkg/errors"
 )
 
@@ -118,7 +119,7 @@ func dispatchRunMounts(d *dispatchState, c *instructions.RunCommand, sources []*
 			mountOpts = append(mountOpts, llb.AsPersistentCacheDir(opt.cacheIDNamespace+"/"+mount.CacheID, sharing))
 		}
 		target := mount.Target
-		if !filepath.IsAbs(filepath.Clean(mount.Target)) {
+		if !system.IsAbsolutePath(filepath.Clean(mount.Target)) {
 			dir, err := d.state.GetDir(context.TODO())
 			if err != nil {
 				return nil, err

--- a/frontend/dockerfile/parser/parser.go
+++ b/frontend/dockerfile/parser/parser.go
@@ -220,7 +220,7 @@ func init() {
 // based on the command and command arguments. A Node is created from the
 // result of the dispatch.
 func newNodeFromLine(line string, d *directives, comments []string) (*Node, error) {
-	cmd, flags, args, err := splitCommand(line)
+	cmd, flags, args, err := splitCommand(line, d)
 	if err != nil {
 		return nil, err
 	}

--- a/frontend/dockerfile/parser/split_command.go
+++ b/frontend/dockerfile/parser/split_command.go
@@ -7,7 +7,7 @@ import (
 
 // splitCommand takes a single line of text and parses out the cmd and args,
 // which are used for dispatching to more exact parsing functions.
-func splitCommand(line string) (string, []string, string, error) {
+func splitCommand(line string, d *directives) (string, []string, string, error) {
 	var args string
 	var flags []string
 
@@ -16,7 +16,7 @@ func splitCommand(line string) (string, []string, string, error) {
 
 	if len(cmdline) == 2 {
 		var err error
-		args, flags, err = extractBuilderFlags(cmdline[1])
+		args, flags, err = extractBuilderFlags(cmdline[1], d)
 		if err != nil {
 			return "", nil, "", err
 		}
@@ -25,7 +25,7 @@ func splitCommand(line string) (string, []string, string, error) {
 	return cmdline[0], flags, strings.TrimSpace(args), nil
 }
 
-func extractBuilderFlags(line string) (string, []string, error) {
+func extractBuilderFlags(line string, d *directives) (string, []string, error) {
 	// Parses the BuilderFlags and returns the remaining part of the line
 
 	const (
@@ -87,7 +87,7 @@ func extractBuilderFlags(line string) (string, []string, error) {
 				phase = inQuote
 				continue
 			}
-			if ch == '\\' {
+			if ch == d.escapeToken {
 				if pos+1 == len(line) {
 					continue // just skip \ at end
 				}
@@ -104,7 +104,7 @@ func extractBuilderFlags(line string) (string, []string, error) {
 				phase = inWord
 				continue
 			}
-			if ch == '\\' {
+			if ch == d.escapeToken {
 				if pos+1 == len(line) {
 					phase = inWord
 					continue // just skip \ at end

--- a/util/system/path_unix.go
+++ b/util/system/path_unix.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package system
+
+import "path/filepath"
+
+// IsAbsolutePath is just a wrapper that calls filepath.IsAbs.
+// Has been added here just for symmetry with Windows.
+func IsAbsolutePath(path string) bool {
+	return filepath.IsAbs(path)
+}
+
+// GetAbsolutePath does nothing on non-Windows, just returns
+// the same path.
+func GetAbsolutePath(path string) string {
+	return path
+}

--- a/util/system/path_windows.go
+++ b/util/system/path_windows.go
@@ -1,0 +1,29 @@
+package system
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// DefaultSystemVolumeName is the default system volume label on Windows
+const DefaultSystemVolumeName = "C:"
+
+// IsAbsolutePath prepends the default system volume label
+// to the path that is presumed absolute, and then calls filepath.IsAbs
+func IsAbsolutePath(path string) bool {
+	path = filepath.Clean(path)
+	if strings.HasPrefix(path, "\\") {
+		path = DefaultSystemVolumeName + path
+	}
+	return filepath.IsAbs(path)
+}
+
+// GetAbsolutePath returns an absolute path rooted
+// to C:\\ on Windows.
+func GetAbsolutePath(path string) string {
+	path = filepath.Clean(path)
+	if len(path) >= 2 && strings.EqualFold(path[:2], DefaultSystemVolumeName) {
+		return path
+	}
+	return DefaultSystemVolumeName + path
+}


### PR DESCRIPTION
Currently, mounts are not supported for WCOW builds, see #5678. This commit introduces support for bind and cache mounts (through the dockerfile frontend). The remaining two require a little more work and consultation with the platform teams for enlightment.

WIP Checklist:
- [x] Support for bind mounts
- [x] Support for cache mounts
- [x] add frontend/dockerfile integration tests
- [x] add client integration tests (not all, others waiting complete `llb.AddMount` support)
- [ ] add documentation

Addresses part of https://github.com/moby/buildkit/issues/5678
Fixes #5603

---

### Demo

Prep the context directory:

```powershell
mkdir mounts-demo
cd mounts-demo
mkdir temp
echo "hello: root" > root.txt
echo "hello: inner" > .\temp\inner.txt
```

Dockerfile:
```dockerfile
FROM mcr.microsoft.com/windows/nanoserver:ltsc2022 AS base
# this is needed for the access of the mounts
USER ContainerAdministrator

# cache mount example
RUN --mount=type=cache,target=/mycache echo "hello" > \mycache\foo
RUN --mount=type=cache,target=/mycache dir \mycache\foo

# bind mount examples
FROM base
# bind root of the context dir
RUN --mount=type=bind,target=/out type out\root.txt
# bind an inner directory (/temp) in the context
RUN --mount=type=bind,src=/temp,dst=/out type out\inner.txt

FROM wintools/nanoserver AS tools
RUN mkdir \bin
RUN copy \Windows\System32\whoami.exe \bin\whoami.exe


FROM base
# bind mount from another stage
RUN --mount=type=bind,from=tools,src=/bin,dst=/bin \bin\whoami.exe
```

Build command:
```powershell
buildctl build --frontend dockerfile.v0 `
--local context=. --local dockerfile=. `
--output type=image,name=docker.io/profnandaa/mount-test,push=false `
--progress plain --no-cache
```

Build log:
```
#8 [base 2/3] RUN --mount=type=cache,target=/mycache echo "hello" > mycachefoo
#8 ...

#9 [tools 2/3] RUN mkdir bin
#9 DONE 2.8s

#8 [base 2/3] RUN --mount=type=cache,target=/mycache echo "hello" > mycachefoo
#8 DONE 2.8s

#10 [base 3/3] RUN --mount=type=cache,target=/mycache dir mycachefoo
#10 ...

#11 [tools 3/3] RUN copy WindowsSystem32whoami.exe binwhoami.exe
#11 8.133         1 file(s) copied.
#11 ...

#10 [base 3/3] RUN --mount=type=cache,target=/mycache dir mycachefoo
#10 8.217  Volume in drive C has no label.
#10 8.218  Volume Serial Number is 1E6D-2BB8
#10 8.218
#10 8.218  Directory of C:\mycache
#10 8.218
#10 8.222 02/06/2025  02:52 PM                10 foo
#10 8.222                1 File(s)             10 bytes
#10 8.222                0 Dir(s)  389,156,036,608 bytes free
#10 ...

#11 [tools 3/3] RUN copy WindowsSystem32whoami.exe binwhoami.exe
#11 DONE 8.6s

#10 [base 3/3] RUN --mount=type=cache,target=/mycache dir mycachefoo
#10 DONE 8.6s

#12 [stage-3 1/1] RUN --mount=type=bind,from=tools,src=/bin,dst=/bin binwhoami.exe
#12 4.449 user manager\containeradministrator
#12 DONE 4.9s

#13 exporting to image
#13 exporting layers
```