### PR TITLE
testutil: set cdi spec dir with config

### DIFF
--- a/util/testutil/workers/containerd.go
+++ b/util/testutil/workers/containerd.go
@@ -212,7 +212,6 @@ disabled_plugins = ["io.containerd.grpc.v1.cri"]
 		"--containerd-worker=true",
 		"--containerd-worker-addr", address,
 		"--containerd-worker-labels=org.mobyproject.buildkit.worker.sandbox=true", // Include use of --containerd-worker-labels to trigger https://github.com/moby/buildkit/pull/603
-		"--cdi-spec-dir=" + cfg.CDISpecDir,
 	}
 	buildkitdArgs = applyBuildkitdPlatformFlags(buildkitdArgs)
 	buildkitdArgs = append(buildkitdArgs, snBuildkitdArgs...)

--- a/util/testutil/workers/oci.go
+++ b/util/testutil/workers/oci.go
@@ -52,7 +52,6 @@ func (s *OCI) New(ctx context.Context, cfg *integration.BackendConfig) (integrat
 		"--containerd-worker=false",
 		"--oci-worker-gc=false",
 		"--oci-worker-labels=org.mobyproject.buildkit.worker.sandbox=true",
-		"--cdi-spec-dir=" + cfg.CDISpecDir,
 	}
 
 	if s.Snapshotter != "" {

--- a/util/testutil/workers/util.go
+++ b/util/testutil/workers/util.go
@@ -25,6 +25,20 @@ func (osp otelSocketPath) UpdateConfigFile(in string) string {
 `, in, osp)
 }
 
+func withCDISpecDir(specDir string) integration.ConfigUpdater {
+	return cdiSpecDir(specDir)
+}
+
+type cdiSpecDir string
+
+func (csd cdiSpecDir) UpdateConfigFile(in string) string {
+	return fmt.Sprintf(`%s
+
+[cdi]
+  specDirs = [%q]
+`, in, csd)
+}
+
 func runBuildkitd(
 	conf *integration.BackendConfig,
 	args []string,
@@ -61,7 +75,11 @@ func runBuildkitd(
 	deferF.Append(func() error { return os.RemoveAll(tmpdir) })
 
 	cfgfile, err := integration.WriteConfig(
-		append(conf.DaemonConfig, withOTELSocketPath(getTraceSocketPath(tmpdir))))
+		append(conf.DaemonConfig,
+			withOTELSocketPath(getTraceSocketPath(tmpdir)),
+			withCDISpecDir(conf.CDISpecDir),
+		),
+	)
 	if err != nil {
 		return "", "", nil, err
 	}


### PR DESCRIPTION
https://github.com/docker/buildx/actions/runs/13273311632/job/37057606640#step:7:10250

```
2025/02/11 22:02:30 Incorrect Usage. flag provided but not defined: -cdi-spec-dir
2025/02/11 22:02:30 
2025/02/11 22:02:30 NAME:
2025/02/11 22:02:30    buildkitd - build daemon
2025/02/11 22:02:30 
2025/02/11 22:02:30 USAGE:
2025/02/11 22:02:30    buildkitd [global options] command [command options] [arguments...]
```