### PR TITLE
fix: cdi: add appdefaults.CDISpecDirs for windows

### DIFF
--- a/docs/cdi.md
+++ b/docs/cdi.md
@@ -8,6 +8,9 @@ name.
 Since BuildKit 0.20.0, you can access devices using the CDI interface. This
 allows you to use devices like GPUs in your builds.
 
+> [!NOTE]
+> CDI support is yet to be tested on Windows.
+
 ## Usage
 
 To use CDI with BuildKit, you need to create the [CDI configuration file](https://github.com/cncf-tags/container-device-interface/blob/main/SPEC.md#cdi-json-specification)

--- a/util/appdefaults/appdefaults_windows.go
+++ b/util/appdefaults/appdefaults_windows.go
@@ -18,7 +18,7 @@ var (
 
 var (
 	UserCNIConfigPath = DefaultCNIConfigPath
-	CDISpecDirs       []string
+	CDISpecDirs       = []string{filepath.Join(os.Getenv("ProgramData"), "buildkitd", "cdi")}
 )
 
 func UserAddress() string {


### PR DESCRIPTION
Since CDI support is enabled by default, add a default CDI spec directory for Windows. Without this, the
buildkitd fails to start with error:

	buildkitd: No CDI specification directories specified

Also add a note on the docs that the support is yet to be tested on Windows.