### PR TITLE
vendor: github.com/package-url/packageurl-go v0.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.0
 	github.com/opencontainers/runtime-spec v1.2.0
 	github.com/opencontainers/selinux v1.11.1
-	github.com/package-url/packageurl-go v0.1.1-0.20220428063043-89078438f170
+	github.com/package-url/packageurl-go v0.1.1
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/profile v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -314,8 +314,8 @@ github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626/go.
 github.com/opencontainers/selinux v1.9.1/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/opencontainers/selinux v1.11.1 h1:nHFvthhM0qY8/m+vfhJylliSshm8G1jJ2jDMcgULaH8=
 github.com/opencontainers/selinux v1.11.1/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
-github.com/package-url/packageurl-go v0.1.1-0.20220428063043-89078438f170 h1:DiLBVp4DAcZlBVBEtJpNWZpZVq0AEeCY7Hqk8URVs4o=
-github.com/package-url/packageurl-go v0.1.1-0.20220428063043-89078438f170/go.mod h1:uQd4a7Rh3ZsVg5j0lNyAfyxIeGde9yrlhjF78GzeW0c=
+github.com/package-url/packageurl-go v0.1.1 h1:KTRE0bK3sKbFKAk3yy63DpeskU7Cvs/x/Da5l+RtzyU=
+github.com/package-url/packageurl-go v0.1.1/go.mod h1:uQd4a7Rh3ZsVg5j0lNyAfyxIeGde9yrlhjF78GzeW0c=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/petermattis/goid v0.0.0-20240813172612-4fcff4a6cae7 h1:Dx7Ovyv/SFnMFw3fD4oEoeorXc6saIiQ23LrGLth0Gw=

--- a/vendor/github.com/package-url/packageurl-go/Makefile
+++ b/vendor/github.com/package-url/packageurl-go/Makefile
@@ -1,11 +1,7 @@
 .PHONY: test clean lint
 
 test:
-	curl -L https://raw.githubusercontent.com/package-url/purl-spec/master/test-suite-data.json -o testdata/test-suite-data.json
 	go test -v -cover ./...
-
-clean:
-	find . -name "test-suite-data.json" | xargs rm -f
 
 lint:
 	go get -u golang.org/x/lint/golint

--- a/vendor/github.com/package-url/packageurl-go/README.md
+++ b/vendor/github.com/package-url/packageurl-go/README.md
@@ -59,16 +59,16 @@ Testing using the normal ``go test`` command. Using ``make test`` will pull the 
 
 ```
 $ make test
-curl -L https://raw.githubusercontent.com/package-url/purl-test-suite/master/test-suite-data.json -o testdata/test-suite-data.json
-  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                 Dload  Upload   Total   Spent    Left  Speed
-100  7181  100  7181    0     0   1202      0  0:00:05  0:00:05 --:--:--  1611
 go test -v -cover ./...
 === RUN   TestFromStringExamples
 --- PASS: TestFromStringExamples (0.00s)
 === RUN   TestToStringExamples
 --- PASS: TestToStringExamples (0.00s)
+=== RUN   TestStringer
+--- PASS: TestStringer (0.00s)
+=== RUN   TestQualifiersMapConversion
+--- PASS: TestQualifiersMapConversion (0.00s)
 PASS
-coverage: 94.7% of statements
-ok      github.com/package-url/packageurl-go    0.002s
+coverage: 90.7% of statements
+ok      github.com/package-url/packageurl-go    0.004s  coverage: 90.7% of statements
 ```

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -670,7 +670,7 @@ github.com/opencontainers/runtime-tools/validate/capabilities
 github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label
 github.com/opencontainers/selinux/pkg/pwalkdir
-# github.com/package-url/packageurl-go v0.1.1-0.20220428063043-89078438f170
+# github.com/package-url/packageurl-go v0.1.1
 ## explicit; go 1.17
 github.com/package-url/packageurl-go
 # github.com/pelletier/go-toml v1.9.5


### PR DESCRIPTION
using a tagged release; picking the nearest release (newer versions are available, but would bring a larger diff)

full diff: https://github.com/package-url/packageurl-go/compare/89078438f170...v0.1.1