### PR TITLE
verifier: do not run invalid platforms check when there are no results

### DIFF
--- a/exporter/verifier/platforms.go
+++ b/exporter/verifier/platforms.go
@@ -19,12 +19,13 @@ func CheckInvalidPlatforms[T comparable](ctx context.Context, res *result.Result
 		return nil, err
 	}
 
-	if req.Request != "" {
-		return nil, nil
-	}
-
-	if _, ok := res.Metadata[exptypes.ExporterPlatformsKey]; len(res.Refs) > 0 && !ok {
-		return nil, errors.Errorf("build result contains multiple refs without platforms mapping")
+	if _, ok := res.Metadata[exptypes.ExporterPlatformsKey]; !ok {
+		if len(res.Refs) > 0 {
+			return nil, errors.Errorf("build result contains multiple refs without platforms mapping")
+		} else if res.IsEmpty() {
+			// No results and no exporter key. Don't run this check.
+			return nil, nil
+		}
 	}
 
 	isMap := len(res.Refs) > 0

--- a/solver/result/result.go
+++ b/solver/result/result.go
@@ -110,6 +110,20 @@ func (r *Result[T]) EachRef(fn func(T) error) (err error) {
 	return err
 }
 
+// IsEmpty returns true if this result does not refer to
+// any references.
+func (r *Result[T]) IsEmpty() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if len(r.Refs) > 0 {
+		return false
+	}
+
+	var zero T
+	return r.Ref == zero
+}
+
 // EachRef iterates over references in both a and b.
 // a and b are assumed to be of the same size and map their references
 // to the same set of keys


### PR DESCRIPTION
When `--call=lint` or `--call=outline` were used, the intention wasn't to run this check because the result doesn't have a platform. When those checks are run, there is no exporter platforms key.

We would check `Request` from the request operations, but this wasn't a reliable way to determine whether the result was from a lint because it is possible for subrequests to have different frontend attributes than the primary request and the primary request would sometimes not have the `requestid` attribute set.

Instead of detecting a subrequest with that method, the check has been updated to exit if there are no references and if there is no exporter key.

Fixes #5693.