### PR TITLE
http: Support additional request headers

### DIFF
--- a/solver/pb/attr.go
+++ b/solver/pb/attr.go
@@ -21,6 +21,7 @@ const AttrHTTPPerm = "http.perm"
 const AttrHTTPUID = "http.uid"
 const AttrHTTPGID = "http.gid"
 const AttrHTTPAuthHeaderSecret = "http.authheadersecret"
+const AttrHTTPHeaderPrefix = "http.header."
 
 const AttrImageResolveMode = "image.resolvemode"
 const AttrImageResolveModeDefault = "default"

--- a/solver/pb/caps.go
+++ b/solver/pb/caps.go
@@ -36,6 +36,7 @@ const (
 	CapSourceHTTPPerm     apicaps.CapID = "source.http.perm"
 	// NOTE the historical typo
 	CapSourceHTTPUIDGID apicaps.CapID = "soruce.http.uidgid"
+	CapSourceHTTPHeader apicaps.CapID = "source.http.header"
 
 	CapSourceOCILayout apicaps.CapID = "source.ocilayout"
 
@@ -238,13 +239,19 @@ func init() {
 	})
 
 	Caps.Init(apicaps.Cap{
-		ID:      CapSourceOCILayout,
+		ID:      CapSourceHTTPUIDGID,
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})
 
 	Caps.Init(apicaps.Cap{
-		ID:      CapSourceHTTPUIDGID,
+		ID:      CapSourceHTTPHeader,
+		Enabled: true,
+		Status:  apicaps.CapStatusExperimental,
+	})
+
+	Caps.Init(apicaps.Cap{
+		ID:      CapSourceOCILayout,
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})

--- a/source/http/identifier.go
+++ b/source/http/identifier.go
@@ -26,6 +26,12 @@ type HTTPIdentifier struct {
 	UID              int
 	GID              int
 	AuthHeaderSecret string
+	Header           []HeaderField
+}
+
+type HeaderField struct {
+	Name  string
+	Value string
 }
 
 var _ source.Identifier = (*HTTPIdentifier)(nil)


### PR DESCRIPTION
Support additional request header fields for HTTP sources, "Accept" and
"User-Agent" as a start.

The "Accept" header is required in some cases and some servers may vary
the response body based on the header value.

The "User-Agent" header may be useful in custom frontends and
potentially other cases.

 - llb: Add `llb.Header` and `HTTPInfo.Header` to allow `client/llb`
   users to set these header fields on HTTP sources. The argument to
   `llb.Header` is a struct to effectively limit header fields to a
   subset.
 - llb: Define and flag new `source.http.header` capability when
   `llb.Header` is used.
 - solver: Define new `http.header.` source attribute prefix. Giving
   each header field its own attribute (opposed to JSON encoding the
   header struct) will allow source policy to make assertions on
   individual header fields.
 - source/http: Parse `http.header.` attributes into a sorted slice and
   include them in cache key digest.
 - source/http: Set request headers accordingly.