### PR TITLE
http: Support authentication

### DIFF
--- a/solver/pb/attr.go
+++ b/solver/pb/attr.go
@@ -20,6 +20,7 @@ const AttrHTTPFilename = "http.filename"
 const AttrHTTPPerm = "http.perm"
 const AttrHTTPUID = "http.uid"
 const AttrHTTPGID = "http.gid"
+const AttrHTTPAuthHeaderSecret = "http.authheadersecret"
 
 const AttrImageResolveMode = "image.resolvemode"
 const AttrImageResolveModeDefault = "default"

--- a/solver/pb/caps.go
+++ b/solver/pb/caps.go
@@ -31,9 +31,11 @@ const (
 	CapSourceGitSubdir        apicaps.CapID = "source.git.subdir"
 
 	CapSourceHTTP         apicaps.CapID = "source.http"
+	CapSourceHTTPAuth     apicaps.CapID = "source.http.auth"
 	CapSourceHTTPChecksum apicaps.CapID = "source.http.checksum"
 	CapSourceHTTPPerm     apicaps.CapID = "source.http.perm"
-	CapSourceHTTPUIDGID   apicaps.CapID = "soruce.http.uidgid"
+	// NOTE the historical typo
+	CapSourceHTTPUIDGID apicaps.CapID = "soruce.http.uidgid"
 
 	CapSourceOCILayout apicaps.CapID = "source.ocilayout"
 
@@ -225,6 +227,12 @@ func init() {
 
 	Caps.Init(apicaps.Cap{
 		ID:      CapSourceHTTPPerm,
+		Enabled: true,
+		Status:  apicaps.CapStatusExperimental,
+	})
+
+	Caps.Init(apicaps.Cap{
+		ID:      CapSourceHTTPAuth,
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})

--- a/source/http/identifier.go
+++ b/source/http/identifier.go
@@ -18,13 +18,14 @@ func NewHTTPIdentifier(str string, tls bool) (*HTTPIdentifier, error) {
 }
 
 type HTTPIdentifier struct {
-	TLS      bool
-	URL      string
-	Checksum digest.Digest
-	Filename string
-	Perm     int
-	UID      int
-	GID      int
+	TLS              bool
+	URL              string
+	Checksum         digest.Digest
+	Filename         string
+	Perm             int
+	UID              int
+	GID              int
+	AuthHeaderSecret string
 }
 
 var _ source.Identifier = (*HTTPIdentifier)(nil)

--- a/source/http/source.go
+++ b/source/http/source.go
@@ -181,12 +181,10 @@ func (hs *httpSourceHandler) CacheKey(ctx context.Context, g session.Group, inde
 		return "", "", nil, false, errors.Wrapf(err, "failed to search metadata for %s", uh)
 	}
 
-	req, err := http.NewRequest("GET", hs.src.URL, nil)
+	req, err := hs.newHTTPRequest(ctx)
 	if err != nil {
 		return "", "", nil, false, err
 	}
-	req = req.WithContext(ctx)
-	req.Header.Add("User-Agent", version.UserAgent())
 	m := map[string]cacheRefMetadata{}
 
 	// If we request a single ETag in 'If-None-Match', some servers omit the
@@ -443,11 +441,10 @@ func (hs *httpSourceHandler) Snapshot(ctx context.Context, g session.Group) (cac
 		}
 	}
 
-	req, err := http.NewRequest("GET", hs.src.URL, nil)
+	req, err := hs.newHTTPRequest(ctx)
 	if err != nil {
 		return nil, err
 	}
-	req = req.WithContext(ctx)
 
 	client := hs.client(g)
 
@@ -469,6 +466,17 @@ func (hs *httpSourceHandler) Snapshot(ctx context.Context, g session.Group) (cac
 	}
 
 	return ref, nil
+}
+
+func (hs *httpSourceHandler) newHTTPRequest(ctx context.Context) (*http.Request, error) {
+	req, err := http.NewRequest("GET", hs.src.URL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("User-Agent", version.UserAgent())
+
+	return req.WithContext(ctx), nil
 }
 
 func getFileName(urlStr, manualFilename string, resp *http.Response) string {


### PR DESCRIPTION
Support authentication for HTTP sources.

 - llb: Define general `llb.AuthOption` interface composed of `HTTPOption` and `GitOption`.
 - llb: Refactor `llb.AuthHeaderSecret` to return an `llb.AuthOption` so it may be used with both `llb.Git` and `llb.HTTP`.
 - llb: Define `HTTPInfo.AuthHeaderSecret`.
 - llb: Define and flag new `source.http.auth` capability when `HTTPInfo.AuthHeaderSecret` is set.
 - solver: Define new `http.auth` source attribute.
 - source/http: If an `http.auth` attribute is specified, resolve a secret named by its value and set the "Authorization" request header.