### PR TITLE
gha: allow url_v2 input attribute

### DIFF
--- a/cache/remotecache/gha/gha.go
+++ b/cache/remotecache/gha/gha.go
@@ -39,6 +39,7 @@ const (
 	attrTimeout    = "timeout"
 	attrToken      = "token"
 	attrURL        = "url"
+	attrURLV2      = "url_v2"
 	attrRepository = "repository"
 	attrGHToken    = "ghtoken"
 	attrAPIVersion = "version"
@@ -78,6 +79,12 @@ func getConfig(attrs map[string]string) (*Config, error) {
 			return nil, errors.Wrapf(err, "failed to parse api version %q, expected positive integer", apiVersion)
 		}
 		apiVersionInt = int(i)
+	}
+	if apiVersionInt != 1 {
+		if v, ok := attrs[attrURLV2]; ok {
+			url = v
+			apiVersionInt = 2
+		}
 	}
 	// best effort on old clients
 	if apiVersionInt == 0 {

--- a/cmd/buildctl/build/util.go
+++ b/cmd/buildctl/build/util.go
@@ -21,25 +21,23 @@ func loadGithubEnv(cache client.CacheOptionsEntry) (client.CacheOptionsEntry, er
 		if v, ok := os.LookupEnv("ACTIONS_CACHE_SERVICE_V2"); ok {
 			if b, err := strconv.ParseBool(v); err == nil && b {
 				version = "2"
-				cache.Attrs["version"] = version
 			}
 		}
 	}
 
-	if _, ok := cache.Attrs["url"]; !ok {
-		if version == "2" {
-			url, ok := os.LookupEnv("ACTIONS_RESULTS_URL")
-			if !ok {
-				return cache, errors.New("cache with type gha requires url parameter or $ACTIONS_RESULTS_URL")
-			}
-			cache.Attrs["url"] = url
-		} else {
-			url, ok := os.LookupEnv("ACTIONS_CACHE_URL")
-			if !ok {
-				return cache, errors.New("cache with type gha requires url parameter or $ACTIONS_CACHE_URL")
-			}
-			cache.Attrs["url"] = url
+	if _, ok := cache.Attrs["url_v2"]; !ok && version == "2" {
+		url, ok := os.LookupEnv("ACTIONS_RESULTS_URL")
+		if !ok {
+			return cache, errors.New("cache with type gha requires url parameter or $ACTIONS_RESULTS_URL")
 		}
+		cache.Attrs["url_v2"] = url
+	}
+	if _, ok := cache.Attrs["url"]; !ok {
+		url, ok := os.LookupEnv("ACTIONS_CACHE_URL")
+		if !ok {
+			return cache, errors.New("cache with type gha requires url parameter or $ACTIONS_CACHE_URL")
+		}
+		cache.Attrs["url"] = url
 	}
 
 	if _, ok := cache.Attrs["token"]; !ok {


### PR DESCRIPTION
If `url_v2` is sent it switches to API v2. Separate field would be needed so client can send either `url` or `url_v2` if they don't know if the buildkit can handle V2 URLs or not.