### PR TITLE
remove unused emulators from exported image

### DIFF
--- a/solver/llbsolver/ops/exec_binfmt.go
+++ b/solver/llbsolver/ops/exec_binfmt.go
@@ -27,7 +27,6 @@ var qemuArchMap = map[string]string{
 	"riscv64": "riscv64",
 	"arm":     "arm",
 	"s390x":   "s390x",
-	"ppc64":   "ppc64",
 	"ppc64le": "ppc64le",
 	"386":     "i386",
 }


### PR DESCRIPTION
New emulators that have been added to binfmt image are not actually referenced from the buildkit embedded loader. They are also rare enough not to be worth including. BuildKit can still use these emulators if they are installed into the kernel externally (what is recommended anyway).