### PR TITLE
dockerfile: update runc to 1.2.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:master
 
-ARG RUNC_VERSION=v1.2.4
+ARG RUNC_VERSION=v1.2.5
 ARG CONTAINERD_VERSION=v2.0.2
 # CONTAINERD_ALT_VERSION_... defines fallback containerd version for integration tests
 ARG CONTAINERD_ALT_VERSION_17=v1.7.25


### PR DESCRIPTION
This is the fifth patch release in the 1.2.z series of runc. It primarily fixes an issue caused by an upstream systemd bug.

* There was a regression in systemd v230 which made the way we define device rule restrictions require a systemctl daemon-reload for our transient units. This caused issues for workloads using NVIDIA GPUs. Workaround the upstream regression by re-arranging how the unit properties are defined.
* Dependency github.com/cyphar/filepath-securejoin is updated to v0.4.1, to allow projects that vendor runc to bump it as well.
* CI: fixed criu-dev compilation.
* Dependency golang.org/x/net is updated to 0.33.0.

diff: [opencontainers/runc@v1.2.4...v1.2.5](https://github.com/opencontainers/runc/compare/v1.2.4...v1.2.5)