### PR TITLE
mark Windows 2025 tests as non-blockin

### DIFF
--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -71,6 +71,7 @@ jobs:
 
   test-windows-amd64:
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.os == 'windows-2025' }}
     needs:
       - build
     env:


### PR DESCRIPTION
**Summary**
Mark Windows 2025 tests as non-blocking by adding `continue-on-error: true`. This allows failures on Windows 2025 to be treated as warnings while keeping Windows 2022 required.

**Changes:**
- Added `continue-on-error: true` for Windows 2025 in the test matrix.

**Why?**
- some of Windows 2025 tests are flaky.