### PR TITLE
cache(gha): don't require url attr if url_v2 is set

### DIFF
--- a/cache/remotecache/gha/gha.go
+++ b/cache/remotecache/gha/gha.go
@@ -63,10 +63,6 @@ func getConfig(attrs map[string]string) (*Config, error) {
 	if !ok {
 		scope = "buildkit"
 	}
-	url, ok := attrs[attrURL]
-	if !ok {
-		return nil, errors.Errorf("url not set for github actions cache")
-	}
 	token, ok := attrs[attrToken]
 	if !ok {
 		return nil, errors.Errorf("token not set for github actions cache")
@@ -80,11 +76,18 @@ func getConfig(attrs map[string]string) (*Config, error) {
 		}
 		apiVersionInt = int(i)
 	}
+	var url string
 	if apiVersionInt != 1 {
 		if v, ok := attrs[attrURLV2]; ok {
 			url = v
 			apiVersionInt = 2
 		}
+	}
+	if v, ok := attrs[attrURL]; ok && url == "" {
+		url = v
+	}
+	if url == "" {
+		return nil, errors.Errorf("url not set for github actions cache")
 	}
 	// best effort on old clients
 	if apiVersionInt == 0 {


### PR DESCRIPTION
relates to https://github.com/docker/buildx/pull/3001#issuecomment-2663752020

`url` will always be empty if cache service v2 is detected and `url_v2` set.