### PR TITLE
refactor: avoid unnecessary calls to platforms.DefaultSpec()

### DIFF
--- a/exporter/containerimage/exptypes/parse.go
+++ b/exporter/containerimage/exptypes/parse.go
@@ -32,7 +32,7 @@ func ParsePlatforms(meta map[string][]byte) (Platforms, error) {
 		return ps, nil
 	}
 
-	p := platforms.DefaultSpec()
+	var p ocispecs.Platform
 	if imgConfig, ok := meta[ExporterImageConfigKey]; ok {
 		var img ocispecs.Image
 		err := json.Unmarshal(imgConfig, &img)
@@ -51,6 +51,8 @@ func ParsePlatforms(meta map[string][]byte) (Platforms, error) {
 		} else if img.OS != "" || img.Architecture != "" {
 			return Platforms{}, errors.Errorf("invalid image config: os and architecture must be specified together")
 		}
+	} else {
+		p = platforms.DefaultSpec()
 	}
 	p = platforms.Normalize(p)
 	pk := platforms.FormatAll(p)

--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -156,9 +156,11 @@ func Build(ctx context.Context, c client.Client) (_ *client.Result, err error) {
 			return nil, nil, nil, err
 		}
 
-		p := platforms.DefaultSpec()
+		var p ocispecs.Platform
 		if platform != nil {
 			p = *platform
+		} else {
+			p = platforms.DefaultSpec()
 		}
 		scanTargets.Store(platforms.FormatAll(platforms.Normalize(p)), scanTarget)
 

--- a/frontend/dockerui/build.go
+++ b/frontend/dockerui/build.go
@@ -54,9 +54,11 @@ func (bc *Client) Build(ctx context.Context, fn BuildFunc) (*ResultBuilder, erro
 				}
 			}
 
-			p := platforms.DefaultSpec()
+			var p ocispecs.Platform
 			if tp != nil {
 				p = *tp
+			} else {
+				p = platforms.DefaultSpec()
 			}
 
 			// in certain conditions we allow input platform to be extended from base image

--- a/frontend/dockerui/config.go
+++ b/frontend/dockerui/config.go
@@ -148,9 +148,11 @@ func (bc *Client) BuildOpts() client.BuildOpts {
 func (bc *Client) init() error {
 	opts := bc.bopts.Opts
 
-	defaultBuildPlatform := platforms.Normalize(platforms.DefaultSpec())
+	var defaultBuildPlatform ocispecs.Platform
 	if workers := bc.bopts.Workers; len(workers) > 0 && len(workers[0].Platforms) > 0 {
 		defaultBuildPlatform = workers[0].Platforms[0]
+	} else {
+		defaultBuildPlatform = platforms.Normalize(platforms.DefaultSpec())
 	}
 	buildPlatforms := []ocispecs.Platform{defaultBuildPlatform}
 	targetPlatforms := []ocispecs.Platform{}
@@ -459,9 +461,11 @@ func (bc *Client) NamedContext(name string, opt ContextOpt) (*NamedContext, erro
 	}
 	name = strings.TrimSuffix(reference.FamiliarString(named), ":latest")
 
-	pp := platforms.DefaultSpec()
+	var pp ocispecs.Platform
 	if opt.Platform != nil {
 		pp = *opt.Platform
+	} else {
+		pp = platforms.DefaultSpec()
 	}
 	pname := name + "::" + platforms.FormatAll(platforms.Normalize(pp))
 	nc, err := bc.namedContext(name, pname, opt)

--- a/solver/llbsolver/ops/exec.go
+++ b/solver/llbsolver/ops/exec.go
@@ -123,7 +123,7 @@ func (e *ExecOp) CacheMap(ctx context.Context, g session.Group, index int) (*sol
 	}
 	op.Meta.ProxyEnv = nil
 
-	p := platforms.DefaultSpec()
+	var p ocispecs.Platform
 	if e.platform != nil {
 		p = ocispecs.Platform{
 			OS:           e.platform.OS,
@@ -132,6 +132,8 @@ func (e *ExecOp) CacheMap(ctx context.Context, g session.Group, index int) (*sol
 			OSVersion:    e.platform.OSVersion,
 			OSFeatures:   e.platform.OSFeatures,
 		}
+	} else {
+		p = platforms.DefaultSpec()
 	}
 
 	// Special case for cache compatibility with buggy versions that wrongly


### PR DESCRIPTION
I came across a number of calls to `platforms.DefaultSpec()` that were not necessary. That prompted me to take a look various other similar places.

At least on Windows, the call is a has some cost till doing a sycall `RtlGetNtVersionNumbers()`.