### PR TITLE
cache: change the default cache mode to max

### DIFF
--- a/cmd/buildctl/build/exportcache.go
+++ b/cmd/buildctl/build/exportcache.go
@@ -35,7 +35,7 @@ func parseExportCacheCSV(s string) (client.CacheOptionsEntry, error) {
 		return ex, errors.New("--export-cache requires type=<type>")
 	}
 	if _, ok := ex.Attrs["mode"]; !ok {
-		ex.Attrs["mode"] = "min"
+		ex.Attrs["mode"] = "max"
 	}
 	if ex.Type == "gha" {
 		return loadGithubEnv(ex)
@@ -54,7 +54,7 @@ func ParseExportCache(exportCaches []string) ([]client.CacheOptionsEntry, error)
 			exports = append(exports, client.CacheOptionsEntry{
 				Type: "registry",
 				Attrs: map[string]string{
-					"mode": "min",
+					"mode": "max",
 					"ref":  exportCache,
 				},
 			})

--- a/cmd/buildctl/build/exportcache_test.go
+++ b/cmd/buildctl/build/exportcache_test.go
@@ -21,7 +21,7 @@ func TestParseExportCache(t *testing.T) {
 					Type: "registry",
 					Attrs: map[string]string{
 						"ref":  "example.com/foo/bar",
-						"mode": "min",
+						"mode": "max",
 					},
 				},
 			},
@@ -33,7 +33,7 @@ func TestParseExportCache(t *testing.T) {
 					Type: "registry",
 					Attrs: map[string]string{
 						"ref":  "example.com/foo/bar",
-						"mode": "min",
+						"mode": "max",
 					},
 				},
 			},


### PR DESCRIPTION
Usually whoever sets buildkit's cache options wants to use the cache as much as possible. The 1% of users that want to use the cache but not too much should explicitly set `mode=min`.

Many users think they set up the cache properly because it works but don't know it could be so much better and end up having a worse experience.

The mode setting is not obvious to all users, let's make the default sane.