### PR TITLE
dockerfile: normalize platform in image config

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -815,6 +815,7 @@ func toDispatchState(ctx context.Context, dt []byte, opt ConvertOpt) (*dispatchS
 			target.image.OSFeatures = append([]string{}, platformOpt.targetPlatform.OSFeatures...)
 		}
 	}
+	target.image.Platform = platforms.Normalize(target.image.Platform)
 
 	return target, nil
 }


### PR DESCRIPTION
Base image may use unnormalized platform so if platform is inherited normalize needs to be called again.

OCI  specs lib could also do it in `MarshalJSON`. 

fix #5774

changed in https://github.com/moby/buildkit/pull/5714