### PR TITLE
fix trace blob detected as leaked blob in tests

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -311,6 +311,7 @@ func (c *Controller) ListenBuildHistory(req *controlapi.BuildHistoryRequest, srv
 
 func (c *Controller) UpdateBuildHistory(ctx context.Context, req *controlapi.UpdateBuildHistoryRequest) (*controlapi.UpdateBuildHistoryResponse, error) {
 	if req.Delete {
+		c.history.Finalize(ctx, req.Ref) // ignore error
 		err := c.history.Delete(ctx, req.Ref)
 		return &controlapi.UpdateBuildHistoryResponse{}, err
 	}


### PR DESCRIPTION
Trace blob is created 3 seconds after build completion. If this happens after test has cleaned all history records and before it checks for leaked blobs, test can report the trace blob as leaked. In practice it would be cleaned up next time containerd GC gets triggered.