### PR TITLE
fix: wcow: pause integration tests on WS2025

### DIFF
--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -71,7 +71,6 @@ jobs:
 
   test-windows-amd64:
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.os == 'windows-2025' }}
     needs:
       - build
     env:
@@ -80,7 +79,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, windows-2025]
+        os: [windows-2022]
         worker:
           - containerd
         pkg:
@@ -103,10 +102,6 @@ jobs:
           - ./frontend/dockerfile#12-12
         include:
           - os: windows-2022
-            worker: containerd
-            pkg: ./...
-            skip-integration-tests: 1
-          - os: windows-2025
             worker: containerd
             pkg: ./...
             skip-integration-tests: 1


### PR DESCRIPTION
Since the integration tests on WS2025 are flaky,
pause them for the time being pending investigation.

Follow up on #5806