### PR TITLE
dockerfile: fix parsing syntax directive from JSON

### DIFF
--- a/frontend/dockerfile/parser/directives.go
+++ b/frontend/dockerfile/parser/directives.go
@@ -148,14 +148,16 @@ func parseDirective(key string, dt []byte, anyFormat bool) (string, string, []Ra
 	}
 
 	// use json directive, and search for { "key": "..." }
-	jsonDirective := map[string]string{}
+	jsonDirective := map[string]any{}
 	if err := json.Unmarshal(dt, &jsonDirective); err == nil {
-		if v, ok := jsonDirective[key]; ok {
-			loc := []Range{{
-				Start: Position{Line: line},
-				End:   Position{Line: line},
-			}}
-			return v, v, loc, true
+		if vAny, ok := jsonDirective[key]; ok {
+			if v, ok := vAny.(string); ok {
+				loc := []Range{{
+					Start: Position{Line: line},
+					End:   Position{Line: line},
+				}}
+				return v, v, loc, true
+			}
 		}
 	}
 

--- a/frontend/dockerfile/parser/directives_test.go
+++ b/frontend/dockerfile/parser/directives_test.go
@@ -89,7 +89,7 @@ RUN ls
 	require.True(t, ok)
 	require.Equal(t, "x", ref)
 
-	dt = `{"syntax": "foo"}`
+	dt = `{"syntax": "foo", "bar": ["abc"]}`
 	ref, _, _, ok = DetectSyntax([]byte(dt))
 	require.True(t, ok)
 	require.Equal(t, "foo", ref)


### PR DESCRIPTION
Parsing would fail if JSON had other datatypes than strings.

regression from https://github.com/moby/buildkit/pull/4962/files#diff-fcba722f8e57e1799015bdfdf19d349bb5ddf5415a50a0f30b74e300568ee076R142