### PR TITLE
integration: simplify test splitting

### DIFF
--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -110,14 +110,13 @@ jobs:
         name: Prepare
         run: |
           TESTPKG=$(echo "${{ matrix.pkg }}" | awk '-F#' '{print $1}')
-          TESTSLICE=$(echo "${{ matrix.pkg }}" | awk '-F#' '{print $2}')
           echo "TESTPKG=$TESTPKG" >> $GITHUB_ENV
           echo "TEST_REPORT_NAME=${{ github.job }}-$(echo "${{ matrix.pkg }}-${{ matrix.skip-integration-tests }}-${{ matrix.worker }}" | tr -dc '[:alnum:]-\n\r' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
           testFlags="${{ env.TESTFLAGS }}"
+          testSlice=$(echo "${{ matrix.pkg }}" | awk '-F#' '{print $2}')
           testSliceOffset=""
-          if [ -n "$TESTSLICE" ]; then
-            echo "TESTSLICE=$TESTSLICE" >> $GITHUB_ENV
-            testSliceOffset="slice=$TESTSLICE/"
+          if [ -n "$testSlice" ]; then
+            testSliceOffset="slice=$testSlice/"
           fi
           if [ -n "${{ matrix.worker }}" ]; then
             testFlags="${testFlags} --run=TestIntegration/$testSliceOffset.*/worker=${{ matrix.worker }}"


### PR DESCRIPTION
Avoid the need to pass slice config with env variable. Instead slice can be set directly in the --run filter.