### PR TITLE
prune: update free-space filter when no max-space set

### DIFF
--- a/cache/manager.go
+++ b/cache/manager.go
@@ -1096,6 +1096,9 @@ func calculateKeepBytes(totalSize int64, dstat disk.DiskStat, opt client.PruneIn
 		} else {
 			keepBytes = min(keepBytes, totalSize-excess)
 		}
+	} else if opt.MinFreeSpace != 0 && keepBytes == 0 {
+		// if only minFreeSpace is set and it doesn't match then we don't delete anything
+		keepBytes = totalSize
 	}
 
 	// but make sure we don't take the total below the reserved space


### PR DESCRIPTION
When free-space filter is set without max-space or reserved-space filter, the behaviour is that if the filter matches some records then these records would be pruned, but if it doesn't match any (there are more free space than filter sets already) then the keepBytes would be left to 0, resulting records to be deleted as if no storage constraint was set at all.