### PR TITLE
solver: fix reading secrets from any session

### DIFF
--- a/frontend/gateway/container/container.go
+++ b/frontend/gateway/container/container.go
@@ -389,14 +389,11 @@ func (gwCtr *gatewayContainer) loadSecretEnv(ctx context.Context, secretEnv []*p
 		err = gwCtr.sm.Any(ctx, gwCtr.group, func(ctx context.Context, _ string, caller session.Caller) error {
 			dt, err = secrets.GetSecret(ctx, caller, id)
 			if err != nil {
-				if errors.Is(err, secrets.ErrNotFound) && sopt.Optional {
-					return nil
-				}
 				return err
 			}
 			return nil
 		})
-		if err != nil {
+		if err != nil && !(errors.Is(err, secrets.ErrNotFound) && sopt.Optional) {
 			return nil, err
 		}
 		out = append(out, fmt.Sprintf("%s=%s", sopt.Name, string(dt)))

--- a/solver/llbsolver/ops/exec.go
+++ b/solver/llbsolver/ops/exec.go
@@ -559,14 +559,11 @@ func (e *ExecOp) loadSecretEnv(ctx context.Context, g session.Group) ([]string, 
 		err = e.sm.Any(ctx, g, func(ctx context.Context, _ string, caller session.Caller) error {
 			dt, err = secrets.GetSecret(ctx, caller, id)
 			if err != nil {
-				if errors.Is(err, secrets.ErrNotFound) && sopt.Optional {
-					return nil
-				}
 				return err
 			}
 			return nil
 		})
-		if err != nil {
+		if err != nil && !(errors.Is(err, secrets.ErrNotFound) && sopt.Optional) {
 			return nil, err
 		}
 		out = append(out, fmt.Sprintf("%s=%s", sopt.Name, string(dt)))


### PR DESCRIPTION
The current logic was incorrect in some places so that if first session randomly chosen by `Any()` returned NotFound then other sessions were not attempted.

For the main use case of mounting secrets as files the logic was correct, but it was incorrect for example for the case of adding secrets as environment variables.

fix https://github.com/docker/buildx/issues/3056
