### PR TITLE
dockerfile: fix sbom attestation for windows targets

### DIFF
--- a/frontend/dockerui/build.go
+++ b/frontend/dockerui/build.go
@@ -62,18 +62,9 @@ func (bc *Client) Build(ctx context.Context, fn BuildFunc) (*ResultBuilder, erro
 				p = platforms.DefaultSpec()
 			}
 
-			// in certain conditions we allow input platform to be extended from base image
-			if p.OS == "windows" && img.OS == p.OS {
-				if p.OSVersion == "" && img.OSVersion != "" {
-					p.OSVersion = img.OSVersion
-				}
-				if p.OSFeatures == nil && len(img.OSFeatures) > 0 {
-					p.OSFeatures = slices.Clone(img.OSFeatures)
-				}
-			}
-
-			p = platforms.Normalize(p)
 			k := platforms.FormatAll(p)
+			p = extendWindowsPlatform(p, img.Platform)
+			p = platforms.Normalize(p)
 
 			if bc.MultiPlatformRequested {
 				res.AddRef(k, ref)
@@ -128,4 +119,17 @@ func (rb *ResultBuilder) EachPlatform(ctx context.Context, fn func(ctx context.C
 		})
 	}
 	return eg.Wait()
+}
+
+func extendWindowsPlatform(p, imgP ocispecs.Platform) ocispecs.Platform {
+	// in certain conditions we allow input platform to be extended from base image
+	if p.OS == "windows" && imgP.OS == p.OS {
+		if p.OSVersion == "" && imgP.OSVersion != "" {
+			p.OSVersion = imgP.OSVersion
+		}
+		if p.OSFeatures == nil && len(imgP.OSFeatures) > 0 {
+			p.OSFeatures = slices.Clone(imgP.OSFeatures)
+		}
+	}
+	return p
 }


### PR DESCRIPTION
Because dockerui added osversion to original reference before calling res.AddRef() that meant that the sbom was looked up by the wrong key in scanTargets.Load(id) .

Currently build would fail with `ERROR: failed to solve: no scan targets for windows(10.0.17763.7009)/amd64`.

Not quite happy with the current fix. If I would keep the `OSVersion` in the key then I would need to copy the `extendWindowsPlatform` logic to `dockerfile/build` pkg as well as current helper is in `dockerui`. I guess collisions shouldn't be a problem for current patch as if multiple osversion are used by the same build then they should be set by user anyway, not detected from image. It would be better if there was some more direct way to capture the actual result key or `sbomTargets` should use some other way for storage than trying to replicate the result key outside of dockerui.

@cpuguy83 