### PR TITLE
create cdi spec folders in buildkit container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -221,6 +221,7 @@ COPY --link examples/buildctl-daemonless/buildctl-daemonless.sh /usr/bin/
 VOLUME /var/lib/buildkit
 
 FROM buildkit-export-${EXPORT_BASE} AS buildkit-export
+RUN mkdir -p /etc/cdi /var/run/cdi /etc/buildkit/cdi
 
 FROM gobuild-base AS containerd-build
 WORKDIR /go/src/github.com/containerd/containerd


### PR DESCRIPTION
BuildKit image does not have any CDI spec folders created so when running this container we have the following "CDI setup error" warnings:

```
time="2025-03-14T10:39:34Z" level=info msg="auto snapshotter: using overlayfs"
time="2025-03-14T10:39:34Z" level=warning msg="CDI setup error /etc/buildkit/cdi: failed to monitor for changes: no such file or directory"
time="2025-03-14T10:39:34Z" level=warning msg="CDI setup error /etc/cdi: failed to monitor for changes: no such file or directory"
time="2025-03-14T10:39:34Z" level=warning msg="CDI setup error /var/run/cdi: failed to monitor for changes: no such file or directory"
time="2025-03-14T10:39:34Z" level=warning msg="using host network as the default"
time="2025-03-14T10:39:34Z" level=info msg="found worker \"y0dyo8y35v6fohh1nepmgsnyz\", labels=map[org.mobyproject.buildkit.worker.executor:oci org.mobyproject.buildkit.worker.hostname:3d5bcf9351a9 org.mobyproject.buildkit.worker.network:host org.mobyproject.buildkit.worker.oci.process-mode:sandbox org.mobyproject.buildkit.worker.selinux.enabled:false org.mobyproject.buildkit.worker.snapshotter:overlayfs], platforms=[linux/amd64 linux/amd64/v2 linux/amd64/v3 linux/arm64 linux/riscv64 linux/ppc64le linux/s390x linux/386 linux/arm/v7 linux/arm/v6]"
time="2025-03-14T10:39:34Z" level=warning msg="skipping containerd worker, as \"/run/containerd/containerd.sock\" does not exist"
time="2025-03-14T10:39:34Z" level=info msg="found 1 workers, default=\"y0dyo8y35v6fohh1nepmgsnyz\""
time="2025-03-14T10:39:34Z" level=warning msg="currently, only the default worker can be used."
time="2025-03-14T10:39:34Z" level=info msg="running server on /run/buildkit/buildkitd.sock"
```

That means these folders are not monitored and therefore creating a CDI specification will not trigger a refresh of CDI devices.

Although if custom CDI specs dir is specified in buildkitd toml it will not work so keeping in draft for now. I think that should be done in Buildx repo when creating the container builder instead.