### PR TITLE
update runc to v1.2.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:master
 
-ARG RUNC_VERSION=v1.2.5
+ARG RUNC_VERSION=v1.2.6
 ARG CONTAINERD_VERSION=v2.0.4
 # CONTAINERD_ALT_VERSION_... defines fallback containerd version for integration tests
 ARG CONTAINERD_ALT_VERSION_17=v1.7.25


### PR DESCRIPTION
https://github.com/opencontainers/runc/releases/tag/v1.2.6