### PR TITLE
don't set go version in golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,6 @@
 run:
   timeout: 30m
   modules-download-mode: vendor
-  # default uses Go version from the go.mod file, fallback on the env var
-  # `GOVERSION`, fallback on 1.17: https://golangci-lint.run/usage/configuration/#run-configuration
-  go: "1.23"
 
 linters:
   enable:


### PR DESCRIPTION
similar to https://github.com/docker/buildx/pull/3069