### PR TITLE
tests: integrate mirror into worker tests

### DIFF
--- a/worker/containerd/containerd_test.go
+++ b/worker/containerd/containerd_test.go
@@ -14,6 +14,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMain(m *testing.M) {
+	defer tests.RunMirror()()
+	m.Run()
+}
+
 func init() {
 	workers.InitContainerdWorker()
 }

--- a/worker/runc/runc_test.go
+++ b/worker/runc/runc_test.go
@@ -27,6 +27,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMain(m *testing.M) {
+	defer tests.RunMirror()()
+	m.Run()
+}
+
 func newWorkerOpt(t *testing.T, processMode oci.ProcessMode) base.WorkerOpt {
 	tmpdir := t.TempDir()
 


### PR DESCRIPTION
Worker unit tests pull images from registry, but don't use the mirroring support in the integration tests and can therefore get rate-limited.