### PR TITLE
containerimage: container image exporter creates dangling images by default

### DIFF
--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -149,6 +149,16 @@ func (e *imageExporter) Resolve(ctx context.Context, id int, opt map[string]stri
 			i.storeAllowIncomplete = b
 		case exptypes.OptKeyDanglingPrefix:
 			i.danglingPrefix = v
+		case exptypes.OptKeyDanglingEmptyOnly:
+			if v == "" {
+				i.danglingEmptyOnly = true
+				continue
+			}
+			b, err := strconv.ParseBool(v)
+			if err != nil {
+				return nil, errors.Wrapf(err, "non-bool value specified for %s", k)
+			}
+			i.danglingEmptyOnly = b
 		case exptypes.OptKeyNameCanonical:
 			if v == "" {
 				i.nameCanonical = true
@@ -183,6 +193,7 @@ type imageExporterInstance struct {
 	insecure             bool
 	nameCanonical        bool
 	danglingPrefix       string
+	danglingEmptyOnly    bool
 	meta                 map[string][]byte
 }
 
@@ -247,9 +258,14 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 	}
 
 	nameCanonical := e.nameCanonical
-	if e.opts.ImageName == "" && e.danglingPrefix != "" {
-		e.opts.ImageName = e.danglingPrefix + "@" + desc.Digest.String()
-		nameCanonical = false
+	if e.danglingPrefix != "" && (!e.danglingEmptyOnly || e.opts.ImageName == "") {
+		danglingImageName := e.danglingPrefix + "@" + desc.Digest.String()
+		if e.opts.ImageName != "" {
+			e.opts.ImageName += "," + danglingImageName
+		} else {
+			e.opts.ImageName = danglingImageName
+			nameCanonical = false
+		}
 	}
 
 	if e.opts.ImageName != "" {
@@ -274,7 +290,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 				}
 
 				sfx := []string{""}
-				if nameCanonical {
+				if nameCanonical && !strings.ContainsRune(targetName, '@') {
 					sfx = append(sfx, "@"+desc.Digest.String())
 				}
 				for _, sfx := range sfx {

--- a/exporter/containerimage/exptypes/keys.go
+++ b/exporter/containerimage/exptypes/keys.go
@@ -26,10 +26,16 @@ var (
 	// Value: bool <true|false>
 	OptKeyUnpack ImageExporterOptKey = "unpack"
 
-	// Fallback image name prefix if image name isn't provided.
-	// If used, image will be named as <value>@<digest>
+	// Image name prefix to be used for tagging a dangling image.
+	// If used, image will be named as <value>@<digest> in addition
+	// to any other specified names.
 	// Value: string
 	OptKeyDanglingPrefix ImageExporterOptKey = "dangling-name-prefix"
+
+	// Only use the dangling image name as a fallback if image name isn't provided.
+	// Ignored if dangling-name-prefix is not set.
+	// Value: bool <true|false>
+	OptKeyDanglingEmptyOnly ImageExporterOptKey = "danging-name-empty-only"
 
 	// Creates additional image name with format <name>@<digest>
 	// Value: bool <true|false>


### PR DESCRIPTION
Modifies the containerd exporter to create dangling images by default. A
new exporter key has been added to keep the previous behavior where a
dangling image is only created when no image name is provided.

Related to moby/moby#48907 and moby/moby#46116.
