### PR TITLE
dockerui: Support extra entrypoint files

### DIFF
--- a/frontend/dockerui/entrypoint_file.go
+++ b/frontend/dockerui/entrypoint_file.go
@@ -1,0 +1,19 @@
+package dockerui
+
+import (
+	"path"
+	"strings"
+)
+
+type EntrypointFile struct {
+	Filename string
+	Language string
+}
+
+func (file EntrypointFile) RelativeTo(filename string) string {
+	if path.IsAbs(file.Filename) {
+		return strings.TrimPrefix(file.Filename, "/")
+	}
+
+	return path.Join(filename, "..", file.Filename)
+}


### PR DESCRIPTION
Some frontends require multiple entrypoint files. Support this use case with a new `Config.ExtraEntrypointFiles` field and `Client.ReadEntrypointFiles` method.

---

My specific use case is a [CUE based frontend](https://gitlab.wikimedia.org/dduvall/masse) and I would like to support CUE module dependencies defined in the `cue.mod/module.cue` file relative to the user configuration.