### PR TITLE
fix entitlements handling for OnDemand CDI devices

### DIFF
--- a/solver/llbsolver/vertex.go
+++ b/solver/llbsolver/vertex.go
@@ -136,6 +136,11 @@ func ValidateEntitlements(ent entitlements.Set, cdiManager *cdidevices.Manager) 
 
 				var allowedDevices []*pb.CDIDevice
 				var nonAliasedDevices []*pb.CDIDevice
+				for _, d := range cdiManager.ListDevices() {
+					if d.OnDemand && d.AutoAllow {
+						allowedDevices = append(allowedDevices, &pb.CDIDevice{Name: d.Name})
+					}
+				}
 				if cfg != nil {
 					for _, d := range op.Exec.CdiDevices {
 						if newName, ok := cfg.Devices[d.Name]; ok && newName != "" {


### PR DESCRIPTION
`OnDemand` devices are never allowed with current entitlements validation logic. That's because this kind of device is not yet registered in CDI cache at this point.