### PR TITLE
contrib: check nvidia device availability for wsl

### DIFF
--- a/contrib/cdisetup/nvidia/nvidia.go
+++ b/contrib/cdisetup/nvidia/nvidia.go
@@ -268,6 +268,13 @@ func hasNvidiaDevices() (bool, error) {
 		}
 	}
 
+	if !found {
+		// WSL-specific GPU mapping that doesn't expose PCI info.
+		if _, err := os.Stat("/dev/dxg"); err == nil {
+			found = true
+		}
+	}
+
 	return found, nil
 }
 


### PR DESCRIPTION
There is no PCI device available on WSL:

```
$ ls -al /sys/class/drm/card0/device/
total 0
drwxr-xr-x 3 root root    0 Feb 24 14:31 .
drwxr-xr-x 8 root root    0 Feb 24 14:31 ..
-rw-r--r-- 1 root root 4096 Feb 24 14:31 driver_override
drwxr-xr-x 4 root root    0 Feb 24 14:31 drm
-r--r--r-- 1 root root 4096 Feb 24 14:31 modalias
lrwxrwxrwx 1 root root    0 Feb 24 14:41 subsystem -> ../../../bus/platform
-rw-r--r-- 1 root root 4096 Feb 24 14:31 uevent
```

There is no `vendor` or `device` which typically appear for PCI-based GPUs. Since the device looks under `bus/platform` instead of `bus/pci`, it is likely a WSL-specific GPU mapping that doesn't expose PCI info.

WSL2 maps GPUs through DirectX, and the presence of `/dev/dxg` means a GPU is available but we don't know what vendor (could be Intel, Nvidia, AMD, ...).

So I think as best effort we can rely on `/dev/dxg` device to validate OnDemand setup.