### PR TITLE
ci: fix freebsd package repository

### DIFF
--- a/hack/Vagrantfile.freebsd
+++ b/hack/Vagrantfile.freebsd
@@ -11,7 +11,10 @@ Vagrant.configure("2") do |config|
     sh.inline = <<~SHELL
       #!/usr/bin/env bash
       set -eux -o pipefail
+      freebsd-version -kru
       kldload nullfs
+      # switching to "release_2" ensures compatibility with the current Vagrant box
+      sed -i '' 's/latest/release_2/' /usr/local/etc/pkg/repos/FreeBSD.conf
       pkg install -y git runj
       mkdir -p /vagrant/coverage /vagrant/.tmp/logs
     SHELL


### PR DESCRIPTION
relates to https://github.com/moby/buildkit/actions/runs/14322174133/job/40153267511#step:6:68

```
    default: Running: inline script
    default: + kldload nullfs
    default: + pkg install -y git runj
    default: Updating FreeBSD repository catalogue...
    default: FreeBSD repository is up to date.
    default: All repositories are up to date.
    default: pkg: No packages available to install matching 'runj' have been found in the repositories
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
Error: Process completed with exit code 1.
```

Latest http://pkg.freebsd.org/FreeBSD:14:amd64/latest/ does not seem compatible anymore with current Vagrant box https://portal.cloud.hashicorp.com/vagrant/discover/generic/freebsd14. Switching to `release_2` seems to do the trick:

```
    default: + sed -i '' s/latest/release_2/ /usr/local/etc/pkg/repos/FreeBSD.conf
    default: + pkg install -y git runj
    default: Updating FreeBSD repository catalogue...
    default: pkg: Repository FreeBSD has a wrong packagesite, need to re-create database
    default: Fetching meta.conf: . done
    default: Fetching data.pkg: .......... done
    default: Processing entries:
    default: Processing entries............. done
    default: FreeBSD repository update completed. 35520 packages processed.
    default: All repositories are up to date.
    default: The following 25 package(s) will be affected (of 0 checked):
    default: 
    default: New packages to be INSTALLED:
    default: 	expat: 2.6.3
    default: 	git: 2.46.2
    default: 	p5-Authen-SASL: 2.17
```

Also looking at:

```
    default: + freebsd-version -kru
    default: 14.0-RELEASE
    default: 14.0-RELEASE
    default: 14.0-RELEASE
```

I guess we could also use `release_0`: http://pkg.freebsd.org/FreeBSD:14:amd64/release_0/. WDYT @AkihiroSuda?

cc @akhramov @catap