### PR TITLE
windows: leave default PATH env to be set by the OS

### DIFF
--- a/client/llb/exec.go
+++ b/client/llb/exec.go
@@ -170,7 +170,10 @@ func (e *ExecOp) Marshal(ctx context.Context, c *Constraints) (digest.Digest, []
 			} else if e.constraints.Platform != nil {
 				os = e.constraints.Platform.OS
 			}
-			env = env.SetDefault("PATH", system.DefaultPathEnv(os))
+			// don't set PATH on Windows. #5445
+			if os != "windows" {
+				env = env.SetDefault("PATH", system.DefaultPathEnv(os))
+			}
 		} else {
 			addCap(&e.constraints, pb.CapExecMetaSetsDefaultPath)
 		}

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -683,7 +683,10 @@ func defaultImageConfig() ([]byte, error) {
 	img.Variant = pl.Variant
 	img.RootFS.Type = "layers"
 	img.Config.WorkingDir = "/"
-	img.Config.Env = []string{"PATH=" + system.DefaultPathEnv(pl.OS)}
+	// don't set default PATH on Windows. #5445
+	if pl.OS != "windows" {
+		img.Config.Env = []string{"PATH=" + system.DefaultPathEnv(pl.OS)}
+	}
 	dt, err := json.Marshal(img)
 	return dt, errors.Wrap(err, "failed to create empty image config")
 }

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -679,7 +679,10 @@ func toDispatchState(ctx context.Context, dt []byte, opt ConvertOpt) (*dispatchS
 			if d.platform != nil {
 				osName = d.platform.OS
 			}
-			d.image.Config.Env = append(d.image.Config.Env, "PATH="+system.DefaultPathEnv(osName))
+			// except for Windows, leave that to the OS. #5445
+			if osName != "windows" {
+				d.image.Config.Env = append(d.image.Config.Env, "PATH="+system.DefaultPathEnv(osName))
+			}
 		}
 
 		// initialize base metadata from image conf

--- a/frontend/dockerfile/dockerfile2llb/image.go
+++ b/frontend/dockerfile/dockerfile2llb/image.go
@@ -37,6 +37,9 @@ func emptyImage(platform ocispecs.Platform) dockerspec.DockerOCIImage {
 	img.Variant = platform.Variant
 	img.RootFS.Type = "layers"
 	img.Config.WorkingDir = "/"
-	img.Config.Env = []string{"PATH=" + system.DefaultPathEnv(platform.OS)}
+	// don't set path for Windows, leave it to the OS. #5445
+	if platform.OS != "windows" {
+		img.Config.Env = []string{"PATH=" + system.DefaultPathEnv(platform.OS)}
+	}
 	return img
 }

--- a/frontend/dockerfile/dockerfile_lint_test.go
+++ b/frontend/dockerfile/dockerfile_lint_test.go
@@ -1086,6 +1086,8 @@ FROM %s
 ENV PATH=$PAHT:/tmp/bin
 		`,
 		baseImg)
+	// not hint on Windows since default PATH is not set
+	hintStr := integration.UnixOrWindows(" (did you mean $PATH?)", "")
 	checkLinterWarnings(t, sb, &lintTestParams{
 		Dockerfile: dockerfile,
 		Warnings: []expectedLintWarning{
@@ -1093,7 +1095,7 @@ ENV PATH=$PAHT:/tmp/bin
 				RuleName:    "UndefinedVar",
 				Description: "Variables should be defined before their use",
 				URL:         "https://docs.docker.com/go/dockerfile/rule/undefined-var/",
-				Detail:      "Usage of undefined variable '$PAHT' (did you mean $PATH?)",
+				Detail:      fmt.Sprintf("Usage of undefined variable '$PAHT'%s", hintStr),
 				Level:       1,
 				Line:        3,
 			},

--- a/solver/llbsolver/ops/exec.go
+++ b/solver/llbsolver/ops/exec.go
@@ -462,7 +462,10 @@ func (e *ExecOp) Exec(ctx context.Context, g session.Group, inputs []solver.Resu
 	if e.platform != nil {
 		currentOS = e.platform.OS
 	}
-	meta.Env = addDefaultEnvvar(meta.Env, "PATH", utilsystem.DefaultPathEnv(currentOS))
+	// don't set PATH for Windows. #5445
+	if currentOS != "windows" {
+		meta.Env = addDefaultEnvvar(meta.Env, "PATH", utilsystem.DefaultPathEnv(currentOS))
+	}
 
 	secretEnv, err := e.loadSecretEnv(ctx, g)
 	if err != nil {


### PR DESCRIPTION
The PATH is very critical during container runs on Windows. Windows stores the PATH details in its
registry hive, while in unix, this is often stored in the image's config. See further details at #5445

Setting a default path like we do on Linux (which is mostly not used since the PATH is
already set in the configs), works against the expected build experience, especially when
it comes to installers and commands like `setx`.

Therefore, we skip setting the default PATH on Windows, and leave it for the OS to load it from its registry hive.

This also further supports backward compatibilitiy with the current experience with docker classic
builder.

Users wishing to explicitly store this in the configs can opt-in by using the `ENV PATH= ..` in the Dockerfile, etc.

See also the same practices on Docker Engine and Containerd:
- https://github.com/moby/moby/blob/da3b31fb2c4e83e77cf928e166982d03ba68a4e7/oci/defaults.go#L24-L33
- https://github.com/containerd/containerd/blob/041743e8afd2bb2189aa904f04bf87b9073892d3/pkg/oci/spec_opts_windows.go#L66-L69

> Follow up issue has been [opened here](https://github.com/microsoft/Windows-Containers/issues/582) for Windows platform team to consider merging PATHs from
> both registry hive and config during container run.

closes #5445 #3158