### PR TITLE
Ignore `com.apple.` extended file attributes in contenthash

### DIFF
--- a/cache/contenthash/tarsum.go
+++ b/cache/contenthash/tarsum.go
@@ -51,7 +51,7 @@ func v1TarHeaderSelect(h *tar.Header) (orderedHeaders [][2]string) {
 	for k := range pax {
 		if strings.HasPrefix(k, "SCHILY.xattr.") {
 			k = strings.TrimPrefix(k, "SCHILY.xattr.")
-			if k == "security.capability" || !strings.HasPrefix(k, "security.") && !strings.HasPrefix(k, "system.") {
+			if k == "security.capability" || !strings.HasPrefix(k, "security.") && !strings.HasPrefix(k, "system.") && !strings.HasPrefix(k, "com.apple.") {
 				xAttrKeys = append(xAttrKeys, k)
 			}
 		}


### PR DESCRIPTION
I'm not sure if this is the correct location to make this change, but this PR attempts to fix https://github.com/docker/for-mac/issues/7636 by ignoring `com.apple.` extended file attributes in the file content hash.

I feel like this is an appropriate action to take because I don't believe extended file attributes are enabled in the linux Docker VM filesystem on Mac, so Mac specific file attributes should not even be taken into account when calculating content hashes.