### PR TITLE
grpc: log non-fatal errors in FromGRPC()

### DIFF
--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -724,7 +724,7 @@ func unaryInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, 
 	if err != nil {
 		bklog.G(ctx).Errorf("%s returned error: %v", info.FullMethod, err)
 		if logrus.GetLevel() >= logrus.DebugLevel {
-			fmt.Fprintf(os.Stderr, "%+v", stack.Formatter(grpcerrors.FromGRPC(err)))
+			fmt.Fprintf(os.Stderr, "%+v", stack.Formatter(grpcerrors.FromGRPC(ctx, err)))
 		}
 	}
 	return resp, err

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -9459,7 +9459,7 @@ COPY notexist /foo
 			}
 		}
 
-		err = grpcerrors.FromGRPC(status.FromProto(&statuspb.Status{
+		err = grpcerrors.FromGRPC(ctx, status.FromProto(&statuspb.Status{
 			Code:    int32(st.Code),
 			Message: st.Message,
 			Details: details,

--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -1025,7 +1025,7 @@ func (lbf *llbBridgeForwarder) Ping(context.Context, *pb.PingRequest) (*pb.PongR
 
 func (lbf *llbBridgeForwarder) Return(ctx context.Context, in *pb.ReturnRequest) (*pb.ReturnResponse, error) {
 	if in.Error != nil {
-		return lbf.setResult(nil, grpcerrors.FromGRPC(status.ErrorProto(&spb.Status{
+		return lbf.setResult(nil, grpcerrors.FromGRPC(ctx, status.ErrorProto(&spb.Status{
 			Code:    in.Error.Code,
 			Message: in.Error.Message,
 			Details: in.Error.Details,

--- a/frontend/gateway/grpcclient/client.go
+++ b/frontend/gateway/grpcclient/client.go
@@ -1078,7 +1078,7 @@ func (ctr *container) Start(ctx context.Context, req client.StartRequest) (clien
 				if exit.Code == 0 {
 					continue
 				}
-				exitError = grpcerrors.FromGRPC(status.ErrorProto(&spb.Status{
+				exitError = grpcerrors.FromGRPC(ctx, status.ErrorProto(&spb.Status{
 					Code:    exit.Error.Code,
 					Message: exit.Error.Message,
 					Details: exit.Error.Details,

--- a/util/grpcerrors/grpcerrors.go
+++ b/util/grpcerrors/grpcerrors.go
@@ -149,7 +149,7 @@ func AsGRPCStatus(err error) (*status.Status, bool) {
 	return nil, false
 }
 
-func FromGRPC(err error) error {
+func FromGRPC(ctx context.Context, err error) error {
 	if err == nil {
 		return nil
 	}
@@ -172,6 +172,7 @@ func FromGRPC(err error) error {
 	for _, d := range pb.Details {
 		m, err := typeurl.UnmarshalAny(d)
 		if err != nil {
+			bklog.G(ctx).Warnf("decoding type %q: %v", d.GetTypeUrl(), err)
 			continue
 		}
 

--- a/util/grpcerrors/intercept.go
+++ b/util/grpcerrors/intercept.go
@@ -38,7 +38,7 @@ func StreamServerInterceptor(srv any, ss grpc.ServerStream, info *grpc.StreamSer
 }
 
 func UnaryClientInterceptor(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-	err := FromGRPC(invoker(ctx, method, req, reply, cc, opts...))
+	err := FromGRPC(ctx, invoker(ctx, method, req, reply, cc, opts...))
 	if err != nil {
 		stack.Helper()
 	}


### PR DESCRIPTION
When decoding a gRPC error, failing to decode one of the details is
considered non-fatal, entirely swallowing the failure.

Instead, pass a context.Context to the function, use it to
obtain a logger via bklog.G() and log any errors decoding the
details at the warning level.

Signed-off-by: Alberto Garcia Hierro <damaso.hierro@docker.com>
