### PR TITLE
feat: Add additional auth mechanisms for AWS S3 remotecache

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,10 +567,18 @@ The simplest way is to use an IAM Instance profile.
 Other options are:
 
 * Any system using environment variables / config files supported by the [AWS Go SDK](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html). The configuration must be available for the buildkit daemon, not for the client.
-* Using the following attributes:
+* Static Credentials:
   * `access_key_id`: Access Key ID
   * `secret_access_key`: Secret Access Key
   * `session_token`: Session Token
+* Assume Role with Web Identity (OIDC Token):
+  * `assume_role_arn`: The ARN of the role to assume
+  * `assume_role_session_name`: A name for the role session (optional)
+  * `oidc_token_id`: OIDC identity token used to authenticate via web identity
+* Assuming a role with an external ID:
+  * `assume_role_arn`: The ARN of the role to assume
+  * `assume_role_session_name`: A name for the role session (optional)
+  * `external_id`: External ID used when assuming the role (optional)
 
 `--export-cache` options:
 * `type=s3`

--- a/cache/remotecache/s3/s3.go
+++ b/cache/remotecache/s3/s3.go
@@ -433,14 +433,14 @@ func newS3Client(ctx context.Context, config Config) (*s3Client, error) {
 		} else if config.AssumeRoleARN != "" {
 			if config.OIDCTokenID != "" {
 				// Assume Role with OIDC
-				creds, err := assumeRoleWithWebIdentity(ctx, cfg, config.AssumeRoleARN, config.AssumeRoleSessionName, config.OIDCTokenID)
+				creds, err := assumeRoleWithWebIdentity(cfg, config.AssumeRoleARN, config.AssumeRoleSessionName, config.OIDCTokenID)
 				if err != nil {
 					return
 				}
 				options.Credentials = creds
 			} else {
 				// Assume Role with external ID
-				creds, err := assumeRole(ctx, cfg, config.AssumeRoleARN, config.AssumeRoleSessionName, config.ExternalID)
+				creds, err := assumeRole(cfg, config.AssumeRoleARN, config.AssumeRoleSessionName, config.ExternalID)
 				if err != nil {
 					return
 				}
@@ -463,7 +463,7 @@ func newS3Client(ctx context.Context, config Config) (*s3Client, error) {
 	}, nil
 }
 
-func assumeRole(ctx context.Context, cfg aws.Config, roleArn, roleSessionName, externalID string) (aws.CredentialsProvider, error) {
+func assumeRole(cfg aws.Config, roleArn, roleSessionName, externalID string) (aws.CredentialsProvider, error) {
 	// Create a new STS client
 	stsClient := sts.NewFromConfig(cfg)
 
@@ -492,7 +492,7 @@ func (r *InMemoryTokenRetriever) GetIdentityToken() ([]byte, error) {
 	return []byte(r.Token), nil
 }
 
-func assumeRoleWithWebIdentity(ctx context.Context, cfg aws.Config, roleArn, roleSessionName, webIdentityToken string) (aws.CredentialsProvider, error) {
+func assumeRoleWithWebIdentity(cfg aws.Config, roleArn, roleSessionName, webIdentityToken string) (aws.CredentialsProvider, error) {
 	// Create a new STS client
 	stsClient := sts.NewFromConfig(cfg)
 	tokenRetriever := &InMemoryTokenRetriever{

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.27
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.8
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.58.2
+	github.com/aws/aws-sdk-go-v2/service/sts v1.30.3
 	github.com/containerd/console v1.0.4
 	github.com/containerd/containerd/api v1.8.0
 	github.com/containerd/containerd/v2 v2.0.4
@@ -130,7 +131,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.17.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.22.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.26.4 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.30.3 // indirect
 	github.com/aws/smithy-go v1.20.3 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect


### PR DESCRIPTION
Adding two new auth mechanisms to make S3 remotecache more robust. Added support for assuming role with oidc and external id

Tested this with buildctl. It might not work with buildx yet since buildx tries to add aws access key and secret key from envs if they are not provided: https://github.com/docker/buildx/blob/372feb38ff00dabc525acbf3e92ab2e57e3bd809/util/buildflags/cache.go#L242
We need to modify buildx code to return if assume_role_arn is given 