### PR TITLE
chore: update broken links to https://docs.docker.com/registry

### DIFF
--- a/docs/stargz-estargz.md
+++ b/docs/stargz-estargz.md
@@ -92,7 +92,7 @@ Hello, world!
 ```
 
 Note that when a stage is exported (e.g. to the registry), the base image (even stargz/eStargz) of that stage needs to be pulled to copy it to the destination.
-However if the destination is a registry and the target repository already contains some blobs of that image or [cross repository blob mount](https://docs.docker.com/registry/spec/api/#cross-repository-blob-mount) can be used, buildkit keeps these blobs lazy.
+However if the destination is a registry and the target repository already contains some blobs of that image or [cross repository blob mount](https://distribution.github.io/distribution/spec/api/#cross-repository-blob-mount) can be used, buildkit keeps these blobs lazy.
 
 ### Using proxy (standalone) snapshotter
 

--- a/util/resolver/authorizer.go
+++ b/util/resolver/authorizer.go
@@ -288,7 +288,7 @@ func (ah *authHandler) doBearerAuth(ctx context.Context, sm *session.Manager, g 
 
 	to.Scopes = parseScopes(docker.GetTokenScopes(ctx, to.Scopes)).normalize()
 
-	// Docs: https://docs.docker.com/registry/spec/auth/scope
+	// Docs: https://distribution.github.io/distribution/spec/auth/scope
 	scoped := strings.Join(to.Scopes, " ")
 
 	res, err := ah.g.Do(ctx, scoped, func(ctx context.Context) (*authResult, error) {
@@ -444,7 +444,7 @@ func sameRequest(r1, r2 *http.Request) bool {
 type scopes map[string]map[string]struct{}
 
 func parseScopes(s []string) scopes {
-	// https://docs.docker.com/registry/spec/auth/scope/
+	// https://distribution.github.io/distribution/spec/auth/scope/
 	m := map[string]map[string]struct{}{}
 	for _, scopeStr := range s {
 		if scopeStr == "" {


### PR DESCRIPTION
Link to https://distribution.github.io/distribution instead

Signed-off-by: Alberto Garcia Hierro <damaso.hierro@docker.com>
