### PR TITLE
[v0.12] GitHub Actions update

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -170,7 +170,7 @@ jobs:
       -
         name: Generate annotations
         if: always()
-        uses: crazy-max/.github/.github/actions/gotest-annotations@5af0882e0496d2f7e98a53ae4048e3d86682496f
+        uses: crazy-max/.github/.github/actions/gotest-annotations@fa6141aedf23596fb8bdcceab9cce8dadaa31bd9
         with:
           directory: ./bin/testreports
       -

--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -119,11 +119,20 @@ jobs:
         include: ${{ fromJson(needs.prepare.outputs.includes) }}
     steps:
       -
-        name: Environment variables
+        name: Prepare
         run: |
           for l in "${{ inputs.env }}"; do
             echo "${l?}" >> $GITHUB_ENV
           done
+          echo "TEST_REPORT_NAME=${{ github.job }}-$(echo "${{ matrix.pkg }}-${{ matrix.skip-integration-tests }}-${{ matrix.kind }}-${{ matrix.worker }}-${{ matrix.tags }}" | tr -dc '[:alnum:]-\n\r' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+          testFlags="${{ env.TESTFLAGS }}"
+          if [ -n "${{ matrix.tags }}" ]; then
+            testFlags="${testFlags} --tags=${{ matrix.tags }}"
+          fi
+          if [ -n "${{ matrix.worker }}" ]; then
+            testFlags="${testFlags} --run=//worker=${{ matrix.worker }}$"
+          fi
+          echo "TESTFLAGS=${testFlags}" >> $GITHUB_ENV
       -
         name: Checkout
         uses: actions/checkout@v4
@@ -144,16 +153,9 @@ jobs:
         name: Test
         continue-on-error: ${{ matrix.tags == 'nydus' }}
         run: |
-          export TEST_REPORT_SUFFIX=-${{ github.job }}-$(echo "${{ matrix.pkg }}-${{ matrix.skip-integration-tests }}-${{ matrix.kind }}-${{ matrix.worker }}-${{ matrix.tags }}" | tr -dc '[:alnum:]-\n\r' | tr '[:upper:]' '[:lower:]')
-          if [ -n "${{ matrix.tags }}" ]; then
-            TESTFLAGS="${TESTFLAGS} --tags=${{ matrix.tags }}"
-            export BUILDKITD_TAGS="${{ matrix.tags }}"
-          fi
-          if [ -n "${{ matrix.worker }}" ]; then
-            export TESTFLAGS="${TESTFLAGS} --run=//worker=${{ matrix.worker }}$"
-          fi
           ./hack/test ${{ matrix.kind }}
         env:
+          TEST_REPORT_SUFFIX: -${{ env.TEST_REPORT_NAME }}
           TEST_COVERAGE: 1
           TESTPKGS: ${{ matrix.pkg }}
           SKIP_INTEGRATION_TESTS: ${{ matrix.skip-integration-tests }}
@@ -174,7 +176,7 @@ jobs:
       -
         name: Upload test reports
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: test-reports
+          name: test-reports-${{ env.TEST_REPORT_NAME }}
           path: ./bin/testreports

--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -65,7 +65,7 @@ jobs:
       -
         name: Set outputs
         id: set
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const yaml = require('js-yaml');

--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Expose GitHub Runtime
         uses: crazy-max/ghaction-github-runtime@v2
@@ -91,7 +91,7 @@ jobs:
             });
       -
         name: Build
-        uses: docker/bake-action@v2
+        uses: docker/bake-action@v3
         with:
           targets: integration-tests-base
           set: |
@@ -126,7 +126,7 @@ jobs:
           done
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Expose GitHub Runtime
         uses: crazy-max/ghaction-github-runtime@v2

--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -161,7 +161,7 @@ jobs:
       -
         name: Send to Codecov
         if: always()
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           directory: ./bin/testreports
           flags: ${{ matrix.codecov_flags }}

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -132,9 +132,9 @@ jobs:
           CACHE_TO: type=gha,scope=binaries-${{ env.PLATFORM_PAIR }}
       -
         name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: buildkit
+          name: buildkit-${{ env.PLATFORM_PAIR }}
           path: ${{ env.DESTDIR }}/*
           if-no-files-found: error
 
@@ -193,10 +193,11 @@ jobs:
     steps:
       -
         name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: buildkit
           path: ${{ env.DESTDIR }}
+          pattern: buildkit-*
+          merge-multiple: true
       -
         name: List artifacts
         run: |

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -62,7 +62,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Prepare
         id: prep
@@ -105,7 +105,7 @@ jobs:
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       -
@@ -152,7 +152,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Expose GitHub Runtime
         uses: crazy-max/ghaction-github-runtime@v2

--- a/.github/workflows/dockerd.yml
+++ b/.github/workflows/dockerd.yml
@@ -7,7 +7,7 @@ on:
       version:
         description: 'Docker version'
         required: true
-        default: '23.0.1'
+        default: '25.0.2'
 
 env:
   SETUP_BUILDX_VERSION: "latest"
@@ -23,7 +23,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const version = `${{ inputs.version }}` || '23.0.1';
+            const version = `${{ inputs.version }}` || '25.0.2';
             let build = 'true';
             try {
               new URL(version);

--- a/.github/workflows/dockerd.yml
+++ b/.github/workflows/dockerd.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       -
         name: Prepare
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const version = `${{ inputs.version }}` || '25.0.2';

--- a/.github/workflows/dockerd.yml
+++ b/.github/workflows/dockerd.yml
@@ -63,7 +63,7 @@ jobs:
           wget -qO- "https://download.docker.com/linux/static/stable/x86_64/docker-${{ env.DOCKER_VERSION }}.tgz" | tar xvz --strip 1
       -
         name: Upload dockerd
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dockerd
           path: /tmp/moby/dockerd
@@ -109,7 +109,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Download dockerd
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dockerd
           path: ./build/

--- a/.github/workflows/dockerd.yml
+++ b/.github/workflows/dockerd.yml
@@ -42,7 +42,7 @@ jobs:
       -
         name: Build
         if: ${{ env.DOCKER_BUILD == 'true' }}
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: ${{ env.DOCKER_VERSION }}
           target: binary
@@ -93,7 +93,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Expose GitHub Runtime
         uses: crazy-max/ghaction-github-runtime@v2

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -93,7 +93,7 @@ jobs:
           fi
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Expose GitHub Runtime
         uses: crazy-max/ghaction-github-runtime@v2

--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -66,7 +66,7 @@ jobs:
       -
         name: Send to Codecov
         if: always()
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           directory: ./bin/testreports
           env_vars: RUNNER_OS

--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -74,7 +74,7 @@ jobs:
       -
         name: Generate annotations
         if: always()
-        uses: crazy-max/.github/.github/actions/gotest-annotations@5af0882e0496d2f7e98a53ae4048e3d86682496f
+        uses: crazy-max/.github/.github/actions/gotest-annotations@fa6141aedf23596fb8bdcceab9cce8dadaa31bd9
         with:
           directory: ./bin/testreports
       -

--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -80,7 +80,7 @@ jobs:
       -
         name: Upload test reports
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: test-reports
+          name: test-reports-${{ matrix.os }}
           path: ./bin/testreports

--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -37,13 +37,12 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: "${{ env.GO_VERSION }}"
-          cache: true
       -
         name: Install gotestsum
         run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Matrix
         id: targets
@@ -45,7 +45,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -55,6 +55,6 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Validate
-        uses: docker/bake-action@v2
+        uses: docker/bake-action@v3
         with:
           targets: ${{ matrix.target }}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -5404,6 +5404,7 @@ func testBasicInlineCacheImportExport(t *testing.T, sb integration.Sandbox) {
 }
 
 func testBasicGhaCacheImportExport(t *testing.T, sb integration.Sandbox) {
+	t.Skipf("Unsupported GHA cache v2 (v1 is EOL)")
 	integration.CheckFeatureCompat(t, sb,
 		integration.FeatureCacheExport,
 		integration.FeatureCacheImport,


### PR DESCRIPTION
- Backport of https://github.com/moby/buildkit/pull/4605
- Skip testBasicGhaCacheImportExport  test due to https://gh.io/gha-cache-sunset

Since Moby 25.0.x LTS relies on the BuildKit v0.12 branch and actively runs its tests in CI, keeping that branch in a solid, working state is crucial for:

- Stability: Ensures Moby LTS users don’t encounter unexpected build issues.
- CI Integration: Prevents downstream failures in Moby’s CI pipeline.

