### PR TITLE
vendor: github.com/docker/docker, docker/cli v28.1.1, containerd v2.0.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/distribution/reference v0.6.0
 	github.com/docker/cli v28.1.0+incompatible
-	github.com/docker/docker v28.1.0+incompatible
+	github.com/docker/docker v28.1.1+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/docker/go-units v0.5.0
 	github.com/gofrs/flock v0.12.1

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.58.2
 	github.com/containerd/console v1.0.4
 	github.com/containerd/containerd/api v1.8.0
-	github.com/containerd/containerd/v2 v2.0.4
+	github.com/containerd/containerd/v2 v2.0.5
 	github.com/containerd/continuity v0.4.5
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/fuse-overlayfs-snapshotter/v2 v2.1.1

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/containernetworking/plugins v1.5.1
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/distribution/reference v0.6.0
-	github.com/docker/cli v28.1.0+incompatible
+	github.com/docker/cli v28.1.1+incompatible
 	github.com/docker/docker v28.1.1+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/docker/go-units v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -146,8 +146,8 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/cli v28.1.0+incompatible h1:WiJhUBbuIH/BsJtth+C1hPwra4P0nsKJiWy9ie5My5s=
 github.com/docker/cli v28.1.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
-github.com/docker/docker v28.1.0+incompatible h1:4iqpcWQCt3Txcz7iWIb1U3SZ/n9ffo4U+ryY5/3eOp0=
-github.com/docker/docker v28.1.0+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v28.1.1+incompatible h1:49M11BFLsVO1gxY9UX9p/zwkE/rswggs8AdFmXQw51I=
+github.com/docker/docker v28.1.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.9.3 h1:gAm/VtF9wgqJMoxzT3Gj5p4AqIjCBS4wrsOh9yRqcz8=
 github.com/docker/docker-credential-helpers v0.9.3/go.mod h1:x+4Gbw9aGmChi3qTLZj8Dfn0TD20M/fuWy0E5+WDeCo=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=

--- a/go.sum
+++ b/go.sum
@@ -144,8 +144,8 @@ github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/docker/cli v28.1.0+incompatible h1:WiJhUBbuIH/BsJtth+C1hPwra4P0nsKJiWy9ie5My5s=
-github.com/docker/cli v28.1.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v28.1.1+incompatible h1:eyUemzeI45DY7eDPuwUcmDyDj1pM98oD5MdSpiItp8k=
+github.com/docker/cli v28.1.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker v28.1.1+incompatible h1:49M11BFLsVO1gxY9UX9p/zwkE/rswggs8AdFmXQw51I=
 github.com/docker/docker v28.1.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.9.3 h1:gAm/VtF9wgqJMoxzT3Gj5p4AqIjCBS4wrsOh9yRqcz8=

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/containerd/console v1.0.4 h1:F2g4+oChYvBTsASRTz8NP6iIAi97J3TtSAsLbIFn
 github.com/containerd/console v1.0.4/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
 github.com/containerd/containerd/api v1.8.0 h1:hVTNJKR8fMc/2Tiw60ZRijntNMd1U+JVMyTRdsD2bS0=
 github.com/containerd/containerd/api v1.8.0/go.mod h1:dFv4lt6S20wTu/hMcP4350RL87qPWLVa/OHOwmmdnYc=
-github.com/containerd/containerd/v2 v2.0.4 h1:+r7yJMwhTfMm3CDyiBjMBQO8a9CTBxL2Bg/JtqtIwB8=
-github.com/containerd/containerd/v2 v2.0.4/go.mod h1:5j9QUUaV/cy9ZeAx4S+8n9ffpf+iYnEj4jiExgcbuLY=
+github.com/containerd/containerd/v2 v2.0.5 h1:2vg/TjUXnaohAxiHnthQg8K06L9I4gdYEMcOLiMc8BQ=
+github.com/containerd/containerd/v2 v2.0.5/go.mod h1:Qqo0UN43i2fX1FLkrSTCg6zcHNfjN7gEnx3NPRZI+N0=
 github.com/containerd/continuity v0.4.5 h1:ZRoN1sXq9u7V6QoHMcVWGhOwDFqZ4B9i5H6un1Wh0x4=
 github.com/containerd/continuity v0.4.5/go.mod h1:/lNJvtJKUQStBzpVQ1+rasXO1LAWtUQssk28EZvJ3nE=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=

--- a/vendor/github.com/containerd/containerd/v2/client/container.go
+++ b/vendor/github.com/containerd/containerd/v2/client/container.go
@@ -279,7 +279,8 @@ func (c *container) NewTask(ctx context.Context, ioCreate cio.Creator, opts ...N
 		}
 	}
 	info := TaskInfo{
-		runtime: r.Runtime.Name,
+		runtime:        r.Runtime.Name,
+		runtimeOptions: r.Runtime.Options,
 	}
 	for _, o := range opts {
 		if err := o(ctx, c.client, &info); err != nil {

--- a/vendor/github.com/containerd/containerd/v2/client/task_opts.go
+++ b/vendor/github.com/containerd/containerd/v2/client/task_opts.go
@@ -54,12 +54,9 @@ func WithRuntimePath(absRuntimePath string) NewTaskOpts {
 // usually it is served inside a sandbox, and we can get it from sandbox status.
 func WithTaskAPIEndpoint(address string, version uint32) NewTaskOpts {
 	return func(ctx context.Context, client *Client, info *TaskInfo) error {
-		if info.Options == nil {
-			info.Options = &options.Options{}
-		}
-		opts, ok := info.Options.(*options.Options)
-		if !ok {
-			return errors.New("invalid runtime v2 options format")
+		opts, err := info.getRuncOptions()
+		if err != nil {
+			return err
 		}
 		opts.TaskApiAddress = address
 		opts.TaskApiVersion = version
@@ -119,12 +116,9 @@ func WithCheckpointImagePath(path string) CheckpointTaskOpts {
 // WithRestoreImagePath sets image path for create option
 func WithRestoreImagePath(path string) NewTaskOpts {
 	return func(ctx context.Context, c *Client, ti *TaskInfo) error {
-		if ti.Options == nil {
-			ti.Options = &options.Options{}
-		}
-		opts, ok := ti.Options.(*options.Options)
-		if !ok {
-			return errors.New("invalid runtime v2 options format")
+		opts, err := ti.getRuncOptions()
+		if err != nil {
+			return err
 		}
 		opts.CriuImagePath = path
 		return nil
@@ -134,12 +128,9 @@ func WithRestoreImagePath(path string) NewTaskOpts {
 // WithRestoreWorkPath sets criu work path for create option
 func WithRestoreWorkPath(path string) NewTaskOpts {
 	return func(ctx context.Context, c *Client, ti *TaskInfo) error {
-		if ti.Options == nil {
-			ti.Options = &options.Options{}
-		}
-		opts, ok := ti.Options.(*options.Options)
-		if !ok {
-			return errors.New("invalid runtime v2 options format")
+		opts, err := ti.getRuncOptions()
+		if err != nil {
+			return err
 		}
 		opts.CriuWorkPath = path
 		return nil

--- a/vendor/github.com/containerd/containerd/v2/client/task_opts_unix.go
+++ b/vendor/github.com/containerd/containerd/v2/client/task_opts_unix.go
@@ -20,20 +20,14 @@ package client
 
 import (
 	"context"
-	"errors"
-
-	"github.com/containerd/containerd/api/types/runc/options"
 )
 
 // WithNoNewKeyring causes tasks not to be created with a new keyring for secret storage.
 // There is an upper limit on the number of keyrings in a linux system
 func WithNoNewKeyring(ctx context.Context, c *Client, ti *TaskInfo) error {
-	if ti.Options == nil {
-		ti.Options = &options.Options{}
-	}
-	opts, ok := ti.Options.(*options.Options)
-	if !ok {
-		return errors.New("invalid v2 shim create options format")
+	opts, err := ti.getRuncOptions()
+	if err != nil {
+		return err
 	}
 	opts.NoNewKeyring = true
 	return nil
@@ -41,12 +35,9 @@ func WithNoNewKeyring(ctx context.Context, c *Client, ti *TaskInfo) error {
 
 // WithNoPivotRoot instructs the runtime not to you pivot_root
 func WithNoPivotRoot(_ context.Context, _ *Client, ti *TaskInfo) error {
-	if ti.Options == nil {
-		ti.Options = &options.Options{}
-	}
-	opts, ok := ti.Options.(*options.Options)
-	if !ok {
-		return errors.New("invalid v2 shim create options format")
+	opts, err := ti.getRuncOptions()
+	if err != nil {
+		return err
 	}
 	opts.NoPivotRoot = true
 	return nil
@@ -55,12 +46,9 @@ func WithNoPivotRoot(_ context.Context, _ *Client, ti *TaskInfo) error {
 // WithShimCgroup sets the existing cgroup for the shim
 func WithShimCgroup(path string) NewTaskOpts {
 	return func(ctx context.Context, c *Client, ti *TaskInfo) error {
-		if ti.Options == nil {
-			ti.Options = &options.Options{}
-		}
-		opts, ok := ti.Options.(*options.Options)
-		if !ok {
-			return errors.New("invalid v2 shim create options format")
+		opts, err := ti.getRuncOptions()
+		if err != nil {
+			return err
 		}
 		opts.ShimCgroup = path
 		return nil
@@ -70,12 +58,9 @@ func WithShimCgroup(path string) NewTaskOpts {
 // WithUIDOwner allows console I/O to work with the remapped UID in user namespace
 func WithUIDOwner(uid uint32) NewTaskOpts {
 	return func(ctx context.Context, c *Client, ti *TaskInfo) error {
-		if ti.Options == nil {
-			ti.Options = &options.Options{}
-		}
-		opts, ok := ti.Options.(*options.Options)
-		if !ok {
-			return errors.New("invalid v2 shim create options format")
+		opts, err := ti.getRuncOptions()
+		if err != nil {
+			return err
 		}
 		opts.IoUid = uid
 		return nil
@@ -85,12 +70,9 @@ func WithUIDOwner(uid uint32) NewTaskOpts {
 // WithGIDOwner allows console I/O to work with the remapped GID in user namespace
 func WithGIDOwner(gid uint32) NewTaskOpts {
 	return func(ctx context.Context, c *Client, ti *TaskInfo) error {
-		if ti.Options == nil {
-			ti.Options = &options.Options{}
-		}
-		opts, ok := ti.Options.(*options.Options)
-		if !ok {
-			return errors.New("invalid v2 shim create options format")
+		opts, err := ti.getRuncOptions()
+		if err != nil {
+			return err
 		}
 		opts.IoGid = gid
 		return nil

--- a/vendor/github.com/containerd/containerd/v2/defaults/defaults_snapshotter_linux.go
+++ b/vendor/github.com/containerd/containerd/v2/defaults/defaults_snapshotter_linux.go
@@ -21,4 +21,6 @@ const (
 	// This will be based on the client compilation target, so take that into
 	// account when choosing this value.
 	DefaultSnapshotter = "overlayfs"
+	// DefaultDiffer will set the default differ for the platform.
+	DefaultDiffer = "walking"
 )

--- a/vendor/github.com/containerd/containerd/v2/defaults/defaults_snapshotter_unix.go
+++ b/vendor/github.com/containerd/containerd/v2/defaults/defaults_snapshotter_unix.go
@@ -23,4 +23,6 @@ const (
 	// This will be based on the client compilation target, so take that into
 	// account when choosing this value.
 	DefaultSnapshotter = "native"
+	// DefaultDiffer will set the default differ for the platform.
+	DefaultDiffer = "walking"
 )

--- a/vendor/github.com/containerd/containerd/v2/pkg/oci/spec_opts.go
+++ b/vendor/github.com/containerd/containerd/v2/pkg/oci/spec_opts.go
@@ -595,13 +595,13 @@ func WithUser(userstr string) SpecOpts {
 		setProcess(s)
 		s.Process.User.AdditionalGids = nil
 		// While the Linux kernel allows the max UID to be MaxUint32 - 2,
-                // and the OCI Runtime Spec has no definition about the max UID,
-                // the runc implementation is known to require the UID to be <= MaxInt32.
-                //
-                // containerd follows runc's limitation here.
-                //
-                // In future we may relax this limitation to allow MaxUint32 - 2,
-                // or, amend the OCI Runtime Spec to codify the implementation limitation.
+		// and the OCI Runtime Spec has no definition about the max UID,
+		// the runc implementation is known to require the UID to be <= MaxInt32.
+		//
+		// containerd follows runc's limitation here.
+		//
+		// In future we may relax this limitation to allow MaxUint32 - 2,
+		// or, amend the OCI Runtime Spec to codify the implementation limitation.
 		const (
 			minUserID  = 0
 			maxUserID  = math.MaxInt32

--- a/vendor/github.com/containerd/containerd/v2/version/version.go
+++ b/vendor/github.com/containerd/containerd/v2/version/version.go
@@ -24,7 +24,7 @@ var (
 	Package = "github.com/containerd/containerd/v2"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "2.0.4+unknown"
+	Version = "2.0.5+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.

--- a/vendor/github.com/docker/docker/libnetwork/internal/resolvconf/resolvconf.go
+++ b/vendor/github.com/docker/docker/libnetwork/internal/resolvconf/resolvconf.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 // Package resolvconf is used to generate a container's /etc/resolv.conf file.
 //
@@ -85,10 +85,10 @@ type metadata struct {
 	SearchOverride  bool
 	OptionsOverride bool
 	NDotsFrom       string
-	UsedDefaultNS   bool
 	Transform       string
 	InvalidNSs      []string
 	ExtNameServers  []ExtDNSEntry
+	Warnings        []string
 }
 
 // Load opens a file at path and parses it as a resolv.conf file.
@@ -229,7 +229,7 @@ func (rc *ResolvConf) TransformForLegacyNw(ipv6 bool) {
 	if len(rc.nameServers) == 0 {
 		log.G(context.TODO()).Info("No non-localhost DNS nameservers are left in resolv.conf. Using default external servers")
 		rc.nameServers = defaultNSAddrs(ipv6)
-		rc.md.UsedDefaultNS = true
+		rc.md.Warnings = append(rc.md.Warnings, "Used default nameservers.")
 	}
 }
 
@@ -280,6 +280,9 @@ func (rc *ResolvConf) TransformForIntNS(
 	}
 
 	rc.md.Transform = "internal resolver"
+	if len(rc.md.ExtNameServers) == 0 {
+		rc.md.Warnings = append(rc.md.Warnings, "NO EXTERNAL NAMESERVERS DEFINED")
+	}
 	return append([]ExtDNSEntry(nil), rc.md.ExtNameServers...), nil
 }
 
@@ -325,8 +328,8 @@ options {{join . " "}}
 {{join . "\n"}}
 {{end}}{{if .Comments}}
 # Based on host file: '{{.Md.SourcePath}}'{{with .Md.Transform}} ({{.}}){{end}}
-{{if .Md.UsedDefaultNS -}}
-# Used default nameservers.
+{{range .Md.Warnings -}}
+# {{.}}
 {{end -}}
 {{with .Md.ExtNameServers -}}
 # ExtServers: {{.}}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -301,8 +301,8 @@ github.com/containerd/containerd/api/types/runc/options
 github.com/containerd/containerd/api/types/runtimeoptions/v1
 github.com/containerd/containerd/api/types/task
 github.com/containerd/containerd/api/types/transfer
-# github.com/containerd/containerd/v2 v2.0.4
-## explicit; go 1.22.0
+# github.com/containerd/containerd/v2 v2.0.5
+## explicit; go 1.23.0
 github.com/containerd/containerd/v2/client
 github.com/containerd/containerd/v2/core/containers
 github.com/containerd/containerd/v2/core/content

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -493,7 +493,7 @@ github.com/docker/cli/cli/config/configfile
 github.com/docker/cli/cli/config/credentials
 github.com/docker/cli/cli/config/types
 github.com/docker/cli/cli/connhelper/commandconn
-# github.com/docker/docker v28.1.0+incompatible
+# github.com/docker/docker v28.1.1+incompatible
 ## explicit
 github.com/docker/docker/libnetwork/internal/resolvconf
 github.com/docker/docker/libnetwork/resolvconf

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -486,7 +486,7 @@ github.com/dimchansky/utfbom
 # github.com/distribution/reference v0.6.0
 ## explicit; go 1.20
 github.com/distribution/reference
-# github.com/docker/cli v28.1.0+incompatible
+# github.com/docker/cli v28.1.1+incompatible
 ## explicit
 github.com/docker/cli/cli/config
 github.com/docker/cli/cli/config/configfile


### PR DESCRIPTION
### vendor: github.com/containerd/containerd v2.0.5

full diff: https://github.com/containerd/containerd/compare/v2.0.4...v2.0.5

### vendor: github.com/docker/docker v28.1.1

diff:  https://github.com/docker/docker/compare/v28.1.0...v28.1.1

### vendor: github.com/docker/cli v28.1.1

no changes in vendored code

diff:  https://github.com/docker/cli/compare/v28.1.0...v28.1.1
