### PR TITLE
Fix for #5931 -  export tlsdir handling logic to a function

### DIFF
--- a/cmd/buildctl/common/common.go
+++ b/cmd/buildctl/common/common.go
@@ -42,7 +42,7 @@ func ResolveTLSFilesFromDir(tlsDir string) (caCert, cert, key string, err error)
 		return caCert, cert, key, nil
 	}
 
-	return "", "", "", errors.New("Directory didn't contain one or more of the needed files")
+	return "", "", "", errors.New("directory didn't contain one or more of the needed files")
 }
 
 // ResolveClient resolves a client from CLI args

--- a/cmd/buildctl/common/common_test.go
+++ b/cmd/buildctl/common/common_test.go
@@ -1,0 +1,55 @@
+package common_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/moby/buildkit/cmd/buildctl/common"
+)
+
+func writeTempFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+	return path
+}
+
+func TestResolveTLSFilesFromDir(t *testing.T) {
+	t.Run("all files present for cert-manager style", func(t *testing.T) {
+		dir := t.TempDir()
+		ca := writeTempFile(t, dir, "ca.crt", "ca")
+		cert := writeTempFile(t, dir, "tls.crt", "cert")
+		key := writeTempFile(t, dir, "tls.key", "key")
+
+		caOut, certOut, keyOut := common.ResolveTLSFilesFromDir(dir)
+		require.Equal(t, ca, caOut)
+		require.Equal(t, cert, certOut)
+		require.Equal(t, key, keyOut)
+	})
+
+	t.Run("all files present for pem style", func(t *testing.T) {
+		dir := t.TempDir()
+		ca := writeTempFile(t, dir, "ca.pem", "ca")
+		cert := writeTempFile(t, dir, "cert.pem", "cert")
+		key := writeTempFile(t, dir, "key.pem", "key")
+
+		caOut, certOut, keyOut := common.ResolveTLSFilesFromDir(dir)
+		require.Equal(t, ca, caOut)
+		require.Equal(t, cert, certOut)
+		require.Equal(t, key, keyOut)
+	})
+
+	t.Run("some files missing", func(t *testing.T) {
+		dir := t.TempDir()
+		ca := writeTempFile(t, dir, "ca.crt", "ca")
+		// cert and key missing
+
+		caOut, certOut, keyOut := common.ResolveTLSFilesFromDir(dir)
+		require.Equal(t, ca, caOut)
+		require.Empty(t, certOut)
+		require.Empty(t, keyOut)
+	})
+}

--- a/cmd/buildctl/main.go
+++ b/cmd/buildctl/main.go
@@ -87,7 +87,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "tlsdir",
-			Usage: "directory containing CA certificate, client certificate, and client key",
+			Usage: "directory containing CA certificate, client certificate, and client key. Supported file names are (ca.pem, cert.pem, key.pem) or (ca.crt, tls.crt, tls.key)",
 			Value: "",
 		},
 		cli.IntFlag{

--- a/docs/reference/buildctl.md
+++ b/docs/reference/buildctl.md
@@ -29,7 +29,7 @@ GLOBAL OPTIONS:
    --tlscacert value      CA certificate for validation
    --tlscert value        client certificate
    --tlskey value         client key
-   --tlsdir value         directory containing CA certificate, client certificate, and client key
+   --tlsdir value         directory containing CA certificate, client certificate, and client key. Supported file names are (ca.pem, cert.pem, key.pem) or (ca.crt, tls.crt, tls.key)
    --timeout value        timeout backend connection after value seconds (default: 5)
    --wait                 block RPCs until the connection becomes available
    --help, -h             show help


### PR DESCRIPTION
Export tlsdir handling logic to a function
Add tests for parsing files using tlsdir
