### PR TITLE
frontend/dockerui/build: fix "no scan targets for linux/arm64/v8"

### DIFF
--- a/frontend/dockerui/build.go
+++ b/frontend/dockerui/build.go
@@ -61,7 +61,7 @@ func (bc *Client) Build(ctx context.Context, fn BuildFunc) (*ResultBuilder, erro
 			} else {
 				p = platforms.DefaultSpec()
 			}
-			expPlat := normalizePlatform(p, img.Platform)
+			expPlat := makeExportPlatform(p, img.Platform)
 			if bc.MultiPlatformRequested {
 				res.AddRef(expPlat.ID, ref)
 				res.AddMeta(fmt.Sprintf("%s/%s", exptypes.ExporterImageConfigKey, expPlat.ID), config)
@@ -127,18 +127,15 @@ func extendWindowsPlatform(p, imgP ocispecs.Platform) ocispecs.Platform {
 	return p
 }
 
-func normalizePlatform(p, imgP ocispecs.Platform) exptypes.Platform {
-	var k string
+func makeExportPlatform(p, imgP ocispecs.Platform) exptypes.Platform {
+	p = platforms.Normalize(p)
+	exp := exptypes.Platform{
+		ID: platforms.FormatAll(p),
+	}
 	if p.OS == "windows" {
-		k = platforms.FormatAll(p)
 		p = extendWindowsPlatform(p, imgP)
 		p = platforms.Normalize(p)
-	} else {
-		p = platforms.Normalize(p)
-		k = platforms.FormatAll(p)
 	}
-	return exptypes.Platform{
-		ID:       k,
-		Platform: p,
-	}
+	exp.Platform = p
+	return exp
 }

--- a/frontend/dockerui/build.go
+++ b/frontend/dockerui/build.go
@@ -61,16 +61,12 @@ func (bc *Client) Build(ctx context.Context, fn BuildFunc) (*ResultBuilder, erro
 			} else {
 				p = platforms.DefaultSpec()
 			}
-
-			k := platforms.FormatAll(p)
-			p = extendWindowsPlatform(p, img.Platform)
-			p = platforms.Normalize(p)
-
+			expPlat := normalizePlatform(p, img.Platform)
 			if bc.MultiPlatformRequested {
-				res.AddRef(k, ref)
-				res.AddMeta(fmt.Sprintf("%s/%s", exptypes.ExporterImageConfigKey, k), config)
+				res.AddRef(expPlat.ID, ref)
+				res.AddMeta(fmt.Sprintf("%s/%s", exptypes.ExporterImageConfigKey, expPlat.ID), config)
 				if len(baseConfig) > 0 {
-					res.AddMeta(fmt.Sprintf("%s/%s", exptypes.ExporterImageBaseConfigKey, k), baseConfig)
+					res.AddMeta(fmt.Sprintf("%s/%s", exptypes.ExporterImageBaseConfigKey, expPlat.ID), baseConfig)
 				}
 			} else {
 				res.SetRef(ref)
@@ -79,10 +75,7 @@ func (bc *Client) Build(ctx context.Context, fn BuildFunc) (*ResultBuilder, erro
 					res.AddMeta(exptypes.ExporterImageBaseConfigKey, baseConfig)
 				}
 			}
-			expPlatforms.Platforms[i] = exptypes.Platform{
-				ID:       k,
-				Platform: p,
-			}
+			expPlatforms.Platforms[i] = expPlat
 			return nil
 		})
 	}
@@ -132,4 +125,14 @@ func extendWindowsPlatform(p, imgP ocispecs.Platform) ocispecs.Platform {
 		}
 	}
 	return p
+}
+
+func normalizePlatform(p, imgP ocispecs.Platform) exptypes.Platform {
+	k := platforms.FormatAll(p)
+	p = extendWindowsPlatform(p, imgP)
+	p = platforms.Normalize(p)
+	return exptypes.Platform{
+		ID:       k,
+		Platform: p,
+	}
 }

--- a/frontend/dockerui/build.go
+++ b/frontend/dockerui/build.go
@@ -128,9 +128,15 @@ func extendWindowsPlatform(p, imgP ocispecs.Platform) ocispecs.Platform {
 }
 
 func normalizePlatform(p, imgP ocispecs.Platform) exptypes.Platform {
-	k := platforms.FormatAll(p)
-	p = extendWindowsPlatform(p, imgP)
-	p = platforms.Normalize(p)
+	var k string
+	if p.OS == "windows" {
+		k = platforms.FormatAll(p)
+		p = extendWindowsPlatform(p, imgP)
+		p = platforms.Normalize(p)
+	} else {
+		p = platforms.Normalize(p)
+		k = platforms.FormatAll(p)
+	}
 	return exptypes.Platform{
 		ID:       k,
 		Platform: p,

--- a/frontend/dockerui/build_test.go
+++ b/frontend/dockerui/build_test.go
@@ -3,6 +3,7 @@ package dockerui
 import (
 	"testing"
 
+	"github.com/containerd/platforms"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/require"
@@ -31,10 +32,69 @@ func TestNormalizePlatform(t *testing.T) {
 				},
 			},
 		},
-		// TODO: cover Windows https://github.com/moby/buildkit/pull/5837
+		{
+			p: ocispecs.Platform{
+				Architecture: "arm64",
+				OS:           "linux",
+				Variant:      "v8",
+			},
+			imgP: ocispecs.Platform{
+				Architecture: "arm64",
+				OS:           "linux",
+				Variant:      "v8",
+			},
+			expected: exptypes.Platform{
+				ID: "linux/arm64",
+				Platform: ocispecs.Platform{
+					Architecture: "arm64",
+					OS:           "linux",
+				},
+			},
+		},
+		{
+			p: ocispecs.Platform{
+				Architecture: "amd64",
+				OS:           "windows",
+			},
+			imgP: ocispecs.Platform{
+				Architecture: "amd64",
+				OS:           "windows",
+				OSVersion:    "10.0.19041.0",
+			},
+			expected: exptypes.Platform{
+				ID: "windows/amd64",
+				Platform: ocispecs.Platform{
+					Architecture: "amd64",
+					OS:           "windows",
+					OSVersion:    "10.0.19041.0",
+				},
+			},
+		},
+		{
+			p: ocispecs.Platform{
+				Architecture: "amd64",
+				OS:           "windows",
+				OSVersion:    "10.0.19041.0",
+			},
+			imgP: ocispecs.Platform{
+				Architecture: "amd64",
+				OS:           "windows",
+				OSVersion:    "11.0.22000.0",
+			},
+			expected: exptypes.Platform{
+				ID: "windows(10.0.19041.0)/amd64",
+				Platform: ocispecs.Platform{
+					Architecture: "amd64",
+					OS:           "windows",
+					OSVersion:    "10.0.19041.0",
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
-		require.Equal(t, tc.expected, normalizePlatform(tc.p, tc.imgP))
+		require.Equal(t, tc.expected, makeExportPlatform(tc.p, tc.imgP))
+		// the ID needs to always be formatall(normalize(p))
+		require.Equal(t, platforms.FormatAll(platforms.Normalize(tc.p)), tc.expected.ID)
 	}
 }

--- a/frontend/dockerui/build_test.go
+++ b/frontend/dockerui/build_test.go
@@ -1,0 +1,40 @@
+package dockerui
+
+import (
+	"testing"
+
+	"github.com/moby/buildkit/exporter/containerimage/exptypes"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizePlatform(t *testing.T) {
+	testCases := []struct {
+		p, imgP  ocispecs.Platform
+		expected exptypes.Platform
+	}{
+		{
+			p: ocispecs.Platform{
+				Architecture: "arm64",
+				OS:           "linux",
+				Variant:      "v8",
+			},
+			imgP: ocispecs.Platform{
+				Architecture: "arm64",
+				OS:           "linux",
+			},
+			expected: exptypes.Platform{
+				ID: "linux/arm64", // Not "linux/arm64/v8" https://github.com/moby/buildkit/issues/5915
+				Platform: ocispecs.Platform{
+					Architecture: "arm64",
+					OS:           "linux",
+				},
+			},
+		},
+		// TODO: cover Windows https://github.com/moby/buildkit/pull/5837
+	}
+
+	for _, tc := range testCases {
+		require.Equal(t, tc.expected, normalizePlatform(tc.p, tc.imgP))
+	}
+}


### PR DESCRIPTION
Fix #5915

Test (on ARM):

```dockerfile
FROM hello-world
```

```console
buildctl build --frontend=dockerfile.v0 --local context=. --local dockerfile=. --opt attest:sbom=
```