### PR TITLE
buildctl: fix tlsdir handling logic for cert-manager.io

### DIFF
--- a/cmd/buildctl/common/common_test.go
+++ b/cmd/buildctl/common/common_test.go
@@ -1,0 +1,74 @@
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeTempFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+	return path
+}
+
+func TestResolveTLSFilesFromDir(t *testing.T) {
+	t.Run("all files present for cert-manager style", func(t *testing.T) {
+		dir := t.TempDir()
+		ca := writeTempFile(t, dir, "ca.crt", "ca")
+		cert := writeTempFile(t, dir, "tls.crt", "cert")
+		key := writeTempFile(t, dir, "tls.key", "key")
+
+		caOut, certOut, keyOut, err := resolveTLSFilesFromDir(dir)
+		require.Equal(t, ca, caOut)
+		require.Equal(t, cert, certOut)
+		require.Equal(t, key, keyOut)
+		require.NoError(t, err)
+	})
+
+	t.Run("all files present for pem style", func(t *testing.T) {
+		dir := t.TempDir()
+		ca := writeTempFile(t, dir, "ca.pem", "ca")
+		cert := writeTempFile(t, dir, "cert.pem", "cert")
+		key := writeTempFile(t, dir, "key.pem", "key")
+
+		caOut, certOut, keyOut, err := resolveTLSFilesFromDir(dir)
+		require.Equal(t, ca, caOut)
+		require.Equal(t, cert, certOut)
+		require.Equal(t, key, keyOut)
+		require.NoError(t, err)
+	})
+
+	t.Run("mixed set is present", func(t *testing.T) {
+		dir := t.TempDir()
+		ca := writeTempFile(t, dir, "ca.crt", "ca-cert-manager")
+		cert := writeTempFile(t, dir, "cert.pem", "cert-pem")
+		key := writeTempFile(t, dir, "key.pem", "key-pem")
+		// ca for cert-manager, cert and key for pem
+
+		caOut, certOut, keyOut, err := resolveTLSFilesFromDir(dir)
+		require.Equal(t, ca, caOut)
+		require.Equal(t, cert, certOut)
+		require.Equal(t, key, keyOut)
+		require.NoError(t, err)
+	})
+
+	t.Run("all files present for cert-manager and pem styles and pem is chosen", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTempFile(t, dir, "ca.crt", "ca-cert-manager")
+		writeTempFile(t, dir, "tls.crt", "cert-cert-manager")
+		writeTempFile(t, dir, "tls.key", "key-cert-manager")
+		ca := writeTempFile(t, dir, "ca.pem", "ca-pem")
+		cert := writeTempFile(t, dir, "cert.pem", "cert-pem")
+		key := writeTempFile(t, dir, "key.pem", "key-pem")
+
+		caOut, certOut, keyOut, err := resolveTLSFilesFromDir(dir)
+		require.Equal(t, ca, caOut)
+		require.Equal(t, cert, certOut)
+		require.Equal(t, key, keyOut)
+		require.NoError(t, err)
+	})
+}

--- a/cmd/buildctl/main.go
+++ b/cmd/buildctl/main.go
@@ -87,7 +87,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "tlsdir",
-			Usage: "directory containing CA certificate, client certificate, and client key",
+			Usage: "directory containing CA certificate, client certificate, and client key. Supported file names are (ca.pem, cert.pem, key.pem) or (ca.crt, tls.crt, tls.key)",
 			Value: "",
 		},
 		cli.IntFlag{

--- a/docs/reference/buildctl.md
+++ b/docs/reference/buildctl.md
@@ -29,7 +29,7 @@ GLOBAL OPTIONS:
    --tlscacert value      CA certificate for validation
    --tlscert value        client certificate
    --tlskey value         client key
-   --tlsdir value         directory containing CA certificate, client certificate, and client key
+   --tlsdir value         directory containing CA certificate, client certificate, and client key. Supported file names are (ca.pem, cert.pem, key.pem) or (ca.crt, tls.crt, tls.key)
    --timeout value        timeout backend connection after value seconds (default: 5)
    --wait                 block RPCs until the connection becomes available
    --help, -h             show help


### PR DESCRIPTION

`tldir` flag handling now properly handles the old logic and the new
logic for cert-manager.io without failing.

Improved error message when files are missing.

Fixes #5931.
Replaces #5935.

Co-authored-by: Gleb Nebolyubov <gleb.nebo@gmail.com>
Signed-off-by: Jonathan A. Sternberg <jonathan.sternberg@docker.com>
