### PR TITLE
util: testutil: enable `dockerd-containerd` worker for wcow integration tests

### DIFF
--- a/util/testutil/dockerd/daemon.go
+++ b/util/testutil/dockerd/daemon.go
@@ -72,7 +72,7 @@ func NewDaemon(workingDir string, ops ...Option) (*Daemon, error) {
 		execRoot:      filepath.Join(os.TempDir(), "dxr", id),
 		dockerdBinary: DefaultDockerdBinary,
 		Log:           nopLog{},
-		sockPath:      filepath.Join(sockRoot, id+".sock"),
+		sockPath:      getDockerdSockPath(sockRoot, id),
 		envs:          os.Environ(),
 	}
 
@@ -96,7 +96,7 @@ func WithExtraEnv(envs []string) Option {
 }
 
 func (d *Daemon) Sock() string {
-	return "unix://" + d.sockPath
+	return socketScheme + d.sockPath
 }
 
 func (d *Daemon) StartWithError(daemonLogs map[string]*bytes.Buffer, providedArgs ...string) error {

--- a/util/testutil/dockerd/daemon_unix.go
+++ b/util/testutil/dockerd/daemon_unix.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package dockerd
+
+import "path/filepath"
+
+const socketScheme = "unix://"
+
+func getDockerdSockPath(sockRoot, id string) string {
+	return filepath.Join(sockRoot, id+".sock")
+}

--- a/util/testutil/dockerd/daemon_windows.go
+++ b/util/testutil/dockerd/daemon_windows.go
@@ -1,0 +1,7 @@
+package dockerd
+
+const socketScheme = "npipe://"
+
+func getDockerdSockPath(_, id string) string {
+	return `//./pipe/dockerd-` + id
+}

--- a/util/testutil/workers/util_unix.go
+++ b/util/testutil/workers/util_unix.go
@@ -13,6 +13,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const buildkitdNetworkProtocol = "unix"
+
 func applyBuildkitdPlatformFlags(args []string) []string {
 	return append(args, "--oci-worker=false")
 }
@@ -74,4 +76,13 @@ func chown(name string, uid, gid int) error {
 func normalizeAddress(address string) string {
 	// for parity with windows, no effect for unix
 	return address
+}
+
+func applyDockerdPlatformFlags(flags []string, _ string) []string {
+	flags = append(flags, "--userland-proxy=false")
+	return flags
+}
+
+func getBuildkitdNetworkAddr(tmpdir string) string {
+	return tmpdir
 }

--- a/util/testutil/workers/util_windows.go
+++ b/util/testutil/workers/util_windows.go
@@ -4,7 +4,11 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+
+	"github.com/containerd/containerd/v2/defaults"
 )
+
+const buildkitdNetworkProtocol = "tcp"
 
 func applyBuildkitdPlatformFlags(args []string) []string {
 	return args
@@ -54,4 +58,16 @@ func normalizeAddress(address string) string {
 		address = "npipe://" + address
 	}
 	return address
+}
+
+func applyDockerdPlatformFlags(flags []string, workerID string) []string {
+	if workerID == "dockerd-containerd" {
+		flags = append(flags, "--default-runtime="+defaults.DefaultRuntime)
+	}
+	return flags
+}
+
+func getBuildkitdNetworkAddr(_ string) string {
+	// Using TCP on Windows, instead of Unix sockets.
+	return "localhost:0"
 }


### PR DESCRIPTION
Currently, dockerd and dockerd-containerd integration tests are only ran for Linux at [moby/moby] `.github/workflows/buildkit.yml`

moby/moby runs this workflow against feature buildkit releases as evaluated by `./hack/buidkit-ref`.

This change facilitates adding support for Windows, see example run here [1], and updated workflow file here [2].

Work to integrate buildkit on Docker Engine is ongoing here [3], and this integration tests are part of what's needed to complete.

[1] https://github.com/profnandaa/moby/actions/runs/14811696298
[2] https://github.com/profnandaa/moby/blob/c9d2649f4ddb86f8f68dd3e56f358537c4d2b8f3/.github/workflows/buildkit.yml#L266-L381
[3] https://github.com/moby/moby/pull/49740