### PR TITLE
cache: improve migration to image manifest cache

### DIFF
--- a/cache/remotecache/export.go
+++ b/cache/remotecache/export.go
@@ -83,7 +83,7 @@ func NewExportableCache(oci bool, imageManifest bool) (*ExportableCache, error) 
 	if imageManifest {
 		mediaType = ocispecs.MediaTypeImageManifest
 		if !oci {
-			return nil, errors.Errorf("invalid configuration for remote cache")
+			return nil, errors.Errorf("invalid configuration for remote cache, OCI mediatypes are required for image-manifest cache format")
 		}
 	} else {
 		if oci {

--- a/cache/remotecache/local/local.go
+++ b/cache/remotecache/local/local.go
@@ -58,7 +58,10 @@ func ResolveCacheExporterFunc(sm *session.Manager) remotecache.ResolveCacheExpor
 				return nil, errors.Wrapf(err, "failed to parse %s", attrImageManifest)
 			}
 			imageManifest = b
+		} else if !ociMediatypes {
+			imageManifest = false
 		}
+
 		csID := contentStoreIDPrefix + store
 		cs, err := getContentStore(ctx, sm, g, csID)
 		if err != nil {

--- a/cache/remotecache/registry/registry.go
+++ b/cache/remotecache/registry/registry.go
@@ -76,6 +76,8 @@ func ResolveCacheExporterFunc(sm *session.Manager, hosts docker.RegistryHosts) r
 				return nil, errors.Wrapf(err, "failed to parse %s", attrImageManifest)
 			}
 			imageManifest = b
+		} else if !ociMediatypes {
+			imageManifest = false
 		}
 		insecure := false
 		if v, ok := attrs[attrInsecure]; ok {


### PR DESCRIPTION
fix #5965

Improve error message and don't default to `image-manifest=true` if user intentionally sets `oci-mediatypes=false`.