### PR TITLE
fix: omit empty list of platforms when serializing worker config

### DIFF
--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -104,7 +104,7 @@ type NetworkConfig struct {
 type OCIConfig struct {
 	Enabled          *bool             `toml:"enabled"`
 	Labels           map[string]string `toml:"labels"`
-	Platforms        []string          `toml:"platforms"`
+	Platforms        []string          `toml:"platforms,omitempty"`
 	Snapshotter      string            `toml:"snapshotter"`
 	Rootless         bool              `toml:"rootless"`
 	NoProcessSandbox bool              `toml:"noProcessSandbox"`
@@ -138,7 +138,7 @@ type ContainerdConfig struct {
 	Address   string            `toml:"address"`
 	Enabled   *bool             `toml:"enabled"`
 	Labels    map[string]string `toml:"labels"`
-	Platforms []string          `toml:"platforms"`
+	Platforms []string          `toml:"platforms,omitempty"`
 	Namespace string            `toml:"namespace"`
 	Runtime   ContainerdRuntime `toml:"runtime"`
 	GCConfig


### PR DESCRIPTION
Previously, when no platforms were explicitly defined in the config,
serialization would emit an empty array instead of omitting the field.
When loading this cofig, this prevented the worker from falling back
to default platform detection during initialization. By using `omitempty`,
we ensure the field is excluded when empty, allowing defaults to be
correctly applied.

Fixes #5740.

Signed-off-by: Alberto Garcia Hierro <damaso.hierro@docker.com>
