### PR TITLE
cdi: fix device request by class annotation

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -11884,7 +11884,7 @@ devices:
 		st = busybox.Run(append(ro, llb.Shlex(cmd), llb.Dir("/wd"))...).AddMount("/wd", st)
 	}
 
-	run(`sh -c 'env|sort | tee class.env'`, llb.AddCDIDevice(llb.CDIDeviceName("vendor1.com/device=class1")))
+	run(`sh -c 'env|sort | tee class.env'`, llb.AddCDIDevice(llb.CDIDeviceName("class1")))
 
 	def, err := st.Marshal(sb.Context())
 	require.NoError(t, err)

--- a/solver/llbsolver/cdidevices/fixtures/vendor1-devicemulti.yaml
+++ b/solver/llbsolver/cdidevices/fixtures/vendor1-devicemulti.yaml
@@ -10,6 +10,8 @@ devices:
       env:
         - BAR=injected
   - name: baz
+    annotations:
+      org.mobyproject.buildkit.device.class: class1
     containerEdits:
       env:
         - BAZ=injected

--- a/solver/llbsolver/cdidevices/manager.go
+++ b/solver/llbsolver/cdidevices/manager.go
@@ -157,49 +157,41 @@ func (m *Manager) parseDevice(dev *pb.CDIDevice, all []string) ([]string, error)
 
 	kind, name, _ := strings.Cut(dev.Name, "=")
 
-	// validate kind
-	if vendor, class := parser.ParseQualifier(kind); vendor == "" {
-		return nil, errors.Errorf("invalid device %q", dev.Name)
-	} else if err := parser.ValidateVendorName(vendor); err != nil {
-		return nil, errors.Wrapf(err, "invalid device %q", dev.Name)
-	} else if err := parser.ValidateClassName(class); err != nil {
-		return nil, errors.Wrapf(err, "invalid device %q", dev.Name)
+	vendor, _ := parser.ParseQualifier(kind)
+	if vendor != "" {
+		switch name {
+		case "":
+			// first device of kind if no name is specified
+			for _, d := range all {
+				if strings.HasPrefix(d, kind+"=") {
+					out = append(out, d)
+					break
+				}
+			}
+		case "*":
+			// all devices of kind if the name is a wildcard
+			for _, d := range all {
+				if strings.HasPrefix(d, kind+"=") {
+					out = append(out, d)
+				}
+			}
+		default:
+			// the specified device
+			for _, d := range all {
+				if d == dev.Name {
+					out = append(out, d)
+					break
+				}
+			}
+		}
 	}
 
-	switch name {
-	case "":
-		// first device of kind if no name is specified
+	// check class annotation if device qualifier invalid or no device found
+	if vendor == "" || len(out) == 0 {
 		for _, d := range all {
-			if strings.HasPrefix(d, kind+"=") {
-				out = append(out, d)
-				break
-			}
-		}
-	case "*":
-		// all devices of kind if the name is a wildcard
-		for _, d := range all {
-			if strings.HasPrefix(d, kind+"=") {
-				out = append(out, d)
-			}
-		}
-	default:
-		// the specified device
-		for _, d := range all {
-			if d == dev.Name {
-				out = append(out, d)
-				break
-			}
-		}
-		if len(out) == 0 {
-			// check class annotation if name unknown
-			for _, d := range all {
-				if !strings.HasPrefix(d, kind+"=") {
-					continue
-				}
-				if a := deviceAnnotations(m.cache.GetDevice(d)); a != nil {
-					if class, ok := a[deviceAnnotationClass]; ok && class == name {
-						out = append(out, d)
-					}
+			if a := deviceAnnotations(m.cache.GetDevice(d)); a != nil {
+				if class, ok := a[deviceAnnotationClass]; ok && class == dev.Name {
+					out = append(out, d)
 				}
 			}
 		}

--- a/solver/llbsolver/cdidevices/manager_test.go
+++ b/solver/llbsolver/cdidevices/manager_test.go
@@ -39,9 +39,9 @@ func TestFindDevices(t *testing.T) {
 		{
 			name: "Find devices by class",
 			devices: []*pb.CDIDevice{
-				{Name: "vendor1.com/deviceclass=class1"},
+				{Name: "class1"},
 			},
-			expected: []string{"vendor1.com/deviceclass=foo", "vendor1.com/deviceclass=bar"},
+			expected: []string{"vendor1.com/deviceclass=foo", "vendor1.com/deviceclass=bar", "vendor1.com/devicemulti=baz"},
 		},
 		{
 			name: "Device not found",


### PR DESCRIPTION
follow-up https://github.com/moby/buildkit/pull/5923#pullrequestreview-2826593148

Current logic to find devices by class annotation was not correct. Now user can just specify the class of the device without it being a device qualifer so it handles multiple CDI specs registered.