### PR TITLE
git url: support query form + support specifying checksum in query

### DIFF
--- a/client/llb/source.go
+++ b/client/llb/source.go
@@ -323,6 +323,9 @@ func Git(url, ref string, opts ...GitOption) State {
 	}
 
 	checksum := gi.Checksum
+	if checksum == "" && remote != nil && remote.Opts != nil {
+		checksum = remote.Opts.Checksum
+	}
 	if checksum != "" {
 		attrs[pb.AttrGitChecksum] = checksum
 		addCap(&gi.Constraints, pb.CapSourceGitChecksum)

--- a/frontend/dockerfile/dfgitutil/git_ref.go
+++ b/frontend/dockerfile/dfgitutil/git_ref.go
@@ -27,6 +27,10 @@ type GitRef struct {
 	// Commit is optional.
 	Commit string
 
+	// Checksum verifies the Commit if specified.
+	// Checksum is optional.
+	Checksum string
+
 	// SubDir is a directory path inside the repo.
 	// SubDir is optional.
 	SubDir string
@@ -99,7 +103,7 @@ func ParseGitRef(ref string) (*GitRef, error) {
 		_, res.Remote, _ = strings.Cut(res.Remote, "://")
 	}
 	if remote.Opts != nil {
-		res.Commit, res.SubDir = remote.Opts.Ref, remote.Opts.Subdir
+		res.Commit, res.Checksum, res.SubDir = remote.Opts.Ref, remote.Opts.Checksum, remote.Opts.Subdir
 	}
 
 	repoSplitBySlash := strings.Split(res.Remote, "/")

--- a/frontend/dockerfile/dfgitutil/git_ref.go
+++ b/frontend/dockerfile/dfgitutil/git_ref.go
@@ -63,11 +63,14 @@ func ParseGitRef(ref string) (*GitRef, error) {
 		return nil, cerrdefs.ErrInvalidArgument
 	} else if strings.HasPrefix(ref, "github.com/") {
 		res.IndistinguishableFromLocal = true // Deprecated
-		remote = gitutil.FromURL(&url.URL{
+		remote, err = gitutil.FromURL(&url.URL{
 			Scheme: "https",
 			Host:   "github.com",
 			Path:   strings.TrimPrefix(ref, "github.com/"),
 		})
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		remote, err = gitutil.ParseURL(ref)
 		if errors.Is(err, gitutil.ErrUnknownProtocol) {

--- a/frontend/dockerfile/dfgitutil/git_ref.go
+++ b/frontend/dockerfile/dfgitutil/git_ref.go
@@ -50,6 +50,12 @@ type GitRef struct {
 	// Discouraged, although not deprecated.
 	// Instead, consider using an encrypted TCP connection such as "git@github.com/foo/bar.git" or "https://github.com/foo/bar.git".
 	UnencryptedTCP bool
+
+	gitURL *gitutil.GitURL
+}
+
+func (r *GitRef) GitURL() *gitutil.GitURL {
+	return r.gitURL
 }
 
 // var gitURLPathWithFragmentSuffix = regexp.MustCompile(`\.git(?:#.+)?$`)
@@ -108,6 +114,7 @@ func ParseGitRef(ref string) (*GitRef, error) {
 
 	repoSplitBySlash := strings.Split(res.Remote, "/")
 	res.ShortName = strings.TrimSuffix(repoSplitBySlash[len(repoSplitBySlash)-1], ".git")
+	res.gitURL = remote
 
 	return res, nil
 }

--- a/frontend/dockerfile/dfgitutil/git_ref_test.go
+++ b/frontend/dockerfile/dfgitutil/git_ref_test.go
@@ -138,6 +138,15 @@ func TestParseGitRef(t *testing.T) {
 			ref:      ".git",
 			expected: nil,
 		},
+		{
+			ref: "https://github.com/docker/docker.git?ref=v1.0.0&subdir=/subdir",
+			expected: &GitRef{
+				Remote:    "https://github.com/docker/docker.git",
+				ShortName: "docker",
+				Commit:    "v1.0.0",
+				SubDir:    "/subdir",
+			},
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.ref, func(t *testing.T) {

--- a/frontend/dockerfile/dfgitutil/git_ref_test.go
+++ b/frontend/dockerfile/dfgitutil/git_ref_test.go
@@ -156,7 +156,7 @@ func TestParseGitRef(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, tt.expected, got)
+				require.EqualExportedValues(t, tt.expected, got)
 			}
 		})
 	}

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -1517,11 +1517,14 @@ func dispatchCopy(d *dispatchState, cfg copyConfig) error {
 			if gitRef.SubDir != "" {
 				commit += ":" + gitRef.SubDir
 			}
-			gitOptions := []llb.GitOption{llb.WithCustomName(pgName)}
+			gitOptions := []llb.GitOption{llb.WithCustomName(pgName), llb.GitChecksum(gitRef.Checksum)}
 			if cfg.keepGitDir {
 				gitOptions = append(gitOptions, llb.KeepGitDir())
 			}
 			if cfg.checksum != "" {
+				if gitRef.Checksum != "" && gitRef.Checksum != cfg.checksum {
+					return errors.Errorf("conflicting checksum: %s vs %s", gitRef.Checksum, cfg.checksum)
+				}
 				gitOptions = append(gitOptions, llb.GitChecksum(cfg.checksum))
 			}
 			st := llb.Git(gitRef.Remote, commit, gitOptions...)

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -1526,7 +1526,13 @@ func dispatchCopy(d *dispatchState, cfg copyConfig) error {
 			if gitRef.SubDir != "" {
 				commit += ":" + gitRef.SubDir
 			}
-			gitOptions := []llb.GitOption{llb.WithCustomName(pgName), llb.GitChecksum(gitRef.Checksum)}
+			gu := gitRef.GitURL()
+			fullURL := src
+			if gu.Remote != "" {
+				fullURL = gu.Remote
+			}
+			gitOptions := []llb.GitOption{llb.WithCustomName(pgName), llb.GitChecksum(gitRef.Checksum),
+				llb.GitIDSuffix(commit), llb.GitFullURL(fullURL)}
 			if cfg.keepGitDir {
 				gitOptions = append(gitOptions, llb.KeepGitDir())
 			}
@@ -1536,7 +1542,7 @@ func dispatchCopy(d *dispatchState, cfg copyConfig) error {
 				}
 				gitOptions = append(gitOptions, llb.GitChecksum(cfg.checksum))
 			}
-			st := llb.Git(gitRef.Remote, commit, gitOptions...)
+			st := llb.Git2(gitRef.GitURL().GitURLBase, gitOptions...)
 			opts := append([]llb.CopyOption{&llb.CopyInfo{
 				Mode:           chopt,
 				CreateDestPath: true,

--- a/frontend/dockerui/context.go
+++ b/frontend/dockerui/context.go
@@ -149,7 +149,7 @@ func DetectGitContext(ref string, keepGit bool) (*llb.State, bool) {
 	if g.SubDir != "" {
 		commit += ":" + g.SubDir
 	}
-	gitOpts := []llb.GitOption{WithInternalName("load git source " + ref)}
+	gitOpts := []llb.GitOption{WithInternalName("load git source " + ref), llb.GitChecksum(g.Checksum)}
 	if keepGit {
 		gitOpts = append(gitOpts, llb.KeepGitDir())
 	}

--- a/frontend/dockerui/context.go
+++ b/frontend/dockerui/context.go
@@ -149,12 +149,17 @@ func DetectGitContext(ref string, keepGit bool) (*llb.State, bool) {
 	if g.SubDir != "" {
 		commit += ":" + g.SubDir
 	}
-	gitOpts := []llb.GitOption{WithInternalName("load git source " + ref), llb.GitChecksum(g.Checksum)}
+	gu := g.GitURL()
+	fullURL := ref
+	if gu.Remote != "" {
+		fullURL = gu.Remote
+	}
+	gitOpts := []llb.GitOption{WithInternalName("load git source " + ref), llb.GitChecksum(g.Checksum),
+		llb.GitIDSuffix(commit), llb.GitFullURL(fullURL)}
 	if keepGit {
 		gitOpts = append(gitOpts, llb.KeepGitDir())
 	}
-
-	st := llb.Git(g.Remote, commit, gitOpts...)
+	st := llb.Git2(gu.GitURLBase, gitOpts...)
 	return &st, true
 }
 

--- a/source/git/identifier.go
+++ b/source/git/identifier.go
@@ -34,6 +34,7 @@ func NewGitIdentifier(remoteURL string) (*GitIdentifier, error) {
 	repo := GitIdentifier{Remote: u.Remote}
 	if u.Opts != nil {
 		repo.Ref = u.Opts.Ref
+		repo.Checksum = u.Opts.Checksum
 		repo.Subdir = u.Opts.Subdir
 	}
 	if sd := path.Clean(repo.Subdir); sd == "/" || sd == "." {

--- a/util/gitutil/git_url.go
+++ b/util/gitutil/git_url.go
@@ -56,7 +56,7 @@ type GitURL struct {
 }
 
 // GitURLOpts is the buildkit-specific metadata extracted from the fragment
-// of a remote URL.
+// or the query of a remote URL.
 type GitURLOpts struct {
 	// Ref is the git reference
 	Ref string
@@ -66,12 +66,63 @@ type GitURLOpts struct {
 
 // parseOpts splits a git URL fragment into its respective git
 // reference and subdirectory components.
-func parseOpts(fragment string) *GitURLOpts {
-	if fragment == "" {
-		return nil
+func parseOpts(fragment string, query url.Values) (*GitURLOpts, error) {
+	if fragment == "" && len(query) == 0 {
+		return nil, nil
 	}
-	ref, subdir, _ := strings.Cut(fragment, ":")
-	return &GitURLOpts{Ref: ref, Subdir: subdir}
+	opts := &GitURLOpts{}
+	if fragment != "" {
+		opts.Ref, opts.Subdir, _ = strings.Cut(fragment, ":")
+	}
+	var tag, branch string
+	for k, v := range query {
+		switch len(v) {
+		case 0:
+			return nil, errors.Errorf("query %q has no value", k)
+		case 1:
+			if v[0] == "" {
+				return nil, errors.Errorf("query %q has no value", k)
+			}
+			// NOP
+		default:
+			return nil, errors.Errorf("query %q has multiple values", k)
+		}
+		switch k {
+		case "ref":
+			if opts.Ref != "" && opts.Ref != v[0] {
+				return nil, errors.Errorf("ref conflicts: %q vs %q", opts.Ref, v[0])
+			}
+			opts.Ref = v[0]
+		case "tag":
+			tag = v[0]
+		case "branch":
+			branch = v[0]
+		case "subdir":
+			if opts.Subdir != "" && opts.Subdir != v[0] {
+				return nil, errors.Errorf("subdir conflicts: %q vs %q", opts.Subdir, v[0])
+			}
+			opts.Subdir = v[0]
+		default:
+			return nil, errors.Errorf("unexpected query %q", k)
+		}
+	}
+	if tag != "" {
+		if opts.Ref != "" {
+			return nil, errors.New("tag conflicts with ref")
+		}
+		opts.Ref = "refs/tags/" + tag
+	}
+	if branch != "" {
+		if tag != "" {
+			// TODO: consider allowing this, when the tag actually exists on the branch
+			return nil, errors.New("branch conflicts with tag")
+		}
+		if opts.Ref != "" {
+			return nil, errors.New("branch conflicts with ref")
+		}
+		opts.Ref = "refs/heads/" + branch
+	}
+	return opts, nil
 }
 
 // ParseURL parses a BuildKit-style Git URL (that may contain additional
@@ -86,11 +137,11 @@ func ParseURL(remote string) (*GitURL, error) {
 		if err != nil {
 			return nil, err
 		}
-		return FromURL(url), nil
+		return FromURL(url)
 	}
 
 	if url, err := sshutil.ParseSCPStyleURL(remote); err == nil {
-		return fromSCPStyleURL(url), nil
+		return fromSCPStyleURL(url)
 	}
 
 	return nil, ErrUnknownProtocol
@@ -105,28 +156,38 @@ func IsGitTransport(remote string) bool {
 	return sshutil.IsImplicitSSHTransport(remote)
 }
 
-func FromURL(url *url.URL) *GitURL {
+func FromURL(url *url.URL) (*GitURL, error) {
 	withoutOpts := *url
 	withoutOpts.Fragment = ""
+	withoutOpts.RawQuery = ""
+	opts, err := parseOpts(url.Fragment, url.Query())
+	if err != nil {
+		return nil, err
+	}
 	return &GitURL{
 		Scheme: url.Scheme,
 		User:   url.User,
 		Host:   url.Host,
 		Path:   url.Path,
-		Opts:   parseOpts(url.Fragment),
+		Opts:   opts,
 		Remote: withoutOpts.String(),
-	}
+	}, nil
 }
 
-func fromSCPStyleURL(url *sshutil.SCPStyleURL) *GitURL {
+func fromSCPStyleURL(url *sshutil.SCPStyleURL) (*GitURL, error) {
 	withoutOpts := *url
 	withoutOpts.Fragment = ""
+	withoutOpts.Query = nil
+	opts, err := parseOpts(url.Fragment, url.Query)
+	if err != nil {
+		return nil, err
+	}
 	return &GitURL{
 		Scheme: SSHProtocol,
 		User:   url.User,
 		Host:   url.Host,
 		Path:   url.Path,
-		Opts:   parseOpts(url.Fragment),
+		Opts:   opts,
 		Remote: withoutOpts.String(),
-	}
+	}, nil
 }

--- a/util/gitutil/git_url.go
+++ b/util/gitutil/git_url.go
@@ -60,6 +60,8 @@ type GitURL struct {
 type GitURLOpts struct {
 	// Ref is the git reference
 	Ref string
+	// Checksum is the commit hash
+	Checksum string
 	// Subdir is the sub-directory inside the git repository to use
 	Subdir string
 }
@@ -97,6 +99,8 @@ func parseOpts(fragment string, query url.Values) (*GitURLOpts, error) {
 			tag = v[0]
 		case "branch":
 			branch = v[0]
+		case "checksum", "commit":
+			opts.Checksum = v[0]
 		case "subdir":
 			if opts.Subdir != "" && opts.Subdir != v[0] {
 				return nil, errors.Errorf("subdir conflicts: %q vs %q", opts.Subdir, v[0])
@@ -121,6 +125,9 @@ func parseOpts(fragment string, query url.Values) (*GitURLOpts, error) {
 			return nil, errors.New("branch conflicts with ref")
 		}
 		opts.Ref = "refs/heads/" + branch
+	}
+	if opts.Checksum != "" && opts.Ref == "" {
+		opts.Ref = opts.Checksum
 	}
 	return opts, nil
 }

--- a/util/gitutil/git_url_test.go
+++ b/util/gitutil/git_url_test.go
@@ -151,6 +151,65 @@ func TestParseURL(t *testing.T) {
 				Path:   "/moby/buildkit",
 			},
 		},
+		{
+			url: "https://github.com/moby/buildkit?ref=v1.0.0&subdir=/subdir",
+			result: GitURL{
+				Scheme: HTTPSProtocol,
+				Host:   "github.com",
+				Path:   "/moby/buildkit",
+				Opts:   &GitURLOpts{Ref: "v1.0.0", Subdir: "/subdir"},
+			},
+		},
+		{
+			url: "https://github.com/moby/buildkit?subdir=/subdir#v1.0.0",
+			result: GitURL{
+				Scheme: HTTPSProtocol,
+				Host:   "github.com",
+				Path:   "/moby/buildkit",
+				Opts:   &GitURLOpts{Ref: "v1.0.0", Subdir: "/subdir"},
+			},
+		},
+		{
+			url: "https://github.com/moby/buildkit?tag=v1.0.0",
+			result: GitURL{
+				Scheme: HTTPSProtocol,
+				Host:   "github.com",
+				Path:   "/moby/buildkit",
+				Opts:   &GitURLOpts{Ref: "refs/tags/v1.0.0"},
+			},
+		},
+		{
+			url: "https://github.com/moby/buildkit?branch=v1.0",
+			result: GitURL{
+				Scheme: HTTPSProtocol,
+				Host:   "github.com",
+				Path:   "/moby/buildkit",
+				Opts:   &GitURLOpts{Ref: "refs/heads/v1.0"},
+			},
+		},
+		{
+			url: "https://github.com/moby/buildkit?ref=v1.0.0#v1.2.3",
+			err: true,
+		},
+		{
+			url: "https://github.com/moby/buildkit?ref=v1.0.0&tag=v1.2.3",
+			err: true,
+		},
+		{
+			// TODO: consider allowing this, when the tag actually exists on the branch
+			url: "https://github.com/moby/buildkit?tag=v1.0.0&branch=v1.0",
+			err: true,
+		},
+		{
+			url: "git@github.com:moby/buildkit.git?subdir=/subdir#v1.0.0",
+			result: GitURL{
+				Scheme: SSHProtocol,
+				Host:   "github.com",
+				Path:   "moby/buildkit.git",
+				User:   url.User("git"),
+				Opts:   &GitURLOpts{Ref: "v1.0.0", Subdir: "/subdir"},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.url, func(t *testing.T) {

--- a/util/gitutil/git_url_test.go
+++ b/util/gitutil/git_url_test.go
@@ -16,127 +16,155 @@ func TestParseURL(t *testing.T) {
 		{
 			url: "http://github.com/moby/buildkit",
 			result: GitURL{
-				Scheme: HTTPProtocol,
-				Host:   "github.com",
-				Path:   "/moby/buildkit",
+				GitURLBase: GitURLBase{
+					Scheme: HTTPProtocol,
+					Host:   "github.com",
+					Path:   "/moby/buildkit",
+				},
 			},
 		},
 		{
 			url: "https://github.com/moby/buildkit",
 			result: GitURL{
-				Scheme: HTTPSProtocol,
-				Host:   "github.com",
-				Path:   "/moby/buildkit",
+				GitURLBase: GitURLBase{
+					Scheme: HTTPSProtocol,
+					Host:   "github.com",
+					Path:   "/moby/buildkit",
+				},
 			},
 		},
 		{
 			url: "http://github.com/moby/buildkit#v1.0.0",
 			result: GitURL{
-				Scheme: HTTPProtocol,
-				Host:   "github.com",
-				Path:   "/moby/buildkit",
-				Opts:   &GitURLOpts{Ref: "v1.0.0"},
+				GitURLBase: GitURLBase{
+					Scheme: HTTPProtocol,
+					Host:   "github.com",
+					Path:   "/moby/buildkit",
+				},
+				Opts: &GitURLOpts{Ref: "v1.0.0"},
 			},
 		},
 		{
 			url: "http://github.com/moby/buildkit#v1.0.0:subdir",
 			result: GitURL{
-				Scheme: HTTPProtocol,
-				Host:   "github.com",
-				Path:   "/moby/buildkit",
-				Opts:   &GitURLOpts{Ref: "v1.0.0", Subdir: "subdir"},
+				GitURLBase: GitURLBase{
+					Scheme: HTTPProtocol,
+					Host:   "github.com",
+					Path:   "/moby/buildkit",
+				},
+				Opts: &GitURLOpts{Ref: "v1.0.0", Subdir: "subdir"},
 			},
 		},
 		{
 			url: "http://foo:bar@github.com/moby/buildkit#v1.0.0",
 			result: GitURL{
-				Scheme: HTTPProtocol,
-				Host:   "github.com",
-				Path:   "/moby/buildkit",
-				Opts:   &GitURLOpts{Ref: "v1.0.0"},
-				User:   url.UserPassword("foo", "bar"),
+				GitURLBase: GitURLBase{
+					Scheme: HTTPProtocol,
+					Host:   "github.com",
+					Path:   "/moby/buildkit",
+				},
+				Opts: &GitURLOpts{Ref: "v1.0.0"},
+				User: url.UserPassword("foo", "bar"),
 			},
 		},
 		{
 			url: "ssh://git@github.com/moby/buildkit.git",
 			result: GitURL{
-				Scheme: SSHProtocol,
-				Host:   "github.com",
-				Path:   "/moby/buildkit.git",
-				User:   url.User("git"),
+				GitURLBase: GitURLBase{
+					Scheme: SSHProtocol,
+					Host:   "github.com",
+					Path:   "/moby/buildkit.git",
+				},
+				User: url.User("git"),
 			},
 		},
 		{
 			url: "ssh://git@github.com:22/moby/buildkit.git",
 			result: GitURL{
-				Scheme: SSHProtocol,
-				Host:   "github.com:22",
-				Path:   "/moby/buildkit.git",
-				User:   url.User("git"),
+				GitURLBase: GitURLBase{
+					Scheme: SSHProtocol,
+					Host:   "github.com:22",
+					Path:   "/moby/buildkit.git",
+				},
+				User: url.User("git"),
 			},
 		},
 		{
 			url: "git@github.com:moby/buildkit.git",
 			result: GitURL{
-				Scheme: SSHProtocol,
-				Host:   "github.com",
-				Path:   "moby/buildkit.git",
-				User:   url.User("git"),
+				GitURLBase: GitURLBase{
+					Scheme: SSHProtocol,
+					Host:   "github.com",
+					Path:   "moby/buildkit.git",
+				},
+				User: url.User("git"),
 			},
 		},
 		{
 			url: "git@github.com:moby/buildkit.git#v1.0.0",
 			result: GitURL{
-				Scheme: SSHProtocol,
-				Host:   "github.com",
-				Path:   "moby/buildkit.git",
-				Opts:   &GitURLOpts{Ref: "v1.0.0"},
-				User:   url.User("git"),
+				GitURLBase: GitURLBase{
+					Scheme: SSHProtocol,
+					Host:   "github.com",
+					Path:   "moby/buildkit.git",
+				},
+				Opts: &GitURLOpts{Ref: "v1.0.0"},
+				User: url.User("git"),
 			},
 		},
 		{
 			url: "git@github.com:moby/buildkit.git#v1.0.0:hack",
 			result: GitURL{
-				Scheme: SSHProtocol,
-				Host:   "github.com",
-				Path:   "moby/buildkit.git",
-				Opts:   &GitURLOpts{Ref: "v1.0.0", Subdir: "hack"},
-				User:   url.User("git"),
+				GitURLBase: GitURLBase{
+					Scheme: SSHProtocol,
+					Host:   "github.com",
+					Path:   "moby/buildkit.git",
+				},
+				Opts: &GitURLOpts{Ref: "v1.0.0", Subdir: "hack"},
+				User: url.User("git"),
 			},
 		},
 		{
 			url: "nonstandarduser@example.com:/srv/repos/weird/project.git",
 			result: GitURL{
-				Scheme: SSHProtocol,
-				Host:   "example.com",
-				Path:   "/srv/repos/weird/project.git",
-				User:   url.User("nonstandarduser"),
+				GitURLBase: GitURLBase{
+					Scheme: SSHProtocol,
+					Host:   "example.com",
+					Path:   "/srv/repos/weird/project.git",
+				},
+				User: url.User("nonstandarduser"),
 			},
 		},
 		{
 			url: "ssh://root@subdomain.example.hostname:2222/root/my/really/weird/path/foo.git",
 			result: GitURL{
-				Scheme: SSHProtocol,
-				Host:   "subdomain.example.hostname:2222",
-				Path:   "/root/my/really/weird/path/foo.git",
-				User:   url.User("root"),
+				GitURLBase: GitURLBase{
+					Scheme: SSHProtocol,
+					Host:   "subdomain.example.hostname:2222",
+					Path:   "/root/my/really/weird/path/foo.git",
+				},
+				User: url.User("root"),
 			},
 		},
 		{
 			url: "git://host.xz:1234/path/to/repo.git",
 			result: GitURL{
-				Scheme: GitProtocol,
-				Host:   "host.xz:1234",
-				Path:   "/path/to/repo.git",
+				GitURLBase: GitURLBase{
+					Scheme: GitProtocol,
+					Host:   "host.xz:1234",
+					Path:   "/path/to/repo.git",
+				},
 			},
 		},
 		{
 			url: "ssh://someuser@192.168.0.123:456/~/repo-in-my-home-dir.git",
 			result: GitURL{
-				Scheme: SSHProtocol,
-				Host:   "192.168.0.123:456",
-				Path:   "/~/repo-in-my-home-dir.git",
-				User:   url.User("someuser"),
+				GitURLBase: GitURLBase{
+					Scheme: SSHProtocol,
+					Host:   "192.168.0.123:456",
+					Path:   "/~/repo-in-my-home-dir.git",
+				},
+				User: url.User("someuser"),
 			},
 		},
 		{
@@ -146,45 +174,55 @@ func TestParseURL(t *testing.T) {
 		{
 			url: "HTTP://github.com/moby/buildkit",
 			result: GitURL{
-				Scheme: HTTPProtocol,
-				Host:   "github.com",
-				Path:   "/moby/buildkit",
+				GitURLBase: GitURLBase{
+					Scheme: HTTPProtocol,
+					Host:   "github.com",
+					Path:   "/moby/buildkit",
+				},
 			},
 		},
 		{
 			url: "https://github.com/moby/buildkit?ref=v1.0.0&subdir=/subdir",
 			result: GitURL{
-				Scheme: HTTPSProtocol,
-				Host:   "github.com",
-				Path:   "/moby/buildkit",
-				Opts:   &GitURLOpts{Ref: "v1.0.0", Subdir: "/subdir"},
+				GitURLBase: GitURLBase{
+					Scheme: HTTPSProtocol,
+					Host:   "github.com",
+					Path:   "/moby/buildkit",
+				},
+				Opts: &GitURLOpts{Ref: "v1.0.0", Subdir: "/subdir"},
 			},
 		},
 		{
 			url: "https://github.com/moby/buildkit?subdir=/subdir#v1.0.0",
 			result: GitURL{
-				Scheme: HTTPSProtocol,
-				Host:   "github.com",
-				Path:   "/moby/buildkit",
-				Opts:   &GitURLOpts{Ref: "v1.0.0", Subdir: "/subdir"},
+				GitURLBase: GitURLBase{
+					Scheme: HTTPSProtocol,
+					Host:   "github.com",
+					Path:   "/moby/buildkit",
+				},
+				Opts: &GitURLOpts{Ref: "v1.0.0", Subdir: "/subdir"},
 			},
 		},
 		{
 			url: "https://github.com/moby/buildkit?tag=v1.0.0&commit=deadbeef",
 			result: GitURL{
-				Scheme: HTTPSProtocol,
-				Host:   "github.com",
-				Path:   "/moby/buildkit",
-				Opts:   &GitURLOpts{Ref: "refs/tags/v1.0.0", Checksum: "deadbeef"},
+				GitURLBase: GitURLBase{
+					Scheme: HTTPSProtocol,
+					Host:   "github.com",
+					Path:   "/moby/buildkit",
+				},
+				Opts: &GitURLOpts{Ref: "refs/tags/v1.0.0", Checksum: "deadbeef"},
 			},
 		},
 		{
 			url: "https://github.com/moby/buildkit?branch=v1.0",
 			result: GitURL{
-				Scheme: HTTPSProtocol,
-				Host:   "github.com",
-				Path:   "/moby/buildkit",
-				Opts:   &GitURLOpts{Ref: "refs/heads/v1.0"},
+				GitURLBase: GitURLBase{
+					Scheme: HTTPSProtocol,
+					Host:   "github.com",
+					Path:   "/moby/buildkit",
+				},
+				Opts: &GitURLOpts{Ref: "refs/heads/v1.0"},
 			},
 		},
 		{
@@ -203,11 +241,13 @@ func TestParseURL(t *testing.T) {
 		{
 			url: "git@github.com:moby/buildkit.git?subdir=/subdir#v1.0.0",
 			result: GitURL{
-				Scheme: SSHProtocol,
-				Host:   "github.com",
-				Path:   "moby/buildkit.git",
-				User:   url.User("git"),
-				Opts:   &GitURLOpts{Ref: "v1.0.0", Subdir: "/subdir"},
+				GitURLBase: GitURLBase{
+					Scheme: SSHProtocol,
+					Host:   "github.com",
+					Path:   "moby/buildkit.git",
+				},
+				User: url.User("git"),
+				Opts: &GitURLOpts{Ref: "v1.0.0", Subdir: "/subdir"},
 			},
 		},
 	}

--- a/util/gitutil/git_url_test.go
+++ b/util/gitutil/git_url_test.go
@@ -170,12 +170,12 @@ func TestParseURL(t *testing.T) {
 			},
 		},
 		{
-			url: "https://github.com/moby/buildkit?tag=v1.0.0",
+			url: "https://github.com/moby/buildkit?tag=v1.0.0&commit=deadbeef",
 			result: GitURL{
 				Scheme: HTTPSProtocol,
 				Host:   "github.com",
 				Path:   "/moby/buildkit",
-				Opts:   &GitURLOpts{Ref: "refs/tags/v1.0.0"},
+				Opts:   &GitURLOpts{Ref: "refs/tags/v1.0.0", Checksum: "deadbeef"},
 			},
 		},
 		{


### PR DESCRIPTION
Split from:
- #5903

- - -

e.g.,
```
https://github.com/moby/example.git?ref=v1.0.0&commit=deadbeef&subdir=/subdir

# alias of ref=refs/tags/v1.0.0
https://github.com/moby/example.git?tag=v1.0.0

# alias of ref=refs/heads/v1.0
https://github.com/moby/example.git?branch=v1.0
```

Fix #4905, but the syntax differs from the original proposal.

The document will be added to
https://github.com/docker/docs/blob/main/content/manuals/build/concepts/context.md#url-fragments