### PR TITLE
Dockerfile: curl: add -S -f

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -148,7 +148,7 @@ ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETPLATFORM
 WORKDIR /opt/cni/bin
-RUN curl -Ls https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-${TARGETOS}-${TARGETARCH}-${CNI_VERSION}.tgz | tar xzv
+RUN curl -fsSL https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-${TARGETOS}-${TARGETARCH}-${CNI_VERSION}.tgz | tar xzv
 RUN xx-verify --static bridge loopback host-local
 COPY --link --from=dnsname /usr/bin/dnsname /opt/cni/bin/
 
@@ -417,13 +417,13 @@ RUN apk add --no-cache shadow shadow-uidmap sudo vim iptables ip6tables dnsmasq 
   && ln -s /sbin/iptables-legacy /usr/bin/iptables \
   && xx-go --wrap
 ARG NERDCTL_VERSION
-RUN curl -Ls https://raw.githubusercontent.com/containerd/nerdctl/$NERDCTL_VERSION/extras/rootless/containerd-rootless.sh > /usr/bin/containerd-rootless.sh \
+RUN curl -fsSL https://raw.githubusercontent.com/containerd/nerdctl/$NERDCTL_VERSION/extras/rootless/containerd-rootless.sh > /usr/bin/containerd-rootless.sh \
   && chmod 0755 /usr/bin/containerd-rootless.sh
 ARG AZURITE_VERSION
 RUN apk add --no-cache nodejs npm \
   && npm install -g azurite@${AZURITE_VERSION}
 # The entrypoint script is needed for enabling nested cgroup v2 (https://github.com/moby/buildkit/issues/3265#issuecomment-1309631736)
-RUN curl -Ls https://raw.githubusercontent.com/moby/moby/v25.0.1/hack/dind > /docker-entrypoint.sh \
+RUN curl -fsSL https://raw.githubusercontent.com/moby/moby/v25.0.1/hack/dind > /docker-entrypoint.sh \
   && chmod 0755 /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]
 # musl is needed to directly use the registry binary that is built on alpine

--- a/docs/cni-networking.md
+++ b/docs/cni-networking.md
@@ -17,7 +17,7 @@ ARG CNI_VERSION
 ARG TARGETOS
 ARG TARGETARCH
 WORKDIR /opt/cni/bin
-RUN curl -Ls https://github.com/containernetworking/plugins/releases/download/$CNI_VERSION/cni-plugins-$TARGETOS-$TARGETARCH-$CNI_VERSION.tgz | tar xzv
+RUN curl -fsSL https://github.com/containernetworking/plugins/releases/download/$CNI_VERSION/cni-plugins-$TARGETOS-$TARGETARCH-$CNI_VERSION.tgz | tar xzv
 
 FROM moby/buildkit:${BUILDKIT_VERSION}
 ARG BUILDKIT_VERSION

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -48,7 +48,7 @@ You will be asked to restart your machine, do so, and then continue with the res
     $url = "https://api.github.com/repos/moby/buildkit/releases/latest"
     $version = (Invoke-RestMethod -Uri $url -UseBasicParsing).tag_name
     $arch = "amd64" # arm64 binary available too
-    curl.exe -LO https://github.com/moby/buildkit/releases/download/$version/buildkit-$version.windows-$arch.tar.gz
+    curl.exe -fSLO https://github.com/moby/buildkit/releases/download/$version/buildkit-$version.windows-$arch.tar.gz
     # there could be another `.\bin` directory from containerd instructions
     # you can move those
     mv bin bin2
@@ -245,7 +245,7 @@ _containers_ and _Hyper-V_ features.
 $cniPluginVersion = "0.3.1"
 $cniBinDir = "$env:ProgramFiles\containerd\cni\bin"
 mkdir $cniBinDir -Force
-curl.exe -LO https://github.com/microsoft/windows-container-networking/releases/download/v$cniPluginVersion/windows-container-networking-cni-amd64-v$cniPluginVersion.zip
+curl.exe -fSLO https://github.com/microsoft/windows-container-networking/releases/download/v$cniPluginVersion/windows-container-networking-cni-amd64-v$cniPluginVersion.zip
 tar xvf windows-container-networking-cni-amd64-v$cniPluginVersion.zip -C $cniBinDir
 
 # NOTE: depending on your host setup, the IPs may change after restart
@@ -307,7 +307,7 @@ ctr run --rm --cni mcr.microsoft.com/windows/nanoserver:ltsc20$YY cni-test cmd /
 # Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V, Containers -All
 
 # get the HNS module that has the New-HnsNetwork function.
-curl.exe -LO https://raw.githubusercontent.com/microsoft/SDN/master/Kubernetes/windows/hns.psm1
+curl.exe -fSLO https://raw.githubusercontent.com/microsoft/SDN/master/Kubernetes/windows/hns.psm1
 Import-Module -Force ./hns.psm1
 
 $adapter = Get-NetAdapter | where { $_.InterfaceDescription -eq 'Microsoft Hyper-V Network Adapter' }


### PR DESCRIPTION
-S, --show-error: show an error on failure
-f, --fail:       fail fast with no output at all on server errors

Prior to this commit, curl was just saving an error HTML as the content