### PR TITLE
file: add chown to archive unpack from copy

### DIFF
--- a/solver/llbsolver/file/backend.go
+++ b/solver/llbsolver/file/backend.go
@@ -255,7 +255,7 @@ func docopy(ctx context.Context, src, dest string, action *pb.FileActionCopy, u 
 
 	for _, s := range m {
 		if action.AttemptUnpackDockerCompatibility {
-			if ok, err := unpack(src, s, dest, destPath, ch, timestampToTime(action.Timestamp), idmap); err != nil {
+			if ok, err := unpack(src, s, dest, destPath, ch, u, timestampToTime(action.Timestamp), idmap); err != nil {
 				return errors.WithStack(err)
 			} else if ok {
 				continue

--- a/solver/llbsolver/file/unpack.go
+++ b/solver/llbsolver/file/unpack.go
@@ -13,7 +13,7 @@ import (
 	copy "github.com/tonistiigi/fsutil/copy"
 )
 
-func unpack(srcRoot string, src string, destRoot string, dest string, ch copy.Chowner, tm *time.Time, idmap *user.IdentityMapping) (bool, error) {
+func unpack(srcRoot string, src string, destRoot string, dest string, ch copy.Chowner, u *copy.User, tm *time.Time, idmap *user.IdentityMapping) (bool, error) {
 	src, err := fs.RootPath(srcRoot, src)
 	if err != nil {
 		return false, err
@@ -41,6 +41,12 @@ func unpack(srcRoot string, src string, destRoot string, dest string, ch copy.Ch
 	}
 	if idmap != nil {
 		opts.IDMap = *idmap
+	}
+	if u != nil {
+		opts.ChownOpts = &archive.ChownOpts{
+			UID: u.UID,
+			GID: u.GID,
+		}
 	}
 	return true, chrootarchive.Untar(file, dest, opts)
 }


### PR DESCRIPTION
Note that chowner callback can't be passed in to unpack because callbacks can not be supported by reexec-chrootarchive because parameters are JSON encoded and because the IDMapping is passed separately to unpack so the passed value doesn't actually represent the real UID.

fix https://github.com/docker/buildx/issues/3144