### PR TITLE
solver: handle not found error on cache export

### DIFF
--- a/solver/exporter_test.go
+++ b/solver/exporter_test.go
@@ -1,0 +1,34 @@
+package solver
+
+import (
+	"slices"
+	"testing"
+	"time"
+)
+
+func TestCompareCacheRecord(t *testing.T) {
+	now := time.Now()
+	a := &CacheRecord{CreatedAt: now, Priority: 1}
+	b := &CacheRecord{CreatedAt: now, Priority: 2}
+	c := &CacheRecord{CreatedAt: now.Add(1 * time.Second), Priority: 1}
+	d := &CacheRecord{CreatedAt: now.Add(-1 * time.Second), Priority: 1}
+
+	records := []*CacheRecord{b, nil, d, a, c, nil}
+	slices.SortFunc(records, compareCacheRecord)
+
+	names := map[*CacheRecord]string{
+		a:   "a",
+		b:   "b",
+		c:   "c",
+		d:   "d",
+		nil: "nil",
+	}
+	var got []string
+	for _, r := range records {
+		got = append(got, names[r])
+	}
+	want := []string{"c", "a", "b", "d", "nil", "nil"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("unexpected order: got %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
fixes #5784 (hopefully)
possible that this appears more frequently after #5692

When a cleanup happens while a build is running it may cause boltdb record to be deleted while that record would have been used for cache export of the running build, causing the cache export to fail with Not Found error. This is possible because when the cache is loaded to snapshots, then snapshots are reference counted, protecting against them being released or deleted, but when the cache key is just an intermediary, the query result just gets saved and is used later.

It should be safe to ignore this error and skip over the result if it doesn't exist anymore.

Note that cache export also gets called on provenance creation because cache chains are used for finding remote descriptors for build steps. This was the more likely codepath for hitting this error.