### PR TITLE
Update buildkitd.toml.md registry examples

### DIFF
--- a/docs/buildkitd.toml.md
+++ b/docs/buildkitd.toml.md
@@ -176,7 +176,9 @@ insecure-entitlements = [ "network.host", "security.insecure" ]
 [registry."docker.io"]
   # mirror configuration to handle path in case a mirror registry requires a /project path rather than just a host:port
   mirrors = ["yourmirror.local:5000", "core.harbor.domain/proxy.docker.io"]
+  # Use plain HTTP to connect to the mirrors.
   http = true
+  # Use HTTPS with self-signed certificates. Do not enable this together with `http`.
   insecure = true
   ca=["/etc/config/myca.pem"]
   [[registry."docker.io".keypair]]


### PR DESCRIPTION
Add a couple of comments explaining what the registry parameters  `http` and `insecure` actually mean.

I was confused by this and I'm not alone: https://github.com/moby/buildkit/issues/4458
Hopefully these extra comments will prevent others from tripping over this.