### PR TITLE
forbid inconsistent logging and shadowing stdlib

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,6 +53,8 @@ linters:
         - pattern: ^ctx\.Err(# use context\.Cause instead)?$
         - pattern: ^fmt\.Errorf(# use errors\.Errorf instead)?$
         - pattern: ^logrus\.(Trace|Debug|Info|Warn|Warning|Error|Fatal)(f|ln)?(# use bklog\.G or bklog\.L instead of logrus directly)?$
+        - pattern: ^log\.G\(ctx\)\.(# use bklog import instead of shadowing stdlib)?
+        - pattern: ^log\.L\.(# use bklog import instead of shadowing stdlib)?
         - pattern: ^platforms\.DefaultString(# use platforms\.Format(platforms\.DefaultSpec()) instead\. Be aware that DefaultSpec is for the local platform, so must be avoided when working cross-platform)?$
     gocritic:
       disabled-checks:

--- a/util/push/push.go
+++ b/util/push/push.go
@@ -12,7 +12,6 @@ import (
 	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/containerd/containerd/v2/core/remotes/docker"
 	cerrdefs "github.com/containerd/errdefs"
-	"github.com/containerd/log"
 	"github.com/distribution/reference"
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/moby/buildkit/session"
@@ -152,7 +151,7 @@ func Push(ctx context.Context, sm *session.Manager, sid string, provider content
 func skipNonDistributableBlobs(f images.HandlerFunc) images.HandlerFunc {
 	return func(ctx context.Context, desc ocispecs.Descriptor) ([]ocispecs.Descriptor, error) {
 		if images.IsNonDistributable(desc.MediaType) {
-			log.G(ctx).WithField("digest", desc.Digest).WithField("mediatype", desc.MediaType).Debug("Skipping non-distributable blob")
+			bklog.G(ctx).WithField("digest", desc.Digest).WithField("mediatype", desc.MediaType).Debug("Skipping non-distributable blob")
 			return nil, images.ErrSkipDesc
 		}
 		return f(ctx, desc)

--- a/util/resolver/authorizer.go
+++ b/util/resolver/authorizer.go
@@ -17,7 +17,7 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/buildkit/session"
 	sessionauth "github.com/moby/buildkit/session/auth"
-	log "github.com/moby/buildkit/util/bklog"
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/flightcontrol"
 	"github.com/moby/buildkit/version"
 	"github.com/pkg/errors"
@@ -390,7 +390,7 @@ func (ah *authHandler) fetchToken(ctx context.Context, sm *session.Manager, g se
 					token = resp.AccessToken
 					return nil, nil
 				}
-				log.G(ctx).WithFields(logrus.Fields{
+				bklog.G(ctx).WithFields(logrus.Fields{
 					"status": errStatus.Status,
 					"body":   string(errStatus.Body),
 				}).Debugf("token request failed")

--- a/util/winlayers/differ.go
+++ b/util/winlayers/differ.go
@@ -16,7 +16,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/archive/compression"
 	"github.com/containerd/containerd/v2/pkg/labels"
 	cerrdefs "github.com/containerd/errdefs"
-	log "github.com/moby/buildkit/util/bklog"
+	"github.com/moby/buildkit/util/bklog"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -91,7 +91,7 @@ func (s *winDiffer) Compare(ctx context.Context, lower, upper []mount.Mount, opt
 					cw.Close()
 					if newReference {
 						if err := s.store.Abort(ctx, config.Reference); err != nil {
-							log.G(ctx).WithField("ref", config.Reference).Warnf("failed to delete diff upload")
+							bklog.G(ctx).WithField("ref", config.Reference).Warnf("failed to delete diff upload")
 						}
 					}
 				}
@@ -258,7 +258,7 @@ func makeWindowsLayer(ctx context.Context, w io.Writer) (io.Writer, func(error),
 			return tarWriter.Close()
 		}()
 		if err != nil {
-			log.G(ctx).Errorf("makeWindowsLayer %+v", err)
+			bklog.G(ctx).Errorf("makeWindowsLayer %+v", err)
 		}
 		pw.CloseWithError(err)
 		done <- err


### PR DESCRIPTION
- bklog is not a drop in replacement for log
- fix wrong containerd log pkg usage