### PR TITLE
gha cache: reload expired cache URLs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/tonistiigi/dchapes-mode v0.0.0-20250318174251-73d941a28323
 	github.com/tonistiigi/fsutil v0.0.0-20250605211040-586307ad452f
-	github.com/tonistiigi/go-actions-cache v0.0.0-20250611155157-388a2ec8cdf8
+	github.com/tonistiigi/go-actions-cache v0.0.0-20250626083717-378c5ed1ddd9
 	github.com/tonistiigi/go-archvariant v1.0.0
 	github.com/tonistiigi/go-csvvalue v0.0.0-20240814133006-030d3b2625d0
 	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea

--- a/go.sum
+++ b/go.sum
@@ -402,8 +402,8 @@ github.com/tonistiigi/dchapes-mode v0.0.0-20250318174251-73d941a28323 h1:r0p7fK5
 github.com/tonistiigi/dchapes-mode v0.0.0-20250318174251-73d941a28323/go.mod h1:3Iuxbr0P7D3zUzBMAZB+ois3h/et0shEz0qApgHYGpY=
 github.com/tonistiigi/fsutil v0.0.0-20250605211040-586307ad452f h1:MoxeMfHAe5Qj/ySSBfL8A7l1V+hxuluj8owsIEEZipI=
 github.com/tonistiigi/fsutil v0.0.0-20250605211040-586307ad452f/go.mod h1:BKdcez7BiVtBvIcef90ZPc6ebqIWr4JWD7+EvLm6J98=
-github.com/tonistiigi/go-actions-cache v0.0.0-20250611155157-388a2ec8cdf8 h1:KbACff2cR+ip6/Kmt8zCzieMlKYyypArQT1ZweFxewQ=
-github.com/tonistiigi/go-actions-cache v0.0.0-20250611155157-388a2ec8cdf8/go.mod h1:gJlfrsY8U+1n9RGKSgWryNFfzHRl/b1a99RUVL1L4Qw=
+github.com/tonistiigi/go-actions-cache v0.0.0-20250626083717-378c5ed1ddd9 h1:GWuTlpuUQBaK6u0R3HwE+eWaQ2aXwHgo8CaXgqtDQZU=
+github.com/tonistiigi/go-actions-cache v0.0.0-20250626083717-378c5ed1ddd9/go.mod h1:cD0SB2270BYw6HYKriFn4H6NRLhGj6ytf48YTpsm8LY=
 github.com/tonistiigi/go-archvariant v1.0.0 h1:5LC1eDWiBNflnTF1prCiX09yfNHIxDC/aukdhCdTyb0=
 github.com/tonistiigi/go-archvariant v1.0.0/go.mod h1:TxFmO5VS6vMq2kvs3ht04iPXtu2rUT/erOnGFYfk5Ho=
 github.com/tonistiigi/go-csvvalue v0.0.0-20240814133006-030d3b2625d0 h1:2f304B10LaZdB8kkVEaoXvAMVan2tl9AiK4G0odjQtE=

--- a/vendor/github.com/tonistiigi/go-actions-cache/cache.go
+++ b/vendor/github.com/tonistiigi/go-actions-cache/cache.go
@@ -593,6 +593,7 @@ type Entry struct {
 	IsAzureBlob bool   `json:"isAzureBlob"`
 
 	client *http.Client
+	reload func(context.Context) error
 }
 
 func (ce *Entry) WriteTo(ctx context.Context, w io.Writer) error {

--- a/vendor/github.com/tonistiigi/go-actions-cache/cache_v2.go
+++ b/vendor/github.com/tonistiigi/go-actions-cache/cache_v2.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"net/http"
 	"strings"
 	"time"
 
@@ -76,17 +77,34 @@ func (c *Cache) uploadV2(ctx context.Context, url string, b Blob) error {
 
 func (ce *Entry) downloadV2(ctx context.Context) ReaderAtCloser {
 	return toReaderAtCloser(func(offset int64) (io.ReadCloser, error) {
-		client, err := blockblob.NewClientWithNoCredential(ce.URL, azureOptions)
-		if err != nil {
-			return nil, errors.WithStack(err)
+		var retried bool
+		for {
+			client, err := blockblob.NewClientWithNoCredential(ce.URL, azureOptions)
+			if err != nil {
+				return nil, errors.WithStack(err)
+			}
+			resp, err := client.DownloadStream(ctx, &blob.DownloadStreamOptions{
+				Range: blob.HTTPRange{Offset: offset},
+			})
+			if err != nil {
+				if !retried {
+					// the URL might have expired, so we try to load it again
+					retried = true
+					var respErr *azcore.ResponseError
+					if errors.As(err, &respErr) {
+						if respErr.StatusCode == http.StatusForbidden || respErr.StatusCode == http.StatusUnauthorized {
+							Log("reload download URL because error %v", err)
+							if err := ce.reload(ctx); err != nil {
+								return nil, errors.WithStack(err)
+							}
+							continue // retry with the new URL
+						}
+					}
+				}
+				return nil, errors.WithStack(err)
+			}
+			return resp.Body, nil
 		}
-		resp, err := client.DownloadStream(ctx, &blob.DownloadStreamOptions{
-			Range: blob.HTTPRange{Offset: offset},
-		})
-		if err != nil {
-			return nil, errors.WithStack(err)
-		}
-		return resp.Body, nil
 	})
 }
 
@@ -187,6 +205,15 @@ func (c *Cache) loadV2(ctx context.Context, keys ...string) (*Entry, error) {
 	ce.URL = val.SignedDownloadURL
 	ce.IsAzureBlob = true
 	ce.client = c.opt.Client
+	ce.reload = func(ctx context.Context) error {
+		v, err := c.loadV2(ctx, keys...)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		ce.URL = v.URL
+		ce.Key = v.Key
+		return nil
+	}
 
 	return &ce, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -787,7 +787,7 @@ github.com/tonistiigi/dchapes-mode
 github.com/tonistiigi/fsutil
 github.com/tonistiigi/fsutil/copy
 github.com/tonistiigi/fsutil/types
-# github.com/tonistiigi/go-actions-cache v0.0.0-20250611155157-388a2ec8cdf8
+# github.com/tonistiigi/go-actions-cache v0.0.0-20250626083717-378c5ed1ddd9
 ## explicit; go 1.23.0
 github.com/tonistiigi/go-actions-cache
 # github.com/tonistiigi/go-archvariant v1.0.0


### PR DESCRIPTION
In some conditions, there can be a pause between the initial load of the entry (that already contains a signed download URL even though we don't need it yet) and the time the cache blob is actually downloaded at the end of the build. One such case seems to be accessing SBOM scanner layers after the main build is completed. The signed URL is only valid for 10 minutes, and if more time has passed, then the old URL may receive a 403 error.

upstream version https://github.com/tonistiigi/go-actions-cache/pull/40