### PR TITLE
fix: display error details on unexpected response status code errors

### DIFF
--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -29,6 +29,7 @@ import (
 	"github.com/moby/buildkit/snapshot"
 	"github.com/moby/buildkit/util/compression"
 	"github.com/moby/buildkit/util/contentutil"
+	"github.com/moby/buildkit/util/errutil"
 	"github.com/moby/buildkit/util/leaseutil"
 	"github.com/moby/buildkit/util/progress"
 	"github.com/moby/buildkit/util/push"
@@ -358,10 +359,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 				if err != nil {
 					var statusErr remoteserrors.ErrUnexpectedStatus
 					if errors.As(err, &statusErr) {
-						var dErr docker.Errors
-						if err1 := json.Unmarshal(statusErr.Body, &dErr); err1 == nil && len(dErr) > 0 {
-							err = &formattedDockerError{dErr: dErr}
-						}
+						err = errutil.WithDetails(err)
 					}
 					return nil, nil, errors.Wrapf(err, "failed to push %v", targetName)
 				}
@@ -549,37 +547,4 @@ func (d *descriptorReference) Descriptor() ocispecs.Descriptor {
 
 func (d *descriptorReference) Release() error {
 	return d.release(context.TODO())
-}
-
-type formattedDockerError struct {
-	dErr docker.Errors
-}
-
-func (e *formattedDockerError) Error() string {
-	format := func(err error) string {
-		out := err.Error()
-		var dErr docker.Error
-		if errors.As(err, &dErr) {
-			if v, ok := dErr.Detail.(string); ok && v != "" {
-				out += " - " + v
-			}
-		}
-		return out
-	}
-	switch len(e.dErr) {
-	case 0:
-		return "<nil>"
-	case 1:
-		return format(e.dErr[0])
-	default:
-		msg := "errors:\n"
-		for _, err := range e.dErr {
-			msg += format(err) + "\n"
-		}
-		return msg
-	}
-}
-
-func (e *formattedDockerError) Unwrap() error {
-	return e.dErr
 }

--- a/session/auth/authprovider/authprovider.go
+++ b/session/auth/authprovider/authprovider.go
@@ -24,6 +24,7 @@ import (
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/auth"
+	"github.com/moby/buildkit/util/errutil"
 	"github.com/moby/buildkit/util/progress/progresswriter"
 	"github.com/moby/buildkit/util/tracing"
 	"github.com/pkg/errors"
@@ -136,7 +137,7 @@ func (ap *authProvider) FetchToken(ctx context.Context, req *auth.FetchTokenRequ
 			return err
 		}
 		defer func() {
-			err = errors.Wrap(err, "failed to fetch oauth token")
+			err = errors.Wrap(errutil.WithDetails(err), "failed to fetch oauth token")
 		}()
 		ap.mu.Lock()
 		name := fmt.Sprintf("[auth] %v token for %s", strings.Join(trimScopePrefix(req.Scopes), " "), req.Host)

--- a/util/errutil/errutil.go
+++ b/util/errutil/errutil.go
@@ -1,0 +1,94 @@
+package errutil
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/containerd/containerd/v2/core/remotes/docker"
+	remoteserrors "github.com/containerd/containerd/v2/core/remotes/errors"
+)
+
+const (
+	maxPrintedBodySize = 256
+)
+
+func WithDetails(err error) error {
+	if err == nil {
+		return nil
+	}
+	var errStatus remoteserrors.ErrUnexpectedStatus
+	if errors.As(err, &errStatus) {
+		var dErr docker.Errors
+		if err1 := json.Unmarshal(errStatus.Body, &dErr); err1 == nil && len(dErr) > 0 {
+			return &formattedDockerError{dErr: dErr}
+		}
+
+		return verboseUnexpectedStatusError{ErrUnexpectedStatus: errStatus}
+	}
+	return err
+}
+
+type verboseUnexpectedStatusError struct {
+	remoteserrors.ErrUnexpectedStatus
+}
+
+func (e verboseUnexpectedStatusError) Unwrap() error {
+	return e.ErrUnexpectedStatus
+}
+
+func (e verboseUnexpectedStatusError) Error() string {
+	if len(e.Body) == 0 {
+		return e.ErrUnexpectedStatus.Error()
+	}
+	var details string
+
+	var errDetails struct {
+		Details string `json:"details"`
+	}
+
+	if err := json.Unmarshal(e.Body, &errDetails); err == nil && errDetails.Details != "" {
+		details = errDetails.Details
+	} else {
+		if len(e.Body) > maxPrintedBodySize {
+			details = string(e.Body[:maxPrintedBodySize]) + fmt.Sprintf("... (%d bytes truncated)", len(e.Body)-maxPrintedBodySize)
+		} else {
+			details = string(e.Body)
+		}
+	}
+
+	return fmt.Sprintf("%s: %s", e.ErrUnexpectedStatus.Error(), details)
+}
+
+type formattedDockerError struct {
+	dErr docker.Errors
+}
+
+func (e *formattedDockerError) Error() string {
+	format := func(err error) string {
+		out := err.Error()
+		var dErr docker.Error
+		if errors.As(err, &dErr) {
+			if v, ok := dErr.Detail.(string); ok && v != "" {
+				out += " - " + v
+			}
+		}
+		return out
+	}
+	switch len(e.dErr) {
+	case 0:
+		return "<nil>"
+	case 1:
+		return format(e.dErr[0])
+	default:
+		msg := "errors:\n"
+		for _, err := range e.dErr {
+			msg += format(err) + "\n"
+		}
+		return msg
+	}
+}
+
+func (e *formattedDockerError) Unwrap() error {
+	return e.dErr
+}

--- a/util/resolver/authorizer.go
+++ b/util/resolver/authorizer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/moby/buildkit/session"
 	sessionauth "github.com/moby/buildkit/session/auth"
 	"github.com/moby/buildkit/util/bklog"
+	"github.com/moby/buildkit/util/errutil"
 	"github.com/moby/buildkit/util/flightcontrol"
 	"github.com/moby/buildkit/version"
 	"github.com/pkg/errors"
@@ -367,7 +368,7 @@ func (ah *authHandler) fetchToken(ctx context.Context, sm *session.Manager, g se
 	// fetch token for the resource scope
 	if to.Secret != "" {
 		defer func() {
-			err = errors.Wrap(err, "failed to fetch oauth token")
+			err = errors.Wrap(errutil.WithDetails(err), "failed to fetch oauth token")
 		}()
 		// try GET first because Docker Hub does not support POST
 		// switch once support has landed


### PR DESCRIPTION
When receiving a remote error due to an unexpected status code, read the
body and try to decode either a docker.Error or a simpler {"details"...}
payload. If those succeed, decode and format them appropriately. Otherwise,
fallback to displaying the raw response body which might contain valuable
information to indicate why authentication failed.

Signed-off-by: Alberto Garcia Hierro <damaso.hierro@docker.com>
