### PR TITLE
Bump go to 1.24.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/moby/buildkit
 
-go 1.23.0
+go 1.24.4
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.16.0


### PR DESCRIPTION
There are a few CVEs now for go 1.23.0. Rather than patching 1.23, using 1.24.4 works and passes all the tests.
