### PR TITLE
Fix infinite loop in cache loop detection algorithm

### DIFF
--- a/cache/remotecache/v1/utils.go
+++ b/cache/remotecache/v1/utils.go
@@ -149,10 +149,8 @@ func (s *normalizeState) checkLoops(ctx context.Context, d digest.Digest, visite
 	if !ok {
 		return
 	}
+
 	visited[d] = struct{}{}
-	defer func() {
-		delete(visited, d)
-	}()
 
 	for l, ids := range links {
 		for id := range ids {


### PR DESCRIPTION
fixes #6008

I was able to repeatedly have the problem with my current project, but I can't share it's code and I'm not really sure what part of it is causing it so unfortunately  I can't create a repeatable environment.

But since I had the issue, after some testing and reading other people's comments I found that the issue was in cache loops removal part of the code.

The already visited digests were being removed from the visited list