### PR TITLE
fix: tests: skip flaky integration tests on Windows

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -11561,6 +11561,8 @@ func testSourcePolicy(t *testing.T, sb integration.Sandbox) {
 }
 
 func testLLBMountPerformance(t *testing.T, sb integration.Sandbox) {
+	// flaky on WS2025 and moby/moby too
+	integration.SkipOnPlatform(t, "windows")
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()

--- a/frontend/dockerfile/dockerfile_mount_test.go
+++ b/frontend/dockerfile/dockerfile_mount_test.go
@@ -646,6 +646,8 @@ COPY --from=base /combined.txt /
 
 // moby/buildkit#5566
 func testCacheMountParallel(t *testing.T, sb integration.Sandbox) {
+	// flaky on WS2025
+	integration.SkipOnPlatform(t, "windows")
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(integration.UnixOrWindows(


### PR DESCRIPTION
This is to address the flaky tests being on moby/moby too.

ref - https://github.com/moby/moby/issues/50389