### PR TITLE
fix: corrected doc comment for llb.State.Env

### DIFF
--- a/client/llb/state.go
+++ b/client/llb/state.go
@@ -351,8 +351,7 @@ func (s State) GetEnv(ctx context.Context, key string, co ...ConstraintsOpt) (st
 	return v, ok, nil
 }
 
-// Env returns a new [State] with the provided environment variable set.
-// See [Env]
+// Env returns the current environment variables for the state.
 func (s State) Env(ctx context.Context, co ...ConstraintsOpt) (*EnvList, error) {
 	c := &Constraints{}
 	for _, f := range co {


### PR DESCRIPTION
The Env method returns the current environment variables for the state, not a new State with updated env variables.

Updated doc comment to reflect actual behavior.