### PR TITLE
[v0.23 backpport] fix: tests: skip flaky integration tests on Windows

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -11536,6 +11536,8 @@ func testSourcePolicy(t *testing.T, sb integration.Sandbox) {
 }
 
 func testLLBMountPerformance(t *testing.T, sb integration.Sandbox) {
+	// flaky on WS2025 and moby/moby too
+	integration.SkipOnPlatform(t, "windows")
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()

--- a/frontend/dockerfile/dockerfile_mount_test.go
+++ b/frontend/dockerfile/dockerfile_mount_test.go
@@ -646,6 +646,8 @@ COPY --from=base /combined.txt /
 
 // moby/buildkit#5566
 func testCacheMountParallel(t *testing.T, sb integration.Sandbox) {
+	// flaky on WS2025
+	integration.SkipOnPlatform(t, "windows")
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(integration.UnixOrWindows(


### PR DESCRIPTION
- backport https://github.com/moby/buildkit/pull/6087
- addresses https://github.com/moby/moby/issues/50389


(cherry picked from commit c91c4069fab5158352a768001e3fbe854297ed51)