### PR TITLE
exporter/containerimage: default to oci-mediatypes=true

### DIFF
--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -1747,7 +1747,7 @@ func TestGetRemotes(t *testing.T) {
 					case compression.EStargz:
 						require.Equal(t, ocispecs.MediaTypeImageLayerGzip, desc.MediaType)
 					case compression.Zstd:
-						require.Equal(t, ocispecs.MediaTypeImageLayer+"+zstd", desc.MediaType)
+						require.Equal(t, ocispecs.MediaTypeImageLayerZstd, desc.MediaType)
 					default:
 						require.Fail(t, "unhandled media type", compressionType)
 					}

--- a/client/client_nydus_test.go
+++ b/client/client_nydus_test.go
@@ -97,7 +97,7 @@ func testBuildExportNydusWithHybrid(t *testing.T, sb integration.Sandbox) {
 
 		mediaTypes := map[compression.Type]string{
 			compression.Gzip: ocispecs.MediaTypeImageLayerGzip,
-			compression.Zstd: ocispecs.MediaTypeImageLayer + "+zstd",
+			compression.Zstd: ocispecs.MediaTypeImageLayerZstd,
 		}
 		target := fmt.Sprintf("%s/%s/alpine:%s", registry, compType, identity.NewID())
 		_, err = c.Solve(sb.Context(), def, SolveOpt{

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2464,7 +2464,7 @@ func testSessionExporter(t *testing.T, sb integration.Sandbox) {
 
 	require.Equal(t, 2, len(mfst.Layers))
 	for _, layer := range mfst.Layers {
-		require.Contains(t, layer.MediaType, "application/vnd.oci.image.layer.v1.tar+zstd")
+		require.Contains(t, layer.MediaType, ocispecs.MediaTypeImageLayerZstd)
 	}
 }
 
@@ -3485,7 +3485,7 @@ func testMultipleExporters(t *testing.T, sb integration.Sandbox) {
 				Type: ExporterImage,
 				Attrs: map[string]string{
 					"name":           target2,
-					"oci-mediatypes": "true",
+					"oci-mediatypes": "false",
 				},
 			},
 		}...)
@@ -4866,7 +4866,7 @@ func testBuildExportZstd(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 
 	lastLayer := mfst.Layers[len(mfst.Layers)-1]
-	require.Equal(t, ocispecs.MediaTypeImageLayer+"+zstd", lastLayer.MediaType)
+	require.Equal(t, ocispecs.MediaTypeImageLayerZstd, lastLayer.MediaType)
 
 	zstdLayerDigest := lastLayer.Digest.Hex()
 	require.Equal(t, []byte{0x28, 0xb5, 0x2f, 0xfd}, m[ocispecs.ImageBlobsDir+"/sha256/"+zstdLayerDigest].Data[:4])
@@ -4902,7 +4902,7 @@ func testBuildExportZstd(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 
 	lastLayer = mfst.Layers[len(mfst.Layers)-1]
-	require.Equal(t, images.MediaTypeDockerSchema2Layer+".zstd", lastLayer.MediaType)
+	require.Equal(t, images.MediaTypeDockerSchema2LayerZstd, lastLayer.MediaType)
 
 	require.Equal(t, lastLayer.Digest.Hex(), zstdLayerDigest)
 }
@@ -4989,9 +4989,9 @@ func testPullZstdImage(t *testing.T, sb integration.Sandbox) {
 
 			firstLayer := mfst.Layers[0]
 			if ociMediaTypes {
-				require.Equal(t, ocispecs.MediaTypeImageLayer+"+zstd", firstLayer.MediaType)
+				require.Equal(t, ocispecs.MediaTypeImageLayerZstd, firstLayer.MediaType)
 			} else {
-				require.Equal(t, images.MediaTypeDockerSchema2Layer+".zstd", firstLayer.MediaType)
+				require.Equal(t, images.MediaTypeDockerSchema2LayerZstd, firstLayer.MediaType)
 			}
 
 			zstdLayerDigest := firstLayer.Digest.Hex()
@@ -5906,7 +5906,7 @@ func testZstdLocalCacheExport(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 
 	lastLayer := layerIndex.Manifests[len(layerIndex.Manifests)-2]
-	require.Equal(t, ocispecs.MediaTypeImageLayer+"+zstd", lastLayer.MediaType)
+	require.Equal(t, ocispecs.MediaTypeImageLayerZstd, lastLayer.MediaType)
 
 	zstdLayerDigest := lastLayer.Digest.Hex()
 	dt, err = os.ReadFile(filepath.Join(destDir, ocispecs.ImageBlobsDir+"/sha256/"+zstdLayerDigest))

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -77,6 +77,7 @@ func (e *imageExporter) Resolve(ctx context.Context, id int, opt map[string]stri
 			RefCfg: cacheconfig.RefConfig{
 				Compression: compression.New(compression.Default),
 			},
+			OCITypes: true,
 			ForceInlineAttestations: true,
 		},
 		store: true,

--- a/exporter/containerimage/exptypes/keys.go
+++ b/exporter/containerimage/exptypes/keys.go
@@ -51,6 +51,7 @@ var (
 	OptKeyOCITypes ImageExporterOptKey = "oci-mediatypes"
 
 	// Use OCI artifact format for the attestation manifest.
+	// Value: bool <true|false>
 	OptKeyOCIArtifact ImageExporterOptKey = "oci-artifact"
 
 	// Force attestation to be attached.

--- a/exporter/containerimage/opts.go
+++ b/exporter/containerimage/opts.go
@@ -91,18 +91,6 @@ func (c *ImageCommitOpts) EnableOCITypes(ctx context.Context, reason string) {
 	}
 }
 
-func (c *ImageCommitOpts) EnableForceCompression(ctx context.Context, reason string) {
-	if !c.RefCfg.Compression.Force {
-		message := "forcibly turning on force-compression mode"
-		if reason != "" {
-			message += " for " + reason
-		}
-		bklog.G(ctx).Warn(message)
-
-		c.RefCfg.Compression.Force = true
-	}
-}
-
 func parseBool(dest *bool, key string, value string) error {
 	b, err := strconv.ParseBool(value)
 	if err != nil {

--- a/exporter/containerimage/opts.go
+++ b/exporter/containerimage/opts.go
@@ -48,7 +48,7 @@ func (c *ImageCommitOpts) Load(ctx context.Context, opt map[string]string) (map[
 		case exptypes.OptKeyName:
 			c.ImageName = v
 		case exptypes.OptKeyOCITypes:
-			err = parseBoolWithDefault(&c.OCITypes, k, v, true)
+			err = parseBool(&c.OCITypes, k, v)
 		case exptypes.OptKeyOCIArtifact:
 			err = parseBool(&c.OCIArtifact, k, v)
 		case exptypes.OptKeyForceInlineAttestations:
@@ -85,14 +85,6 @@ func parseBool(dest *bool, key string, value string) error {
 	}
 	*dest = b
 	return nil
-}
-
-func parseBoolWithDefault(dest *bool, key string, value string, defaultValue bool) error {
-	if value == "" {
-		*dest = defaultValue
-		return nil
-	}
-	return parseBool(dest, key, value)
 }
 
 func toBytesMap(m map[string]string) map[string][]byte {

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -114,7 +114,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 
 	if !isMap {
 		if len(ps.Platforms) > 1 {
-			return nil, errors.Errorf("cannot export multiple platforms without multi-platform enabled")
+			return nil, errors.New("cannot export multiple platforms without multi-platform enabled")
 		}
 
 		var ref cache.ImmutableRef

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -108,7 +108,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 			}
 		}
 		if len(a.Index)+len(a.IndexDescriptor)+len(a.ManifestDescriptor) > 0 {
-			opts.EnableOCITypes(ctx, "annotations")
+			return nil, errors.New("cannot export annotations with \"oci-mediatypes=false\"")
 		}
 	}
 
@@ -186,7 +186,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 	}
 
 	if len(inp.Attestations) > 0 {
-		opts.EnableOCITypes(ctx, "attestations")
+		return nil, errors.New("cannot export attestations with \"oci-mediatypes=false\"")
 	}
 
 	refs := make([]cache.ImmutableRef, 0, len(inp.Refs))

--- a/util/compression/compression.go
+++ b/util/compression/compression.go
@@ -75,10 +75,6 @@ func (c Config) SetLevel(l int) Config {
 	return c
 }
 
-const (
-	mediaTypeDockerSchema2LayerZstd = images.MediaTypeDockerSchema2Layer + ".zstd"
-)
-
 var Default = Gzip
 
 func parse(t string) (Type, error) {
@@ -191,8 +187,8 @@ var toDockerLayerType = map[string]string{
 	images.MediaTypeDockerSchema2LayerForeignGzip:    images.MediaTypeDockerSchema2LayerForeignGzip,
 	ocispecs.MediaTypeImageLayerNonDistributable:     images.MediaTypeDockerSchema2LayerForeign,     //nolint:staticcheck // ignore SA1019: Non-distributable layers are deprecated, and not recommended for future use.
 	ocispecs.MediaTypeImageLayerNonDistributableGzip: images.MediaTypeDockerSchema2LayerForeignGzip, //nolint:staticcheck // ignore SA1019: Non-distributable layers are deprecated, and not recommended for future use.
-	ocispecs.MediaTypeImageLayerZstd:                 mediaTypeDockerSchema2LayerZstd,
-	mediaTypeDockerSchema2LayerZstd:                  mediaTypeDockerSchema2LayerZstd,
+	ocispecs.MediaTypeImageLayerZstd:                 images.MediaTypeDockerSchema2LayerZstd:,
+	images.MediaTypeDockerSchema2LayerZstd:           images.MediaTypeDockerSchema2LayerZstd:,
 }
 
 var toOCILayerType = map[string]string{
@@ -206,7 +202,7 @@ var toOCILayerType = map[string]string{
 	images.MediaTypeDockerSchema2LayerForeign:        ocispecs.MediaTypeImageLayerNonDistributable,     //nolint:staticcheck // ignore SA1019: Non-distributable layers are deprecated, and not recommended for future use.
 	images.MediaTypeDockerSchema2LayerForeignGzip:    ocispecs.MediaTypeImageLayerNonDistributableGzip, //nolint:staticcheck // ignore SA1019: Non-distributable layers are deprecated, and not recommended for future use.
 	ocispecs.MediaTypeImageLayerZstd:                 ocispecs.MediaTypeImageLayerZstd,
-	mediaTypeDockerSchema2LayerZstd:                  ocispecs.MediaTypeImageLayerZstd,
+	images.MediaTypeDockerSchema2LayerZstd:           ocispecs.MediaTypeImageLayerZstd,
 }
 
 func convertLayerMediaType(ctx context.Context, mediaType string, oci bool) string {

--- a/util/winlayers/applier.go
+++ b/util/winlayers/applier.go
@@ -39,7 +39,7 @@ type winApplier struct {
 func (s *winApplier) Apply(ctx context.Context, desc ocispecs.Descriptor, mounts []mount.Mount, opts ...diff.ApplyOpt) (d ocispecs.Descriptor, err error) {
 	// HACK:, containerd doesn't know about vnd.docker.image.rootfs.diff.tar.zstd, but that
 	// media type is compatible w/ the oci type, so just lie and say it's the oci type
-	if desc.MediaType == images.MediaTypeDockerSchema2Layer+".zstd" {
+	if desc.MediaType == images.MediaTypeDockerSchema2LayerZstd {
 		desc.MediaType = ocispecs.MediaTypeImageLayerZstd
 	}
 


### PR DESCRIPTION
The change to provenance-by-default implicitly changed the default mediaTypes to OCI, but an explicit `--provenance=false` negates this and causes surprising behavior.

To fix this, we make the explicit default `oci-mediatypes=true` and make `oci-mediatypes=false` fail for incompatible cases.

Addresses https://github.com/moby/buildkit/issues/6094.

Tests are needed/missing; I've had some issues getting the tests working locally and skipped them for now.