### PR TITLE
fix: client New - add nil check for TracerDelegate to prevent panic

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -70,7 +70,7 @@ func New(ctx context.Context, address string, opts ...ClientOpt) (*Client, error
 			gopts = append(gopts, grpc.WithContextDialer(wd.dialer))
 			needDialer = false
 		}
-		if wt, ok := o.(*withTracerDelegate); ok {
+		if wt, ok := o.(*withTracerDelegate); ok && wt.TracerDelegate != nil {
 			tracerDelegate = wt
 		}
 		if sd, ok := o.(*withSessionDialer); ok {


### PR DESCRIPTION
- error message

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xda1552]
goroutine 23 [running]:
github.com/moby/buildkit/client.(*withTracerDelegate).SetSpanExporter(0xc0005b42f0, 0x21bee20, 0xc0002b2100, 0x218dca8, 0xc000800500, 0x0, 0x0)
	<autogenerated>:1 +0x32
github.com/moby/buildkit/client.(*Client).setupDelegatedTracing(0xc0001142b8, 0x21bee20, 0xc0002b2100, 0x2179140, 0xc0005b42f0, 0x7, 0x8)
	/src/vendor/github.com/moby/buildkit/client/client.go:150 +0x132
github.com/moby/buildkit/client.New(0x21bee20, 0xc0002b2100, 0x1f21075, 0x23, 0xc00033fd98, 0x2, 0x2, 0x40, 0x21d4f68, 0xc00000f1b8)
	/src/vendor/github.com/moby/buildkit/client/client.go:138 +0x6e8
github.com/docker/buildx/driver/docker-container.(*Driver).Client(0xc00029e2a0, 0x21bee20, 0xc0002b2100, 0xc000102480, 0xc000079618, 0xc000353760)
	/src/driver/docker-container/driver.go:315 +0x285
github.com/docker/buildx/driver.(*cachedDriver).Client.func1()
	/src/driver/manager.go:145 +0x4d
sync.(*Once).doSlow(0xc0002b2068, 0xc00033fe70)
	/usr/local/go/src/sync/once.go:68 +0xec
sync.(*Once).Do(...)
	/usr/local/go/src/sync/once.go:59
github.com/docker/buildx/driver.(*cachedDriver).Client(0xc0002b2040, 0x21bee20, 0xc0002b2100, 0xc0006d4bc0, 0x0, 0x0)
	/src/driver/manager.go:144 +0xa5
github.com/docker/buildx/driver.Boot(0x21bee20, 0xc0002b2100, 0x21d70b8, 0xc0002b2040, 0x2178120, 0xc0005b6060, 0xc000079701, 0xc000079798, 0x113e239)
	/src/driver/driver.go:81 +0xb6
github.com/docker/buildx/build.ensureBooted.func1.1(0x0, 0xc0005d4fc0)
	/src/build/build.go:151 +0x85
golang.org/x/sync/errgroup.(*Group).Go.func1(0xc0005a85a0, 0xc00009c120)
	/src/vendor/golang.org/x/sync/errgroup/errgroup.go:57 +0x59
created by golang.org/x/sync/errgroup.(*Group).Go
	/src/vendor/golang.org/x/sync/errgroup/errgroup.go:54 +0x66
task: Failed to run task "backend": exit status 2
```