### PR TITLE
dap: add hint to copy when there is no parent

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -1217,7 +1217,7 @@ func dispatchRun(d *dispatchState, c *instructions.RunCommand, proxy *llb.ProxyE
 	// Run command can potentially access any file. Mark the full filesystem as used.
 	d.paths["/"] = struct{}{}
 
-	var args = c.CmdLine
+	args := c.CmdLine
 	if len(c.Files) > 0 {
 		if len(args) != 1 || !c.PrependShell {
 			return errors.Errorf("parsing produced an invalid run command: %v", args)
@@ -1658,6 +1658,13 @@ func dispatchCopy(d *dispatchState, cfg copyConfig) error {
 		fileOpt = append(fileOpt, llb.IgnoreCache)
 	}
 
+	if d.state.Output() == nil {
+		// Give a hint to DAP that this copy has no real parent.
+		fileOpt = append(fileOpt, llb.WithDescription(map[string]string{
+			"com.docker.dap.v1.hint.noparent": "true",
+		}))
+	}
+
 	// cfg.opt.llbCaps can be nil in unit tests
 	if cfg.opt.llbCaps != nil && cfg.opt.llbCaps.Supports(pb.CapMergeOp) == nil && cfg.link && cfg.chmod == "" {
 		pgID := identity.NewID()
@@ -1729,7 +1736,7 @@ func dispatchOnbuild(d *dispatchState, c *instructions.OnbuildCommand) error {
 func dispatchCmd(d *dispatchState, c *instructions.CmdCommand, lint *linter.Linter) error {
 	validateUsedOnce(c, &d.cmd, lint)
 
-	var args = c.CmdLine
+	args := c.CmdLine
 	if c.PrependShell {
 		if len(d.image.Config.Shell) == 0 {
 			msg := linter.RuleJSONArgsRecommended.Format(c.Name())
@@ -1745,7 +1752,7 @@ func dispatchCmd(d *dispatchState, c *instructions.CmdCommand, lint *linter.Lint
 func dispatchEntrypoint(d *dispatchState, c *instructions.EntrypointCommand, lint *linter.Linter) error {
 	validateUsedOnce(c, &d.entrypoint, lint)
 
-	var args = c.CmdLine
+	args := c.CmdLine
 	if c.PrependShell {
 		if len(d.image.Config.Shell) == 0 {
 			msg := linter.RuleJSONArgsRecommended.Format(c.Name())


### PR DESCRIPTION
When a copy has no real parent, we add an annotation of the name
`com.docker.dap.v1.hints.noparent=true` to the node to signal to DAP that the LLB node
has no real parent so it doesn't follow the first index assuming that
index is the direct ancestor.