### PR TITLE
vendor: github.com/docker/go-connections v0.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/distribution/reference v0.6.0
 	github.com/docker/cli v28.3.0+incompatible
-	github.com/docker/go-connections v0.5.0
+	github.com/docker/go-connections v0.6.0
 	github.com/docker/go-units v0.5.0
 	github.com/gofrs/flock v0.12.1
 	github.com/golang/protobuf v1.5.4

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,8 @@ github.com/docker/docker v28.3.3+incompatible h1:Dypm25kh4rmk49v1eiVbsAtpAsYURjY
 github.com/docker/docker v28.3.3+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.9.3 h1:gAm/VtF9wgqJMoxzT3Gj5p4AqIjCBS4wrsOh9yRqcz8=
 github.com/docker/docker-credential-helpers v0.9.3/go.mod h1:x+4Gbw9aGmChi3qTLZj8Dfn0TD20M/fuWy0E5+WDeCo=
-github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=
-github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
+github.com/docker/go-connections v0.6.0 h1:LlMG9azAe1TqfR7sO+NJttz1gy6KO7VJBh+pMmjSD94=
+github.com/docker/go-connections v0.6.0/go.mod h1:AahvXYshr6JgfUJGdDCs2b5EZG/vmaMAntpSFH5BFKE=
 github.com/docker/go-metrics v0.0.1 h1:AgB/0SvBxihN0X8OR4SjsblXkbMvalQ8cjmtKQ2rQV8=
 github.com/docker/go-metrics v0.0.1/go.mod h1:cG1hvH2utMXtqgqqYE9plW6lDxS3/5ayHzueweSI3Vw=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=

--- a/vendor/github.com/docker/go-connections/nat/nat.go
+++ b/vendor/github.com/docker/go-connections/nat/nat.go
@@ -2,6 +2,7 @@
 package nat
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -43,19 +44,19 @@ func NewPort(proto, port string) (Port, error) {
 
 // ParsePort parses the port number string and returns an int
 func ParsePort(rawPort string) (int, error) {
-	if len(rawPort) == 0 {
+	if rawPort == "" {
 		return 0, nil
 	}
 	port, err := strconv.ParseUint(rawPort, 10, 16)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("invalid port '%s': %w", rawPort, errors.Unwrap(err))
 	}
 	return int(port), nil
 }
 
 // ParsePortRangeToInt parses the port range string and returns start/end ints
 func ParsePortRangeToInt(rawPort string) (int, int, error) {
-	if len(rawPort) == 0 {
+	if rawPort == "" {
 		return 0, 0, nil
 	}
 	start, end, err := ParsePortRange(rawPort)
@@ -91,29 +92,31 @@ func (p Port) Range() (int, int, error) {
 	return ParsePortRangeToInt(p.Port())
 }
 
-// SplitProtoPort splits a port in the format of proto/port
-func SplitProtoPort(rawPort string) (string, string) {
-	parts := strings.Split(rawPort, "/")
-	l := len(parts)
-	if len(rawPort) == 0 || l == 0 || len(parts[0]) == 0 {
+// SplitProtoPort splits a port(range) and protocol, formatted as "<portnum>/[<proto>]"
+// "<startport-endport>/[<proto>]". It returns an empty string for both if
+// no port(range) is provided. If a port(range) is provided, but no protocol,
+// the default ("tcp") protocol is returned.
+//
+// SplitProtoPort does not validate or normalize the returned values.
+func SplitProtoPort(rawPort string) (proto string, port string) {
+	port, proto, _ = strings.Cut(rawPort, "/")
+	if port == "" {
 		return "", ""
 	}
-	if l == 1 {
-		return "tcp", rawPort
+	if proto == "" {
+		proto = "tcp"
 	}
-	if len(parts[1]) == 0 {
-		return "tcp", parts[0]
-	}
-	return parts[1], parts[0]
+	return proto, port
 }
 
-func validateProto(proto string) bool {
-	for _, availableProto := range []string{"tcp", "udp", "sctp"} {
-		if availableProto == proto {
-			return true
-		}
+func validateProto(proto string) error {
+	switch proto {
+	case "tcp", "udp", "sctp":
+		// All good
+		return nil
+	default:
+		return errors.New("invalid proto: " + proto)
 	}
-	return false
 }
 
 // ParsePortSpecs receives port specs in the format of ip:public:private/proto and parses
@@ -123,22 +126,18 @@ func ParsePortSpecs(ports []string) (map[Port]struct{}, map[Port][]PortBinding, 
 		exposedPorts = make(map[Port]struct{}, len(ports))
 		bindings     = make(map[Port][]PortBinding)
 	)
-	for _, rawPort := range ports {
-		portMappings, err := ParsePortSpec(rawPort)
+	for _, p := range ports {
+		portMappings, err := ParsePortSpec(p)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		for _, portMapping := range portMappings {
-			port := portMapping.Port
-			if _, exists := exposedPorts[port]; !exists {
+		for _, pm := range portMappings {
+			port := pm.Port
+			if _, ok := exposedPorts[port]; !ok {
 				exposedPorts[port] = struct{}{}
 			}
-			bslice, exists := bindings[port]
-			if !exists {
-				bslice = []PortBinding{}
-			}
-			bindings[port] = append(bslice, portMapping.Binding)
+			bindings[port] = append(bindings[port], pm.Binding)
 		}
 	}
 	return exposedPorts, bindings, nil
@@ -150,28 +149,34 @@ type PortMapping struct {
 	Binding PortBinding
 }
 
-func splitParts(rawport string) (string, string, string) {
-	parts := strings.Split(rawport, ":")
-	n := len(parts)
-	containerPort := parts[n-1]
+func (p *PortMapping) String() string {
+	return net.JoinHostPort(p.Binding.HostIP, p.Binding.HostPort+":"+string(p.Port))
+}
 
-	switch n {
+func splitParts(rawport string) (hostIP, hostPort, containerPort string) {
+	parts := strings.Split(rawport, ":")
+
+	switch len(parts) {
 	case 1:
-		return "", "", containerPort
+		return "", "", parts[0]
 	case 2:
-		return "", parts[0], containerPort
+		return "", parts[0], parts[1]
 	case 3:
-		return parts[0], parts[1], containerPort
+		return parts[0], parts[1], parts[2]
 	default:
-		return strings.Join(parts[:n-2], ":"), parts[n-2], containerPort
+		n := len(parts)
+		return strings.Join(parts[:n-2], ":"), parts[n-2], parts[n-1]
 	}
 }
 
 // ParsePortSpec parses a port specification string into a slice of PortMappings
 func ParsePortSpec(rawPort string) ([]PortMapping, error) {
-	var proto string
 	ip, hostPort, containerPort := splitParts(rawPort)
-	proto, containerPort = SplitProtoPort(containerPort)
+	proto, containerPort := SplitProtoPort(containerPort)
+	proto = strings.ToLower(proto)
+	if err := validateProto(proto); err != nil {
+		return nil, err
+	}
 
 	if ip != "" && ip[0] == '[' {
 		// Strip [] from IPV6 addresses
@@ -182,7 +187,7 @@ func ParsePortSpec(rawPort string) ([]PortMapping, error) {
 		ip = rawIP
 	}
 	if ip != "" && net.ParseIP(ip) == nil {
-		return nil, fmt.Errorf("invalid IP address: %s", ip)
+		return nil, errors.New("invalid IP address: " + ip)
 	}
 	if containerPort == "" {
 		return nil, fmt.Errorf("no port specified: %s<empty>", rawPort)
@@ -190,51 +195,43 @@ func ParsePortSpec(rawPort string) ([]PortMapping, error) {
 
 	startPort, endPort, err := ParsePortRange(containerPort)
 	if err != nil {
-		return nil, fmt.Errorf("invalid containerPort: %s", containerPort)
+		return nil, errors.New("invalid containerPort: " + containerPort)
 	}
 
-	var startHostPort, endHostPort uint64 = 0, 0
-	if len(hostPort) > 0 {
+	var startHostPort, endHostPort uint64
+	if hostPort != "" {
 		startHostPort, endHostPort, err = ParsePortRange(hostPort)
 		if err != nil {
-			return nil, fmt.Errorf("invalid hostPort: %s", hostPort)
+			return nil, errors.New("invalid hostPort: " + hostPort)
+		}
+		if (endPort - startPort) != (endHostPort - startHostPort) {
+			// Allow host port range iff containerPort is not a range.
+			// In this case, use the host port range as the dynamic
+			// host port range to allocate into.
+			if endPort != startPort {
+				return nil, fmt.Errorf("invalid ranges specified for container and host Ports: %s and %s", containerPort, hostPort)
+			}
 		}
 	}
 
-	if hostPort != "" && (endPort-startPort) != (endHostPort-startHostPort) {
-		// Allow host port range iff containerPort is not a range.
-		// In this case, use the host port range as the dynamic
-		// host port range to allocate into.
-		if endPort != startPort {
-			return nil, fmt.Errorf("invalid ranges specified for container and host Ports: %s and %s", containerPort, hostPort)
-		}
-	}
+	count := endPort - startPort + 1
+	ports := make([]PortMapping, 0, count)
 
-	if !validateProto(strings.ToLower(proto)) {
-		return nil, fmt.Errorf("invalid proto: %s", proto)
-	}
-
-	ports := []PortMapping{}
-	for i := uint64(0); i <= (endPort - startPort); i++ {
-		containerPort = strconv.FormatUint(startPort+i, 10)
-		if len(hostPort) > 0 {
-			hostPort = strconv.FormatUint(startHostPort+i, 10)
+	for i := uint64(0); i < count; i++ {
+		cPort := Port(strconv.FormatUint(startPort+i, 10) + "/" + proto)
+		hPort := ""
+		if hostPort != "" {
+			hPort = strconv.FormatUint(startHostPort+i, 10)
+			// Set hostPort to a range only if there is a single container port
+			// and a dynamic host port.
+			if count == 1 && startHostPort != endHostPort {
+				hPort += "-" + strconv.FormatUint(endHostPort, 10)
+			}
 		}
-		// Set hostPort to a range only if there is a single container port
-		// and a dynamic host port.
-		if startPort == endPort && startHostPort != endHostPort {
-			hostPort = fmt.Sprintf("%s-%s", hostPort, strconv.FormatUint(endHostPort, 10))
-		}
-		port, err := NewPort(strings.ToLower(proto), containerPort)
-		if err != nil {
-			return nil, err
-		}
-
-		binding := PortBinding{
-			HostIP:   ip,
-			HostPort: hostPort,
-		}
-		ports = append(ports, PortMapping{Port: port, Binding: binding})
+		ports = append(ports, PortMapping{
+			Port:    cPort,
+			Binding: PortBinding{HostIP: ip, HostPort: hPort},
+		})
 	}
 	return ports, nil
 }

--- a/vendor/github.com/docker/go-connections/nat/parse.go
+++ b/vendor/github.com/docker/go-connections/nat/parse.go
@@ -1,7 +1,7 @@
 package nat
 
 import (
-	"fmt"
+	"errors"
 	"strconv"
 	"strings"
 )
@@ -9,7 +9,7 @@ import (
 // ParsePortRange parses and validates the specified string as a port-range (8000-9000)
 func ParsePortRange(ports string) (uint64, uint64, error) {
 	if ports == "" {
-		return 0, 0, fmt.Errorf("empty string specified for ports")
+		return 0, 0, errors.New("empty string specified for ports")
 	}
 	if !strings.Contains(ports, "-") {
 		start, err := strconv.ParseUint(ports, 10, 16)
@@ -27,7 +27,7 @@ func ParsePortRange(ports string) (uint64, uint64, error) {
 		return 0, 0, err
 	}
 	if end < start {
-		return 0, 0, fmt.Errorf("invalid range specified for port: %s", ports)
+		return 0, 0, errors.New("invalid range specified for port: " + ports)
 	}
 	return start, end, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -493,7 +493,7 @@ github.com/docker/cli/cli/connhelper/commandconn
 ## explicit; go 1.21
 github.com/docker/docker-credential-helpers/client
 github.com/docker/docker-credential-helpers/credentials
-# github.com/docker/go-connections v0.5.0
+# github.com/docker/go-connections v0.6.0
 ## explicit; go 1.18
 github.com/docker/go-connections/nat
 # github.com/docker/go-metrics v0.0.1


### PR DESCRIPTION
- deprecate sockets.GetProxyEnv, sockets.DialerFromEnvironment
- add support for unix sockets on Windows
- remove legacy CBC cipher suites from client config
- align client and server defaults to be the same.
- remove support for encrypted TLS private keys.
- nat: optimize ParsePortSpec

full diff: https://github.com/docker/go-connections/compare/v0.5.0...v0.6.0