### PR TITLE
Remove mention of --oci-worker-no-process-sandbox on daemonless mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -780,7 +780,7 @@ docker run \
     --rm \
     --security-opt seccomp=unconfined \
     --security-opt apparmor=unconfined \
-    -e BUILDKITD_FLAGS=--oci-worker-no-process-sandbox \
+    --security-opt systempaths=unconfined \
     -v /path/to/dir:/tmp/work \
     --entrypoint buildctl-daemonless.sh \
     moby/buildkit:master-rootless \

--- a/docs/images-readme.md
+++ b/docs/images-readme.md
@@ -82,7 +82,7 @@ docker run \
     --rm \
     --security-opt seccomp=unconfined \
     --security-opt apparmor=unconfined \
-    -e BUILDKITD_FLAGS=--oci-worker-no-process-sandbox \
+    --security-opt systempaths=unconfined \
     -v /path/to/dir:/tmp/work \
     --entrypoint buildctl-daemonless.sh \
     moby/buildkit:master-rootless \


### PR DESCRIPTION
Follow suit on what Rootless mode docs state, as to not confuse users.