### PR TITLE
remotecache: avoid ultra deep recursion for complex cache layouts

### DIFF
--- a/cache/remotecache/v1/utils.go
+++ b/cache/remotecache/v1/utils.go
@@ -134,13 +134,21 @@ func (s *normalizeState) removeLoops(ctx context.Context) {
 	}
 
 	visited := map[digest.Digest]struct{}{}
+	processed := map[digest.Digest]struct{}{}
 
 	for _, d := range roots {
-		s.checkLoops(ctx, d, visited)
+		s.checkLoops(ctx, d, visited, processed)
 	}
 }
 
-func (s *normalizeState) checkLoops(ctx context.Context, d digest.Digest, visited map[digest.Digest]struct{}) {
+func (s *normalizeState) checkLoops(ctx context.Context, d digest.Digest, visited map[digest.Digest]struct{}, processed map[digest.Digest]struct{}) {
+	if _, ok := processed[d]; ok {
+		return
+	}
+	defer func() {
+		processed[d] = struct{}{}
+	}()
+
 	it, ok := s.byKey[d]
 	if !ok {
 		return
@@ -166,7 +174,7 @@ func (s *normalizeState) checkLoops(ctx context.Context, d digest.Digest, visite
 				}
 				delete(links[l], id)
 			} else {
-				s.checkLoops(ctx, id, visited)
+				s.checkLoops(ctx, id, visited, processed)
 			}
 		}
 	}


### PR DESCRIPTION
This is a follow-up to #6082 and #6008
I don't have a way to easily reproduce the cache loop detection issue, but I have run into it multiple times.
Looking at the logs and the code, this should hopefully greatly reduce the detph and width the recursion can reach here, hopefully speeding it up in the process.

I have not been able to verify if this actually solves the issue yet. But the change looks sensible to me either way.