### PR TITLE
dfgitutil: don't initialize ref from checksum

### DIFF
--- a/frontend/dockerfile/dfgitutil/git_ref.go
+++ b/frontend/dockerfile/dfgitutil/git_ref.go
@@ -176,8 +176,5 @@ func (gf *GitRef) loadQuery(query url.Values) error {
 		}
 		gf.Ref = branch
 	}
-	if gf.Checksum != "" && gf.Ref == "" {
-		gf.Ref = gf.Checksum
-	}
 	return nil
 }

--- a/frontend/dockerfile/dockerfile_addgit_test.go
+++ b/frontend/dockerfile/dockerfile_addgit_test.go
@@ -473,9 +473,24 @@ COPY foo out
 			expectOut: "v0.0.2\n",
 		},
 		{
+			name:      "v2 by commit (wrong short)",
+			url:       serverURL + "/.git?commit=" + commitHashV2[:8],
+			expectErr: "expected checksum to match",
+		},
+		{
+			name:      "v2 by commit (short)",
+			url:       serverURL + "/.git?commit=" + commitHashLatest[:8],
+			expectOut: "latest\n",
+		},
+		{
 			name:      "v2 ref by commit",
 			url:       serverURL + "/.git?ref=" + commitHashV2,
 			expectOut: "v0.0.2\n",
+		},
+		{
+			name:      "v2 ref by commit (short)",
+			url:       serverURL + "/.git?ref=" + commitHashV2[:8],
+			expectErr: "repository does not contain ref",
 		},
 		{
 			name:      "tag with commit",


### PR DESCRIPTION
closes #6174
fixes https://github.com/moby/buildkit/issues/6175

Initializing ref from checksum has unexpected side effects:
- Short checksum can't be used for fetching
- Default branch would be missing when fetching with keep-git-dir