### PR TITLE
docs: use latest "labs" for --parents and --exclude

### DIFF
--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -1905,7 +1905,7 @@ conditions for cache reuse.
 ### COPY --parents
 
 > [!NOTE]
-> Not yet available in stable syntax, use [`docker/dockerfile:1.7-labs`](#syntax) version.
+> Not yet available in stable syntax, use [`docker/dockerfile:1-labs`](#syntax) version.
 
 ```dockerfile
 COPY [--parents[=<boolean>]] <src> ... <dest>
@@ -1962,7 +1962,7 @@ with the `--parents` flag, the Buildkit is capable of packing multiple
 ### COPY --exclude
 
 > [!NOTE]
-> Not yet available in stable syntax, use [`docker/dockerfile:1.7-labs`](#syntax) version.
+> Not yet available in stable syntax, use [`docker/dockerfile:1-labs`](#syntax) version.
 
 ```dockerfile
 COPY [--exclude=<path> ...] <src> ... <dest>


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/15771#issuecomment-1784789258


The `--parents` and `--exclude` options have been part of the labs channel since 1.7, but have not yet been promoted to stable.

Using the 1.7-labs version in these examples means that users would be downgrading their Dockerfile syntax from 1.17 (soon 1.18.0) to a much older syntax.

Let's update the notes to use the latest labs syntax so that users are not surprised by other features no longer being supported when using the labs syntax.