### PR TITLE
gateway: no such ref now prints the all refs properly

### DIFF
--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -898,7 +898,7 @@ func (lbf *llbBridgeForwarder) getImmutableRef(ctx context.Context, id string) (
 		}
 		if ref == nil {
 			lbf.mu.Unlock()
-			return nil, errors.Errorf("no such ref: %s, all %+v", id, maps.Keys(lbf.refs))
+			return nil, errors.Errorf("no such ref: %s, all %+v", id, slices.Collect(maps.Keys(lbf.refs)))
 		}
 	}
 	lbf.mu.Unlock()


### PR DESCRIPTION

The `iter.Seq` returned from `maps.Keys` does not print properly with
`%+v` so it prints the pointer location instead of the contents. Use
`slices.Collect` to collect the iterator into a slice so it can be
printed properly into the error message.
