### PR TITLE
fix(security): upgrade Go to 1.23.12 to address CVE-2025-22871

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/moby/buildkit
 
-go 1.23.0
+go 1.23.12
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.16.0


### PR DESCRIPTION
Upgrades Go version from 1.23.0 to 1.23.12 to fix a critical vulnerability
in the net/http package. CVE-2025-22871.

Signed-off-by: Daniel Wright <danielwright@bitgo.com>
