### PR TITLE
llbsolver: don't set materials=false on inputs

### DIFF
--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -994,10 +994,6 @@ func getRefProvenance(ref solver.ResultProxy, br *provenanceBridge) (*provenance
 		pr.Frontend = br.req.Frontend
 		pr.Args = provenance.FilterArgs(br.req.FrontendOpt)
 		// TODO: should also save some output options like compression
-
-		if len(br.req.FrontendInputs) > 0 {
-			pr.IncompleteMaterials = true // not implemented
-		}
 	}
 
 	return pr, nil


### PR DESCRIPTION
I'm not really sure why this was set originally. We don't support nested builds in provenance that would allow replay (meaning we don't save the subbuild properties), but this shouldn't affect materials collection. If input contained sources they are still captured in the provenance.

Example build showing the issue: https://oci.dag.dev/?blob=docker.io/tonistiigi/dockerfile@sha256:29d88a9d397e45c98e475225bd510622b4eef65bdf9274729ddb166ce75ee91e&mt=application%2Fvnd.in-toto%2Bjson&size=1544