### PR TITLE
Fix rootless systemd install target

### DIFF
--- a/examples/systemd/user/buildkit-proxy.service
+++ b/examples/systemd/user/buildkit-proxy.service
@@ -9,4 +9,4 @@ After=buildkit-proxy.socket
 ExecStart=/usr/lib/systemd/systemd-socket-proxyd %t/buildkit/rootless
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target

--- a/examples/systemd/user/buildkit.service
+++ b/examples/systemd/user/buildkit.service
@@ -8,4 +8,4 @@ NotifyAccess=all
 ExecStart=rootlesskit --net=slirp4netns --copy-up=/etc --disable-host-loopback /usr/local/bin/buildkitd --addr unix://%t/buildkit/rootless
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target


### PR DESCRIPTION
Was setting up a rootless buildkit service, got warning while enabling systemd service: "Unit /home/user/.config/systemd/user/buildkit.service is added as a dependency to a non-existent unit multi-user.target". I had copied service files from example. On searching, got to know that it is warning because multi-user.target does not exist in the user systemd instance — it only exists in the system instance. For user services, one should use default.target instead of multi-user.target. Have tested the changes, and warning was removed on Ubuntu 24.04. So, have fixed the systemd user service files in example.