### PR TITLE
provenance: handle input:context frontend opt to set config source

### DIFF
--- a/solver/llbsolver/provenance/predicate.go
+++ b/solver/llbsolver/provenance/predicate.go
@@ -102,6 +102,8 @@ func NewPredicate(c *Capture) (*provenancetypes.ProvenancePredicateSLSA02, error
 	contextKey := "context"
 	if v, ok := args["contextkey"]; ok && v != "" {
 		contextKey = v
+	} else if v, ok := c.Args["input:context"]; ok && v != "" {
+		contextKey = "input:context"
 	}
 
 	if v, ok := args[contextKey]; ok && v != "" {


### PR DESCRIPTION
follow-up: https://github.com/docker/buildx/pull/3415

```
BUILDX_SEND_GIT_QUERY_AS_INPUT=true BUILDX_BUILDER=builder docker buildx build -t crazymax/dockerfile:1.18.0-builder2  --platform linux/amd64  --push "https://github.com/moby/buildkit.git?tag=dockerfile/1.18.0&checksum=b772c318368090fb2ffc9c0fed92e0a35bf82389&keep-git-dir=true"
```

https://oci.dag.dev/?blob=docker.io/crazymax/dockerfile@sha256:132c00161686ce417f1909cfbe34b75ed698c5c79958f70b0195928a70a82784&mt=application%2Fvnd.in-toto%2Bjson&size=2280