### PR TITLE
contenthash: do not follow nested symlinks when computing checksum

### DIFF
--- a/cache/contenthash/checksum_test.go
+++ b/cache/contenthash/checksum_test.go
@@ -527,6 +527,25 @@ func TestSymlinksNoFollow(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expectedSym, dgst)
 
+	expectedSym = digest.Digest("sha256:9b761577efcb1239cf4be971914c5d7404914dd32ff436401af1764dc5446b83")
+
+	// Broken symlink is not followed in subdirectory.
+	dgst, err = cc.Checksum(context.TODO(), ref, "foo", ChecksumOpts{FollowLinks: true}, nil)
+	require.NoError(t, err)
+	require.Equal(t, expectedSym, dgst)
+
+	expectedSym = digest.Digest("sha256:e14a98332f46b81993ff4a3b7898bb00fc3d245d84e4c42e57c9ee6b129c7c41")
+
+	// Same with wildcard used.
+	dgst, err = cc.Checksum(context.TODO(), ref, "fo?", ChecksumOpts{FollowLinks: true, Wildcard: true}, nil)
+	require.NoError(t, err)
+	require.Equal(t, expectedSym, dgst)
+
+	// Still works with exclude pattern.
+	dgst, err = cc.Checksum(context.TODO(), ref, "foo", ChecksumOpts{FollowLinks: true, ExcludePatterns: []string{"*.git"}}, nil)
+	require.NoError(t, err)
+	require.Equal(t, expectedSym, dgst)
+
 	err = ref.Release(context.TODO())
 	require.NoError(t, err)
 }


### PR DESCRIPTION
Nested symlinks were not intended to be followed after the first level
of wildcard expansion. When include/exclude patterns were used or a
wildcard was present higher up in the tree, we would erroneously follow
ALL symlinks to compute the hash.

When a symlink was broken, this would result in an error. We weren't
supposed to be following the symlinks at all.

This fixes things by changing `includedPaths` to also return whether a
path should follow links. If a parent directory exists for the path,
then the symlink is not followed.

Fixes https://github.com/moby/buildkit/issues/4946.