### PR TITLE
Support `HyperVIsolation` option in containerd executor in Windows

### DIFF
--- a/executor/containerdexecutor/executor.go
+++ b/executor/containerdexecutor/executor.go
@@ -40,7 +40,7 @@ type containerdExecutor struct {
 	selinux          bool
 	traceSocket      string
 	rootless         bool
-	isolated         bool
+	hypervIsolation  bool
 	runtime          *RuntimeInfo
 	cdiManager       *cdidevices.Manager
 }
@@ -74,7 +74,7 @@ type ExecutorOptions struct {
 	Selinux          bool
 	TraceSocket      string
 	Rootless         bool
-	Isolated         bool
+	HyperVIsolation  bool
 	Runtime          *RuntimeInfo
 	CDIManager       *cdidevices.Manager
 }
@@ -96,7 +96,7 @@ func New(executorOpts ExecutorOptions) executor.Executor {
 		selinux:          executorOpts.Selinux,
 		traceSocket:      executorOpts.TraceSocket,
 		rootless:         executorOpts.Rootless,
-		isolated:         executorOpts.Isolated,
+		hypervIsolation:  executorOpts.HyperVIsolation,
 		runtime:          executorOpts.Runtime,
 		cdiManager:       executorOpts.CDIManager,
 	}

--- a/executor/containerdexecutor/executor_windows.go
+++ b/executor/containerdexecutor/executor_windows.go
@@ -80,7 +80,7 @@ func (w *containerdExecutor) createOCISpec(ctx context.Context, id, _, _ string,
 	opts := []containerdoci.SpecOpts{
 		containerdoci.WithUser(meta.User),
 	}
-	if w.isolated {
+	if w.hypervIsolation {
 		opts = append(opts, containerdoci.WithWindowsHyperV)
 	}
 


### PR DESCRIPTION
This is a continuation of review in https://github.com/moby/buildkit/pull/6206#issuecomment-3286225621, and is the prerequisite of https://github.com/moby/moby/pull/50942.

Instead of exposing an overly broad `SpecOpts`, this PR only exposes an `Isolated` flag to make buildkit create containers in Hyper-V VM in Windows.

The name `Isolated` is taken from the flag `--isolated` from `ctr` command in [containerd](https://github.com/containerd/containerd/blob/1a8d84b826f80b65ed8d1f31cd4239dafea0052d/cmd/ctr/commands/run/run_windows.go#L140-L142):

```go
var platformRunFlags = []cli.Flag{
	&cli.BoolFlag{
		Name:  "isolated",
		Usage: "Run the container with vm isolation",
	},
}

if cliContext.Bool("isolated") {
	opts = append(opts, oci.WithWindowsHyperV)
}
```