### PR TITLE
grpcerrors: Ensure errors from errors.Join are preserved

### DIFF
--- a/util/grpcerrors/grpcerrors.go
+++ b/util/grpcerrors/grpcerrors.go
@@ -107,6 +107,14 @@ func withDetails(ctx context.Context, s *status.Status, details ...proto.Message
 	return status.FromProto(p), nil
 }
 
+// Code returns the gRPC status code for the given error.
+// If the error type has a `Code() codes.Code` method, it is used.
+// If the error type has a `GRPCStatus() *status.Status` method, its code is used.
+// As a fallback:
+// Supports `Unwrap() error` and `Unwrap() []error` for wrapped errors.
+// When the `Unwrap() []error` returns multiple errors, the first one that
+// contains a non-OK code is returned.
+// Finally, if the error is a context error, the corresponding code is returned.
 func Code(err error) codes.Code {
 	if errdefs.IsInternal(err) {
 		if errdefs.IsResourceExhausted(err) {
@@ -127,14 +135,20 @@ func Code(err error) codes.Code {
 		return se.GRPCStatus().Code()
 	}
 
-	wrapped, ok := err.(interface {
-		Unwrap() error
-	})
-	if ok {
+	if wrapped, ok := err.(singleUnwrapper); ok {
 		if err := wrapped.Unwrap(); err != nil {
 			return Code(err)
 		}
 	}
+
+	if wrapped, ok := err.(multiUnwrapper); ok {
+		for _, err := range wrapped.Unwrap() {
+			if c := Code(err); c != codes.OK && c != codes.Unknown {
+				return c
+			}
+		}
+	}
+
 	return status.FromContextError(err).Code()
 }
 
@@ -142,6 +156,10 @@ func WrapCode(err error, code codes.Code) error {
 	return &withCodeError{error: err, code: code}
 }
 
+// AsGRPCStatus tries to extract a gRPC status from the error.
+// Supports  `Unwrap() error` and `Unwrap() []error` for wrapped errors.
+// When the `Unwrap() []error` returns multiple errors, the first one that
+// contains a gRPC status is returned.
 func AsGRPCStatus(err error) (*status.Status, bool) {
 	if err == nil {
 		return nil, true
@@ -152,12 +170,17 @@ func AsGRPCStatus(err error) (*status.Status, bool) {
 		return se.GRPCStatus(), true
 	}
 
-	wrapped, ok := err.(interface {
-		Unwrap() error
-	})
-	if ok {
+	if wrapped, ok := err.(singleUnwrapper); ok {
 		if err := wrapped.Unwrap(); err != nil {
 			return AsGRPCStatus(err)
+		}
+	}
+
+	if wrapped, ok := err.(multiUnwrapper); ok {
+		for _, err := range wrapped.Unwrap() {
+			if st, ok := AsGRPCStatus(err); ok && st != nil {
+				return st, true
+			}
 		}
 	}
 
@@ -253,14 +276,6 @@ func (e *withCodeError) Unwrap() error {
 func each(err error, fn func(error)) {
 	fn(err)
 
-	type singleUnwrapper interface {
-		Unwrap() error
-	}
-
-	type multiUnwrapper interface {
-		Unwrap() []error
-	}
-
 	switch e := err.(type) { //nolint:errorlint // using errors.Is/As is not appropriate here
 	case singleUnwrapper:
 		each(e.Unwrap(), fn)
@@ -270,4 +285,12 @@ func each(err error, fn func(error)) {
 		}
 	default:
 	}
+}
+
+type singleUnwrapper interface {
+	Unwrap() error
+}
+
+type multiUnwrapper interface {
+	Unwrap() []error
 }

--- a/util/grpcerrors/grpcerrors_test.go
+++ b/util/grpcerrors/grpcerrors_test.go
@@ -17,6 +17,17 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
+// helper types used by Code/AsGRPCStatus tests
+type testCodeError struct{ c codes.Code }
+
+func (e testCodeError) Error() string    { return e.c.String() }
+func (e testCodeError) Code() codes.Code { return e.c }
+
+type testGRPCStatusError struct{ st *status.Status }
+
+func (e testGRPCStatusError) Error() string              { return e.st.Err().Error() }
+func (e testGRPCStatusError) GRPCStatus() *status.Status { return e.st }
+
 func TestFromGRPCPreserveUnknownTypes(t *testing.T) {
 	t.Parallel()
 	const (
@@ -111,6 +122,80 @@ func TestFromGRPCPreserveTypes(t *testing.T) {
 	assert.ErrorContains(t, reDecoded, errMessage)
 }
 
+func TestCode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("uses Code() method", func(t *testing.T) {
+		c := grpcerrors.Code(testCodeError{c: codes.InvalidArgument})
+		assert.Equal(t, codes.InvalidArgument, c)
+	})
+
+	t.Run("uses GRPCStatus() method", func(t *testing.T) {
+		st := status.New(codes.PermissionDenied, "denied")
+		c := grpcerrors.Code(testGRPCStatusError{st: st})
+		assert.Equal(t, codes.PermissionDenied, c)
+	})
+
+	t.Run("unwraps single wrapped error", func(t *testing.T) {
+		inner := testCodeError{c: codes.FailedPrecondition}
+		outer := errors.Wrap(inner, "wrap")
+		c := grpcerrors.Code(outer)
+		assert.Equal(t, codes.FailedPrecondition, c)
+	})
+
+	t.Run("chooses first non-OK from joined errors", func(t *testing.T) {
+		j := stderrors.Join(testCodeError{c: codes.OK}, testCodeError{c: codes.InvalidArgument}, testCodeError{c: codes.FailedPrecondition})
+		c := grpcerrors.Code(j)
+		assert.Equal(t, codes.InvalidArgument, c)
+	})
+
+	t.Run("maps context errors to codes", func(t *testing.T) {
+		c := grpcerrors.Code(context.Canceled)
+		assert.Equal(t, codes.Canceled, c)
+		c = grpcerrors.Code(context.DeadlineExceeded)
+		assert.Equal(t, codes.DeadlineExceeded, c)
+	})
+}
+
+func TestAsGRPCStatus(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil returns ok with nil status", func(t *testing.T) {
+		st, ok := grpcerrors.AsGRPCStatus(nil)
+		require.True(t, ok)
+		assert.Nil(t, st)
+	})
+
+	t.Run("direct GRPCStatus is returned", func(t *testing.T) {
+		in := status.New(codes.NotFound, "nope")
+		st, ok := grpcerrors.AsGRPCStatus(testGRPCStatusError{st: in})
+		require.True(t, ok)
+		assert.Equal(t, in.Code(), st.Code())
+	})
+
+	t.Run("finds status through a wrapped error", func(t *testing.T) {
+		in := status.New(codes.Unavailable, "down")
+		outer := errors.Wrap(testGRPCStatusError{st: in}, "wrap")
+		st, ok := grpcerrors.AsGRPCStatus(outer)
+		require.True(t, ok)
+		assert.Equal(t, in.Code(), st.Code())
+	})
+
+	t.Run("finds status in joined errors", func(t *testing.T) {
+		in := status.New(codes.ResourceExhausted, "res")
+		j := stderrors.Join(testCodeError{c: codes.InvalidArgument}, testGRPCStatusError{st: in})
+		st, ok := grpcerrors.AsGRPCStatus(j)
+		require.True(t, ok)
+		assert.Equal(t, in.Code(), st.Code())
+	})
+
+	t.Run("returns false when no status found", func(t *testing.T) {
+		st, ok := grpcerrors.AsGRPCStatus(testCodeError{c: codes.InvalidArgument})
+		assert.False(t, ok)
+		assert.Nil(t, st)
+	})
+}
+
 func TestToGRPCMessage(t *testing.T) {
 	t.Parallel()
 	t.Run("avoid prepending grpc status code", func(t *testing.T) {
@@ -131,7 +216,7 @@ func TestToGRPCMessage(t *testing.T) {
 		encoded := grpcerrors.ToGRPC(context.TODO(), joined)
 		decoded := grpcerrors.FromGRPC(encoded)
 
-		assert.ErrorContains(t, decoded, wrapped.Error()) //nolint:testifylint // don't use require since its not critical
+		assert.ErrorContains(t, decoded, wrapped.Error()) //nolint:testifylint // error is not critical
 		assert.ErrorContains(t, decoded, anotherErr.Error())
 	})
 }


### PR DESCRIPTION
Adds support for the `Unwrap() []error` interface used by `errors.Join` so that roundtripping through grpcerrors preserves types.

Fixes #6225 