### PR TITLE
frontend: add required paths to LLB and use it with --parents

### DIFF
--- a/client/llb/fileop.go
+++ b/client/llb/fileop.go
@@ -569,6 +569,7 @@ type CopyInfo struct {
 	CopyDirContentsOnly            bool
 	IncludePatterns                []string
 	ExcludePatterns                []string
+	RequiredPaths                  []string
 	AttemptUnpack                  bool
 	CreateDestPath                 bool
 	AllowWildcard                  bool
@@ -603,6 +604,7 @@ func (a *fileActionCopy) toProtoAction(ctx context.Context, parent string, base 
 		Owner:                            a.info.ChownOpt.marshal(base),
 		IncludePatterns:                  a.info.IncludePatterns,
 		ExcludePatterns:                  a.info.ExcludePatterns,
+		RequiredPaths:                    a.info.RequiredPaths,
 		AllowWildcard:                    a.info.AllowWildcard,
 		AllowEmptyWildcard:               a.info.AllowEmptyWildcard,
 		FollowSymlink:                    a.info.FollowSymlinks,
@@ -646,6 +648,9 @@ func (a *fileActionCopy) sourcePath(ctx context.Context) (string, error) {
 func (a *fileActionCopy) addCaps(f *FileOp) {
 	if len(a.info.IncludePatterns) != 0 || len(a.info.ExcludePatterns) != 0 {
 		addCap(&f.constraints, pb.CapFileCopyIncludeExcludePatterns)
+	}
+	if len(a.info.RequiredPaths) != 0 {
+		addCap(&f.constraints, pb.CapFileCopyRequiredPaths)
 	}
 	if a.info.AlwaysReplaceExistingDestPaths {
 		addCap(&f.constraints, pb.CapFileCopyAlwaysReplaceExistingDestPaths)

--- a/solver/llbsolver/ops/file.go
+++ b/solver/llbsolver/ops/file.go
@@ -105,7 +105,7 @@ func (f *fileOp) CacheMap(ctx context.Context, g session.Group, index int) (*sol
 			markInvalid(action.Input)
 			processOwner(p.Owner, selectors)
 			if action.SecondaryInput != -1 && int(action.SecondaryInput) < f.numInputs {
-				addSelector(selectors, int(action.SecondaryInput), p.Src, p.AllowWildcard, p.FollowSymlink, p.IncludePatterns, p.ExcludePatterns)
+				addSelector(selectors, int(action.SecondaryInput), p.Src, p.AllowWildcard, p.FollowSymlink, p.IncludePatterns, p.ExcludePatterns, p.RequiredPaths)
 				p.Src = path.Base(p.Src)
 			}
 			dt, err = json.Marshal(p)
@@ -215,13 +215,14 @@ func (f *fileOp) Acquire(ctx context.Context) (solver.ReleaseFunc, error) {
 	}, nil
 }
 
-func addSelector(m map[int][]opsutils.Selector, idx int, sel string, wildcard, followLinks bool, includePatterns, excludePatterns []string) {
+func addSelector(m map[int][]opsutils.Selector, idx int, sel string, wildcard, followLinks bool, includePatterns, excludePatterns, requiredPaths []string) {
 	s := opsutils.Selector{
 		Path:            sel,
 		FollowLinks:     followLinks,
 		Wildcard:        wildcard && containsWildcards(sel),
 		IncludePatterns: includePatterns,
 		ExcludePatterns: excludePatterns,
+		RequiredPaths:   requiredPaths,
 	}
 
 	m[idx] = append(m[idx], s)
@@ -284,7 +285,7 @@ func processOwner(chopt *pb.ChownOpt, selectors map[int][]opsutils.Selector) err
 			if u.ByName.Input < 0 {
 				return errors.Errorf("invalid user index %d", u.ByName.Input)
 			}
-			addSelector(selectors, int(u.ByName.Input), "/etc/passwd", false, true, nil, nil)
+			addSelector(selectors, int(u.ByName.Input), "/etc/passwd", false, true, nil, nil, nil)
 		}
 	}
 	if chopt.Group != nil {
@@ -292,7 +293,7 @@ func processOwner(chopt *pb.ChownOpt, selectors map[int][]opsutils.Selector) err
 			if u.ByName.Input < 0 {
 				return errors.Errorf("invalid user index %d", u.ByName.Input)
 			}
-			addSelector(selectors, int(u.ByName.Input), "/etc/group", false, true, nil, nil)
+			addSelector(selectors, int(u.ByName.Input), "/etc/group", false, true, nil, nil, nil)
 		}
 	}
 	return nil

--- a/solver/llbsolver/ops/opsutils/contenthash.go
+++ b/solver/llbsolver/ops/opsutils/contenthash.go
@@ -21,6 +21,7 @@ type Selector struct {
 	FollowLinks     bool
 	IncludePatterns []string
 	ExcludePatterns []string
+	RequiredPaths   []string
 }
 
 func (sel Selector) HasWildcardOrFilters() bool {
@@ -52,6 +53,7 @@ func NewContentHashFunc(selectors []Selector) solver.ResultBasedCacheFunc {
 						FollowLinks:     sel.FollowLinks,
 						IncludePatterns: sel.IncludePatterns,
 						ExcludePatterns: sel.ExcludePatterns,
+						RequiredPaths:   sel.RequiredPaths,
 					},
 					s,
 				)

--- a/solver/pb/caps.go
+++ b/solver/pb/caps.go
@@ -73,6 +73,7 @@ const (
 	CapFileBase                               apicaps.CapID = "file.base"
 	CapFileRmWildcard                         apicaps.CapID = "file.rm.wildcard"
 	CapFileCopyIncludeExcludePatterns         apicaps.CapID = "file.copy.includeexcludepatterns"
+	CapFileCopyRequiredPaths                  apicaps.CapID = "file.copy.requiredpaths"
 	CapFileRmNoFollowSymlink                  apicaps.CapID = "file.rm.nofollowsymlink"
 	CapFileCopyAlwaysReplaceExistingDestPaths apicaps.CapID = "file.copy.alwaysreplaceexistingdestpaths"
 	CapFileCopyModeStringFormat               apicaps.CapID = "file.copy.modestring"
@@ -447,6 +448,12 @@ func init() {
 
 	Caps.Init(apicaps.Cap{
 		ID:      CapFileCopyIncludeExcludePatterns,
+		Enabled: true,
+		Status:  apicaps.CapStatusExperimental,
+	})
+
+	Caps.Init(apicaps.Cap{
+		ID:      CapFileCopyRequiredPaths,
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})

--- a/solver/pb/ops.pb.go
+++ b/solver/pb/ops.pb.go
@@ -2527,7 +2527,10 @@ type FileActionCopy struct {
 	// alwaysReplaceExistingDestPaths results in an existing dest path that differs in type from the src path being replaced rather than the default of returning an error
 	AlwaysReplaceExistingDestPaths bool `protobuf:"varint,14,opt,name=alwaysReplaceExistingDestPaths,proto3" json:"alwaysReplaceExistingDestPaths,omitempty"`
 	// mode in non-octal format
-	ModeStr       string `protobuf:"bytes,15,opt,name=modeStr,proto3" json:"modeStr,omitempty"`
+	ModeStr string `protobuf:"bytes,15,opt,name=modeStr,proto3" json:"modeStr,omitempty"`
+	// required paths that must be included in the copy. This is only used when
+	// include_patterns has at least one pattern.
+	RequiredPaths []string `protobuf:"bytes,16,rep,name=required_paths,json=requiredPaths,proto3" json:"required_paths,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2665,6 +2668,13 @@ func (x *FileActionCopy) GetModeStr() string {
 		return x.ModeStr
 	}
 	return ""
+}
+
+func (x *FileActionCopy) GetRequiredPaths() []string {
+	if x != nil {
+		return x.RequiredPaths
+	}
+	return nil
 }
 
 type FileActionMkFile struct {
@@ -3581,7 +3591,7 @@ const file_github_com_moby_buildkit_solver_pb_ops_proto_rawDesc = "" +
 	"\x05mkdir\x18\x06 \x01(\v2\x13.pb.FileActionMkDirH\x00R\x05mkdir\x12\"\n" +
 	"\x02rm\x18\a \x01(\v2\x10.pb.FileActionRmH\x00R\x02rm\x121\n" +
 	"\asymlink\x18\b \x01(\v2\x15.pb.FileActionSymlinkH\x00R\asymlinkB\b\n" +
-	"\x06action\"\xde\x04\n" +
+	"\x06action\"\x85\x05\n" +
 	"\x0eFileActionCopy\x12\x10\n" +
 	"\x03src\x18\x01 \x01(\tR\x03src\x12\x12\n" +
 	"\x04dest\x18\x02 \x01(\tR\x04dest\x12\"\n" +
@@ -3598,7 +3608,8 @@ const file_github_com_moby_buildkit_solver_pb_ops_proto_rawDesc = "" +
 	"\x10include_patterns\x18\f \x03(\tR\x0fincludePatterns\x12)\n" +
 	"\x10exclude_patterns\x18\r \x03(\tR\x0fexcludePatterns\x12F\n" +
 	"\x1ealwaysReplaceExistingDestPaths\x18\x0e \x01(\bR\x1ealwaysReplaceExistingDestPaths\x12\x18\n" +
-	"\amodeStr\x18\x0f \x01(\tR\amodeStr\"\x90\x01\n" +
+	"\amodeStr\x18\x0f \x01(\tR\amodeStr\x12%\n" +
+	"\x0erequired_paths\x18\x10 \x03(\tR\rrequiredPaths\"\x90\x01\n" +
 	"\x10FileActionMkFile\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12\x12\n" +
 	"\x04mode\x18\x02 \x01(\x05R\x04mode\x12\x12\n" +

--- a/solver/pb/ops.proto
+++ b/solver/pb/ops.proto
@@ -355,6 +355,9 @@ message FileActionCopy {
 	bool alwaysReplaceExistingDestPaths = 14;
 	// mode in non-octal format
 	string modeStr = 15;
+	// required paths that must be included in the copy. This is only used when
+	// include_patterns has at least one pattern.
+	repeated string required_paths = 16;
 }
 
 message FileActionMkFile {

--- a/solver/pb/ops_vtproto.pb.go
+++ b/solver/pb/ops_vtproto.pb.go
@@ -886,6 +886,11 @@ func (m *FileActionCopy) CloneVT() *FileActionCopy {
 		copy(tmpContainer, rhs)
 		r.ExcludePatterns = tmpContainer
 	}
+	if rhs := m.RequiredPaths; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.RequiredPaths = tmpContainer
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -2577,6 +2582,15 @@ func (this *FileActionCopy) EqualVT(that *FileActionCopy) bool {
 	}
 	if this.ModeStr != that.ModeStr {
 		return false
+	}
+	if len(this.RequiredPaths) != len(that.RequiredPaths) {
+		return false
+	}
+	for i, vx := range this.RequiredPaths {
+		vy := that.RequiredPaths[i]
+		if vx != vy {
+			return false
+		}
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -5183,6 +5197,17 @@ func (m *FileActionCopy) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.RequiredPaths) > 0 {
+		for iNdEx := len(m.RequiredPaths) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.RequiredPaths[iNdEx])
+			copy(dAtA[i:], m.RequiredPaths[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RequiredPaths[iNdEx])))
+			i--
+			dAtA[i] = 0x1
+			i--
+			dAtA[i] = 0x82
+		}
+	}
 	if len(m.ModeStr) > 0 {
 		i -= len(m.ModeStr)
 		copy(dAtA[i:], m.ModeStr)
@@ -6949,6 +6974,12 @@ func (m *FileActionCopy) SizeVT() (n int) {
 	l = len(m.ModeStr)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.RequiredPaths) > 0 {
+		for _, s := range m.RequiredPaths {
+			l = len(s)
+			n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
 	}
 	n += len(m.unknownFields)
 	return n
@@ -13312,6 +13343,38 @@ func (m *FileActionCopy) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.ModeStr = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 16:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RequiredPaths", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.RequiredPaths = append(m.RequiredPaths, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex


### PR DESCRIPTION
This adds an additional `RequiredPaths` that is primarily intended for
use with `COPY --parents`. This parameter specifies expected directories
or files that should exist when performing the checksum. A not found
error will be produced if one of these paths is missing.

This fixes an issue with `COPY --parents` where a non existent directory
that was intended to be copied would be ignored.

Fixes #4900.
