### PR TITLE
llb: add checksum option to llb.Image

### DIFF
--- a/client/llb/resolver.go
+++ b/client/llb/resolver.go
@@ -2,6 +2,7 @@ package llb
 
 import (
 	"github.com/moby/buildkit/client/llb/sourceresolver"
+	digest "github.com/opencontainers/go-digest"
 )
 
 // WithMetaResolver adds a metadata resolver to an image
@@ -23,6 +24,12 @@ func ResolveDigest(v bool) ImageOption {
 func WithLayerLimit(l int) ImageOption {
 	return imageOptionFunc(func(ii *ImageInfo) {
 		ii.layerLimit = &l
+	})
+}
+
+func WithImageChecksum(dgst digest.Digest) ImageOption {
+	return imageOptionFunc(func(ii *ImageInfo) {
+		ii.checksum = dgst
 	})
 }
 

--- a/client/llb/source.go
+++ b/client/llb/source.go
@@ -130,6 +130,11 @@ func Image(ref string, opts ...ImageOption) State {
 		addCap(&info.Constraints, pb.CapSourceImageLayerLimit)
 	}
 
+	if info.checksum != "" {
+		attrs[pb.AttrImageChecksum] = info.checksum.String()
+		addCap(&info.Constraints, pb.CapSourceImageChecksum)
+	}
+
 	src := NewSource("docker-image://"+ref, attrs, info.Constraints) // controversial
 	if err != nil {
 		src.err = err
@@ -227,6 +232,7 @@ type ImageInfo struct {
 	resolveDigest bool
 	resolveMode   ResolveMode
 	layerLimit    *int
+	checksum      digest.Digest
 	RecordType    string
 }
 
@@ -623,11 +629,18 @@ func OCILayerLimit(limit int) OCILayoutOption {
 	})
 }
 
+func OCIChecksum(dgst digest.Digest) OCILayoutOption {
+	return ociLayoutOptionFunc(func(oi *OCILayoutInfo) {
+		oi.checksum = dgst
+	})
+}
+
 type OCILayoutInfo struct {
 	constraintsWrapper
 	sessionID  string
 	storeID    string
 	layerLimit *int
+	checksum   digest.Digest
 }
 
 type DiffType string

--- a/solver/pb/attr.go
+++ b/solver/pb/attr.go
@@ -34,6 +34,7 @@ const AttrImageResolveModeForcePull = "pull"
 const AttrImageResolveModePreferLocal = "local"
 const AttrImageRecordType = "image.recordtype"
 const AttrImageLayerLimit = "image.layerlimit"
+const AttrImageChecksum = "image.checksum"
 
 const AttrOCILayoutSessionID = "oci.session"
 const AttrOCILayoutStoreID = "oci.store"

--- a/solver/pb/caps.go
+++ b/solver/pb/caps.go
@@ -12,6 +12,7 @@ const (
 	CapSourceImage            apicaps.CapID = "source.image"
 	CapSourceImageResolveMode apicaps.CapID = "source.image.resolvemode"
 	CapSourceImageLayerLimit  apicaps.CapID = "source.image.layerlimit"
+	CapSourceImageChecksum    apicaps.CapID = "source.image.checksum"
 
 	CapSourceLocal                apicaps.CapID = "source.local"
 	CapSourceLocalUnique          apicaps.CapID = "source.local.unique"
@@ -124,6 +125,12 @@ func init() {
 
 	Caps.Init(apicaps.Cap{
 		ID:      CapSourceImageLayerLimit,
+		Enabled: true,
+		Status:  apicaps.CapStatusExperimental,
+	})
+
+	Caps.Init(apicaps.Cap{
+		ID:      CapSourceImageChecksum,
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})

--- a/source/containerimage/identifier.go
+++ b/source/containerimage/identifier.go
@@ -19,6 +19,7 @@ type ImageIdentifier struct {
 	ResolveMode resolver.ResolveMode
 	RecordType  client.UsageRecordType
 	LayerLimit  *int
+	Checksum    digest.Digest
 }
 
 func NewImageIdentifier(str string) (*ImageIdentifier, error) {

--- a/source/containerimage/pull.go
+++ b/source/containerimage/pull.go
@@ -46,6 +46,7 @@ type puller struct {
 	Ref            string
 	SessionManager *session.Manager
 	layerLimit     *int
+	checksum       digest.Digest
 	vtx            solver.Vertex
 	ResolverType
 	store sourceresolver.ResolveImageConfigOptStore
@@ -128,6 +129,10 @@ func (p *puller) CacheKey(ctx context.Context, g session.Group, index int) (cach
 		p.manifest, err = p.PullManifests(ctx, getResolver)
 		if err != nil {
 			return struct{}{}, err
+		}
+
+		if p.checksum != "" && p.manifest.MainManifestDesc.Digest != p.checksum {
+			return struct{}{}, errors.Errorf("image digest %s for %s does not match expected checksum %s", p.manifest.MainManifestDesc.Digest, p.Ref, p.checksum)
 		}
 
 		if ll := p.layerLimit; ll != nil {

--- a/source/containerimage/source.go
+++ b/source/containerimage/source.go
@@ -93,6 +93,7 @@ func (is *Source) Resolve(ctx context.Context, id source.Identifier, sm *session
 		ref        reference.Spec
 		store      sourceresolver.ResolveImageConfigOptStore
 		layerLimit *int
+		checksum   digest.Digest
 	)
 	switch is.ResolverType {
 	case ResolverTypeRegistry:
@@ -108,6 +109,7 @@ func (is *Source) Resolve(ctx context.Context, id source.Identifier, sm *session
 		recordType = imageIdentifier.RecordType
 		ref = imageIdentifier.Reference
 		layerLimit = imageIdentifier.LayerLimit
+		checksum = imageIdentifier.Checksum
 	case ResolverTypeOCILayout:
 		ociIdentifier, ok := id.(*OCIIdentifier)
 		if !ok {
@@ -146,6 +148,7 @@ func (is *Source) Resolve(ctx context.Context, id source.Identifier, sm *session
 		vtx:            vtx,
 		store:          store,
 		layerLimit:     layerLimit,
+		checksum:       checksum,
 	}
 	return p, nil
 }
@@ -245,6 +248,12 @@ func (is *Source) registryIdentifier(ref string, attrs map[string]string, platfo
 				return nil, errors.Errorf("invalid layer limit %s", v)
 			}
 			id.LayerLimit = &l
+		case pb.AttrImageChecksum:
+			dgst, err := digest.Parse(v)
+			if err != nil {
+				return nil, errors.Wrapf(err, "invalid image checksum %s", v)
+			}
+			id.Checksum = dgst
 		}
 	}
 


### PR DESCRIPTION
This allows images to be pulled by tag and then
checked against the digest. If digest is added directly to the image reference, then tag is ignored.

This matches the behavior of `llb.Git` that was added in the previous release, where you can now check out a commit by SHA, or check out by reg, and then verify the SHA.

Main use case for this would be via source policy.