### PR TITLE
hack: update hack/compose with newer otel collector

### DIFF
--- a/hack/composefiles/compose.yaml
+++ b/hack/composefiles/compose.yaml
@@ -13,6 +13,8 @@ services:
     environment:
       OTEL_SERVICE_NAME: buildkitd
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
+    command:
+      - '--save-cache-debug'
     configs:
       - source: buildkit_config
         target: /etc/buildkit/buildkitd.toml
@@ -21,22 +23,19 @@ services:
     depends_on:
       - otel-collector
 
-  jaeger:
-    image: jaegertracing/all-in-one:latest
-    ports:
-      - 127.0.0.1:16686:16686
-
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.92.0
+    image: otel/opentelemetry-collector-contrib:0.135.0
     restart: always
     configs:
       - source: otelcol_config
         target: /etc/otelcol-contrib/config.yaml
+
+  jaeger:
+    image: jaegertracing/all-in-one:latest
     ports:
-      - 127.0.0.1:4317:4317
-      - 127.0.0.1:8000:8000
-    depends_on:
-      - jaeger
+      - 127.0.0.1:16686:16686
+    profiles:
+      - tracing
 
   prometheus:
     image: prom/prometheus:v2.48.1
@@ -47,6 +46,8 @@ services:
       - prometheus:/prometheus
     depends_on:
       - buildkit
+    profiles:
+      - metrics
 
   grafana:
     image: grafana/grafana-oss:10.2.3
@@ -61,6 +62,8 @@ services:
       - grafana:/var/lib/grafana
     depends_on:
       - prometheus
+    profiles:
+      - metrics
 
 volumes:
   buildkit:

--- a/hack/composefiles/otelcol.yaml
+++ b/hack/composefiles/otelcol.yaml
@@ -6,9 +6,20 @@ exporters:
   otlp/jaeger:
     endpoint: jaeger:4317
     tls::insecure: true
+    retry_on_failure::max_elapsed_time: 1m
+
+  nop:
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
       exporters: [otlp/jaeger]
+
+    metrics:
+      receivers: [otlp]
+      exporters: [nop]
+
+  telemetry:
+    metrics::level: none
+    logs::level: ERROR


### PR DESCRIPTION

Modifies the hack/compose script to use a newer otel collector and try
to suppress miscellaneous logs when it fails to export traces. Disable
jaeger, prometheus, and grafana by default.

It also adds a metrics pipeline that goes to a nop exporter. This is
force the otel collector to start the metrics service and prevent an
error when buildkit exports metrics to the otel collector related to the
metrics service being missing.
