### PR TITLE
hack: enable oci-artifact for buildkit and frontend images

### DIFF
--- a/frontend/dockerfile/cmd/dockerfile-frontend/hack/release
+++ b/frontend/dockerfile/cmd/dockerfile-frontend/hack/release
@@ -75,7 +75,7 @@ if [[ "$RELEASE" = "true" ]] && [[ "$GITHUB_ACTIONS" = "true" ]]; then
   nocacheFilterFlag="--no-cache-filter=base"
 fi
 
-outputFlag="type=image,$pushFlag"
+outputFlag="type=image,$pushFlag,oci-artifact=true"
 if [ "$GITHUB_ACTIONS" = "true" ]; then
   outputFlag="${outputFlag},\"annotation.org.opencontainers.image.title=Dockerfile Frontend\""
   if [ -n "$GITHUB_SHA" ]; then

--- a/hack/images
+++ b/hack/images
@@ -49,6 +49,8 @@ fi
 if [ -n "$localmode" ]; then
   outputFlag="--output=type=docker"
   attestFlags=""
+else
+  outputFlag="${outputFlag},oci-artifact=true"
 fi
 
 if [ -z "$localmode" ] && [ "$GITHUB_ACTIONS" = "true" ]; then


### PR DESCRIPTION
This enables OCI artifact for attestation manifest when pushing buildkit and frontend images.