### PR TITLE
create provenance.d folder in buildkit container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -224,7 +224,7 @@ COPY --link examples/buildctl-daemonless/buildctl-daemonless.sh /usr/bin/
 VOLUME /var/lib/buildkit
 
 FROM buildkit-export-${EXPORT_BASE} AS buildkit-export
-RUN mkdir -p /etc/cdi /var/run/cdi /etc/buildkit/cdi
+RUN mkdir -p /etc/cdi /var/run/cdi /etc/buildkit/cdi /etc/buildkit/provenance.d
 
 FROM gobuild-base AS containerd-build
 WORKDIR /go/src/github.com/containerd/containerd


### PR DESCRIPTION
relates to https://github.com/moby/buildkit/pull/6210

Creates `/etc/buildkit/provenance.d` in buildkit container so then we can mount JSON payloads for provenance custom fields. This will be specially useful when creating a buildkit container using the buildx docker-container driver.