### PR TITLE
vendor: github.com/containerd/go-cni v1.1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/containerd/continuity v0.4.5
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/fuse-overlayfs-snapshotter/v2 v2.1.6
-	github.com/containerd/go-cni v1.1.12
+	github.com/containerd/go-cni v1.1.13
 	github.com/containerd/go-runc v1.1.0
 	github.com/containerd/log v0.1.0
 	github.com/containerd/nydus-snapshotter v0.15.4

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ github.com/containerd/fifo v1.1.0 h1:4I2mbh5stb1u6ycIABlBw9zgtlK8viPI9QkQNRQEEmY
 github.com/containerd/fifo v1.1.0/go.mod h1:bmC4NWMbXlt2EZ0Hc7Fx7QzTFxgPID13eH0Qu+MAb2o=
 github.com/containerd/fuse-overlayfs-snapshotter/v2 v2.1.6 h1:gfW1JsN//B97zhsQ84Kkar7WJqod1fmWf8zKHmz+ieY=
 github.com/containerd/fuse-overlayfs-snapshotter/v2 v2.1.6/go.mod h1:Mau9LZ7ZnyKCIgcNT7sMG5fjaZ9YCOHU5RuolUikhBQ=
-github.com/containerd/go-cni v1.1.12 h1:wm/5VD/i255hjM4uIZjBRiEQ7y98W9ACy/mHeLi4+94=
-github.com/containerd/go-cni v1.1.12/go.mod h1:+jaqRBdtW5faJxj2Qwg1Of7GsV66xcvnCx4mSJtUlxU=
+github.com/containerd/go-cni v1.1.13 h1:eFSGOKlhoYNxpJ51KRIMHZNlg5UgocXEIEBGkY7Hnis=
+github.com/containerd/go-cni v1.1.13/go.mod h1:nTieub0XDRmvCZ9VI/SBG6PyqT95N4FIhxsauF1vSBI=
 github.com/containerd/go-runc v1.1.0 h1:OX4f+/i2y5sUT7LhmcJH7GYrjjhHa1QI4e8yO0gGleA=
 github.com/containerd/go-runc v1.1.0/go.mod h1:xJv2hFF7GvHtTJd9JqTS2UVxMkULUYw4JN5XAUZqH5U=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=

--- a/vendor/github.com/containerd/go-cni/.golangci.yml
+++ b/vendor/github.com/containerd/go-cni/.golangci.yml
@@ -11,7 +11,13 @@ linters:
     - misspell
   disable:
     - errcheck
-
+  # Continue supporting deprecated CNI conf formats (ref: https://github.com/containernetworking/cni/pull/1052#issuecomment-1922233640)
+  exclusions:
+    rules:
+      - path: opts.go
+        linters:
+          - staticcheck
+        text: "SA1019:"
 # FIXME: re-enable after fixing GoDoc in this repository
 #issues:
 #  include:

--- a/vendor/github.com/containerd/go-cni/opts.go
+++ b/vendor/github.com/containerd/go-cni/opts.go
@@ -66,9 +66,9 @@ func WithPluginConfDir(dir string) Opt {
 
 // WithPluginMaxConfNum can be used to configure the
 // max cni plugin config file num.
-func WithPluginMaxConfNum(max int) Opt {
+func WithPluginMaxConfNum(maxConfigs int) Opt {
 	return func(c *libcni) error {
-		c.pluginMaxConfNum = max
+		c.pluginMaxConfNum = maxConfigs
 		return nil
 	}
 }
@@ -209,7 +209,7 @@ func WithAllConf(c *libcni) error {
 // loadFromConfDir detects network config files from the
 // configured cni config directory and load them. max is
 // the maximum network config to load (max i<= 0 means no limit).
-func loadFromConfDir(c *libcni, max int) error {
+func loadFromConfDir(c *libcni, maxConfigs int) error {
 	files, err := cnilibrary.ConfFiles(c.pluginConfDir, []string{".conf", ".conflist", ".json"})
 	switch {
 	case err != nil:
@@ -245,7 +245,6 @@ func loadFromConfDir(c *libcni, max int) error {
 			if conf.Network.Type == "" {
 				return fmt.Errorf("network type not found in %s: %w", confFile, ErrInvalidConfig)
 			}
-
 			confList, err = cnilibrary.ConfListFromConf(conf)
 			if err != nil {
 				return fmt.Errorf("failed to convert CNI config file %s to CNI config list: %v: %w", confFile, err, ErrInvalidConfig)
@@ -261,7 +260,7 @@ func loadFromConfDir(c *libcni, max int) error {
 			ifName: getIfName(c.prefix, i),
 		})
 		i++
-		if i == max {
+		if i == maxConfigs {
 			break
 		}
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -398,7 +398,7 @@ github.com/containerd/fifo
 # github.com/containerd/fuse-overlayfs-snapshotter/v2 v2.1.6
 ## explicit; go 1.23.0
 github.com/containerd/fuse-overlayfs-snapshotter/v2
-# github.com/containerd/go-cni v1.1.12
+# github.com/containerd/go-cni v1.1.13
 ## explicit; go 1.21
 github.com/containerd/go-cni
 # github.com/containerd/go-runc v1.1.0


### PR DESCRIPTION
full diff: https://github.com/containerd/go-cni/compare/v1.1.12...v1.1.13