### PR TITLE
[v0.25 backport] fix cache export error handling

### DIFF
--- a/cache/remotecache/azblob/importer.go
+++ b/cache/remotecache/azblob/importer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/pkg/labels"
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/buildkit/cache/remotecache"
 	v1 "github.com/moby/buildkit/cache/remotecache/v1"
 	"github.com/moby/buildkit/session"
@@ -214,7 +215,7 @@ type ciProvider struct {
 
 func (p *ciProvider) Info(ctx context.Context, dgst digest.Digest) (content.Info, error) {
 	if dgst != p.desc.Digest {
-		return content.Info{}, errors.Errorf("content not found %s", dgst)
+		return content.Info{}, errors.Wrapf(cerrdefs.ErrNotFound, "blob %s", dgst)
 	}
 
 	if p.checked {
@@ -234,7 +235,7 @@ func (p *ciProvider) Info(ctx context.Context, dgst digest.Digest) (content.Info
 	}
 
 	if !exists {
-		return content.Info{}, errors.Errorf("blob %s not found", dgst)
+		return content.Info{}, errors.Wrapf(cerrdefs.ErrNotFound, "blob %s", dgst)
 	}
 
 	p.checked = true

--- a/cache/remotecache/gha/gha.go
+++ b/cache/remotecache/gha/gha.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/pkg/labels"
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/buildkit/cache/remotecache"
 	v1 "github.com/moby/buildkit/cache/remotecache/v1"
 	"github.com/moby/buildkit/session"
@@ -440,7 +441,7 @@ type ciProvider struct {
 
 func (p *ciProvider) Info(ctx context.Context, dgst digest.Digest) (content.Info, error) {
 	if dgst != p.desc.Digest {
-		return content.Info{}, errors.Errorf("content not found %s", dgst)
+		return content.Info{}, errors.Wrapf(cerrdefs.ErrNotFound, "blob %s", dgst)
 	}
 
 	if _, err := p.loadEntry(ctx, p.desc); err != nil {
@@ -465,7 +466,7 @@ func (p *ciProvider) loadEntry(ctx context.Context, desc ocispecs.Descriptor) (*
 		return nil, err
 	}
 	if ce == nil {
-		return nil, errors.Errorf("blob %s not found", desc.Digest)
+		return nil, errors.Wrapf(cerrdefs.ErrNotFound, "blob %s", desc.Digest)
 	}
 	if p.entries == nil {
 		p.entries = make(map[digest.Digest]*actionscache.Entry)

--- a/cache/remotecache/v1/chains.go
+++ b/cache/remotecache/v1/chains.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cespare/xxhash/v2"
 	"github.com/containerd/containerd/v2/core/content"
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver"
 	digest "github.com/opencontainers/go-digest"
@@ -246,7 +247,7 @@ func (p DescriptorProviderPair) Info(ctx context.Context, dgst digest.Digest) (c
 		return p.InfoProvider.Info(ctx, dgst)
 	}
 	if dgst != p.Descriptor.Digest {
-		return content.Info{}, errors.Errorf("content not found %s", dgst)
+		return content.Info{}, errors.Wrapf(cerrdefs.ErrNotFound, "blob %s", dgst)
 	}
 	return content.Info{
 		Digest: p.Descriptor.Digest,

--- a/solver/exporter.go
+++ b/solver/exporter.go
@@ -237,7 +237,7 @@ func (e *exporter) ExportTo(ctx context.Context, t CacheExporterTarget, opt Cach
 		for _, dep := range deps {
 			rec, err := dep.CacheKey.Exporter.ExportTo(ctx, t, opt)
 			if err != nil {
-				return nil, err
+				continue
 			}
 			for _, r := range rec {
 				srcs[i] = append(srcs[i], CacheLink{Src: r, Selector: string(dep.Selector)})
@@ -249,7 +249,7 @@ func (e *exporter) ExportTo(ctx context.Context, t CacheExporterTarget, opt Cach
 		for _, de := range e.edge.secondaryExporters {
 			recs, err := de.cacheKey.CacheKey.Exporter.ExportTo(mainCtx, t, opt)
 			if err != nil {
-				return nil, nil
+				continue
 			}
 			for _, r := range recs {
 				srcs[de.index] = append(srcs[de.index], CacheLink{Src: r, Selector: de.cacheKey.Selector.String()})
@@ -263,6 +263,14 @@ func (e *exporter) ExportTo(ctx context.Context, t CacheExporterTarget, opt Cach
 			if err != nil {
 				return nil, err
 			}
+		}
+	}
+
+	// validate deps are present
+	for _, deps := range srcs {
+		if len(deps) == 0 {
+			res[e] = nil
+			return res[e], nil
 		}
 	}
 


### PR DESCRIPTION
- backport https://github.com/moby/buildkit/pull/6261

---

Fixes cache export error handling for the case where a blob that is part of the imported cache, but doesn't actually participate in the current build has been removed in the cache source, and fails when in it transferred to new cache on export.

Two commits. Technically, either of them solves the issue of the build failing. First commit doesn't drop any cache metadata but is specific to the error caused by the blob being removed. The second one works on any export error in the cache chain, but causes the branch that the error affects to be dropped (that may cause the parents to be dropped if there are no valid input combinations left).

This is a regression in v0.25 from [cache refactor](https://github.com/moby/buildkit/pull/6129). The reason it worked before is this nil return https://github.com/moby/buildkit/blob/v0.24.0/solver/exporter.go#L201 from subchain export error. Note that there was no similar return for "subexporters". There is also "exist" check in `marshalRemote` in both versions, but in this specific case it is not reached. While v0.24 there was no error, when this case was hit the `return nil` likely corrupted the exported cache chains (at least that is what happens in my reproducer). This PR seems to work correctly, blob is skipped but the rest of the updated cache is still perfectly valid.
