### PR TITLE
dockerfile: fix customenv test for dockerd

### DIFF
--- a/frontend/dockerfile/dockerfile_provenance_test.go
+++ b/frontend/dockerfile/dockerfile_provenance_test.go
@@ -186,7 +186,7 @@ RUN echo ok> /foo
 					"numbers": []any{1.0, 2.0, 3.0},
 				}
 				if isDockerd {
-					expCustom = nil
+					expCustom = provenancetypes.ProvenanceCustomEnv{}
 				}
 
 				if slsaVersion == "v1" {


### PR DESCRIPTION
Zero value after unmarshal changed in https://github.com/moby/buildkit/pull/6275/files .

Would be better to change it back to nil, but this can be done in another release as v0.25.1 is already tagged.