### PR TITLE
solver: add jobcontext to ops caller

### DIFF
--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -73,6 +73,10 @@ type state struct {
 	solver    *Solver
 }
 
+func (s *state) Session() session.Group {
+	return s
+}
+
 func (s *state) SessionIterator() session.Iterator {
 	return s.sessionIterator()
 }

--- a/solver/llbsolver/ops/build.go
+++ b/solver/llbsolver/ops/build.go
@@ -8,7 +8,6 @@ import (
 	"github.com/containerd/continuity/fs"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/frontend"
-	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/snapshot"
 	"github.com/moby/buildkit/solver"
 	"github.com/moby/buildkit/solver/llbsolver/ops/opsutils"
@@ -40,7 +39,7 @@ func NewBuildOp(v solver.Vertex, op *pb.Op_Build, b frontend.FrontendLLBBridge, 
 	}, nil
 }
 
-func (b *BuildOp) CacheMap(ctx context.Context, g session.Group, index int) (*solver.CacheMap, bool, error) {
+func (b *BuildOp) CacheMap(ctx context.Context, job solver.JobContext, index int) (*solver.CacheMap, bool, error) {
 	dt, err := json.Marshal(struct {
 		Type string
 		Exec *pb.BuildOp
@@ -66,7 +65,7 @@ func (b *BuildOp) CacheMap(ctx context.Context, g session.Group, index int) (*so
 	}, true, nil
 }
 
-func (b *BuildOp) Exec(ctx context.Context, g session.Group, inputs []solver.Result) (outputs []solver.Result, retErr error) {
+func (b *BuildOp) Exec(ctx context.Context, job solver.JobContext, inputs []solver.Result) (outputs []solver.Result, retErr error) {
 	if b.op.Builder != int64(pb.LLBBuilder) {
 		return nil, errors.Errorf("only LLB builder is currently allowed")
 	}
@@ -88,6 +87,7 @@ func (b *BuildOp) Exec(ctx context.Context, g session.Group, inputs []solver.Res
 		return nil, errors.Errorf("invalid reference for build %T", inp.Sys())
 	}
 
+	g := job.Session()
 	mount, err := ref.ImmutableRef.Mount(ctx, true, g)
 	if err != nil {
 		return nil, err

--- a/solver/llbsolver/ops/diff.go
+++ b/solver/llbsolver/ops/diff.go
@@ -8,7 +8,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/moby/buildkit/cache"
-	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver"
 	"github.com/moby/buildkit/solver/llbsolver/ops/opsutils"
 	"github.com/moby/buildkit/solver/pb"
@@ -34,7 +33,7 @@ func NewDiffOp(v solver.Vertex, op *pb.Op_Diff, w worker.Worker) (solver.Op, err
 	}, nil
 }
 
-func (d *diffOp) CacheMap(ctx context.Context, group session.Group, index int) (*solver.CacheMap, bool, error) {
+func (d *diffOp) CacheMap(ctx context.Context, jobCtx solver.JobContext, index int) (*solver.CacheMap, bool, error) {
 	dt, err := json.Marshal(struct {
 		Type string
 		Diff *pb.DiffOp
@@ -66,7 +65,7 @@ func (d *diffOp) CacheMap(ctx context.Context, group session.Group, index int) (
 	return cm, true, nil
 }
 
-func (d *diffOp) Exec(ctx context.Context, g session.Group, inputs []solver.Result) ([]solver.Result, error) {
+func (d *diffOp) Exec(ctx context.Context, jobCtx solver.JobContext, inputs []solver.Result) ([]solver.Result, error) {
 	var curInput int
 
 	var lowerRef cache.ImmutableRef

--- a/solver/llbsolver/ops/exec.go
+++ b/solver/llbsolver/ops/exec.go
@@ -104,7 +104,7 @@ func checkShouldClearCacheOpts(m *pb.Mount) bool {
 	return true
 }
 
-func (e *ExecOp) CacheMap(ctx context.Context, g session.Group, index int) (*solver.CacheMap, bool, error) {
+func (e *ExecOp) CacheMap(ctx context.Context, jobCtx solver.JobContext, index int) (*solver.CacheMap, bool, error) {
 	op := cloneExecOp(e.op)
 
 	for i := range op.Meta.ExtraHosts {
@@ -362,7 +362,7 @@ func addDefaultEnvvar(env []string, k, v string) []string {
 	return append(env, k+"="+v)
 }
 
-func (e *ExecOp) Exec(ctx context.Context, g session.Group, inputs []solver.Result) (results []solver.Result, err error) {
+func (e *ExecOp) Exec(ctx context.Context, jobCtx solver.JobContext, inputs []solver.Result) (results []solver.Result, err error) {
 	trace.SpanFromContext(ctx).AddEvent("ExecOp started")
 
 	refs := make([]*worker.WorkerRef, len(inputs))
@@ -378,6 +378,7 @@ func (e *ExecOp) Exec(ctx context.Context, g session.Group, inputs []solver.Resu
 	if e.platform != nil {
 		platformOS = e.platform.OS
 	}
+	g := jobCtx.Session()
 	p, err := container.PrepareMounts(ctx, e.mm, e.cm, g, e.op.Meta.Cwd, e.op.Mounts, refs, func(m *pb.Mount, ref cache.ImmutableRef) (cache.MutableRef, error) {
 		desc := fmt.Sprintf("mount %s from exec %s", m.Dest, strings.Join(e.op.Meta.Args, " "))
 		return e.cm.New(ctx, ref, g, cache.WithDescription(desc))

--- a/solver/llbsolver/ops/exec_test.go
+++ b/solver/llbsolver/ops/exec_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/solver"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/stretchr/testify/require"
 )
@@ -110,11 +111,11 @@ func TestExecOpCacheMap(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			m1, ok, err := tc.op1.CacheMap(ctx, session.NewGroup(t.Name()), 1)
+			m1, ok, err := tc.op1.CacheMap(ctx, testJobContext(t), 1)
 			require.NoError(t, err)
 			require.True(t, ok)
 
-			m2, ok, err := tc.op2.CacheMap(ctx, session.NewGroup(t.Name()), 1)
+			m2, ok, err := tc.op2.CacheMap(ctx, testJobContext(t), 1)
 			require.NoError(t, err)
 			require.True(t, ok)
 
@@ -195,7 +196,7 @@ func TestExecOpContentCache(t *testing.T) {
 			t.Parallel()
 
 			// default is always valid, and can sometimes have slow-cache
-			m, ok, err := tc.op.CacheMap(ctx, session.NewGroup(t.Name()), 1)
+			m, ok, err := tc.op.CacheMap(ctx, testJobContext(t), 1)
 			require.NoError(t, err)
 			require.True(t, ok)
 			for _, dep := range m.Deps {
@@ -210,7 +211,7 @@ func TestExecOpContentCache(t *testing.T) {
 			for _, mnt := range tc.op.op.Mounts {
 				mnt.ContentCache = pb.MountContentCache_OFF
 			}
-			m, ok, err = tc.op.CacheMap(ctx, session.NewGroup(t.Name()), 1)
+			m, ok, err = tc.op.CacheMap(ctx, testJobContext(t), 1)
 			require.NoError(t, err)
 			require.True(t, ok)
 			for _, dep := range m.Deps {
@@ -221,7 +222,7 @@ func TestExecOpContentCache(t *testing.T) {
 			for _, mnt := range tc.op.op.Mounts {
 				mnt.ContentCache = pb.MountContentCache_ON
 			}
-			m, ok, err = tc.op.CacheMap(ctx, session.NewGroup(t.Name()), 1)
+			m, ok, err = tc.op.CacheMap(ctx, testJobContext(t), 1)
 			if tc.cacheIsSafe {
 				require.NoError(t, err)
 				require.True(t, ok)
@@ -288,4 +289,16 @@ func withoutOutput() func(*pb.Mount) {
 	return func(m *pb.Mount) {
 		m.Output = int64(pb.SkipOutput)
 	}
+}
+
+func testJobContext(t *testing.T) solver.JobContext {
+	return &jobCtx{g: session.NewGroup(t.Name())}
+}
+
+type jobCtx struct {
+	g session.Group
+}
+
+func (j *jobCtx) Session() session.Group {
+	return j.g
 }

--- a/solver/llbsolver/ops/file.go
+++ b/solver/llbsolver/ops/file.go
@@ -52,7 +52,7 @@ func NewFileOp(v solver.Vertex, op *pb.Op_File, cm cache.Manager, parallelism *s
 	}, nil
 }
 
-func (f *fileOp) CacheMap(ctx context.Context, g session.Group, index int) (*solver.CacheMap, bool, error) {
+func (f *fileOp) CacheMap(ctx context.Context, jobCtx solver.JobContext, index int) (*solver.CacheMap, bool, error) {
 	selectors := map[int][]opsutils.Selector{}
 	invalidSelectors := map[int]struct{}{}
 
@@ -173,7 +173,7 @@ func (f *fileOp) CacheMap(ctx context.Context, g session.Group, index int) (*sol
 	return cm, true, nil
 }
 
-func (f *fileOp) Exec(ctx context.Context, g session.Group, inputs []solver.Result) ([]solver.Result, error) {
+func (f *fileOp) Exec(ctx context.Context, jobCtx solver.JobContext, inputs []solver.Result) ([]solver.Result, error) {
 	inpRefs := make([]fileoptypes.Ref, 0, len(inputs))
 	for _, inp := range inputs {
 		workerRef, ok := inp.Sys().(*worker.WorkerRef)
@@ -189,7 +189,7 @@ func (f *fileOp) Exec(ctx context.Context, g session.Group, inputs []solver.Resu
 	}
 
 	fs := NewFileOpSolver(f.w, backend, f.refManager)
-	outs, err := fs.Solve(ctx, inpRefs, f.op.Actions, g)
+	outs, err := fs.Solve(ctx, inpRefs, f.op.Actions, jobCtx.Session())
 	if err != nil {
 		return nil, err
 	}

--- a/solver/llbsolver/ops/merge.go
+++ b/solver/llbsolver/ops/merge.go
@@ -9,7 +9,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/moby/buildkit/cache"
-	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver"
 	"github.com/moby/buildkit/solver/llbsolver/ops/opsutils"
 	"github.com/moby/buildkit/solver/pb"
@@ -35,7 +34,7 @@ func NewMergeOp(v solver.Vertex, op *pb.Op_Merge, w worker.Worker) (solver.Op, e
 	}, nil
 }
 
-func (m *mergeOp) CacheMap(ctx context.Context, group session.Group, index int) (*solver.CacheMap, bool, error) {
+func (m *mergeOp) CacheMap(ctx context.Context, jobCtx solver.JobContext, index int) (*solver.CacheMap, bool, error) {
 	dt, err := json.Marshal(struct {
 		Type  string
 		Merge *pb.MergeOp
@@ -63,7 +62,7 @@ func (m *mergeOp) CacheMap(ctx context.Context, group session.Group, index int) 
 	return cm, true, nil
 }
 
-func (m *mergeOp) Exec(ctx context.Context, g session.Group, inputs []solver.Result) ([]solver.Result, error) {
+func (m *mergeOp) Exec(ctx context.Context, jobCtx solver.JobContext, inputs []solver.Result) ([]solver.Result, error) {
 	refs := make([]cache.ImmutableRef, len(inputs))
 	var index int
 	for _, inp := range inputs {

--- a/solver/llbsolver/ops/source.go
+++ b/solver/llbsolver/ops/source.go
@@ -74,13 +74,13 @@ func (s *SourceOp) instance(ctx context.Context) (source.SourceInstance, error) 
 	return s.src, nil
 }
 
-func (s *SourceOp) CacheMap(ctx context.Context, g session.Group, index int) (*solver.CacheMap, bool, error) {
+func (s *SourceOp) CacheMap(ctx context.Context, jobCtx solver.JobContext, index int) (*solver.CacheMap, bool, error) {
 	src, err := s.instance(ctx)
 	if err != nil {
 		return nil, false, err
 	}
 
-	k, pin, cacheOpts, done, err := src.CacheKey(ctx, g, index)
+	k, pin, cacheOpts, done, err := src.CacheKey(ctx, jobCtx.Session(), index)
 	if err != nil {
 		return nil, false, err
 	}
@@ -104,12 +104,12 @@ func (s *SourceOp) CacheMap(ctx context.Context, g session.Group, index int) (*s
 	}, done, nil
 }
 
-func (s *SourceOp) Exec(ctx context.Context, g session.Group, _ []solver.Result) (outputs []solver.Result, err error) {
+func (s *SourceOp) Exec(ctx context.Context, jobCtx solver.JobContext, _ []solver.Result) (outputs []solver.Result, err error) {
 	src, err := s.instance(ctx)
 	if err != nil {
 		return nil, err
 	}
-	ref, err := src.Snapshot(ctx, g)
+	ref, err := src.Snapshot(ctx, jobCtx.Session())
 	if err != nil {
 		return nil, err
 	}

--- a/solver/scheduler_test.go
+++ b/solver/scheduler_test.go
@@ -3678,6 +3678,8 @@ type vertex struct {
 	execCallCount  *int64
 }
 
+var _ Op = &vertex{}
+
 func (v *vertex) Digest() digest.Digest {
 	return digest.FromBytes([]byte(v.opt.name))
 }
@@ -3752,7 +3754,7 @@ func (v *vertex) cacheMap(ctx context.Context) error {
 	return nil
 }
 
-func (v *vertex) CacheMap(ctx context.Context, g session.Group, index int) (*CacheMap, bool, error) {
+func (v *vertex) CacheMap(ctx context.Context, jobCtx JobContext, index int) (*CacheMap, bool, error) {
 	if index == 0 {
 		if err := v.cacheMap(ctx); err != nil {
 			return nil, false, err
@@ -3789,7 +3791,7 @@ func (v *vertex) exec(ctx context.Context, inputs []Result) error {
 	return nil
 }
 
-func (v *vertex) Exec(ctx context.Context, g session.Group, inputs []Result) (outputs []Result, err error) {
+func (v *vertex) Exec(ctx context.Context, job JobContext, inputs []Result) (outputs []Result, err error) {
 	if err := v.exec(ctx, inputs); err != nil {
 		return nil, err
 	}
@@ -3834,11 +3836,13 @@ type vertexConst struct {
 	value int
 }
 
+var _ Op = &vertexConst{}
+
 func (v *vertexConst) Sys() any {
 	return v
 }
 
-func (v *vertexConst) Exec(ctx context.Context, g session.Group, inputs []Result) (outputs []Result, err error) {
+func (v *vertexConst) Exec(ctx context.Context, jobCtx JobContext, inputs []Result) (outputs []Result, err error) {
 	if err := v.exec(ctx, inputs); err != nil {
 		return nil, err
 	}
@@ -3865,11 +3869,13 @@ type vertexSum struct {
 	value int
 }
 
+var _ Op = &vertexSum{}
+
 func (v *vertexSum) Sys() any {
 	return v
 }
 
-func (v *vertexSum) Exec(ctx context.Context, g session.Group, inputs []Result) (outputs []Result, err error) {
+func (v *vertexSum) Exec(ctx context.Context, jobCtx JobContext, inputs []Result) (outputs []Result, err error) {
 	if err := v.exec(ctx, inputs); err != nil {
 		return nil, err
 	}
@@ -3904,11 +3910,13 @@ type vertexAdd struct {
 	value int
 }
 
+var _ Op = &vertexAdd{}
+
 func (v *vertexAdd) Sys() any {
 	return v
 }
 
-func (v *vertexAdd) Exec(ctx context.Context, g session.Group, inputs []Result) (outputs []Result, err error) {
+func (v *vertexAdd) Exec(ctx context.Context, jobCtx JobContext, inputs []Result) (outputs []Result, err error) {
 	if err := v.exec(ctx, inputs); err != nil {
 		return nil, err
 	}
@@ -3942,11 +3950,13 @@ type vertexSubBuild struct {
 	b Builder
 }
 
+var _ Op = &vertexSubBuild{}
+
 func (v *vertexSubBuild) Sys() any {
 	return v
 }
 
-func (v *vertexSubBuild) Exec(ctx context.Context, g session.Group, inputs []Result) (outputs []Result, err error) {
+func (v *vertexSubBuild) Exec(ctx context.Context, jobCtx JobContext, inputs []Result) (outputs []Result, err error) {
 	if err := v.exec(ctx, inputs); err != nil {
 		return nil, err
 	}

--- a/solver/types.go
+++ b/solver/types.go
@@ -166,13 +166,17 @@ type ReleaseFunc func()
 type Op interface {
 	// CacheMap returns structure describing how the operation is cached.
 	// Currently only roots are allowed to return multiple cache maps per op.
-	CacheMap(context.Context, session.Group, int) (*CacheMap, bool, error)
+	CacheMap(context.Context, JobContext, int) (*CacheMap, bool, error)
 
 	// Exec runs an operation given results from previous operations.
-	Exec(ctx context.Context, g session.Group, inputs []Result) (outputs []Result, err error)
+	Exec(ctx context.Context, jobCtx JobContext, inputs []Result) (outputs []Result, err error)
 
 	// Acquire acquires the necessary resources to execute the `Op`.
 	Acquire(ctx context.Context) (release ReleaseFunc, err error)
+}
+
+type JobContext interface {
+	Session() session.Group
 }
 
 type ProvenanceProvider interface {


### PR DESCRIPTION
Generalize session.Group to JobContext so it
can be updated with additional job properties in
addition to retrieving the current session.