### PR TITLE
feat: Change HTTP client transport to use Docker fallback Resolver

### DIFF
--- a/util/resolver/resolver.go
+++ b/util/resolver/resolver.go
@@ -185,7 +185,7 @@ func newMirrorRegistryHost(mirror string) docker.RegistryHost {
 
 func newDefaultClient() *http.Client {
 	return &http.Client{
-		Transport: tracing.NewTransport(newDefaultTransport()),
+		Transport: docker.NewHTTPFallback(newDefaultTransport()),
 	}
 }
 


### PR DESCRIPTION
I have a scenario where image building is performed on the server-side. Since the client is unknown, I cannot declare and configure settings in advance for all possible HTTP addresses. Therefore, I made this modification.

depends on: #5667