### PR TITLE
fix metadata resp.Body leak

### DIFF
--- a/source/http/source.go
+++ b/source/http/source.go
@@ -387,6 +387,7 @@ func (hs *httpSourceHandler) resolveMetadata(ctx context.Context, jobCtx solver.
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
 		return nil, errors.Errorf("invalid response status %d", resp.StatusCode)
 	}
@@ -408,7 +409,6 @@ func (hs *httpSourceHandler) resolveMetadata(ctx context.Context, jobCtx solver.
 			return nil, errors.Errorf("invalid metadata change")
 		}
 
-		resp.Body.Close()
 		var modTime *time.Time
 		if modTimeStr := md.getHTTPModTime(); modTimeStr != "" {
 			if t, err := http.ParseTime(modTimeStr); err == nil {


### PR DESCRIPTION
Hello!

In `(*httpSourceHandler).resolveMetadata` method there is a potential `resp.Body` leak in case when response status code is not valid (< 200 or >= 400). Also `resp.Body` is not closed before exiting if status code is okay.

This PR adds resp.Body closing before exiting from `resolveMetadata` method.