### PR TITLE
dockerfile: add syntax to skip a check

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -177,7 +177,7 @@ func ListTargets(ctx context.Context, dt []byte) (*targets.List, error) {
 	for i, s := range stages {
 		t := targets.Target{
 			Name:        s.Name,
-			Description: s.Comment,
+			Description: s.DocComment,
 			Default:     i == len(stages)-1,
 			Base:        s.BaseName,
 			Platform:    s.Platform,
@@ -296,6 +296,8 @@ func toDispatchState(ctx context.Context, dt []byte, opt ConvertOpt) (*dispatchS
 
 	// set base state for every image
 	for i, st := range stages {
+		lint := lint.WithMergedConfigFromComments(st.Comments)
+
 		nameMatch, err := shlex.ProcessWordWithMatches(st.BaseName, globalArgs)
 		argKeys := unusedFromArgsCheckKeys(globalArgs, outline.allArgs)
 		reportUnusedFromArgs(argKeys, nameMatch.Unmatched, st.Location, lint)
@@ -914,6 +916,8 @@ func (e *envsFromState) Keys() []string {
 }
 
 func dispatch(d *dispatchState, cmd command, opt dispatchOpt) error {
+	opt.lint = opt.lint.WithMergedConfigFromComments(cmd.Comments())
+
 	d.cmdIsOnBuild = cmd.isOnBuild
 	var err error
 	// ARG command value could be ignored, so defer handling the expansion error

--- a/frontend/dockerfile/dockerfile2llb/outline.go
+++ b/frontend/dockerfile/dockerfile2llb/outline.go
@@ -75,7 +75,7 @@ func (ds *dispatchState) args(visited map[string]struct{}) []outline.Arg {
 				args = append(args, outline.Arg{
 					Name:        a.definition.Key,
 					Value:       a.value,
-					Description: a.definition.Comment,
+					Description: a.definition.DocComment,
 					Location:    toSourceLocation(a.location),
 				})
 				visited[k] = struct{}{}
@@ -153,7 +153,7 @@ func (ds *dispatchState) Outline(dt []byte) outline.Outline {
 
 	out := outline.Outline{
 		Name:        ds.stage.Name,
-		Description: ds.stage.Comment,
+		Description: ds.stage.DocComment,
 		Sources:     [][]byte{dt},
 		Args:        args,
 		Secrets:     secrets,

--- a/frontend/dockerfile/dockerfile_outline_test.go
+++ b/frontend/dockerfile/dockerfile_outline_test.go
@@ -54,6 +54,11 @@ RUN true
 
 FROM scratch AS third
 ARG ABC=a
+# check=skip=all
+ARG password
+# alternate_password will show up in the outline
+# check=skip=all
+ARG alternate_password
 
 # target defines build target
 FROM third AS target
@@ -81,6 +86,11 @@ RUN exit 0
 
 FROM nanoserver AS third
 ARG ABC=a
+# check=skip=all
+ARG password
+# alternate_password will show up in the outline
+# check=skip=all
+ARG alternate_password
 
 # target defines build target
 FROM third AS target
@@ -125,7 +135,7 @@ FROM second
 		require.Equal(t, 1, len(outline.Sources))
 		require.Equal(t, dockerfile, outline.Sources[0])
 
-		require.Equal(t, 5, len(outline.Args))
+		require.Equal(t, 7, len(outline.Args))
 
 		arg := outline.Args[0]
 		require.Equal(t, "inherited", arg.Name)
@@ -154,6 +164,18 @@ FROM second
 		arg = outline.Args[4]
 		require.Equal(t, "ABC", arg.Name)
 		require.Equal(t, "a", arg.Value)
+
+		arg = outline.Args[5]
+		require.Equal(t, "password", arg.Name)
+		require.Equal(t, "", arg.Value)
+		require.Equal(t, "", arg.Description)
+		require.Equal(t, int32(22), arg.Location.Ranges[0].Start.Line)
+
+		arg = outline.Args[6]
+		require.Equal(t, "alternate_password", arg.Name)
+		require.Equal(t, "", arg.Value)
+		require.Equal(t, "will show up in the outline", arg.Description)
+		require.Equal(t, int32(25), arg.Location.Ranges[0].Start.Line)
 
 		called = true
 		return nil, nil

--- a/frontend/dockerfile/instructions/commands.go
+++ b/frontend/dockerfile/instructions/commands.go
@@ -24,9 +24,9 @@ func (kvp *KeyValuePair) String() string {
 
 // KeyValuePairOptional is identical to KeyValuePair, but allows for optional values.
 type KeyValuePairOptional struct {
-	Key     string
-	Value   *string
-	Comment string
+	Key        string
+	Value      *string
+	DocComment string
 }
 
 func (kvpo *KeyValuePairOptional) String() string {
@@ -49,6 +49,7 @@ func (kvpo *KeyValuePairOptional) ValueString() string {
 type Command interface {
 	Name() string
 	Location() []parser.Range
+	Comments() []string
 }
 
 // KeyValuePairs is a slice of KeyValuePair
@@ -59,6 +60,7 @@ type withNameAndCode struct {
 	code     string
 	name     string
 	location []parser.Range
+	comments []string
 }
 
 func (c *withNameAndCode) String() string {
@@ -75,8 +77,17 @@ func (c *withNameAndCode) Location() []parser.Range {
 	return c.location
 }
 
+func (c *withNameAndCode) Comments() []string {
+	return c.comments
+}
+
 func newWithNameAndCode(req parseRequest) withNameAndCode {
-	return withNameAndCode{code: strings.TrimSpace(req.original), name: req.command, location: req.location}
+	return withNameAndCode{
+		code:     strings.TrimSpace(req.original),
+		name:     req.command,
+		location: req.location,
+		comments: req.comments,
+	}
 }
 
 // SingleWordExpander is a provider for variable expansion where a single word
@@ -511,10 +522,11 @@ type Stage struct {
 	BaseName string    // name of the base stage or source
 	Platform string    // platform of base source to use
 
-	Comment string // doc-comment directly above the stage
+	DocComment string // doc-comment directly above the stage
 
 	SourceCode string         // contents of the defining FROM command
 	Location   []parser.Range // location of the defining FROM command
+	Comments   []string
 }
 
 // AddCommand appends a command to the stage.

--- a/frontend/dockerfile/instructions/parse.go
+++ b/frontend/dockerfile/instructions/parse.go
@@ -72,6 +72,8 @@ func ParseInstruction(node *parser.Node) (v any, err error) {
 
 // ParseInstruction converts an AST to a typed instruction (either a command or a build stage beginning when encountering a `FROM` statement)
 func ParseInstructionWithLinter(node *parser.Node, lint *linter.Linter) (v any, err error) {
+	lint = lint.WithMergedConfigFromComments(node.PrevComment)
+
 	defer func() {
 		if err != nil {
 			err = parser.WithLocation(err, node.Location())
@@ -424,7 +426,8 @@ func parseFrom(req parseRequest) (*Stage, error) {
 		Commands:   []Command{},
 		Platform:   flPlatform.Value,
 		Location:   req.location,
-		Comment:    getComment(req.comments, stageName),
+		Comments:   req.comments,
+		DocComment: getDocComment(req.comments, stageName),
 	}, nil
 }
 
@@ -775,7 +778,7 @@ func parseArg(req parseRequest) (*ArgCommand, error) {
 		} else {
 			kvpo.Key = arg
 		}
-		kvpo.Comment = getComment(req.comments, kvpo.Key)
+		kvpo.DocComment = getDocComment(req.comments, kvpo.Key)
 		pairs[i] = kvpo
 	}
 
@@ -831,7 +834,7 @@ func errTooManyArguments(command string) error {
 	return errors.Errorf("Bad input to %s, too many arguments", command)
 }
 
-func getComment(comments []string, name string) string {
+func getDocComment(comments []string, name string) string {
 	if name == "" {
 		return ""
 	}

--- a/frontend/dockerfile/instructions/parse_test.go
+++ b/frontend/dockerfile/instructions/parse_test.go
@@ -193,18 +193,18 @@ ARG bar baz=123
 	stages, meta, err := Parse(ast.AST, nil)
 	require.NoError(t, err)
 
-	require.Equal(t, "defines first stage", stages[0].Comment)
+	require.Equal(t, "defines first stage", stages[0].DocComment)
 	require.Equal(t, "foo", meta[0].Args[0].Key)
-	require.Equal(t, "sets foo", meta[0].Args[0].Comment)
+	require.Equal(t, "sets foo", meta[0].Args[0].DocComment)
 
 	st := stages[0]
 
 	require.Equal(t, "foo", st.Commands[0].(*ArgCommand).Args[0].Key)
-	require.Equal(t, "", st.Commands[0].(*ArgCommand).Args[0].Comment)
+	require.Equal(t, "", st.Commands[0].(*ArgCommand).Args[0].DocComment)
 	require.Equal(t, "bar", st.Commands[1].(*ArgCommand).Args[0].Key)
-	require.Equal(t, "defines bar", st.Commands[1].(*ArgCommand).Args[0].Comment)
+	require.Equal(t, "defines bar", st.Commands[1].(*ArgCommand).Args[0].DocComment)
 	require.Equal(t, "baz", st.Commands[1].(*ArgCommand).Args[1].Key)
-	require.Equal(t, "is something else", st.Commands[1].(*ArgCommand).Args[1].Comment)
+	require.Equal(t, "is something else", st.Commands[1].(*ArgCommand).Args[1].DocComment)
 }
 
 func TestErrorCases(t *testing.T) {


### PR DESCRIPTION

Adds a syntax to skip a check by adding a comment above the area where
the linter rule is triggered.
