### PR TITLE
oci: Isolate cgroups under the current hierarchy

### DIFF
--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -122,6 +122,10 @@ type OCIConfig struct {
 	ProxySnapshotterPath string `toml:"proxySnapshotterPath"`
 	DefaultCgroupParent  string `toml:"defaultCgroupParent"`
 
+	// IsolateCgroups keeps all cgroups (including DefaultCgroupParent) under
+	// the cgroup hierarchy of the buildkitd process.
+	IsolateCgroups bool `toml:"isolateCgroups"`
+
 	// StargzSnapshotterConfig is configuration for stargz snapshotter.
 	// We use a generic map[string]interface{} in order to remove the dependency
 	// on stargz snapshotter's config pkg from our config.

--- a/cmd/buildkitd/main_oci_worker.go
+++ b/cmd/buildkitd/main_oci_worker.go
@@ -126,6 +126,10 @@ func init() {
 			Usage: "limit the number of parallel build steps that can run at the same time",
 			Value: defaultConf.Workers.OCI.MaxParallelism,
 		},
+		cli.BoolFlag{
+			Name:  "oci-isolate-cgroups",
+			Usage: "isolate cgroups to the cgroup hierarchy of the buildkitd process",
+		},
 	}
 	n := "oci-worker-rootless"
 	u := "enable rootless mode"
@@ -260,6 +264,9 @@ func applyOCIFlags(c *cli.Context, cfg *config.Config) error {
 	if c.GlobalIsSet("oci-max-parallelism") {
 		cfg.Workers.OCI.MaxParallelism = c.GlobalInt("oci-max-parallelism")
 	}
+	if c.GlobalIsSet("oci-isolate-cgroups") {
+		cfg.Workers.OCI.IsolateCgroups = c.GlobalBool("oci-isolate-cgroups")
+	}
 
 	return nil
 }
@@ -327,7 +334,7 @@ func ociWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([]worker
 		parallelismSem = semaphore.NewWeighted(int64(cfg.MaxParallelism))
 	}
 
-	opt, err := runc.NewWorkerOpt(common.config.Root, snFactory, cfg.Rootless, processMode, cfg.Labels, idmapping, nc, dns, cfg.Binary, cfg.ApparmorProfile, cfg.SELinux, parallelismSem, common.traceSocket, cfg.DefaultCgroupParent, cdiManager)
+	opt, err := runc.NewWorkerOpt(common.config.Root, snFactory, cfg.Rootless, processMode, cfg.Labels, idmapping, nc, dns, cfg.Binary, cfg.ApparmorProfile, cfg.SELinux, parallelismSem, common.traceSocket, cfg.DefaultCgroupParent, cfg.IsolateCgroups, cdiManager)
 	if err != nil {
 		return nil, err
 	}

--- a/docs/buildkitd.toml.md
+++ b/docs/buildkitd.toml.md
@@ -102,6 +102,12 @@ provenanceEnvDir = "/etc/buildkit/provenance.d"
   # maintain a pool of reusable CNI network namespaces to amortize the overhead
   # of allocating and releasing the namespaces
   cniPoolSize = 16
+  # defaultCgroupParent sets the parent cgroup of all containers.
+  defaultCgroupParent = "buildkit"
+  # isolateCgroups keeps all buildkitd managed cgroups under the cgroup
+  # hierarchy of the buildkitd process. if you are running buildkitd in
+  # Kubernetes, set this to true to ensure resource limits work as expected.
+  isolateCgroups = true
 
   [worker.oci.labels]
     "foo" = "bar"

--- a/executor/containerdexecutor/executor_unix.go
+++ b/executor/containerdexecutor/executor_unix.go
@@ -140,7 +140,7 @@ func (w *containerdExecutor) createOCISpec(ctx context.Context, id, resolvConf, 
 	}
 
 	processMode := oci.ProcessSandbox // FIXME(AkihiroSuda)
-	spec, cleanup, err := oci.GenerateSpec(ctx, meta, mounts, id, resolvConf, hostsFile, namespace, w.cgroupParent, processMode, nil, w.apparmorProfile, w.selinux, w.traceSocket, w.cdiManager, opts...)
+	spec, cleanup, err := oci.GenerateSpec(ctx, meta, mounts, id, resolvConf, hostsFile, namespace, w.cgroupParent, "", processMode, nil, w.apparmorProfile, w.selinux, w.traceSocket, w.cdiManager, opts...)
 	if err != nil {
 		releaseAll()
 		return nil, nil, err

--- a/executor/containerdexecutor/executor_windows.go
+++ b/executor/containerdexecutor/executor_windows.go
@@ -85,7 +85,7 @@ func (w *containerdExecutor) createOCISpec(ctx context.Context, id, _, _ string,
 	}
 
 	processMode := oci.ProcessSandbox // FIXME(AkihiroSuda)
-	spec, cleanup, err := oci.GenerateSpec(ctx, meta, mounts, id, "", "", namespace, "", processMode, nil, "", false, w.traceSocket, nil, opts...)
+	spec, cleanup, err := oci.GenerateSpec(ctx, meta, mounts, id, "", "", namespace, "", "", processMode, nil, "", false, w.traceSocket, nil, opts...)
 	if err != nil {
 		releaseAll()
 		return nil, nil, err

--- a/worker/runc/runc.go
+++ b/worker/runc/runc.go
@@ -40,7 +40,7 @@ type SnapshotterFactory struct {
 }
 
 // NewWorkerOpt creates a WorkerOpt.
-func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, processMode oci.ProcessMode, labels map[string]string, idmap *user.IdentityMapping, nopt netproviders.Opt, dns *oci.DNSConfig, binary, apparmorProfile string, selinux bool, parallelismSem *semaphore.Weighted, traceSocket, defaultCgroupParent string, cdiManager *cdidevices.Manager) (base.WorkerOpt, error) {
+func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, processMode oci.ProcessMode, labels map[string]string, idmap *user.IdentityMapping, nopt netproviders.Opt, dns *oci.DNSConfig, binary, apparmorProfile string, selinux bool, parallelismSem *semaphore.Weighted, traceSocket, defaultCgroupParent string, isolateCgroups bool, cdiManager *cdidevices.Manager) (base.WorkerOpt, error) {
 	var opt base.WorkerOpt
 	name := "runc-" + snFactory.Name
 	root = filepath.Join(root, name)
@@ -59,7 +59,7 @@ func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, proc
 		cmds = append(cmds, binary)
 	}
 
-	rm, err := resources.NewMonitor()
+	rm, err := resources.NewMonitor(isolateCgroups)
 	if err != nil {
 		return opt, err
 	}
@@ -79,6 +79,7 @@ func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, proc
 		SELinux:             selinux,
 		TracingSocket:       traceSocket,
 		DefaultCgroupParent: defaultCgroupParent,
+		RootCgroup:          rm.RootCgroup(),
 		ResourceMonitor:     rm,
 		CDIManager:          cdiManager,
 	}, np)

--- a/worker/runc/runc_test.go
+++ b/worker/runc/runc_test.go
@@ -42,7 +42,7 @@ func newWorkerOpt(t *testing.T, processMode oci.ProcessMode) base.WorkerOpt {
 		},
 	}
 	rootless := false
-	workerOpt, err := NewWorkerOpt(tmpdir, snFactory, rootless, processMode, nil, nil, netproviders.Opt{Mode: "host"}, nil, "", "", false, nil, "", "", nil)
+	workerOpt, err := NewWorkerOpt(tmpdir, snFactory, rootless, processMode, nil, nil, netproviders.Opt{Mode: "host"}, nil, "", "", false, nil, "", "", false, nil)
 	require.NoError(t, err)
 
 	return workerOpt


### PR DESCRIPTION
When buildkitd is run in a privileged container on Kubernetes, the `/sys/fs/cgroup` mount may be that of the host (depends on the cgroup driver and ultimately whether the buildkitd container is started within a `cgroup` namespace) which allows buildkitd to remove itself from its assigned cgroup hierarchy. When buildkitd's worker creates cgroups outside of the cgroup hierarchy managed by Kubernetes, resource accounting is incorrect and resource limits are not enforced. This can lead to OOM and other CPU contention issues on nodes.

Introduce a new `isolateCgroups` configuration for the OCI worker. If set, all cgroups are created beneath the cgroup hierarchy of the buildkitd process.