### PR TITLE
solver: add cap for source policy session

### DIFF
--- a/solver/pb/caps.go
+++ b/solver/pb/caps.go
@@ -102,7 +102,8 @@ const (
 	CapMultipleExporters apicaps.CapID = "exporter.multiple"
 	CapSessionExporter   apicaps.CapID = "exporter.session"
 
-	CapSourcePolicy apicaps.CapID = "source.policy"
+	CapSourcePolicy        apicaps.CapID = "source.policy"
+	CapSourcePolicySession apicaps.CapID = "source.policy.session"
 
 	// GC/Prune controls allow MinFreeSpace and MaxUsedSpace to be set
 	CapGCFreeSpaceFilter apicaps.CapID = "gc.freespacefilter"
@@ -563,6 +564,12 @@ func init() {
 
 	Caps.Init(apicaps.Cap{
 		ID:      CapSourcePolicy,
+		Enabled: true,
+		Status:  apicaps.CapStatusExperimental,
+	})
+
+	Caps.Init(apicaps.Cap{
+		ID:      CapSourcePolicySession,
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})


### PR DESCRIPTION
Add cleaner way for client to detect the daemon
has session policy support.