### PR TITLE
gateway: remove development gateway frontend

### DIFF
--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -17,6 +17,8 @@ const (
 	// KeySource is the option key used by the gateway frontend to represent
 	// the source for the external frontend
 	KeySource = "source"
+
+	KeyDevelDeprecated = "gateway-devel"
 )
 
 type Result = result.Result[solver.ResultProxy]

--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -27,7 +27,6 @@ import (
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/client/llb/sourceresolver"
 	"github.com/moby/buildkit/executor"
-	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/frontend"
 	"github.com/moby/buildkit/frontend/dockerui"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
@@ -63,10 +62,6 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const (
-	keyDevel = "gateway-devel"
-)
-
 func NewGatewayFrontend(workers worker.Infos, allowedRepositories []string) (frontend.Frontend, error) {
 	var parsedAllowedRepositories []string
 
@@ -87,16 +82,6 @@ func NewGatewayFrontend(workers worker.Infos, allowedRepositories []string) (fro
 type gatewayFrontend struct {
 	workers             worker.Infos
 	allowedRepositories []string
-}
-
-func filterPrefix(opts map[string]string, pfx string) map[string]string {
-	m := map[string]string{}
-	for k, v := range opts {
-		if after, ok := strings.CutPrefix(k, pfx); ok {
-			m[after] = v
-		}
-	}
-	return m
 }
 
 func (gf *gatewayFrontend) checkSourceIsAllowed(source string) error {
@@ -122,12 +107,15 @@ func (gf *gatewayFrontend) checkSourceIsAllowed(source string) error {
 }
 
 func (gf *gatewayFrontend) Solve(ctx context.Context, llbBridge frontend.FrontendLLBBridge, exec executor.Executor, opts map[string]string, inputs map[string]*opspb.Definition, sid string, sm *session.Manager) (*frontend.Result, error) {
+	if _, isDevel := opts[frontend.KeyDevelDeprecated]; isDevel {
+		return nil, errors.New("development gateway is no longer supported")
+	}
+
 	source, ok := opts[frontend.KeySource]
 	if !ok {
 		return nil, errors.Errorf("no source specified for gateway")
 	}
 
-	_, isDevel := opts[keyDevel]
 	var img dockerspec.DockerOCIImage
 	var mfstDigest digest.Digest
 	var rootFS cache.MutableRef
@@ -140,142 +128,99 @@ func (gf *gatewayFrontend) Solve(ctx context.Context, llbBridge frontend.Fronten
 		return nil, err
 	}
 
-	if isDevel {
-		devRes, err := llbBridge.Solve(ctx,
-			frontend.SolveRequest{
-				Frontend:       source,
-				FrontendOpt:    filterPrefix(opts, "gateway-"),
-				FrontendInputs: inputs,
-			}, "gateway:"+sid)
-		if err != nil {
-			return nil, err
-		}
-		defer func() {
-			ctx := context.WithoutCancel(ctx)
-			devRes.EachRef(func(ref solver.ResultProxy) error {
-				return ref.Release(ctx)
-			})
-		}()
-		if devRes.Ref == nil {
-			return nil, errors.Errorf("development gateway didn't return default result")
-		}
-		frontendDef = devRes.Ref.Definition()
-		res, err := devRes.Ref.Result(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		workerRef, ok := res.Sys().(*worker.WorkerRef)
-		if !ok {
-			return nil, errors.Errorf("invalid ref: %T", res.Sys())
-		}
-
-		rootFS, err = workerRef.Worker.CacheManager().New(ctx, workerRef.ImmutableRef, session.NewGroup(sid))
-		if err != nil {
-			return nil, err
-		}
-		defer rootFS.Release(context.TODO())
-		config, ok := devRes.Metadata[exptypes.ExporterImageConfigKey]
-		if ok {
-			if err := json.Unmarshal(config, &img); err != nil {
-				return nil, err
-			}
-		}
-	} else {
-		c, err := forwarder.LLBBridgeToGatewayClient(ctx, llbBridge, exec, opts, inputs, gf.workers, sid, sm)
-		if err != nil {
-			return nil, err
-		}
-		dc, err := dockerui.NewClient(c)
-		if err != nil {
-			return nil, err
-		}
-		nc, err := dc.NamedContext(source, dockerui.ContextOpt{
-			CaptureDigest: &mfstDigest,
-		})
-		if err != nil {
-			return nil, err
-		}
-		var st *llb.State
-		if nc != nil {
-			var dockerImage *dockerspec.DockerOCIImage
-			st, dockerImage, err = nc.Load(ctx)
-			if err != nil {
-				return nil, err
-			}
-			if dockerImage != nil {
-				img = *dockerImage
-			}
-		}
-		if st == nil {
-			sourceRef, err := reference.ParseNormalizedNamed(source)
-			if err != nil {
-				return nil, err
-			}
-
-			imr := sourceresolver.NewImageMetaResolver(llbBridge)
-			ref, dgst, config, err := imr.ResolveImageConfig(ctx, reference.TagNameOnly(sourceRef).String(), sourceresolver.Opt{})
-			if err != nil {
-				return nil, err
-			}
-
-			sourceRef, err = reference.ParseNormalizedNamed(ref)
-			if err != nil {
-				return nil, err
-			}
-
-			mfstDigest = dgst
-
-			if err := json.Unmarshal(config, &img); err != nil {
-				return nil, err
-			}
-
-			if dgst != "" {
-				sourceRef, err = reference.WithDigest(sourceRef, dgst)
-				if err != nil {
-					return nil, err
-				}
-			}
-
-			src := llb.Image(sourceRef.String(), &markTypeFrontend{})
-			st = &src
-		}
-
-		def, err := st.Marshal(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		res, err := llbBridge.Solve(ctx, frontend.SolveRequest{
-			Definition: def.ToPB(),
-		}, sid)
-		if err != nil {
-			return nil, err
-		}
-		defer func() {
-			ctx := context.WithoutCancel(ctx)
-			res.EachRef(func(ref solver.ResultProxy) error {
-				return ref.Release(ctx)
-			})
-		}()
-		if res.Ref == nil {
-			return nil, errors.Errorf("gateway source didn't return default result")
-		}
-		frontendDef = res.Ref.Definition()
-		r, err := res.Ref.Result(ctx)
-		if err != nil {
-			return nil, err
-		}
-		workerRef, ok := r.Sys().(*worker.WorkerRef)
-		if !ok {
-			return nil, errors.Errorf("invalid ref: %T", r.Sys())
-		}
-		rootFS, err = workerRef.Worker.CacheManager().New(ctx, workerRef.ImmutableRef, session.NewGroup(sid))
-		if err != nil {
-			return nil, err
-		}
-		defer rootFS.Release(context.TODO())
+	c, err := forwarder.LLBBridgeToGatewayClient(ctx, llbBridge, exec, opts, inputs, gf.workers, sid, sm)
+	if err != nil {
+		return nil, err
 	}
+	dc, err := dockerui.NewClient(c)
+	if err != nil {
+		return nil, err
+	}
+	nc, err := dc.NamedContext(source, dockerui.ContextOpt{
+		CaptureDigest: &mfstDigest,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var st *llb.State
+	if nc != nil {
+		var dockerImage *dockerspec.DockerOCIImage
+		st, dockerImage, err = nc.Load(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if dockerImage != nil {
+			img = *dockerImage
+		}
+	}
+	if st == nil {
+		sourceRef, err := reference.ParseNormalizedNamed(source)
+		if err != nil {
+			return nil, err
+		}
+
+		imr := sourceresolver.NewImageMetaResolver(llbBridge)
+		ref, dgst, config, err := imr.ResolveImageConfig(ctx, reference.TagNameOnly(sourceRef).String(), sourceresolver.Opt{})
+		if err != nil {
+			return nil, err
+		}
+
+		sourceRef, err = reference.ParseNormalizedNamed(ref)
+		if err != nil {
+			return nil, err
+		}
+
+		mfstDigest = dgst
+
+		if err := json.Unmarshal(config, &img); err != nil {
+			return nil, err
+		}
+
+		if dgst != "" {
+			sourceRef, err = reference.WithDigest(sourceRef, dgst)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		src := llb.Image(sourceRef.String(), &markTypeFrontend{})
+		st = &src
+	}
+
+	def, err := st.Marshal(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := llbBridge.Solve(ctx, frontend.SolveRequest{
+		Definition: def.ToPB(),
+	}, sid)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		ctx := context.WithoutCancel(ctx)
+		res.EachRef(func(ref solver.ResultProxy) error {
+			return ref.Release(ctx)
+		})
+	}()
+	if res.Ref == nil {
+		return nil, errors.Errorf("gateway source didn't return default result")
+	}
+	frontendDef = res.Ref.Definition()
+	r, err := res.Ref.Result(ctx)
+	if err != nil {
+		return nil, err
+	}
+	workerRef, ok := r.Sys().(*worker.WorkerRef)
+	if !ok {
+		return nil, errors.Errorf("invalid ref: %T", r.Sys())
+	}
+	rootFS, err = workerRef.Worker.CacheManager().New(ctx, workerRef.ImmutableRef, session.NewGroup(sid))
+	if err != nil {
+		return nil, err
+	}
+	defer rootFS.Release(context.TODO())
 
 	args := []string{"/run"}
 	env := []string{}


### PR DESCRIPTION
This legacy pathway wasn't being used anywhere and has since been succeeded by using named-contexts to modify the syntax directive.

This was added all the back in https://github.com/moby/buildkit/pull/134, but no one seems to have been relying on this internal option: see https://github.com/search?type=code&q=%5C%22gateway-devel%5C%22.

If anyone *was* using it (for prototyping a local frontend for instance), you can instead replace it using named contexts, e.g. to build the dockerfile frontend, and then use it to replace a `#syntax=foobar` directive:

```bash
docker buildx build . --file=./frontend/dockerfile/cmd/dockerfile-frontend/Dockerfile --output type=oci,dest=./build/dockerfile,tar=false
docker buildx build . --build-context foobar=oci-layout://./build/dockerfile
```

Or using bake `target:`s also works :tada: