### PR TITLE
gateway: add missing unlock in bridge forwarder

### DIFF
--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -880,6 +880,7 @@ func (lbf *llbBridgeForwarder) Solve(ctx context.Context, req *pb.SolveRequest) 
 			for _, att := range atts {
 				pbAtt, err := gwclient.AttestationToPB(&att)
 				if err != nil {
+					lbf.mu.Unlock()
 					return nil, err
 				}
 


### PR DESCRIPTION
It doesn't look like this could have been *practically* triggered right now, since this would require that a frontend solve returns an attestation with a content func. But does look like a bug waiting to appear.