### PR TITLE
linter: CopyIgnoredFile correctly cleans the path before attempting a match

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -2045,6 +2045,7 @@ func validateCopySourcePath(src string, cfg *copyConfig) error {
 		cmd = "Add"
 	}
 
+	src = filepath.ToSlash(filepath.Clean(src))
 	ok, err := cfg.ignoreMatcher.MatchesOrParentMatches(src)
 	if err != nil {
 		return err

--- a/frontend/dockerfile/dockerfile_lint_test.go
+++ b/frontend/dockerfile/dockerfile_lint_test.go
@@ -216,6 +216,19 @@ COPY --from=base /foobar /Dockerfile
 		Dockerfile:   dockerfile,
 		DockerIgnore: dockerignore,
 	})
+
+	dockerignore = []byte(`
+**
+!Dockerfile
+`)
+	dockerfile = []byte(`
+FROM scratch
+COPY ./Dockerfile .
+`)
+	checkLinterWarnings(t, sb, &lintTestParams{
+		Dockerfile:   dockerfile,
+		DockerIgnore: dockerignore,
+	})
 }
 
 func testSecretsUsedInArgOrEnv(t *testing.T, sb integration.Sandbox) {


### PR DESCRIPTION

When walking the filesystem, the walk would not have any leading paths
because it used `Walk("")` which didn't contain patterns like
`./myfile.txt`. When attempting to match a file path with the linter
rule, the initial section wouldn't be removed which would cause
`myfile.txt` not to match `./myfile.txt`.

For `CopyIgnoredFile`, this mostly affected things with exclusions since
a file path could match something very broad, like `**`, and then the
exclusion wouldn't match because it was too specific.

Fixes #5884.
