### PR TITLE
fix(daemonless): correctly track and clean up buildkitd/rootlesskit in daemonless script

### DIFF
--- a/examples/buildctl-daemonless/buildctl-daemonless.sh
+++ b/examples/buildctl-daemonless/buildctl-daemonless.sh
@@ -15,25 +15,79 @@ set -eu
 : ${ROOTLESSKIT=rootlesskit}
 
 # $tmp holds the following files:
-# * pid
-# * addr
-# * log
+# * pid - pid of buildkitd or rootlesskit
+# * addr - address where you can connect to buildkitd
+# * log - stdout+stderr of buildkitd
+# * log_tail_pid - tail -f on log file so that stdout is preserved
 tmp=$(mktemp -d /tmp/buildctl-daemonless.XXXXXX)
-trap "kill \$(cat $tmp/pid) || true; wait \$(cat $tmp/pid) || true; rm -rf $tmp" EXIT
+echo "Runtime dir: $tmp"
+
+trap_cleanup() {
+	# cleanup tail on log file
+    log_tail_pid=$(cat "$tmp/log_tail_pid" 2>/dev/null || true)
+
+    if [ -n "$log_tail_pid" ] && kill -0 "$log_tail_pid" 2>/dev/null; then
+		kill -s TERM "$log_tail_pid" 2>/dev/null || true
+	fi
+
+    pid=$(cat "$tmp/pid" 2>/dev/null || true)
+	# -n - string is non-zero
+	# kill -0 - test if the process exists and we can send signal to it
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        echo "Stopping buildkitd (pid=$pid)..."
+        kill -s TERM "$pid" 2>/dev/null || true
+
+        # Wait up to 5 seconds for clean exit
+        for i in $(seq 1 5); do
+            if ! kill -0 "$pid" 2>/dev/null; then
+                echo "buildkitd exited"
+                break
+            fi
+            sleep 1
+        done
+
+        # Force kill if still running
+        if kill -0 "$pid" 2>/dev/null; then
+            echo "buildkitd did not exit in time, forcibly killing..."
+            kill -9 "$pid" 2>/dev/null || true
+        fi
+    fi
+
+	echo "cleaning up runtime dir $tmp"
+    rm -rf "$tmp"
+}
+trap trap_cleanup EXIT
+
+DEBUG_FLAGS=""
+
+if [ ! -z "${DEBUG+x}" ]; then
+  DEBUG_FLAGS="--debug"
+fi
 
 startBuildkitd() {
     addr=
     helper=
     if [ $(id -u) = 0 ]; then
         addr=unix:///run/buildkit/buildkitd.sock
+        echo "Running as root"
     else
         addr=unix://$XDG_RUNTIME_DIR/buildkit/buildkitd.sock
         helper=$ROOTLESSKIT
+        echo "Running as non-root"
     fi
-    $helper $BUILDKITD $BUILDKITD_FLAGS --addr=$addr >$tmp/log 2>&1 &
+
+	$helper "$BUILDKITD" $BUILDKITD_FLAGS $DEBUG_FLAGS --addr="$addr" >>"$tmp/log" 2>&1 &
+	# gets pid of helper or buildkitd
     pid=$!
+
+	# pipe buildkitd logs to stdout
+	tail -F "$tmp/log" &
+	log_tail_pid=$!
+	
+	echo $log_tail_pid >$tmp/log_tail_pid
     echo $pid >$tmp/pid
     echo $addr >$tmp/addr
+    echo "Started buildkitd with pid $pid and addr $addr"
 }
 
 # buildkitd supports NOTIFY_SOCKET but as far as we know, there is no easy way
@@ -56,5 +110,4 @@ waitForBuildkitd() {
 
 startBuildkitd
 waitForBuildkitd
-$BUILDCTL --addr=$(cat $tmp/addr) "$@"
-
+$BUILDCTL $DEBUG_FLAGS --addr=$(cat $tmp/addr) "$@"


### PR DESCRIPTION
When running buildctl-daemonless.sh outside of a container (e.g., locally), the script often failed to shut down the ephemeral buildkitd instance on exit. This left rootlesskit/buildkitd processes orphaned and reparented to PID 1. In some cases the script would also hang indefinitely during cleanup, requiring the user to abort with Ctrl+C.

The root cause was that the script stored the PID of the `tee` process (the log pipe) instead of the PID of the actual rootlesskit/buildkitd supervisor. As a result, the EXIT trap was killing the wrong process and the daemon continued running in the background.

This patch fixes the PID tracking by redirecting buildkitd logs to a file and spawning a separate `tail -F` process for live output. The PID file now contains the correct supervisor PID.

The cleanup trap was also improved: it now reliably terminates the correct process, and falls back to SIGKILL if the daemon does not shut down after SIGTERM.