### PR TITLE
dockerfile: promote experimental linter rule

### DIFF
--- a/frontend/dockerfile/docs/rules/_index.md
+++ b/frontend/dockerfile/docs/rules/_index.md
@@ -100,7 +100,7 @@ To learn more about how to use build checks, see
       <td>FROM --platform flag should not use a constant value</td>
     </tr>
     <tr>
-      <td><a href="./copy-ignored-file/">CopyIgnoredFile (experimental)</a></td>
+      <td><a href="./copy-ignored-file/">CopyIgnoredFile</a></td>
       <td>Attempting to Copy file that is excluded by .dockerignore</td>
     </tr>
     <tr>

--- a/frontend/dockerfile/docs/rules/copy-ignored-file.md
+++ b/frontend/dockerfile/docs/rules/copy-ignored-file.md
@@ -6,10 +6,6 @@ aliases:
   - /go/dockerfile/rule/copy-ignored-file/
 ---
 
-> [!NOTE]
-> This check is experimental and is not enabled by default. To enable it, see
-> [Experimental checks](https://docs.docker.com/go/build-checks-experimental/).
-
 ## Output
 
 ```text

--- a/frontend/dockerfile/linter/ruleset.go
+++ b/frontend/dockerfile/linter/ruleset.go
@@ -163,7 +163,6 @@ var (
 		Format: func(cmd, file string) string {
 			return fmt.Sprintf("Attempting to %s file %q that is excluded by .dockerignore", cmd, file)
 		},
-		Experimental: true,
 	}
 	RuleInvalidDefinitionDescription = LinterRule[func(string, string) string]{
 		Name:        "InvalidDefinitionDescription",


### PR DESCRIPTION
This promotes the `CopyIgnoredFile` linter rule out of experimental.