### PR TITLE
Fix Windows COPY --parents with SeBackupPrivilege

### DIFF
--- a/cache/contenthash/checksum_windows.go
+++ b/cache/contenthash/checksum_windows.go
@@ -2,47 +2,29 @@ package contenthash
 
 import (
 	"path/filepath"
-	"sync"
 
 	"github.com/Microsoft/go-winio"
-)
-
-var (
-	privileges        = []string{winio.SeBackupPrivilege}
-	privilegeLock     sync.Mutex
-	privilegeRefCount int
+	"github.com/moby/buildkit/util/winprivileges"
 )
 
 func (cc *cacheContext) walk(scanPath string, walkFunc filepath.WalkFunc) error {
 	// elevating the admin privileges to walk special files/directory
 	// like `System Volume Information`, etc. See similar in #4994
-	return winio.RunWithPrivileges(privileges, func() error {
+	return winio.RunWithPrivileges([]string{winio.SeBackupPrivilege}, func() error {
 		return filepath.Walk(scanPath, walkFunc)
 	})
 }
 
 // Adds the SeBackupPrivilege to the process
 // to be able to access some special files and directories.
+// Uses the centralized privilege manager to coordinate with other components.
 func enableProcessPrivileges() {
-	privilegeLock.Lock()
-	defer privilegeLock.Unlock()
-
-	if privilegeRefCount == 0 {
-		_ = winio.EnableProcessPrivileges(privileges)
-	}
-	privilegeRefCount++
+	_ = winprivileges.EnableSeBackupPrivilege()
 }
 
 // Disables the SeBackupPrivilege on the process
 // once the group of functions that needed it is complete.
+// Uses the centralized privilege manager to coordinate with other components.
 func disableProcessPrivileges() {
-	privilegeLock.Lock()
-	defer privilegeLock.Unlock()
-
-	if privilegeRefCount > 0 {
-		privilegeRefCount--
-		if privilegeRefCount == 0 {
-			_ = winio.DisableProcessPrivileges(privileges)
-		}
-	}
+	winprivileges.DisableSeBackupPrivilege()
 }

--- a/session/filesync/diffcopy_windows.go
+++ b/session/filesync/diffcopy_windows.go
@@ -3,18 +3,20 @@
 package filesync
 
 import (
-	"github.com/Microsoft/go-winio"
+	"github.com/moby/buildkit/util/winprivileges"
 	"github.com/pkg/errors"
 	"github.com/tonistiigi/fsutil"
 )
 
 func sendDiffCopy(stream Stream, fs fsutil.FS, progress progressCb) error {
-	// adding one SeBackupPrivilege to the process so as to be able
-	// to run the subsequent goroutines in fsutil.Send that need
-	// to copy over special Windows metadata files.
-	// TODO(profnandaa): need to cross-check that this cannot be
-	// exploited in any way.
-	winio.EnableProcessPrivileges([]string{winio.SeBackupPrivilege})
-	defer winio.DisableProcessPrivileges([]string{winio.SeBackupPrivilege})
+	// Enable SeBackupPrivilege to allow copying special Windows metadata files.
+	// Uses the centralized privilege manager to prevent race conditions when
+	// multiple goroutines in fsutil.Send need the privilege concurrently.
+	if err := winprivileges.EnableSeBackupPrivilege(); err != nil {
+		// Continue even if privilege elevation fails - it may already be enabled
+		// or the process may not have permission to enable it
+		_ = err
+	}
+	defer winprivileges.DisableSeBackupPrivilege()
 	return errors.WithStack(fsutil.Send(stream.Context(), stream, fs, progress))
 }

--- a/solver/llbsolver/file/backend.go
+++ b/solver/llbsolver/file/backend.go
@@ -261,7 +261,7 @@ func docopy(ctx context.Context, src, dest string, action *pb.FileActionCopy, u 
 				continue
 			}
 		}
-		if err := copy.Copy(ctx, src, s, dest, destPath, opt...); err != nil {
+		if err := copyWithElevatedPrivileges(ctx, src, s, dest, destPath, opt...); err != nil {
 			return errors.WithStack(err)
 		}
 	}

--- a/solver/llbsolver/file/backend_unix.go
+++ b/solver/llbsolver/file/backend_unix.go
@@ -3,6 +3,8 @@
 package file
 
 import (
+	"context"
+
 	"github.com/moby/sys/user"
 	"github.com/pkg/errors"
 	copy "github.com/tonistiigi/fsutil/copy"
@@ -40,4 +42,8 @@ func mapUserToChowner(user *copy.User, idmap *user.IdentityMapping) (copy.Chowne
 	return func(*copy.User) (*copy.User, error) {
 		return &u, nil
 	}, nil
+}
+
+func copyWithElevatedPrivileges(ctx context.Context, srcRoot string, src string, destRoot string, dest string, opt ...copy.Opt) error {
+	return copy.Copy(ctx, srcRoot, src, destRoot, dest, opt...)
 }

--- a/solver/llbsolver/file/backend_windows.go
+++ b/solver/llbsolver/file/backend_windows.go
@@ -1,7 +1,10 @@
 package file
 
 import (
+	"context"
+
 	"github.com/moby/buildkit/util/windows"
+	"github.com/moby/buildkit/util/winprivileges"
 	"github.com/moby/sys/user"
 	copy "github.com/tonistiigi/fsutil/copy"
 )
@@ -20,4 +23,27 @@ func mapUserToChowner(user *copy.User, _ *user.IdentityMapping) (copy.Chowner, e
 	return func(*copy.User) (*copy.User, error) {
 		return user, nil
 	}, nil
+}
+
+// copyWithElevatedPrivileges wraps copy.Copy to handle Windows protected system folders.
+// On Windows, container snapshots mounted to the host filesystem include protected folders
+// ("System Volume Information" and "WcSandboxState") at the mount root, which cause "Access is denied"
+// errors when attempting to read their metadata. This function uses SeBackupPrivilege to allow
+// reading these protected files.
+//
+// SeBackupPrivilege must be enabled process-wide (not thread-local) because copy.Copy spawns
+// goroutines that may execute in different OS threads.
+//
+// Uses the centralized privilege manager to coordinate with other components and prevent
+// race conditions in parallel builds.
+func copyWithElevatedPrivileges(ctx context.Context, srcRoot string, src string, destRoot string, dest string, opt ...copy.Opt) error {
+	if err := winprivileges.EnableSeBackupPrivilege(); err != nil {
+		// Continue even if privilege elevation fails - it may already be enabled
+		// or the process may not have permission to enable it
+		_ = err
+	}
+	defer winprivileges.DisableSeBackupPrivilege()
+
+	// Perform copy with elevated privileges
+	return copy.Copy(ctx, srcRoot, src, destRoot, dest, opt...)
 }

--- a/util/winprivileges/privileges.go
+++ b/util/winprivileges/privileges.go
@@ -1,0 +1,55 @@
+//go:build windows
+
+package winprivileges
+
+import (
+	"sync"
+
+	"github.com/Microsoft/go-winio"
+)
+
+var (
+	privileges        = []string{winio.SeBackupPrivilege}
+	privilegeLock     sync.Mutex
+	privilegeRefCount int
+)
+
+// EnableSeBackupPrivilege adds the SeBackupPrivilege to the process.
+// It uses reference counting to safely handle parallel operations.
+// Must be paired with DisableSeBackupPrivilege.
+func EnableSeBackupPrivilege() error {
+	privilegeLock.Lock()
+	defer privilegeLock.Unlock()
+
+	if privilegeRefCount == 0 {
+		if err := winio.EnableProcessPrivileges(privileges); err != nil {
+			return err
+		}
+	}
+	privilegeRefCount++
+	return nil
+}
+
+// DisableSeBackupPrivilege removes the SeBackupPrivilege from the process.
+// It uses reference counting, only actually disabling when the count reaches zero.
+func DisableSeBackupPrivilege() {
+	privilegeLock.Lock()
+	defer privilegeLock.Unlock()
+
+	if privilegeRefCount > 0 {
+		privilegeRefCount--
+		if privilegeRefCount == 0 {
+			_ = winio.DisableProcessPrivileges(privileges)
+		}
+	}
+}
+
+// RunWithPrivilege executes the given function with SeBackupPrivilege enabled.
+// This is a convenience wrapper that handles enable/disable automatically.
+func RunWithPrivilege(fn func() error) error {
+	if err := EnableSeBackupPrivilege(); err != nil {
+		return err
+	}
+	defer DisableSeBackupPrivilege()
+	return fn()
+}


### PR DESCRIPTION
Fixes copying from Windows container mount roots by using SeBackupPrivilege to handle protected system files ('System Volume Information' and 'WcSandboxState') that cause 'Access is denied' errors when reading file metadata.

Implementation:
- Uses process-wide EnableProcessPrivileges (not thread-local RunWithPrivileges)
- Simple wrapper around copy.Copy with privilege elevation and restoration

Test changes:
- Enabled testCopyRelativeParents for Windows with nanoserver:ltsc2022
- Added Windows-specific test implementations for 7 target stages
- Enabled testCopyParentsMissingDirectory on Windows

The access denied errors occur during os.Lstat() when reading file metadata. SeBackupPrivilege allows reading this metadata even with restrictive ACLs on Windows container volumes.

Fixes #6335 