### PR TITLE
contentutil: avoid defaulting to ReadAt for fetch

### DIFF
--- a/util/contentutil/fetcher.go
+++ b/util/contentutil/fetcher.go
@@ -51,10 +51,6 @@ type readerAt struct {
 }
 
 func (r *readerAt) ReadAt(b []byte, off int64) (int, error) {
-	if ra, ok := r.Reader.(io.ReaderAt); ok {
-		return ra.ReadAt(b, off)
-	}
-
 	if r.offset != off {
 		if seeker, ok := r.Reader.(io.Seeker); ok {
 			if _, err := seeker.Seek(off, io.SeekStart); err != nil {
@@ -62,6 +58,9 @@ func (r *readerAt) ReadAt(b []byte, off int64) (int, error) {
 			}
 			r.offset = off
 		} else {
+			if ra, ok := r.Reader.(io.ReaderAt); ok {
+				return ra.ReadAt(b, off)
+			}
 			return 0, errors.Errorf("unsupported offset")
 		}
 	}


### PR DESCRIPTION
Containerd v2.2 updated the ReadCloser returned from Fetcher to implement ReadAt, but it works by making a separate HTTP request for each read. This means lots of requests depending on the buffer size used by copy. In containerd content pkg buffer is 1MB.

Containerd change https://github.com/containerd/containerd/commit/4bf1705a880261a4cebd0766824a5a4548b4a947

@cpuguy83 @dmcgowan I think this is unexpected that the objects return common interfaces but their performance may differ multiple times (100x+ more requests). This seems to fix the main pull case for buildkit, but there may be more accidental cases for hitting the new `ReadAt` method assuming it works with similar performance as `Read/Seek`. Lots of things like `SectionReader` use `ReadAt` by default and containerd `content.Provider` is `ReadAt` based.