### PR TITLE
[v0.26] contentutil: avoid defaulting to ReadAt for fetch

### DIFF
--- a/util/contentutil/fetcher.go
+++ b/util/contentutil/fetcher.go
@@ -51,10 +51,6 @@ type readerAt struct {
 }
 
 func (r *readerAt) ReadAt(b []byte, off int64) (int, error) {
-	if ra, ok := r.Reader.(io.ReaderAt); ok {
-		return ra.ReadAt(b, off)
-	}
-
 	if r.offset != off {
 		if seeker, ok := r.Reader.(io.Seeker); ok {
 			if _, err := seeker.Seek(off, io.SeekStart); err != nil {
@@ -62,6 +58,9 @@ func (r *readerAt) ReadAt(b []byte, off int64) (int, error) {
 			}
 			r.offset = off
 		} else {
+			if ra, ok := r.Reader.(io.ReaderAt); ok {
+				return ra.ReadAt(b, off)
+			}
 			return 0, errors.Errorf("unsupported offset")
 		}
 	}


### PR DESCRIPTION
cherry-pick #6366

Containerd v2.2 updated the ReadCloser returned from Fetcher to implement ReadAt, but it works by making a separate HTTP request for each read. This means lots of requests depending on the buffer size used by copy. In containerd content pkg buffer is 1MB.


(cherry picked from commit d5b7dda613dd06552c8e489e05c0229d3d8ddec3)