### PR TITLE
[FIX]: Removed unwanted comma from the sentence.

### DIFF
--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -2359,7 +2359,7 @@ USER <UID>[:<GID>]
 The `USER` instruction sets the user name (or UID) and optionally the user
 group (or GID) to use as the default user and group for the remainder of the
 current stage. The specified user is used for `RUN` instructions and at
-runtime, runs the relevant `ENTRYPOINT` and `CMD` commands.
+runtime runs the relevant `ENTRYPOINT` and `CMD` commands.
 
 > Note that when specifying a group for the user, the user will have _only_ the
 > specified group membership. Any other configured group memberships will be ignored.


### PR DESCRIPTION
## Description

Fixed typo in a sentence at [`https://docs.docker.com/reference/dockerfile/`](https://docs.docker.com/reference/dockerfile/) which is an unwanted comma.

### Actual sentence
> The specified user is used for RUN instructions and at runtime, runs the relevant ENTRYPOINT and CMD commands.

### Expected sentence
> The specified user is used for RUN instructions and at runtime runs the relevant ENTRYPOINT and CMD commands.

## Related issues or tickets

This was the issue that mentioned the problem  [docker/docs/issues/23168](https://github.com/docker/docs/issues/23168). This is the PR that was already cleared but because of some mixup it got closed without merge [docker/docs/pull/23276](https://github.com/docker/docs/pull/23276), I got the bug location from their PR.

## Reviews

Just a comma change, Its a quick review one. 
