### PR TITLE
Fix markdown/links for AWS auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,7 +565,7 @@ S3 configuration:
 
 AWS Authentication:
 
-BuildKit relies on the [AWS Go SDK](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/config#EnvConfig). This means that all standard authentication methods through environment variables or config files are supported. This is especially true for AWS EC2 IAM Profile and AWS Web Identity Token (IAM roles in Kubernetes).
+BuildKit relies on the [AWS Go SDK](https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-gosdk.html). This means that all standard authentication methods through [environment variables](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/config#EnvConfig) or config files are supported. This is especially true for AWS EC2 IAM Profile and AWS Web Identity Token (IAM roles in Kubernetes).
 
 Beware, these configurations must be available at buildkit daemon level, not at client level.
 


### PR DESCRIPTION
The SDK link didn't end in a parenthesis, resulting in the markdown not getting rendered as intended.

The resulting 'bare' go.dev link looked out of place, so moved it to a more natural location.

Lastly, the SDK link was for v1 docs, though the code actually uses v2; it has been replaced with the v2 equivalent.

@bpaquet I couldn't tell if your intent was possibly to to replace the AWS link with the go.dev link, but based on the context of #5926 I'm sure the presence of the go.dev link was intentional.  If your intent was to have the go.dev link as-is, adjacent to the AWS link, I'll change it back.  My main goal was simply fixing the markdown.