### PR TITLE
Inherit registry options as defaults for undefined mirrors

### DIFF
--- a/util/resolver/resolver.go
+++ b/util/resolver/resolver.go
@@ -134,7 +134,11 @@ func NewRegistryConfig(m map[string]config.RegistryConfig) docker.RegistryHosts 
 			for _, rawMirror := range c.Mirrors {
 				h := newMirrorRegistryHost(rawMirror)
 				mirrorHost := h.Host
-				host, err := fillInsecureOpts(mirrorHost, m[mirrorHost], h)
+				cfg := c
+				if mirrorCfg, ok := m[mirrorHost]; ok {
+					cfg = mirrorCfg
+				}
+				host, err := fillInsecureOpts(mirrorHost, cfg, h)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
Reference: https://github.com/moby/buildkit/issues/6177, https://github.com/moby/buildkit/blob/master/docs/buildkitd.toml.md

This PR adds support to inherit registry options as defaults for mirrors without explicit config.

Before:
```
[registry."docker.io"]
  mirrors = ["mirror1.example.dev", "mirror2.example.dev"]

[registry."mirror1.example.dev"]
  http = true

[registry."mirror2.example.dev"]
  http = true
```

After:
```
[registry."docker.io"]
  mirrors = ["mirror.example.dev", "mirror2.example.dev"]
  http = true
```