### PR TITLE
resolver: auth refactor for better readability

### DIFF
--- a/cache/remotecache/registry/registry.go
+++ b/cache/remotecache/registry/registry.go
@@ -90,7 +90,7 @@ func ResolveCacheExporterFunc(sm *session.Manager, hosts docker.RegistryHosts) r
 			insecure = b
 		}
 
-		scope, hosts := registryConfig(hosts, ref, "push", insecure)
+		scope, hosts := registryConfig(hosts, ref, resolver.ScopeType{Push: true}, insecure)
 		remote := resolver.DefaultPool.GetResolver(hosts, refString, scope, sm, g)
 		pusher, err := push.Pusher(ctx, remote, refString)
 		if err != nil {
@@ -116,7 +116,7 @@ func ResolveCacheImporterFunc(sm *session.Manager, cs content.Store, hosts docke
 			insecure = b
 		}
 
-		scope, hosts := registryConfig(hosts, ref, "pull", insecure)
+		scope, hosts := registryConfig(hosts, ref, resolver.ScopeType{}, insecure)
 		remote := resolver.DefaultPool.GetResolver(hosts, refString, scope, sm, g)
 		xref, desc, err := remote.Resolve(ctx, refString)
 		if err != nil {
@@ -173,7 +173,7 @@ func (dsl *withDistributionSourceLabel) SnapshotLabels(descs []ocispecs.Descript
 	return labels
 }
 
-func registryConfig(hosts docker.RegistryHosts, ref reference.Named, scope string, insecure bool) (string, docker.RegistryHosts) {
+func registryConfig(hosts docker.RegistryHosts, ref reference.Named, scope resolver.ScopeType, insecure bool) (resolver.ScopeType, docker.RegistryHosts) {
 	if insecure {
 		insecureTrue := true
 		httpTrue := true
@@ -183,7 +183,7 @@ func registryConfig(hosts docker.RegistryHosts, ref reference.Named, scope strin
 				PlainHTTP: &httpTrue,
 			},
 		})
-		scope += ":insecure"
+		scope.Insecure = true
 	}
 	return scope, hosts
 }

--- a/cmd/buildkitd/main_oci_worker.go
+++ b/cmd/buildkitd/main_oci_worker.go
@@ -525,7 +525,7 @@ func sourceWithSession(hosts docker.RegistryHosts, sm *session.Manager) sgzsourc
 			// Get source information based on labels and RegistryHosts containing
 			// session-based authorizer.
 			parse := sgzsource.FromDefaultLabels(func(ref reference.Spec) ([]docker.RegistryHost, error) {
-				return resolver.DefaultPool.GetResolver(hosts, named.String(), "pull", sm, session.NewGroup(sids...)).
+				return resolver.DefaultPool.GetResolver(hosts, named.String(), resolver.ScopeType{}, sm, session.NewGroup(sids...)).
 					HostsFunc(ref.Hostname())
 			})
 			if s, err := parse(map[string]string{

--- a/source/containerimage/pull.go
+++ b/source/containerimage/pull.go
@@ -94,7 +94,7 @@ func (p *puller) CacheKey(ctx context.Context, jobCtx solver.JobContext, index i
 	var getResolver pull.SessionResolver
 	switch p.ResolverType {
 	case ResolverTypeRegistry:
-		resolver := resolver.DefaultPool.GetResolver(p.RegistryHosts, p.Ref, "pull", p.SessionManager, g).WithImageStore(p.ImageStore, p.Mode)
+		resolver := resolver.DefaultPool.GetResolver(p.RegistryHosts, p.Ref, resolver.ScopeType{}, p.SessionManager, g).WithImageStore(p.ImageStore, p.Mode)
 		p.Resolver = resolver
 		getResolver = func(g session.Group) remotes.Resolver { return resolver.WithSession(g) }
 	case ResolverTypeOCILayout:
@@ -218,7 +218,7 @@ func (p *puller) Snapshot(ctx context.Context, jobCtx solver.JobContext) (ir cac
 	var getResolver pull.SessionResolver
 	switch p.ResolverType {
 	case ResolverTypeRegistry:
-		resolver := resolver.DefaultPool.GetResolver(p.RegistryHosts, p.Ref, "pull", p.SessionManager, g).WithImageStore(p.ImageStore, p.Mode)
+		resolver := resolver.DefaultPool.GetResolver(p.RegistryHosts, p.Ref, resolver.ScopeType{}, p.SessionManager, g).WithImageStore(p.ImageStore, p.Mode)
 		p.Resolver = resolver
 		getResolver = func(g session.Group) remotes.Resolver { return resolver.WithSession(g) }
 	case ResolverTypeOCILayout:

--- a/source/containerimage/source.go
+++ b/source/containerimage/source.go
@@ -173,7 +173,7 @@ func (is *Source) ResolveImageMetadata(ctx context.Context, id *ImageIdentifier,
 	if err != nil {
 		return nil, err
 	}
-	rslvr := resolver.DefaultPool.GetResolver(is.RegistryHosts, ref, "pull", sm, g).WithImageStore(is.ImageStore, rm)
+	rslvr := resolver.DefaultPool.GetResolver(is.RegistryHosts, ref, resolver.ScopeType{}, sm, g).WithImageStore(is.ImageStore, rm)
 	key += rm.String()
 
 	ret := &sourceresolver.ResolveImageResponse{}

--- a/util/push/push.go
+++ b/util/push/push.go
@@ -69,7 +69,7 @@ func Push(ctx context.Context, sm *session.Manager, sid string, provider content
 		ref = r.String()
 	}
 
-	scope := "push"
+	scope := resolver.ScopeType{Push: true}
 	if insecure {
 		insecureTrue := true
 		httpTrue := true
@@ -79,7 +79,7 @@ func Push(ctx context.Context, sm *session.Manager, sid string, provider content
 				PlainHTTP: &httpTrue,
 			},
 		})
-		scope += ":insecure"
+		scope.Insecure = true
 	}
 
 	resolver := resolver.DefaultPool.GetResolver(hosts, ref, scope, sm, session.NewGroup(sid))


### PR DESCRIPTION
These are the changes I made to resolver when working on https://github.com/docker/buildx/pull/3562

Initially, I thought I needed to track tokens for different HTTP methods and added support for that in the Resolver. Eventually, I realized that because the readonly requests made by pusher are `HEAD` requests that don't count against rate-limiting, this extra complexity is not needed. I reverted that part, but I think the general refactors I made are still useful and improve the codebase. No functional changes in this PR and https://github.com/docker/buildx/pull/3562 does not require specific daemon-side updates.