### PR TITLE
authprovider: make it possible to provide custom AuthConfig providers

### DIFF
--- a/cmd/buildctl/build.go
+++ b/cmd/buildctl/build.go
@@ -189,8 +189,8 @@ func buildAction(clicontext *cli.Context) error {
 	}
 
 	attachable := []session.Attachable{authprovider.NewDockerAuthProvider(authprovider.DockerAuthProviderConfig{
-		ConfigFile: dockerConfig,
-		TLSConfigs: tlsConfigs,
+		AuthConfigProvider: authprovider.LoadAuthConfig(dockerConfig),
+		TLSConfigs:         tlsConfigs,
 	})}
 
 	if ssh := clicontext.StringSlice("ssh"); len(ssh) > 0 {

--- a/session/auth/authprovider/authconfigprovider.go
+++ b/session/auth/authprovider/authconfigprovider.go
@@ -1,0 +1,58 @@
+package authprovider
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/docker/cli/cli/config/configfile"
+	"github.com/docker/cli/cli/config/types"
+)
+
+func LoadAuthConfig(config *configfile.ConfigFile) AuthConfigProvider {
+	acp := &authConfigProvider{
+		config:          config,
+		authConfigCache: map[string]authConfigCacheEntry{},
+	}
+	return acp.load
+}
+
+type authConfigProvider struct {
+	config          *configfile.ConfigFile
+	authConfigCache map[string]authConfigCacheEntry
+	mu              sync.Mutex
+}
+
+func (ap *authConfigProvider) load(ctx context.Context, host string, scopes []string, cacheExpireCheck ExpireCachedAuthCheck) (types.AuthConfig, error) {
+	ap.mu.Lock()
+	defer ap.mu.Unlock()
+
+	entry, exists := ap.authConfigCache[host]
+	if exists && (cacheExpireCheck == nil || !cacheExpireCheck(entry.Created, host)) {
+		return *entry.Auth, nil
+	}
+
+	hostKey := host
+	if host == DockerHubRegistryHost {
+		hostKey = DockerHubConfigfileKey
+	}
+
+	ac, err := ap.config.GetAuthConfig(hostKey)
+	if err != nil {
+		return types.AuthConfig{}, err
+	}
+
+	entry = authConfigCacheEntry{
+		Created: time.Now(),
+		Auth:    &ac,
+	}
+
+	ap.authConfigCache[host] = entry
+
+	return ac, nil
+}
+
+type authConfigCacheEntry struct {
+	Created time.Time
+	Auth    *types.AuthConfig
+}


### PR DESCRIPTION
This enables client to provide their own functionality for AuthConfig lookup, rather than just passing in dockercli.ConfigFile.

These are the buildkit client-side changes extracted from https://github.com/docker/buildx/pull/3562 . 