### PR TITLE
gitsign: fix for RejectExpiredKeys logic

### DIFF
--- a/util/gitutil/gitsign/gitsign.go
+++ b/util/gitutil/gitsign/gitsign.go
@@ -67,11 +67,18 @@ func verifyPGPSignature(obj *gitobject.GitObject, sig *packet.Signature, pubKeyD
 		return err
 	}
 
+	config := &packet.Config{}
+	if policy == nil || !policy.RejectExpiredKeys {
+		config.Time = func() time.Time {
+			return sig.CreationTime
+		}
+	}
+
 	signer, err := openpgp.CheckDetachedSignature(
 		ents,
 		bytes.NewReader([]byte(obj.SignedData)),
 		bytes.NewReader(sigBlock),
-		&packet.Config{},
+		config,
 	)
 	if err != nil {
 		if sig.IssuerKeyId != nil {


### PR DESCRIPTION
Current RejectExpiredKeys didn't work (for the `false` case) as CheckDetachedSignature validates expiration date internally.

It looks like go-crypto library does not allow signature checks with completely ignoring exipration times (as Github UI allows for example). With this change we allow (option for) keys to be expired, but the signature creation time can not be after key expiry.

If we would set the reference time to the key creation time that would cause a different error where validation would not work because signatures are created in future.