### PR TITLE
fix: send mTLS client certificates to OAuth token endpoints

### DIFF
--- a/util/resolver/authorizer_test.go
+++ b/util/resolver/authorizer_test.go
@@ -1,8 +1,13 @@
 package resolver
 
 import (
+	"crypto/tls"
+	"net/http"
 	"reflect"
 	"testing"
+
+	"github.com/moby/buildkit/util/tracing"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseScopes(t *testing.T) {
@@ -51,6 +56,155 @@ func TestParseScopes(t *testing.T) {
 			if !reflect.DeepEqual(parsed, tc.expected) {
 				t.Fatalf("expected %v, got %v", tc.expected, parsed)
 			}
+		})
+	}
+}
+
+func TestClientHasMTLS(t *testing.T) {
+	tests := []struct {
+		name     string
+		client   *http.Client
+		expected bool
+	}{
+		{
+			name:     "nil client",
+			client:   nil,
+			expected: false,
+		},
+		{
+			name:     "client with nil transport",
+			client:   &http.Client{Transport: nil},
+			expected: false,
+		},
+		{
+			name: "client without TLS config",
+			client: &http.Client{
+				Transport: &http.Transport{},
+			},
+			expected: false,
+		},
+		{
+			name: "client with empty TLS config",
+			client: &http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "client with TLS config but no certificates",
+			client: &http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{
+						Certificates: []tls.Certificate{},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "client with mTLS certificates",
+			client: &http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{
+						Certificates: []tls.Certificate{{}},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "client with tracing wrapper and mTLS certificates",
+			client: &http.Client{
+				Transport: tracing.NewTransport(&http.Transport{
+					TLSClientConfig: &tls.Config{
+						Certificates: []tls.Certificate{{}},
+					},
+				}),
+			},
+			expected: true,
+		},
+		{
+			name: "client with tracing wrapper but no mTLS",
+			client: &http.Client{
+				Transport: tracing.NewTransport(&http.Transport{}),
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := clientHasMTLS(tt.client)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestTransportHasMTLS(t *testing.T) {
+	tests := []struct {
+		name      string
+		transport http.RoundTripper
+		expected  bool
+	}{
+		{
+			name:      "nil transport",
+			transport: nil,
+			expected:  false,
+		},
+		{
+			name:      "plain http.Transport without TLS",
+			transport: &http.Transport{},
+			expected:  false,
+		},
+		{
+			name: "http.Transport with mTLS",
+			transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					Certificates: []tls.Certificate{{}},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "TracingTransport wrapping http.Transport with mTLS",
+			transport: tracing.NewTransport(&http.Transport{
+				TLSClientConfig: &tls.Config{
+					Certificates: []tls.Certificate{{}},
+				},
+			}),
+			expected: true,
+		},
+		{
+			name:      "TracingTransport wrapping http.Transport without mTLS",
+			transport: tracing.NewTransport(&http.Transport{}),
+			expected:  false,
+		},
+		{
+			name: "httpFallback wrapping TracingTransport with mTLS",
+			transport: &httpFallback{
+				super: tracing.NewTransport(&http.Transport{
+					TLSClientConfig: &tls.Config{
+						Certificates: []tls.Certificate{{}},
+					},
+				}),
+			},
+			expected: true,
+		},
+		{
+			name: "httpFallback wrapping TracingTransport without mTLS",
+			transport: &httpFallback{
+				super: tracing.NewTransport(&http.Transport{}),
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := transportHasMTLS(tt.transport)
+			require.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/util/resolver/pool.go
+++ b/util/resolver/pool.go
@@ -186,7 +186,11 @@ func (r *Resolver) HostsFunc(host string) ([]docker.RegistryHost, error) {
 		// make a copy so authorizer is set on unique instance
 		res := make([]docker.RegistryHost, len(v))
 		copy(res, v)
-		auth := newDockerAuthorizer(res[0].Client, r.handler, r.sm, r.g)
+		// Use the last host's client (the actual registry, not mirrors) to ensure
+		// mTLS client certificates are properly propagated to OAuth token endpoints.
+		// Mirrors are added first to the slice in NewRegistryConfig, so the last
+		// entry is always the actual registry with the correct TLS configuration.
+		auth := newDockerAuthorizer(res[len(res)-1].Client, r.handler, r.sm, r.g)
 		for i := range res {
 			res[i].Authorizer = auth
 		}

--- a/util/resolver/pool_test.go
+++ b/util/resolver/pool_test.go
@@ -1,0 +1,98 @@
+package resolver
+
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/remotes/docker"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHostsFuncUsesLastClientForAuthorizer(t *testing.T) {
+	// This test verifies that when multiple registry hosts are returned
+	// (e.g., mirrors + actual registry), the authorizer uses the LAST
+	// host's client, not the first. This is important for mTLS because
+	// mirrors are added first in NewRegistryConfig, and the actual registry
+	// (with proper TLS config) is added last.
+
+	// Create distinct clients to track which one is used
+	mirrorClient := &http.Client{Transport: &http.Transport{}}
+	registryClient := &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{
+			// This simulates a client with mTLS certificates configured
+			Certificates: []tls.Certificate{{}},
+		},
+	}}
+
+	// Create mock hosts function that returns mirror first, actual registry last
+	hosts := func(host string) ([]docker.RegistryHost, error) {
+		return []docker.RegistryHost{
+			{
+				Host:   "mirror.example.com",
+				Scheme: "https",
+				Path:   "/v2",
+				Client: mirrorClient,
+			},
+			{
+				Host:   "registry.example.com",
+				Scheme: "https",
+				Path:   "/v2",
+				Client: registryClient,
+			},
+		}, nil
+	}
+
+	// Create resolver with our mock hosts function
+	pool := NewPool()
+	resolver := pool.GetResolver(hosts, "registry.example.com/image:tag", "pull", nil, nil)
+
+	// Call HostsFunc to get the configured hosts
+	result, err := resolver.HostsFunc("registry.example.com")
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+
+	// Verify all hosts have the same authorizer
+	require.NotNil(t, result[0].Authorizer)
+	require.NotNil(t, result[1].Authorizer)
+	require.Equal(t, result[0].Authorizer, result[1].Authorizer)
+
+	// The authorizer should be using the LAST host's client (registryClient)
+	// which has the TLS config with certificates, not the mirror's client.
+	// We verify this by checking the dockerAuthorizer's client field.
+	auth, ok := result[0].Authorizer.(*dockerAuthorizer)
+	require.True(t, ok, "authorizer should be *dockerAuthorizer")
+
+	// The client should be the registry client (last in list), not the mirror client
+	require.Equal(t, registryClient, auth.client,
+		"authorizer should use the last host's client (actual registry), not the first (mirror)")
+}
+
+func TestHostsFuncSingleHost(t *testing.T) {
+	// Test that single host case still works correctly
+	client := &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{},
+	}}
+
+	hosts := func(host string) ([]docker.RegistryHost, error) {
+		return []docker.RegistryHost{
+			{
+				Host:   "registry.example.com",
+				Scheme: "https",
+				Path:   "/v2",
+				Client: client,
+			},
+		}, nil
+	}
+
+	pool := NewPool()
+	resolver := pool.GetResolver(hosts, "registry.example.com/image:tag", "pull", nil, nil)
+
+	result, err := resolver.HostsFunc("registry.example.com")
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+
+	auth, ok := result[0].Authorizer.(*dockerAuthorizer)
+	require.True(t, ok)
+	require.Equal(t, client, auth.client)
+}


### PR DESCRIPTION
When buildkitd has mTLS client certificates configured for a registry, the certificates were not being sent to OAuth token endpoints, causing authentication to fail with "tls: certificate required" errors.

This happened because modern clients (docker buildx) delegate token fetching to the client side via session auth, which doesn't have access to buildkitd's mTLS certificates.

The fix:
1. Add TracingTransport wrapper to expose base transport for TLS inspection
2. Detect when HTTP client has mTLS certificates configured
3. Skip session auth and use direct auth when mTLS is present
4. Use the actual registry's client (last in list) instead of mirror's

Fixes moby/buildkit#6416

🤖 Generated with [Claude Code](https://claude.com/claude-code)