### PR TITLE
exporter: expose build ref to the exporter as part of buildinfo

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -24,7 +24,13 @@ type ExporterInstance interface {
 	Config() *Config
 	Type() string
 	Attrs() map[string]string
-	Export(ctx context.Context, src *Source, inlineCache exptypes.InlineCache, sessionID string) (map[string]string, DescriptorReference, error)
+	Export(ctx context.Context, src *Source, buildInfo ExportBuildInfo) (map[string]string, DescriptorReference, error)
+}
+
+type ExportBuildInfo struct {
+	Ref         string
+	InlineCache exptypes.InlineCache
+	SessionID   string
 }
 
 type DescriptorReference interface {

--- a/exporter/local/export.go
+++ b/exporter/local/export.go
@@ -78,7 +78,7 @@ func (e *localExporter) Config() *exporter.Config {
 	return exporter.NewConfig()
 }
 
-func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source, _ exptypes.InlineCache, sessionID string) (map[string]string, exporter.DescriptorReference, error) {
+func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source, buildInfo exporter.ExportBuildInfo) (map[string]string, exporter.DescriptorReference, error) {
 	timeoutCtx, cancel := context.WithCancelCause(ctx)
 	timeoutCtx, _ = context.WithTimeoutCause(timeoutCtx, 5*time.Second, errors.WithStack(context.DeadlineExceeded)) //nolint:govet
 	defer func() { cancel(errors.WithStack(context.Canceled)) }()
@@ -91,7 +91,7 @@ func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source
 		}
 	}
 
-	caller, err := e.opt.SessionManager.Get(timeoutCtx, sessionID, false)
+	caller, err := e.opt.SessionManager.Get(timeoutCtx, buildInfo.SessionID, false)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -117,7 +117,7 @@ func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source
 
 	export := func(ctx context.Context, k string, ref cache.ImmutableRef, attestations []exporter.Attestation) func() error {
 		return func() error {
-			outputFS, cleanup, err := CreateFS(ctx, sessionID, k, ref, attestations, now, isMap, e.opts)
+			outputFS, cleanup, err := CreateFS(ctx, buildInfo.SessionID, k, ref, attestations, now, isMap, e.opts)
 			if err != nil {
 				return err
 			}

--- a/exporter/tar/export.go
+++ b/exporter/tar/export.go
@@ -77,7 +77,7 @@ func (e *localExporterInstance) Config() *exporter.Config {
 	return exporter.NewConfig()
 }
 
-func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source, _ exptypes.InlineCache, sessionID string) (map[string]string, exporter.DescriptorReference, error) {
+func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source, buildInfo exporter.ExportBuildInfo) (map[string]string, exporter.DescriptorReference, error) {
 	var defers []func() error
 
 	defer func() {
@@ -98,7 +98,7 @@ func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source
 	isMap := len(inp.Refs) > 0
 
 	getDir := func(ctx context.Context, k string, ref cache.ImmutableRef, attestations []exporter.Attestation) (*fsutil.Dir, error) {
-		outputFS, cleanup, err := local.CreateFS(ctx, sessionID, k, ref, attestations, now, isMap, e.opts)
+		outputFS, cleanup, err := local.CreateFS(ctx, buildInfo.SessionID, k, ref, attestations, now, isMap, e.opts)
 		if err != nil {
 			return nil, err
 		}
@@ -167,7 +167,7 @@ func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source
 	timeoutCtx, _ = context.WithTimeoutCause(timeoutCtx, 5*time.Second, errors.WithStack(context.DeadlineExceeded)) //nolint:govet
 	defer func() { cancel(errors.WithStack(context.Canceled)) }()
 
-	caller, err := e.opt.SessionManager.Get(timeoutCtx, sessionID, false)
+	caller, err := e.opt.SessionManager.Get(timeoutCtx, buildInfo.SessionID, false)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Expose build ref (unique ID per build) to the exporter. To avoid an ever-growing list of parameters, add a new struct and move the existing build-specific properties (inlineCache, sessionID) there as well.