### PR TITLE
vendor: github.com/moby/go-archive v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/klauspost/compress v1.18.2
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/moby/docker-image-spec v1.3.1
-	github.com/moby/go-archive v0.1.0
+	github.com/moby/go-archive v0.2.0
 	github.com/moby/locker v1.0.1
 	github.com/moby/patternmatcher v0.6.0
 	github.com/moby/policy-helpers v0.0.0-20251105011237-bcaa71c99f14

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,8 @@ github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4
 github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
-github.com/moby/go-archive v0.1.0 h1:Kk/5rdW/g+H8NHdJW2gsXyZ7UnzvJNOy6VKJqueWdcQ=
-github.com/moby/go-archive v0.1.0/go.mod h1:G9B+YoujNohJmrIYFBpSd54GTUB4lt9S+xVQvsJyFuo=
+github.com/moby/go-archive v0.2.0 h1:zg5QDUM2mi0JIM9fdQZWC7U8+2ZfixfTYoHL7rWUcP8=
+github.com/moby/go-archive v0.2.0/go.mod h1:mNeivT14o8xU+5q1YnNrkQVpK+dnNe/K6fHqnTg4qPU=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
 github.com/moby/patternmatcher v0.6.0 h1:GmP9lR19aU5GqSSFko+5pRqHi+Ohk1O69aFiKkVGiPk=

--- a/vendor/github.com/moby/go-archive/archive.go
+++ b/vendor/github.com/moby/go-archive/archive.go
@@ -36,10 +36,6 @@ import (
 const ImpliedDirectoryMode = 0o755
 
 type (
-	// Compression is the state represents if compressed or not.
-	//
-	// Deprecated: use [compression.Compression].
-	Compression = compression.Compression
 	// WhiteoutFormat is the format of whiteouts unpacked
 	WhiteoutFormat int
 
@@ -96,14 +92,6 @@ func NewDefaultArchiver() *Archiver {
 type breakoutError error
 
 const (
-	Uncompressed = compression.None  // Deprecated: use [compression.None].
-	Bzip2        = compression.Bzip2 // Deprecated: use [compression.Bzip2].
-	Gzip         = compression.Gzip  // Deprecated: use [compression.Gzip].
-	Xz           = compression.Xz    // Deprecated: use [compression.Xz].
-	Zstd         = compression.Zstd  // Deprecated: use [compression.Zstd].
-)
-
-const (
 	AUFSWhiteoutFormat    WhiteoutFormat = 0 // AUFSWhiteoutFormat is the default format for whiteouts
 	OverlayWhiteoutFormat WhiteoutFormat = 1 // OverlayWhiteoutFormat formats whiteout according to the overlay standard.
 )
@@ -124,27 +112,6 @@ func IsArchivePath(path string) bool {
 	r := tar.NewReader(rdr)
 	_, err = r.Next()
 	return err == nil
-}
-
-// DetectCompression detects the compression algorithm of the source.
-//
-// Deprecated: use [compression.Detect].
-func DetectCompression(source []byte) compression.Compression {
-	return compression.Detect(source)
-}
-
-// DecompressStream decompresses the archive and returns a ReaderCloser with the decompressed archive.
-//
-// Deprecated: use [compression.DecompressStream].
-func DecompressStream(archive io.Reader) (io.ReadCloser, error) {
-	return compression.DecompressStream(archive)
-}
-
-// CompressStream compresses the dest with specified compression algorithm.
-//
-// Deprecated: use [compression.CompressStream].
-func CompressStream(dest io.Writer, comp compression.Compression) (io.WriteCloser, error) {
-	return compression.CompressStream(dest, comp)
 }
 
 // TarModifierFunc is a function that can be passed to ReplaceFileTarWrapper to
@@ -233,13 +200,6 @@ func ReplaceFileTarWrapper(inputTarStream io.ReadCloser, mods map[string]TarModi
 		pipeWriter.Close()
 	}()
 	return pipeReader
-}
-
-// FileInfoHeaderNoLookups creates a partially-populated tar.Header from fi.
-//
-// Deprecated: use [tarheader.FileInfoHeaderNoLookups].
-func FileInfoHeaderNoLookups(fi os.FileInfo, link string) (*tar.Header, error) {
-	return tarheader.FileInfoHeaderNoLookups(fi, link)
 }
 
 // FileInfoHeader creates a populated Header from fi.

--- a/vendor/github.com/moby/go-archive/chrootarchive/archive_unix.go
+++ b/vendor/github.com/moby/go-archive/chrootarchive/archive_unix.go
@@ -5,20 +5,11 @@ package chrootarchive
 import (
 	"errors"
 	"io"
-	"net"
-	"os/user"
 	"path/filepath"
 	"strings"
 
 	"github.com/moby/go-archive"
 )
-
-func init() {
-	// initialize nss libraries in Glibc so that the dynamic libraries are loaded in the host
-	// environment not in the chroot from untrusted files.
-	_, _ = user.Lookup("docker")
-	_, _ = net.LookupHost("localhost")
-}
 
 func invokeUnpack(decompressedArchive io.Reader, dest string, options *archive.TarOptions, root string) error {
 	relDest, err := resolvePathInChroot(root, dest)

--- a/vendor/github.com/moby/go-archive/xattr_supported_unix.go
+++ b/vendor/github.com/moby/go-archive/xattr_supported_unix.go
@@ -1,4 +1,4 @@
-//go:build !linux && !windows
+//go:build darwin || freebsd || netbsd
 
 package archive
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -666,7 +666,7 @@ github.com/mitchellh/hashstructure/v2
 # github.com/moby/docker-image-spec v1.3.1
 ## explicit; go 1.18
 github.com/moby/docker-image-spec/specs-go/v1
-# github.com/moby/go-archive v0.1.0
+# github.com/moby/go-archive v0.2.0
 ## explicit; go 1.23.0
 github.com/moby/go-archive
 github.com/moby/go-archive/chrootarchive


### PR DESCRIPTION
- remove aliases for deprecated types and functions
- chrootarchive: remove redundant "init" mitigation for CVE-2019-14271
- xattr: Fix OS matching

full diff: https://github.com/moby/go-archive/compare/v0.1.0...v0.2.0