### PR TITLE
Update apt cache example (fix warning)

### DIFF
--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -880,7 +880,7 @@ FROM ubuntu
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt,sharing=locked \
-  apt update && apt-get --no-install-recommends install -y gcc
+  apt-get update && apt-get --no-install-recommends install -y gcc
 ```
 
 Apt needs exclusive access to its data, so the caches use the option


### PR DESCRIPTION
Fixes warning from `apt`:

> WARNING: apt does not have a stable CLI interface. Use with caution in scripts.