### PR TITLE
Fix concurrency issues with source policy

### DIFF
--- a/sourcepolicy/engine.go
+++ b/sourcepolicy/engine.go
@@ -49,7 +49,7 @@ func (e *Engine) selectorCache(src *spb.Selector) *selectorCache {
 		return s
 	}
 
-	s := &selectorCache{Selector: src}
+	s := newSelectorCache(src)
 	e.sources[key] = s
 	return s
 }

--- a/sourcepolicy/matcher_test.go
+++ b/sourcepolicy/matcher_test.go
@@ -319,7 +319,7 @@ func TestMatch(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			matches, err := match(&selectorCache{Selector: tc.src}, tc.ref, tc.src.Constraints, tc.attrs)
+			matches, err := match(newSelectorCache(tc.src), tc.ref, tc.src.Constraints, tc.attrs)
 			if !tc.xErr {
 				require.NoError(t, err)
 			} else {

--- a/sourcepolicy/mutate_test.go
+++ b/sourcepolicy/mutate_test.go
@@ -130,7 +130,7 @@ func TestMutate(t *testing.T) {
 		op := tc.op
 		t.Run(op.String(), func(t *testing.T) {
 			src := op.GetSource()
-			mutated, err := mutate(ctx, src, tc.rule, &selectorCache{Selector: tc.rule.Selector}, src.GetIdentifier())
+			mutated, err := mutate(ctx, src, tc.rule, newSelectorCache(tc.rule.Selector), src.GetIdentifier())
 			require.Equal(t, tc.expected, mutated)
 			if tc.expectedErr != "" {
 				require.Error(t, err, tc.expectedErr)


### PR DESCRIPTION
This is more stuff where we weren't accounting for concurrent access.

Seen this on latest buildx stable image:

```
fatal error: concurrent map writes

goroutine 23041 [running]:
internal/runtime/maps.fatal({0x2068176?, 0x1d660e0?})
	/usr/local/go/src/runtime/panic.go:1046 +0x18
github.com/moby/buildkit/sourcepolicy.(*wildcardCache).Match(0xc003813a30, {0xc001f020c0, 0x3e})
	/src/sourcepolicy/formatter.go:66 +0xbf
github.com/moby/buildkit/sourcepolicy.match(0xc0055ed320, {0xc001f020c0, 0x3e}, {0x0, 0x0, 0xc0027fa2a0?}, 0x0)
	/src/sourcepolicy/matcher.go:56 +0x48f
github.com/moby/buildkit/sourcepolicy.(*Engine).evaluatePolicy(0xc002ccb5c0, {0x23ad8b8, 0xc0026926c0}, 0xc001cdaaa0, 0xc00344cd40)
	/src/sourcepolicy/engine.go:133 +0x305
github.com/moby/buildkit/sourcepolicy.(*Engine).evaluatePolicies(0xc002ccb5c0, {0x23ad8b8, 0xc0026926c0}, 0xc00344cd40)
	/src/sourcepolicy/engine.go:101 +0x7a
github.com/moby/buildkit/sourcepolicy.(*Engine).Evaluate(0xc002ccb5c0, {0x23ad8f0, 0xc001cdaa50}, 0xc00344cd40)
	/src/sourcepolicy/engine.go:84 +0x312
github.com/moby/buildkit/solver/llbsolver.(*policyEvaluator).Evaluate(0xc002f8f950, {0x23ad8f0, 0xc001cdaa50}, 0xc003d10420)
	/src/solver/llbsolver/policy.go:27 +0x90
github.com/moby/buildkit/solver/llbsolver.loadLLB.func1()
	/src/solver/llbsolver/vertex.go:353 +0x6e
golang.org/x/sync/errgroup.(*Group).Go.func1()
	/src/vendor/golang.org/x/sync/errgroup/errgroup.go:93 +0x50
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 22895
	/src/vendor/golang.org/x/sync/errgroup/errgroup.go:78 +0x95
```