### PR TITLE
solver: run image and cache exports in parallel

### DIFF
--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -219,7 +219,7 @@ func (e *imageExporterInstance) Attrs() map[string]string {
 	return e.attrs
 }
 
-func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source, buildInfo exporter.ExportBuildInfo) (_ map[string]string, descref exporter.DescriptorReference, err error) {
+func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source, buildInfo exporter.ExportBuildInfo) (_ map[string]string, _ exporter.FinalizeFunc, descref exporter.DescriptorReference, err error) {
 	src = src.Clone()
 	if src.Metadata == nil {
 		src.Metadata = make(map[string][]byte)
@@ -229,14 +229,17 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 	opts := e.opts
 	as, _, err := ParseAnnotations(src.Metadata)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	opts.Annotations = opts.Annotations.Merge(as)
 
 	ctx, done, err := leaseutil.WithLease(ctx, e.opt.LeaseManager, leaseutil.MakeTemporary)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
+	// On success, we create descref which holds the lease's done function.
+	// The solver will release descref after recording the descriptor in build
+	// history. On error (descref is nil), we release the lease here.
 	defer func() {
 		if descref == nil {
 			done(context.WithoutCancel(ctx))
@@ -245,13 +248,8 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 
 	desc, err := e.opt.ImageWriter.Commit(ctx, src, buildInfo.SessionID, buildInfo.InlineCache, &opts)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	defer func() {
-		if err == nil {
-			descref = NewDescriptorReference(*desc, done)
-		}
-	}()
 
 	resp := make(map[string]string)
 
@@ -269,6 +267,9 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 			nameCanonical = false
 		}
 	}
+
+	// Collect names for finalize callback to push
+	var namesToPush []string
 
 	if e.opts.ImageName != "" {
 		targetNames := strings.SplitSeq(e.opts.ImageName, ",")
@@ -299,11 +300,11 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 					img.Name = targetName + sfx
 					if _, err := e.opt.Images.Update(imageClientCtx, img); err != nil {
 						if !errors.Is(err, cerrdefs.ErrNotFound) {
-							return nil, nil, tagDone(err)
+							return nil, nil, nil, tagDone(err)
 						}
 
 						if _, err := e.opt.Images.Create(imageClientCtx, img); err != nil {
-							return nil, nil, tagDone(err)
+							return nil, nil, nil, tagDone(err)
 						}
 					}
 				}
@@ -315,10 +316,10 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 						// /
 						// TODO: change e.unpackImage so that it takes Result[Remote] as parameter.
 						// https://github.com/moby/buildkit/pull/4057#discussion_r1324106088
-						return nil, nil, errors.New("exporter option \"rewrite-timestamp\" conflicts with \"unpack\"")
+						return nil, nil, nil, errors.New("exporter option \"rewrite-timestamp\" conflicts with \"unpack\"")
 					}
 					if err := e.unpackImage(ctx, img, src, session.NewGroup(buildInfo.SessionID)); err != nil {
-						return nil, nil, err
+						return nil, nil, nil, err
 					}
 				}
 
@@ -350,19 +351,13 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 						})
 					}
 					if err := eg.Wait(); err != nil {
-						return nil, nil, err
+						return nil, nil, nil, err
 					}
 				}
 			}
+			// Collect names for pushing in finalize
 			if e.push {
-				err = e.pushImage(ctx, src, buildInfo.SessionID, targetName, desc.Digest)
-				if err != nil {
-					var statusErr remoteserrors.ErrUnexpectedStatus
-					if errors.As(err, &statusErr) {
-						err = errutil.WithDetails(err)
-					}
-					return nil, nil, errors.Wrapf(err, "failed to push %v", targetName)
-				}
+				namesToPush = append(namesToPush, targetName)
 			}
 		}
 		resp[exptypes.ExporterImageNameKey] = e.opts.ImageName
@@ -376,11 +371,34 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 
 	dtdesc, err := json.Marshal(desc)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	resp[exptypes.ExporterImageDescriptorKey] = base64.StdEncoding.EncodeToString(dtdesc)
 
-	return resp, nil, nil
+	// Create descref so descriptor is recorded in build history.
+	// Transfer lease ownership to descref - caller releases after finalize.
+	descref = NewDescriptorReference(*desc, done)
+
+	if len(namesToPush) == 0 {
+		return resp, nil, descref, nil
+	}
+
+	// Create finalize callback for pushing
+	finalize := func(ctx context.Context) error {
+		for _, targetName := range namesToPush {
+			err := e.pushImage(ctx, src, buildInfo.SessionID, targetName, desc.Digest)
+			if err != nil {
+				var statusErr remoteserrors.ErrUnexpectedStatus
+				if errors.As(err, &statusErr) {
+					err = errutil.WithDetails(err)
+				}
+				return errors.Wrapf(err, "failed to push %v", targetName)
+			}
+		}
+		return nil
+	}
+
+	return resp, finalize, descref, nil
 }
 
 func (e *imageExporterInstance) pushImage(ctx context.Context, src *exporter.Source, sessionID string, targetName string, dgst digest.Digest) error {

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -18,13 +18,35 @@ type Exporter interface {
 	Resolve(context.Context, int, map[string]string) (ExporterInstance, error)
 }
 
+// FinalizeFunc completes an export operation after all exports have created
+// their artifacts. It may perform network operations like pushing to a registry.
+//
+// Calling FinalizeFunc is optional. If not called (e.g., due to cancellation or
+// an error in another operation), the export will be incomplete but no resources
+// will leak. FinalizeFunc performs completion work only, not cleanup.
+//
+// FinalizeFunc is safe to call concurrently with other FinalizeFunc calls.
+type FinalizeFunc func(ctx context.Context) error
+
 type ExporterInstance interface {
 	ID() int
 	Name() string
 	Config() *Config
 	Type() string
 	Attrs() map[string]string
-	Export(ctx context.Context, src *Source, buildInfo ExportBuildInfo) (map[string]string, DescriptorReference, error)
+
+	// Export performs the export operation and optionally returns a finalize
+	// callback. This separates work that must run sequentially from work that
+	// can run in parallel with other exports (e.g., cache export).
+	//
+	// For exporters that complete all work during Export (tar, local),
+	// return nil for the finalize callback.
+	Export(ctx context.Context, src *Source, buildInfo ExportBuildInfo) (
+		response map[string]string,
+		finalize FinalizeFunc,
+		ref DescriptorReference,
+		err error,
+	)
 }
 
 type ExportBuildInfo struct {

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -643,9 +643,11 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 	}
 
 	// Functions that create new objects in containerd (eg. content blobs) need to have a lease to ensure
-	// that the object is not garbage collected immediately. This is protected by the indivual components,
+	// that the object is not garbage collected immediately. This is protected by the individual components,
 	// but because creating a lease is not cheap and requires a disk write, we create a single lease here
-	// early and let all the exporters, cache export and provenance creation use the same one.
+	// early and let all the exporters, cache export, provenance creation, and finalize callbacks use the
+	// same one. The lease must span both artifact creation and the finalize phase (registry push) to
+	// prevent GC from collecting blobs before they are pushed.
 	lm, err := s.leaseManager()
 	if err != nil {
 		return nil, err
@@ -669,13 +671,31 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 	}
 
 	var exporterResponse map[string]string
-	exporterResponse, descrefs, err = s.runExporters(ctx, id, exp.Exporters, inlineCacheExporter, j, cached, inp)
+	var finalizers []exporter.FinalizeFunc
+	exporterResponse, finalizers, descrefs, err = s.runExporters(ctx, id, exp.Exporters, inlineCacheExporter, j, cached, inp)
 	if err != nil {
 		return nil, err
 	}
 
-	cacheExporterResponse, err := runCacheExporters(ctx, cacheExporters, j, cached, inp)
-	if err != nil {
+	// Run image finalize and cache export in parallel.
+	// Image Export has already created layers in the content store,
+	// so cache exporters can see and reuse them.
+	eg, egCtx := errgroup.WithContext(ctx)
+	for _, finalize := range finalizers {
+		if finalize == nil {
+			continue
+		}
+		eg.Go(func() error {
+			return finalize(egCtx)
+		})
+	}
+	var cacheExporterResponse map[string]string
+	eg.Go(func() error {
+		var err error
+		cacheExporterResponse, err = runCacheExporters(egCtx, cacheExporters, j, cached, inp)
+		return err
+	})
+	if err := eg.Wait(); err != nil {
 		return nil, err
 	}
 
@@ -772,11 +792,10 @@ func validateSourcePolicy(pol *spb.Policy) error {
 func runCacheExporters(ctx context.Context, exporters []RemoteCacheExporter, j *solver.Job, cached *result.Result[solver.CachedResult], inp *result.Result[cache.ImmutableRef]) (map[string]string, error) {
 	eg, ctx := errgroup.WithContext(ctx)
 	g := session.NewGroup(j.SessionID)
-	var cacheExporterResponse map[string]string
 	resps := make([]map[string]string, len(exporters))
 	for i, exp := range exporters {
+		id := fmt.Sprint(j.SessionID, "-cache-", i)
 		eg.Go(func() (err error) {
-			id := fmt.Sprint(j.SessionID, "-cache-", i)
 			err = inBuilderContext(ctx, j, exp.Name(), id, func(ctx context.Context, _ solver.JobContext) error {
 				prepareDone := progress.OneOff(ctx, "preparing build cache for export")
 				if err := result.EachRef(cached, inp, func(res solver.CachedResult, ref cache.ImmutableRef) error {
@@ -796,8 +815,10 @@ func runCacheExporters(ctx context.Context, exporters []RemoteCacheExporter, j *
 				}); err != nil {
 					return prepareDone(err)
 				}
+				prepareDone(nil)
+				finalizeDone := progress.OneOff(ctx, "sending cache export")
 				resps[i], err = exp.Finalize(ctx)
-				return prepareDone(err)
+				return finalizeDone(err)
 			})
 			if exp.IgnoreError {
 				err = nil
@@ -809,8 +830,7 @@ func runCacheExporters(ctx context.Context, exporters []RemoteCacheExporter, j *
 		return nil, err
 	}
 
-	// TODO: separate these out, and return multiple cache exporter responses
-	// to the client
+	var cacheExporterResponse map[string]string
 	for _, resp := range resps {
 		if cacheExporterResponse == nil {
 			cacheExporterResponse = make(map[string]string)
@@ -839,14 +859,15 @@ func runInlineCacheExporter(ctx context.Context, e exporter.ExporterInstance, in
 	return res, done(err)
 }
 
-func (s *Solver) runExporters(ctx context.Context, ref string, exporters []exporter.ExporterInstance, inlineCacheExporter inlineCacheExporter, job *solver.Job, cached *result.Result[solver.CachedResult], inp *exporter.Source) (exporterResponse map[string]string, descrefs []exporter.DescriptorReference, err error) {
+func (s *Solver) runExporters(ctx context.Context, ref string, exporters []exporter.ExporterInstance, inlineCacheExporter inlineCacheExporter, job *solver.Job, cached *result.Result[solver.CachedResult], inp *exporter.Source) (exporterResponse map[string]string, finalizers []exporter.FinalizeFunc, descrefs []exporter.DescriptorReference, err error) {
 	warnings, err := verifier.CheckInvalidPlatforms(ctx, inp)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	eg, ctx := errgroup.WithContext(ctx)
 	resps := make([]map[string]string, len(exporters))
+	finalizeFuncs := make([]exporter.FinalizeFunc, len(exporters))
 	descs := make([]exporter.DescriptorReference, len(exporters))
 	var inlineCacheMu sync.Mutex
 	for i, exp := range exporters {
@@ -871,20 +892,21 @@ func (s *Solver) runExporters(ctx context.Context, ref string, exporters []expor
 					return runInlineCacheExporter(ctx, exp, inlineCacheExporter, job, cached)
 				})
 
-				resps[i], descs[i], err = exp.Export(ctx, inp, exporter.ExportBuildInfo{
+				resp, finalize, desc, expErr := exp.Export(ctx, inp, exporter.ExportBuildInfo{
 					Ref:         ref,
 					SessionID:   job.SessionID,
 					InlineCache: inlineCache,
 				})
-				if err != nil {
-					return err
+				resps[i], finalizeFuncs[i], descs[i] = resp, finalize, desc
+				if expErr != nil {
+					return expErr
 				}
 				return nil
 			})
 		})
 	}
 	if err := eg.Wait(); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	if len(exporters) == 0 && len(warnings) > 0 {
@@ -896,7 +918,7 @@ func (s *Solver) runExporters(ctx context.Context, ref string, exporters []expor
 			return pw.Close()
 		})
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 	}
 
@@ -911,7 +933,7 @@ func (s *Solver) runExporters(ctx context.Context, ref string, exporters []expor
 		}
 	}
 
-	return exporterResponse, descs, nil
+	return exporterResponse, finalizeFuncs, descs, nil
 }
 
 func (s *Solver) leaseManager() (*leaseutil.Manager, error) {


### PR DESCRIPTION
Image export and cache export currently run sequentially. This adds unnecessary latency when both are configured, especially when exporting to different destinations.

Tested with vLLM CI builds. A full build-from-cache takes about 7 minutes, with export dominating: image export runs for ~2min, then cache export for another ~2min. Running them in parallel cuts export time in half, saving ~2 minutes per build (~30% of total time).

The one exception is inline cache: it works by running the cache export first to generate metadata, which is then embedded into the image config before export. This means image export cannot start until inline cache completes, so we preserve sequential execution in that case.