### PR TITLE
registry remotecache: push cache blobs in parallel

### DIFF
--- a/util/resolver/limited/group.go
+++ b/util/resolver/limited/group.go
@@ -20,7 +20,10 @@ type contextKeyT string
 
 var contextKey = contextKeyT("buildkit/util/resolver/limited")
 
-var Default = New(4)
+// DefaultMaxConcurrency is the default number of concurrent connections per registry.
+var DefaultMaxConcurrency int64 = 4
+
+var Default = New(int(DefaultMaxConcurrency))
 
 type Group struct {
 	mu   sync.Mutex


### PR DESCRIPTION
Registry cache blob pushing was sequential, copying one layer at a time. This uses images.Dispatch to push all cache layer blobs in parallel, similar to how image export already handles layer pushing.

The blobs are collected upfront, pushed concurrently, then added to the cache manifest in order after all pushes complete.