### PR TITLE
policy: propagate deny messages from policy error

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -252,6 +252,7 @@ var allTests = []func(t *testing.T, sb integration.Sandbox){
 	testGitResolveMutatedSource,
 	testImageResolveAttestationChainRequiresNetwork,
 	testSourcePolicySession,
+	testSourcePolicySessionDenyMessages,
 	testSourceMetaPolicySession,
 	testSourcePolicyParallelSession,
 	testSourcePolicySignedCommit,

--- a/cmd/buildctl/main.go
+++ b/cmd/buildctl/main.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/moby/buildkit/client/connhelper/ssh"
 	bccommon "github.com/moby/buildkit/cmd/buildctl/common"
 	"github.com/moby/buildkit/solver/errdefs"
+	"github.com/moby/buildkit/sourcepolicy/policysession"
 	"github.com/moby/buildkit/util/apicaps"
 	"github.com/moby/buildkit/util/appdefaults"
 	_ "github.com/moby/buildkit/util/grpcutil/encoding/proto"
@@ -145,6 +146,11 @@ func handleErr(debug bool, err error) {
 	}
 	for _, s := range errdefs.Sources(err) {
 		s.Print(os.Stderr)
+	}
+	for _, msg := range policysession.DenyMessages(err) {
+		if msg.GetMessage() != "" {
+			fmt.Fprintf(os.Stderr, "policy deny: %s\n", msg.GetMessage())
+		}
 	}
 	if debug {
 		fmt.Fprintf(os.Stderr, "error: %+v", stack.Formatter(err))

--- a/solver/llbsolver/policy.go
+++ b/solver/llbsolver/policy.go
@@ -133,7 +133,8 @@ func (p *policyEvaluator) evaluate(ctx context.Context, op *pb.Op, max int) (boo
 			return true, nil
 		}
 		if decision.Action != spb.PolicyAction_ALLOW {
-			return false, errors.Errorf("source %q not allowed by policy: action %s", source.Identifier, decision.Action.String())
+			err := errors.Errorf("source %q not allowed by policy: action %s", source.Identifier, decision.Action.String())
+			return false, policysession.WrapDenyMessages(err, decision.GetDenyMessages())
 		}
 		return ok, nil
 	}

--- a/sourcepolicy/policysession/denyerror.go
+++ b/sourcepolicy/policysession/denyerror.go
@@ -1,0 +1,54 @@
+package policysession
+
+import (
+	"github.com/containerd/typeurl/v2"
+	spb "github.com/moby/buildkit/sourcepolicy/pb"
+	"github.com/moby/buildkit/util/grpcerrors"
+	"github.com/pkg/errors"
+)
+
+func init() {
+	typeurl.Register((*DecisionResponse)(nil), "github.com/moby/buildkit", "policysession.DecisionResponse+json")
+}
+
+// DenyMessagesError wraps an error with policy deny messages so they can be
+// propagated as a typed error detail.
+type DenyMessagesError struct {
+	Messages []*DenyMessage
+	error
+}
+
+func (e *DenyMessagesError) Unwrap() error {
+	return e.error
+}
+
+func (e *DenyMessagesError) ToProto() grpcerrors.TypedErrorProto {
+	return &DecisionResponse{
+		Action:       spb.PolicyAction_DENY,
+		DenyMessages: e.Messages,
+	}
+}
+
+// WrapDenyMessages adds deny messages to an error when available.
+func WrapDenyMessages(err error, msgs []*DenyMessage) error {
+	if err == nil || len(msgs) == 0 {
+		return err
+	}
+	return &DenyMessagesError{Messages: msgs, error: err}
+}
+
+// DenyMessages extracts policy deny messages from an error chain.
+func DenyMessages(err error) []*DenyMessage {
+	var out []*DenyMessage
+	var de *DenyMessagesError
+	if errors.As(err, &de) {
+		out = DenyMessages(de.Unwrap())
+		out = append(out, de.Messages...)
+	}
+	return out
+}
+
+// WrapError implements grpcerrors.TypedErrorProto for DecisionResponse.
+func (d *DecisionResponse) WrapError(err error) error {
+	return WrapDenyMessages(err, d.GetDenyMessages())
+}


### PR DESCRIPTION
If policy responds deny messages, make sure they
carry over to the build error.