### PR TITLE
feat: add release support for linux/arm/v6 arch

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -146,6 +146,7 @@ target "binaries-cross" {
     "darwin/amd64",
     "darwin/arm64",
     "linux/amd64",
+    "linux/arm/v6",
     "linux/arm/v7",
     "linux/arm64",
     "linux/s390x",


### PR DESCRIPTION
This PR enables building BuildKit binaries for the ARMv6 architecture. 

This is needed to support older ARM devices like the Raspberry Pi Zero, Zero W, and original Raspberry Pi Model A/B, which use ARMv6 processors.

The change adds linux/arm/v6 to the binaries-cross target platforms list, alongside the existing ARM targets (arm/v7 and arm64).