### PR TITLE
buildctl: enabled bash completion

### DIFF
--- a/cmd/buildctl/main.go
+++ b/cmd/buildctl/main.go
@@ -44,6 +44,7 @@ func main() {
 	app.Name = "buildctl"
 	app.Usage = "build utility"
 	app.Version = version.Version
+	app.EnableBashCompletion = true
 
 	defaultAddress := os.Getenv("BUILDKIT_HOST")
 	if defaultAddress == "" {


### PR DESCRIPTION
enabled [bash completion](https://cli.urfave.org/v1/examples/bash-completions/)

related https://github.com/carapace-sh/carapace-bin/issues/3194#issuecomment-3768530750