### PR TITLE
dockerui: allow sharedkey sent for local named contexts

### DIFF
--- a/frontend/dockerui/namedcontext.go
+++ b/frontend/dockerui/namedcontext.go
@@ -31,6 +31,7 @@ type NamedContext struct {
 	bc               *Client
 	name             string
 	nameWithPlatform string
+	sharedKey        string
 	opt              ContextOpt
 }
 
@@ -41,12 +42,14 @@ func (bc *Client) namedContext(name string, nameWithPlatform string, opt Context
 	if !ok {
 		return nil, nil
 	}
+	sharedKey := opts["sharedkey:localdir:"+nameWithPlatform]
 
 	return &NamedContext{
 		input:            v,
 		bc:               bc,
 		name:             name,
 		nameWithPlatform: nameWithPlatform,
+		sharedKey:        sharedKey,
 		opt:              opt,
 	}, nil
 }
@@ -265,6 +268,7 @@ func (nc *NamedContext) load(ctx context.Context, count int) (*llb.State, *docke
 			name:             vv[1],
 			nameWithPlatform: nc.nameWithPlatform,
 			sessionID:        sessionID,
+			sharedKey:        nc.sharedKey,
 			excludes:         excludes,
 			extraOpts:        opt.AsyncLocalOpts,
 		}
@@ -310,6 +314,7 @@ type asyncLocalOutput struct {
 	name             string
 	nameWithPlatform string
 	sessionID        string
+	sharedKey        string
 	excludes         []string
 	extraOpts        func() []llb.LocalOption
 	once             sync.Once
@@ -330,10 +335,11 @@ func (a *asyncLocalOutput) do() {
 	if a.extraOpts != nil {
 		extraOpts = a.extraOpts()
 	}
+	sharedKey := "context:" + a.nameWithPlatform + "-" + a.sharedKey
 	opts := append([]llb.LocalOption{
 		llb.WithCustomName("[context " + a.nameWithPlatform + "] load from client"),
 		llb.SessionID(a.sessionID),
-		llb.SharedKeyHint("context:" + a.nameWithPlatform),
+		llb.SharedKeyHint(sharedKey),
 		llb.ExcludePatterns(a.excludes),
 	}, extraOpts...)
 


### PR DESCRIPTION
Avoids the case where two projects that use the named context with the same name would share the destination directory for the upload.

Assuming the client sets a different sharedkey
for them based on the local dir basename.

closes #6470