### PR TITLE
util/tracing/otlptracegrpc: remove errNoClient, and use consistent alias

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -79,6 +79,8 @@ linters:
         - unusedwrite
     importas:
       alias:
+        - pkg: errors
+          alias: stderrors
         - pkg: github.com/containerd/errdefs
           alias: cerrdefs
         - pkg: github.com/opencontainers/image-spec/specs-go/v1

--- a/util/tracing/otlptracegrpc/client.go
+++ b/util/tracing/otlptracegrpc/client.go
@@ -16,6 +16,7 @@ package otlptracegrpc
 
 import (
 	"context"
+	stderrors "errors"
 	"sync"
 	"time"
 
@@ -80,7 +81,8 @@ func (c *client) UploadTraces(ctx context.Context, protoSpans []*tracepb.Resourc
 		c.lock.Lock()
 		defer c.lock.Unlock()
 		if c.tracesClient == nil {
-			return errNoClient
+			// Intentionally using a stdlib error here; see https://github.com/moby/buildkit/commit/f57b3ef89b3053048e7f46d0296d98bcef79448b
+			return stderrors.New("no client")
 		}
 
 		_, err := c.tracesClient.Export(ctx, &coltracepb.ExportTraceServiceRequest{

--- a/util/tracing/otlptracegrpc/errors.go
+++ b/util/tracing/otlptracegrpc/errors.go
@@ -1,7 +1,0 @@
-package otlptracegrpc
-
-import "errors"
-
-var (
-	errNoClient = errors.New("no client")
-)


### PR DESCRIPTION
### util/tracing/otlptracegrpc: remove errNoClient

This error was not exported, and didn't appear to be used as a sentinel
error. It was added in 750f9af97c9c75df4e67374427ea3ef561eb3019. In a later
refactor (f57b3ef89b3053048e7f46d0296d98bcef79448b), it was moved to a separate
file, as it appears to be intentional to use a stdlib error, instead of an
error from `pkg/errors`. Moving it iniline makes it slightly more clear that
it's intentionally using stdlib, but also adding a comment, just in case.