### PR TITLE
frontend: prevent `SecretsUsedInArgOrEnv` warning for `_FILE`/`_VERSION` ARG/ENV names

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -2616,6 +2616,8 @@ func getSecretsRegex() (*regexp.Regexp, *regexp.Regexp) {
 
 		allowTokens := []string{
 			"public",
+			"file",
+			"version",
 		}
 		allowPattern := `(?i)(?:_|^)(?:` + strings.Join(allowTokens, "|") + `)(?:_|$)`
 		secretsAllowRegexp = regexp.MustCompile(allowPattern)

--- a/frontend/dockerfile/dockerfile_lint_test.go
+++ b/frontend/dockerfile/dockerfile_lint_test.go
@@ -244,6 +244,9 @@ ENV apikey=bar sunflower=foo
 ENV git_key=
 ENV PUBLIC_KEY=
 ARG public_token
+ARG SECRET_PASSPHRASE_FILE
+ENV password_file=bar secret_File=baz
+ARG AUTH_MODULE_VERSION
 # check=skip=SecretsUsedInArgOrEnv // allow secret in environment
 ENV password=bar
 # check=skip=SecretsUsedInArgOrEnv // allow secret in arg


### PR DESCRIPTION
Closes #5504

Extending on the PR #5410, I added more allowed tokens to the list.
This should prevent the `SecretsUsedInArgOrEnv` warning when using environment variables like:
- `SESSION_SECRET_FILE` - indicating a file path, not an actual secret value (a common pattern in the community)
- `AUTH_MODULE_VERSION` - indicating a mere version number, not a secret value