### PR TITLE
Add `--automount` flag

### DIFF
--- a/cmd/buildctl/build.go
+++ b/cmd/buildctl/build.go
@@ -95,6 +95,10 @@ var buildCommand = cli.Command{
 			Name:  "ssh",
 			Usage: "Allow forwarding SSH agent or a raw Unix socket to the builder. Format default|<id>[=<socket>[,raw=false]|<key>[,<key>]]",
 		},
+		cli.StringSliceFlag{
+			Name:  "automount",
+			Usage: "Automatically apply mounts to all RUN commands, e.g. --automount type=bind,source=ca.crt,target=/etc/ssl/certs/ca-certificates.crt",
+		},
 		cli.StringFlag{
 			Name:  "metadata-file",
 			Usage: "Output build metadata (e.g., image digest) to a file as JSON",
@@ -265,6 +269,12 @@ func buildAction(clicontext *cli.Context) error {
 	solveOpt.FrontendAttrs, err = build.ParseOpt(clicontext.StringSlice("opt"))
 	if err != nil {
 		return errors.Wrap(err, "invalid opt")
+	}
+
+	if automounts := clicontext.StringSlice("automount"); len(automounts) > 0 {
+		for k, v := range build.ParseAutomount(automounts) {
+			solveOpt.FrontendAttrs[k] = v
+		}
 	}
 
 	solveOpt.LocalMounts, err = build.ParseLocal(clicontext.StringSlice("local"))

--- a/cmd/buildctl/build/automount.go
+++ b/cmd/buildctl/build/automount.go
@@ -1,0 +1,22 @@
+package build
+
+import (
+	"fmt"
+)
+
+const automountPrefix = "automount:"
+
+// ParseAutomount parses --automount flags and returns frontend attributes
+// that can be passed to the dockerfile frontend. Each automount is stored
+// as a separate frontend attribute with a numeric index (automount:0, automount:1, etc.)
+func ParseAutomount(sl []string) map[string]string {
+	if len(sl) == 0 {
+		return nil
+	}
+	attrs := make(map[string]string, len(sl))
+	for i, v := range sl {
+		key := fmt.Sprintf("%s%d", automountPrefix, i)
+		attrs[key] = v
+	}
+	return attrs
+}

--- a/cmd/buildctl/build/automount_test.go
+++ b/cmd/buildctl/build/automount_test.go
@@ -1,0 +1,54 @@
+package build
+
+import (
+	"testing"
+)
+
+func TestParseAutomount(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected map[string]string
+	}{
+		{
+			name:     "empty",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "single automount",
+			input:    []string{"type=bind,source=ca.crt,target=/etc/ssl/certs/ca-certificates.crt"},
+			expected: map[string]string{"automount:0": "type=bind,source=ca.crt,target=/etc/ssl/certs/ca-certificates.crt"},
+		},
+		{
+			name:  "multiple automounts",
+			input: []string{"type=secret,id=https_proxy,env=HTTPS_PROXY", "type=bind,source=proxy.crt,target=/etc/ssl/certs/ca-certificates.crt"},
+			expected: map[string]string{
+				"automount:0": "type=secret,id=https_proxy,env=HTTPS_PROXY",
+				"automount:1": "type=bind,source=proxy.crt,target=/etc/ssl/certs/ca-certificates.crt",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseAutomount(tt.input)
+			if tt.expected == nil {
+				if result != nil {
+					t.Errorf("expected nil, got %v", result)
+				}
+				return
+			}
+
+			if len(result) != len(tt.expected) {
+				t.Errorf("expected %d entries, got %d", len(tt.expected), len(result))
+			}
+
+			for k, v := range tt.expected {
+				if result[k] != v {
+					t.Errorf("expected result[%q] = %q, got %q", k, v, result[k])
+				}
+			}
+		})
+	}
+}

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -1305,17 +1305,17 @@ func dispatchRun(d *dispatchState, c *instructions.RunCommand, proxy *llb.ProxyE
 		opt = append(opt, llb.WithProxy(*proxy))
 	}
 
-	runMounts, err := dispatchRunMounts(d, c, sources, dopt)
-	if err != nil {
-		return err
-	}
-	opt = append(opt, runMounts...)
-
 	automountOpts, err := dispatchAutomounts(d, dopt)
 	if err != nil {
 		return err
 	}
 	opt = append(opt, automountOpts...)
+
+	runMounts, err := dispatchRunMounts(d, c, sources, dopt)
+	if err != nil {
+		return err
+	}
+	opt = append(opt, runMounts...)
 
 	securityOpt, err := dispatchRunSecurity(c)
 	if err != nil {

--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -736,6 +736,7 @@ func toDispatchState(ctx context.Context, dt []byte, opt ConvertOpt) (*dispatchS
 			sourceMap:           opt.SourceMap,
 			lint:                lint,
 			dockerIgnoreMatcher: dockerIgnoreMatcher,
+			automounts:          opt.Automounts,
 		}
 
 		for _, cmd := range d.commands {
@@ -885,6 +886,7 @@ type dispatchOpt struct {
 	sourceMap           *llb.SourceMap
 	lint                *linter.Linter
 	dockerIgnoreMatcher *patternmatcher.PatternMatcher
+	automounts          []string
 }
 
 func getEnv(state llb.State) shell.EnvGetter {
@@ -1308,6 +1310,12 @@ func dispatchRun(d *dispatchState, c *instructions.RunCommand, proxy *llb.ProxyE
 		return err
 	}
 	opt = append(opt, runMounts...)
+
+	automountOpts, err := dispatchAutomounts(d, dopt)
+	if err != nil {
+		return err
+	}
+	opt = append(opt, automountOpts...)
 
 	securityOpt, err := dispatchRunSecurity(c)
 	if err != nil {

--- a/frontend/dockerfile/dockerfile2llb/convert_automount.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_automount.go
@@ -38,15 +38,10 @@ func dispatchAutomounts(d *dispatchState, opt dispatchOpt) ([]llb.RunOption, err
 				return nil, errors.Errorf("automount cannot reference Dockerfile stage %q: only external images and named contexts are allowed", mount.From)
 			}
 			
-			// Create an unregistered state for external image or named context
-			// This follows the same pattern as detectRunMount for external references
-			src := &dispatchState{
-				stage:        instructions.Stage{BaseName: mount.From},
-				deps:         make(map[*dispatchState]instructions.Command),
-				paths:        make(map[string]struct{}),
-				unregistered: true,
-			}
-			st = src.state
+			// Use llb.Image() for external images/named contexts
+			// This is simpler than creating an unregistered dispatch state since we don't
+			// need the full dispatch machinery for external references in automounts
+			st = llb.Image(mount.From)
 		} else if mount.Type == instructions.MountTypeCache {
 			// For cache mounts without a from, use scratch like regular mounts do
 			st = llb.Scratch()

--- a/frontend/dockerfile/dockerfile2llb/convert_automount.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_automount.go
@@ -1,0 +1,54 @@
+package dockerfile2llb
+
+import (
+	"path"
+	"path/filepath"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+	"github.com/pkg/errors"
+)
+
+// dispatchAutomounts converts automount specifications to LLB run options.
+// Automounts are applied to all RUN commands, allowing users to inject mounts
+// like CA certificates or proxy configuration without modifying the Dockerfile.
+func dispatchAutomounts(d *dispatchState, opt dispatchOpt) ([]llb.RunOption, error) {
+	if len(opt.automounts) == 0 {
+		return nil, nil
+	}
+
+	var out []llb.RunOption
+
+	for _, automountSpec := range opt.automounts {
+		mount, err := instructions.ParseMount(automountSpec, nil)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to parse automount %q", automountSpec)
+		}
+
+		// Automounts don't support "from" - they always use the build context
+		if mount.From != "" {
+			return nil, errors.Errorf("automount does not support 'from' option: %q", automountSpec)
+		}
+
+		// For cache mounts without a from, use scratch like regular mounts do
+		st := opt.buildContext
+		if mount.Type == instructions.MountTypeCache {
+			st = llb.Scratch()
+		}
+
+		runOpt, err := dispatchMount(d, mount, st, opt)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to dispatch automount %q", automountSpec)
+		}
+		if runOpt != nil {
+			out = append(out, runOpt)
+		}
+
+		// Track context paths for bind mounts
+		if mount.Type == instructions.MountTypeBind {
+			d.ctxPaths[path.Join("/", filepath.ToSlash(mount.Source))] = struct{}{}
+		}
+	}
+
+	return out, nil
+}

--- a/frontend/dockerfile/dockerfile2llb/convert_automount.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_automount.go
@@ -19,6 +19,12 @@ func dispatchAutomounts(d *dispatchState, opt dispatchOpt) ([]llb.RunOption, err
 
 	var out []llb.RunOption
 
+	// Create a no-op expander that doesn't expand variables
+	// Automounts should not support variable expansion
+	noopExpander := func(word string) (string, error) {
+		return word, nil
+	}
+
 	for _, automountSpec := range opt.automounts {
 		// Use a simple pass-through expander for automount specs.
 		// NOTE: This intentionally does NOT perform any variable or build-arg expansion.

--- a/frontend/dockerfile/dockerfile2llb/convert_automount.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_automount.go
@@ -20,7 +20,10 @@ func dispatchAutomounts(d *dispatchState, opt dispatchOpt) ([]llb.RunOption, err
 	var out []llb.RunOption
 
 	for _, automountSpec := range opt.automounts {
-		// Use a simple pass-through expander since automount specs are literal (not from Dockerfile)
+		// Use a simple pass-through expander for automount specs.
+		// NOTE: This intentionally does NOT perform any variable or build-arg expansion.
+		// Automounts are specified at the CLI level and treated as literal values, so
+		// patterns like "source=${MY_VAR}" will not be expanded here.
 		expander := func(s string) (string, error) {
 			return s, nil
 		}

--- a/frontend/dockerfile/dockerfile2llb/convert_automount.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_automount.go
@@ -20,7 +20,11 @@ func dispatchAutomounts(d *dispatchState, opt dispatchOpt) ([]llb.RunOption, err
 	var out []llb.RunOption
 
 	for _, automountSpec := range opt.automounts {
-		mount, err := instructions.ParseMount(automountSpec, nil)
+		// Use a simple pass-through expander since automount specs are literal (not from Dockerfile)
+		expander := func(s string) (string, error) {
+			return s, nil
+		}
+		mount, err := instructions.ParseMount(automountSpec, expander)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to parse automount %q", automountSpec)
 		}
@@ -36,7 +40,7 @@ func dispatchAutomounts(d *dispatchState, opt dispatchOpt) ([]llb.RunOption, err
 			st = llb.Scratch()
 		}
 
-		runOpt, err := dispatchMount(d, mount, st, opt)
+		runOpt, err := dispatchMount(d, mount, st, opt, nil)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to dispatch automount %q", automountSpec)
 		}

--- a/frontend/dockerfile/dockerfile2llb/convert_automount.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_automount.go
@@ -19,12 +19,6 @@ func dispatchAutomounts(d *dispatchState, opt dispatchOpt) ([]llb.RunOption, err
 
 	var out []llb.RunOption
 
-	// Create a no-op expander that doesn't expand variables
-	// Automounts should not support variable expansion
-	noopExpander := func(word string) (string, error) {
-		return word, nil
-	}
-
 	for _, automountSpec := range opt.automounts {
 		// Use a simple pass-through expander for automount specs.
 		// NOTE: This intentionally does NOT perform any variable or build-arg expansion.

--- a/frontend/dockerfile/dockerfile2llb/convert_runmount.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_runmount.go
@@ -77,73 +77,81 @@ func dispatchRunMounts(d *dispatchState, c *instructions.RunCommand, sources []*
 				return nil, errors.Errorf("cannot mount from stage %q to %q, stage needs to be defined before current command", mount.From, mount.Target)
 			}
 		}
-		var mountOpts []llb.MountOption
-		if mount.Type == instructions.MountTypeTmpfs {
-			st = llb.Scratch()
-			mountOpts = append(mountOpts, llb.Tmpfs(
-				llb.TmpfsSize(mount.SizeLimit),
-			))
+
+		runOpt, err := dispatchMount(d, mount, st, opt)
+		if err != nil {
+			return nil, err
 		}
-		if mount.Type == instructions.MountTypeSecret {
-			secret, err := dispatchSecret(d, mount, c.Location())
-			if err != nil {
-				return nil, err
-			}
-			out = append(out, secret)
-			continue
-		}
-		if mount.Type == instructions.MountTypeSSH {
-			ssh, err := dispatchSSH(d, mount, c.Location())
-			if err != nil {
-				return nil, err
-			}
-			out = append(out, ssh)
-			continue
-		}
-		if mount.ReadOnly {
-			mountOpts = append(mountOpts, llb.Readonly)
-		} else if mount.Type == instructions.MountTypeBind && opt.llbCaps.Supports(pb.CapExecMountBindReadWriteNoOutput) == nil {
-			mountOpts = append(mountOpts, llb.ForceNoOutput)
-		}
-		if mount.Type == instructions.MountTypeCache {
-			sharing := llb.CacheMountShared
-			if mount.CacheSharing == instructions.MountSharingPrivate {
-				sharing = llb.CacheMountPrivate
-			}
-			if mount.CacheSharing == instructions.MountSharingLocked {
-				sharing = llb.CacheMountLocked
-			}
-			if mount.CacheID == "" {
-				mount.CacheID = path.Clean(mount.Target)
-			}
-			mountOpts = append(mountOpts, llb.AsPersistentCacheDir(opt.cacheIDNamespace+"/"+mount.CacheID, sharing))
-		}
-		target := mount.Target
-		if !system.IsAbsolutePath(filepath.Clean(mount.Target)) {
-			dir, err := d.state.GetDir(context.TODO())
-			if err != nil {
-				return nil, err
-			}
-			target = filepath.Join("/", dir, mount.Target)
-		}
-		if target == "/" {
-			return nil, errors.Errorf("invalid mount target %q", target)
-		}
-		if src := path.Join("/", mount.Source); src != "/" {
-			mountOpts = append(mountOpts, llb.SourcePath(src))
-		} else if mount.UID != nil || mount.GID != nil || mount.Mode != nil {
-			st = setCacheUIDGID(mount, st)
-			mountOpts = append(mountOpts, llb.SourcePath("/cache"))
+		if runOpt != nil {
+			out = append(out, runOpt)
 		}
 
-		out = append(out, llb.AddMount(target, st, mountOpts...))
-
-		if mount.From == "" {
-			d.ctxPaths[path.Join("/", filepath.ToSlash(mount.Source))] = struct{}{}
-		} else {
-			source := sources[i]
-			source.paths[path.Join("/", filepath.ToSlash(mount.Source))] = struct{}{}
+		// Track paths for incremental context transfer
+		if mount.Type != instructions.MountTypeSecret && mount.Type != instructions.MountTypeSSH && mount.Type != instructions.MountTypeTmpfs {
+			if mount.From == "" {
+				d.ctxPaths[path.Join("/", filepath.ToSlash(mount.Source))] = struct{}{}
+			} else {
+				source := sources[i]
+				source.paths[path.Join("/", filepath.ToSlash(mount.Source))] = struct{}{}
+			}
 		}
 	}
 	return out, nil
+}
+
+// dispatchMount converts a single mount specification to an LLB run option.
+// This is shared between dispatchRunMounts (for RUN --mount=...) and
+// dispatchAutomounts (for --automount CLI flag).
+func dispatchMount(d *dispatchState, mount *instructions.Mount, st llb.State, opt dispatchOpt) (llb.RunOption, error) {
+	var mountOpts []llb.MountOption
+
+	if mount.Type == instructions.MountTypeTmpfs {
+		st = llb.Scratch()
+		mountOpts = append(mountOpts, llb.Tmpfs(
+			llb.TmpfsSize(mount.SizeLimit),
+		))
+	}
+	if mount.Type == instructions.MountTypeSecret {
+		return dispatchSecret(d, mount, nil)
+	}
+	if mount.Type == instructions.MountTypeSSH {
+		return dispatchSSH(d, mount, nil)
+	}
+	if mount.ReadOnly {
+		mountOpts = append(mountOpts, llb.Readonly)
+	} else if mount.Type == instructions.MountTypeBind && opt.llbCaps != nil && opt.llbCaps.Supports(pb.CapExecMountBindReadWriteNoOutput) == nil {
+		mountOpts = append(mountOpts, llb.ForceNoOutput)
+	}
+	if mount.Type == instructions.MountTypeCache {
+		sharing := llb.CacheMountShared
+		if mount.CacheSharing == instructions.MountSharingPrivate {
+			sharing = llb.CacheMountPrivate
+		}
+		if mount.CacheSharing == instructions.MountSharingLocked {
+			sharing = llb.CacheMountLocked
+		}
+		if mount.CacheID == "" {
+			mount.CacheID = path.Clean(mount.Target)
+		}
+		mountOpts = append(mountOpts, llb.AsPersistentCacheDir(opt.cacheIDNamespace+"/"+mount.CacheID, sharing))
+	}
+	target := mount.Target
+	if !system.IsAbsolutePath(filepath.Clean(mount.Target)) {
+		dir, err := d.state.GetDir(context.TODO())
+		if err != nil {
+			return nil, err
+		}
+		target = filepath.Join("/", dir, mount.Target)
+	}
+	if target == "/" {
+		return nil, errors.Errorf("invalid mount target %q", target)
+	}
+	if src := path.Join("/", mount.Source); src != "/" {
+		mountOpts = append(mountOpts, llb.SourcePath(src))
+	} else if mount.UID != nil || mount.GID != nil || mount.Mode != nil {
+		st = setCacheUIDGID(mount, st)
+		mountOpts = append(mountOpts, llb.SourcePath("/cache"))
+	}
+
+	return llb.AddMount(target, st, mountOpts...), nil
 }

--- a/frontend/dockerfile/dockerfile2llb/convert_test.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_test.go
@@ -230,3 +230,73 @@ RUN echo bar
 	assert.Equal(t, []digest.Digest{"sha256:2e112031b4b923a873c8b3d685d48037e4d5ccd967b658743d93a6e56c3064b9"}, baseImg.RootFS.DiffIDs)
 	assert.Equal(t, "2024-01-17 21:49:12 +0000 UTC", baseImg.Created.String())
 }
+
+func TestAutomounts(t *testing.T) {
+	t.Parallel()
+
+	// Test basic automount with bind mount
+	df := `FROM scratch
+RUN echo test
+RUN echo test2
+`
+	_, _, _, _, err := Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{
+		Config: dockerui.Config{
+			Automounts: []string{
+				"type=bind,source=/src,target=/mnt/src",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Test automount with cache mount
+	_, _, _, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{
+		Config: dockerui.Config{
+			Automounts: []string{
+				"type=cache,target=/cache",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Test automount with tmpfs mount
+	_, _, _, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{
+		Config: dockerui.Config{
+			Automounts: []string{
+				"type=tmpfs,target=/tmp/data",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Test multiple automounts
+	_, _, _, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{
+		Config: dockerui.Config{
+			Automounts: []string{
+				"type=bind,source=/src,target=/mnt/src",
+				"type=cache,target=/cache",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Test that automount with 'from' fails
+	_, _, _, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{
+		Config: dockerui.Config{
+			Automounts: []string{
+				"type=bind,from=stage1,source=/src,target=/mnt/src",
+			},
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "automount does not support 'from' option")
+
+	// Test invalid automount spec
+	_, _, _, _, err = Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{
+		Config: dockerui.Config{
+			Automounts: []string{
+				"invalid-mount-spec",
+			},
+		},
+	})
+	require.Error(t, err)
+}

--- a/frontend/dockerfile/dockerfile_automount_test.go
+++ b/frontend/dockerfile/dockerfile_automount_test.go
@@ -1,0 +1,379 @@
+package dockerfile
+
+import (
+	"testing"
+
+	"github.com/containerd/continuity/fs/fstest"
+	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/frontend/dockerui"
+	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/session/secrets/secretsprovider"
+	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/stretchr/testify/require"
+	"github.com/tonistiigi/fsutil"
+)
+
+var automountTests = integration.TestFuncs(
+	testAutomountSecret,
+	testAutomountSecretMultipleRuns,
+	testAutomountMultiple,
+	testAutomountCache,
+	testAutomountBind,
+	testAutomountTmpfs,
+	testAutomountWithExplicitMount,
+	testAutomountAppliesAllStages,
+	testAutomountInvalidFrom,
+	testAutomountInvalidSpec,
+)
+
+func init() {
+	allTests = append(allTests, automountTests...)
+}
+
+func testAutomountSecret(t *testing.T, sb integration.Sandbox) {
+	integration.SkipOnPlatform(t, "windows")
+	f := getFrontend(t, sb)
+
+	dockerfile := []byte(`
+FROM busybox
+RUN [ "$(cat /run/secrets/mysecret)" = "secret-content" ]
+`)
+
+	dir := integration.Tmpdir(
+		t,
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+	)
+
+	c, err := client.New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
+		FrontendAttrs: map[string]string{
+			"automount:0": "type=secret,id=mysecret,target=/run/secrets/mysecret",
+		},
+		Session: []session.Attachable{
+			secretsprovider.FromMap(map[string][]byte{
+				"mysecret": []byte("secret-content"),
+			}),
+		},
+		LocalMounts: map[string]fsutil.FS{
+			dockerui.DefaultLocalNameDockerfile: dir,
+			dockerui.DefaultLocalNameContext:    dir,
+		},
+	}, nil)
+	require.NoError(t, err)
+}
+
+func testAutomountSecretMultipleRuns(t *testing.T, sb integration.Sandbox) {
+	integration.SkipOnPlatform(t, "windows")
+	f := getFrontend(t, sb)
+
+	dockerfile := []byte(`
+FROM busybox
+RUN [ "$(cat /run/secrets/token)" = "my-token" ]
+RUN echo "Second RUN" && [ -f /run/secrets/token ]
+RUN cat /run/secrets/token > /tmp/verify && [ "$(cat /tmp/verify)" = "my-token" ]
+`)
+
+	dir := integration.Tmpdir(
+		t,
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+	)
+
+	c, err := client.New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
+		FrontendAttrs: map[string]string{
+			"automount:0": "type=secret,id=token,target=/run/secrets/token",
+		},
+		Session: []session.Attachable{
+			secretsprovider.FromMap(map[string][]byte{
+				"token": []byte("my-token"),
+			}),
+		},
+		LocalMounts: map[string]fsutil.FS{
+			dockerui.DefaultLocalNameDockerfile: dir,
+			dockerui.DefaultLocalNameContext:    dir,
+		},
+	}, nil)
+	require.NoError(t, err)
+}
+
+func testAutomountMultiple(t *testing.T, sb integration.Sandbox) {
+	integration.SkipOnPlatform(t, "windows")
+	f := getFrontend(t, sb)
+
+	dockerfile := []byte(`
+FROM busybox
+RUN [ "$(cat /secrets/secret1)" = "value1" ]
+RUN [ "$(cat /secrets/secret2)" = "value2" ]
+RUN echo "cached" > /cache/test.txt
+RUN [ "$(cat /cache/test.txt)" = "cached" ]
+`)
+
+	dir := integration.Tmpdir(
+		t,
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+	)
+
+	c, err := client.New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
+		FrontendAttrs: map[string]string{
+			"automount:0": "type=secret,id=secret1,target=/secrets/secret1",
+			"automount:1": "type=secret,id=secret2,target=/secrets/secret2",
+			"automount:2": "type=cache,target=/cache",
+		},
+		Session: []session.Attachable{
+			secretsprovider.FromMap(map[string][]byte{
+				"secret1": []byte("value1"),
+				"secret2": []byte("value2"),
+			}),
+		},
+		LocalMounts: map[string]fsutil.FS{
+			dockerui.DefaultLocalNameDockerfile: dir,
+			dockerui.DefaultLocalNameContext:    dir,
+		},
+	}, nil)
+	require.NoError(t, err)
+}
+
+func testAutomountCache(t *testing.T, sb integration.Sandbox) {
+	integration.SkipOnPlatform(t, "windows")
+	f := getFrontend(t, sb)
+
+	dockerfile := []byte(`
+FROM busybox
+RUN echo "first" > /mycache/data.txt
+RUN [ "$(cat /mycache/data.txt)" = "first" ]
+RUN echo "second" >> /mycache/data.txt
+RUN grep -q "first" /mycache/data.txt && grep -q "second" /mycache/data.txt
+`)
+
+	dir := integration.Tmpdir(
+		t,
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+	)
+
+	c, err := client.New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
+		FrontendAttrs: map[string]string{
+			"automount:0": "type=cache,target=/mycache,id=testcache",
+		},
+		LocalMounts: map[string]fsutil.FS{
+			dockerui.DefaultLocalNameDockerfile: dir,
+			dockerui.DefaultLocalNameContext:    dir,
+		},
+	}, nil)
+	require.NoError(t, err)
+}
+
+func testAutomountBind(t *testing.T, sb integration.Sandbox) {
+	integration.SkipOnPlatform(t, "windows")
+	f := getFrontend(t, sb)
+
+	dockerfile := []byte(`
+FROM busybox
+RUN [ "$(cat /context/config)" = "config-data" ]
+`)
+
+	dir := integration.Tmpdir(
+		t,
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+		fstest.CreateFile("config", []byte("config-data"), 0600),
+	)
+
+	c, err := client.New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
+		FrontendAttrs: map[string]string{
+			"automount:0": "type=bind,source=.,target=/context",
+		},
+		LocalMounts: map[string]fsutil.FS{
+			dockerui.DefaultLocalNameDockerfile: dir,
+			dockerui.DefaultLocalNameContext:    dir,
+		},
+	}, nil)
+	require.NoError(t, err)
+}
+
+func testAutomountTmpfs(t *testing.T, sb integration.Sandbox) {
+	integration.SkipOnPlatform(t, "windows")
+	f := getFrontend(t, sb)
+
+	dockerfile := []byte(`
+FROM busybox
+RUN touch /tmpdata/foo && [ -f /tmpdata/foo ]
+RUN [ ! -f /tmpdata/foo ]
+`)
+
+	dir := integration.Tmpdir(
+		t,
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+	)
+
+	c, err := client.New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
+		FrontendAttrs: map[string]string{
+			"automount:0": "type=tmpfs,target=/tmpdata",
+		},
+		LocalMounts: map[string]fsutil.FS{
+			dockerui.DefaultLocalNameDockerfile: dir,
+			dockerui.DefaultLocalNameContext:    dir,
+		},
+	}, nil)
+	require.NoError(t, err)
+}
+
+func testAutomountWithExplicitMount(t *testing.T, sb integration.Sandbox) {
+	integration.SkipOnPlatform(t, "windows")
+	f := getFrontend(t, sb)
+
+	dockerfile := []byte(`
+FROM busybox
+RUN [ "$(cat /run/secrets/auto)" = "auto-secret" ]
+RUN --mount=type=secret,id=explicit,target=/run/secrets/explicit [ "$(cat /run/secrets/explicit)" = "explicit-secret" ] && [ "$(cat /run/secrets/auto)" = "auto-secret" ]
+`)
+
+	dir := integration.Tmpdir(
+		t,
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+	)
+
+	c, err := client.New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
+		FrontendAttrs: map[string]string{
+			"automount:0": "type=secret,id=auto,target=/run/secrets/auto",
+		},
+		Session: []session.Attachable{
+			secretsprovider.FromMap(map[string][]byte{
+				"auto":     []byte("auto-secret"),
+				"explicit": []byte("explicit-secret"),
+			}),
+		},
+		LocalMounts: map[string]fsutil.FS{
+			dockerui.DefaultLocalNameDockerfile: dir,
+			dockerui.DefaultLocalNameContext:    dir,
+		},
+	}, nil)
+	require.NoError(t, err)
+}
+
+func testAutomountAppliesAllStages(t *testing.T, sb integration.Sandbox) {
+	integration.SkipOnPlatform(t, "windows")
+	f := getFrontend(t, sb)
+
+	dockerfile := []byte(`
+FROM busybox AS stage1
+RUN [ "$(cat /run/secrets/shared)" = "shared-value" ]
+
+FROM busybox AS stage2
+RUN [ "$(cat /run/secrets/shared)" = "shared-value" ]
+
+FROM busybox
+RUN [ "$(cat /run/secrets/shared)" = "shared-value" ]
+`)
+
+	dir := integration.Tmpdir(
+		t,
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+	)
+
+	c, err := client.New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
+		FrontendAttrs: map[string]string{
+			"automount:0": "type=secret,id=shared,target=/run/secrets/shared",
+		},
+		Session: []session.Attachable{
+			secretsprovider.FromMap(map[string][]byte{
+				"shared": []byte("shared-value"),
+			}),
+		},
+		LocalMounts: map[string]fsutil.FS{
+			dockerui.DefaultLocalNameDockerfile: dir,
+			dockerui.DefaultLocalNameContext:    dir,
+		},
+	}, nil)
+	require.NoError(t, err)
+}
+
+func testAutomountInvalidFrom(t *testing.T, sb integration.Sandbox) {
+	integration.SkipOnPlatform(t, "windows")
+	f := getFrontend(t, sb)
+
+	dockerfile := []byte(`
+FROM busybox
+RUN echo "test"
+`)
+
+	dir := integration.Tmpdir(
+		t,
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+	)
+
+	c, err := client.New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
+		FrontendAttrs: map[string]string{
+			"automount:0": "type=bind,from=builder,target=/data",
+		},
+		LocalMounts: map[string]fsutil.FS{
+			dockerui.DefaultLocalNameDockerfile: dir,
+			dockerui.DefaultLocalNameContext:    dir,
+		},
+	}, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "automount does not support 'from' option")
+}
+
+func testAutomountInvalidSpec(t *testing.T, sb integration.Sandbox) {
+	integration.SkipOnPlatform(t, "windows")
+	f := getFrontend(t, sb)
+
+	dockerfile := []byte(`
+FROM busybox
+RUN echo "test"
+`)
+
+	dir := integration.Tmpdir(
+		t,
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+	)
+
+	c, err := client.New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
+		FrontendAttrs: map[string]string{
+			"automount:0": "invalid-mount-spec",
+		},
+		LocalMounts: map[string]fsutil.FS{
+			dockerui.DefaultLocalNameDockerfile: dir,
+			dockerui.DefaultLocalNameContext:    dir,
+		},
+	}, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to parse automount")
+}

--- a/frontend/dockerfile/instructions/commands_runmount.go
+++ b/frontend/dockerfile/instructions/commands_runmount.go
@@ -85,7 +85,7 @@ func setMountState(cmd *RunCommand, expander SingleWordExpander) error {
 	}
 	mounts := make([]*Mount, len(st.flag.StringValues))
 	for i, str := range st.flag.StringValues {
-		m, err := parseMount(str, expander)
+		m, err := ParseMount(str, expander)
 		if err != nil {
 			return err
 		}
@@ -130,7 +130,9 @@ type Mount struct {
 	GID  *uint64
 }
 
-func parseMount(val string, expander SingleWordExpander) (*Mount, error) {
+// ParseMount parses a mount specification string (e.g. "type=bind,source=/src,target=/dst")
+// and returns a Mount struct. The expander parameter is used for variable expansion.
+func ParseMount(val string, expander SingleWordExpander) (*Mount, error) {
 	fields, err := csvvalue.Fields(val, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse csv mounts")

--- a/frontend/dockerui/attr.go
+++ b/frontend/dockerui/attr.go
@@ -2,6 +2,7 @@ package dockerui
 
 import (
 	"net"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -143,4 +144,32 @@ func filter(opt map[string]string, key string) map[string]string {
 		}
 	}
 	return m
+}
+
+// filterValues extracts values from opt map where keys start with the given prefix.
+// The values are returned as a slice, sorted by key to maintain stable ordering.
+func filterValues(opt map[string]string, prefix string) []string {
+	// First collect all matching values
+	m := filter(opt, prefix)
+	if len(m) == 0 {
+		return nil
+	}
+
+	// Sort keys numerically (automount:0, automount:1, etc.)
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	// Keys are numeric strings, sort them
+	slices.SortFunc(keys, func(a, b string) int {
+		ai, _ := strconv.Atoi(a)
+		bi, _ := strconv.Atoi(b)
+		return ai - bi
+	})
+
+	values := make([]string, 0, len(m))
+	for _, k := range keys {
+		values = append(values, m[k])
+	}
+	return values
 }

--- a/frontend/dockerui/attr_test.go
+++ b/frontend/dockerui/attr_test.go
@@ -1,0 +1,68 @@
+package dockerui
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFilterValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		opt      map[string]string
+		prefix   string
+		expected []string
+	}{
+		{
+			name:     "empty map",
+			opt:      map[string]string{},
+			prefix:   "automount:",
+			expected: nil,
+		},
+		{
+			name: "no matching prefix",
+			opt: map[string]string{
+				"build-arg:FOO": "bar",
+			},
+			prefix:   "automount:",
+			expected: nil,
+		},
+		{
+			name: "single match",
+			opt: map[string]string{
+				"automount:0": "type=bind,source=ca.crt,target=/etc/ssl/certs/ca-certificates.crt",
+			},
+			prefix:   "automount:",
+			expected: []string{"type=bind,source=ca.crt,target=/etc/ssl/certs/ca-certificates.crt"},
+		},
+		{
+			name: "multiple matches sorted",
+			opt: map[string]string{
+				"automount:2": "third",
+				"automount:0": "first",
+				"automount:1": "second",
+			},
+			prefix:   "automount:",
+			expected: []string{"first", "second", "third"},
+		},
+		{
+			name: "mixed with other prefixes",
+			opt: map[string]string{
+				"build-arg:FOO": "bar",
+				"automount:1":   "second",
+				"automount:0":   "first",
+				"label:app":     "myapp",
+			},
+			prefix:   "automount:",
+			expected: []string{"first", "second"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterValues(tt.opt, tt.prefix)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}

--- a/frontend/dockerui/config.go
+++ b/frontend/dockerui/config.go
@@ -29,6 +29,7 @@ const (
 	buildArgPrefix       = "build-arg:"
 	labelPrefix          = "label:"
 	localSessionIDPrefix = "local-sessionid:"
+	automountPrefix      = "automount:"
 
 	keyTarget           = "target"
 	keyCgroupParent     = "cgroup-parent"
@@ -75,6 +76,10 @@ type Config struct {
 	BuildPlatforms         []ocispecs.Platform
 	MultiPlatformRequested bool
 	SBOM                   *SBOM
+
+	// Automounts are mounts that are automatically applied to all RUN commands.
+	// These are specified via --automount on the command line.
+	Automounts []string
 }
 
 type Client struct {
@@ -287,6 +292,7 @@ func (bc *Client) init() error {
 
 	bc.BuildArgs = filter(opts, buildArgPrefix)
 	bc.Labels = filter(opts, labelPrefix)
+	bc.Automounts = filterValues(opts, automountPrefix)
 	bc.CacheIDNamespace = opts[keyCacheNSArg]
 	bc.CgroupParent = opts[keyCgroupParent]
 	bc.Target = opts[keyTarget]


### PR DESCRIPTION
This PR adds and `--automount` flag to `buildctl build` that behaves semantically as if a corresponding implied `--mount` flag was specified on every `RUN` command of a Dockerfile. This is based on an original suggestion by @rittneje  in https://github.com/moby/buildkit/issues/2594.

The primary use case from my PoV is to inject a custom SSL certificate chain at build time, which is usually a property of the environment in which the build takes place that one does not want to encode into the Dockerfile itself.

Example use:

```
$ buildctl build --frontend dockerfile.v0 --local context=. --local dockerfile=. \
    --automount type=bind,source=$SSL_CERT_FILE,target=/etc/ssl/certs/ca-certificates.crt,readonly
```

I'm hoping that down the line we can expose the same flag to `docker buildx build`.

---

Disclaimer: This PR was assisted by Claude Code (writing) and GitHub Copilot (review). I've reviewed the contents and claim them to be adequate, but I have not contributed to a Go project before nor am I much familiar with the language. If the quality of the PR is not up to standards, I'm happy to take pointers and go back to the drawing board.