### PR TITLE
policy: fix ResolveAttestations via policy callback

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -257,6 +257,7 @@ var allTests = []func(t *testing.T, sb integration.Sandbox){
 	testSourcePolicySession,
 	testSourcePolicySessionDenyMessages,
 	testSourceMetaPolicySession,
+	testSourceMetaPolicySessionResolveAttestations,
 	testSourcePolicyParallelSession,
 	testSourcePolicySignedCommit,
 	testSourcePolicySessionConvert,
@@ -12590,7 +12591,7 @@ func buildProvenanceImage(ctx context.Context, t *testing.T, c *Client, sb integ
 
 	_, err = c.Build(ctx, SolveOpt{
 		FrontendAttrs: map[string]string{
-			"attest:provenance": "mode=max",
+			"attest:provenance": "mode=max,version=v1",
 		},
 		Exports: []ExportEntry{
 			{

--- a/solver/llbsolver/policy.go
+++ b/solver/llbsolver/policy.go
@@ -2,6 +2,7 @@ package llbsolver
 
 import (
 	"context"
+	"slices"
 	"strings"
 
 	"github.com/moby/buildkit/client/llb/sourceresolver"
@@ -99,6 +100,7 @@ func (p *policyEvaluator) evaluate(ctx context.Context, op *pb.Op, max int) (boo
 				}
 				op.ImageOpt.NoConfig = metareq.Image.NoConfig
 				op.ImageOpt.AttestationChain = metareq.Image.AttestationChain
+				op.ImageOpt.ResolveAttestations = slices.Clone(metareq.Image.ResolveAttestations)
 			}
 
 			if metareq.Git != nil {


### PR DESCRIPTION
follow-up fix for #6514

Metadata was not resolved if request came via policy response.