### PR TITLE
util/resolver/limited: make registry concurrency configurable via BUILDKIT_MAX_REGISTRY_CONCURRENCY

### DIFF
--- a/util/resolver/limited/group.go
+++ b/util/resolver/limited/group.go
@@ -3,7 +3,9 @@ package limited
 import (
 	"context"
 	"io"
+	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -21,9 +23,19 @@ type contextKeyT string
 var contextKey = contextKeyT("buildkit/util/resolver/limited")
 
 // DefaultMaxConcurrency is the default number of concurrent connections per registry.
-var DefaultMaxConcurrency int64 = 4
+// It can be overridden by setting the BUILDKIT_MAX_REGISTRY_CONCURRENCY environment variable.
+var DefaultMaxConcurrency = getMaxConcurrency()
 
 var Default = New(int(DefaultMaxConcurrency))
+
+func getMaxConcurrency() int64 {
+	if v := os.Getenv("BUILDKIT_MAX_REGISTRY_CONCURRENCY"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			return n
+		}
+	}
+	return 4
+}
 
 type Group struct {
 	mu   sync.Mutex

--- a/util/resolver/limited/group_test.go
+++ b/util/resolver/limited/group_test.go
@@ -1,0 +1,59 @@
+package limited
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetMaxConcurrency(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected int64
+	}{
+		{
+			name:     "default when unset",
+			envValue: "",
+			expected: 4,
+		},
+		{
+			name:     "custom valid value",
+			envValue: "20",
+			expected: 20,
+		},
+		{
+			name:     "minimum valid value",
+			envValue: "1",
+			expected: 1,
+		},
+		{
+			name:     "zero falls back to default",
+			envValue: "0",
+			expected: 4,
+		},
+		{
+			name:     "negative falls back to default",
+			envValue: "-1",
+			expected: 4,
+		},
+		{
+			name:     "non-numeric falls back to default",
+			envValue: "abc",
+			expected: 4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue == "" {
+				os.Unsetenv("BUILDKIT_MAX_REGISTRY_CONCURRENCY")
+			} else {
+				t.Setenv("BUILDKIT_MAX_REGISTRY_CONCURRENCY", tt.envValue)
+			}
+			result := getMaxConcurrency()
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `BUILDKIT_MAX_REGISTRY_CONCURRENCY` environment variable to allow overriding the default max concurrency of 4 connections per registry
- Users with high-bandwidth networks pulling or pushing large images (100+ GB) are bottlenecked by the hardcoded 4 concurrent connections
- The env var approach requires no config schema changes and works with any deployment method (`docker buildx create --driver-opt env.BUILDKIT_MAX_REGISTRY_CONCURRENCY=20`, Kubernetes pod env, etc.)

Relates to #6123

## Changes

- `util/resolver/limited/group.go`: Replace hardcoded `DefaultMaxConcurrency int64 = 4` with a `getMaxConcurrency()` function that reads the env var at init time, falling back to 4 if unset/invalid
- `util/resolver/limited/group_test.go`: Add table-driven test for `getMaxConcurrency()` covering valid values, zero, negative, and non-numeric input

## Test plan

- [x] Unit test verifies env var parsing for valid, zero, negative, and non-numeric values
- [x] Manual test: run buildkitd with `BUILDKIT_MAX_REGISTRY_CONCURRENCY=20` and verify increased parallelism on large image pulls

🤖 Generated with [Claude Code](https://claude.com/claude-code)