### PR TITLE
contentutil: fix referrer blob ingest cleanup

### DIFF
--- a/util/contentutil/buffer.go
+++ b/util/contentutil/buffer.go
@@ -19,6 +19,7 @@ import (
 type Buffer interface {
 	content.Provider
 	content.Ingester
+	content.IngestManager
 	content.Manager
 }
 
@@ -117,6 +118,21 @@ func (b *buffer) Writer(ctx context.Context, opts ...content.WriterOpt) (content
 			b.mu.Unlock()
 		},
 	}, nil
+}
+
+func (b *buffer) Status(ctx context.Context, ref string) (content.Status, error) {
+	return content.Status{}, cerrdefs.ErrNotFound
+}
+
+func (b *buffer) ListStatuses(ctx context.Context, filters ...string) ([]content.Status, error) {
+	return nil, nil
+}
+
+func (b *buffer) Abort(ctx context.Context, ref string) error {
+	b.mu.Lock()
+	delete(b.refs, ref)
+	b.mu.Unlock()
+	return nil
 }
 
 func (b *buffer) ReaderAt(ctx context.Context, desc ocispecs.Descriptor) (content.ReaderAt, error) {


### PR DESCRIPTION
Abort uncommitted ingest on ReaderAt failures and reset resumed writer offset before copy to avoid stale partial state for digest refs. Tests for canceled-read poisoning and resumed-ingest offset handling.

Fixes possible "ERROR: reading blob sha256:<hex>: failed to read expected number of bytes: unexpected EOF" error that has been showing up in buildx CI policy tests.
