### PR TITLE
Add support for riscv64 architecture in llb client

### DIFF
--- a/client/llb/state.go
+++ b/client/llb/state.go
@@ -736,6 +736,7 @@ var (
 	LinuxS390x   = Platform(ocispecs.Platform{OS: "linux", Architecture: "s390x"})
 	LinuxPpc64   = Platform(ocispecs.Platform{OS: "linux", Architecture: "ppc64"})
 	LinuxPpc64le = Platform(ocispecs.Platform{OS: "linux", Architecture: "ppc64le"})
+	LinuxRiscv64 = Platform(ocispecs.Platform{OS: "linux", Architecture: "riscv64"})
 	Darwin       = Platform(ocispecs.Platform{OS: "darwin", Architecture: "amd64"})
 	Windows      = Platform(ocispecs.Platform{OS: "windows", Architecture: "amd64"})
 )


### PR DESCRIPTION
Introduce support for the riscv64 architecture in the llb client to enhance compatibility with additional platforms.

See the following discussion: https://github.com/moby/buildkit/discussions/6485#discussioncomment-15728373