### PR TITLE
compression: add zstd:chunked compression type

### DIFF
--- a/util/compression/compression.go
+++ b/util/compression/compression.go
@@ -37,6 +37,7 @@ type (
 	gzipType         struct{}
 	estargzType      struct{}
 	zstdType         struct{}
+	zstdChunkedType  struct{}
 )
 
 var (
@@ -51,6 +52,13 @@ var (
 
 	// Zstd is used for Zstandard data.
 	Zstd = zstdType{}
+
+	// ZstdChunked is used for zstd:chunked data, where each file in the
+	// tar stream is compressed independently with a TOC appended as a
+	// zstd skippable frame. This enables partial/lazy pulling by
+	// consumers that understand the format (e.g. podman/containers-storage).
+	// The resulting blob is backwards-compatible with standard zstd.
+	ZstdChunked = zstdChunkedType{}
 )
 
 type Config struct {
@@ -91,6 +99,8 @@ func parse(t string) (Type, error) {
 		return EStargz, nil
 	case Zstd.String():
 		return Zstd, nil
+	case ZstdChunked.String():
+		return ZstdChunked, nil
 	default:
 		return nil, errors.Errorf("unsupported compression type %s", t)
 	}

--- a/util/compression/zstdchunked.go
+++ b/util/compression/zstdchunked.go
@@ -1,0 +1,63 @@
+package compression
+
+import (
+	"context"
+	"io"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
+	chunkedcompressor "github.com/containers/storage/pkg/chunked/compressor"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func (c zstdChunkedType) Compress(ctx context.Context, comp Config) (compressorFunc Compressor, finalize Finalizer) {
+	return func(dest io.Writer, _ string) (io.WriteCloser, error) {
+		level := 3
+		if comp.Level != nil {
+			level = *comp.Level
+		}
+		return chunkedcompressor.ZstdCompressor(dest, nil, &level)
+	}, nil
+}
+
+func (c zstdChunkedType) Decompress(ctx context.Context, cs content.Store, desc ocispecs.Descriptor) (io.ReadCloser, error) {
+	// zstd:chunked is a valid zstd stream — standard decompression works.
+	return decompress(ctx, cs, desc)
+}
+
+func (c zstdChunkedType) NeedsConversion(ctx context.Context, cs content.Store, desc ocispecs.Descriptor) (bool, error) {
+	if !images.IsLayerType(desc.MediaType) {
+		return false, nil
+	}
+	ct, err := FromMediaType(desc.MediaType)
+	if err != nil {
+		return false, err
+	}
+	// zstd:chunked uses the same media type as zstd, so if the layer is
+	// already zstd we skip conversion. The chunked structure is an
+	// optimization; re-encoding an existing zstd layer would require
+	// full decompression and recompression.
+	if ct == Zstd {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (c zstdChunkedType) NeedsComputeDiffBySelf(comp Config) bool {
+	return true
+}
+
+func (c zstdChunkedType) OnlySupportOCITypes() bool {
+	return false
+}
+
+func (c zstdChunkedType) MediaType() string {
+	// zstd:chunked uses the same OCI media type as zstd — the chunked
+	// structure is transparent to registries and runtimes that don't
+	// understand it. They simply decompress it as a regular zstd blob.
+	return ocispecs.MediaTypeImageLayerZstd
+}
+
+func (c zstdChunkedType) String() string {
+	return "zstd:chunked"
+}


### PR DESCRIPTION
## Summary

Add support for `zstd:chunked` as a compression option for image layer export. This enables partial/lazy pulling by consumers that understand the format (e.g. podman, containers/storage).

When specified via `--output "compression=zstd:chunked"`, each file in the tar stream is compressed as an independent zstd frame with a table of contents (TOC) appended as a zstd skippable frame.

### Format

The output blob structure follows the [containers/storage zstd:chunked spec](https://github.com/containers/storage/blob/main/docs/containers-storage-zstd-chunked.md):

```
[FILE_1][FILE_2]..[FILE_N][SKIPPABLE FRAME: TOC][SKIPPABLE FRAME: FOOTER]
```

Where each `[FILE_N]` is an independently compressed zstd frame containing the tar header + payload for that file, and the TOC contains file metadata (name, size, offset, digest) enabling consumers to fetch individual files without downloading the entire layer.

### Key design decisions

- **Same OCI media type as zstd** (`application/vnd.oci.image.layer.v1.tar+zstd`) — fully backwards-compatible. Registries and runtimes that don't understand zstd:chunked simply decompress it as a regular zstd blob.
- **Decompression reuses existing zstd decompressor** — no changes needed on the pull side for non-chunked-aware consumers.
- **Wraps the containers/storage compressor** — the implementation in `containers/storage/pkg/chunked/compressor` is [explicitly designed for standalone use](https://github.com/containers/storage/blob/main/pkg/chunked/compressor/compressor.go#L3) by external callers and is well-tested in production by podman and buildah.

### Usage

```bash
docker buildx build \
  --output "type=image,compression=zstd:chunked,push=true,name=registry.example.com/myapp:latest" \
  .
```

### Impact

- Fedora has [adopted zstd:chunked as the default](https://fedoraproject.org/wiki/Changes/zstd:chunked) for container images, reporting up to **90% faster pulls** for incremental updates.
- This bridges the gap between BuildKit (which produces images) and the containers/storage ecosystem (which consumes them with partial pulling).

### Changes

- `util/compression/zstdchunked.go` (new) — implements the `Type` interface
- `util/compression/compression.go` — registers the new type and adds it to the parser

### New dependency

`github.com/containers/storage/pkg/chunked/compressor` — lightweight, standalone package. Most of its transitive deps (`klauspost/compress/zstd`, `opencontainers/go-digest`) are already vendored in BuildKit.

Related: #2345