### PR TITLE
linter: do not attempt to check for copying ignored file when negated patterns exist

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -2041,7 +2041,13 @@ func addReachableStages(s *dispatchState, stages map[*dispatchState]struct{}) {
 }
 
 func validateCopySourcePath(src string, cfg *copyConfig) error {
-	if cfg.ignoreMatcher == nil {
+	// Do not validate copy source paths if there is no dockerignore file
+	// or if the dockerignore file contains exclusions.
+	//
+	// Exclusions are too difficult to statically determine if they're proper
+	// because it's ok for a directory to be excluded and a file inside the directory
+	// to be negated.
+	if cfg.ignoreMatcher == nil || cfg.ignoreMatcher.Exclusions() {
 		return nil
 	}
 	cmd := "Copy"

--- a/frontend/dockerfile/dockerfile_lint_test.go
+++ b/frontend/dockerfile/dockerfile_lint_test.go
@@ -230,6 +230,16 @@ COPY ./Dockerfile .
 		Dockerfile:   dockerfile,
 		DockerIgnore: dockerignore,
 	})
+
+	// No warnings should occur if we copy the directory.
+	dockerfile = []byte(`
+FROM scratch
+COPY . .
+	`)
+	checkLinterWarnings(t, sb, &lintTestParams{
+		Dockerfile:   dockerfile,
+		DockerIgnore: dockerignore,
+	})
 }
 
 func testSecretsUsedInArgOrEnv(t *testing.T, sb integration.Sandbox) {


### PR DESCRIPTION
It becomes too difficult to statically check whether a source path is an
error or expected when negated patterns are involved. This is because a
pattern may point to a directory and may exclude the directory, but a
further pattern may exclude a specific pattern in that directory.

In order to determine whether this happened when copying a source
directory, we'd need to either have some knowledge of the actual files
copied (wouldn't be a static pattern) or we would need to go through
each exclusion and try to determine if there exists a certain text that
would match both the original pattern and the excluded pattern.

This is likely too difficult or too computationally intense for what's
meant to be a simple linter check so just disable this linter check when
exclusions exist.

Fixes https://github.com/moby/buildkit/issues/6512.
