### PR TITLE
tests: use t.Context in unit tests

### DIFF
--- a/client/llb/definition_test.go
+++ b/client/llb/definition_test.go
@@ -30,9 +30,9 @@ func TestDefinitionEquivalence(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.TODO()
+			ctx := t.Context()
 
-			def, err := tc.state.Marshal(context.TODO())
+			def, err := tc.state.Marshal(ctx)
 			require.NoError(t, err)
 
 			op, err := NewDefinitionOp(def.ToPB())
@@ -43,7 +43,7 @@ func TestDefinitionEquivalence(t *testing.T) {
 
 			st2 := NewState(op.Output())
 
-			def2, err := st2.Marshal(context.TODO())
+			def2, err := st2.Marshal(ctx)
 			require.NoError(t, err)
 			require.Equal(t, len(def.Def), len(def2.Def))
 			require.Equal(t, len(def.Metadata), len(def2.Metadata))
@@ -93,9 +93,9 @@ func TestDefinitionInputCache(t *testing.T) {
 		AddMount("/b2", stB.GetMount("/mnt")),
 	).Root()
 
-	ctx := context.TODO()
+	ctx := t.Context()
 
-	def, err := st.Marshal(context.TODO())
+	def, err := st.Marshal(ctx)
 	require.NoError(t, err)
 
 	op, err := NewDefinitionOp(def.ToPB())
@@ -127,11 +127,11 @@ func TestDefinitionInputCache(t *testing.T) {
 		}
 		all = append(all, AddMount("/mnt", Scratch().Run(append([]RunOption{Shlex("args")}, sts...)...).Root()))
 	}
-	def, err = Scratch().Run(append([]RunOption{Shlex("args")}, all...)...).Root().Marshal(context.TODO())
+	def, err = Scratch().Run(append([]RunOption{Shlex("args")}, all...)...).Root().Marshal(ctx)
 	require.NoError(t, err)
 	op, err = NewDefinitionOp(def.ToPB())
 	require.NoError(t, err)
-	require.NoError(t, testParallelWalk(context.Background(), op.Output()))
+	require.NoError(t, testParallelWalk(ctx, op.Output()))
 }
 
 func TestDefinitionNil(t *testing.T) {

--- a/client/llb/fileop_test.go
+++ b/client/llb/fileop_test.go
@@ -1,7 +1,6 @@
 package llb
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -15,7 +14,7 @@ func TestFileMkdir(t *testing.T) {
 	t.Parallel()
 
 	st := Image("foo").File(Mkdir("/foo", 0700))
-	def, err := st.Marshal(context.TODO())
+	def, err := st.Marshal(t.Context())
 
 	require.NoError(t, err)
 
@@ -49,7 +48,7 @@ func TestFileMkdirChain(t *testing.T) {
 	t.Parallel()
 
 	st := Image("foo").Dir("/etc").File(Mkdir("/foo", 0700).Mkdir("bar", 0600, WithParents(true)).Mkdir("bar/baz", 0701, WithParents(false)))
-	def, err := st.Marshal(context.TODO())
+	def, err := st.Marshal(t.Context())
 
 	require.NoError(t, err)
 
@@ -102,7 +101,7 @@ func TestFileMkdirMkfile(t *testing.T) {
 	t.Parallel()
 
 	st := Scratch().File(Mkdir("/foo", 0700).Mkfile("bar", 0700, []byte("data")))
-	def, err := st.Marshal(context.TODO())
+	def, err := st.Marshal(t.Context())
 
 	require.NoError(t, err)
 
@@ -148,7 +147,7 @@ func TestFileMkfile(t *testing.T) {
 	t.Parallel()
 
 	st := Image("foo").File(Mkfile("/foo", 0700, []byte("data")))
-	def, err := st.Marshal(context.TODO())
+	def, err := st.Marshal(t.Context())
 
 	require.NoError(t, err)
 
@@ -192,7 +191,7 @@ func TestFileSymlink(t *testing.T) {
 
 	const numOps = 2
 	const numActions = 6
-	def, err := st.Marshal(context.TODO())
+	def, err := st.Marshal(t.Context())
 
 	require.NoError(t, err)
 
@@ -244,7 +243,7 @@ func TestFileRm(t *testing.T) {
 	t.Parallel()
 
 	st := Image("foo").File(Rm("/foo"))
-	def, err := st.Marshal(context.TODO())
+	def, err := st.Marshal(t.Context())
 
 	require.NoError(t, err)
 
@@ -285,7 +284,7 @@ func TestFileSimpleChains(t *testing.T) {
 			Rm("foo").
 				Mkfile("/abc", 0701, []byte("d1")),
 		)
-	def, err := st.Marshal(context.TODO())
+	def, err := st.Marshal(t.Context())
 
 	require.NoError(t, err)
 
@@ -353,7 +352,7 @@ func TestFileCopy(t *testing.T) {
 	t.Parallel()
 
 	st := Image("foo").Dir("/tmp").File(Copy(Image("bar").Dir("/etc"), "foo", "bar"))
-	def, err := st.Marshal(context.TODO())
+	def, err := st.Marshal(t.Context())
 
 	require.NoError(t, err)
 
@@ -394,7 +393,7 @@ func TestFileCopyFromAction(t *testing.T) {
 				Mkfile("foo/bar", 0600, []byte("dt")).
 				WithState(Scratch().Dir("/tmp")),
 			"foo/bar", "baz"))
-	def, err := st.Marshal(context.TODO())
+	def, err := st.Marshal(t.Context())
 
 	require.NoError(t, err)
 
@@ -461,7 +460,7 @@ func TestFilePipeline(t *testing.T) {
 				Copy(Image("foo"), "in", "out").
 				Copy(Image("baz").Dir("/base"), "in2", "out2"),
 		)
-	def, err := st.Marshal(context.TODO())
+	def, err := st.Marshal(t.Context())
 
 	require.NoError(t, err)
 
@@ -563,7 +562,7 @@ func TestFileOwner(t *testing.T) {
 	t.Parallel()
 
 	st := Image("foo").File(Mkdir("/foo", 0700).Mkdir("bar", 0600, WithUIDGID(123, 456)).Mkdir("bar/baz", 0701, WithUser("foouser")))
-	def, err := st.Marshal(context.TODO())
+	def, err := st.Marshal(t.Context())
 
 	require.NoError(t, err)
 
@@ -602,7 +601,7 @@ func TestFileOwnerRoot(t *testing.T) {
 	t.Parallel()
 
 	st := Image("foo").File(Mkdir("bar/baz", 0701, WithUser("root:root")))
-	def, err := st.Marshal(context.TODO())
+	def, err := st.Marshal(t.Context())
 
 	require.NoError(t, err)
 
@@ -619,7 +618,7 @@ func TestFileOwnerWithGroup(t *testing.T) {
 	t.Parallel()
 
 	st := Image("foo").File(Mkdir("bar/baz", 0701, WithUser("foo:bar")))
-	def, err := st.Marshal(context.TODO())
+	def, err := st.Marshal(t.Context())
 
 	require.NoError(t, err)
 
@@ -636,7 +635,7 @@ func TestFileOwnerWithUIDAndGID(t *testing.T) {
 	t.Parallel()
 
 	st := Image("foo").File(Mkdir("bar/baz", 0701, WithUser("1000:1001")))
-	def, err := st.Marshal(context.TODO())
+	def, err := st.Marshal(t.Context())
 
 	require.NoError(t, err)
 
@@ -660,7 +659,7 @@ func TestFileCopyOwner(t *testing.T) {
 				"src2", "dst", WithUser("user4")).
 			Copy(Image("foo"), "src3", "dst", WithUIDGID(1, 2)),
 		)
-	def, err := st.Marshal(context.TODO())
+	def, err := st.Marshal(t.Context())
 
 	require.NoError(t, err)
 
@@ -723,7 +722,7 @@ func TestFileCreatedTime(t *testing.T) {
 		Mkdir("/foo", 0700, WithCreatedTime(dt)).
 			Mkfile("bar", 0600, []byte{}, WithCreatedTime(dt2)).
 			Copy(Scratch(), "src", "dst", WithCreatedTime(dt3)))
-	def, err := st.Marshal(context.TODO())
+	def, err := st.Marshal(t.Context())
 
 	require.NoError(t, err)
 
@@ -789,7 +788,7 @@ func TestFileOpMarshalConsistency(t *testing.T) {
 		File(Copy(f2, "/a", "/b"))
 
 	for range 100 {
-		def, err := st.Marshal(context.TODO())
+		def, err := st.Marshal(t.Context())
 		require.NoError(t, err)
 
 		if prevDef != nil {
@@ -802,7 +801,7 @@ func TestFileOpMarshalConsistency(t *testing.T) {
 
 func TestParallelMarshal(t *testing.T) {
 	st := Scratch().File(Mkfile("/tmp", 0644, []byte("tmp 1")))
-	eg, ctx := errgroup.WithContext(context.Background())
+	eg, ctx := errgroup.WithContext(t.Context())
 	for range 100 {
 		eg.Go(func() error {
 			_, err := st.Marshal(ctx)

--- a/executor/oci/resolvconf_test.go
+++ b/executor/oci/resolvconf_test.go
@@ -1,7 +1,6 @@
 package oci
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path"
@@ -104,7 +103,7 @@ func TestResolvConf(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			tempDir := t.TempDir()
 			oldResolvconfPath := resolvconfPath
 			t.Cleanup(func() {

--- a/session/auth/authprovider/authprovider_test.go
+++ b/session/auth/authprovider/authprovider_test.go
@@ -1,7 +1,6 @@
 package authprovider
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -25,12 +24,12 @@ func TestFetchTokenCaching(t *testing.T) {
 	p := NewDockerAuthProvider(DockerAuthProviderConfig{
 		AuthConfigProvider: LoadAuthConfig(cfg),
 	}).(*authProvider)
-	res, err := p.FetchToken(context.Background(), &auth.FetchTokenRequest{Host: DockerHubRegistryHost})
+	res, err := p.FetchToken(t.Context(), &auth.FetchTokenRequest{Host: DockerHubRegistryHost})
 	require.NoError(t, err)
 	assert.Equal(t, "hunter2", res.Token)
 
 	cfg.AuthConfigs[DockerHubConfigfileKey] = types.AuthConfig{Username: "user", RegistryToken: "hunter3"}
-	res, err = p.FetchToken(context.Background(), &auth.FetchTokenRequest{Host: DockerHubRegistryHost})
+	res, err = p.FetchToken(t.Context(), &auth.FetchTokenRequest{Host: DockerHubRegistryHost})
 	require.NoError(t, err)
 
 	// Verify that we cached the result instead of returning hunter3.
@@ -47,12 +46,12 @@ func TestFetchTokenCaching(t *testing.T) {
 		},
 	}).(*authProvider)
 
-	res, err = p.FetchToken(context.Background(), &auth.FetchTokenRequest{Host: DockerHubRegistryHost})
+	res, err = p.FetchToken(t.Context(), &auth.FetchTokenRequest{Host: DockerHubRegistryHost})
 	require.NoError(t, err)
 	assert.Equal(t, "hunter2", res.Token)
 
 	cfg.AuthConfigs[DockerHubConfigfileKey] = types.AuthConfig{Username: "user", RegistryToken: "hunter3"}
-	res, err = p.FetchToken(context.Background(), &auth.FetchTokenRequest{Host: DockerHubRegistryHost})
+	res, err = p.FetchToken(t.Context(), &auth.FetchTokenRequest{Host: DockerHubRegistryHost})
 	require.NoError(t, err)
 
 	// Verify that we re-fetched the token after it expired.

--- a/session/filesync/filesync_test.go
+++ b/session/filesync/filesync_test.go
@@ -1,7 +1,6 @@
 package filesync
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,7 +15,7 @@ import (
 )
 
 func TestFileSyncIncludePatterns(t *testing.T) {
-	ctx := context.TODO()
+	ctx := t.Context()
 	t.Parallel()
 
 	tmpDir := t.TempDir()
@@ -41,7 +40,7 @@ func TestFileSyncIncludePatterns(t *testing.T) {
 
 	dialer := session.Dialer(testutil.TestStream(testutil.Handler(m.HandleConn)))
 
-	g, ctx := errgroup.WithContext(context.Background())
+	g, ctx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
 		return s.Run(ctx, dialer)

--- a/solver/cache_test.go
+++ b/solver/cache_test.go
@@ -1,7 +1,6 @@
 package solver
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -38,7 +37,7 @@ func expKey(k *CacheKey) ExportableCacheKey {
 }
 
 func TestInMemoryCache(t *testing.T) {
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	m := NewInMemoryCacheManager()
 
@@ -49,7 +48,7 @@ func TestInMemoryCache(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(keys))
 
-	matches, err := m.Records(context.TODO(), keys[0])
+	matches, err := m.Records(ctx, keys[0])
 	require.NoError(t, err)
 	require.Equal(t, 1, len(matches))
 
@@ -65,7 +64,7 @@ func TestInMemoryCache(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(keys))
 
-	matches, err = m.Records(context.TODO(), keys[0])
+	matches, err = m.Records(ctx, keys[0])
 	require.NoError(t, err)
 	require.Equal(t, 1, len(matches))
 
@@ -99,7 +98,7 @@ func TestInMemoryCache(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(keys))
 
-	matches, err = m.Records(context.TODO(), keys[0])
+	matches, err = m.Records(ctx, keys[0])
 	require.NoError(t, err)
 	require.Equal(t, 1, len(matches))
 
@@ -121,7 +120,7 @@ func TestInMemoryCache(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(keys))
 
-	matches, err = m.Records(context.TODO(), keys[0])
+	matches, err = m.Records(ctx, keys[0])
 	require.NoError(t, err)
 	require.Equal(t, 2, len(matches))
 
@@ -151,7 +150,7 @@ func TestInMemoryCache(t *testing.T) {
 }
 
 func TestInMemoryCacheSelector(t *testing.T) {
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	m := NewInMemoryCacheManager()
 
@@ -175,7 +174,7 @@ func TestInMemoryCacheSelector(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(keys))
 
-	matches, err := m.Records(context.TODO(), keys[0])
+	matches, err := m.Records(ctx, keys[0])
 	require.NoError(t, err)
 	require.Equal(t, 1, len(matches))
 
@@ -185,7 +184,7 @@ func TestInMemoryCacheSelector(t *testing.T) {
 }
 
 func TestInMemoryCacheSelectorNested(t *testing.T) {
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	m := NewInMemoryCacheManager()
 
@@ -203,7 +202,7 @@ func TestInMemoryCacheSelectorNested(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(keys))
 
-	matches, err := m.Records(context.TODO(), keys[0])
+	matches, err := m.Records(ctx, keys[0])
 	require.NoError(t, err)
 	require.Equal(t, 1, len(matches))
 
@@ -223,7 +222,7 @@ func TestInMemoryCacheSelectorNested(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(keys))
 
-	matches, err = m.Records(context.TODO(), keys[0])
+	matches, err = m.Records(ctx, keys[0])
 	require.NoError(t, err)
 	require.Equal(t, 1, len(matches))
 
@@ -239,7 +238,8 @@ func TestInMemoryCacheSelectorNested(t *testing.T) {
 func TestInMemoryCacheReleaseParent(t *testing.T) {
 	storage := NewInMemoryCacheStorage()
 	results := NewInMemoryResultStorage()
-	m := NewCacheManager(context.TODO(), identity.NewID(), storage, results)
+	ctx := t.Context()
+	m := NewCacheManager(ctx, identity.NewID(), storage, results)
 
 	res0 := testResult("result0")
 	cacheFoo, err := m.Save(NewCacheKey(dgst("foo"), "", 0), res0, time.Now())
@@ -253,7 +253,7 @@ func TestInMemoryCacheReleaseParent(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(keys))
 
-	matches, err := m.Records(context.TODO(), keys[0])
+	matches, err := m.Records(ctx, keys[0])
 	require.NoError(t, err)
 	require.Equal(t, 1, len(matches))
 
@@ -265,7 +265,7 @@ func TestInMemoryCacheReleaseParent(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(keys))
 
-	matches, err = m.Records(context.TODO(), keys[0])
+	matches, err = m.Records(ctx, keys[0])
 	require.NoError(t, err)
 	require.Equal(t, 0, len(matches))
 
@@ -273,7 +273,7 @@ func TestInMemoryCacheReleaseParent(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(keys))
 
-	matches, err = m.Records(context.TODO(), keys[0])
+	matches, err = m.Records(ctx, keys[0])
 	require.NoError(t, err)
 	require.Equal(t, 1, len(matches))
 
@@ -291,7 +291,8 @@ func TestInMemoryCacheReleaseParent(t *testing.T) {
 func TestInMemoryCacheRestoreOfflineDeletion(t *testing.T) {
 	storage := NewInMemoryCacheStorage()
 	results := NewInMemoryResultStorage()
-	m := NewCacheManager(context.TODO(), identity.NewID(), storage, results)
+	ctx := t.Context()
+	m := NewCacheManager(ctx, identity.NewID(), storage, results)
 
 	res0 := testResult("result0")
 	cacheFoo, err := m.Save(NewCacheKey(dgst("foo"), "", 0), res0, time.Now())
@@ -305,13 +306,13 @@ func TestInMemoryCacheRestoreOfflineDeletion(t *testing.T) {
 	_, err = results2.Save(res1, time.Now()) // only add bar
 	require.NoError(t, err)
 
-	m = NewCacheManager(context.TODO(), identity.NewID(), storage, results2)
+	m = NewCacheManager(ctx, identity.NewID(), storage, results2)
 
 	keys, err := m.Query(nil, 0, dgst("foo"), 0)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(keys))
 
-	matches, err := m.Records(context.TODO(), keys[0])
+	matches, err := m.Records(ctx, keys[0])
 	require.NoError(t, err)
 	require.Equal(t, 0, len(matches))
 
@@ -319,7 +320,7 @@ func TestInMemoryCacheRestoreOfflineDeletion(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(keys))
 
-	matches, err = m.Records(context.TODO(), keys[0])
+	matches, err = m.Records(ctx, keys[0])
 	require.NoError(t, err)
 	require.Equal(t, 1, len(matches))
 }
@@ -327,7 +328,8 @@ func TestInMemoryCacheRestoreOfflineDeletion(t *testing.T) {
 func TestCarryOverFromSublink(t *testing.T) {
 	storage := NewInMemoryCacheStorage()
 	results := NewInMemoryResultStorage()
-	m := NewCacheManager(context.TODO(), identity.NewID(), storage, results)
+	ctx := t.Context()
+	m := NewCacheManager(ctx, identity.NewID(), storage, results)
 
 	cacheFoo, err := m.Save(NewCacheKey(dgst("foo"), "", 0), testResult("resultFoo"), time.Now())
 	require.NoError(t, err)

--- a/solver/llbsolver/ops/file_test.go
+++ b/solver/llbsolver/ops/file_test.go
@@ -46,7 +46,7 @@ func TestMkdirMkfile(t *testing.T) {
 
 	s, rb := newTestFileSolver()
 	inp := rb.NewRef("ref1")
-	outs, err := s.Solve(context.TODO(), []fileoptypes.Ref{inp}, fo.Actions, nil)
+	outs, err := s.Solve(t.Context(), []fileoptypes.Ref{inp}, fo.Actions, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(outs))
 	rb.checkReleased(t, append(outs, inp))
@@ -116,7 +116,7 @@ func TestChownOpt(t *testing.T) {
 	s, rb := newTestFileSolver()
 	inp := rb.NewRef("ref1")
 	inp2 := rb.NewRef("usermount")
-	outs, err := s.Solve(context.TODO(), []fileoptypes.Ref{inp, inp2}, fo.Actions, nil)
+	outs, err := s.Solve(t.Context(), []fileoptypes.Ref{inp, inp2}, fo.Actions, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(outs))
 	rb.checkReleased(t, append(outs, inp, inp2))
@@ -178,7 +178,7 @@ func TestChownCopy(t *testing.T) {
 	s, rb := newTestFileSolver()
 	inpSrc := rb.NewRef("src")
 	inpDest := rb.NewRef("dest")
-	outs, err := s.Solve(context.TODO(), []fileoptypes.Ref{inpSrc, inpDest}, fo.Actions, nil)
+	outs, err := s.Solve(t.Context(), []fileoptypes.Ref{inpSrc, inpDest}, fo.Actions, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(outs))
 	rb.checkReleased(t, append(outs, inpSrc, inpDest))
@@ -209,7 +209,7 @@ func TestInvalidNoOutput(t *testing.T) {
 	}
 
 	s, rb := newTestFileSolver()
-	outs, err := s.Solve(context.TODO(), []fileoptypes.Ref{}, fo.Actions, nil)
+	outs, err := s.Solve(t.Context(), []fileoptypes.Ref{}, fo.Actions, nil)
 	rb.checkReleased(t, outs)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no outputs specified")
@@ -246,7 +246,7 @@ func TestInvalidDuplicateOutput(t *testing.T) {
 	}
 
 	s, rb := newTestFileSolver()
-	_, err := s.Solve(context.TODO(), []fileoptypes.Ref{}, fo.Actions, nil)
+	_, err := s.Solve(t.Context(), []fileoptypes.Ref{}, fo.Actions, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "duplicate output")
 	rb.checkReleased(t, nil)
@@ -272,7 +272,7 @@ func TestActionInvalidIndex(t *testing.T) {
 	}
 
 	s, rb := newTestFileSolver()
-	_, err := s.Solve(context.TODO(), []fileoptypes.Ref{}, fo.Actions, nil)
+	_, err := s.Solve(t.Context(), []fileoptypes.Ref{}, fo.Actions, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "loop from index")
 	rb.checkReleased(t, nil)
@@ -309,7 +309,7 @@ func TestActionLoop(t *testing.T) {
 	}
 
 	s, rb := newTestFileSolver()
-	_, err := s.Solve(context.TODO(), []fileoptypes.Ref{}, fo.Actions, nil)
+	_, err := s.Solve(t.Context(), []fileoptypes.Ref{}, fo.Actions, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "loop from index")
 	rb.checkReleased(t, nil)
@@ -347,7 +347,7 @@ func TestMultiOutput(t *testing.T) {
 
 	s, rb := newTestFileSolver()
 	inp := rb.NewRef("ref1")
-	outs, err := s.Solve(context.TODO(), []fileoptypes.Ref{inp}, fo.Actions, nil)
+	outs, err := s.Solve(t.Context(), []fileoptypes.Ref{inp}, fo.Actions, nil)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(outs))
 	rb.checkReleased(t, append(outs, inp))
@@ -395,7 +395,7 @@ func TestFileFromScratch(t *testing.T) {
 	}
 
 	s, rb := newTestFileSolver()
-	outs, err := s.Solve(context.TODO(), []fileoptypes.Ref{}, fo.Actions, nil)
+	outs, err := s.Solve(t.Context(), []fileoptypes.Ref{}, fo.Actions, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(outs))
 	rb.checkReleased(t, outs)
@@ -429,7 +429,7 @@ func TestFileCopyInputSrc(t *testing.T) {
 	s, rb := newTestFileSolver()
 	inp0 := rb.NewRef("srcref")
 	inp1 := rb.NewRef("destref")
-	outs, err := s.Solve(context.TODO(), []fileoptypes.Ref{inp0, inp1}, fo.Actions, nil)
+	outs, err := s.Solve(t.Context(), []fileoptypes.Ref{inp0, inp1}, fo.Actions, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(outs))
 	rb.checkReleased(t, append(outs, inp0, inp1))
@@ -483,7 +483,7 @@ func TestFileCopyInputRm(t *testing.T) {
 	s, rb := newTestFileSolver()
 	inp0 := rb.NewRef("srcref")
 	inp1 := rb.NewRef("destref")
-	outs, err := s.Solve(context.TODO(), []fileoptypes.Ref{inp0, inp1}, fo.Actions, nil)
+	outs, err := s.Solve(t.Context(), []fileoptypes.Ref{inp0, inp1}, fo.Actions, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(outs))
 	rb.checkReleased(t, append(outs, inp0, inp1))
@@ -547,7 +547,7 @@ func TestFileParallelActions(t *testing.T) {
 		<-ch
 	}
 
-	outs, err := s.Solve(context.TODO(), []fileoptypes.Ref{inp}, fo.Actions, nil)
+	outs, err := s.Solve(t.Context(), []fileoptypes.Ref{inp}, fo.Actions, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(outs))
 
@@ -703,7 +703,7 @@ func (b *testFileRefBackend) Prepare(ctx context.Context, ref fileoptypes.Ref, r
 
 func (b *testFileRefBackend) Commit(ctx context.Context, mount fileoptypes.Mount) (fileoptypes.Ref, error) {
 	m := mount.(*testMount)
-	if err := b.mounts[m.initID].Release(context.TODO()); err != nil {
+	if err := b.mounts[m.initID].Release(ctx); err != nil {
 		return nil, err
 	}
 	m2 := *m

--- a/solver/scheduler_test.go
+++ b/solver/scheduler_test.go
@@ -30,7 +30,7 @@ func init() {
 
 func TestSingleLevelActiveGraph(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	s := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
@@ -209,7 +209,7 @@ func TestSingleLevelActiveGraph(t *testing.T) {
 
 func TestSingleLevelCache(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	s := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
@@ -305,7 +305,7 @@ func TestSingleLevelCache(t *testing.T) {
 
 func TestSingleLevelCacheParallel(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	s := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
@@ -380,7 +380,7 @@ func TestSingleLevelCacheParallel(t *testing.T) {
 
 func TestMultiLevelCacheParallel(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	s := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
@@ -471,7 +471,7 @@ func TestMultiLevelCacheParallel(t *testing.T) {
 
 func TestSingleCancelCache(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	s := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
@@ -513,7 +513,7 @@ func TestSingleCancelCache(t *testing.T) {
 }
 func TestSingleCancelExec(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	s := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
@@ -556,7 +556,7 @@ func TestSingleCancelExec(t *testing.T) {
 
 func TestSingleCancelParallel(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	s := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
@@ -631,7 +631,7 @@ func TestSingleCancelParallel(t *testing.T) {
 
 func TestMultiLevelCalculation(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
@@ -714,7 +714,7 @@ func TestMultiLevelCalculation(t *testing.T) {
 
 func TestHugeGraph(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
@@ -774,7 +774,7 @@ func TestHugeGraph(t *testing.T) {
 // they are really needed
 func TestOptimizedCacheAccess(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
@@ -881,7 +881,7 @@ func TestOptimizedCacheAccess(t *testing.T) {
 // inputs that didn't.
 func TestOptimizedCacheAccess2(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
@@ -1032,7 +1032,7 @@ func TestOptimizedCacheAccess2(t *testing.T) {
 
 func TestSlowCache(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
@@ -1111,7 +1111,7 @@ func TestSlowCache(t *testing.T) {
 // TestParallelInputs validates that inputs are processed in parallel
 func TestParallelInputs(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
@@ -1167,7 +1167,7 @@ func TestParallelInputs(t *testing.T) {
 
 func TestErrorReturns(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
@@ -1298,7 +1298,7 @@ func TestErrorReturns(t *testing.T) {
 
 func TestMultipleCacheSources(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
@@ -1416,7 +1416,7 @@ func TestMultipleCacheSources(t *testing.T) {
 
 func TestRepeatBuildWithIgnoreCache(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
@@ -1540,7 +1540,7 @@ func TestRepeatBuildWithIgnoreCache(t *testing.T) {
 // with ignore-cache generates same slow cache key
 func TestIgnoreCacheResumeFromSlowCache(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
@@ -1629,7 +1629,7 @@ func TestIgnoreCacheResumeFromSlowCache(t *testing.T) {
 
 func TestParallelBuildsIgnoreCache(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
@@ -1786,7 +1786,7 @@ func TestParallelBuildsIgnoreCache(t *testing.T) {
 
 func TestSubbuild(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	l := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
@@ -1847,7 +1847,7 @@ func TestSubbuild(t *testing.T) {
 
 func TestCacheWithSelector(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
@@ -1981,7 +1981,7 @@ func TestCacheWithSelector(t *testing.T) {
 
 func TestCacheSlowWithSelector(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
@@ -2080,7 +2080,7 @@ func TestCacheSlowWithSelector(t *testing.T) {
 
 func TestCacheExporting(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
@@ -2161,7 +2161,7 @@ func TestCacheExporting(t *testing.T) {
 
 func TestCacheExportingModeMin(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
@@ -2287,7 +2287,7 @@ func TestCacheExportingModeMin(t *testing.T) {
 
 func TestSlowCacheAvoidAccess(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
@@ -2380,7 +2380,7 @@ func TestSlowCacheAvoidAccess(t *testing.T) {
 // moby/buildkit#648
 func TestSlowCacheAvoidLoadOnCache(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
@@ -2532,7 +2532,7 @@ func TestSlowCacheAvoidLoadOnCache(t *testing.T) {
 
 func TestCacheMultipleMaps(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
@@ -2650,7 +2650,7 @@ func TestCacheMultipleMaps(t *testing.T) {
 
 func TestCacheInputMultipleMaps(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
@@ -2741,7 +2741,7 @@ func TestCacheInputMultipleMaps(t *testing.T) {
 
 func TestCacheExportingPartialSelector(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
@@ -2939,7 +2939,7 @@ func TestCacheExportingPartialSelector(t *testing.T) {
 
 func TestCacheExportingMergedKey(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
@@ -3028,7 +3028,7 @@ func TestMergedEdgesLookup(t *testing.T) {
 	// this test requires multiple runs to trigger the race
 	for range 20 {
 		func() {
-			ctx := context.TODO()
+			ctx := t.Context()
 
 			cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
@@ -3079,7 +3079,7 @@ func TestMergedEdgesCycle(t *testing.T) {
 	t.Parallel()
 
 	for range 20 {
-		ctx := context.TODO()
+		ctx := t.Context()
 
 		cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
@@ -3134,7 +3134,7 @@ func TestMergedEdgesCycleMultipleOwners(t *testing.T) {
 	t.Parallel()
 
 	for range 20 {
-		ctx := context.TODO()
+		ctx := t.Context()
 
 		cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
@@ -3197,7 +3197,7 @@ func TestMergedEdgesCycleMultipleOwners(t *testing.T) {
 }
 
 func TestCacheErrNotFound(t *testing.T) {
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	cm := newTrackingCacheManager(NewInMemoryCacheManager())
 	l := NewSolver(SolverOpt{
@@ -3249,7 +3249,7 @@ func TestCacheErrNotFound(t *testing.T) {
 func TestCacheLoadError(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
 
@@ -3346,7 +3346,7 @@ func TestCacheLoadError(t *testing.T) {
 
 func TestInputRequestDeadlock(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	s := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,
@@ -3485,7 +3485,7 @@ func TestUnknownBuildID(t *testing.T) {
 func TestStaleEdgeMerge(t *testing.T) {
 	// should not be possible to merge to an edge no longer in the actives map
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	s := NewSolver(SolverOpt{
 		ResolveOpFunc: testOpResolver,

--- a/sourcepolicy/engine_test.go
+++ b/sourcepolicy/engine_test.go
@@ -1,7 +1,6 @@
 package sourcepolicy
 
 import (
-	"context"
 	"testing"
 
 	"github.com/moby/buildkit/solver/pb"
@@ -53,7 +52,7 @@ func testLastRuleWins(t *testing.T) {
 	}
 
 	e := NewEngine(pol)
-	mut, err := e.Evaluate(context.Background(), &pb.SourceOp{
+	mut, err := e.Evaluate(t.Context(), &pb.SourceOp{
 		Identifier: "docker-image://docker.io/library/busybox:latest",
 	})
 	require.NoError(t, err)
@@ -85,7 +84,7 @@ func testMultiplePolicies(t *testing.T) {
 	}
 
 	e := NewEngine(pol)
-	mut, err := e.Evaluate(context.Background(), &pb.SourceOp{
+	mut, err := e.Evaluate(t.Context(), &pb.SourceOp{
 		Identifier: "docker-image://docker.io/library/busybox:latest",
 	})
 	require.ErrorIs(t, err, ErrSourceDenied)
@@ -131,7 +130,7 @@ func testConvertMultiple(t *testing.T) {
 		Identifier: "docker-image://docker.io/library/busybox:latest",
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	e := NewEngine(pol)
 
 	mutated, err := e.Evaluate(ctx, op)
@@ -161,7 +160,7 @@ func testConvertWildcard(t *testing.T) {
 		Identifier: "docker-image://docker.io/library/golang:1.19",
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	e := NewEngine(pol)
 
 	mutated, err := e.Evaluate(ctx, op)
@@ -190,7 +189,7 @@ func testConvertRegex(t *testing.T) {
 		Identifier: "docker-image://docker.io/library/golang:1.19",
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	e := NewEngine([]*spb.Policy{pol})
 
 	mutated, err := e.Evaluate(ctx, op)
@@ -218,7 +217,7 @@ func testConvertHTTP(t *testing.T) {
 		Identifier: "https://example.com/foo",
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	e := NewEngine([]*spb.Policy{pol})
 
 	mutated, err := e.Evaluate(ctx, op)
@@ -255,7 +254,7 @@ func testConvertLoop(t *testing.T) {
 		Identifier: "docker-image://docker.io/library/busybox:latest",
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	e := NewEngine([]*spb.Policy{pol})
 
 	mutated, err := e.Evaluate(ctx, op)
@@ -300,7 +299,7 @@ func testAllowConvertDeny(t *testing.T) {
 		Identifier: "docker-image://docker.io/library/busybox:latest",
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	e := NewEngine([]*spb.Policy{pol})
 
 	mutated, err := e.Evaluate(ctx, op)
@@ -334,7 +333,7 @@ func testConvertDeny(t *testing.T) {
 		Identifier: "docker-image://docker.io/library/busybox:latest",
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	e := NewEngine([]*spb.Policy{pol})
 
 	mutated, err := e.Evaluate(ctx, op)
@@ -370,7 +369,7 @@ func testConvert(t *testing.T) {
 				},
 			}
 
-			ctx := context.Background()
+			ctx := t.Context()
 			e := NewEngine([]*spb.Policy{pol})
 
 			mutated, err := e.Evaluate(ctx, op)
@@ -402,7 +401,7 @@ func testAllowDeny(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	e := NewEngine([]*spb.Policy{pol})
 
 	mutated, err := e.Evaluate(ctx, op)
@@ -439,7 +438,7 @@ func testDenyAll(t *testing.T) {
 			}
 
 			e := NewEngine([]*spb.Policy{pol})
-			ctx := context.Background()
+			ctx := t.Context()
 
 			op := &pb.SourceOp{
 				Identifier: ref,

--- a/util/grpcerrors/grpcerrors_test.go
+++ b/util/grpcerrors/grpcerrors_test.go
@@ -72,7 +72,7 @@ func TestFromGRPCPreserveUnknownTypes(t *testing.T) {
 
 		decodedErr := grpcerrors.FromGRPC(status.FromProto(pb).Err())
 
-		reEncodedErr := grpcerrors.ToGRPC(context.TODO(), decodedErr)
+		reEncodedErr := grpcerrors.ToGRPC(t.Context(), decodedErr)
 
 		reDecodedErr := grpcerrors.FromGRPC(reEncodedErr)
 		assertErrorProperties(t, reDecodedErr)
@@ -107,7 +107,7 @@ func TestFromGRPCPreserveTypes(t *testing.T) {
 	joined := stderrors.Join(decodedErr, typedErr)
 
 	// Re-encode and decode the joined error and ensure the unknown detail is preserved
-	reEncoded := grpcerrors.ToGRPC(context.TODO(), joined)
+	reEncoded := grpcerrors.ToGRPC(t.Context(), joined)
 	reDecoded := grpcerrors.FromGRPC(reEncoded)
 
 	require.Error(t, reDecoded)
@@ -201,19 +201,19 @@ func TestToGRPCMessage(t *testing.T) {
 	t.Run("avoid prepending grpc status code", func(t *testing.T) {
 		t.Parallel()
 		err := errors.New("something")
-		decoded := grpcerrors.FromGRPC(grpcerrors.ToGRPC(context.TODO(), err))
+		decoded := grpcerrors.FromGRPC(grpcerrors.ToGRPC(t.Context(), err))
 		assert.Equal(t, err.Error(), decoded.Error())
 	})
 	t.Run("keep extra context", func(t *testing.T) {
 		t.Parallel()
 		err := errors.New("something")
-		wrapped := errors.Wrap(grpcerrors.ToGRPC(context.TODO(), err), "extra context")
+		wrapped := errors.Wrap(grpcerrors.ToGRPC(t.Context(), err), "extra context")
 
 		anotherErr := errors.New("another error")
 		joined := stderrors.Join(wrapped, anotherErr)
 
 		// Check that wrapped.Error() starts with "extra context"
-		encoded := grpcerrors.ToGRPC(context.TODO(), joined)
+		encoded := grpcerrors.ToGRPC(t.Context(), joined)
 		decoded := grpcerrors.FromGRPC(encoded)
 
 		assert.ErrorContains(t, decoded, wrapped.Error()) //nolint:testifylint // error is not critical


### PR DESCRIPTION
Replace context.TODO/background calls in targeted unit tests with t.Context().