### PR TITLE
exporter/containerimage: support platform-suffixed config keys

### DIFF
--- a/exporter/containerimage/exptypes/parse.go
+++ b/exporter/containerimage/exptypes/parse.go
@@ -3,6 +3,7 @@ package exptypes
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/containerd/platforms"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -33,7 +34,19 @@ func ParsePlatforms(meta map[string][]byte) (Platforms, error) {
 	}
 
 	var p ocispecs.Platform
-	if imgConfig, ok := meta[ExporterImageConfigKey]; ok {
+	var imgConfig []byte
+	if c, ok := meta[ExporterImageConfigKey]; ok {
+		imgConfig = c
+	} else {
+		for k, v := range meta {
+			if len(v) > 0 && strings.HasPrefix(k, ExporterImageConfigKey+"/") {
+				imgConfig = v
+				break
+			}
+		}
+	}
+
+	if len(imgConfig) > 0 {
 		var img ocispecs.Image
 		err := json.Unmarshal(imgConfig, &img)
 		if err != nil {

--- a/exporter/containerimage/exptypes/parse_test.go
+++ b/exporter/containerimage/exptypes/parse_test.go
@@ -1,0 +1,30 @@
+package exptypes
+
+import (
+	"encoding/json"
+	"testing"
+
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePlatforms(t *testing.T) {
+	img := ocispecs.Image{
+		Platform: ocispecs.Platform{
+			OS:           "linux",
+			Architecture: "arm64",
+		},
+	}
+	dt, err := json.Marshal(img)
+	require.NoError(t, err)
+
+	meta := map[string][]byte{
+		ExporterImageConfigKey + "/linux/arm64": dt,
+	}
+
+	ps, err := ParsePlatforms(meta)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(ps.Platforms))
+	require.Equal(t, "linux", ps.Platforms[0].Platform.OS)
+	require.Equal(t, "arm64", ps.Platforms[0].Platform.Architecture)
+}


### PR DESCRIPTION
This PR allows ParsePlatforms to correctly identify platform-suffixed configuration keys (e.g., containerimage.config/linux/arm64) if the base key is missing. This is necessary when using FROM --platform in a Dockerfile without an explicit --platform build flag. Fixes moby/moby#52050