### PR TITLE
[v0.12] test: remove testSchema1Image

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -6129,23 +6129,6 @@ func testMoveParentDir(t *testing.T, sb integration.Sandbox) {
 	require.True(t, ok)
 }
 
-// #296
-func testSchema1Image(t *testing.T, sb integration.Sandbox) {
-	c, err := New(sb.Context(), sb.Address())
-	require.NoError(t, err)
-	defer c.Close()
-
-	st := llb.Image("gcr.io/google_containers/pause:3.0@sha256:0d093c962a6c2dd8bb8727b661e2b5f13e9df884af9945b4cc7088d9350cd3ee")
-
-	def, err := st.Marshal(sb.Context())
-	require.NoError(t, err)
-
-	_, err = c.Solve(sb.Context(), def, SolveOpt{}, nil)
-	require.NoError(t, err)
-
-	checkAllReleasable(t, c, sb, true)
-}
-
 // #319
 func testMountWithNoSource(t *testing.T, sb integration.Sandbox) {
 	c, err := New(sb.Context(), sb.Address())


### PR DESCRIPTION
- Skip testSchema1Image: gcr.io no longer supports Schema1 manifests
- Update Alpine pins from 3.18 to 3.20 with current digests

These changes ensure buildkit v0.12 tests pass with Moby v25.

Related PR: https://github.com/moby/moby/pull/52027