### PR TITLE
util/tracing: remove semconv dependency

### DIFF
--- a/util/tracing/detect/resource.go
+++ b/util/tracing/detect/resource.go
@@ -10,9 +10,9 @@ import (
 	"sync"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 )
 
 var (
@@ -21,6 +21,35 @@ var (
 	detectedResource     *resource.Resource
 	detectedResourceOnce sync.Once
 )
+
+// schemaURL is the OpenTelemetry semantic conventions schema URL. See [OTel Schema].
+//
+// [OTel Schema]: https://opentelemetry.io/docs/specs/otel/schemas/
+const schemaURL = "https://opentelemetry.io/schemas/1.37.0"
+
+// serviceNameKey is the OpenTelemetry semantic convention key for the
+// service name. See [service.name].
+//
+// [service.name]: https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/#service-name
+const serviceNameKey = "service.name"
+
+// telemetrySDKNameKey is the OpenTelemetry semantic convention key for
+// the telemetry SDK name. See [telemetry.sdk.name].
+//
+// [telemetry.sdk.name]: https://opentelemetry.io/docs/specs/semconv/registry/attributes/telemetry/#telemetry-sdk-name
+const telemetrySDKNameKey = "telemetry.sdk.name"
+
+// telemetrySDKLanguageKey is the OpenTelemetry semantic convention key for
+// the telemetry SDK language. See [telemetry.sdk.language].
+//
+// [telemetry.sdk.language]: https://opentelemetry.io/docs/specs/semconv/registry/attributes/telemetry/#telemetry-sdk-language
+const telemetrySDKLanguageKey = "telemetry.sdk.language"
+
+// telemetrySDKVersionKey is the OpenTelemetry semantic convention key for
+// the telemetry SDK version. See [telemetry.sdk.version].
+//
+// [telemetry.sdk.version]: https://opentelemetry.io/docs/specs/semconv/registry/attributes/telemetry/#telemetry-sdk-version
+const telemetrySDKVersionKey = "telemetry.sdk.version"
 
 func Resource() *resource.Resource {
 	detectedResourceOnce.Do(func() {
@@ -58,8 +87,8 @@ var (
 
 func (serviceNameDetector) Detect(ctx context.Context) (*resource.Resource, error) {
 	return resource.StringDetector(
-		semconv.SchemaURL,
-		semconv.ServiceNameKey,
+		schemaURL,
+		serviceNameKey,
 		func() (string, error) {
 			if ServiceName != "" {
 				return ServiceName, nil
@@ -69,12 +98,12 @@ func (serviceNameDetector) Detect(ctx context.Context) (*resource.Resource, erro
 	).Detect(ctx)
 }
 
-// Detect returns a *Resource that describes the OpenTelemetry SDK used.
+// Detect returns a [*resource.Resource] that describes the OpenTelemetry SDK used.
 func (telemetrySDK) Detect(context.Context) (*resource.Resource, error) {
 	return resource.NewWithAttributes(
-		semconv.SchemaURL,
-		semconv.TelemetrySDKName("opentelemetry"),
-		semconv.TelemetrySDKLanguageGo,
-		semconv.TelemetrySDKVersion(sdk.Version()),
+		schemaURL,
+		attribute.String(telemetrySDKNameKey, "opentelemetry"),
+		attribute.String(telemetrySDKLanguageKey, "go"),
+		attribute.String(telemetrySDKVersionKey, sdk.Version()),
 	), nil
 }

--- a/util/tracing/detect/resource_test.go
+++ b/util/tracing/detect/resource_test.go
@@ -22,7 +22,16 @@ func TestResource(t *testing.T) {
 
 	// Should not have an empty schema url. Only happens when
 	// there is a schema conflict.
-	require.NotEqual(t, "", res.SchemaURL())
+	require.NotEmpty(t, res.SchemaURL())
+
+	var found bool
+	for iter := res.Iter(); iter.Next(); {
+		if iter.Attribute().Key == serviceNameKey {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "expected to find service name attribute")
 
 	// No error should have been invoked.
 	require.NoError(t, resourceErr)

--- a/util/tracing/tracing.go
+++ b/util/tracing/tracing.go
@@ -11,9 +11,9 @@ import (
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
-	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
 )
@@ -37,12 +37,18 @@ func hasStacktrace(err error) bool {
 	return errors.As(err, &stack) || errors.As(err, &pkgStack)
 }
 
+// exceptionStacktraceKey is the OTEL semantic convention key for an exception
+// stacktrace. See [exception.stacktrace],
+//
+// [exception.stacktrace]: https://opentelemetry.io/docs/specs/semconv/registry/attributes/exception/#exception-stacktrace
+const exceptionStacktraceKey = "exception.stacktrace"
+
 // FinishWithError finalizes the span and sets the error if one is passed
 func FinishWithError(span trace.Span, err error) {
 	if err != nil {
 		span.RecordError(err)
 		if hasStacktrace(err) {
-			span.SetAttributes(semconv.ExceptionStacktrace(fmt.Sprintf("%+v", stack.Formatter(err))))
+			span.SetAttributes(attribute.String(exceptionStacktraceKey, fmt.Sprintf("%+v", stack.Formatter(err))))
 		}
 		span.SetStatus(codes.Error, err.Error())
 	}


### PR DESCRIPTION
Replace semconv imports with local constants for semconv keys.

These attributes are marked Stable in the OpenTelemetry Semantic Conventions and are not expected to change across semver releases:

- https://opentelemetry.io/docs/specs/semconv/
- https://opentelemetry.io/docs/specs/otel/versioning-and-stability/#semantic-conventions-stability

This avoids pulling in versioned semconv packages solely for stable attribute keys and prevents duplicate semconv versions in the module graph.