### PR TITLE
dockerfile2llb: make proxyEnvFromBuildArgs deterministic

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/frontend/dockerfile/dockerfile2llb/convert.go
@@ -2137,7 +2137,10 @@ func filterPaths(paths map[string]struct{}) []llb.LocalOption {
 func proxyEnvFromBuildArgs(args map[string]string) *llb.ProxyEnv {
 	pe := &llb.ProxyEnv{}
 	isNil := true
-	for k, v := range args {
+	keys := slices.Collect(maps.Keys(args))
+	slices.Sort(keys)
+	for _, k := range keys {
+		v := args[k]
 		if strings.EqualFold(k, "http_proxy") {
 			pe.HTTPProxy = v
 			isNil = false

--- a/frontend/dockerfile/dockerfile2llb/convert_test.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/shell"
 	"github.com/moby/buildkit/frontend/dockerui"
@@ -194,6 +195,29 @@ func TestToEnvList(t *testing.T) {
 	env = []string{"key1=val1"}
 	result = toEnvMap(args, env)
 	assert.Equal(t, map[string]string{"key1": "val1", "key2": "v1"}, result)
+}
+
+func TestProxyEnvFromBuildArgsDeterministicOrder(t *testing.T) {
+	pe := proxyEnvFromBuildArgs(map[string]string{
+		"ALL_PROXY":  "all-upper",
+		"all_proxy":  "all-lower",
+		"HTTP_PROXY": "http-upper",
+		"http_proxy": "http-lower",
+		"NO_PROXY":   "no-proxy",
+	})
+	require.NotNil(t, pe)
+	require.Equal(t, &llb.ProxyEnv{
+		HTTPProxy: "http-lower",
+		NoProxy:   "no-proxy",
+		AllProxy:  "all-lower",
+	}, pe)
+}
+
+func TestProxyEnvFromBuildArgsNilWhenNoProxyArgs(t *testing.T) {
+	pe := proxyEnvFromBuildArgs(map[string]string{
+		"FOO": "bar",
+	})
+	require.Nil(t, pe)
 }
 
 func TestDockerfileCircularDependencies(t *testing.T) {


### PR DESCRIPTION
follow-up https://github.com/docker/buildx/pull/3697

Updates `proxyEnvFromBuildArgs` to iterate build args in sorted key order so proxy variable selection is stable and no longer random.