### PR TITLE
refactor: deduplicate NopWriteCloser into util/iohelper

### DIFF
--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -2660,14 +2660,6 @@ func (b *buf) close() {
 	<-b.closed
 }
 
-type bufferCloser struct {
-	*bytes.Buffer
-}
-
-func (b bufferCloser) Close() error {
-	return nil
-}
-
 func mapToBlob(m map[string]string, compress bool) ([]byte, ocispecs.Descriptor, error) {
 	if !compress {
 		return mapToBlobWithCompression(m, nil)
@@ -2681,7 +2673,7 @@ func mapToBlobWithCompression(m map[string]string, compress func(io.Writer) (io.
 	buf := bytes.NewBuffer(nil)
 	sha := digest.SHA256.Digester()
 
-	var dest io.WriteCloser = bufferCloser{buf}
+	var dest io.WriteCloser = &iohelper.NopWriteCloser{Writer: buf}
 	mediaType := ocispecs.MediaTypeImageLayer
 	if compress != nil {
 		var err error
@@ -2724,7 +2716,7 @@ func fileToBlob(file *os.File, compress bool) ([]byte, ocispecs.Descriptor, erro
 	buf := bytes.NewBuffer(nil)
 	sha := digest.SHA256.Digester()
 
-	var dest io.WriteCloser = bufferCloser{buf}
+	var dest io.WriteCloser = &iohelper.NopWriteCloser{Writer: buf}
 	if compress {
 		dest = gzip.NewWriter(buf)
 	}

--- a/client/build_test.go
+++ b/client/build_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/entitlements"
 	"github.com/moby/buildkit/util/grpcerrors"
+	"github.com/moby/buildkit/util/iohelper"
 	utilsystem "github.com/moby/buildkit/util/system"
 	"github.com/moby/buildkit/util/testutil/echoserver"
 	"github.com/moby/buildkit/util/testutil/integration"
@@ -488,7 +489,7 @@ func testClientGatewayContainerExecPipe(t *testing.T, sb integration.Sandbox) {
 
 		pid4, err := ctr.Start(ctx, client.StartRequest{
 			Args:   []string{"cat", "/tmp/test"},
-			Stdout: &nopCloser{output},
+			Stdout: &iohelper.NopWriteCloser{Writer: output},
 		})
 		if err != nil {
 			return nil, err
@@ -836,7 +837,7 @@ func testClientGatewayContainerMounts(t *testing.T, sb integration.Sandbox) {
 		secretOutput := bytes.NewBuffer(nil)
 		pid, err = ctr.Start(ctx, client.StartRequest{
 			Args:   []string{"cat", "/run/secrets/mysecret"},
-			Stdout: &nopCloser{secretOutput},
+			Stdout: &iohelper.NopWriteCloser{Writer: secretOutput},
 		})
 		require.NoError(t, err)
 		err = pid.Wait()
@@ -987,8 +988,8 @@ func testClientGatewayContainerPID1Tty(t *testing.T, sb integration.Sandbox) {
 			Args:   []string{"sh"},
 			Tty:    true,
 			Stdin:  inputR,
-			Stdout: &nopCloser{output},
-			Stderr: &nopCloser{output},
+			Stdout: &iohelper.NopWriteCloser{Writer: output},
+			Stderr: &iohelper.NopWriteCloser{Writer: output},
 			Env:    []string{fmt.Sprintf("PS1=%s", prompt.String())},
 		})
 		require.NoError(t, err)
@@ -1069,8 +1070,8 @@ func testClientGatewayContainerCancelPID1Tty(t *testing.T, sb integration.Sandbo
 			Args:   []string{"sh"},
 			Tty:    true,
 			Stdin:  inputR,
-			Stdout: &nopCloser{output},
-			Stderr: &nopCloser{output},
+			Stdout: &iohelper.NopWriteCloser{Writer: output},
+			Stderr: &iohelper.NopWriteCloser{Writer: output},
 			Env:    []string{fmt.Sprintf("PS1=%s", prompt.String())},
 		})
 		require.NoError(t, err)
@@ -1201,8 +1202,8 @@ func testClientGatewayContainerExecTty(t *testing.T, sb integration.Sandbox) {
 			Args:   []string{"sh"},
 			Tty:    true,
 			Stdin:  inputR,
-			Stdout: &nopCloser{output},
-			Stderr: &nopCloser{output},
+			Stdout: &iohelper.NopWriteCloser{Writer: output},
+			Stderr: &iohelper.NopWriteCloser{Writer: output},
 			Env:    []string{fmt.Sprintf("PS1=%s", prompt.String())},
 		})
 		require.NoError(t, err)
@@ -1296,8 +1297,8 @@ func testClientGatewayContainerCancelExecTty(t *testing.T, sb integration.Sandbo
 			Args:   []string{"sh"},
 			Tty:    true,
 			Stdin:  inputR,
-			Stdout: &nopCloser{output},
-			Stderr: &nopCloser{output},
+			Stdout: &iohelper.NopWriteCloser{Writer: output},
+			Stderr: &iohelper.NopWriteCloser{Writer: output},
 			Env:    []string{fmt.Sprintf("PS1=%s", prompt.String())},
 		})
 		require.NoError(t, err)
@@ -1439,7 +1440,7 @@ func testClientGatewayContainerPlatformPATH(t *testing.T, sb integration.Sandbox
 				output := bytes.NewBuffer(nil)
 				pid1, err := ctr.Start(ctx, client.StartRequest{
 					Args:   []string{"/bin/sh", "-c", "echo -n $PATH"},
-					Stdout: &nopCloser{output},
+					Stdout: &iohelper.NopWriteCloser{Writer: output},
 				})
 				require.NoError(t, err)
 
@@ -1580,8 +1581,8 @@ func testClientGatewayExecError(t *testing.T, sb integration.Sandbox) {
 					Args:   []string{"sh"},
 					Tty:    true,
 					Stdin:  inputR,
-					Stdout: &nopCloser{pid1Output},
-					Stderr: &nopCloser{pid1Output},
+					Stdout: &iohelper.NopWriteCloser{Writer: pid1Output},
+					Stderr: &iohelper.NopWriteCloser{Writer: pid1Output},
 					Env:    []string{fmt.Sprintf("PS1=%s", prompt.String())},
 				})
 				require.NoError(t, err)
@@ -1594,7 +1595,7 @@ func testClientGatewayExecError(t *testing.T, sb integration.Sandbox) {
 						Env:          meta.Env,
 						User:         meta.User,
 						Cwd:          meta.Cwd,
-						Stdout:       &nopCloser{output},
+						Stdout:       &iohelper.NopWriteCloser{Writer: output},
 						SecurityMode: exec.Security,
 					})
 					require.NoError(t, err)
@@ -1693,7 +1694,7 @@ func testClientGatewaySlowCacheExecError(t *testing.T, sb integration.Sandbox) {
 		output := bytes.NewBuffer(nil)
 		proc, err := ctr.Start(ctx, client.StartRequest{
 			Args:   []string{"cat", "/problem/found/data"},
-			Stdout: &nopCloser{output},
+			Stdout: &iohelper.NopWriteCloser{Writer: output},
 		})
 		require.NoError(t, err)
 
@@ -1843,7 +1844,7 @@ func testClientGatewayExecFileActionError(t *testing.T, sb integration.Sandbox) 
 				output := bytes.NewBuffer(nil)
 				proc, err := ctr.Start(ctx, client.StartRequest{
 					Args:   []string{"cat", tt.Path},
-					Stdout: &nopCloser{output},
+					Stdout: &iohelper.NopWriteCloser{Writer: output},
 				})
 				require.NoError(t, err)
 
@@ -1957,8 +1958,8 @@ func testClientGatewayContainerSecurityMode(t *testing.T, sb integration.Sandbox
 
 		pid, err := ctr.Start(ctx, client.StartRequest{
 			Args:         command,
-			Stdout:       &nopCloser{stdout},
-			Stderr:       &nopCloser{stderr},
+			Stdout:       &iohelper.NopWriteCloser{Writer: stdout},
+			Stderr:       &iohelper.NopWriteCloser{Writer: stderr},
 			SecurityMode: mode,
 		})
 		if err != nil {
@@ -2048,8 +2049,8 @@ func testClientGatewayContainerExtraHosts(t *testing.T, sb integration.Sandbox) 
 
 		pid, err := ctr.Start(ctx, client.StartRequest{
 			Args:   []string{"grep", "169.254.11.22\tsome.host", "/etc/hosts"},
-			Stdout: &nopCloser{stdout},
-			Stderr: &nopCloser{stderr},
+			Stdout: &iohelper.NopWriteCloser{Writer: stdout},
+			Stderr: &iohelper.NopWriteCloser{Writer: stderr},
 		})
 		if err != nil {
 			ctr.Release(ctx)
@@ -2147,8 +2148,8 @@ func testClientGatewayContainerHostNetworking(t *testing.T, sb integration.Sandb
 
 		pid, err := ctr.Start(ctx, client.StartRequest{
 			Args:   []string{"/bin/sh", "-c", fmt.Sprintf("nc 127.0.0.1 %s | grep foo", port)},
-			Stdout: &nopCloser{stdout},
-			Stderr: &nopCloser{stderr},
+			Stdout: &iohelper.NopWriteCloser{Writer: stdout},
+			Stderr: &iohelper.NopWriteCloser{Writer: stderr},
 		})
 		if err != nil {
 			ctr.Release(ctx)
@@ -2363,12 +2364,4 @@ func testClientGatewayEmptyImageExec(t *testing.T, sb integration.Sandbox) {
 		return nil, nil
 	}, nil)
 	require.NoError(t, err)
-}
-
-type nopCloser struct {
-	io.Writer
-}
-
-func (n *nopCloser) Close() error {
-	return nil
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -67,6 +67,7 @@ import (
 	"github.com/moby/buildkit/util/contentutil"
 	"github.com/moby/buildkit/util/entitlements"
 	"github.com/moby/buildkit/util/gitutil/gitobject"
+	"github.com/moby/buildkit/util/iohelper"
 	"github.com/moby/buildkit/util/purl"
 	"github.com/moby/buildkit/util/testutil"
 	containerdutil "github.com/moby/buildkit/util/testutil/containerd"
@@ -99,12 +100,6 @@ func init() {
 		workers.InitContainerdWorker()
 	}
 }
-
-type nopWriteCloser struct {
-	io.Writer
-}
-
-func (nopWriteCloser) Close() error { return nil }
 
 var allTests = []func(t *testing.T, sb integration.Sandbox){
 	testCacheExportCacheKeyLoop,
@@ -2188,7 +2183,7 @@ func testFileOpCopyUIDCache(t *testing.T, sb integration.Sandbox) {
 		Exports: []ExportEntry{
 			{
 				Type:   ExporterTar,
-				Output: fixedWriteCloser(&nopWriteCloser{&buf}),
+				Output: fixedWriteCloser(&iohelper.NopWriteCloser{Writer: &buf}),
 			},
 		},
 	}, nil)
@@ -2214,7 +2209,7 @@ func testFileOpCopyUIDCache(t *testing.T, sb integration.Sandbox) {
 		Exports: []ExportEntry{
 			{
 				Type:   ExporterTar,
-				Output: fixedWriteCloser(&nopWriteCloser{&buf}),
+				Output: fixedWriteCloser(&iohelper.NopWriteCloser{Writer: &buf}),
 			},
 		},
 	}, nil)
@@ -2600,7 +2595,7 @@ func testOCILayoutSource(t *testing.T, sb integration.Sandbox) {
 			{
 				Type:   ExporterOCI,
 				Attrs:  attrs,
-				Output: fixedWriteCloser(nopWriteCloser{outW}),
+				Output: fixedWriteCloser(&iohelper.NopWriteCloser{Writer: outW}),
 			},
 		},
 	}, nil)
@@ -2723,7 +2718,7 @@ func testSessionExporter(t *testing.T, sb integration.Sandbox) {
 		require.Equal(t, "foo", resp.Entries[1].Path)
 
 		exporterCalled = true
-		target.Add(filesync.WithFSSync(0, fixedWriteCloser(nopWriteCloser{outW})))
+		target.Add(filesync.WithFSSync(0, fixedWriteCloser(&iohelper.NopWriteCloser{Writer: outW})))
 		return []*exporter.ExporterRequest{
 			{
 				Type: ExporterOCI,
@@ -2838,7 +2833,7 @@ func testOCILayoutPlatformSource(t *testing.T, sb integration.Sandbox) {
 			{
 				Type:   ExporterOCI,
 				Attrs:  attrs,
-				Output: fixedWriteCloser(nopWriteCloser{outW}),
+				Output: fixedWriteCloser(&iohelper.NopWriteCloser{Writer: outW}),
 			},
 		},
 	}, "", frontend, nil)
@@ -4720,7 +4715,7 @@ func testFrontendMetadataReturn(t *testing.T, sb integration.Sandbox) {
 		exports = []ExportEntry{{
 			Type:   ExporterOCI,
 			Attrs:  map[string]string{},
-			Output: fixedWriteCloser(nopWriteCloser{io.Discard}),
+			Output: fixedWriteCloser(&iohelper.NopWriteCloser{Writer: io.Discard}),
 		}}
 	}
 
@@ -4847,7 +4842,7 @@ func testTarExporterWithSocket(t *testing.T, sb integration.Sandbox) {
 				Type:  ExporterTar,
 				Attrs: map[string]string{},
 				Output: func(m map[string]string) (io.WriteCloser, error) {
-					return nopWriteCloser{io.Discard}, nil
+					return &iohelper.NopWriteCloser{Writer: io.Discard}, nil
 				},
 			},
 		},
@@ -4903,7 +4898,7 @@ func testTarExporterSymlink(t *testing.T, sb integration.Sandbox) {
 		Exports: []ExportEntry{
 			{
 				Type:   ExporterTar,
-				Output: fixedWriteCloser(&nopWriteCloser{&buf}),
+				Output: fixedWriteCloser(&iohelper.NopWriteCloser{Writer: &buf}),
 			},
 		},
 	}, nil)

--- a/client/validation_test.go
+++ b/client/validation_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/frontend/gateway/client"
 	sppb "github.com/moby/buildkit/sourcepolicy/pb"
+	"github.com/moby/buildkit/util/iohelper"
 	"github.com/moby/buildkit/util/testutil/integration"
 	"github.com/moby/buildkit/util/testutil/workers"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -55,7 +56,7 @@ func testValidateNullConfig(t *testing.T, sb integration.Sandbox) {
 		Exports: []ExportEntry{
 			{
 				Type:   ExporterOCI,
-				Output: fixedWriteCloser(nopWriteCloser{io.Discard}),
+				Output: fixedWriteCloser(&iohelper.NopWriteCloser{Writer: io.Discard}),
 			},
 		},
 	}, "", b, nil)
@@ -102,7 +103,7 @@ func testValidateInvalidConfig(t *testing.T, sb integration.Sandbox) {
 		Exports: []ExportEntry{
 			{
 				Type:   ExporterOCI,
-				Output: fixedWriteCloser(nopWriteCloser{io.Discard}),
+				Output: fixedWriteCloser(&iohelper.NopWriteCloser{Writer: io.Discard}),
 			},
 		},
 	}, "", b, nil)
@@ -141,7 +142,7 @@ func testValidatePlatformsEmpty(t *testing.T, sb integration.Sandbox) {
 		Exports: []ExportEntry{
 			{
 				Type:   ExporterOCI,
-				Output: fixedWriteCloser(nopWriteCloser{io.Discard}),
+				Output: fixedWriteCloser(&iohelper.NopWriteCloser{Writer: io.Discard}),
 			},
 		},
 	}, "", b, nil)
@@ -209,7 +210,7 @@ func testValidatePlatformsInvalid(t *testing.T, sb integration.Sandbox) {
 				Exports: []ExportEntry{
 					{
 						Type:   ExporterOCI,
-						Output: fixedWriteCloser(nopWriteCloser{io.Discard}),
+						Output: fixedWriteCloser(&iohelper.NopWriteCloser{Writer: io.Discard}),
 					},
 				},
 			}, "", b, nil)

--- a/executor/containerdexecutor/executor.go
+++ b/executor/containerdexecutor/executor.go
@@ -24,6 +24,7 @@ import (
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/solver/llbsolver/cdidevices"
 	"github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/util/iohelper"
 	"github.com/moby/buildkit/util/network"
 	"github.com/pkg/errors"
 )
@@ -324,10 +325,10 @@ func fixProcessOutput(process *executor.ProcessInfo) {
 	// failed to start io pipe copy: unable to copy pipes: containerd-shim: opening file "" failed: open : no such file or directory: unknown
 	// So just stub out any missing output
 	if process.Stdout == nil {
-		process.Stdout = &nopCloser{io.Discard}
+		process.Stdout = &iohelper.NopWriteCloser{Writer: io.Discard}
 	}
 	if process.Stderr == nil {
-		process.Stderr = &nopCloser{io.Discard}
+		process.Stderr = &iohelper.NopWriteCloser{Writer: io.Discard}
 	}
 }
 
@@ -448,12 +449,4 @@ func (w *containerdExecutor) runProcess(ctx context.Context, p ctd.Process, resi
 			return errors.Errorf("failed to kill process on cancel")
 		}
 	}
-}
-
-type nopCloser struct {
-	io.Writer
-}
-
-func (c *nopCloser) Close() error {
-	return nil
 }

--- a/frontend/dockerfile/dockerfile_provenance_test.go
+++ b/frontend/dockerfile/dockerfile_provenance_test.go
@@ -33,6 +33,7 @@ import (
 	provenancetypes "github.com/moby/buildkit/solver/llbsolver/provenance/types"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/contentutil"
+	"github.com/moby/buildkit/util/iohelper"
 	"github.com/moby/buildkit/util/testutil"
 	"github.com/moby/buildkit/util/testutil/integration"
 	"github.com/moby/buildkit/util/testutil/workers"
@@ -1313,7 +1314,7 @@ ENV FOO=bar
 			export: func() client.ExportEntry {
 				return client.ExportEntry{
 					Type:   client.ExporterTar,
-					Output: fixedWriteCloser(&nopWriteCloser{buf}),
+					Output: fixedWriteCloser(&iohelper.NopWriteCloser{Writer: buf}),
 				}
 			}(),
 		},

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -54,6 +54,7 @@ import (
 	spb "github.com/moby/buildkit/sourcepolicy/pb"
 	"github.com/moby/buildkit/util/contentutil"
 	"github.com/moby/buildkit/util/grpcerrors"
+	"github.com/moby/buildkit/util/iohelper"
 	"github.com/moby/buildkit/util/stack"
 	"github.com/moby/buildkit/util/testutil"
 	"github.com/moby/buildkit/util/testutil/httpserver"
@@ -805,7 +806,7 @@ COPY foo foo
 		Exports: []client.ExportEntry{
 			{
 				Type:   client.ExporterTar,
-				Output: fixedWriteCloser(&nopWriteCloser{buf}),
+				Output: fixedWriteCloser(&iohelper.NopWriteCloser{Writer: buf}),
 			},
 		},
 		LocalMounts: map[string]fsutil.FS{
@@ -853,7 +854,7 @@ FROM stage-$TARGETOS
 		Exports: []client.ExportEntry{
 			{
 				Type:   client.ExporterTar,
-				Output: fixedWriteCloser(&nopWriteCloser{buf}),
+				Output: fixedWriteCloser(&iohelper.NopWriteCloser{Writer: buf}),
 			},
 		},
 		LocalMounts: map[string]fsutil.FS{
@@ -876,7 +877,7 @@ FROM stage-$TARGETOS
 		Exports: []client.ExportEntry{
 			{
 				Type:   client.ExporterTar,
-				Output: fixedWriteCloser(&nopWriteCloser{buf}),
+				Output: fixedWriteCloser(&iohelper.NopWriteCloser{Writer: buf}),
 			},
 		},
 		FrontendAttrs: map[string]string{
@@ -3430,7 +3431,7 @@ ADD --chown=100:200 t.tar /out/
 		Exports: []client.ExportEntry{
 			{
 				Type:   client.ExporterTar,
-				Output: fixedWriteCloser(&nopWriteCloser{outBuf}),
+				Output: fixedWriteCloser(&iohelper.NopWriteCloser{Writer: outBuf}),
 			},
 		},
 		LocalMounts: map[string]fsutil.FS{
@@ -5561,7 +5562,7 @@ func testOnBuildNamedContext(t *testing.T, sb integration.Sandbox) {
 		Exports: []client.ExportEntry{
 			{
 				Type:   client.ExporterOCI,
-				Output: fixedWriteCloser(nopWriteCloser{outW}),
+				Output: fixedWriteCloser(&iohelper.NopWriteCloser{Writer: outW}),
 			},
 		},
 	}, nil)
@@ -8220,7 +8221,7 @@ func testNamedOCILayoutContext(t *testing.T, sb integration.Sandbox) {
 		Exports: []client.ExportEntry{
 			{
 				Type:   client.ExporterOCI,
-				Output: fixedWriteCloser(nopWriteCloser{outW}),
+				Output: fixedWriteCloser(&iohelper.NopWriteCloser{Writer: outW}),
 			},
 		},
 	}, nil)
@@ -8370,7 +8371,7 @@ ENV foo=bar
 		},
 		Exports: []client.ExportEntry{{
 			Type:   client.ExporterOCI,
-			Output: fixedWriteCloser(nopWriteCloser{outW}),
+			Output: fixedWriteCloser(&iohelper.NopWriteCloser{Writer: outW}),
 		}},
 	}, nil)
 	require.NoError(t, err)
@@ -8425,7 +8426,7 @@ FROM nonexistent AS base
 		Exports: []client.ExportEntry{
 			{
 				Type:   client.ExporterOCI,
-				Output: fixedWriteCloser(nopWriteCloser{outW}),
+				Output: fixedWriteCloser(&iohelper.NopWriteCloser{Writer: outW}),
 			},
 		},
 	}, nil)
@@ -9324,7 +9325,7 @@ EOF
 		Exports: []client.ExportEntry{
 			{
 				Type:   client.ExporterOCI,
-				Output: fixedWriteCloser(&nopWriteCloser{buf}),
+				Output: fixedWriteCloser(&iohelper.NopWriteCloser{Writer: buf}),
 				Attrs: map[string]string{
 					"name": "org/repo:tag1,org/repo:tag2",
 				},
@@ -10659,12 +10660,6 @@ func getFrontend(t *testing.T, sb integration.Sandbox) frontend {
 	require.True(t, ok)
 	return fn
 }
-
-type nopWriteCloser struct {
-	io.Writer
-}
-
-func (nopWriteCloser) Close() error { return nil }
 
 type secModeSandbox struct{}
 

--- a/worker/runc/runc_test.go
+++ b/worker/runc/runc_test.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -21,6 +20,7 @@ import (
 	"github.com/moby/buildkit/executor/oci"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/snapshot"
+	"github.com/moby/buildkit/util/iohelper"
 	"github.com/moby/buildkit/util/network/netproviders"
 	"github.com/moby/buildkit/worker/base"
 	"github.com/moby/buildkit/worker/tests"
@@ -111,7 +111,7 @@ func TestRuncWorker(t *testing.T) {
 	}
 
 	stderr := bytes.NewBuffer(nil)
-	_, err = w.WorkerOpt.Executor.Run(ctx, "", execMount(snap, true), nil, executor.ProcessInfo{Meta: meta, Stderr: &nopCloser{stderr}}, nil)
+	_, err = w.WorkerOpt.Executor.Run(ctx, "", execMount(snap, true), nil, executor.ProcessInfo{Meta: meta, Stderr: &iohelper.NopWriteCloser{Writer: stderr}}, nil)
 	require.Error(t, err) // Read-only root
 	// typical error is like `mkdir /.../rootfs/proc: read-only file system`.
 	// make sure the error is caused before running `echo foo > /bar`.
@@ -120,7 +120,7 @@ func TestRuncWorker(t *testing.T) {
 	root, err := w.CacheMgr.New(ctx, snap, nil, cache.CachePolicyRetain)
 	require.NoError(t, err)
 
-	_, err = w.WorkerOpt.Executor.Run(ctx, "", execMount(root, false), nil, executor.ProcessInfo{Meta: meta, Stderr: &nopCloser{stderr}}, nil)
+	_, err = w.WorkerOpt.Executor.Run(ctx, "", execMount(root, false), nil, executor.ProcessInfo{Meta: meta, Stderr: &iohelper.NopWriteCloser{Writer: stderr}}, nil)
 	require.NoError(t, err)
 
 	meta = executor.Meta{
@@ -128,7 +128,7 @@ func TestRuncWorker(t *testing.T) {
 		Cwd:  "/",
 	}
 
-	_, err = w.WorkerOpt.Executor.Run(ctx, "", execMount(root, false), nil, executor.ProcessInfo{Meta: meta, Stderr: &nopCloser{stderr}}, nil)
+	_, err = w.WorkerOpt.Executor.Run(ctx, "", execMount(root, false), nil, executor.ProcessInfo{Meta: meta, Stderr: &iohelper.NopWriteCloser{Writer: stderr}}, nil)
 	require.NoError(t, err)
 
 	rf, err := root.Commit(ctx)
@@ -206,7 +206,7 @@ func TestRuncWorkerNoProcessSandbox(t *testing.T) {
 	}
 	stdout := bytes.NewBuffer(nil)
 	stderr := bytes.NewBuffer(nil)
-	_, err = w.WorkerOpt.Executor.Run(ctx, "", execMount(root, false), nil, executor.ProcessInfo{Meta: meta, Stdout: &nopCloser{stdout}, Stderr: &nopCloser{stderr}}, nil)
+	_, err = w.WorkerOpt.Executor.Run(ctx, "", execMount(root, false), nil, executor.ProcessInfo{Meta: meta, Stdout: &iohelper.NopWriteCloser{Writer: stdout}, Stderr: &iohelper.NopWriteCloser{Writer: stderr}}, nil)
 	require.NoError(t, err, "stdout=%q, stderr=%q", stdout.String(), stderr.String())
 	require.Equal(t, string(selfCmdline), stdout.String())
 }
@@ -242,14 +242,6 @@ func TestRuncWorkerCancel(t *testing.T) {
 	require.NoError(t, err)
 
 	tests.TestWorkerCancel(t, w)
-}
-
-type nopCloser struct {
-	io.Writer
-}
-
-func (n *nopCloser) Close() error {
-	return nil
 }
 
 func execMount(m cache.Mountable, readonly bool) executor.Mount {

--- a/worker/tests/common.go
+++ b/worker/tests/common.go
@@ -15,6 +15,7 @@ import (
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/snapshot"
 	"github.com/moby/buildkit/source/containerimage"
+	"github.com/moby/buildkit/util/iohelper"
 	"github.com/moby/buildkit/util/testutil/integration"
 	"github.com/moby/buildkit/worker/base"
 	"github.com/pkg/errors"
@@ -95,8 +96,8 @@ func TestWorkerExec(t *testing.T, w *base.Worker) {
 			Env:  []string{"PATH=/bin:/usr/bin:/sbin:/usr/sbin"},
 		},
 		Stdin:  pipeR,
-		Stdout: &nopCloser{stdout},
-		Stderr: &nopCloser{stderr},
+		Stdout: &iohelper.NopWriteCloser{Writer: stdout},
+		Stderr: &iohelper.NopWriteCloser{Writer: stderr},
 	}, started)
 	cancelTimeout()
 	t.Logf("Stdout: %s", stdout.String())
@@ -133,8 +134,8 @@ func TestWorkerExec(t *testing.T, w *base.Worker) {
 		Meta: executor.Meta{
 			Args: []string{"ps", "-o", "pid,comm"},
 		},
-		Stdout: &nopCloser{stdout},
-		Stderr: &nopCloser{stderr},
+		Stdout: &iohelper.NopWriteCloser{Writer: stdout},
+		Stderr: &iohelper.NopWriteCloser{Writer: stderr},
 	})
 	t.Logf("Stdout: %s", stdout.String())
 	t.Logf("Stderr: %s", stderr.String())
@@ -152,8 +153,8 @@ func TestWorkerExec(t *testing.T, w *base.Worker) {
 			Args: []string{"sh", "-c", "cat > /tmp/msg"},
 		},
 		Stdin:  io.NopCloser(stdin),
-		Stdout: &nopCloser{stdout},
-		Stderr: &nopCloser{stderr},
+		Stdout: &iohelper.NopWriteCloser{Writer: stdout},
+		Stderr: &iohelper.NopWriteCloser{Writer: stderr},
 	})
 	require.NoError(t, err)
 	require.Empty(t, stdout.String())
@@ -166,8 +167,8 @@ func TestWorkerExec(t *testing.T, w *base.Worker) {
 		Meta: executor.Meta{
 			Args: []string{"cat", "/tmp/msg"},
 		},
-		Stdout: &nopCloser{stdout},
-		Stderr: &nopCloser{stderr},
+		Stdout: &iohelper.NopWriteCloser{Writer: stdout},
+		Stderr: &iohelper.NopWriteCloser{Writer: stderr},
 	})
 	t.Logf("Stdout: %s", stdout.String())
 	t.Logf("Stderr: %s", stderr.String())
@@ -331,14 +332,6 @@ func TestWorkerCancel(t *testing.T, w *base.Worker) {
 	pid1Cancel(errors.WithStack(context.Canceled))
 	<-pid1Done
 	require.Contains(t, pid1Err.Error(), "exit code: 137", "pid1 exits with sigkill")
-}
-
-type nopCloser struct {
-	io.Writer
-}
-
-func (n *nopCloser) Close() error {
-	return nil
 }
 
 func execMount(m cache.Mountable) executor.Mount {


### PR DESCRIPTION
Replace duplicate definitions across test and production code with the (already existing) shared `iohelper.NopWriteCloser` type.