### PR TITLE
solver: skip eager extraction of destination inputs in file ops

### DIFF
--- a/solver/llbsolver/ops/file.go
+++ b/solver/llbsolver/ops/file.go
@@ -167,7 +167,14 @@ func (f *fileOp) CacheMap(ctx context.Context, jobCtx solver.JobContext, index i
 		cm.Deps[idx].ComputeDigestFunc = opsutils.NewContentHashFunc(dedupeSelectors(m))
 	}
 	for idx := range cm.Deps {
-		cm.Deps[idx].PreprocessFunc = unlazyResultFunc
+		// Only set PreprocessFunc on deps that need content-based cache key computation.
+		// Destination inputs (marked invalid) don't have ComputeDigestFunc, so extracting
+		// them eagerly during the slow cache phase is wasted work — they get downloaded and
+		// decompressed just to advance the solver state machine, producing no cache key.
+		// On cache miss, Exec() handles extraction of any blob-only refs before use.
+		if cm.Deps[idx].ComputeDigestFunc != nil {
+			cm.Deps[idx].PreprocessFunc = unlazyResultFunc
+		}
 	}
 
 	return cm, true, nil
@@ -179,6 +186,14 @@ func (f *fileOp) Exec(ctx context.Context, jobCtx solver.JobContext, inputs []so
 		workerRef, ok := inp.Sys().(*worker.WorkerRef)
 		if !ok {
 			return nil, errors.Errorf("invalid reference for exec %T", inp.Sys())
+		}
+		// Ensure blob-only refs are extracted before use. Refs whose PreprocessFunc
+		// was not set during CacheMap (e.g. destination inputs) may still be lazy
+		// at this point. Extract is a no-op if the snapshot already exists.
+		if workerRef.ImmutableRef != nil {
+			if err := workerRef.ImmutableRef.Extract(ctx, jobCtx.Session()); err != nil {
+				return nil, err
+			}
 		}
 		inpRefs = append(inpRefs, workerRef.ImmutableRef)
 	}

--- a/solver/llbsolver/ops/file_test.go
+++ b/solver/llbsolver/ops/file_test.go
@@ -554,6 +554,75 @@ func TestFileParallelActions(t *testing.T) {
 	require.Equal(t, int64(2), sem)
 }
 
+func TestFileOpCacheMapPreprocessFunc(t *testing.T) {
+	t.Parallel()
+
+	t.Run("copy sets PreprocessFunc only on source input", func(t *testing.T) {
+		t.Parallel()
+		// Copy action: input 0 is destination (marked invalid), input 1 is source (secondary).
+		// Only the source input should get ComputeDigestFunc and PreprocessFunc.
+		fo := &pb.FileOp{
+			Actions: []*pb.FileAction{
+				{
+					Input:          0,
+					SecondaryInput: 1,
+					Output:         0,
+					Action: &pb.FileAction_Copy{
+						Copy: &pb.FileActionCopy{
+							Src:  "/src",
+							Dest: "/dest",
+						},
+					},
+				},
+			},
+		}
+
+		f := &fileOp{op: fo, numInputs: 2}
+		cm, ok, err := f.CacheMap(t.Context(), testJobContext(t), 0)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Len(t, cm.Deps, 2)
+
+		// Dep 0 is the destination input — no content hash, no preprocess.
+		require.Nil(t, cm.Deps[0].ComputeDigestFunc)
+		require.Nil(t, cm.Deps[0].PreprocessFunc)
+
+		// Dep 1 is the source input — has content hash and preprocess.
+		require.NotNil(t, cm.Deps[1].ComputeDigestFunc)
+		require.NotNil(t, cm.Deps[1].PreprocessFunc)
+	})
+
+	t.Run("mkdir sets no PreprocessFunc on destination-only input", func(t *testing.T) {
+		t.Parallel()
+		// Mkdir only has a destination input (input 0). No source input exists,
+		// so no dep should get ComputeDigestFunc or PreprocessFunc.
+		fo := &pb.FileOp{
+			Actions: []*pb.FileAction{
+				{
+					Input:          0,
+					SecondaryInput: -1,
+					Output:         0,
+					Action: &pb.FileAction_Mkdir{
+						Mkdir: &pb.FileActionMkDir{
+							Path: "/foo",
+							Mode: 0700,
+						},
+					},
+				},
+			},
+		}
+
+		f := &fileOp{op: fo, numInputs: 1}
+		cm, ok, err := f.CacheMap(t.Context(), testJobContext(t), 0)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Len(t, cm.Deps, 1)
+
+		require.Nil(t, cm.Deps[0].ComputeDigestFunc)
+		require.Nil(t, cm.Deps[0].PreprocessFunc)
+	})
+}
+
 func newTestFileSolver() (*FileOpSolver, *testFileRefBackend) {
 	trb := &testFileRefBackend{refs: map[*testFileRef]struct{}{}, mounts: map[string]*testMount{}}
 	return NewFileOpSolver(nil, &testFileBackend{}, trb), trb


### PR DESCRIPTION
This PR improves the local cache by skipping unnecessary extraction of destination-input layers.

Example without the change:
```
2026-03-10T10:56:48.589Z #1 [internal] load build definition from .actor/Dockerfile
2026-03-10T10:56:48.592Z #1 transferring dockerfile: 1.68kB done
2026-03-10T10:56:48.594Z #1 DONE 0.0s
2026-03-10T10:56:48.596Z #2 [internal] load metadata for docker.io/apify/actor-node:20
2026-03-10T10:56:49.635Z #2 DONE 1.2s
2026-03-10T10:56:49.752Z #3 [internal] load .dockerignore
2026-03-10T10:56:49.755Z #3 transferring context: 210B done
2026-03-10T10:56:49.756Z #3 DONE 0.0s
2026-03-10T10:56:49.757Z #4 [builder 1/5] FROM docker.io/apify/actor-node:20@sha256:1be650017bc1fdc161a4948a3ebbe9acc3305c8fcf9ebab12f69f58893c8e82d
2026-03-10T10:56:49.758Z #4 resolve docker.io/apify/actor-node:20@sha256:1be650017bc1fdc161a4948a3ebbe9acc3305c8fcf9ebab12f69f58893c8e82d done
2026-03-10T10:56:49.759Z #4 DONE 0.0s
2026-03-10T10:56:49.760Z #5 importing cache manifest from local:12386051227344261556
2026-03-10T10:56:49.763Z #5 inferred cache manifest type: application/vnd.oci.image.index.v1+json done
2026-03-10T10:56:49.764Z #5 DONE 0.0s
2026-03-10T10:56:49.765Z #6 importing cache manifest from host.docker.internal:5678/buildkit-cache:cache
2026-03-10T10:56:49.766Z #6 inferred cache manifest type: application/vnd.oci.image.index.v1+json done
2026-03-10T10:56:49.767Z #6 DONE 0.0s
2026-03-10T10:56:49.768Z #7 [internal] load build context
2026-03-10T10:56:49.768Z #7 transferring context: 10.22kB done
2026-03-10T10:56:49.769Z #7 DONE 0.0s
2026-03-10T10:56:49.770Z #8 [stage-1 3/5] RUN npm --quiet set progress=false     && npm install --omit=dev --omit=optional     && echo "Installed NPM packages:"     && (npm list --omit=dev --all || true)     && echo "Node.js version:"     && node --version     && echo "NPM version:"     && npm --version     && rm -r ~/.npm
2026-03-10T10:56:49.771Z #8 CACHED
2026-03-10T10:56:49.771Z #9 [builder 4/5] COPY . ./
2026-03-10T10:56:49.772Z #9 CACHED
2026-03-10T10:56:49.773Z #10 [builder 3/5] RUN npm install --include=dev --audit=false
2026-03-10T10:56:49.774Z #10 CACHED
2026-03-10T10:56:49.775Z #11 [stage-1 4/5] COPY --from=builder /usr/src/app/dist ./dist
2026-03-10T10:56:49.775Z #11 CACHED
2026-03-10T10:56:49.776Z #12 [builder 5/5] RUN npm run build
2026-03-10T10:56:49.777Z #12 CACHED
2026-03-10T10:56:49.778Z #13 [builder 2/5] COPY package*.json ./
2026-03-10T10:56:49.778Z #13 CACHED
2026-03-10T10:56:49.779Z #14 [stage-1 5/5] COPY . ./
2026-03-10T10:56:49.779Z #14 sha256:589002ba0eaed121a1dbf42f6648f29e5be55d5c8a6ee0f8eaa0285cc21ac153 3.86MB / 3.86MB 0.0s done
2026-03-10T10:56:49.780Z #14 extracting sha256:589002ba0eaed121a1dbf42f6648f29e5be55d5c8a6ee0f8eaa0285cc21ac153 0.0s done
2026-03-10T10:56:49.909Z #14 sha256:ad6d96c196e3198e14ea37df8bba4f54bf92fb525eb65e49fa4027c7dee13f80 36.70MB / 42.78MB 0.2s
2026-03-10T10:56:50.131Z #14 sha256:ad6d96c196e3198e14ea37df8bba4f54bf92fb525eb65e49fa4027c7dee13f80 42.78MB / 42.78MB 0.2s done
2026-03-10T10:56:50.133Z #14 extracting sha256:ad6d96c196e3198e14ea37df8bba4f54bf92fb525eb65e49fa4027c7dee13f80
2026-03-10T10:56:50.883Z #14 extracting sha256:ad6d96c196e3198e14ea37df8bba4f54bf92fb525eb65e49fa4027c7dee13f80 0.9s done
2026-03-10T10:56:51.130Z #14 sha256:eb87f4721c91769ed5206f34a9ab6ec98fc1d5235c12c2fc956665b1155e9ecb 1.26MB / 1.26MB done
2026-03-10T10:56:51.132Z #14 extracting sha256:eb87f4721c91769ed5206f34a9ab6ec98fc1d5235c12c2fc956665b1155e9ecb 0.0s done
2026-03-10T10:56:51.133Z #14 sha256:e31b2016552274339ed88ed4a438d78bf37e0f6bdf328d02207b2a598c1ef86d 445B / 445B done
2026-03-10T10:56:51.135Z #14 extracting sha256:e31b2016552274339ed88ed4a438d78bf37e0f6bdf328d02207b2a598c1ef86d done
2026-03-10T10:56:51.136Z #14 sha256:1d5c5cbda73ff1cf0a50de2dd1cc0ef60f9b2a5fb452b9361cc80894f1c7a16f 1.54kB / 1.54kB done
2026-03-10T10:56:51.137Z #14 extracting sha256:1d5c5cbda73ff1cf0a50de2dd1cc0ef60f9b2a5fb452b9361cc80894f1c7a16f done
2026-03-10T10:56:51.138Z #14 sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1 32B / 32B done
2026-03-10T10:56:51.139Z #14 extracting sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1 done
2026-03-10T10:56:51.140Z #14 sha256:fef9cad10dd8ab866c4d59ae306789215b33a94bc2919a9ef962283abfdcee56 900B / 900B done
2026-03-10T10:56:51.141Z #14 extracting sha256:fef9cad10dd8ab866c4d59ae306789215b33a94bc2919a9ef962283abfdcee56 done
2026-03-10T10:56:51.142Z #14 sha256:e04775480e845feaeb4097c9390e70f07119ac61320f1f986f57f2d797c64a1f 36.70MB / 81.13MB 0.2s
2026-03-10T10:56:51.278Z #14 sha256:e04775480e845feaeb4097c9390e70f07119ac61320f1f986f57f2d797c64a1f 75.50MB / 81.13MB 0.3s
2026-03-10T10:56:51.533Z #14 sha256:e04775480e845feaeb4097c9390e70f07119ac61320f1f986f57f2d797c64a1f 81.13MB / 81.13MB 0.4s done
2026-03-10T10:56:51.534Z #14 extracting sha256:e04775480e845feaeb4097c9390e70f07119ac61320f1f986f57f2d797c64a1f
2026-03-10T10:56:53.897Z #14 extracting sha256:e04775480e845feaeb4097c9390e70f07119ac61320f1f986f57f2d797c64a1f 2.5s done
2026-03-10T10:56:54.072Z #14 sha256:103d178176d1a18a40ab7b2df66ca5406de097dc8f5496825178bfb541cedde1 533B / 533B done
2026-03-10T10:56:54.073Z #14 extracting sha256:103d178176d1a18a40ab7b2df66ca5406de097dc8f5496825178bfb541cedde1 done
2026-03-10T10:56:54.074Z #14 sha256:4594b9db33e115e6ea32e8d6e10db3d41b18d4e7ef2ca9d134e86a025424f198 48.34kB / 48.34kB done
2026-03-10T10:56:54.075Z #14 extracting sha256:4594b9db33e115e6ea32e8d6e10db3d41b18d4e7ef2ca9d134e86a025424f198
2026-03-10T10:56:54.737Z #14 extracting sha256:4594b9db33e115e6ea32e8d6e10db3d41b18d4e7ef2ca9d134e86a025424f198 0.8s done
2026-03-10T10:56:54.915Z #14 sha256:07d4169c4932df01c81c6a2383df74b888b921f03031a32a9256f8c7a764957c 31.39kB / 31.39kB done
2026-03-10T10:56:54.917Z #14 extracting sha256:07d4169c4932df01c81c6a2383df74b888b921f03031a32a9256f8c7a764957c done
2026-03-10T10:56:54.918Z #14 sha256:03be4c3ebbefe575d13efef126655ec7fde382e0f9045853b7cdc26905807086 3.99kB / 3.99kB done
2026-03-10T10:56:54.919Z #14 extracting sha256:03be4c3ebbefe575d13efef126655ec7fde382e0f9045853b7cdc26905807086 done
2026-03-10T10:56:54.920Z #14 CACHED
```
Example with the change:
```
2026-03-10T10:55:34.864Z #1 [internal] load build definition from .actor/Dockerfile
2026-03-10T10:55:34.865Z #1 transferring dockerfile: 1.68kB 0.0s done
2026-03-10T10:55:34.866Z #1 DONE 0.1s
2026-03-10T10:55:34.868Z #2 [internal] load metadata for docker.io/apify/actor-node:20
2026-03-10T10:55:36.050Z #2 DONE 1.3s
2026-03-10T10:55:36.194Z #3 [internal] load .dockerignore
2026-03-10T10:55:36.196Z #3 transferring context: 210B done
2026-03-10T10:55:36.197Z #3 DONE 0.0s
2026-03-10T10:55:36.198Z #4 [builder 1/5] FROM docker.io/apify/actor-node:20@sha256:1be650017bc1fdc161a4948a3ebbe9acc3305c8fcf9ebab12f69f58893c8e82d
2026-03-10T10:55:36.199Z #4 resolve docker.io/apify/actor-node:20@sha256:1be650017bc1fdc161a4948a3ebbe9acc3305c8fcf9ebab12f69f58893c8e82d done
2026-03-10T10:55:36.200Z #4 DONE 0.0s
2026-03-10T10:55:36.201Z #5 importing cache manifest from local:3838470765326055733
2026-03-10T10:55:36.201Z #5 inferred cache manifest type: application/vnd.oci.image.manifest.v1+json done
2026-03-10T10:55:36.202Z #5 DONE 0.0s
2026-03-10T10:55:36.203Z #6 importing cache manifest from host.docker.internal:5678/buildkit-cache:cache
2026-03-10T10:55:36.204Z #6 inferred cache manifest type: application/vnd.oci.image.manifest.v1+json done
2026-03-10T10:55:36.205Z #6 DONE 0.0s
2026-03-10T10:55:36.206Z #7 [internal] load build context
2026-03-10T10:55:36.208Z #7 transferring context: 10.22kB done
2026-03-10T10:55:36.209Z #7 DONE 0.0s
2026-03-10T10:55:36.211Z #8 [builder 4/5] COPY . ./
2026-03-10T10:55:36.212Z #8 CACHED
2026-03-10T10:55:36.213Z #9 [builder 5/5] RUN npm run build
2026-03-10T10:55:36.215Z #9 CACHED
2026-03-10T10:55:36.216Z #10 [builder 2/5] COPY package*.json ./
2026-03-10T10:55:36.217Z #10 CACHED
2026-03-10T10:55:36.219Z #11 [stage-1 3/5] RUN npm --quiet set progress=false     && npm install --omit=dev --omit=optional     && echo "Installed NPM packages:"     && (npm list --omit=dev --all || true)     && echo "Node.js version:"     && node --version     && echo "NPM version:"     && npm --version     && rm -r ~/.npm
2026-03-10T10:55:36.221Z #11 CACHED
2026-03-10T10:55:36.222Z #12 [stage-1 4/5] COPY --from=builder /usr/src/app/dist ./dist
2026-03-10T10:55:36.225Z #12 CACHED
2026-03-10T10:55:36.228Z #13 [builder 3/5] RUN npm install --include=dev --audit=false
2026-03-10T10:55:36.229Z #13 CACHED
2026-03-10T10:55:36.231Z #14 [stage-1 5/5] COPY . ./
2026-03-10T10:55:36.232Z #14 CACHED
```

Notice the difference in `step 14`. As you can see, the total duration of the build is much lower.

Previously, `PreprocessFunc` was set on all deps, this was wasted on a cache hit.
Now we only set it on deps that have `ComputeDigestFunc`. There's a safety net in `Exec()` as well.

Let me know if you have any other questions or feedback. Thanks