### PR TITLE
Test Updates for client, secrets and provenance

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1083,8 +1083,15 @@ func testRawSocketMount(t *testing.T, sb integration.Sandbox) {
 	require.True(t, called.Load(), "server should have been called")
 }
 
+/*
+testExtraHosts verifies that custom host entries added via llb.AddExtraHost() are resolvable
+during a RUN step. It adds "myhost" pointing to 1.2.3.4 and checks /etc/hosts for the entry.
+
+Skipped on Windows because BuildKit for Windows does not support llb.AddExtraHost()
+at the moment due to fundamental differences in how Linux and Windows containers handle hosts file injections
+*/
 func testExtraHosts(t *testing.T, sb integration.Sandbox) {
-	integration.SkipOnPlatform(t, "windows")
+	integration.SkipOnPlatform(t, "windows", "extra hosts not supported on BuildKit for Windows at the moment")
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
@@ -1723,12 +1730,35 @@ func testFrontendImageNaming(t *testing.T, sb integration.Sandbox) {
 	checkAllReleasable(t, c, sb, true)
 }
 
+/*
+testSecretMounts verifies file-based secret mounts: content readability, optional/required
+behavior, custom permissions, and empty secrets. Skipped on Windows because BuildKit uses
+tmpfs for secret mounts, which Windows does not support. See testSecretEnv for a
+cross-platform alternative using environment-based secrets.
+*/
 func testSecretMounts(t *testing.T, sb integration.Sandbox) {
-	integration.SkipOnPlatform(t, "windows")
+	// Windows vs Linux secret implementation differences:
+	//
+	// Linux: Secrets are mounted as files using tmpfs at /run/secrets/ (RAM-based, encrypted)
+	//
+	// Windows: Secrets are stored in C:\ProgramData\Docker\internal\secrets (clear text on disk)
+	//          Symbolic links point to the desired target (default: C:\ProgramData\Docker\secrets)
+	//          Windows does NOT support tmpfs or non-directory file bind-mounts
+	//          UID/GID/mode options are NOT supported on Windows
+	//          Recommend BitLocker for at-rest encryption
+	//
+	// BuildKit Issue: The "invalid windows mount type: 'tmpfs'" error occurs because BuildKit
+	// currently tries to use tmpfs for all secret mounts. This needs to be fixed in BuildKit's
+	// secret mount implementation to use the Windows symlink approach instead.
+
+	// For now, this test is Linux-only until BuildKit properly implements Windows secret mounts
+	// without tmpfs. Use testSecretEnv for Windows-compatible environment-based secrets.
+	integration.SkipOnPlatform(t, "windows", "Windows does not support tmpfs for secret mounts")
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
 
+	// Test 1: Basic secret mount with content verification (Linux only)
 	st := llb.Image("busybox:latest").
 		Run(llb.Shlex(`sh -c 'mount | grep mysecret | grep "type tmpfs" && [ "$(cat /run/secrets/mysecret)" = 'foo-secret' ]'`), llb.AddSecret("/run/secrets/mysecret"))
 
@@ -1742,7 +1772,7 @@ func testSecretMounts(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	// test optional, mount should not exist when secret not present in SolveOpt
+	// Test 2: Optional secret - mount should not exist when secret not present in SolveOpt
 	st = llb.Image("busybox:latest").
 		Run(llb.Shlex(`test ! -f /run/secrets/mysecret2`), llb.AddSecret("/run/secrets/mysecret2", llb.SecretOptional))
 
@@ -1757,6 +1787,7 @@ func testSecretMounts(t *testing.T, sb integration.Sandbox) {
 	_, err = c.Solve(sb.Context(), def, SolveOpt{}, nil)
 	require.NoError(t, err)
 
+	// Test 3: Required secret missing - should error
 	st = llb.Image("busybox:latest").
 		Run(llb.Shlex(`echo secret3`), llb.AddSecret("/run/secrets/mysecret3"))
 
@@ -1768,7 +1799,7 @@ func testSecretMounts(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.Error(t, err)
 
-	// test id,perm,uid
+	// Test 4: Secret with custom ID and file permissions
 	st = llb.Image("busybox:latest").
 		Run(llb.Shlex(`sh -c '[ "$(stat -c "%u %g %f" /run/secrets/mysecret4)" = "1 1 81ff" ]' `), llb.AddSecret("/run/secrets/mysecret4", llb.SecretID("mysecret"), llb.SecretFileOpt(1, 1, 0777)))
 
@@ -1782,7 +1813,7 @@ func testSecretMounts(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	// test empty cert still creates secret file
+	// Test 5: Empty secret still creates secret file
 	st = llb.Image("busybox:latest").
 		Run(llb.Shlex(`test -f /run/secrets/mysecret5`), llb.AddSecret("/run/secrets/mysecret5", llb.SecretID("mysecret")))
 
@@ -1797,14 +1828,30 @@ func testSecretMounts(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 }
 
+/*
+testSecretEnv verifies that secrets can be injected as environment variables during a build.
+It tests four scenarios: (1) a provided secret is accessible via env var, (2) an optional
+secret that is not provided results in an unset/empty env var, (3) a required secret that
+is not provided causes an error, and (4) multiple secrets with custom IDs are resolved correctly.
+Works on both Linux (busybox) and Windows (nanoserver).
+*/
 func testSecretEnv(t *testing.T, sb integration.Sandbox) {
-	integration.SkipOnPlatform(t, "windows")
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
 
-	st := llb.Image("busybox:latest").
-		Run(llb.Shlex(`sh -c '[ "$(echo ${MY_SECRET})" = 'foo-secret' ]'`), llb.AddSecret("MY_SECRET", llb.SecretAsEnv(true)))
+	imgName := integration.UnixOrWindows("busybox:latest", "nanoserver:latest")
+	var st llb.ExecState
+
+	// Test 1: Verify secret value is accessible as environment variable
+	switch imgName {
+	case "nanoserver:latest":
+		st = llb.Image(imgName).
+			Run(llb.Shlex(`cmd /C "if "%MY_SECRET%"=="foo-secret" (exit 0) else (exit 1)"`), llb.AddSecret("MY_SECRET", llb.SecretAsEnv(true)))
+	case "busybox:latest":
+		st = llb.Image(imgName).
+			Run(llb.Shlex(`sh -c '[ "$(echo ${MY_SECRET})" = 'foo-secret' ]'`), llb.AddSecret("MY_SECRET", llb.SecretAsEnv(true)))
+	}
 
 	def, err := st.Marshal(sb.Context())
 	require.NoError(t, err)
@@ -1816,9 +1863,15 @@ func testSecretEnv(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	// test optional
-	st = llb.Image("busybox:latest").
-		Run(llb.Shlex(`sh -c '[ -z "${MY_SECRET}" ]'`), llb.AddSecret("MY_SECRET", llb.SecretAsEnv(true), llb.SecretOptional))
+	// Test 2: Optional secret not provided should be unset/empty
+	switch imgName {
+	case "nanoserver:latest":
+		st = llb.Image(imgName).
+			Run(llb.Shlex(`cmd /C "if not defined MY_SECRET (exit 0) else (exit 1)"`), llb.AddSecret("MY_SECRET", llb.SecretAsEnv(true), llb.SecretOptional))
+	case "busybox:latest":
+		st = llb.Image(imgName).
+			Run(llb.Shlex(`sh -c '[ -z "${MY_SECRET}" ]'`), llb.AddSecret("MY_SECRET", llb.SecretAsEnv(true), llb.SecretOptional))
+	}
 
 	def, err = st.Marshal(sb.Context())
 	require.NoError(t, err)
@@ -1831,8 +1884,15 @@ func testSecretEnv(t *testing.T, sb integration.Sandbox) {
 	_, err = c.Solve(sb.Context(), def, SolveOpt{}, nil)
 	require.NoError(t, err)
 
-	st = llb.Image("busybox:latest").
-		Run(llb.Shlex(`echo foo`), llb.AddSecret("MY_SECRET", llb.SecretAsEnv(true)))
+	// Test 3: Required secret not provided should error
+	switch imgName {
+	case "nanoserver:latest":
+		st = llb.Image(imgName).
+			Run(llb.Shlex(`cmd /C "echo foo"`), llb.AddSecret("MY_SECRET", llb.SecretAsEnv(true)))
+	case "busybox:latest":
+		st = llb.Image(imgName).
+			Run(llb.Shlex(`echo foo`), llb.AddSecret("MY_SECRET", llb.SecretAsEnv(true)))
+	}
 
 	def, err = st.Marshal(sb.Context())
 	require.NoError(t, err)
@@ -1842,12 +1902,21 @@ func testSecretEnv(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.Error(t, err)
 
-	// test id
-	st = llb.Image("busybox:latest").
-		Run(llb.Shlex(`sh -c '[ "$(echo ${MYPASSWORD}-${MYTOKEN})" = "pw-token" ]' `),
-			llb.AddSecret("MYPASSWORD", llb.SecretID("pass"), llb.SecretAsEnv(true)),
-			llb.AddSecret("MYTOKEN", llb.SecretAsEnv(true)),
-		)
+	// Test 4: Multiple secrets with custom IDs
+	switch imgName {
+	case "nanoserver:latest":
+		st = llb.Image(imgName).
+			Run(llb.Shlex(`cmd /C "if "%MYPASSWORD%-%MYTOKEN%"=="pw-token" (exit 0) else (exit 1)"`),
+				llb.AddSecret("MYPASSWORD", llb.SecretID("pass"), llb.SecretAsEnv(true)),
+				llb.AddSecret("MYTOKEN", llb.SecretAsEnv(true)),
+			)
+	case "busybox:latest":
+		st = llb.Image(imgName).
+			Run(llb.Shlex(`sh -c '[ "$(echo ${MYPASSWORD}-${MYTOKEN})" = "pw-token" ]' `),
+				llb.AddSecret("MYPASSWORD", llb.SecretID("pass"), llb.SecretAsEnv(true)),
+				llb.AddSecret("MYTOKEN", llb.SecretAsEnv(true)),
+			)
+	}
 
 	def, err = st.Marshal(sb.Context())
 	require.NoError(t, err)
@@ -5225,8 +5294,19 @@ func testBuildExportWithUncompressed(t *testing.T, sb integration.Sandbox) {
 	require.Equal(t, []byte("gzip"), item.Data)
 }
 
+/*
+testBuildExportZstd verifies OCI export with Zstd-compressed layers.
+It builds a simple layer, exports it with Zstd compression, and validates both
+OCI and Docker schema 2 media types.
+*/
 func testBuildExportZstd(t *testing.T, sb integration.Sandbox) {
-	integration.SkipOnPlatform(t, "windows")
+	/*
+		Skipped on Windows:
+		1. AddMount() fails because Windows snapshots allow only a single mount per layer.
+		2. OCI export fails because windowsLcowDiff lacks the Compare method needed to
+		   generate compressed layer diffs.
+	*/
+	integration.SkipOnPlatform(t, "windows", "Windows container support incomplete: AddMount() fails with 'number of mounts should always be 1 for Windows layers', OCI export fails with 'windowsLcowDiff does not implement Compare method'")
 	workers.CheckFeatureCompat(t, sb, workers.FeatureOCIExporter)
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)

--- a/frontend/dockerfile/dockerfile_provenance_test.go
+++ b/frontend/dockerfile/dockerfile_provenance_test.go
@@ -1130,6 +1130,10 @@ RUN --mount=type=secret,id=mysecret --mount=type=secret,id=othersecret --mount=t
 	require.True(t, pred.BuildDefinition.ExternalParameters.Request.SSH[0].Optional)
 }
 
+// testOCILayoutProvenance verifies that when you build a Docker image using a
+// locally stored image (OCI layout) as its base, the build system properly
+// tracks where that base image came from — recording its identity and checksum
+// in the build's provenance record so you can trace what went into the final image.
 func testOCILayoutProvenance(t *testing.T, sb integration.Sandbox) {
 	integration.SkipOnPlatform(t, "windows")
 	workers.CheckFeatureCompat(t, sb, workers.FeatureProvenance)
@@ -1345,8 +1349,13 @@ ENV FOO=bar
 }
 
 // https://github.com/moby/buildkit/issues/3562
+/*
+testDuplicatePlatformProvenance verifies that provenance attestation is generated correctly
+when a multi-platform build specifies the same platform twice (e.g., linux/amd64,linux/amd64).
+It uses a Dockerfile that selects the base image based on TARGETOS, making it cross-platform.
+The test ensures the build completes without errors despite the duplicate platform entry.
+*/
 func testDuplicatePlatformProvenance(t *testing.T, sb integration.Sandbox) {
-	integration.SkipOnPlatform(t, "windows")
 	workers.CheckFeatureCompat(t, sb, workers.FeatureProvenance)
 	ctx := sb.Context()
 
@@ -1358,8 +1367,8 @@ func testDuplicatePlatformProvenance(t *testing.T, sb integration.Sandbox) {
 
 	dockerfile := []byte(
 		`
-FROM alpine as base-linux
-FROM nanoserver as base-windows
+FROM alpine AS base-linux
+FROM nanoserver AS base-windows
 FROM base-$TARGETOS
 `,
 	)
@@ -1367,10 +1376,15 @@ FROM base-$TARGETOS
 		t,
 		fstest.CreateFile("Dockerfile", dockerfile, 0600),
 	)
+
+	platform := integration.UnixOrWindows(
+		"linux/amd64,linux/amd64",     // Linux worker: duplicate call on Linux platform
+		"windows/amd64,windows/amd64", // Windows worker: duplicate call on Windows platform
+	)
 	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
 		FrontendAttrs: map[string]string{
 			"attest:provenance": "mode=max",
-			"platform":          "linux/amd64,linux/amd64",
+			"platform":          platform,
 		},
 		LocalMounts: map[string]fsutil.FS{
 			dockerui.DefaultLocalNameDockerfile: dir,
@@ -1430,6 +1444,11 @@ FROM nanoserver
 	require.NoError(t, err)
 }
 
+// testCommandSourceMapping validates that SLSA v1 provenance source mapping links each
+// Dockerfile command to its originating line in the Dockerfile definition.
+//
+// This test is currently skipped on Windows because this path has been unstable there and
+// can produce incomplete source-mapping payloads (for example missing BuildConfig).
 func testCommandSourceMapping(t *testing.T, sb integration.Sandbox) {
 	integration.SkipOnPlatform(t, "windows")
 	workers.CheckFeatureCompat(t, sb, workers.FeatureDirectPush, workers.FeatureProvenance)
@@ -1704,8 +1723,8 @@ COPY bar bar2
 	require.NotEqual(t, 0, len(sources[0].Definition))
 }
 
+// testDuplicateLayersProvenance builds a Dockerfile with a diamond dependency pattern (stages "a" and "b" both derive from "base"), pushes the image with max provenance, and checks that the base layer referenced by step0 appears exactly once in the provenance metadata rather than being listed multiple times.
 func testDuplicateLayersProvenance(t *testing.T, sb integration.Sandbox) {
-	integration.SkipOnPlatform(t, "windows")
 	workers.CheckFeatureCompat(t, sb, workers.FeatureDirectPush, workers.FeatureProvenance)
 	ctx := sb.Context()
 
@@ -1724,16 +1743,29 @@ func testDuplicateLayersProvenance(t *testing.T, sb integration.Sandbox) {
 	// Create a triangle shape with the layers.
 	// This will trigger the provenance attestation to attempt to add the base
 	// layer multiple times.
-	dockerfile := []byte(`
-FROM busybox:latest AS base
+	// On Windows, use USER ContainerAdministrator so nanoserver's default user
+	// (ContainerUser) can write to the root directory.
+	dockerfile := []byte(integration.UnixOrWindows(
+		`FROM busybox:latest AS base
 
-FROM base AS a
-RUN date +%s > /a.txt
+		FROM base AS a
+		RUN date +%s > /a.txt
 
-FROM base AS b
-COPY --from=a /a.txt /
-RUN date +%s > /b.txt
-`)
+		FROM base AS b
+		COPY --from=a /a.txt /
+		RUN date +%s > /b.txt`,
+
+		`FROM nanoserver:latest AS base
+		USER ContainerAdministrator
+
+		FROM base AS a
+		RUN echo %TIME% > /a.txt
+
+		FROM base AS b
+		COPY --from=a /a.txt /
+		RUN echo %TIME% > /b.txt`,
+	))
+
 	dir := integration.Tmpdir(
 		t,
 		fstest.CreateFile("Dockerfile", dockerfile, 0600),
@@ -1760,6 +1792,7 @@ RUN date +%s > /b.txt
 			},
 		},
 	}, nil)
+
 	require.NoError(t, err)
 
 	desc, provider, err := contentutil.ProviderFromRef(target)
@@ -1786,8 +1819,19 @@ RUN date +%s > /b.txt
 	require.Len(t, layers, 1)
 }
 
+/*
+testProvenanceExportLocal tests exporting build output with provenance attestation to a local
+directory. It builds a simple Dockerfile, exports the result using the local exporter with
+provenance enabled (mode=max), and verifies that both the build output file and a provenance.json
+file are written to the destination directory. It then parses the provenance.json to confirm it
+contains a valid SLSA 0.2 predicate.
+
+Skipped on Windows because the provenance code path in fs.go does not acquire SeBackupPrivilege
+when walking the output filesystem, and system-protected paths (e.g., System Volume Information)
+cause "Access is denied" errors, preventing provenance.json from being generated.
+*/
 func testProvenanceExportLocal(t *testing.T, sb integration.Sandbox) {
-	integration.SkipOnPlatform(t, "windows")
+	integration.SkipOnPlatform(t, "windows", "local export with provenance is not supported on Windows")
 	workers.CheckFeatureCompat(t, sb, workers.FeatureProvenance)
 	ctx := sb.Context()
 
@@ -1841,8 +1885,16 @@ COPY --from=base /out /
 	require.NoError(t, json.Unmarshal(dt, &pred))
 }
 
+/*
+testProvenanceExportLocalForceSplit verifies that the local exporter writes build output and a
+valid provenance.json (SLSA 0.2) into a platform-specific subdirectory (e.g., linux_amd64/)
+when platform-split is enabled.
+
+Skipped on Windows: same provenance generation issue as testProvenanceExportLocal — fs.go does
+not acquire SeBackupPrivilege, causing "Access is denied" on system-protected paths.
+*/
 func testProvenanceExportLocalForceSplit(t *testing.T, sb integration.Sandbox) {
-	integration.SkipOnPlatform(t, "windows")
+	integration.SkipOnPlatform(t, "windows", "local export with provenance is not supported on Windows")
 	workers.CheckFeatureCompat(t, sb, workers.FeatureProvenance)
 	ctx := sb.Context()
 
@@ -1901,8 +1953,16 @@ COPY --from=base /out /
 	require.NoError(t, json.Unmarshal(dt, &pred))
 }
 
+/*
+testProvenanceExportLocalMultiPlatform verifies that a multi-platform build (linux/amd64, linux/arm64)
+exported locally writes each platform's output and provenance.json (SLSA 0.2) into separate
+platform-specific subdirectories.
+
+Skipped on Windows: same provenance generation issue as testProvenanceExportLocal — fs.go does
+not acquire SeBackupPrivilege, causing "Access is denied" on system-protected paths.
+*/
 func testProvenanceExportLocalMultiPlatform(t *testing.T, sb integration.Sandbox) {
-	integration.SkipOnPlatform(t, "windows")
+	integration.SkipOnPlatform(t, "windows", "local export with provenance is not supported on Windows")
 	workers.CheckFeatureCompat(t, sb, workers.FeatureMultiPlatform, workers.FeatureProvenance)
 	ctx := sb.Context()
 
@@ -1959,8 +2019,17 @@ COPY --from=base /out /
 	}
 }
 
+/*
+testProvenanceExportLocalMultiPlatformNoSplit verifies that a multi-platform build (linux/amd64,
+linux/arm64) exported locally with platform-split disabled writes all platform outputs into a
+single directory, with per-platform provenance files (e.g., provenance.linux_amd64.json) each
+containing a valid SLSA 0.2 predicate.
+
+Skipped on Windows: same provenance generation issue as testProvenanceExportLocal — fs.go does
+not acquire SeBackupPrivilege, causing "Access is denied" on system-protected paths.
+*/
 func testProvenanceExportLocalMultiPlatformNoSplit(t *testing.T, sb integration.Sandbox) {
-	integration.SkipOnPlatform(t, "windows")
+	integration.SkipOnPlatform(t, "windows", "local export with provenance is not supported on Windows")
 	workers.CheckFeatureCompat(t, sb, workers.FeatureMultiPlatform, workers.FeatureProvenance)
 	ctx := sb.Context()
 

--- a/frontend/dockerfile/dockerfile_secrets_test.go
+++ b/frontend/dockerfile/dockerfile_secrets_test.go
@@ -27,8 +27,18 @@ func init() {
 	allTests = append(allTests, secretsTests...)
 }
 
+/*
+testSecretFileParams verifies that a secret mounted with custom permissions (mode=741,
+uid=100, gid=102) is accessible with the correct ownership and mode, and that no stub file
+is left behind after the RUN step.
+
+Skipped on Windows because mode/uid/gid are POSIX permission concepts that have no direct equivalent in Windows' ACL model. BuildKit's
+secret mount implementation only applies these as POSIX permissions — there is no code path
+to translate them to Windows ACLs. Supporting this on Windows would require both a new
+mapping from POSIX permissions to Windows ACLs in BuildKit and new test verification logic.
+*/
 func testSecretFileParams(t *testing.T, sb integration.Sandbox) {
-	integration.SkipOnPlatform(t, "windows")
+	integration.SkipOnPlatform(t, "windows", "Secret permission parameters not implemented for Windows in BuildKit")
 	f := getFrontend(t, sb)
 
 	dockerfile := []byte(`


### PR DESCRIPTION
**This PR consists of a continuation of #6503**

<ins>client/client_test.go</ins>
- Continued to skip testExtraHosts, testSecretMounts and testBuildExportZstd, while providing detailed explanations.
- Fixed the skip for testSecretEnv and provided compatibility for both Linux and Windows.

<ins>dockerfile/dockerfile_provenance_test.go</ins>

Fixed the skips and provided Linux and Windows compatibility with summary:
- testDuplicateLayersProvenance
- testDuplicatePlatformProvenance

Continued to skip while providing detailed explanations:
- testOCILayoutProvenance
- testCommandSourceMapping
- testProvenanceExportLocal
- testProvenanceExportLocalForceSplit
- testProvenanceExportLocalMultiPlatform
- testProvenanceExportLocalMultiPlatformNoSplit

<ins>frontend\dockerfile\dockerfile_secrets_test.go</ins>
- Continued to skip testSecretFileParams and provided detailed explanations.

This pull request ensures that the integration tests are up to-date with regard to Windows compatibility.

