### PR TITLE
hack: fall back when cgroup remount setup is unavailable

### DIFF
--- a/hack/buildkitd-entrypoint
+++ b/hack/buildkitd-entrypoint
@@ -14,8 +14,11 @@ set -e
 
 if [ -e /sys/fs/cgroup/cgroup.controllers ]; then
   if [ "$(cut -d: -f3 /proc/self/cgroup)" != "/" ]; then
-    echo creating cgroup namespace >&2
-    exec /usr/bin/unshare --cgroup --mount /usr/bin/with-cgroupfs-remount /usr/bin/buildkitd "$@"
+    if /usr/bin/unshare --cgroup --mount /usr/bin/with-cgroupfs-remount true 2>/dev/null; then
+      echo creating cgroup namespace >&2
+      exec /usr/bin/unshare --cgroup --mount /usr/bin/with-cgroupfs-remount /usr/bin/buildkitd "$@"
+    fi
+    echo skipping cgroup namespace setup, unable to remount /sys/fs/cgroup >&2
   fi
 fi
 


### PR DESCRIPTION
relates to:

```
    #1 [internal] booting buildkit
    #1 pulling image moby/buildkit:buildx-stable-1
    #1 pulling image moby/buildkit:buildx-stable-1 8.5s done
    #1 creating container buildx_buildkit_fervent_perlman0
    #1 29.74 creating cgroup namespace
    #1 creating container buildx_buildkit_fervent_perlman0 21.2s done
    #1 29.74 creating cgroup namespace
    #1 29.74 �������>umount: can't unmount /sys/fcreating cgroup namespace
    #1 29.74 umount: can't unmount /sys/fs/cgroup: Operation not permitted
    #1 29.74 umount: can't unmount /sysumount: can't unmount /sys/fs/cgroup: Operation not permitted
    #1 29.74 creating cgroup namespace
    #1 29.74 creating cgroup namespace
    #1 29.74 �������>umount: can't unmount /sys/fcreating cgroup namespace
    #1 29.74 umount: can't unmount /sys/fs/cgroup: Operation not permitted
    #1 29.74 umount: can't unmount /sysumount: can't unmount /sys/fs/cgroup: Operation not permitted
    #1 29.74
```

#6368 made the entrypoint automatically attempt the cgroup namespace remount workaround whenever the current cgroup path is not `/`. That works for the Kubernetes case, but it might break in other cases where unshare succeeds but the helper then fails to umount `/sys/fs/cgroup` with "Operation not permitted", which leaves the BuildKit container restarting during bootstrap in Buildx.

cc @marxarelli