### PR TITLE
git: add opt-in command tracing

### DIFF
--- a/client/llb/git_test.go
+++ b/client/llb/git_test.go
@@ -69,6 +69,17 @@ func TestGit(t *testing.T) {
 				"git.fullurl":          "https://github.com/foo/bar.git",
 			},
 		},
+		{
+			name:       "debug commands",
+			st:         Git("github.com/foo/bar.git", "ref", GitDebugCommands()),
+			identifier: "git://github.com/foo/bar.git#ref",
+			attrs: map[string]string{
+				"git.authheadersecret": "GIT_AUTH_HEADER",
+				"git.authtokensecret":  "GIT_AUTH_TOKEN",
+				"git.debugcommands":    "true",
+				"git.fullurl":          "https://github.com/foo/bar.git",
+			},
+		},
 	}
 
 	for _, tc := range tcases {

--- a/client/llb/source.go
+++ b/client/llb/source.go
@@ -470,10 +470,13 @@ func Git(url, fragment string, opts ...GitOption) State {
 		attrs[pb.AttrGitChecksum] = checksum
 		addCap(&gi.Constraints, pb.CapSourceGitChecksum)
 	}
-
 	if gi.SkipSubmodules {
 		attrs[pb.AttrGitSkipSubmodules] = "true"
 		addCap(&gi.Constraints, pb.CapSourceGitSkipSubmodules)
+	}
+	if gi.DebugCommands {
+		attrs[pb.AttrGitDebugCommands] = "true"
+		addCap(&gi.Constraints, pb.CapSourceGitDebugCommands)
 	}
 
 	addCap(&gi.Constraints, pb.CapSourceGit)
@@ -503,6 +506,7 @@ type GitInfo struct {
 	Ref              string
 	SubDir           string
 	SkipSubmodules   bool
+	DebugCommands    bool
 }
 
 func GitRef(v string) GitOption {
@@ -526,6 +530,12 @@ func GitSkipSubmodules() GitOption {
 func KeepGitDir() GitOption {
 	return gitOptionFunc(func(gi *GitInfo) {
 		gi.KeepGitDir = true
+	})
+}
+
+func GitDebugCommands() GitOption {
+	return gitOptionFunc(func(gi *GitInfo) {
+		gi.DebugCommands = true
 	})
 }
 

--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -2715,16 +2715,17 @@ RUN echo "I'm building for $TARGETPLATFORM"
 
 ### BuildKit built-in build args
 
-| Arg                              | Type   | Description                                                                                                                                                                                                      |
-|----------------------------------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `BUILDKIT_BUILD_NAME`            | String | Override the build name shown in [`buildx history` command](https://docs.docker.com/reference/cli/docker/buildx/history/) and [Docker Desktop Builds view](https://docs.docker.com/desktop/use-desktop/builds/). |
-| `BUILDKIT_CACHE_MOUNT_NS`        | String | Set optional cache ID namespace.                                                                                                                                                                                 |
-| `BUILDKIT_CONTEXT_KEEP_GIT_DIR`  | Bool   | Trigger Git context to keep the `.git` directory.                                                                                                                                                                |
-| `BUILDKIT_INLINE_CACHE`[^2]      | Bool   | Inline cache metadata to image config or not.                                                                                                                                                                    |
-| `BUILDKIT_MULTI_PLATFORM`        | Bool   | Opt into deterministic output regardless of multi-platform output or not.                                                                                                                                        |
-| `BUILDKIT_SANDBOX_HOSTNAME`      | String | Set the hostname (default `buildkitsandbox`)                                                                                                                                                                     |
-| `BUILDKIT_SYNTAX`                | String | Set frontend image                                                                                                                                                                                               |
-| `SOURCE_DATE_EPOCH`              | Int    | Set the Unix timestamp for created image and layers. More info from [reproducible builds](https://reproducible-builds.org/docs/source-date-epoch/). Supported since Dockerfile 1.5, BuildKit 0.11                |
+| Arg                             | Type   | Description                                                                                                                                                                                                      |
+|---------------------------------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `BUILDKIT_BUILD_NAME`           | String | Override the build name shown in [`buildx history` command](https://docs.docker.com/reference/cli/docker/buildx/history/) and [Docker Desktop Builds view](https://docs.docker.com/desktop/use-desktop/builds/). |
+| `BUILDKIT_CACHE_MOUNT_NS`       | String | Set optional cache ID namespace.                                                                                                                                                                                 |
+| `BUILDKIT_CONTEXT_KEEP_GIT_DIR` | Bool   | Trigger Git context to keep the `.git` directory.                                                                                                                                                                |
+| `BUILDKIT_DEBUG_GIT_COMMANDS`   | Bool   | Trigger Git context to print executed Git commands in the build log.                                                                                                                                             |
+| `BUILDKIT_INLINE_CACHE`[^2]     | Bool   | Inline cache metadata to image config or not.                                                                                                                                                                    |
+| `BUILDKIT_MULTI_PLATFORM`       | Bool   | Opt into deterministic output regardless of multi-platform output or not.                                                                                                                                        |
+| `BUILDKIT_SANDBOX_HOSTNAME`     | String | Set the hostname (default `buildkitsandbox`)                                                                                                                                                                     |
+| `BUILDKIT_SYNTAX`               | String | Set frontend image                                                                                                                                                                                               |
+| `SOURCE_DATE_EPOCH`             | Int    | Set the Unix timestamp for created image and layers. More info from [reproducible builds](https://reproducible-builds.org/docs/source-date-epoch/). Supported since Dockerfile 1.5, BuildKit 0.11                |
 
 #### Example: keep `.git` dir
 

--- a/frontend/dockerui/build_test.go
+++ b/frontend/dockerui/build_test.go
@@ -1,10 +1,14 @@
 package dockerui
 
 import (
+	"context"
 	"testing"
 
 	"github.com/containerd/platforms"
+	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
+	"github.com/moby/buildkit/solver/pb"
+	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/require"
 )
@@ -97,4 +101,66 @@ func TestNormalizePlatform(t *testing.T) {
 		// the ID needs to always be formatall(normalize(p))
 		require.Equal(t, platforms.FormatAll(platforms.Normalize(tc.p)), tc.expected.ID)
 	}
+}
+
+func TestDetectGitContextForwardsDebugCommands(t *testing.T) {
+	t.Parallel()
+
+	enabled := true
+	st, ok, err := DetectGitContext("https://github.com/docker/buildx.git?ref=refs/pull/3732/merge", nil, &enabled)
+	require.True(t, ok)
+	require.NoError(t, err)
+
+	g := marshalGitContext(t, st)
+	require.Equal(t, "git://github.com/docker/buildx.git#refs/pull/3732/merge", g.Identifier)
+	require.Equal(t, map[string]string{
+		"git.authheadersecret": "GIT_AUTH_HEADER",
+		"git.authtokensecret":  "GIT_AUTH_TOKEN",
+		"git.debugcommands":    "true",
+		"git.fullurl":          "https://github.com/docker/buildx.git",
+	}, g.Attrs)
+}
+
+func marshalGitContext(t *testing.T, st *llb.State) *pb.SourceOp {
+	t.Helper()
+
+	def, err := st.Marshal(context.TODO())
+	require.NoError(t, err)
+
+	m, arr := parseDef(t, def.Def)
+	require.Equal(t, 2, len(arr))
+
+	dgst, idx := last(t, arr)
+	require.Equal(t, 0, idx)
+	require.Equal(t, m[dgst], arr[0])
+
+	return arr[0].Op.(*pb.Op_Source).Source
+}
+
+func parseDef(t *testing.T, def [][]byte) (map[string]*pb.Op, []*pb.Op) {
+	t.Helper()
+
+	m := map[string]*pb.Op{}
+	arr := make([]*pb.Op, 0, len(def))
+
+	for _, dt := range def {
+		var op pb.Op
+		err := op.Unmarshal(dt)
+		require.NoError(t, err)
+		dgst := digest.FromBytes(dt)
+		m[string(dgst)] = &op
+		arr = append(arr, &op)
+	}
+
+	return m, arr
+}
+
+func last(t *testing.T, arr []*pb.Op) (string, int) {
+	t.Helper()
+
+	require.Greater(t, len(arr), 1)
+
+	op := arr[len(arr)-1]
+	require.Equal(t, 1, len(op.Inputs))
+	return op.Inputs[0].Digest, int(op.Inputs[0].Index)
 }

--- a/frontend/dockerui/config.go
+++ b/frontend/dockerui/config.go
@@ -51,6 +51,7 @@ const (
 	keyHostnameArg          = "build-arg:BUILDKIT_SANDBOX_HOSTNAME"
 	keyDockerfileLintArg    = "build-arg:BUILDKIT_DOCKERFILE_CHECK"
 	keyContextKeepGitDirArg = "build-arg:BUILDKIT_CONTEXT_KEEP_GIT_DIR"
+	keyDebugGitCommandsArg  = "build-arg:BUILDKIT_DEBUG_GIT_COMMANDS"
 	keySourceDateEpoch      = "build-arg:SOURCE_DATE_EPOCH"
 )
 

--- a/frontend/dockerui/context.go
+++ b/frontend/dockerui/context.go
@@ -73,7 +73,11 @@ func (bc *Client) initContext(ctx context.Context) (*buildContext, error) {
 	if v, err := strconv.ParseBool(opts[keyContextKeepGitDirArg]); err == nil {
 		keepGit = &v
 	}
-	if st, ok, err := DetectGitContext(opts[localNameContext], keepGit); ok {
+	var debugGitCommands *bool
+	if v, err := strconv.ParseBool(opts[keyDebugGitCommandsArg]); err == nil {
+		debugGitCommands = &v
+	}
+	if st, ok, err := DetectGitContext(opts[localNameContext], keepGit, debugGitCommands); ok {
 		if err != nil {
 			return nil, err
 		}
@@ -143,7 +147,7 @@ func (bc *Client) initContext(ctx context.Context) (*buildContext, error) {
 	return bctx, nil
 }
 
-func DetectGitContext(ref string, keepGit *bool) (*llb.State, bool, error) {
+func DetectGitContext(ref string, keepGit *bool, debugGitCommands *bool) (*llb.State, bool, error) {
 	g, isGit, err := dfgitutil.ParseGitRef(ref)
 	if err != nil {
 		return nil, isGit, err
@@ -157,6 +161,9 @@ func DetectGitContext(ref string, keepGit *bool) (*llb.State, bool, error) {
 	}
 	if keepGit != nil && *keepGit {
 		gitOpts = append(gitOpts, llb.KeepGitDir())
+	}
+	if debugGitCommands != nil && *debugGitCommands {
+		gitOpts = append(gitOpts, llb.GitDebugCommands())
 	}
 	if g.SubDir != "" {
 		gitOpts = append(gitOpts, llb.GitSubDir(g.SubDir))

--- a/frontend/dockerui/namedcontext.go
+++ b/frontend/dockerui/namedcontext.go
@@ -141,7 +141,7 @@ func (nc *NamedContext) load(ctx context.Context, count int) (*llb.State, *docke
 		}
 		return &st, &img, nil
 	case "git":
-		st, ok, err := DetectGitContext(nc.input, nil)
+		st, ok, err := DetectGitContext(nc.input, nil, nil)
 		if !ok {
 			return nil, nil, errors.Errorf("invalid git context %s", nc.input)
 		}
@@ -150,7 +150,7 @@ func (nc *NamedContext) load(ctx context.Context, count int) (*llb.State, *docke
 		}
 		return st, nil, nil
 	case "http", "https":
-		st, ok, err := DetectGitContext(nc.input, nil)
+		st, ok, err := DetectGitContext(nc.input, nil, nil)
 		if !ok {
 			httpst := llb.HTTP(nc.input, llb.WithCustomName("[context "+nc.nameWithPlatform+"] "+nc.input))
 			st = &httpst

--- a/solver/pb/attr.go
+++ b/solver/pb/attr.go
@@ -8,6 +8,7 @@ const AttrKnownSSHHosts = "git.knownsshhosts"
 const AttrMountSSHSock = "git.mountsshsock"
 const AttrGitChecksum = "git.checksum"
 const AttrGitSkipSubmodules = "git.skipsubmodules"
+const AttrGitDebugCommands = "git.debugcommands"
 
 const AttrGitSignatureVerifyPubKey = "git.sig.pubkey"
 const AttrGitSignatureVerifyRejectExpired = "git.sig.rejectexpired"

--- a/solver/pb/caps.go
+++ b/solver/pb/caps.go
@@ -33,6 +33,7 @@ const (
 	CapSourceGitSubdir          apicaps.CapID = "source.git.subdir"
 	CapSourceGitChecksum        apicaps.CapID = "source.git.checksum"
 	CapSourceGitSkipSubmodules  apicaps.CapID = "source.git.skipsubmodules"
+	CapSourceGitDebugCommands   apicaps.CapID = "source.git.debugcommands"
 	CapSourceGitSignatureVerify apicaps.CapID = "source.git.signatureverify"
 
 	CapSourceHTTP         apicaps.CapID = "source.http"
@@ -245,6 +246,12 @@ func init() {
 
 	Caps.Init(apicaps.Cap{
 		ID:      CapSourceGitSkipSubmodules,
+		Enabled: true,
+		Status:  apicaps.CapStatusExperimental,
+	})
+
+	Caps.Init(apicaps.Cap{
+		ID:      CapSourceGitDebugCommands,
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})

--- a/source/git/identifier.go
+++ b/source/git/identifier.go
@@ -21,6 +21,7 @@ type GitIdentifier struct {
 	MountSSHSock     string
 	KnownSSHHosts    string
 	SkipSubmodules   bool
+	DebugCommands    bool
 
 	VerifySignature *GitSignatureVerifyOptions
 }

--- a/source/git/source.go
+++ b/source/git/source.go
@@ -114,6 +114,10 @@ func (gs *Source) Identifier(scheme, ref string, attrs map[string]string, platfo
 			if v == "true" {
 				id.SkipSubmodules = true
 			}
+		case pb.AttrGitDebugCommands:
+			if v == "true" {
+				id.DebugCommands = true
+			}
 		case pb.AttrGitSignatureVerifyPubKey:
 			if id.VerifySignature == nil {
 				id.VerifySignature = &GitSignatureVerifyOptions{}
@@ -141,7 +145,7 @@ func (gs *Source) Identifier(scheme, ref string, attrs map[string]string, platfo
 }
 
 // needs to be called with repo lock
-func (gs *Source) mountRemote(ctx context.Context, remote string, authArgs []string, sha256 bool, reset bool, g session.Group) (target string, release func() error, retErr error) {
+func (gs *Source) mountRemote(ctx context.Context, remote string, authArgs []string, debugCommands bool, sha256 bool, reset bool, g session.Group) (target string, release func() error, retErr error) {
 	sis, err := searchGitRemote(ctx, gs.cache, remote)
 	if err != nil {
 		return "", nil, errors.Wrapf(err, "failed to search metadata for %s", urlutil.RedactCredentials(remote))
@@ -206,6 +210,7 @@ func (gs *Source) mountRemote(ctx context.Context, remote string, authArgs []str
 	git := gitCLI(
 		gitutil.WithGitDir(dir),
 		gitutil.WithArgs(authArgs...),
+		gitutil.WithDebugCommands(debugCommands),
 	)
 
 	if initializeRepo {
@@ -844,7 +849,7 @@ func (gs *gitSourceHandler) tryRemoteFetch(ctx context.Context, g session.Group,
 	}
 	repo.releasers = append(repo.releasers, cleanup)
 
-	gitDir, unmountGitDir, err := gs.mountRemote(ctx, gs.src.Remote, gs.authArgs, gs.sha256, reset, g)
+	gitDir, unmountGitDir, err := gs.mountRemote(ctx, gs.src.Remote, gs.authArgs, gs.src.DebugCommands, gs.sha256, reset, g)
 	if err != nil {
 		return nil, err
 	}
@@ -1207,6 +1212,7 @@ func (gs *gitSourceHandler) emptyGitCli(ctx context.Context, g session.Group, op
 
 	opts = append([]gitutil.Option{
 		gitutil.WithArgs(gs.authArgs...),
+		gitutil.WithDebugCommands(gs.src.DebugCommands),
 		gitutil.WithSSHAuthSock(sock),
 		gitutil.WithSSHKnownHosts(knownHosts),
 	}, opts...)

--- a/source/git/source_test.go
+++ b/source/git/source_test.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -55,6 +56,14 @@ func TestRepeatedFetchSHA256(t *testing.T) {
 }
 func TestRepeatedFetchKeepGitDirSHA256(t *testing.T) {
 	testRepeatedFetch(t, true, "sha256")
+}
+
+func TestDebugCommandsSHA1(t *testing.T) {
+	testDebugCommands(t, "sha1")
+}
+
+func TestDebugCommandsSHA256(t *testing.T) {
+	testDebugCommands(t, "sha256")
 }
 
 func testRepeatedFetch(t *testing.T, keepGitDir bool, format string) {
@@ -173,6 +182,48 @@ func testRepeatedFetch(t *testing.T, keepGitDir bool, format string) {
 	require.NoError(t, err)
 	require.Equal(t, key3, key4)
 	require.Equal(t, pin3, pin4)
+}
+
+func testDebugCommands(t *testing.T, format string) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Depends on unimplemented containerd bind-mount support on Windows")
+	}
+
+	t.Parallel()
+	ctx, logs := captureProgressLogs(context.Background(), t)
+
+	gs := setupGitSource(t, t.TempDir())
+	repo := setupGitRepo(t, format)
+
+	id := &GitIdentifier{Remote: repo.mainURL, Ref: "feature", KeepGitDir: true, DebugCommands: true}
+	g, err := gs.Resolve(ctx, id, nil, nil)
+	require.NoError(t, err)
+
+	ref, err := g.Snapshot(ctx, nil)
+	require.NoError(t, err)
+	defer ref.Release(context.TODO())
+
+	_ = mountRef(ctx, t, ref)
+
+	require.Eventually(t, func() bool {
+		out := logs.String()
+		return strings.Contains(out, "+ git ") && strings.Contains(out, " fetch ") && strings.Contains(out, " checkout ")
+	}, 5*time.Second, 50*time.Millisecond)
+}
+
+func mountRef(ctx context.Context, t *testing.T, ref cache.ImmutableRef) string {
+	t.Helper()
+
+	mount, err := ref.Mount(ctx, true, nil)
+	require.NoError(t, err)
+
+	lm := snapshot.LocalMounter(mount)
+	dir, err := lm.Mount()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, lm.Unmount())
+	})
+	return dir
 }
 
 func TestFetchBySHA1(t *testing.T) {
@@ -2364,4 +2415,46 @@ func logProgressStreams(ctx context.Context, t *testing.T) context.Context {
 		}
 	}()
 	return ctx
+}
+
+type progressLogBuffer struct {
+	mu sync.Mutex
+	sb strings.Builder
+}
+
+func (b *progressLogBuffer) Write(dt []byte) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.sb.Write(dt)
+}
+
+func (b *progressLogBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.sb.String()
+}
+
+func captureProgressLogs(ctx context.Context, t *testing.T) (context.Context, *progressLogBuffer) {
+	pr, ctx, cancel := progress.NewContext(ctx)
+	buf := &progressLogBuffer{}
+	done := make(chan struct{})
+	t.Cleanup(func() {
+		cancel(errors.WithStack(context.Canceled))
+		<-done
+	})
+	go func() {
+		defer close(done)
+		for {
+			prog, err := pr.Read(context.Background())
+			if err != nil {
+				return
+			}
+			for _, log := range prog {
+				if lsys, ok := log.Sys.(client.VertexLog); ok {
+					buf.Write(lsys.Data)
+				}
+			}
+		}
+	}()
+	return ctx, buf
 }

--- a/util/gitutil/git_cli.go
+++ b/util/gitutil/git_cli.go
@@ -7,8 +7,10 @@ import (
 	"os"
 	"os/exec"
 	"slices"
+	"strconv"
 	"strings"
 
+	"github.com/moby/buildkit/util/urlutil"
 	"github.com/pkg/errors"
 )
 
@@ -18,9 +20,10 @@ type GitCLI struct {
 	git  string
 	exec func(context.Context, *exec.Cmd) error
 
-	args    []string
-	dir     string
-	streams StreamFunc
+	args          []string
+	dir           string
+	streams       StreamFunc
+	debugCommands bool
 
 	workTree string
 	gitDir   string
@@ -80,6 +83,12 @@ func WithWorkTree(workTree string) Option {
 func WithGitDir(gitDir string) Option {
 	return func(b *GitCLI) {
 		b.gitDir = gitDir
+	}
+}
+
+func WithDebugCommands(debugCommands bool) Option {
+	return func(b *GitCLI) {
+		b.debugCommands = debugCommands
 	}
 }
 
@@ -169,21 +178,27 @@ func (cli *GitCLI) Run(ctx context.Context, args ...string) (_ []byte, err error
 		cmd.Stdin = nil
 		cmd.Stdout = buf
 		cmd.Stderr = errbuf
+		var stdoutStream io.WriteCloser
+		var stderrStream io.WriteCloser
+		flush := func() {}
 		if cli.streams != nil {
-			stdout, stderr, flush := cli.streams(ctx)
-			if stdout != nil {
-				cmd.Stdout = io.MultiWriter(stdout, cmd.Stdout)
+			stdoutStream, stderrStream, flush = cli.streams(ctx)
+			if stdoutStream != nil {
+				cmd.Stdout = io.MultiWriter(stdoutStream, cmd.Stdout)
 			}
-			if stderr != nil {
-				cmd.Stderr = io.MultiWriter(stderr, cmd.Stderr)
+			if stderrStream != nil {
+				cmd.Stderr = io.MultiWriter(stderrStream, cmd.Stderr)
 			}
-			defer stdout.Close()
-			defer stderr.Close()
+			defer stdoutStream.Close()
+			defer stderrStream.Close()
 			defer func() {
 				if err != nil {
 					flush()
 				}
 			}()
+		}
+		if cli.debugCommands && stderrStream != nil {
+			_, _ = io.WriteString(stderrStream, "+ "+formatDebugCommand(cmd.Args)+"\n")
 		}
 
 		cmd.Env = []string{
@@ -241,6 +256,45 @@ func (cli *GitCLI) Run(ctx context.Context, args ...string) (_ []byte, err error
 		}
 		return buf.Bytes(), nil
 	}
+}
+
+func formatDebugCommand(args []string) string {
+	redacted := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "-c" && i+1 < len(args) {
+			cfg := args[i+1]
+			if key, _, ok := strings.Cut(cfg, "="); ok && strings.HasSuffix(strings.ToLower(key), ".extraheader") {
+				cfg = key + "=xxxxx"
+			} else if strings.Contains(cfg, "://") {
+				if redactedURL := urlutil.RedactCredentials(cfg); redactedURL != cfg {
+					cfg = redactedURL
+				}
+			}
+			redacted = append(redacted, arg, cfg)
+			i++
+			continue
+		}
+		if strings.Contains(arg, "://") {
+			if redactedURL := urlutil.RedactCredentials(arg); redactedURL != arg {
+				arg = redactedURL
+			}
+		}
+		redacted = append(redacted, arg)
+	}
+	quoted := make([]string, 0, len(redacted))
+	for _, arg := range redacted {
+		if arg == "" {
+			quoted = append(quoted, `""`)
+			continue
+		}
+		if strings.ContainsAny(arg, " \t\n\r\"'`$&|;<>()[]{}*?!#\\") {
+			quoted = append(quoted, strconv.Quote(arg))
+			continue
+		}
+		quoted = append(quoted, arg)
+	}
+	return strings.Join(quoted, " ")
 }
 
 func getGitSSHCommand(knownHosts string) string {

--- a/util/gitutil/git_cli_test.go
+++ b/util/gitutil/git_cli_test.go
@@ -1,0 +1,46 @@
+package gitutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatDebugCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected string
+	}{
+		{
+			name: "quotes and redacts urls and config",
+			args: []string{
+				"git",
+				"-c", "protocol.file.allow=user",
+				"--work-tree", "/tmp/work tree",
+				"--git-dir", "/tmp/work tree/.git",
+				"-c", "http.https://github.com/.extraheader=Authorization: Basic c2VjcmV0",
+				"-c", "core.abbrev=12",
+				"fetch",
+				"https://user:pass@example.com/repo.git",
+				"refs/heads/main",
+			},
+			expected: `git -c protocol.file.allow=user --work-tree "/tmp/work tree" --git-dir "/tmp/work tree/.git" -c http.https://github.com/.extraheader=xxxxx -c core.abbrev=12 fetch https://xxxxx:xxxxx@example.com/repo.git refs/heads/main`,
+		},
+		{
+			name: "redacts extraheader config only",
+			args: []string{
+				"git",
+				"-c", "http.https://github.com/.extraheader=Authorization: Basic dXNlcjp0b2tlbg==",
+				"-c", "core.abbrev=12",
+				"fetch",
+			},
+			expected: `git -c http.https://github.com/.extraheader=xxxxx -c core.abbrev=12 fetch`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, formatDebugCommand(tt.args))
+		})
+	}
+}


### PR DESCRIPTION
Adds an opt-in Git command tracing mode for Git sources so BuildKit can show the effective Git commands it's running during source resolution and checkout. This feature is disabled by default and can be enabled with `BUILDKIT_DEBUG_GIT_COMMANDS=1` build-arg (similar to `BUILDKIT_CONTEXT_KEEP_GIT_DIR`).

Main motivation relates to https://github.com/crazy-max/diun/pull/1544#issuecomment-3528382004. While working through Git source behavior differences around remote contexts, shallow fetches, tags, and `.git` preservation, it became clear that the existing logs show Git output but don't make the executed commands themselves obvious. That makes troubleshooting slower than it should be, especially for remote Git contexts where the user only sees side effects such as fetched refs, detached HEAD messages, or cache hits without seeing the exact `git fetch`, `git checkout`, `git remote`, or `git update-ref` calls that produced them:

```
$ docker buildx --builder builder build --build-arg=BUILDKIT_DEBUG_GIT_COMMANDS=1 https://github.com/docker/buildx.git
#0 building with "builder" instance using docker-container driver

#1 [internal] load git source https://github.com/docker/buildx.git
#1 0.420 ref: refs/heads/master HEAD
#1 0.424 c461e702bf2550c98b16d1e231ec855c19a4facc       HEAD
#1 0.880 c461e702bf2550c98b16d1e231ec855c19a4facc       refs/heads/master
#1 0.056 Initialized empty Git repository in /var/lib/buildkit/runc-overlayfs/snapshots/snapshots/1/fs/
#1 0.414 ref: refs/heads/master HEAD
#1 0.418 c461e702bf2550c98b16d1e231ec855c19a4facc       HEAD
#1 3.407 From https://github.com/docker/buildx
#1 3.407  * [new branch]      master     -> master
#1 3.407  * [new branch]      master     -> origin/master
#1 3.411 c461e702bf2550c98b16d1e231ec855c19a4facc
#1 DONE 5.8s

#2 [internal] load git source https://github.com/docker/buildx.git
#2 0.003 + git -c protocol.file.allow=user ls-remote --symref https://github.com/docker/buildx.git HEAD
#2 0.366 ref: refs/heads/master HEAD
#2 0.370 c461e702bf2550c98b16d1e231ec855c19a4facc       HEAD
#2 0.370 + git -c protocol.file.allow=user ls-remote https://github.com/docker/buildx.git master "master^{}"
#2 0.809 c461e702bf2550c98b16d1e231ec855c19a4facc       refs/heads/master
#2 DONE 0.8s

#1 [internal] load git source https://github.com/docker/buildx.git
#1 DONE 5.8s
...
```

Not sure if we should have a git query param to enable this like we do for `keep-git-dir`? Maybe `debug`?