### PR TITLE
dockerfile: use dockerfile.v0 for built-in syntax override

### DIFF
--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -51,13 +51,16 @@ func Build(ctx context.Context, c client.Client) (_ *client.Result, err error) {
 	}
 
 	if _, ok := opts["cmdline"]; !ok {
-		if cmdline, ok := opts[keySyntaxArg]; ok {
-			p := strings.SplitN(strings.TrimSpace(cmdline), " ", 2)
-			res, err := forwardGateway(ctx, c, p[0], cmdline)
-			if err != nil && len(errdefs.Sources(err)) == 0 {
-				return nil, errors.Wrapf(err, "failed with %s = %s", keySyntaxArg, cmdline)
+		if v, ok := opts[keySyntaxArg]; ok {
+			// dockerfile.v0 is the built-in frontend selector, not a source ref to forward.
+			if cmdline := strings.TrimSpace(v); cmdline != "dockerfile.v0" {
+				ref, _, _ := strings.Cut(cmdline, " ")
+				res, err := forwardGateway(ctx, c, ref, cmdline)
+				if err != nil && len(errdefs.Sources(err)) == 0 {
+					return nil, errors.Wrapf(err, "failed with %s = %s", keySyntaxArg, cmdline)
+				}
+				return res, err
 			}
-			return res, err
 		} else if ref, cmdline, loc, ok := parser.DetectSyntax(src.Data); ok {
 			res, err := forwardGateway(ctx, c, ref, cmdline)
 			if err != nil && len(errdefs.Sources(err)) == 0 {

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -108,6 +108,8 @@ var allTests = integration.TestFuncs(
 	testCacheMountModeNoCache,
 	testDockerfileFromHTTP,
 	testBuiltinArgs,
+	testBuiltinSyntaxOverrideDockerfileV0,
+	testBuiltinSyntaxOverrideEmpty,
 	testPullScratch,
 	testSymlinkDestination,
 	testHTTPDockerfile,
@@ -6905,6 +6907,114 @@ COPY --from=build out /
 	require.NoError(t, err)
 	expectedStr = integration.UnixOrWindows("hpvalue2::::foocontents2::::bazcontent", "hpvalue2::%NO_PROXY%::foocontents2::%BAR%::bazcontent\r\n")
 	require.Equal(t, expectedStr, string(dt))
+}
+
+func testBuiltinSyntaxOverrideDockerfileV0(t *testing.T, sb integration.Sandbox) {
+	f := getFrontend(t, sb)
+
+	dockerfile := []byte(integration.UnixOrWindows(
+		`
+# syntax=docker/dockerfile-upstream:master
+FROM busybox AS build
+RUN echo -n ok > /out
+FROM scratch
+COPY --from=build /out /out
+`,
+		`
+# syntax=docker/dockerfile-upstream:master
+FROM nanoserver:latest AS build
+USER ContainerAdministrator
+RUN echo ok>C:\out
+FROM nanoserver:latest
+USER ContainerAdministrator
+COPY --from=build /out /out
+`,
+	))
+
+	dir := integration.Tmpdir(
+		t,
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+	)
+
+	c, err := client.New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	destDir := t.TempDir()
+
+	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
+		FrontendAttrs: map[string]string{
+			"build-arg:BUILDKIT_SYNTAX": "dockerfile.v0",
+		},
+		Exports: []client.ExportEntry{
+			{
+				Type:      client.ExporterLocal,
+				OutputDir: destDir,
+			},
+		},
+		LocalMounts: map[string]fsutil.FS{
+			dockerui.DefaultLocalNameDockerfile: dir,
+			dockerui.DefaultLocalNameContext:    dir,
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	dt, err := os.ReadFile(filepath.Join(destDir, "out"))
+	require.NoError(t, err)
+	require.Equal(t, "ok", strings.TrimSpace(string(dt)))
+}
+
+func testBuiltinSyntaxOverrideEmpty(t *testing.T, sb integration.Sandbox) {
+	f := getFrontend(t, sb)
+
+	dockerfile := []byte(integration.UnixOrWindows(
+		`
+# syntax=docker/dockerfile-upstream:master
+FROM busybox AS build
+RUN echo -n ok > /out
+FROM scratch
+COPY --from=build /out /out
+`,
+		`
+# syntax=docker/dockerfile-upstream:master
+FROM nanoserver:latest AS build
+USER ContainerAdministrator
+RUN echo ok>C:\out
+FROM nanoserver:latest
+USER ContainerAdministrator
+COPY --from=build /out /out
+`,
+	))
+
+	dir := integration.Tmpdir(
+		t,
+		fstest.CreateFile("Dockerfile", dockerfile, 0600),
+	)
+
+	c, err := client.New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	destDir := t.TempDir()
+
+	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
+		FrontendAttrs: map[string]string{
+			"build-arg:BUILDKIT_SYNTAX": "",
+		},
+		Exports: []client.ExportEntry{
+			{
+				Type:      client.ExporterLocal,
+				OutputDir: destDir,
+			},
+		},
+		LocalMounts: map[string]fsutil.FS{
+			dockerui.DefaultLocalNameDockerfile: dir,
+			dockerui.DefaultLocalNameContext:    dir,
+		},
+	}, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid context name")
+	require.Contains(t, err.Error(), "invalid reference format")
 }
 
 func testTarContext(t *testing.T, sb integration.Sandbox) {

--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -2715,16 +2715,16 @@ RUN echo "I'm building for $TARGETPLATFORM"
 
 ### BuildKit built-in build args
 
-| Arg                              | Type   | Description                                                                                                                                                                                                      |
-|----------------------------------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `BUILDKIT_BUILD_NAME`            | String | Override the build name shown in [`buildx history` command](https://docs.docker.com/reference/cli/docker/buildx/history/) and [Docker Desktop Builds view](https://docs.docker.com/desktop/use-desktop/builds/). |
-| `BUILDKIT_CACHE_MOUNT_NS`        | String | Set optional cache ID namespace.                                                                                                                                                                                 |
-| `BUILDKIT_CONTEXT_KEEP_GIT_DIR`  | Bool   | Trigger Git context to keep the `.git` directory.                                                                                                                                                                |
-| `BUILDKIT_INLINE_CACHE`[^2]      | Bool   | Inline cache metadata to image config or not.                                                                                                                                                                    |
-| `BUILDKIT_MULTI_PLATFORM`        | Bool   | Opt into deterministic output regardless of multi-platform output or not.                                                                                                                                        |
-| `BUILDKIT_SANDBOX_HOSTNAME`      | String | Set the hostname (default `buildkitsandbox`)                                                                                                                                                                     |
-| `BUILDKIT_SYNTAX`                | String | Set frontend image                                                                                                                                                                                               |
-| `SOURCE_DATE_EPOCH`              | Int    | Set the Unix timestamp for created image and layers. More info from [reproducible builds](https://reproducible-builds.org/docs/source-date-epoch/). Supported since Dockerfile 1.5, BuildKit 0.11                |
+| Arg                             | Type   | Description                                                                                                                                                                                                      |
+|---------------------------------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `BUILDKIT_BUILD_NAME`           | String | Override the build name shown in [`buildx history` command](https://docs.docker.com/reference/cli/docker/buildx/history/) and [Docker Desktop Builds view](https://docs.docker.com/desktop/use-desktop/builds/). |
+| `BUILDKIT_CACHE_MOUNT_NS`       | String | Set optional cache ID namespace.                                                                                                                                                                                 |
+| `BUILDKIT_CONTEXT_KEEP_GIT_DIR` | Bool   | Trigger Git context to keep the `.git` directory.                                                                                                                                                                |
+| `BUILDKIT_INLINE_CACHE`[^2]     | Bool   | Inline cache metadata to image config or not.                                                                                                                                                                    |
+| `BUILDKIT_MULTI_PLATFORM`       | Bool   | Opt into deterministic output regardless of multi-platform output or not.                                                                                                                                        |
+| `BUILDKIT_SANDBOX_HOSTNAME`     | String | Set the hostname (default `buildkitsandbox`)                                                                                                                                                                     |
+| `BUILDKIT_SYNTAX`               | String | Set frontend image. Set to `dockerfile.v0` to ignore the Dockerfile `# syntax=` directive and use the built-in frontend instead.                                                                                 |
+| `SOURCE_DATE_EPOCH`             | Int    | Set the Unix timestamp for created image and layers. More info from [reproducible builds](https://reproducible-builds.org/docs/source-date-epoch/). Supported since Dockerfile 1.5, BuildKit 0.11                |
 
 #### Example: keep `.git` dir
 


### PR DESCRIPTION
Treat `BUILDKIT_SYNTAX=dockerfile.v0` as an explicit request to ignore the Dockerfile `# syntax=` directive and use the built-in Dockerfile frontend.

This keeps empty `BUILDKIT_SYNTAX` values behaving like any other invalid frontend reference instead of silently falling back to the built-in frontend.

Before:

```
$ docker buildx build https://github.com/docker/compose.git
#0 building with "default" instance using docker driver

#1 [internal] load git source https://github.com/docker/compose.git
#1 0.598 ref: refs/heads/main   HEAD
#1 0.605 b043368028e9fcb4545fa340c8ad635c370825da       HEAD
#1 0.993 b043368028e9fcb4545fa340c8ad635c370825da       refs/heads/main
#1 0.059 Initialized empty Git repository in /var/lib/buildkit/runc-overlayfs/snapshots/snapshots/1/fs/
#1 0.644 ref: refs/heads/main   HEAD
#1 0.649 b043368028e9fcb4545fa340c8ad635c370825da       HEAD
#1 1.325 From https://github.com/docker/compose
#1 1.325  * [new branch]      main       -> main
#1 1.325  * [new branch]      main       -> origin/main
#1 1.329 b043368028e9fcb4545fa340c8ad635c370825da
#1 DONE 2.5s

#1 [internal] load git source https://github.com/docker/compose.git
#1 DONE 3.3s

#2 resolve image config for docker-image://docker.io/docker/dockerfile:1
#2 ...

#3 [auth] docker/dockerfile:pull token for registry-1.docker.io
#3 DONE 0.0s

#2 resolve image config for docker-image://docker.io/docker/dockerfile:1
#2 DONE 0.8s

#4 docker-image://docker.io/docker/dockerfile:1@sha256:4a43a54dd1fedceb30ba47e76cfcf2b47304f4161c0caeac2db1c61804ea3c91
#4 resolve docker.io/docker/dockerfile:1@sha256:4a43a54dd1fedceb30ba47e76cfcf2b47304f4161c0caeac2db1c61804ea3c91 0.0s done
#4 CACHED

#5 [internal] load metadata for docker.io/tonistiigi/xx:1.9.0
```

After:

```
$ docker buildx --builder builder build --build-arg BUILDKIT_SYNTAX="dockerfile.v0" https://github.com/docker/compose.git
#0 building with "builder" instance using docker-container driver

#1 [internal] load git source https://github.com/docker/compose.git
#1 0.598 ref: refs/heads/main   HEAD
#1 0.605 b043368028e9fcb4545fa340c8ad635c370825da       HEAD
#1 0.993 b043368028e9fcb4545fa340c8ad635c370825da       refs/heads/main
#1 0.059 Initialized empty Git repository in /var/lib/buildkit/runc-overlayfs/snapshots/snapshots/1/fs/
#1 0.644 ref: refs/heads/main   HEAD
#1 0.649 b043368028e9fcb4545fa340c8ad635c370825da       HEAD
#1 1.325 From https://github.com/docker/compose
#1 1.325  * [new branch]      main       -> main
#1 1.325  * [new branch]      main       -> origin/main
#1 1.329 b043368028e9fcb4545fa340c8ad635c370825da
#1 DONE 2.5s

#1 [internal] load git source https://github.com/docker/compose.git
#1 DONE 4.0s

#2 [internal] load metadata for docker.io/tonistiigi/xx:1.9.0
#2 ...
```