### PR TITLE
solver/llbsolver/history: fix panic when listing history

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -263,6 +263,7 @@ var allTests = []func(t *testing.T, sb integration.Sandbox){
 	testSourcePolicySignedCommit,
 	testSourcePolicySessionHTTPChecksumAssist,
 	testSourcePolicySessionConvert,
+	testListenBuildHistoryExcludesSoftDeletedRecords,
 }
 
 func TestIntegration(t *testing.T) {
@@ -13433,6 +13434,81 @@ func (w warningsListOutput) String() string {
 		_, _ = b.Write(warn.Short)
 	}
 	return b.String()
+}
+
+func testListenBuildHistoryExcludesSoftDeletedRecords(t *testing.T, sb integration.Sandbox) {
+	c, err := New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	// Create 3 completed builds so we have multiple history records.
+	var buildRefs [3]string
+	for i := range buildRefs {
+		def, err := llb.Scratch().File(llb.Mkfile(fmt.Sprintf("file%d", i), 0o644, nil)).Marshal(sb.Context())
+		require.NoError(t, err)
+
+		buildRefs[i] = identity.NewID()
+		_, err = c.Solve(sb.Context(), def, SolveOpt{Ref: buildRefs[i]}, nil)
+		require.NoError(t, err)
+	}
+
+	refToDelete := buildRefs[1]
+
+	// Start a streaming listener on one specific ref. This increments the
+	// internal reference count, which causes Delete to soft-delete instead
+	// of removing the record from the database.
+	listenerCtx, listenerCancel := context.WithCancel(sb.Context())
+	defer listenerCancel()
+
+	cl, err := c.ControlClient().ListenBuildHistory(listenerCtx, &controlapi.BuildHistoryRequest{
+		Ref: refToDelete,
+	})
+	require.NoError(t, err)
+
+	// Read the initial record so the listener is fully registered.
+	_, err = cl.Recv()
+	require.NoError(t, err)
+
+	// Soft-delete: the record is marked deleted but stays in the DB because
+	// the listener above still holds a reference.
+	_, err = c.ControlClient().UpdateBuildHistory(sb.Context(), &controlapi.UpdateBuildHistoryRequest{
+		Ref:    refToDelete,
+		Delete: true,
+	})
+	require.NoError(t, err)
+
+	// List all remaining history records with a limit to trigger sorting.
+	// Before the fix this panicked with a nil pointer dereference because
+	// the soft-deleted record left a nil entry in the event slice.
+	cl2, err := c.ControlClient().ListenBuildHistory(sb.Context(), &controlapi.BuildHistoryRequest{
+		EarlyExit: true,
+		Limit:     10,
+	})
+	require.NoError(t, err)
+
+	gotRefs := map[string]bool{}
+	for {
+		resp, err := cl2.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		gotRefs[resp.Record.Ref] = true
+	}
+
+	// The soft-deleted record must not appear in the results.
+	assert.False(t, gotRefs[refToDelete], "soft-deleted ref %s should not appear in history list", refToDelete)
+	assert.True(t, gotRefs[buildRefs[0]], "ref %s should appear in history list", buildRefs[0])
+	assert.True(t, gotRefs[buildRefs[2]], "ref %s should appear in history list", buildRefs[2])
+
+	// Clean up the streaming listener.
+	listenerCancel()
+	// Drain the stream so gRPC can clean up.
+	for {
+		if _, err := cl.Recv(); err != nil {
+			break
+		}
+	}
 }
 
 func parseFSMetadata(t *testing.T, dt []byte) []fsutiltypes.Stat {

--- a/solver/llbsolver/history/filter.go
+++ b/solver/llbsolver/history/filter.go
@@ -46,11 +46,15 @@ func filterHistoryEvents(in []*controlapi.BuildHistoryEvent, filters []string, l
 			return nil, errors.Errorf("invalid limit %d", limit)
 		}
 		slices.SortFunc(out, func(a, b *controlapi.BuildHistoryEvent) int {
-			if a.Record == nil || b.Record == nil {
+			aRec := a != nil && a.Record != nil
+			bRec := b != nil && b.Record != nil
+			switch {
+			case !aRec && !bRec:
 				return 0
-			}
-			if a.Record == nil {
+			case !aRec:
 				return 1
+			case !bRec:
+				return -1
 			}
 			return b.Record.CreatedAt.AsTime().Compare(a.Record.CreatedAt.AsTime())
 		})


### PR DESCRIPTION
I observed following panics couple of times while running 'docker buildx history ls'. This commit should fix it together with test which allows reproducing the panic.

Stacktrace:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x5571e75c90ae]
goroutine 16989985 [running]:
github.com/moby/buildkit/solver/llbsolver.filterHistoryEvents.func1(0xc015db4740?, 0x26?)
        github.com/moby/buildkit@v0.27.1/solver/llbsolver/history.go:1074 +0xe
slices.partitionCmpFunc[...]({0xc0014bb400?, 0x35, 0x40}, 0x0?, 0x7f13d47d6130, 0x5571e894e008?, 0x5571e894e008?)
        slices/zsortanyfunc.go:154 +0x27b
slices.pdqsortCmpFunc[...]({0xc0014bb400, 0x35, 0x40}, 0x5571e5660de7, 0xc00eeb1c98?, 0xc0011757a8?, 0x5571e894e008?)
        slices/zsortanyfunc.go:114 +0x2fe
slices.SortFunc[...](...)
        slices/sort.go:32
github.com/moby/buildkit/solver/llbsolver.filterHistoryEvents({0xc0014bb400, 0x35, 0x40}, {0x0?, 0x5571e7b577f2?, 0xc00442b410?}, 0x32)
        github.com/moby/buildkit@v0.27.1/solver/llbsolver/history.go:1073 +0x134
github.com/moby/buildkit/solver/llbsolver.(*HistoryQueue).Listen(0xc001b979e0, {0x5571e8999588, 0xc00d0ae930}, 0xc002e37e30, 0xc001175a28)
        github.com/moby/buildkit@v0.27.1/solver/llbsolver/history.go:1011 +0x80e
github.com/moby/buildkit/control.(*Controller).ListenBuildHistory(0xc0004c1500, 0xc002e37e30, {0x5571e89a8e40, 0xc00442b3e0})
        github.com/moby/buildkit@v0.27.1/control/control.go:311 +0xaf
github.com/moby/buildkit/api/services/control._Control_ListenBuildHistory_Handler({0x5571e8825da0, 0xc0004c1500}, {0x5571e89a4798, 0xc003c6c300})
        github.com/moby/buildkit@v0.27.1/api/services/control/control_grpc.pb.go:351 +0x110
github.com/moby/buildkit/util/grpcerrors.StreamServerInterceptor({0x5571e8825da0, 0xc0004c1500}, {0x5571e89a4798, 0xc003c6c300}, 0x5571e81b5140?, 0x5571e894bfc8)
        github.com/moby/buildkit@v0.27.1/util/grpcerrors/intercept.go:33 +0x5f
google.golang.org/grpc.(*Server).processStreamingRPC(0xc00189d448, {0x5571e8999588, 0xc00d0ae7b0}, 0xc002533a00, 0xc001362180, 0x5571ea24c8c0, 0x0)
        google.golang.org/grpc@v1.78.0/server.go:1721 +0x1151
google.golang.org/grpc.(*Server).handleStream(0xc00189d448, {0x5571e899b0d0, 0xc001f3ac30}, 0xc002533a00)
        google.golang.org/grpc@v1.78.0/server.go:1836 +0xd85
google.golang.org/grpc.(*Server).serveStreams.func2.1()
        google.golang.org/grpc@v1.78.0/server.go:1063 +0x7f
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 16989982
        google.golang.org/grpc@v1.78.0/server.go:1074 +0x11d
```

Tests successfully fail and pass when run as `TESTPKGS=./client TESTFLAGS="-v -run TestIntegration/TestListenBuildHistoryExcludesSoftDeletedRecords" ./hack/test integration`.