### PR TITLE
attestation: migrate emitted in-toto statements to v1

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -10479,7 +10479,7 @@ func testExportAttestations(t *testing.T, sb integration.Sandbox, ociArtifact bo
 				purls[k] = p
 			}
 
-			require.Equal(t, "https://in-toto.io/Statement/v0.1", attest.Type)
+			require.Equal(t, intoto.StatementInTotoV1, attest.Type)
 			require.Equal(t, "https://example.com/attestations/v1.0", attest.PredicateType)
 			require.Equal(t, map[string]any{"success": true}, attest.Predicate)
 			subjects := []intoto.Subject{
@@ -10501,7 +10501,7 @@ func testExportAttestations(t *testing.T, sb integration.Sandbox, ociArtifact bo
 			var attest2 intoto.Statement
 			require.NoError(t, json.Unmarshal(att.LayersRaw[1], &attest2))
 
-			require.Equal(t, "https://in-toto.io/Statement/v0.1", attest2.Type)
+			require.Equal(t, intoto.StatementInTotoV1, attest2.Type)
 			require.Equal(t, "https://example.com/attestations2/v1.0", attest2.PredicateType)
 			require.Nil(t, attest2.Predicate)
 			subjects = []intoto.Subject{{
@@ -10550,7 +10550,7 @@ func testExportAttestations(t *testing.T, sb integration.Sandbox, ociArtifact bo
 			require.NoError(t, err)
 			require.NoError(t, json.Unmarshal(dt, &attest))
 
-			require.Equal(t, "https://in-toto.io/Statement/v0.1", attest.Type)
+			require.Equal(t, intoto.StatementInTotoV1, attest.Type)
 			require.Equal(t, "https://example.com/attestations/v1.0", attest.PredicateType)
 			require.Equal(t, map[string]any{"success": true}, attest.Predicate)
 
@@ -10564,7 +10564,7 @@ func testExportAttestations(t *testing.T, sb integration.Sandbox, ociArtifact bo
 			require.NoError(t, err)
 			require.NoError(t, json.Unmarshal(dt, &attest2))
 
-			require.Equal(t, "https://in-toto.io/Statement/v0.1", attest2.Type)
+			require.Equal(t, intoto.StatementInTotoV1, attest2.Type)
 			require.Equal(t, "https://example.com/attestations2/v1.0", attest2.PredicateType)
 			require.Nil(t, attest2.Predicate)
 			subjects := []intoto.Subject{{
@@ -10608,7 +10608,7 @@ func testExportAttestations(t *testing.T, sb integration.Sandbox, ociArtifact bo
 			require.NotNil(t, item)
 			require.NoError(t, json.Unmarshal(item.Data, &attest))
 
-			require.Equal(t, "https://in-toto.io/Statement/v0.1", attest.Type)
+			require.Equal(t, intoto.StatementInTotoV1, attest.Type)
 			require.Equal(t, "https://example.com/attestations/v1.0", attest.PredicateType)
 			require.Equal(t, map[string]any{"success": true}, attest.Predicate)
 
@@ -10622,7 +10622,7 @@ func testExportAttestations(t *testing.T, sb integration.Sandbox, ociArtifact bo
 			require.NotNil(t, item)
 			require.NoError(t, json.Unmarshal(item.Data, &attest2))
 
-			require.Equal(t, "https://in-toto.io/Statement/v0.1", attest2.Type)
+			require.Equal(t, intoto.StatementInTotoV1, attest2.Type)
 			require.Equal(t, "https://example.com/attestations2/v1.0", attest2.PredicateType)
 			require.Nil(t, attest2.Predicate)
 			subjects := []intoto.Subject{{
@@ -10761,7 +10761,7 @@ func testAttestationDefaultSubject(t *testing.T, sb integration.Sandbox) {
 		var attest intoto.Statement
 		require.NoError(t, json.Unmarshal(att.LayersRaw[0], &attest))
 
-		require.Equal(t, "https://in-toto.io/Statement/v0.1", attest.Type)
+		require.Equal(t, intoto.StatementInTotoV1, attest.Type)
 		require.Equal(t, "https://example.com/attestations/v1.0", attest.PredicateType)
 		require.Equal(t, map[string]any{"success": true}, attest.Predicate)
 
@@ -10830,7 +10830,7 @@ func testAttestationBundle(t *testing.T, sb integration.Sandbox) {
 
 			stmt := intoto.Statement{
 				StatementHeader: intoto.StatementHeader{
-					Type:          intoto.StatementInTotoV01,
+					Type:          intoto.StatementInTotoV1,
 					PredicateType: "https://example.com/attestations/v1.0",
 				},
 				Predicate: map[string]any{
@@ -10981,7 +10981,7 @@ func testSBOMScan(t *testing.T, sb integration.Sandbox) {
 		cmd := `
 cat <<EOF > $BUILDKIT_SCAN_DESTINATION/spdx.json
 {
-  "_type": "https://in-toto.io/Statement/v0.1",
+  "_type": "https://in-toto.io/Statement/v1",
   "predicateType": "https://spdx.dev/Document",
   "predicate": {
 	"name": "fallback",
@@ -11145,7 +11145,7 @@ EOF
 	att := imgs.Find("unknown/unknown")
 	attest := intoto.Statement{}
 	require.NoError(t, json.Unmarshal(att.LayersRaw[0], &attest))
-	require.Equal(t, "https://in-toto.io/Statement/v0.1", attest.Type)
+	require.Equal(t, intoto.StatementInTotoV1, attest.Type)
 	require.Equal(t, intoto.PredicateSPDX, attest.PredicateType)
 	require.Subset(t, attest.Predicate, map[string]any{"name": "frontend"})
 
@@ -11177,7 +11177,7 @@ EOF
 	att = imgs.Find("unknown/unknown")
 	attest = intoto.Statement{}
 	require.NoError(t, json.Unmarshal(att.LayersRaw[0], &attest))
-	require.Equal(t, "https://in-toto.io/Statement/v0.1", attest.Type)
+	require.Equal(t, intoto.StatementInTotoV1, attest.Type)
 	require.Equal(t, intoto.PredicateSPDX, attest.PredicateType)
 	require.Subset(t, attest.Predicate, map[string]any{"name": "fallback"})
 
@@ -11209,7 +11209,7 @@ EOF
 	att = imgs.Find("unknown/unknown")
 	attest = intoto.Statement{}
 	require.NoError(t, json.Unmarshal(att.LayersRaw[0], &attest))
-	require.Equal(t, "https://in-toto.io/Statement/v0.1", attest.Type)
+	require.Equal(t, intoto.StatementInTotoV1, attest.Type)
 	require.Equal(t, intoto.PredicateSPDX, attest.PredicateType)
 	require.Subset(t, attest.Predicate, map[string]any{"name": "frontend"})
 
@@ -11241,7 +11241,7 @@ EOF
 	att = imgs.Find("unknown/unknown")
 	attest = intoto.Statement{}
 	require.NoError(t, json.Unmarshal(att.LayersRaw[0], &attest))
-	require.Equal(t, "https://in-toto.io/Statement/v0.1", attest.Type)
+	require.Equal(t, intoto.StatementInTotoV1, attest.Type)
 	require.Equal(t, intoto.PredicateSPDX, attest.PredicateType)
 	require.Subset(t, attest.Predicate, map[string]any{
 		"extraParams": map[string]any{"ARG1": "foo", "ARG2": "bar"},
@@ -11275,7 +11275,7 @@ EOF
 	att = imgs.Find("unknown/unknown")
 	attest = intoto.Statement{}
 	require.NoError(t, json.Unmarshal(att.LayersRaw[0], &attest))
-	require.Equal(t, "https://in-toto.io/Statement/v0.1", attest.Type)
+	require.Equal(t, intoto.StatementInTotoV1, attest.Type)
 	require.Equal(t, intoto.PredicateSPDX, attest.PredicateType)
 	require.Subset(t, attest.Predicate, map[string]any{
 		"extraParams": map[string]any{"ARG1": "foo", "ARG2": "hello,world"},
@@ -11334,7 +11334,7 @@ func testSBOMScanSingleRef(t *testing.T, sb integration.Sandbox) {
 		cmd := `
 cat <<EOF > $BUILDKIT_SCAN_DESTINATION/spdx.json
 {
-  "_type": "https://in-toto.io/Statement/v0.1",
+  "_type": "https://in-toto.io/Statement/v1",
   "predicateType": "https://spdx.dev/Document",
   "predicate": {"name": "fallback"}
 }
@@ -11445,7 +11445,7 @@ EOF
 	require.NotNil(t, att)
 	attest := intoto.Statement{}
 	require.NoError(t, json.Unmarshal(att.LayersRaw[0], &attest))
-	require.Equal(t, "https://in-toto.io/Statement/v0.1", attest.Type)
+	require.Equal(t, intoto.StatementInTotoV1, attest.Type)
 	require.Equal(t, intoto.PredicateSPDX, attest.PredicateType)
 	require.Subset(t, attest.Predicate, map[string]any{"name": "fallback"})
 }
@@ -11590,7 +11590,7 @@ func testSBOMSupplements(t *testing.T, sb integration.Sandbox) {
 		Predicate spdx.Document
 	}{}
 	require.NoError(t, json.Unmarshal(att.LayersRaw[0], &attest))
-	require.Equal(t, "https://in-toto.io/Statement/v0.1", attest.Type)
+	require.Equal(t, intoto.StatementInTotoV1, attest.Type)
 	require.Equal(t, intoto.PredicateSPDX, attest.PredicateType)
 
 	require.Equal(t, "DOCUMENT", string(attest.Predicate.SPDXIdentifier))
@@ -13123,7 +13123,7 @@ func testImageResolveProvenanceAttestation(t *testing.T, sb integration.Sandbox)
 
 		var stmt intoto.Statement
 		require.NoError(t, json.Unmarshal(stmtBytes, &stmt))
-		require.Equal(t, "https://in-toto.io/Statement/v0.1", stmt.Type)
+		require.Equal(t, intoto.StatementInTotoV1, stmt.Type)
 		require.Contains(t, []string{
 			policyimage.SLSAProvenancePredicateType02,
 			policyimage.SLSAProvenancePredicateType1,

--- a/client/policy_test.go
+++ b/client/policy_test.go
@@ -344,7 +344,7 @@ func testSourceMetaPolicySessionResolveAttestations(t *testing.T, sb integration
 
 				var stmt intoto.Statement
 				require.NoError(t, json.Unmarshal(blob.Data, &stmt))
-				require.Equal(t, "https://in-toto.io/Statement/v0.1", stmt.Type)
+				require.Equal(t, intoto.StatementInTotoV1, stmt.Type)
 				require.Equal(t, layerPredicateType, stmt.PredicateType)
 				require.NotEmpty(t, stmt.Subject)
 				require.Equal(t, imageManifestDigest.Hex(), stmt.Subject[0].Digest["sha256"])

--- a/docs/attestations/attestation-storage.md
+++ b/docs/attestations/attestation-storage.md
@@ -62,7 +62,7 @@ The contents of each layer will be a blob dependent on its `mediaType`.
 
   ```json
   {
-    "_type": "https://in-toto.io/Statement/v0.1",
+    "_type": "https://in-toto.io/Statement/v1",
     "subject": [
       {
         "name": "<NAME>",
@@ -200,7 +200,7 @@ Attestation body containing the SBOM data listing the packages used during the b
 
 ```json
 {
-  "_type": "https://in-toto.io/Statement/v0.1",
+  "_type": "https://in-toto.io/Statement/v1",
   "predicateType": "https://spdx.dev/Document",
   "subject": [
     {

--- a/docs/attestations/sbom.md
+++ b/docs/attestations/sbom.md
@@ -111,7 +111,7 @@ the following SBOM:
 
 ```json
 {
-  "_type": "https://in-toto.io/Statement/v0.1",
+  "_type": "https://in-toto.io/Statement/v1",
   "predicateType": "https://spdx.dev/Document",
   "subject": [
     {

--- a/docs/attestations/slsa-provenance.md
+++ b/docs/attestations/slsa-provenance.md
@@ -136,7 +136,7 @@ build:
 
 ```json
 {
-  "_type": "https://in-toto.io/Statement/v0.1",
+  "_type": "https://in-toto.io/Statement/v1",
   "predicateType": "https://slsa.dev/provenance/v1",
   "subject": [
     {
@@ -202,7 +202,7 @@ For a similar build, but with `mode=max`:
 
 ```json
 {
-  "_type": "https://in-toto.io/Statement/v0.1",
+  "_type": "https://in-toto.io/Statement/v1",
   "predicateType": "https://slsa.dev/provenance/v1",
   "subject": [
     {

--- a/exporter/attestation/intoto/json.go
+++ b/exporter/attestation/intoto/json.go
@@ -1,0 +1,147 @@
+package intoto
+
+import (
+	"bytes"
+	"encoding/json"
+	"maps"
+
+	attestationv1 "github.com/in-toto/attestation/go/v1"
+	legacyintoto "github.com/in-toto/in-toto-golang/in_toto"
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+var (
+	marshalOptions   = protojson.MarshalOptions{}
+	unmarshalOptions = protojson.UnmarshalOptions{}
+)
+
+// Subject is the subset of the in-toto v1 resource descriptor.
+type Subject struct {
+	Name   string            `json:"name,omitempty"`
+	Digest map[string]string `json:"digest,omitempty"`
+}
+
+// Statement is a local compatibility wrapper around the in-toto v1 protobuf
+// statement. It keeps protojson isolated at the boundary while still accepting
+// legacy v0.1 JSON on decode.
+type Statement struct {
+	Type          string
+	Subject       []Subject
+	PredicateType string
+	Predicate     json.RawMessage
+}
+
+func ToResourceDescriptors(subjects []Subject) []*attestationv1.ResourceDescriptor {
+	out := make([]*attestationv1.ResourceDescriptor, 0, len(subjects))
+	for _, subject := range subjects {
+		out = append(out, &attestationv1.ResourceDescriptor{
+			Name:   subject.Name,
+			Digest: maps.Clone(subject.Digest),
+		})
+	}
+	return out
+}
+
+func FromResourceDescriptors(subjects []*attestationv1.ResourceDescriptor) []Subject {
+	out := make([]Subject, 0, len(subjects))
+	for _, subject := range subjects {
+		if subject == nil {
+			continue
+		}
+		out = append(out, Subject{
+			Name:   subject.GetName(),
+			Digest: maps.Clone(subject.GetDigest()),
+		})
+	}
+	return out
+}
+
+func (s Statement) MarshalJSON() ([]byte, error) {
+	stmt, err := s.toProtobuf()
+	if err != nil {
+		return nil, err
+	}
+	return marshalOptions.Marshal(stmt)
+}
+
+func (s *Statement) UnmarshalJSON(data []byte) error {
+	var stmt attestationv1.Statement
+	if err := unmarshalOptions.Unmarshal(data, &stmt); err != nil {
+		return errors.Wrap(err, "cannot decode in-toto statement")
+	}
+	if !validStatementType(stmt.GetType()) {
+		return errors.Errorf("unsupported in-toto statement type %q", stmt.GetType())
+	}
+	return s.fromProtobuf(&stmt)
+}
+
+func (s Statement) toProtobuf() (*attestationv1.Statement, error) {
+	predicate, err := toPredicateStruct(s.Predicate)
+	if err != nil {
+		return nil, err
+	}
+	return &attestationv1.Statement{
+		Type:          attestationv1.StatementTypeUri,
+		Subject:       ToResourceDescriptors(s.Subject),
+		PredicateType: s.PredicateType,
+		Predicate:     predicate,
+	}, nil
+}
+
+func (s *Statement) fromProtobuf(stmt *attestationv1.Statement) error {
+	predicate, err := fromPredicateStruct(stmt.GetPredicate())
+	if err != nil {
+		return err
+	}
+	s.Type = stmt.GetType()
+	s.Subject = FromResourceDescriptors(stmt.GetSubject())
+	s.PredicateType = stmt.GetPredicateType()
+	s.Predicate = predicate
+	return nil
+}
+
+func toPredicateStruct(raw json.RawMessage) (*structpb.Struct, error) {
+	raw = normalizePredicate(raw)
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var predicate map[string]any
+	if err := json.Unmarshal(raw, &predicate); err != nil {
+		return nil, errors.Wrap(err, "cannot decode in-toto predicate as object")
+	}
+	st, err := structpb.NewStruct(predicate)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot convert in-toto predicate to protobuf")
+	}
+	return st, nil
+}
+
+func fromPredicateStruct(predicate *structpb.Struct) (json.RawMessage, error) {
+	if predicate == nil {
+		return nil, nil
+	}
+	dt, err := marshalOptions.Marshal(predicate)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot encode in-toto predicate")
+	}
+	return normalizePredicate(dt), nil
+}
+
+func normalizePredicate(raw json.RawMessage) json.RawMessage {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return nil
+	}
+	return bytes.Clone(raw)
+}
+
+func validStatementType(t string) bool {
+	switch t {
+	case legacyintoto.StatementInTotoV01, attestationv1.StatementTypeUri:
+		return true
+	default:
+		return false
+	}
+}

--- a/exporter/attestation/intoto/json_test.go
+++ b/exporter/attestation/intoto/json_test.go
@@ -1,0 +1,156 @@
+package intoto
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	attestationv1 "github.com/in-toto/attestation/go/v1"
+	legacyintoto "github.com/in-toto/in-toto-golang/in_toto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatementMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	stmt := Statement{
+		Type: legacyintoto.StatementInTotoV01,
+		Subject: []Subject{{
+			Name: "pkg:docker/example@sha256:abc",
+			Digest: map[string]string{
+				"sha256": strings.Repeat("a", 64),
+			},
+		}},
+		PredicateType: "https://example.com/attestations/v1.0",
+		Predicate:     json.RawMessage(`{"success":true}`),
+	}
+
+	expected := `{
+		"_type":"https://in-toto.io/Statement/v1",
+		"subject":[{"name":"pkg:docker/example@sha256:abc","digest":{"sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}],
+		"predicateType":"https://example.com/attestations/v1.0",
+		"predicate":{"success":true}
+	}`
+
+	for _, tc := range []struct {
+		name string
+		v    any
+	}{
+		{"value", stmt},
+		{"pointer", &stmt},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dt, err := json.Marshal(tc.v)
+			require.NoError(t, err)
+			require.JSONEq(t, expected, string(dt))
+		})
+	}
+}
+
+func TestStatementMarshalJSONOmitsEmptyPredicate(t *testing.T) {
+	t.Parallel()
+
+	stmt := Statement{
+		Subject: []Subject{{
+			Name: "artifact",
+			Digest: map[string]string{
+				"sha256": strings.Repeat("b", 64),
+			},
+		}},
+		PredicateType: "https://example.com/attestations/v1.0",
+	}
+
+	dt, err := json.Marshal(&stmt)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"_type":"https://in-toto.io/Statement/v1",
+		"subject":[{"name":"artifact","digest":{"sha256":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}}],
+		"predicateType":"https://example.com/attestations/v1.0"
+	}`, string(dt))
+}
+
+func TestStatementUnmarshalJSONLegacyV01(t *testing.T) {
+	t.Parallel()
+
+	var stmt Statement
+	err := json.Unmarshal([]byte(`{
+		"_type":"https://in-toto.io/Statement/v0.1",
+		"subject":[{"name":"artifact","digest":{"sha256":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"}}],
+		"predicateType":"https://example.com/attestations/v1.0",
+		"predicate":{"success":true}
+	}`), &stmt)
+	require.NoError(t, err)
+
+	require.Equal(t, legacyintoto.StatementInTotoV01, stmt.Type)
+	require.Equal(t, []Subject{{
+		Name: "artifact",
+		Digest: map[string]string{
+			"sha256": strings.Repeat("c", 64),
+		},
+	}}, stmt.Subject)
+	require.Equal(t, "https://example.com/attestations/v1.0", stmt.PredicateType)
+	require.JSONEq(t, `{"success":true}`, string(stmt.Predicate))
+}
+
+func TestStatementUnmarshalJSONV1(t *testing.T) {
+	t.Parallel()
+
+	var stmt Statement
+	err := json.Unmarshal([]byte(`{
+		"_type":"https://in-toto.io/Statement/v1",
+		"subject":[{"name":"artifact","digest":{"sha256":"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"}}],
+		"predicateType":"https://example.com/attestations/v1.0",
+		"predicate":{"success":true}
+	}`), &stmt)
+	require.NoError(t, err)
+
+	require.Equal(t, attestationv1.StatementTypeUri, stmt.Type)
+	require.Equal(t, []Subject{{
+		Name: "artifact",
+		Digest: map[string]string{
+			"sha256": strings.Repeat("d", 64),
+		},
+	}}, stmt.Subject)
+	require.Equal(t, "https://example.com/attestations/v1.0", stmt.PredicateType)
+	require.JSONEq(t, `{"success":true}`, string(stmt.Predicate))
+}
+
+func TestStatementUnmarshalJSONNullPredicate(t *testing.T) {
+	t.Parallel()
+
+	var stmt Statement
+	err := json.Unmarshal([]byte(`{
+		"_type":"https://in-toto.io/Statement/v0.1",
+		"subject":[{"name":"artifact","digest":{"sha256":"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"}}],
+		"predicateType":"https://example.com/attestations/v1.0",
+		"predicate":null
+	}`), &stmt)
+	require.NoError(t, err)
+	require.Nil(t, stmt.Predicate)
+}
+
+func TestStatementUnmarshalJSONOmittedPredicate(t *testing.T) {
+	t.Parallel()
+
+	var stmt Statement
+	err := json.Unmarshal([]byte(`{
+		"_type":"https://in-toto.io/Statement/v1",
+		"subject":[{"name":"artifact","digest":{"sha256":"abababababababababababababababababababababababababababababababab"}}],
+		"predicateType":"https://example.com/attestations/v1.0"
+	}`), &stmt)
+	require.NoError(t, err)
+	require.Nil(t, stmt.Predicate)
+}
+
+func TestStatementUnmarshalJSONRejectsUnknownType(t *testing.T) {
+	t.Parallel()
+
+	var stmt Statement
+	err := json.Unmarshal([]byte(`{
+		"_type":"https://in-toto.io/Statement/v9",
+		"subject":[{"name":"artifact","digest":{"sha256":"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"}}],
+		"predicateType":"https://example.com/attestations/v1.0",
+		"predicate":{"success":true}
+	}`), &stmt)
+	require.Error(t, err)
+}

--- a/exporter/attestation/make.go
+++ b/exporter/attestation/make.go
@@ -6,8 +6,8 @@ import (
 	"os"
 
 	"github.com/containerd/continuity/fs"
-	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/moby/buildkit/exporter"
+	intotojson "github.com/moby/buildkit/exporter/attestation/intoto"
 	gatewaypb "github.com/moby/buildkit/frontend/gateway/pb"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/snapshot"
@@ -56,9 +56,9 @@ func ReadAll(ctx context.Context, s session.Group, att exporter.Attestation) ([]
 
 // MakeInTotoStatements iterates over all provided result attestations and
 // generates intoto attestation statements.
-func MakeInTotoStatements(ctx context.Context, s session.Group, attestations []exporter.Attestation, defaultSubjects []intoto.Subject) ([]intoto.Statement, error) {
+func MakeInTotoStatements(ctx context.Context, s session.Group, attestations []exporter.Attestation, defaultSubjects []intotojson.Subject) ([]*intotojson.Statement, error) {
 	eg, ctx := errgroup.WithContext(ctx)
-	statements := make([]intoto.Statement, len(attestations))
+	statements := make([]*intotojson.Statement, len(attestations))
 
 	for i, att := range attestations {
 		eg.Go(func() error {
@@ -73,7 +73,7 @@ func MakeInTotoStatements(ctx context.Context, s session.Group, attestations []e
 				if err != nil {
 					return err
 				}
-				statements[i] = *stmt
+				statements[i] = stmt
 			case gatewaypb.AttestationKind_Bundle:
 				return errors.New("bundle attestation kind must be un-bundled first")
 			}
@@ -86,13 +86,13 @@ func MakeInTotoStatements(ctx context.Context, s session.Group, attestations []e
 	return statements, nil
 }
 
-func makeInTotoStatement(content []byte, attestation exporter.Attestation, defaultSubjects []intoto.Subject) (*intoto.Statement, error) {
+func makeInTotoStatement(content []byte, attestation exporter.Attestation, defaultSubjects []intotojson.Subject) (*intotojson.Statement, error) {
 	if len(attestation.InToto.Subjects) == 0 {
 		attestation.InToto.Subjects = []result.InTotoSubject{{
 			Kind: gatewaypb.InTotoSubjectKind_Self,
 		}}
 	}
-	subjects := []intoto.Subject{}
+	var subjects []intotojson.Subject
 	for _, subject := range attestation.InToto.Subjects {
 		subjectName := "_"
 		if subject.Name != "" {
@@ -109,14 +109,14 @@ func makeInTotoStatement(content []byte, attestation exporter.Attestation, defau
 				}
 
 				for _, name := range subjectNames {
-					subjects = append(subjects, intoto.Subject{
+					subjects = append(subjects, intotojson.Subject{
 						Name:   name,
 						Digest: defaultSubject.Digest,
 					})
 				}
 			}
 		case gatewaypb.InTotoSubjectKind_Raw:
-			subjects = append(subjects, intoto.Subject{
+			subjects = append(subjects, intotojson.Subject{
 				Name:   subjectName,
 				Digest: result.ToDigestMap(subject.Digest...),
 			})
@@ -124,14 +124,10 @@ func makeInTotoStatement(content []byte, attestation exporter.Attestation, defau
 			return nil, errors.Errorf("unknown attestation subject type %T", subject)
 		}
 	}
-
-	stmt := intoto.Statement{
-		StatementHeader: intoto.StatementHeader{
-			Type:          intoto.StatementInTotoV01,
-			PredicateType: attestation.InToto.PredicateType,
-			Subject:       subjects,
-		},
-		Predicate: json.RawMessage(content),
+	stmt := intotojson.Statement{
+		Subject:       subjects,
+		PredicateType: attestation.InToto.PredicateType,
+		Predicate:     json.RawMessage(content),
 	}
 	return &stmt, nil
 }

--- a/exporter/attestation/unbundle.go
+++ b/exporter/attestation/unbundle.go
@@ -1,6 +1,7 @@
 package attestation
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -9,8 +10,8 @@ import (
 	"strings"
 
 	"github.com/containerd/continuity/fs"
-	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/moby/buildkit/exporter"
+	intotojson "github.com/moby/buildkit/exporter/attestation/intoto"
 	gatewaypb "github.com/moby/buildkit/frontend/gateway/pb"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/snapshot"
@@ -137,7 +138,7 @@ func unbundle(root string, bundle exporter.Attestation) ([]exporter.Attestation,
 			return nil, err
 		}
 		dec := json.NewDecoder(f)
-		var stmt intoto.Statement
+		var stmt intotojson.Statement
 		if err := dec.Decode(&stmt); err != nil {
 			return nil, errors.Wrap(err, "cannot decode in-toto statement")
 		}
@@ -146,11 +147,6 @@ func unbundle(root string, bundle exporter.Attestation) ([]exporter.Attestation,
 		}
 		if bundle.InToto.PredicateType != "" && stmt.PredicateType != bundle.InToto.PredicateType {
 			return nil, errors.Errorf("bundle entry %s does not match required predicate type %s", stmt.PredicateType, bundle.InToto.PredicateType)
-		}
-
-		predicate, err := json.Marshal(stmt.Predicate)
-		if err != nil {
-			return nil, err
 		}
 
 		subjects := make([]result.InTotoSubject, len(stmt.Subject))
@@ -165,7 +161,7 @@ func unbundle(root string, bundle exporter.Attestation) ([]exporter.Attestation,
 			Kind:        gatewaypb.AttestationKind_InToto,
 			Metadata:    bundle.Metadata,
 			Path:        path.Join(bundle.Path, entry.Name()),
-			ContentFunc: func(context.Context) ([]byte, error) { return predicate, nil },
+			ContentFunc: func(context.Context) ([]byte, error) { return bytes.Clone(stmt.Predicate), nil },
 			InToto: result.InTotoAttestation{
 				PredicateType: stmt.PredicateType,
 				Subjects:      subjects,

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -20,6 +20,7 @@ import (
 	cacheconfig "github.com/moby/buildkit/cache/config"
 	"github.com/moby/buildkit/exporter"
 	"github.com/moby/buildkit/exporter/attestation"
+	intotojson "github.com/moby/buildkit/exporter/attestation/intoto"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/exporter/util/epoch"
 	"github.com/moby/buildkit/session"
@@ -320,7 +321,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 				return nil, err
 			}
 
-			var defaultSubjects []intoto.Subject
+			var defaultSubjects []intotojson.Subject
 			for name := range strings.SplitSeq(opts.ImageName, ",") {
 				if name == "" {
 					continue
@@ -329,7 +330,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 				if err != nil {
 					return nil, err
 				}
-				defaultSubjects = append(defaultSubjects, intoto.Subject{
+				defaultSubjects = append(defaultSubjects, intotojson.Subject{
 					Name:   pl,
 					Digest: result.ToDigestMap(desc.Digest),
 				})
@@ -579,7 +580,7 @@ func (ic *ImageWriter) commitDistributionManifest(ctx context.Context, opts *Ima
 	}, &configDesc, nil
 }
 
-func (ic *ImageWriter) commitAttestationsManifest(ctx context.Context, opts *ImageCommitOpts, target ocispecs.Descriptor, statements []intoto.Statement, ociArtifact bool) (*ocispecs.Descriptor, error) {
+func (ic *ImageWriter) commitAttestationsManifest(ctx context.Context, opts *ImageCommitOpts, target ocispecs.Descriptor, statements []*intotojson.Statement, ociArtifact bool) (*ocispecs.Descriptor, error) {
 	var (
 		manifestType = ocispecs.MediaTypeImageManifest
 		configType   = ocispecs.MediaTypeImageConfig

--- a/exporter/local/fs.go
+++ b/exporter/local/fs.go
@@ -12,10 +12,10 @@ import (
 	"strings"
 	"time"
 
-	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/exporter"
 	"github.com/moby/buildkit/exporter/attestation"
+	intotojson "github.com/moby/buildkit/exporter/attestation/intoto"
 	"github.com/moby/buildkit/exporter/util/epoch"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/snapshot"
@@ -148,7 +148,7 @@ func CreateFS(ctx context.Context, sessionID string, k string, ref cache.Immutab
 		return nil, nil, err
 	}
 	if len(attestations) > 0 {
-		subjects := []intoto.Subject{}
+		subjects := []intotojson.Subject{}
 		err = outputFS.Walk(ctx, "", func(path string, entry fs.DirEntry, err error) error {
 			if err != nil {
 				return err
@@ -165,7 +165,7 @@ func CreateFS(ctx context.Context, sessionID string, k string, ref cache.Immutab
 			if _, err := io.Copy(d.Hash(), f); err != nil {
 				return err
 			}
-			subjects = append(subjects, intoto.Subject{
+			subjects = append(subjects, intotojson.Subject{
 				Name:   path,
 				Digest: result.ToDigestMap(d.Digest()),
 			})

--- a/frontend/dockerfile/dockerfile_provenance_test.go
+++ b/frontend/dockerfile/dockerfile_provenance_test.go
@@ -172,7 +172,7 @@ RUN echo ok> /foo
 				require.Equal(t, "attestation-manifest", att.Desc.Annotations["vnd.docker.reference.type"])
 				var attest intoto.Statement
 				require.NoError(t, json.Unmarshal(att.LayersRaw[0], &attest))
-				require.Equal(t, "https://in-toto.io/Statement/v0.1", attest.Type)
+				require.Equal(t, intoto.StatementInTotoV1, attest.Type)
 
 				if slsaVersion == "" || slsaVersion == "v1" {
 					require.Equal(t, "https://slsa.dev/provenance/v1", attest.PredicateType) // intentionally not const
@@ -512,7 +512,7 @@ COPY myapp.Dockerfile /
 			require.Equal(t, "attestation-manifest", att.Desc.Annotations["vnd.docker.reference.type"])
 			var attest intoto.Statement
 			require.NoError(t, json.Unmarshal(att.LayersRaw[0], &attest))
-			require.Equal(t, "https://in-toto.io/Statement/v0.1", attest.Type)
+			require.Equal(t, intoto.StatementInTotoV1, attest.Type)
 
 			_, isClient := f.(*clientFrontend)
 			_, isGateway := f.(*gatewayFrontend)
@@ -708,7 +708,7 @@ RUN echo "ok-$TARGETARCH" > /foo
 		require.Equal(t, "attestation-manifest", att.Desc.Annotations["vnd.docker.reference.type"])
 		var attest intoto.Statement
 		require.NoError(t, json.Unmarshal(att.LayersRaw[0], &attest))
-		require.Equal(t, "https://in-toto.io/Statement/v0.1", attest.Type)
+		require.Equal(t, intoto.StatementInTotoV1, attest.Type)
 		require.Equal(t, "https://slsa.dev/provenance/v1", attest.PredicateType) // intentionally not const
 		type stmtT struct {
 			Predicate provenancetypes.ProvenancePredicateSLSA1 `json:"predicate"`
@@ -889,7 +889,7 @@ func testClientFrontendProvenance(t *testing.T, sb integration.Sandbox) {
 	require.Equal(t, "attestation-manifest", att.Desc.Annotations["vnd.docker.reference.type"])
 	var attest intoto.Statement
 	require.NoError(t, json.Unmarshal(att.LayersRaw[0], &attest))
-	require.Equal(t, "https://in-toto.io/Statement/v0.1", attest.Type)
+	require.Equal(t, intoto.StatementInTotoV1, attest.Type)
 	require.Equal(t, "https://slsa.dev/provenance/v1", attest.PredicateType) // intentionally not const
 	type stmtT struct {
 		Predicate provenancetypes.ProvenancePredicateSLSA1 `json:"predicate"`
@@ -921,7 +921,7 @@ func testClientFrontendProvenance(t *testing.T, sb integration.Sandbox) {
 	require.Equal(t, "attestation-manifest", att.Desc.Annotations["vnd.docker.reference.type"])
 	attest = intoto.Statement{}
 	require.NoError(t, json.Unmarshal(att.LayersRaw[0], &attest))
-	require.Equal(t, "https://in-toto.io/Statement/v0.1", attest.Type)
+	require.Equal(t, intoto.StatementInTotoV1, attest.Type)
 	require.Equal(t, "https://slsa.dev/provenance/v1", attest.PredicateType) // intentionally not const
 	stmt = stmtT{}
 	require.NoError(t, json.Unmarshal(att.LayersRaw[0], &stmt))
@@ -1029,7 +1029,7 @@ COPY --from=base C:\out C:\Files
 
 	var attest intoto.Statement
 	require.NoError(t, json.Unmarshal(att.LayersRaw[0], &attest))
-	require.Equal(t, "https://in-toto.io/Statement/v0.1", attest.Type)
+	require.Equal(t, intoto.StatementInTotoV1, attest.Type)
 	require.Equal(t, "https://slsa.dev/provenance/v1", attest.PredicateType)
 
 	type stmtT struct {
@@ -1142,7 +1142,7 @@ func testClientLLBProvenance(t *testing.T, sb integration.Sandbox) {
 	require.Equal(t, "attestation-manifest", att.Desc.Annotations["vnd.docker.reference.type"])
 	var attest intoto.Statement
 	require.NoError(t, json.Unmarshal(att.LayersRaw[0], &attest))
-	require.Equal(t, "https://in-toto.io/Statement/v0.1", attest.Type)
+	require.Equal(t, intoto.StatementInTotoV1, attest.Type)
 	require.Equal(t, "https://slsa.dev/provenance/v1", attest.PredicateType) // intentionally not const
 	type stmtT struct {
 		Predicate provenancetypes.ProvenancePredicateSLSA1 `json:"predicate"`

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -9794,7 +9794,7 @@ COPY <<-"EOF" /scan.sh
 	set -e
 	cat <<BUNDLE > $BUILDKIT_SCAN_DESTINATION/spdx.json
 	{
-	  "_type": "https://in-toto.io/Statement/v0.1",
+	  "_type": "https://in-toto.io/Statement/v1",
 	  "predicateType": "https://spdx.dev/Document",
 	  "predicate": {"name": "sbom-scan"}
 	}
@@ -9871,7 +9871,7 @@ EOF
 	require.Equal(t, 1, len(att.LayersRaw))
 	var attest intoto.Statement
 	require.NoError(t, json.Unmarshal(att.LayersRaw[0], &attest))
-	require.Equal(t, "https://in-toto.io/Statement/v0.1", attest.Type)
+	require.Equal(t, intoto.StatementInTotoV1, attest.Type)
 	require.Equal(t, intoto.PredicateSPDX, attest.PredicateType)
 	require.Subset(t, attest.Predicate, map[string]any{"name": "sbom-scan"})
 }
@@ -9899,7 +9899,7 @@ COPY <<-"EOF" /scan.sh
 	set -e
 	cat <<BUNDLE > $BUILDKIT_SCAN_DESTINATION/spdx.json
 	{
-	  "_type": "https://in-toto.io/Statement/v0.1",
+	  "_type": "https://in-toto.io/Statement/v1",
 	  "predicateType": "https://spdx.dev/Document",
 	  "predicate": {"name": "core"}
 	}
@@ -9908,7 +9908,7 @@ COPY <<-"EOF" /scan.sh
 		for src in "${BUILDKIT_SCAN_SOURCE_EXTRAS}"/*; do
 			cat <<BUNDLE > $BUILDKIT_SCAN_DESTINATION/$(basename $src).spdx.json
 			{
-			  "_type": "https://in-toto.io/Statement/v0.1",
+			  "_type": "https://in-toto.io/Statement/v1",
 			  "predicateType": "https://spdx.dev/Document",
 			  "predicate": {"name": "extra"}
 			}

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/hashicorp/go-immutable-radix/v2 v2.1.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/hiddeco/sshsig v0.2.0
+	github.com/in-toto/attestation v1.1.2
 	github.com/in-toto/in-toto-golang v0.10.0
 	github.com/klauspost/compress v1.18.5
 	github.com/mitchellh/hashstructure/v2 v2.0.2
@@ -194,7 +195,6 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/hanwen/go-fuse/v2 v2.9.0 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
-	github.com/in-toto/attestation v1.1.2 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/moby/sys/capability v0.4.0 // indirect
 	github.com/moby/sys/mount v0.3.4 // indirect


### PR DESCRIPTION
follow-up:
* https://github.com/moby/buildkit/pull/6005#issuecomment-2958138795
* https://github.com/moby/buildkit/pull/4269

Emit in-toto Statement v1 for attestations while keeping compatibility for decoding legacy v0.1 statements.

First adds a small local JSON compatibility wrapper around the in-toto v1 protobuf types and isolates `protojson` handling at the attestation boundary. Then switches the exporter-side attestation paths to use that wrapper for statement creation, marshaling, and unbundling.

Compatibility is preserved on the read path. The new wrapper still accepts legacy `https://in-toto.io/Statement/v0.1` JSON so bundled attestations and older fixtures can still be decoded. The write path always normalizes emitted statements to `https://in-toto.io/Statement/v1`.

It does not introduce a broader protobuf refactor across unrelated packages, and it doesn't add a new schema generation pipeline. The only new abstraction is the small attestation JSON wrapper that keeps the `protojson` requirement contained.

There are a few remaining `github.com/in-toto/in-toto-golang` usages outside the new wrapper path that are only used for constants or in tests, and those could be looked at as follow-up. The bigger remaining dependency on `in-toto-golang` is the SLSA provenance predicate modeling in the solver path, and switching that to `github.com/in-toto/attestation` would be a meaningfully larger protobuf-backed refactor that is better handled on its own.

Example: https://oci.dag.dev/?blob=crazymax/buildkit@sha256:7b1f485c470d4db8d7f244c369970b45a67f0ee92f52ac5f16fba09389649c11&mt=application%2Fvnd.in-toto%2Bjson&size=2249