### PR TITLE
[v0.28 backport] vendor: github.com/moby/patternmatcher v0.6.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/moby/docker-image-spec v1.3.1
 	github.com/moby/go-archive v0.2.0
 	github.com/moby/locker v1.0.1
-	github.com/moby/patternmatcher v0.6.0
+	github.com/moby/patternmatcher v0.6.1
 	github.com/moby/policy-helpers v0.0.0-20260211190020-824747bfdd3c
 	github.com/moby/profiles/seccomp v0.1.0
 	github.com/moby/sys/mountinfo v0.7.2

--- a/go.sum
+++ b/go.sum
@@ -439,8 +439,8 @@ github.com/moby/go-archive v0.2.0 h1:zg5QDUM2mi0JIM9fdQZWC7U8+2ZfixfTYoHL7rWUcP8
 github.com/moby/go-archive v0.2.0/go.mod h1:mNeivT14o8xU+5q1YnNrkQVpK+dnNe/K6fHqnTg4qPU=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
-github.com/moby/patternmatcher v0.6.0 h1:GmP9lR19aU5GqSSFko+5pRqHi+Ohk1O69aFiKkVGiPk=
-github.com/moby/patternmatcher v0.6.0/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
+github.com/moby/patternmatcher v0.6.1 h1:qlhtafmr6kgMIJjKJMDmMWq7WLkKIo23hsrpR3x084U=
+github.com/moby/patternmatcher v0.6.1/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/moby/policy-helpers v0.0.0-20260211190020-824747bfdd3c h1:hRUo0Ir9PEaa0PQCgg8WvGku0sgmTo/NgnCzMb83iII=
 github.com/moby/policy-helpers v0.0.0-20260211190020-824747bfdd3c/go.mod h1:2P1OGoTVIrybI4M7yhpkDpqiwOnI3yR+HnNhEyo8ovs=
 github.com/moby/profiles/seccomp v0.1.0 h1:kVf1lc5ytNB1XPxEdZUVF+oPpbBYJHR50eEvPt/9k8A=

--- a/vendor/github.com/moby/patternmatcher/patternmatcher.go
+++ b/vendor/github.com/moby/patternmatcher/patternmatcher.go
@@ -331,14 +331,20 @@ func (p *Pattern) match(path string) (bool, error) {
 		// **/foo matches "foo"
 		return suffix[0] == os.PathSeparator && path == suffix[1:], nil
 	case regexpMatch:
+		if p.regexp == nil {
+			return false, filepath.ErrBadPattern
+		}
 		return p.regexp.MatchString(path), nil
+	case unknownMatch:
+		return false, filepath.ErrBadPattern
+	default:
+		return false, nil
 	}
-
-	return false, nil
 }
 
 func (p *Pattern) compile(sl string) error {
 	regStr := "^"
+	detectedType := exactMatch // assume exact match
 	pattern := p.cleanedPattern
 	// Go through the pattern and convert it to a regexp.
 	// We use a scanner so we can support utf-8 chars.
@@ -350,7 +356,6 @@ func (p *Pattern) compile(sl string) error {
 		escSL += `\`
 	}
 
-	p.matchType = exactMatch
 	for i := 0; scan.Peek() != scanner.EOF; i++ {
 		ch := scan.Next()
 
@@ -366,32 +371,32 @@ func (p *Pattern) compile(sl string) error {
 
 				if scan.Peek() == scanner.EOF {
 					// is "**EOF" - to align with .gitignore just accept all
-					if p.matchType == exactMatch {
-						p.matchType = prefixMatch
+					if detectedType == exactMatch {
+						detectedType = prefixMatch
 					} else {
 						regStr += ".*"
-						p.matchType = regexpMatch
+						detectedType = regexpMatch
 					}
 				} else {
 					// is "**"
 					// Note that this allows for any # of /'s (even 0) because
 					// the .* will eat everything, even /'s
 					regStr += "(.*" + escSL + ")?"
-					p.matchType = regexpMatch
+					detectedType = regexpMatch
 				}
 
 				if i == 0 {
-					p.matchType = suffixMatch
+					detectedType = suffixMatch
 				}
 			} else {
 				// is "*" so map it to anything but "/"
 				regStr += "[^" + escSL + "]*"
-				p.matchType = regexpMatch
+				detectedType = regexpMatch
 			}
 		} else if ch == '?' {
 			// "?" is any char except "/"
 			regStr += "[^" + escSL + "]"
-			p.matchType = regexpMatch
+			detectedType = regexpMatch
 		} else if shouldEscape(ch) {
 			// Escape some regexp special chars that have no meaning
 			// in golang's filepath.Match
@@ -408,31 +413,29 @@ func (p *Pattern) compile(sl string) error {
 			}
 			if scan.Peek() != scanner.EOF {
 				regStr += `\` + string(scan.Next())
-				p.matchType = regexpMatch
+				detectedType = regexpMatch
 			} else {
 				regStr += `\`
 			}
 		} else if ch == '[' || ch == ']' {
 			regStr += string(ch)
-			p.matchType = regexpMatch
+			detectedType = regexpMatch
 		} else {
 			regStr += string(ch)
 		}
 	}
 
-	if p.matchType != regexpMatch {
-		return nil
+	if detectedType == regexpMatch {
+		regStr += "$"
+
+		re, err := regexp.Compile(regStr)
+		if err != nil {
+			return err
+		}
+
+		p.regexp = re
 	}
-
-	regStr += "$"
-
-	re, err := regexp.Compile(regStr)
-	if err != nil {
-		return err
-	}
-
-	p.regexp = re
-	p.matchType = regexpMatch
+	p.matchType = detectedType
 	return nil
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -810,7 +810,7 @@ github.com/moby/go-archive/tarheader
 # github.com/moby/locker v1.0.1
 ## explicit; go 1.13
 github.com/moby/locker
-# github.com/moby/patternmatcher v0.6.0
+# github.com/moby/patternmatcher v0.6.1
 ## explicit; go 1.19
 github.com/moby/patternmatcher
 github.com/moby/patternmatcher/ignorefile


### PR DESCRIPTION
- backport https://github.com/moby/buildkit/pull/6609

### vendor: github.com/moby/patternmatcher v0.6.1

- fix panic / nil pointer dereference on invalid patterns

full diff: https://github.com/moby/patternmatcher/compare/v0.6.0...v0.6.1


(cherry picked from commit 565f1c05579f2d304ed51415339a06ec725ff1cd)