### PR TITLE
[carry] history: fix panic when listing history

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -13457,8 +13457,8 @@ func testListenBuildHistoryExcludesSoftDeletedRecords(t *testing.T, sb integrati
 	// Start a streaming listener on one specific ref. This increments the
 	// internal reference count, which causes Delete to soft-delete instead
 	// of removing the record from the database.
-	listenerCtx, listenerCancel := context.WithCancel(sb.Context())
-	defer listenerCancel()
+	listenerCtx, listenerCancel := context.WithCancelCause(sb.Context())
+	defer listenerCancel(nil)
 
 	cl, err := c.ControlClient().ListenBuildHistory(listenerCtx, &controlapi.BuildHistoryRequest{
 		Ref: refToDelete,
@@ -13502,7 +13502,7 @@ func testListenBuildHistoryExcludesSoftDeletedRecords(t *testing.T, sb integrati
 	assert.True(t, gotRefs[buildRefs[2]], "ref %s should appear in history list", buildRefs[2])
 
 	// Clean up the streaming listener.
-	listenerCancel()
+	listenerCancel(nil)
 	// Drain the stream so gRPC can clean up.
 	for {
 		if _, err := cl.Recv(); err != nil {

--- a/solver/llbsolver/history/filter.go
+++ b/solver/llbsolver/history/filter.go
@@ -25,13 +25,21 @@ func filterHistoryEvents(in []*controlapi.BuildHistoryEvent, filters []string, l
 		return nil, err
 	}
 
-	out := make([]*controlapi.BuildHistoryEvent, 0, len(in))
+	events := make([]*controlapi.BuildHistoryEvent, 0, len(in))
+	for _, ev := range in {
+		if ev == nil {
+			continue
+		}
+		events = append(events, ev)
+	}
+
+	out := make([]*controlapi.BuildHistoryEvent, 0, len(events))
 
 	if len(f) == 0 {
-		out = in
+		out = events
 	} else {
 	loop0:
-		for _, ev := range in {
+		for _, ev := range events {
 			for _, fn := range f {
 				if fn(ev) {
 					out = append(out, ev)
@@ -46,8 +54,8 @@ func filterHistoryEvents(in []*controlapi.BuildHistoryEvent, filters []string, l
 			return nil, errors.Errorf("invalid limit %d", limit)
 		}
 		slices.SortFunc(out, func(a, b *controlapi.BuildHistoryEvent) int {
-			aRec := a != nil && a.Record != nil
-			bRec := b != nil && b.Record != nil
+			aRec := a.Record != nil
+			bRec := b.Record != nil
 			switch {
 			case !aRec && !bRec:
 				return 0


### PR DESCRIPTION
carry of #6598 with extra commit

Seemed that #6598 missed the actual cause of the nil events and still returned nils by just ignoring them inside the sorter to avoid panic.

Also fix linter issues.