### PR TITLE
resolver/auth: prevent deadlocks on disconnected clients and narrow authorizer lock scope [1/3]

### DIFF
--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -313,7 +313,7 @@ func main() {
 			// Keepalive configuration to detect and close dead client connections
 			// that disconnect during registry auth callbacks, preventing daemon deadlock
 			grpc.KeepaliveParams(keepalive.ServerParameters{
-				Time:    2 * time.Minute, // Ping client if idle for 2m
+				Time:    2 * time.Minute,  // Ping client if idle for 2m
 				Timeout: 20 * time.Second, // Wait 20s for ping ack before closing
 			}),
 			grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/containerd/containerd/v2/core/remotes/docker"
 	"github.com/containerd/containerd/v2/defaults"
@@ -77,6 +78,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	healthv1 "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/reflection"
 	"tags.cncf.io/container-device-interface/pkg/cdi"
 )
@@ -308,6 +310,16 @@ func main() {
 			grpc.StreamInterceptor(grpcerrors.StreamServerInterceptor),
 			grpc.MaxRecvMsgSize(defaults.DefaultMaxRecvMsgSize),
 			grpc.MaxSendMsgSize(defaults.DefaultMaxSendMsgSize),
+			// Keepalive configuration to detect and close dead client connections
+			// that disconnect during registry auth callbacks, preventing daemon deadlock
+			grpc.KeepaliveParams(keepalive.ServerParameters{
+				Time:    2 * time.Minute, // Ping client if idle for 2m
+				Timeout: 20 * time.Second, // Wait 20s for ping ack before closing
+			}),
+			grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+				MinTime:             5 * time.Second, // Allow pings no more frequently than every 5s
+				PermitWithoutStream: true,            // Allow pings even when no streams are active
+			}),
 		}
 		server := grpc.NewServer(opts...)
 

--- a/session/auth/auth.go
+++ b/session/auth/auth.go
@@ -25,10 +25,10 @@ func getSalt() []byte {
 	return salt
 }
 
-func CredentialsFunc(sm *session.Manager, g session.Group) func(string) (session, username, secret string, err error) {
-	return func(host string) (string, string, string, error) {
+func CredentialsFunc(sm *session.Manager, g session.Group) func(context.Context, string) (sessionID, username, secret string, err error) {
+	return func(ctx context.Context, host string) (string, string, string, error) {
 		var sessionID, user, secret string
-		err := sm.Any(context.TODO(), g, func(ctx context.Context, id string, c session.Caller) error {
+		err := sm.Any(ctx, g, func(ctx context.Context, id string, c session.Caller) error {
 			client := NewAuthClient(c.Conn())
 
 			resp, err := client.Credentials(ctx, &CredentialsRequest{

--- a/util/resolver/authorizer.go
+++ b/util/resolver/authorizer.go
@@ -78,7 +78,7 @@ func (a *authHandlerNS) get(ctx context.Context, host string, sm *session.Manage
 					return h
 				}
 			} else {
-				sessionID, username, password, err := sessionauth.CredentialsFunc(sm, g)(host)
+				sessionID, username, password, err := sessionauth.CredentialsFunc(sm, g)(ctx, host)
 				if err == nil {
 					if username == h.common.Username && password == h.common.Secret {
 						a.fetchers[host+"/"+sessionID] = h
@@ -125,6 +125,12 @@ func (a *dockerAuthorizer) Authorize(ctx context.Context, req *http.Request) err
 	a.handlerNS.muHandlers.Lock()
 	defer a.handlerNS.muHandlers.Unlock()
 
+	// Add timeout to prevent deadlock if client disconnects during auth callbacks.
+	// This ensures the lock is released within 30s even if the client is unresponsive.
+	// Timeout is set AFTER acquiring the lock so waiting for the lock doesn't consume the budget.
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	// skip if there is no auth handler
 	ah := a.handlerNS.get(ctx, req.URL.Host, a.sm, a.session)
 	if ah == nil {
@@ -140,8 +146,8 @@ func (a *dockerAuthorizer) Authorize(ctx context.Context, req *http.Request) err
 	return nil
 }
 
-func (a *dockerAuthorizer) getCredentials(host string) (sessionID, username, secret string, err error) {
-	return sessionauth.CredentialsFunc(a.sm, a.session)(host)
+func (a *dockerAuthorizer) getCredentials(ctx context.Context, host string) (sessionID, username, secret string, err error) {
+	return sessionauth.CredentialsFunc(a.sm, a.session)(ctx, host)
 }
 
 func (a *dockerAuthorizer) AddResponses(ctx context.Context, responses []*http.Response) error {
@@ -149,6 +155,12 @@ func (a *dockerAuthorizer) AddResponses(ctx context.Context, responses []*http.R
 
 	handlerNS.muHandlers.Lock()
 	defer handlerNS.muHandlers.Unlock()
+
+	// Add timeout to prevent deadlock if client disconnects during auth callbacks.
+	// This ensures the lock is released within 30s even if the client is unresponsive.
+	// Timeout is set AFTER acquiring the lock so waiting for the lock doesn't consume the budget.
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
 
 	last := responses[len(responses)-1]
 	host := last.Request.URL.Host
@@ -189,7 +201,7 @@ func (a *dockerAuthorizer) AddResponses(ctx context.Context, responses []*http.R
 				return err
 			}
 			if pubKey == nil {
-				sessionID, username, secret, err = a.getCredentials(host)
+				sessionID, username, secret, err = a.getCredentials(ctx, host)
 				if err != nil {
 					return err
 				}
@@ -205,7 +217,7 @@ func (a *dockerAuthorizer) AddResponses(ctx context.Context, responses []*http.R
 
 			return nil
 		case auth.BasicAuth:
-			sessionID, username, secret, err := a.getCredentials(host)
+			sessionID, username, secret, err := a.getCredentials(ctx, host)
 			if err != nil {
 				return err
 			}

--- a/util/resolver/authorizer.go
+++ b/util/resolver/authorizer.go
@@ -32,10 +32,10 @@ type authHandlerNS struct {
 
 	fetchers      *fetcherNS
 	fetcherLookup flightcontrol.Group[*authFetcher]
-	hosts      map[string][]docker.RegistryHost
-	muHosts    sync.Mutex
-	sm         *session.Manager
-	g          flightcontrol.Group[[]docker.RegistryHost]
+	hosts         map[string][]docker.RegistryHost
+	muHosts       sync.Mutex
+	sm            *session.Manager
+	g             flightcontrol.Group[[]docker.RegistryHost]
 }
 
 type fetcherState struct {
@@ -130,7 +130,7 @@ func (a *dockerAuthorizer) Authorize(ctx context.Context, req *http.Request) err
 	// Add timeout to prevent deadlock if client disconnects during auth callbacks.
 	// This ensures the lock is released within 30s even if the client is unresponsive.
 	// Locking is now scoped to short map operations and does not cover session/network calls.
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	ctx, cancel := context.WithTimeoutCause(ctx, 30*time.Second, errors.WithStack(context.DeadlineExceeded))
 	defer cancel()
 
 	// skip if there is no auth handler
@@ -141,7 +141,7 @@ func (a *dockerAuthorizer) Authorize(ctx context.Context, req *http.Request) err
 
 	authHeader, err := ah.authorize(ctx, a.sm, a.session)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "authorizing registry request for host %q", req.URL.Host)
 	}
 
 	req.Header.Set("Authorization", authHeader)
@@ -244,7 +244,7 @@ func (a *dockerAuthorizer) AddResponses(ctx context.Context, responses []*http.R
 	// Add timeout to prevent deadlock if client disconnects during auth callbacks.
 	// This ensures the lock is released within 30s even if the client is unresponsive.
 	// Locking is now scoped to short map operations and does not cover session/network calls.
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	ctx, cancel := context.WithTimeoutCause(ctx, 30*time.Second, errors.WithStack(context.DeadlineExceeded))
 	defer cancel()
 
 	last := responses[len(responses)-1]
@@ -285,18 +285,18 @@ func (a *dockerAuthorizer) AddResponses(ctx context.Context, responses []*http.R
 			var username, secret string
 			sessionID, pubKey, err := sessionauth.GetTokenAuthority(ctx, host, a.sm, a.session)
 			if err != nil {
-				return err
+				return errors.Wrapf(err, "getting token authority for host %q", host)
 			}
 			if pubKey == nil {
 				sessionID, username, secret, err = a.getCredentials(ctx, host)
 				if err != nil {
-					return err
+					return errors.Wrapf(err, "getting credentials for host %q", host)
 				}
 			}
 
 			common, err := auth.GenerateTokenOptions(ctx, host, username, secret, c)
 			if err != nil {
-				return err
+				return errors.Wrapf(err, "generating token options for host %q", host)
 			}
 			common.Scopes = parseScopes(append(common.Scopes, oldScopes...)).normalize()
 
@@ -308,7 +308,7 @@ func (a *dockerAuthorizer) AddResponses(ctx context.Context, responses []*http.R
 		case auth.BasicAuth:
 			sessionID, username, secret, err := a.getCredentials(ctx, host)
 			if err != nil {
-				return err
+				return errors.Wrapf(err, "getting basic auth credentials for host %q", host)
 			}
 
 			if username != "" && secret != "" {

--- a/util/resolver/authorizer.go
+++ b/util/resolver/authorizer.go
@@ -30,77 +30,82 @@ const defaultExpiration = 60
 type authHandlerNS struct {
 	counter int64 // needs to be 64bit aligned for 32bit systems
 
-	fetchers   map[string]*authFetcher
-	muHandlers sync.Mutex
+	fetchers      *fetcherNS
+	fetcherLookup flightcontrol.Group[*authFetcher]
 	hosts      map[string][]docker.RegistryHost
 	muHosts    sync.Mutex
 	sm         *session.Manager
 	g          flightcontrol.Group[[]docker.RegistryHost]
 }
 
+type fetcherState struct {
+	fetchers map[string]*authFetcher
+}
+
+func newFetcherState() *fetcherState {
+	return &fetcherState{
+		fetchers: map[string]*authFetcher{},
+	}
+}
+
+func fetcherMapKey(host, session string) string {
+	return host + "/" + session
+}
+
+func (s *fetcherState) get(host, session string) *authFetcher {
+	return s.fetchers[fetcherMapKey(host, session)]
+}
+
+func (s *fetcherState) set(host, session string, f *authFetcher) {
+	s.fetchers[fetcherMapKey(host, session)] = f
+}
+
+func (s *fetcherState) delete(f *authFetcher) {
+	maps.DeleteFunc(s.fetchers, func(_ string, v *authFetcher) bool {
+		return v == f
+	})
+}
+
+func (s *fetcherState) hostFetchers(host string) []*authFetcher {
+	out := make([]*authFetcher, 0)
+	seen := map[*authFetcher]struct{}{}
+	for k, h := range s.fetchers {
+		parts := strings.SplitN(k, "/", 2)
+		if len(parts) != 2 || parts[0] != host {
+			continue
+		}
+		if _, ok := seen[h]; ok {
+			continue
+		}
+		seen[h] = struct{}{}
+		out = append(out, h)
+	}
+	return out
+}
+
+type fetcherNS struct {
+	mu    sync.Mutex
+	state *fetcherState
+}
+
+func newFetcherNS() *fetcherNS {
+	return &fetcherNS{
+		state: newFetcherState(),
+	}
+}
+
+func (ns *fetcherNS) withLock(fn func(state *fetcherState)) {
+	ns.mu.Lock()
+	defer ns.mu.Unlock()
+	fn(ns.state)
+}
+
 func newAuthHandlerNS(sm *session.Manager) *authHandlerNS {
 	return &authHandlerNS{
-		fetchers: map[string]*authFetcher{},
+		fetchers: newFetcherNS(),
 		hosts:    map[string][]docker.RegistryHost{},
 		sm:       sm,
 	}
-}
-
-func (a *authHandlerNS) get(ctx context.Context, host string, sm *session.Manager, g session.Group) *authFetcher {
-	if g != nil {
-		if iter := g.SessionIterator(); iter != nil {
-			for {
-				id := iter.NextSession()
-				if id == "" {
-					break
-				}
-				h, ok := a.fetchers[host+"/"+id]
-				if ok {
-					h.lastUsed = time.Now()
-					return h
-				}
-			}
-		}
-	}
-
-	// link existing fetcher
-	for k, h := range a.fetchers {
-		parts := strings.SplitN(k, "/", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		if parts[0] == host {
-			if h.authority != nil {
-				sessionID, ok, err := sessionauth.VerifyTokenAuthority(ctx, host, h.authority, sm, g)
-				if err == nil && ok {
-					a.fetchers[host+"/"+sessionID] = h
-					h.lastUsed = time.Now()
-					return h
-				}
-			} else {
-				sessionID, username, password, err := sessionauth.CredentialsFunc(sm, g)(ctx, host)
-				if err == nil {
-					if username == h.common.Username && password == h.common.Secret {
-						a.fetchers[host+"/"+sessionID] = h
-						h.lastUsed = time.Now()
-						return h
-					}
-				}
-			}
-		}
-	}
-
-	return nil
-}
-
-func (a *authHandlerNS) set(host, session string, f *authFetcher) {
-	a.fetchers[host+"/"+session] = f
-}
-
-func (a *authHandlerNS) delete(f *authFetcher) {
-	maps.DeleteFunc(a.fetchers, func(_ string, v *authFetcher) bool {
-		return v == f
-	})
 }
 
 type dockerAuthorizer struct {
@@ -122,17 +127,14 @@ func newDockerAuthorizer(client *http.Client, handlerNS *authHandlerNS, sm *sess
 
 // Authorize handles auth request.
 func (a *dockerAuthorizer) Authorize(ctx context.Context, req *http.Request) error {
-	a.handlerNS.muHandlers.Lock()
-	defer a.handlerNS.muHandlers.Unlock()
-
 	// Add timeout to prevent deadlock if client disconnects during auth callbacks.
 	// This ensures the lock is released within 30s even if the client is unresponsive.
-	// Timeout is set AFTER acquiring the lock so waiting for the lock doesn't consume the budget.
+	// Locking is now scoped to short map operations and does not cover session/network calls.
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	// skip if there is no auth handler
-	ah := a.handlerNS.get(ctx, req.URL.Host, a.sm, a.session)
+	ah := a.getAuthFetcher(ctx, req.URL.Host)
 	if ah == nil {
 		return nil
 	}
@@ -150,29 +152,114 @@ func (a *dockerAuthorizer) getCredentials(ctx context.Context, host string) (ses
 	return sessionauth.CredentialsFunc(a.sm, a.session)(ctx, host)
 }
 
+func (a *dockerAuthorizer) fetcherLookupKey(host string) string {
+	return host + "::" + strings.Join(session.AllSessionIDs(a.session), ":")
+}
+
+func (a *dockerAuthorizer) getSessionScopedFetcher(host string) *authFetcher {
+	sessionIDs := session.AllSessionIDs(a.session)
+	if len(sessionIDs) == 0 {
+		return nil
+	}
+
+	var h *authFetcher
+	a.handlerNS.fetchers.withLock(func(state *fetcherState) {
+		for _, id := range sessionIDs {
+			h = state.get(host, id)
+			if h != nil {
+				h.lastUsed = time.Now()
+				return
+			}
+		}
+	})
+	return h
+}
+
+func (a *dockerAuthorizer) resolveAndLinkAuthFetcher(ctx context.Context, host string) *authFetcher {
+	var candidates []*authFetcher
+	a.handlerNS.fetchers.withLock(func(state *fetcherState) {
+		candidates = state.hostFetchers(host)
+	})
+
+	var (
+		credsFetched bool
+		sessionID    string
+		username     string
+		password     string
+		credsErr     error
+	)
+
+	for _, h := range candidates {
+		if h.authority != nil {
+			verifiedSessionID, ok, err := sessionauth.VerifyTokenAuthority(ctx, host, h.authority, a.sm, a.session)
+			if err == nil && ok {
+				a.handlerNS.fetchers.withLock(func(state *fetcherState) {
+					state.set(host, verifiedSessionID, h)
+					h.lastUsed = time.Now()
+				})
+				return h
+			}
+			continue
+		}
+
+		if !credsFetched {
+			sessionID, username, password, credsErr = a.getCredentials(ctx, host)
+			credsFetched = true
+		}
+		if credsErr == nil && username == h.common.Username && password == h.common.Secret {
+			a.handlerNS.fetchers.withLock(func(state *fetcherState) {
+				state.set(host, sessionID, h)
+				h.lastUsed = time.Now()
+			})
+			return h
+		}
+	}
+
+	return nil
+}
+
+func (a *dockerAuthorizer) getAuthFetcher(ctx context.Context, host string) *authFetcher {
+	if h := a.getSessionScopedFetcher(host); h != nil {
+		return h
+	}
+
+	key := a.fetcherLookupKey(host)
+	h, err := a.handlerNS.fetcherLookup.Do(ctx, key, func(ctx context.Context) (*authFetcher, error) {
+		// Re-check under dedupe in case another waiter has already linked a usable
+		// fetcher while we were waiting for this flight.
+		if h := a.getSessionScopedFetcher(host); h != nil {
+			return h, nil
+		}
+		return a.resolveAndLinkAuthFetcher(ctx, host), nil
+	})
+	if err != nil {
+		return nil
+	}
+	return h
+}
+
 func (a *dockerAuthorizer) AddResponses(ctx context.Context, responses []*http.Response) error {
 	handlerNS := a.handlerNS
 
-	handlerNS.muHandlers.Lock()
-	defer handlerNS.muHandlers.Unlock()
-
 	// Add timeout to prevent deadlock if client disconnects during auth callbacks.
 	// This ensures the lock is released within 30s even if the client is unresponsive.
-	// Timeout is set AFTER acquiring the lock so waiting for the lock doesn't consume the budget.
+	// Locking is now scoped to short map operations and does not cover session/network calls.
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	last := responses[len(responses)-1]
 	host := last.Request.URL.Host
 
-	handler := handlerNS.get(ctx, host, a.sm, a.session)
+	handler := a.getAuthFetcher(ctx, host)
 
 	for _, c := range auth.ParseAuthHeader(last.Header) {
 		switch c.Scheme {
 		case auth.BearerAuth:
 			var oldScopes []string
 			if err := invalidAuthorization(c, responses); err != nil {
-				handlerNS.delete(handler)
+				handlerNS.fetchers.withLock(func(state *fetcherState) {
+					state.delete(handler)
+				})
 
 				if handler != nil {
 					oldScopes = handler.common.Scopes
@@ -213,7 +300,9 @@ func (a *dockerAuthorizer) AddResponses(ctx context.Context, responses []*http.R
 			}
 			common.Scopes = parseScopes(append(common.Scopes, oldScopes...)).normalize()
 
-			handlerNS.set(host, sessionID, newAuthFetcher(host, a.client, c.Scheme, pubKey, common))
+			handlerNS.fetchers.withLock(func(state *fetcherState) {
+				state.set(host, sessionID, newAuthFetcher(host, a.client, c.Scheme, pubKey, common))
+			})
 
 			return nil
 		case auth.BasicAuth:
@@ -223,10 +312,12 @@ func (a *dockerAuthorizer) AddResponses(ctx context.Context, responses []*http.R
 			}
 
 			if username != "" && secret != "" {
-				handlerNS.set(host, sessionID, newAuthFetcher(host, a.client, c.Scheme, nil, auth.TokenOptions{
-					Username: username,
-					Secret:   secret,
-				}))
+				handlerNS.fetchers.withLock(func(state *fetcherState) {
+					state.set(host, sessionID, newAuthFetcher(host, a.client, c.Scheme, nil, auth.TokenOptions{
+						Username: username,
+						Secret:   secret,
+					}))
+				})
 				return nil
 			}
 		}

--- a/util/resolver/authorizer_test.go
+++ b/util/resolver/authorizer_test.go
@@ -122,7 +122,7 @@ func TestAuthorizeDoesNotGloballyBlockOnSlowAuthFetch(t *testing.T) {
 	fastReq, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://"+fastHost+"/v2/library/alpine/manifests/latest", nil)
 	require.NoError(t, err)
 
-	blockedCtx, blockedCancel := context.WithTimeout(t.Context(), 10*time.Second)
+	blockedCtx, blockedCancel := context.WithTimeoutCause(t.Context(), 10*time.Second, context.DeadlineExceeded)
 	defer blockedCancel()
 	blockedDone := make(chan error, 1)
 	go func() {

--- a/util/resolver/authorizer_test.go
+++ b/util/resolver/authorizer_test.go
@@ -1,8 +1,17 @@
 package resolver
 
 import (
+	"context"
+	"io"
+	"net/http"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/containerd/containerd/v2/core/remotes/docker/auth"
+	"github.com/moby/buildkit/session"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseScopes(t *testing.T) {
@@ -52,5 +61,101 @@ func TestParseScopes(t *testing.T) {
 				t.Fatalf("expected %v, got %v", tc.expected, parsed)
 			}
 		})
+	}
+}
+
+type blockingRoundTripper struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (rt *blockingRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	select {
+	case <-rt.started:
+	default:
+		close(rt.started)
+	}
+
+	<-rt.release
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"token":"token-value","expires_in":60}`)),
+	}, nil
+}
+
+func TestAuthorizeDoesNotGloballyBlockOnSlowAuthFetch(t *testing.T) {
+	sm, err := session.NewManager()
+	require.NoError(t, err)
+
+	handlerNS := newAuthHandlerNS(sm)
+	blockingRT := &blockingRoundTripper{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+
+	blockedHost := "blocked.example.com"
+	blockedSession := "blocked-session"
+	blockedClient := &http.Client{Transport: blockingRT}
+
+	fastHost := "fast.example.com"
+	fastSession := "fast-session"
+	fastClient := &http.Client{}
+
+	handlerNS.fetchers.withLock(func(state *fetcherState) {
+		state.set(blockedHost, blockedSession, newAuthFetcher(blockedHost, blockedClient, auth.BearerAuth, nil, auth.TokenOptions{
+			Realm:   "https://auth.blocked.example.com/token",
+			Service: "registry.blocked",
+			Scopes:  []string{"repository:foo/bar:pull"},
+		}))
+		state.set(fastHost, fastSession, newAuthFetcher(fastHost, fastClient, auth.BasicAuth, nil, auth.TokenOptions{
+			Username: "u",
+			Secret:   "s",
+		}))
+	})
+
+	blockedAuthorizer := newDockerAuthorizer(blockedClient, handlerNS, sm, session.NewGroup(blockedSession))
+	fastAuthorizer := newDockerAuthorizer(fastClient, handlerNS, sm, session.NewGroup(fastSession))
+
+	blockedReq, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://"+blockedHost+"/v2/library/alpine/manifests/latest", nil)
+	require.NoError(t, err)
+	fastReq, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://"+fastHost+"/v2/library/alpine/manifests/latest", nil)
+	require.NoError(t, err)
+
+	blockedCtx, blockedCancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer blockedCancel()
+	blockedDone := make(chan error, 1)
+	go func() {
+		blockedDone <- blockedAuthorizer.Authorize(blockedCtx, blockedReq)
+	}()
+
+	select {
+	case <-blockingRT.started:
+		// slow auth request has entered bearer token fetch.
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for blocked authorize request to start token fetch")
+	}
+
+	fastDone := make(chan error, 1)
+	fastStart := time.Now()
+	go func() {
+		fastDone <- fastAuthorizer.Authorize(t.Context(), fastReq)
+	}()
+
+	select {
+	case err := <-fastDone:
+		require.NoError(t, err)
+		require.Equal(t, "Basic dTpz", fastReq.Header.Get("Authorization"))
+		require.Less(t, time.Since(fastStart), 500*time.Millisecond, "fast authorize should not wait on unrelated slow auth request")
+	case <-time.After(1 * time.Second):
+		t.Fatal("fast authorize blocked behind slow auth request")
+	}
+
+	close(blockingRT.release)
+	select {
+	case err := <-blockedDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("blocked authorize did not finish after releasing transport")
 	}
 }

--- a/util/resolver/pool.go
+++ b/util/resolver/pool.go
@@ -56,8 +56,13 @@ func (p *Pool) gc() {
 				delete(ns.fetchers, key)
 				continue
 			}
-			c, err := ns.sm.Get(context.TODO(), parts[1], true)
-			if c == nil || err != nil {
+			isExpiredSession := func() bool {
+				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+				c, err := ns.sm.Get(ctx, parts[1], true)
+				return c == nil || err != nil
+			}
+			if isExpiredSession() {
 				delete(ns.fetchers, key)
 			}
 		}
@@ -176,7 +181,10 @@ type Resolver struct {
 // HostsFunc implements registry configuration of this Resolver
 func (r *Resolver) HostsFunc(host string) ([]docker.RegistryHost, error) {
 	return func(domain string) ([]docker.RegistryHost, error) {
-		v, err := r.handler.g.Do(context.TODO(), domain, func(ctx context.Context) ([]docker.RegistryHost, error) {
+		// Use timeout for registry host resolution to prevent indefinite blocking on DNS/network issues
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		v, err := r.handler.g.Do(ctx, domain, func(ctx context.Context) ([]docker.RegistryHost, error) {
 			// long lock not needed because flightcontrol.Do
 			r.handler.muHosts.Lock()
 			v, ok := r.handler.hosts[domain]

--- a/util/resolver/pool.go
+++ b/util/resolver/pool.go
@@ -45,31 +45,58 @@ func (p *Pool) gc() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
+	type staleCandidate struct {
+		key       string
+		sessionID string
+		fetcher   *authFetcher
+	}
+
 	for k, ns := range p.m {
-		ns.muHandlers.Lock()
-		for key, h := range ns.fetchers {
-			if time.Since(h.lastUsed) < 10*time.Minute {
-				continue
+		candidates := make([]staleCandidate, 0)
+		ns.fetchers.withLock(func(state *fetcherState) {
+			for key, h := range state.fetchers {
+				if time.Since(h.lastUsed) < 10*time.Minute {
+					continue
+				}
+				parts := strings.SplitN(key, "/", 2)
+				if len(parts) != 2 {
+					delete(state.fetchers, key)
+					continue
+				}
+				candidates = append(candidates, staleCandidate{
+					key:       key,
+					sessionID: parts[1],
+					fetcher:   h,
+				})
 			}
-			parts := strings.SplitN(key, "/", 2)
-			if len(parts) != 2 {
-				delete(ns.fetchers, key)
-				continue
-			}
-			isExpiredSession := func() bool {
-				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-				defer cancel()
-				c, err := ns.sm.Get(ctx, parts[1], true)
-				return c == nil || err != nil
-			}
-			if isExpiredSession() {
-				delete(ns.fetchers, key)
-			}
+		})
+
+		isExpiredSession := func(sessionID string) bool {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			c, err := ns.sm.Get(ctx, sessionID, true)
+			return c == nil || err != nil
 		}
-		if len(ns.fetchers) == 0 {
+
+		for _, candidate := range candidates {
+			if !isExpiredSession(candidate.sessionID) {
+				continue
+			}
+			ns.fetchers.withLock(func(state *fetcherState) {
+				current, ok := state.fetchers[candidate.key]
+				if ok && current == candidate.fetcher {
+					delete(state.fetchers, candidate.key)
+				}
+			})
+		}
+
+		empty := false
+		ns.fetchers.withLock(func(state *fetcherState) {
+			empty = len(state.fetchers) == 0
+		})
+		if empty {
 			delete(p.m, k)
 		}
-		ns.muHandlers.Unlock()
 	}
 
 	time.AfterFunc(5*time.Minute, p.gc)

--- a/util/resolver/pool.go
+++ b/util/resolver/pool.go
@@ -72,7 +72,7 @@ func (p *Pool) gc() {
 		})
 
 		isExpiredSession := func(sessionID string) bool {
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			ctx, cancel := context.WithTimeoutCause(context.Background(), 30*time.Second, errors.WithStack(context.DeadlineExceeded))
 			defer cancel()
 			c, err := ns.sm.Get(ctx, sessionID, true)
 			return c == nil || err != nil
@@ -209,7 +209,7 @@ type Resolver struct {
 func (r *Resolver) HostsFunc(host string) ([]docker.RegistryHost, error) {
 	return func(domain string) ([]docker.RegistryHost, error) {
 		// Use timeout for registry host resolution to prevent indefinite blocking on DNS/network issues
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		ctx, cancel := context.WithTimeoutCause(context.Background(), 30*time.Second, errors.WithStack(context.DeadlineExceeded))
 		defer cancel()
 		v, err := r.handler.g.Do(ctx, domain, func(ctx context.Context) ([]docker.RegistryHost, error) {
 			// long lock not needed because flightcontrol.Do
@@ -228,8 +228,11 @@ func (r *Resolver) HostsFunc(host string) ([]docker.RegistryHost, error) {
 			r.handler.muHosts.Unlock()
 			return res, nil
 		})
-		if err != nil || v == nil {
-			return nil, err
+		if err != nil {
+			return nil, errors.Wrapf(err, "resolving registry hosts for %q", host)
+		}
+		if v == nil {
+			return nil, nil
 		}
 		if len(v) == 0 {
 			return nil, nil


### PR DESCRIPTION
## Summary

This branch fixes a deadlock class in `buildkitd` that can occur when a client disconnects unexpectedly during registry auth callbacks, and refactors authorizer middleware locking so unrelated auth flows are not serialized behind slow/hung requests.

We discovered this problem when buildkit nodes would get stuck and need to be restarted. We took goroutine dumps of the builder while stuck and discovered the deadlock in the auth flow. 

We have been running this change in our internal fork for a couple weeks now and it seems to have completely resolved the issue. The rest of the changes we made are included in https://github.com/moby/buildkit/pull/6631 and https://github.com/moby/buildkit/pull/6632

### Problem

When image resolution gets `401 Unauthorized`, BuildKit calls back to the client session (`VerifyTokenAuthority`) to obtain/verify credentials. If the client silently disappears (half-open TCP, blackholed network, abrupt termination), that callback can hang long enough to block resolver progress.

In the wedged state:
- one auth request hangs waiting on a dead client
- other requests block on resolver/authorizer lock paths
- waiters pile up in `flightcontrol`
- daemon appears healthy but affected builds stop progressing until restart

### Root Cause

Auth/session calls were in paths that could hold shared synchronization for too long under failure conditions, and dead transport detection was not bounded quickly enough for silent disconnects.

### Changes

#### Deadlock failsafes (`add timeouts to break deadlocks`)
- Add bounded timeouts around auth/session-dependent operations so dead client callbacks cannot block indefinitely.
- Add server-side gRPC keepalive parameters in `buildkitd` to proactively detect and close dead idle peers.

#### Authorizer lock refactor (`refactor authorizer middleware locking`)
- Remove broad/global authorizer critical sections from `Authorize` and `AddResponses`.
- Scope locking to short in-memory fetcher map operations (`fetcherNS`/`fetcherState`).
- Add per-key deduped fetcher lookup using `flightcontrol` rather than serializing all hosts/sessions.
- Update resolver pool GC to avoid holding fetcher locks while doing potentially slow session-manager calls (collect -> validate -> conditional delete).
- Add regression coverage that verifies unrelated auth requests are not blocked by a slow bearer token fetch (`TestAuthorizeDoesNotGloballyBlockOnSlowAuthFetch`)

Fixes https://github.com/moby/buildkit/issues/6633