### PR TITLE
Refactor session manager to use simpler concurrency control [2/3]

### DIFF
--- a/session/group_test.go
+++ b/session/group_test.go
@@ -1,0 +1,119 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllSessionIDs(t *testing.T) {
+	require.Nil(t, AllSessionIDs(nil))
+	require.Equal(t, []string{"a", "b", "c"}, AllSessionIDs(NewGroup("a", "b", "c")))
+}
+
+func TestManagerAnyNilGroupIsNoop(t *testing.T) {
+	sm, err := NewManager()
+	require.NoError(t, err)
+
+	err = sm.Any(t.Context(), nil, func(context.Context, string, Caller) error {
+		return errors.New("callback should not execute for nil group")
+	})
+	require.NoError(t, err)
+}
+
+func TestManagerAnyReturnsLastErrorWhenContextCanceled(t *testing.T) {
+	sm, err := NewManager()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancelCause(t.Context())
+	cancel(context.Canceled)
+
+	err = sm.Any(ctx, NewGroup("missing-a", "missing-b"), func(context.Context, string, Caller) error {
+		return nil
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `session "missing-b" did not start`)
+	require.Contains(t, err.Error(), "missing-b")
+	require.Contains(t, err.Error(), "context canceled")
+}
+
+func TestManagerAnyCallbackErrorIsReturned(t *testing.T) {
+	sm, err := NewManager()
+	require.NoError(t, err)
+
+	const sessionID = "any-callback-session"
+	_, cleanup := startSessionForTest(t, t.Context(), sm, sessionID, "any-key")
+	defer cleanup()
+
+	callbackErr := errors.New("callback failed")
+	err = sm.Any(t.Context(), NewGroup(sessionID), func(_ context.Context, id string, c Caller) error {
+		require.Equal(t, sessionID, id)
+		require.NotNil(t, c)
+		return callbackErr
+	})
+	require.ErrorContains(t, err, callbackErr.Error())
+}
+
+func TestManagerAnyReturnsFirstSuccessfulSession(t *testing.T) {
+	sm, err := NewManager()
+	require.NoError(t, err)
+
+	const sessionID = "any-success-session"
+	_, cleanup := startSessionForTest(t, t.Context(), sm, sessionID, "any-success-key")
+	defer cleanup()
+
+	var called int32
+	err = sm.Any(t.Context(), NewGroup(sessionID), func(_ context.Context, id string, c Caller) error {
+		atomic.AddInt32(&called, 1)
+		require.Equal(t, sessionID, id)
+		require.NotNil(t, c)
+		require.Equal(t, "any-success-key", c.SharedKey())
+		return nil
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, atomic.LoadInt32(&called))
+}
+
+func TestManagerAnyHighConcurrencyContention(t *testing.T) {
+	sm, err := NewManager()
+	require.NoError(t, err)
+
+	const sessionID = "any-contention"
+	_, cleanup := startSessionForTest(t, t.Context(), sm, sessionID, "any-contention-key")
+	defer cleanup()
+
+	const workers = 250
+	errCh := make(chan error, workers)
+
+	for i := 0; i < workers; i++ {
+		i := i
+		go func() {
+			ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+			defer cancel()
+
+			err := sm.Any(ctx, NewGroup(sessionID), func(cbCtx context.Context, id string, c Caller) error {
+				if id != sessionID {
+					return fmt.Errorf("unexpected session id %q", id)
+				}
+				if c == nil {
+					return fmt.Errorf("nil caller")
+				}
+				if c.SharedKey() != "any-contention-key" {
+					return fmt.Errorf("unexpected shared key %q", c.SharedKey())
+				}
+				_, err := sm.Get(cbCtx, sessionID, i%2 == 0)
+				return err
+			})
+			errCh <- err
+		}()
+	}
+
+	for i := 0; i < workers; i++ {
+		require.NoError(t, <-errCh)
+	}
+}

--- a/session/group_test.go
+++ b/session/group_test.go
@@ -2,12 +2,11 @@ package session
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,7 +46,7 @@ func TestManagerAnyCallbackErrorIsReturned(t *testing.T) {
 	require.NoError(t, err)
 
 	const sessionID = "any-callback-session"
-	_, cleanup := startSessionForTest(t, t.Context(), sm, sessionID, "any-key")
+	_, cleanup := startSessionForTest(t.Context(), t, sm, sessionID, "any-key")
 	defer cleanup()
 
 	callbackErr := errors.New("callback failed")
@@ -64,7 +63,7 @@ func TestManagerAnyReturnsFirstSuccessfulSession(t *testing.T) {
 	require.NoError(t, err)
 
 	const sessionID = "any-success-session"
-	_, cleanup := startSessionForTest(t, t.Context(), sm, sessionID, "any-success-key")
+	_, cleanup := startSessionForTest(t.Context(), t, sm, sessionID, "any-success-key")
 	defer cleanup()
 
 	var called int32
@@ -84,27 +83,26 @@ func TestManagerAnyHighConcurrencyContention(t *testing.T) {
 	require.NoError(t, err)
 
 	const sessionID = "any-contention"
-	_, cleanup := startSessionForTest(t, t.Context(), sm, sessionID, "any-contention-key")
+	_, cleanup := startSessionForTest(t.Context(), t, sm, sessionID, "any-contention-key")
 	defer cleanup()
 
 	const workers = 250
 	errCh := make(chan error, workers)
 
-	for i := 0; i < workers; i++ {
-		i := i
+	for i := range workers {
 		go func() {
-			ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+			ctx, cancel := context.WithTimeoutCause(t.Context(), 3*time.Second, errors.WithStack(context.DeadlineExceeded))
 			defer cancel()
 
 			err := sm.Any(ctx, NewGroup(sessionID), func(cbCtx context.Context, id string, c Caller) error {
 				if id != sessionID {
-					return fmt.Errorf("unexpected session id %q", id)
+					return errors.Errorf("unexpected session id %q", id)
 				}
 				if c == nil {
-					return fmt.Errorf("nil caller")
+					return errors.Errorf("nil caller")
 				}
 				if c.SharedKey() != "any-contention-key" {
-					return fmt.Errorf("unexpected shared key %q", c.SharedKey())
+					return errors.Errorf("unexpected shared key %q", c.SharedKey())
 				}
 				_, err := sm.Get(cbCtx, sessionID, i%2 == 0)
 				return err
@@ -113,7 +111,7 @@ func TestManagerAnyHighConcurrencyContention(t *testing.T) {
 		}()
 	}
 
-	for i := 0; i < workers; i++ {
+	for range workers {
 		require.NoError(t, <-errCh)
 	}
 }

--- a/session/manager.go
+++ b/session/manager.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
-	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
@@ -25,20 +25,157 @@ type client struct {
 	supported map[string]struct{}
 }
 
+type sessionState struct {
+	active   map[string]*client
+	pending  map[string]*pendingWaiters
+	reserved map[string]struct{}
+}
+
+type pendingWaiters struct {
+	ch      chan struct{}
+	waiters int
+}
+
+func newSessionState() *sessionState {
+	return &sessionState{
+		active:   make(map[string]*client),
+		pending:  make(map[string]*pendingWaiters),
+		reserved: make(map[string]struct{}),
+	}
+}
+
+func (s *sessionState) getActive(id string) *client {
+	c, ok := s.active[id]
+	if !ok {
+		return nil
+	}
+	if c.closed() {
+		delete(s.active, id)
+		return nil
+	}
+	return c
+}
+
+func (s *sessionState) reserve(id string) error {
+	if c := s.getActive(id); c != nil {
+		return errors.Errorf("session %s already exists", id)
+	}
+	if _, ok := s.reserved[id]; ok {
+		return errors.Errorf("session %s already exists", id)
+	}
+	s.reserved[id] = struct{}{}
+	return nil
+}
+
+func (s *sessionState) activate(id string, c *client) {
+	s.active[id] = c
+	delete(s.reserved, id)
+	s.notifyPending(id)
+}
+
+func (s *sessionState) remove(id string) {
+	delete(s.active, id)
+	delete(s.reserved, id)
+}
+
+func (s *sessionState) pendingWait(id string) chan struct{} {
+	pw, ok := s.pending[id]
+	if !ok {
+		pw = &pendingWaiters{ch: make(chan struct{})}
+		s.pending[id] = pw
+	}
+	pw.waiters++
+	return pw.ch
+}
+
+func (s *sessionState) releasePendingWait(id string, ch chan struct{}) {
+	pw, ok := s.pending[id]
+	if !ok || pw.ch != ch {
+		return
+	}
+	pw.waiters--
+	if pw.waiters <= 0 {
+		delete(s.pending, id)
+	}
+}
+
+func (s *sessionState) notifyPending(id string) {
+	pw, ok := s.pending[id]
+	if !ok {
+		return
+	}
+	delete(s.pending, id)
+	close(pw.ch)
+}
+
 // Manager is a controller for accessing currently active sessions
 type Manager struct {
-	sessions        map[string]*client
-	mu              sync.Mutex
-	updateCondition *sync.Cond
+	state chan *sessionState
+}
+
+type sessionCallbacks struct {
+	setup   func(ctx context.Context, state *sessionState) error
+	session func(ctx context.Context) error
+	cleanup func(state *sessionState)
 }
 
 // NewManager returns a new Manager
 func NewManager() (*Manager, error) {
 	sm := &Manager{
-		sessions: make(map[string]*client),
+		state: make(chan *sessionState, 1),
 	}
-	sm.updateCondition = sync.NewCond(&sm.mu)
+	sm.state <- newSessionState()
 	return sm, nil
+}
+
+func (sm *Manager) withState(ctx context.Context, fn func(state *sessionState) error) error {
+	var state *sessionState
+	select {
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	case state = <-sm.state:
+	}
+	defer func() {
+		sm.state <- state
+	}()
+	return fn(state)
+}
+
+func (sm *Manager) tryWithState(fn func(state *sessionState) error) (bool, error) {
+	select {
+	case state := <-sm.state:
+		defer func() {
+			sm.state <- state
+		}()
+		return true, fn(state)
+	default:
+		return false, nil
+	}
+}
+
+func (sm *Manager) runSession(ctx context.Context, cb sessionCallbacks) (retErr error) {
+	if cb.setup != nil {
+		if err := sm.withState(ctx, func(state *sessionState) error {
+			return cb.setup(ctx, state)
+		}); err != nil {
+			return errors.Wrapf(err, "setting up session")
+		}
+	}
+	if cb.cleanup != nil {
+		defer func() {
+			err := sm.withState(context.Background(), func(state *sessionState) error {
+				cb.cleanup(state)
+				return nil
+			})
+			if retErr == nil && err != nil {
+				retErr = err
+			}
+		}()
+	}
+	if cb.session == nil {
+		return nil
+	}
+	return cb.session(ctx)
 }
 
 // HandleHTTPRequest handles an incoming HTTP request
@@ -52,52 +189,70 @@ func (sm *Manager) HandleHTTPRequest(ctx context.Context, w http.ResponseWriter,
 
 	proto := r.Header.Get("Upgrade")
 
-	sm.mu.Lock()
-	if _, ok := sm.sessions[id]; ok {
-		sm.mu.Unlock()
-		return errors.Errorf("session %s already exists", id)
-	}
-
 	if proto == "" {
-		sm.mu.Unlock()
 		return errors.New("no upgrade proto in request")
 	}
 
 	if proto != "h2c" {
-		sm.mu.Unlock()
 		return errors.Errorf("protocol %s not supported", proto)
 	}
 
-	conn, _, err := hijacker.Hijack()
-	if err != nil {
-		sm.mu.Unlock()
-		return errors.Wrap(err, "failed to hijack connection")
-	}
+	var conn net.Conn
+	return sm.runSession(ctx, sessionCallbacks{
+		setup: func(_ context.Context, state *sessionState) error {
+			return state.reserve(id)
+		},
+		session: func(ctx context.Context) error {
+			var err error
+			conn, _, err = hijacker.Hijack()
+			if err != nil {
+				return errors.Wrap(err, "failed to hijack connection")
+			}
 
-	resp := &http.Response{
-		StatusCode: http.StatusSwitchingProtocols,
-		ProtoMajor: 1,
-		ProtoMinor: 1,
-		Header:     http.Header{},
-	}
-	resp.Header.Set("Connection", "Upgrade")
-	resp.Header.Set("Upgrade", proto)
+			resp := &http.Response{
+				StatusCode: http.StatusSwitchingProtocols,
+				ProtoMajor: 1,
+				ProtoMinor: 1,
+				Header:     http.Header{},
+			}
+			resp.Header.Set("Connection", "Upgrade")
+			resp.Header.Set("Upgrade", proto)
 
-	// set raw mode
-	conn.Write([]byte{})
-	resp.Write(conn)
-
-	return sm.handleConn(ctx, conn, r.Header)
+			// set raw mode
+			if _, err := conn.Write([]byte{}); err != nil {
+				_ = conn.Close()
+				return errors.Wrap(err, "failed to switch connection to raw mode")
+			}
+			if err := resp.Write(conn); err != nil {
+				_ = conn.Close()
+				return errors.Wrap(err, "failed to write upgrade response")
+			}
+			return sm.serveConnSession(ctx, conn, r.Header)
+		},
+		cleanup: func(state *sessionState) {
+			state.remove(id)
+		},
+	})
 }
 
 // HandleConn handles an incoming raw connection
 func (sm *Manager) HandleConn(ctx context.Context, conn net.Conn, opts map[string][]string) error {
-	sm.mu.Lock()
-	return sm.handleConn(ctx, conn, opts)
+	opts = canonicalHeaders(opts)
+	id := http.Header(opts).Get(headerSessionID)
+	return sm.runSession(ctx, sessionCallbacks{
+		setup: func(_ context.Context, state *sessionState) error {
+			return state.reserve(id)
+		},
+		session: func(ctx context.Context) error {
+			return sm.serveConnSession(ctx, conn, opts)
+		},
+		cleanup: func(state *sessionState) {
+			state.remove(id)
+		},
+	})
 }
 
-// caller needs to take lock, this function will release it
-func (sm *Manager) handleConn(ctx context.Context, conn net.Conn, opts map[string][]string) error {
+func (sm *Manager) serveConnSession(ctx context.Context, conn net.Conn, opts map[string][]string) error {
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer func() { cancel(errors.WithStack(context.Canceled)) }()
 
@@ -109,8 +264,7 @@ func (sm *Manager) handleConn(ctx context.Context, conn net.Conn, opts map[strin
 
 	ctx, cc, err := grpcClientConn(ctx, conn)
 	if err != nil {
-		sm.mu.Unlock()
-		return err
+		return errors.Wrapf(err, "creating gRPC client connection for session %q", id)
 	}
 
 	c := &client{
@@ -128,20 +282,17 @@ func (sm *Manager) handleConn(ctx context.Context, conn net.Conn, opts map[strin
 	for _, m := range opts[headerSessionMethod] {
 		c.supported[strings.ToLower(m)] = struct{}{}
 	}
-	sm.sessions[id] = c
-	sm.updateCondition.Broadcast()
-	sm.mu.Unlock()
+	defer conn.Close()
+	defer close(c.done)
 
-	defer func() {
-		sm.mu.Lock()
-		delete(sm.sessions, id)
-		sm.mu.Unlock()
-	}()
+	if err := sm.withState(ctx, func(state *sessionState) error {
+		state.activate(id, c)
+		return nil
+	}); err != nil {
+		return errors.Wrapf(err, "activating session %q", id)
+	}
 
 	<-c.ctx.Done()
-	conn.Close()
-	close(c.done)
-
 	return nil
 }
 
@@ -153,41 +304,59 @@ func (sm *Manager) Get(ctx context.Context, id string, noWait bool) (Caller, err
 		id = p[1]
 	}
 
-	ctx, cancel := context.WithCancelCause(ctx)
-	defer func() { cancel(errors.WithStack(context.Canceled)) }()
+	start := time.Now()
 
-	go func() {
-		<-ctx.Done()
-		sm.mu.Lock()
-		sm.updateCondition.Broadcast()
-		sm.mu.Unlock()
-	}()
-
+	// Fast path: do a single non-blocking state check. This allows immediate
+	// success for active/noWait lookups even when ctx is already canceled.
 	var c *client
+	ok, err := sm.tryWithState(func(state *sessionState) error {
+		c = state.getActive(id)
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Wrapf(context.Cause(ctx), "looking up active session for %q", id)
+	}
+	if ok {
+		if c != nil {
+			return c, nil
+		}
+		if noWait {
+			return nil, nil
+		}
+		if ctx.Err() != nil {
+			return nil, errors.Wrapf(context.Cause(ctx), "cannot get session %q; context already terminated", id)
+		}
+	}
 
-	sm.mu.Lock()
 	for {
+		var waitCh chan struct{}
+		err := sm.withState(ctx, func(state *sessionState) error {
+			c = state.getActive(id)
+			if c != nil || noWait {
+				return nil
+			}
+			waitCh = state.pendingWait(id)
+			return nil
+		})
+		if err != nil {
+			return nil, errors.Wrapf(context.Cause(ctx), "looking up active session for %q", id)
+		}
+		if c != nil {
+			return c, nil
+		}
+		if noWait {
+			return nil, nil
+		}
 		select {
 		case <-ctx.Done():
-			sm.mu.Unlock()
-			return nil, errors.Wrapf(context.Cause(ctx), "no active session for %s", id)
-		default:
+			_ = sm.withState(context.Background(), func(state *sessionState) error {
+				state.releasePendingWait(id, waitCh)
+				return nil
+			})
+			return nil, errors.Wrapf(context.Cause(ctx), "session %q did not start (waited for %s)", id, time.Since(start).Truncate(time.Millisecond))
+		case <-waitCh:
 		}
-		var ok bool
-		c, ok = sm.sessions[id]
-		if (!ok || c.closed()) && !noWait {
-			sm.updateCondition.Wait()
-			continue
-		}
-		sm.mu.Unlock()
-		break
 	}
-
-	if c == nil {
-		return nil, nil
-	}
-
-	return c, nil
 }
 
 func (c *client) Context() context.Context {

--- a/session/manager.go
+++ b/session/manager.go
@@ -323,7 +323,7 @@ func (sm *Manager) Get(ctx context.Context, id string, noWait bool) (Caller, err
 		if noWait {
 			return nil, nil
 		}
-		if ctx.Err() != nil {
+		if context.Cause(ctx) != nil {
 			return nil, errors.Wrapf(context.Cause(ctx), "cannot get session %q; context already terminated", id)
 		}
 	}

--- a/session/manager_concurrency_test.go
+++ b/session/manager_concurrency_test.go
@@ -1,0 +1,74 @@
+package session
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestManagerGetThunderingHerd(t *testing.T) {
+	sm, err := NewManager()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a dummy session to hit the "success" path of Get
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := sm.withState(t.Context(), func(state *sessionState) error {
+		state.active["test-session"] = &client{
+			Session: Session{
+				id:        "test-session",
+				ctx:       ctx,
+				cancelCtx: func(err error) { cancel() },
+				done:      make(chan struct{}),
+			},
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	var ops int64
+
+	start := time.Now()
+	
+	// 100 goroutines waiting for a non-existent session
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			waitCtx, waitCancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer waitCancel()
+			
+			// This will block in Wait() until timeout
+			_, err := sm.Get(waitCtx, "non-existent", false)
+			if err != nil {
+				// expected to fail with timeout
+				t.Logf("Waiter %d finished with error: %v", i, err)
+			}
+		}(i)
+	}
+
+	// 100 goroutines hammering Get for the existing session
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for time.Since(start) < 2*time.Second {
+				_, _ = sm.Get(context.Background(), "test-session", false)
+				atomic.AddInt64(&ops, 1)
+			}
+		}()
+	}
+
+	wg.Wait()
+	t.Logf("Completed %d Get operations in 2 seconds", ops)
+	
+	if ops < 10000 {
+		t.Errorf("Performance is abnormally low: only %d ops in 2 seconds", ops)
+	}
+}

--- a/session/manager_concurrency_test.go
+++ b/session/manager_concurrency_test.go
@@ -6,6 +6,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 func TestManagerGetThunderingHerd(t *testing.T) {
@@ -15,14 +17,14 @@ func TestManagerGetThunderingHerd(t *testing.T) {
 	}
 
 	// Create a dummy session to hit the "success" path of Get
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(context.Canceled)
 	if err := sm.withState(t.Context(), func(state *sessionState) error {
 		state.active["test-session"] = &client{
 			Session: Session{
 				id:        "test-session",
 				ctx:       ctx,
-				cancelCtx: func(err error) { cancel() },
+				cancelCtx: func(err error) { cancel(context.Canceled) },
 				done:      make(chan struct{}),
 			},
 		}
@@ -35,15 +37,15 @@ func TestManagerGetThunderingHerd(t *testing.T) {
 	var ops int64
 
 	start := time.Now()
-	
+
 	// 100 goroutines waiting for a non-existent session
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			waitCtx, waitCancel := context.WithTimeout(context.Background(), 2*time.Second)
+			waitCtx, waitCancel := context.WithTimeoutCause(context.Background(), 2*time.Second, errors.WithStack(context.DeadlineExceeded))
 			defer waitCancel()
-			
+
 			// This will block in Wait() until timeout
 			_, err := sm.Get(waitCtx, "non-existent", false)
 			if err != nil {
@@ -54,20 +56,18 @@ func TestManagerGetThunderingHerd(t *testing.T) {
 	}
 
 	// 100 goroutines hammering Get for the existing session
-	for i := 0; i < 100; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 100 {
+		wg.Go(func() {
 			for time.Since(start) < 2*time.Second {
 				_, _ = sm.Get(context.Background(), "test-session", false)
 				atomic.AddInt64(&ops, 1)
 			}
-		}()
+		})
 	}
 
 	wg.Wait()
 	t.Logf("Completed %d Get operations in 2 seconds", ops)
-	
+
 	if ops < 10000 {
 		t.Errorf("Performance is abnormally low: only %d ops in 2 seconds", ops)
 	}

--- a/session/manager_test.go
+++ b/session/manager_test.go
@@ -1,0 +1,992 @@
+package session
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/moby/buildkit/session/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func waitForActiveCaller(t *testing.T, sm *Manager, id string, timeout time.Duration) Caller {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		c, err := sm.Get(ctx, id, true)
+		cancel()
+		if err == nil && c != nil {
+			select {
+			case <-c.Context().Done():
+			default:
+				return c
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("session %s did not become active in time", id)
+	return nil
+}
+
+func waitForActiveCallerErr(sm *Manager, id string, timeout time.Duration) (Caller, error) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		c, err := sm.Get(ctx, id, true)
+		cancel()
+		if err == nil && c != nil {
+			select {
+			case <-c.Context().Done():
+			default:
+				return c, nil
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return nil, fmt.Errorf("session %s did not become active in time", id)
+}
+
+type bufferedConn struct {
+	net.Conn
+	reader *bufio.Reader
+}
+
+func (c *bufferedConn) Read(p []byte) (int, error) {
+	return c.reader.Read(p)
+}
+
+type blockingWriteConn struct {
+	writeStarted chan struct{}
+	releaseWrite chan struct{}
+}
+
+type testAddr struct{}
+
+func (c *blockingWriteConn) Read(_ []byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (c *blockingWriteConn) Write(p []byte) (int, error) {
+	select {
+	case <-c.writeStarted:
+	default:
+		close(c.writeStarted)
+	}
+	<-c.releaseWrite
+	return len(p), nil
+}
+
+func (c *blockingWriteConn) Close() error {
+	return nil
+}
+
+func (c *blockingWriteConn) LocalAddr() net.Addr {
+	return testAddr{}
+}
+
+func (c *blockingWriteConn) RemoteAddr() net.Addr {
+	return testAddr{}
+}
+
+func (c *blockingWriteConn) SetDeadline(_ time.Time) error {
+	return nil
+}
+
+func (c *blockingWriteConn) SetReadDeadline(_ time.Time) error {
+	return nil
+}
+
+func (c *blockingWriteConn) SetWriteDeadline(_ time.Time) error {
+	return nil
+}
+
+func (testAddr) Network() string {
+	return "tcp"
+}
+
+func (testAddr) String() string {
+	return "localhost"
+}
+
+type hijackOnlyResponseWriter struct {
+	conn net.Conn
+	hdr  http.Header
+}
+
+func (w *hijackOnlyResponseWriter) Header() http.Header {
+	if w.hdr == nil {
+		w.hdr = make(http.Header)
+	}
+	return w.hdr
+}
+
+func (w *hijackOnlyResponseWriter) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (w *hijackOnlyResponseWriter) WriteHeader(_ int) {}
+
+func (w *hijackOnlyResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	rw := bufio.NewReadWriter(bufio.NewReader(w.conn), bufio.NewWriter(w.conn))
+	return w.conn, rw, nil
+}
+
+func httpUpgradeTestDialer(sm *Manager) Dialer {
+	return func(ctx context.Context, proto string, meta map[string][]string) (net.Conn, error) {
+		serverConn, clientConn := net.Pipe()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://session.local/upgrade", nil)
+		if err != nil {
+			_ = serverConn.Close()
+			_ = clientConn.Close()
+			return nil, err
+		}
+		req.Header = make(http.Header)
+		for k, v := range meta {
+			req.Header[k] = append([]string(nil), v...)
+		}
+		req.Header.Set("Upgrade", proto)
+
+		rw := &hijackOnlyResponseWriter{conn: serverConn}
+		go func() {
+			_ = sm.HandleHTTPRequest(ctx, rw, req)
+		}()
+
+		reader := bufio.NewReader(clientConn)
+		resp, err := http.ReadResponse(reader, req)
+		if err != nil {
+			_ = serverConn.Close()
+			_ = clientConn.Close()
+			return nil, err
+		}
+		if resp.StatusCode != http.StatusSwitchingProtocols {
+			_ = serverConn.Close()
+			_ = clientConn.Close()
+			return nil, fmt.Errorf("unexpected upgrade status: %d", resp.StatusCode)
+		}
+
+		return &bufferedConn{Conn: clientConn, reader: reader}, nil
+	}
+}
+
+func startSessionForTest(t *testing.T, parent context.Context, sm *Manager, id, sharedKey string) (*Session, func()) {
+	t.Helper()
+
+	s, err := NewSession(parent, sharedKey)
+	require.NoError(t, err)
+	if id != "" {
+		s.id = id
+	}
+
+	dialer := Dialer(testutil.TestStream(testutil.Handler(sm.HandleConn)))
+	runCtx, runCancel := context.WithCancelCause(parent)
+	runErrCh := make(chan error, 1)
+	go func() {
+		runErrCh <- s.Run(runCtx, dialer)
+	}()
+
+	waitForActiveCaller(t, sm, s.ID(), 2*time.Second)
+
+	cleanup := func() {
+		require.NoError(t, s.Close())
+		runCancel(context.Canceled)
+		select {
+		case err := <-runErrCh:
+			require.NoError(t, err)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("session run did not exit in time for %s", s.ID())
+		}
+	}
+
+	return s, cleanup
+}
+
+func TestManagerGetNoWaitMissingSessionReturnsNil(t *testing.T) {
+	sm, err := NewManager()
+	require.NoError(t, err)
+
+	c, err := sm.Get(t.Context(), "missing-session", true)
+	require.NoError(t, err)
+	require.Nil(t, c)
+}
+
+func TestManagerGetPrefixLookupOnActiveSession(t *testing.T) {
+	sm, err := NewManager()
+	require.NoError(t, err)
+
+	sessionID := "prefix-target"
+	_, cleanup := startSessionForTest(t, t.Context(), sm, sessionID, "prefix-shared-key")
+	defer cleanup()
+
+	c, err := sm.Get(t.Context(), "vertex:"+sessionID, false)
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	require.Equal(t, "prefix-shared-key", c.SharedKey())
+}
+
+func TestManagerGetContextCancelWhileWaiting(t *testing.T) {
+	sm, err := NewManager()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+
+	c, err := sm.Get(ctx, "missing-cancel", false)
+	require.Error(t, err)
+	require.Nil(t, c)
+	require.Contains(t, err.Error(), `session "missing-cancel" did not start`)
+	require.Contains(t, err.Error(), "context deadline exceeded")
+}
+
+func TestManagerGetCanceledContextFastPathOnActiveSession(t *testing.T) {
+	sm, err := NewManager()
+	require.NoError(t, err)
+
+	activeCtx, activeCancel := context.WithCancelCause(t.Context())
+	defer activeCancel(context.Canceled)
+
+	const sessionID = "active-fastpath-cancel"
+	require.NoError(t, sm.withState(t.Context(), func(state *sessionState) error {
+		state.active[sessionID] = &client{
+			Session: Session{
+				id:        sessionID,
+				sharedKey: "active-fastpath-key",
+				ctx:       activeCtx,
+				done:      make(chan struct{}),
+			},
+			supported: map[string]struct{}{},
+		}
+		return nil
+	}))
+
+	ctx, cancel := context.WithCancelCause(t.Context())
+	cancel(context.Canceled)
+
+	c, err := sm.Get(ctx, sessionID, false)
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	require.Equal(t, "active-fastpath-key", c.SharedKey())
+}
+
+func TestManagerGetCanceledContextFastPathNoWait(t *testing.T) {
+	sm, err := NewManager()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancelCause(t.Context())
+	cancel(context.Canceled)
+
+	c, err := sm.Get(ctx, "missing-fastpath-no-wait", true)
+	require.NoError(t, err)
+	require.Nil(t, c)
+}
+
+func TestManagerGetContextCancelCleansPendingWaiters(t *testing.T) {
+	sm, err := NewManager()
+	require.NoError(t, err)
+
+	const waiters = 200
+	var wg sync.WaitGroup
+	wg.Add(waiters)
+
+	for i := 0; i < waiters; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(t.Context(), 25*time.Millisecond)
+			defer cancel()
+			_, err := sm.Get(ctx, fmt.Sprintf("missing-pending-%d", i), false)
+			require.Error(t, err)
+		}()
+	}
+
+	wg.Wait()
+
+	require.NoError(t, sm.withState(t.Context(), func(state *sessionState) error {
+		require.Zero(t, len(state.pending), "timed-out Get waiters should not leak pending channels")
+		return nil
+	}))
+}
+
+func TestManagerGetHighConcurrencyInactiveThenCreate(t *testing.T) {
+	sm, err := NewManager()
+	require.NoError(t, err)
+
+	const waiters = 300
+	sessionID := "inactive-then-create"
+
+	errCh := make(chan error, waiters)
+	var startWG sync.WaitGroup
+	startWG.Add(waiters)
+
+	for i := 0; i < waiters; i++ {
+		go func() {
+			startWG.Done()
+			ctx, cancel := context.WithTimeout(t.Context(), 4*time.Second)
+			defer cancel()
+			c, err := sm.Get(ctx, sessionID, false)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			if c == nil {
+				errCh <- fmt.Errorf("received nil caller")
+				return
+			}
+			errCh <- nil
+		}()
+	}
+
+	startWG.Wait()
+	time.Sleep(75 * time.Millisecond)
+
+	_, cleanup := startSessionForTest(t, t.Context(), sm, sessionID, "inactive-shared")
+	defer cleanup()
+
+	for i := 0; i < waiters; i++ {
+		require.NoError(t, <-errCh)
+	}
+}
+
+func TestManagerGetHighConcurrencyAlreadyActive(t *testing.T) {
+	sm, err := NewManager()
+	require.NoError(t, err)
+
+	sessionID := "already-active"
+	_, cleanup := startSessionForTest(t, t.Context(), sm, sessionID, "active-shared")
+	defer cleanup()
+
+	const (
+		rounds  = 8
+		callers = 250
+	)
+	for round := 0; round < rounds; round++ {
+		errCh := make(chan error, callers)
+		for i := 0; i < callers; i++ {
+			i := i
+			go func() {
+				noWait := i%2 == 0
+				lookupID := sessionID
+				if i%5 == 0 {
+					lookupID = "vertex:" + sessionID
+				}
+
+				ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+				defer cancel()
+				c, err := sm.Get(ctx, lookupID, noWait)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				if c == nil {
+					errCh <- fmt.Errorf("nil caller from Get(noWait=%v)", noWait)
+					return
+				}
+				if c.SharedKey() != "active-shared" {
+					errCh <- fmt.Errorf("unexpected shared key %q", c.SharedKey())
+					return
+				}
+				errCh <- nil
+			}()
+		}
+
+		for i := 0; i < callers; i++ {
+			require.NoError(t, <-errCh)
+		}
+	}
+}
+
+func TestManagerGetBroadcastCancelStorm(t *testing.T) {
+	sm, err := NewManager()
+	require.NoError(t, err)
+
+	const waiters = 300
+	sessionID := "cancel-storm"
+
+	cancels := make([]context.CancelCauseFunc, 0, waiters)
+	errCh := make(chan error, waiters)
+
+	for i := 0; i < waiters; i++ {
+		ctx, cancel := context.WithCancelCause(t.Context())
+		cancels = append(cancels, cancel)
+		go func(ctx context.Context) {
+			c, err := sm.Get(ctx, sessionID, false)
+			if err == nil {
+				errCh <- fmt.Errorf("expected error for canceled waiter")
+				return
+			}
+			if c != nil {
+				errCh <- fmt.Errorf("expected nil caller for canceled waiter")
+				return
+			}
+			errCh <- nil
+		}(ctx)
+	}
+
+	time.Sleep(75 * time.Millisecond)
+	for _, cancel := range cancels {
+		cancel(context.Canceled)
+	}
+
+	for i := 0; i < waiters; i++ {
+		select {
+		case err := <-errCh:
+			require.NoError(t, err)
+		case <-time.After(3 * time.Second):
+			t.Fatal("timeout waiting for canceled waiters to drain")
+		}
+	}
+}
+
+func TestManagerGetBroadcastNoMissedWakeups(t *testing.T) {
+	sm, err := NewManager()
+	require.NoError(t, err)
+
+	const (
+		rounds  = 15
+		waiters = 120
+	)
+
+	for round := 0; round < rounds; round++ {
+		sessionID := fmt.Sprintf("broadcast-round-%d", round)
+		errCh := make(chan error, waiters)
+		var startWG sync.WaitGroup
+		startWG.Add(waiters)
+
+		for i := 0; i < waiters; i++ {
+			go func() {
+				startWG.Done()
+				ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+				defer cancel()
+				c, err := sm.Get(ctx, sessionID, false)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				if c == nil {
+					errCh <- fmt.Errorf("nil caller during broadcast round %d", round)
+					return
+				}
+				errCh <- nil
+			}()
+		}
+
+		startWG.Wait()
+		time.Sleep(50 * time.Millisecond)
+
+		_, cleanup := startSessionForTest(t, t.Context(), sm, sessionID, fmt.Sprintf("round-%d", round))
+		for i := 0; i < waiters; i++ {
+			require.NoError(t, <-errCh)
+		}
+		cleanup()
+	}
+}
+
+func TestManagerHandleConnDuplicateSessionIDOverwritesExisting(t *testing.T) {
+	// Known failing hypothesis:
+	// HandleConn does not reject duplicate session IDs, so the second registration overwrites
+	// sm.sessions[id] while the first session is still active.
+	// Fix direction: enforce duplicate-ID rejection in HandleConn/handleConn (matching HTTP path
+	// behavior), or otherwise guarantee first-writer-wins semantics without map replacement races.
+	sm, err := NewManager()
+	require.NoError(t, err)
+
+	dialer := Dialer(testutil.TestStream(testutil.Handler(sm.HandleConn)))
+	ctx, cancel := context.WithCancelCause(t.Context())
+	defer cancel(context.Canceled)
+
+	s1, err := NewSession(ctx, "first-shared")
+	require.NoError(t, err)
+	s2, err := NewSession(ctx, "second-shared")
+	require.NoError(t, err)
+
+	const duplicatedID = "duplicate-session-id"
+	s1.id = duplicatedID
+	s2.id = duplicatedID
+
+	errCh1 := make(chan error, 1)
+	errCh2 := make(chan error, 1)
+	go func() { errCh1 <- s1.Run(ctx, dialer) }()
+	waitForActiveCaller(t, sm, duplicatedID, 2*time.Second)
+
+	go func() { errCh2 <- s2.Run(ctx, dialer) }()
+	time.Sleep(150 * time.Millisecond)
+
+	// This asserts desired behavior and intentionally exposes current overwrite behavior.
+	c := waitForActiveCaller(t, sm, duplicatedID, 2*time.Second)
+	require.Equal(t, "first-shared", c.SharedKey(), "duplicate session registration should not replace existing active session")
+
+	require.NoError(t, s2.Close())
+	require.NoError(t, s1.Close())
+	cancel(context.Canceled)
+
+	require.NoError(t, <-errCh1)
+	require.NoError(t, <-errCh2)
+}
+
+func TestManagerParallelCreateGetNeedFiveSecondChurn(t *testing.T) {
+	sm, err := NewManager()
+	require.NoError(t, err)
+
+	dialer := Dialer(testutil.TestStream(testutil.Handler(sm.HandleConn)))
+	deadline := time.Now().Add(5 * time.Second)
+	workers := runtime.GOMAXPROCS(0) * 4
+	if workers < 8 {
+		workers = 8
+	}
+
+	errCh := make(chan error, workers*16)
+	var seq atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(workers)
+
+	for worker := 0; worker < workers; worker++ {
+		worker := worker
+		go func() {
+			defer wg.Done()
+			localCounter := int64(0)
+
+			for time.Now().Before(deadline) {
+				localCounter++
+				id := fmt.Sprintf("churn-%d-%d", worker, localCounter)
+				sharedKey := "key-" + id
+
+				needCtx, needCancel := context.WithTimeout(t.Context(), 2*time.Second)
+				needDone := make(chan error, 1)
+				go func() {
+					c, err := sm.Get(needCtx, id, false)
+					if err != nil {
+						needDone <- fmt.Errorf("need Get failed for %s: %w", id, err)
+						return
+					}
+					if c == nil {
+						needDone <- fmt.Errorf("need Get returned nil caller for %s", id)
+						return
+					}
+					needDone <- nil
+				}()
+
+				s, err := NewSession(t.Context(), sharedKey)
+				if err != nil {
+					needCancel()
+					errCh <- err
+					return
+				}
+				s.id = id
+
+				runCtx, runCancel := context.WithCancelCause(t.Context())
+				runDone := make(chan error, 1)
+				go func() {
+					runDone <- s.Run(runCtx, dialer)
+				}()
+
+				if _, err := waitForActiveCallerErr(sm, id, 2*time.Second); err != nil {
+					_ = s.Close()
+					runCancel(context.Canceled)
+					select {
+					case <-runDone:
+					case <-time.After(2 * time.Second):
+					}
+					needCancel()
+					errCh <- err
+					return
+				}
+
+				select {
+				case err := <-needDone:
+					if err != nil {
+						_ = s.Close()
+						runCancel(context.Canceled)
+						select {
+						case <-runDone:
+						case <-time.After(2 * time.Second):
+						}
+						needCancel()
+						errCh <- err
+						return
+					}
+				case <-time.After(2 * time.Second):
+					_ = s.Close()
+					runCancel(context.Canceled)
+					select {
+					case <-runDone:
+					case <-time.After(2 * time.Second):
+					}
+					needCancel()
+					errCh <- fmt.Errorf("timed out waiting for need Get on %s", id)
+					return
+				}
+				needCancel()
+
+				for i := 0; i < 4; i++ {
+					lookupID := id
+					if i%2 == 1 {
+						lookupID = "vertex:" + id
+					}
+					getCtx, getCancel := context.WithTimeout(t.Context(), 2*time.Second)
+					c, err := sm.Get(getCtx, lookupID, i%2 == 0)
+					getCancel()
+					if err != nil {
+						_ = s.Close()
+						runCancel(context.Canceled)
+						select {
+						case <-runDone:
+						case <-time.After(2 * time.Second):
+						}
+						errCh <- fmt.Errorf("active Get failed for %s: %w", id, err)
+						return
+					}
+					if c == nil {
+						_ = s.Close()
+						runCancel(context.Canceled)
+						select {
+						case <-runDone:
+						case <-time.After(2 * time.Second):
+						}
+						errCh <- fmt.Errorf("active Get returned nil caller for %s", id)
+						return
+					}
+				}
+
+				if err := s.Close(); err != nil {
+					runCancel(context.Canceled)
+					select {
+					case <-runDone:
+					case <-time.After(2 * time.Second):
+					}
+					errCh <- err
+					return
+				}
+				runCancel(context.Canceled)
+				select {
+				case err := <-runDone:
+					if err != nil {
+						errCh <- err
+						return
+					}
+				case <-time.After(2 * time.Second):
+					errCh <- fmt.Errorf("session run did not exit in time for %s", id)
+					return
+				}
+
+				seq.Add(1)
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+	require.Greater(t, seq.Load(), int64(workers), "expected churn loop to perform multiple operations")
+}
+
+func TestManagerGetParallelPairsWakeupsHTTPAndRawFiveSeconds(t *testing.T) {
+	sm, err := NewManager()
+	require.NoError(t, err)
+
+	rawDialer := Dialer(testutil.TestStream(testutil.Handler(sm.HandleConn)))
+	httpDialer := httpUpgradeTestDialer(sm)
+
+	deadline := time.Now().Add(5 * time.Second)
+	pairs := runtime.GOMAXPROCS(0) * 3
+	if pairs < 12 {
+		pairs = 12
+	}
+
+	errCh := make(chan error, pairs*32)
+	var loops atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(pairs)
+
+	for pairID := 0; pairID < pairs; pairID++ {
+		pairID := pairID
+		go func() {
+			defer wg.Done()
+			localIter := 0
+			for time.Now().Before(deadline) {
+				localIter++
+				sessionID := fmt.Sprintf("pair-session-%d-%d", pairID, localIter)
+				sharedKey := fmt.Sprintf("pair-key-%d-%d", pairID, localIter)
+
+				waiterStarted := make(chan struct{})
+				waiterErrCh := make(chan error, 1)
+				waiterCtx, waiterCancel := context.WithTimeout(t.Context(), 2*time.Second)
+				go func() {
+					close(waiterStarted)
+					c, err := sm.Get(waiterCtx, sessionID, false)
+					if err != nil {
+						waiterErrCh <- fmt.Errorf("blocking Get failed for %s: %w", sessionID, err)
+						return
+					}
+					if c == nil {
+						waiterErrCh <- fmt.Errorf("blocking Get returned nil for %s", sessionID)
+						return
+					}
+					if c.SharedKey() != sharedKey {
+						waiterErrCh <- fmt.Errorf("blocking Get shared key mismatch for %s: %q", sessionID, c.SharedKey())
+						return
+					}
+					waiterErrCh <- nil
+				}()
+
+				<-waiterStarted
+
+				creatorRelease := make(chan struct{})
+				creatorErrCh := make(chan error, 1)
+				useHTTP := (pairID+localIter)%2 == 0
+				go func() {
+					s, err := NewSession(t.Context(), sharedKey)
+					if err != nil {
+						creatorErrCh <- err
+						return
+					}
+					s.id = sessionID
+
+					runCtx, runCancel := context.WithCancelCause(t.Context())
+					runErrCh := make(chan error, 1)
+					dialer := rawDialer
+					if useHTTP {
+						dialer = httpDialer
+					}
+					go func() {
+						runErrCh <- s.Run(runCtx, dialer)
+					}()
+
+					if _, err := waitForActiveCallerErr(sm, sessionID, 2*time.Second); err != nil {
+						_ = s.Close()
+						runCancel(context.Canceled)
+						select {
+						case <-runErrCh:
+						case <-time.After(2 * time.Second):
+						}
+						creatorErrCh <- err
+						return
+					}
+
+					<-creatorRelease
+
+					if err := s.Close(); err != nil {
+						runCancel(context.Canceled)
+						select {
+						case <-runErrCh:
+						case <-time.After(2 * time.Second):
+						}
+						creatorErrCh <- err
+						return
+					}
+					runCancel(context.Canceled)
+					select {
+					case err := <-runErrCh:
+						if err != nil {
+							creatorErrCh <- err
+							return
+						}
+					case <-time.After(2 * time.Second):
+						creatorErrCh <- fmt.Errorf("session run did not exit for %s", sessionID)
+						return
+					}
+
+					creatorErrCh <- nil
+				}()
+
+				var waiterErr error
+				select {
+				case waiterErr = <-waiterErrCh:
+				case <-time.After(2 * time.Second):
+					waiterErr = fmt.Errorf("timeout waiting for blocking Get for %s", sessionID)
+				}
+				waiterCancel()
+
+				close(creatorRelease)
+				var creatorErr error
+				select {
+				case creatorErr = <-creatorErrCh:
+				case <-time.After(3 * time.Second):
+					creatorErr = fmt.Errorf("timeout waiting for creator cleanup for %s", sessionID)
+				}
+
+				if waiterErr != nil {
+					errCh <- waiterErr
+					return
+				}
+				if creatorErr != nil {
+					errCh <- creatorErr
+					return
+				}
+
+				loops.Add(1)
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+	require.Greater(t, loops.Load(), int64(pairs), "expected each pair worker to complete multiple loops")
+}
+
+func TestManagerHandleHTTPRequestDoesNotTreatClosedSessionAsActive(t *testing.T) {
+	sm, err := NewManager()
+	require.NoError(t, err)
+
+	sessionID := "closed-http-recreate"
+	closedCtx, closedCancel := context.WithCancelCause(context.Background())
+	closedCancel(context.Canceled)
+
+	require.NoError(t, sm.withState(t.Context(), func(state *sessionState) error {
+		state.active[sessionID] = &client{
+			Session: Session{
+				id:   sessionID,
+				ctx:  closedCtx,
+				done: make(chan struct{}),
+			},
+			supported: map[string]struct{}{},
+		}
+		return nil
+	}))
+
+	s, err := NewSession(t.Context(), "new-http-shared")
+	require.NoError(t, err)
+	s.id = sessionID
+
+	runCtx, runCancel := context.WithCancelCause(t.Context())
+	defer runCancel(context.Canceled)
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- s.Run(runCtx, httpUpgradeTestDialer(sm))
+	}()
+
+	c, err := waitForActiveCallerErr(sm, sessionID, 2*time.Second)
+	require.NoError(t, err, "a closed stale session should not block HTTP re-registration")
+	require.NotNil(t, c)
+	require.Equal(t, "new-http-shared", c.SharedKey())
+
+	require.NoError(t, s.Close())
+	runCancel(context.Canceled)
+	select {
+	case err := <-runDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatalf("session run did not exit in time for %s", sessionID)
+	}
+}
+
+func TestManagerHandleHTTPRequestDoesNotBlockUnrelatedGet(t *testing.T) {
+	sm, err := NewManager()
+	require.NoError(t, err)
+
+	activeCtx, activeCancel := context.WithCancelCause(t.Context())
+	defer activeCancel(context.Canceled)
+
+	const activeID = "existing-active"
+	require.NoError(t, sm.withState(t.Context(), func(state *sessionState) error {
+		state.active[activeID] = &client{
+			Session: Session{
+				id:        activeID,
+				sharedKey: "existing-key",
+				ctx:       activeCtx,
+				done:      make(chan struct{}),
+			},
+			supported: map[string]struct{}{},
+		}
+		return nil
+	}))
+
+	conn := &blockingWriteConn{
+		writeStarted: make(chan struct{}),
+		releaseWrite: make(chan struct{}),
+	}
+	reqCtx, reqCancel := context.WithTimeout(t.Context(), 250*time.Millisecond)
+	defer reqCancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, "http://session.local/upgrade", nil)
+	require.NoError(t, err)
+	req.Header.Set(headerSessionID, "other-http-session")
+	req.Header.Set("Upgrade", "h2c")
+
+	rw := &hijackOnlyResponseWriter{conn: conn}
+	httpErrCh := make(chan error, 1)
+	go func() {
+		httpErrCh <- sm.HandleHTTPRequest(reqCtx, rw, req)
+	}()
+
+	select {
+	case <-conn.writeStarted:
+		// HandleHTTPRequest is blocked in response write.
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for HandleHTTPRequest response write")
+	}
+
+	getCtx, getCancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer getCancel()
+	getDone := make(chan struct{})
+	var c Caller
+	var getErr error
+	go func() {
+		c, getErr = sm.Get(getCtx, activeID, true)
+		close(getDone)
+	}()
+
+	blocked := false
+	select {
+	case <-getDone:
+	case <-time.After(300 * time.Millisecond):
+		blocked = true
+	}
+
+	close(conn.releaseWrite)
+	select {
+	case <-httpErrCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("HandleHTTPRequest did not exit after unblocking write")
+	}
+
+	if blocked {
+		select {
+		case <-getDone:
+		case <-time.After(2 * time.Second):
+			t.Fatal("Get did not return after releasing blocked HTTP write")
+		}
+		t.Fatal("Get call was blocked by unrelated HandleHTTPRequest lock hold despite deadline")
+	}
+
+	require.NoError(t, getErr, "unrelated active session lookup should not be blocked by another handshake")
+	require.NotNil(t, c)
+	require.Equal(t, "existing-key", c.SharedKey())
+}
+
+func TestManagerGetDoesNotBlockOnMutexPastDeadline(t *testing.T) {
+	sm, err := NewManager()
+	require.NoError(t, err)
+
+	held := <-sm.state
+	defer func() { sm.state <- held }()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = sm.Get(ctx, "never-available", true)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Good: returned despite state lock contention.
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("Get remained blocked on state lock past context deadline")
+	}
+}

--- a/session/manager_test.go
+++ b/session/manager_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/moby/buildkit/session/testutil"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,7 +23,7 @@ func waitForActiveCaller(t *testing.T, sm *Manager, id string, timeout time.Dura
 
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		ctx, cancel := context.WithTimeoutCause(context.Background(), 50*time.Millisecond, errors.WithStack(context.DeadlineExceeded))
 		c, err := sm.Get(ctx, id, true)
 		cancel()
 		if err == nil && c != nil {
@@ -41,7 +42,7 @@ func waitForActiveCaller(t *testing.T, sm *Manager, id string, timeout time.Dura
 func waitForActiveCallerErr(sm *Manager, id string, timeout time.Duration) (Caller, error) {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		ctx, cancel := context.WithTimeoutCause(context.Background(), 50*time.Millisecond, errors.WithStack(context.DeadlineExceeded))
 		c, err := sm.Get(ctx, id, true)
 		cancel()
 		if err == nil && c != nil {
@@ -53,7 +54,7 @@ func waitForActiveCallerErr(sm *Manager, id string, timeout time.Duration) (Call
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	return nil, fmt.Errorf("session %s did not become active in time", id)
+	return nil, errors.Errorf("session %s did not become active in time", id)
 }
 
 type bufferedConn struct {
@@ -169,17 +170,18 @@ func httpUpgradeTestDialer(sm *Manager) Dialer {
 			_ = clientConn.Close()
 			return nil, err
 		}
+		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusSwitchingProtocols {
 			_ = serverConn.Close()
 			_ = clientConn.Close()
-			return nil, fmt.Errorf("unexpected upgrade status: %d", resp.StatusCode)
+			return nil, errors.Errorf("unexpected upgrade status: %d", resp.StatusCode)
 		}
 
 		return &bufferedConn{Conn: clientConn, reader: reader}, nil
 	}
 }
 
-func startSessionForTest(t *testing.T, parent context.Context, sm *Manager, id, sharedKey string) (*Session, func()) {
+func startSessionForTest(parent context.Context, t *testing.T, sm *Manager, id, sharedKey string) (*Session, func()) {
 	t.Helper()
 
 	s, err := NewSession(parent, sharedKey)
@@ -225,7 +227,7 @@ func TestManagerGetPrefixLookupOnActiveSession(t *testing.T) {
 	require.NoError(t, err)
 
 	sessionID := "prefix-target"
-	_, cleanup := startSessionForTest(t, t.Context(), sm, sessionID, "prefix-shared-key")
+	_, cleanup := startSessionForTest(t.Context(), t, sm, sessionID, "prefix-shared-key")
 	defer cleanup()
 
 	c, err := sm.Get(t.Context(), "vertex:"+sessionID, false)
@@ -238,7 +240,7 @@ func TestManagerGetContextCancelWhileWaiting(t *testing.T) {
 	sm, err := NewManager()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	ctx, cancel := context.WithTimeoutCause(t.Context(), 50*time.Millisecond, errors.WithStack(context.DeadlineExceeded))
 	defer cancel()
 
 	c, err := sm.Get(ctx, "missing-cancel", false)
@@ -298,14 +300,15 @@ func TestManagerGetContextCancelCleansPendingWaiters(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(waiters)
 
-	for i := 0; i < waiters; i++ {
-		i := i
+	for i := range waiters {
 		go func() {
 			defer wg.Done()
-			ctx, cancel := context.WithTimeout(t.Context(), 25*time.Millisecond)
+			ctx, cancel := context.WithTimeoutCause(t.Context(), 25*time.Millisecond, errors.WithStack(context.DeadlineExceeded))
 			defer cancel()
 			_, err := sm.Get(ctx, fmt.Sprintf("missing-pending-%d", i), false)
-			require.Error(t, err)
+			if err == nil {
+				t.Errorf("expected timeout error for missing pending waiter %d", i)
+			}
 		}()
 	}
 
@@ -328,10 +331,10 @@ func TestManagerGetHighConcurrencyInactiveThenCreate(t *testing.T) {
 	var startWG sync.WaitGroup
 	startWG.Add(waiters)
 
-	for i := 0; i < waiters; i++ {
+	for range waiters {
 		go func() {
 			startWG.Done()
-			ctx, cancel := context.WithTimeout(t.Context(), 4*time.Second)
+			ctx, cancel := context.WithTimeoutCause(t.Context(), 4*time.Second, errors.WithStack(context.DeadlineExceeded))
 			defer cancel()
 			c, err := sm.Get(ctx, sessionID, false)
 			if err != nil {
@@ -339,7 +342,7 @@ func TestManagerGetHighConcurrencyInactiveThenCreate(t *testing.T) {
 				return
 			}
 			if c == nil {
-				errCh <- fmt.Errorf("received nil caller")
+				errCh <- errors.Errorf("received nil caller")
 				return
 			}
 			errCh <- nil
@@ -349,10 +352,10 @@ func TestManagerGetHighConcurrencyInactiveThenCreate(t *testing.T) {
 	startWG.Wait()
 	time.Sleep(75 * time.Millisecond)
 
-	_, cleanup := startSessionForTest(t, t.Context(), sm, sessionID, "inactive-shared")
+	_, cleanup := startSessionForTest(t.Context(), t, sm, sessionID, "inactive-shared")
 	defer cleanup()
 
-	for i := 0; i < waiters; i++ {
+	for range waiters {
 		require.NoError(t, <-errCh)
 	}
 }
@@ -362,17 +365,16 @@ func TestManagerGetHighConcurrencyAlreadyActive(t *testing.T) {
 	require.NoError(t, err)
 
 	sessionID := "already-active"
-	_, cleanup := startSessionForTest(t, t.Context(), sm, sessionID, "active-shared")
+	_, cleanup := startSessionForTest(t.Context(), t, sm, sessionID, "active-shared")
 	defer cleanup()
 
 	const (
 		rounds  = 8
 		callers = 250
 	)
-	for round := 0; round < rounds; round++ {
+	for range rounds {
 		errCh := make(chan error, callers)
-		for i := 0; i < callers; i++ {
-			i := i
+		for i := range callers {
 			go func() {
 				noWait := i%2 == 0
 				lookupID := sessionID
@@ -380,7 +382,7 @@ func TestManagerGetHighConcurrencyAlreadyActive(t *testing.T) {
 					lookupID = "vertex:" + sessionID
 				}
 
-				ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+				ctx, cancel := context.WithTimeoutCause(t.Context(), 3*time.Second, errors.WithStack(context.DeadlineExceeded))
 				defer cancel()
 				c, err := sm.Get(ctx, lookupID, noWait)
 				if err != nil {
@@ -388,18 +390,18 @@ func TestManagerGetHighConcurrencyAlreadyActive(t *testing.T) {
 					return
 				}
 				if c == nil {
-					errCh <- fmt.Errorf("nil caller from Get(noWait=%v)", noWait)
+					errCh <- errors.Errorf("nil caller from Get(noWait=%v)", noWait)
 					return
 				}
 				if c.SharedKey() != "active-shared" {
-					errCh <- fmt.Errorf("unexpected shared key %q", c.SharedKey())
+					errCh <- errors.Errorf("unexpected shared key %q", c.SharedKey())
 					return
 				}
 				errCh <- nil
 			}()
 		}
 
-		for i := 0; i < callers; i++ {
+		for range callers {
 			require.NoError(t, <-errCh)
 		}
 	}
@@ -415,17 +417,17 @@ func TestManagerGetBroadcastCancelStorm(t *testing.T) {
 	cancels := make([]context.CancelCauseFunc, 0, waiters)
 	errCh := make(chan error, waiters)
 
-	for i := 0; i < waiters; i++ {
+	for range waiters {
 		ctx, cancel := context.WithCancelCause(t.Context())
 		cancels = append(cancels, cancel)
 		go func(ctx context.Context) {
 			c, err := sm.Get(ctx, sessionID, false)
 			if err == nil {
-				errCh <- fmt.Errorf("expected error for canceled waiter")
+				errCh <- errors.Errorf("expected error for canceled waiter")
 				return
 			}
 			if c != nil {
-				errCh <- fmt.Errorf("expected nil caller for canceled waiter")
+				errCh <- errors.Errorf("expected nil caller for canceled waiter")
 				return
 			}
 			errCh <- nil
@@ -437,7 +439,7 @@ func TestManagerGetBroadcastCancelStorm(t *testing.T) {
 		cancel(context.Canceled)
 	}
 
-	for i := 0; i < waiters; i++ {
+	for range waiters {
 		select {
 		case err := <-errCh:
 			require.NoError(t, err)
@@ -456,16 +458,16 @@ func TestManagerGetBroadcastNoMissedWakeups(t *testing.T) {
 		waiters = 120
 	)
 
-	for round := 0; round < rounds; round++ {
+	for round := range rounds {
 		sessionID := fmt.Sprintf("broadcast-round-%d", round)
 		errCh := make(chan error, waiters)
 		var startWG sync.WaitGroup
 		startWG.Add(waiters)
 
-		for i := 0; i < waiters; i++ {
+		for range waiters {
 			go func() {
 				startWG.Done()
-				ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+				ctx, cancel := context.WithTimeoutCause(t.Context(), 3*time.Second, errors.WithStack(context.DeadlineExceeded))
 				defer cancel()
 				c, err := sm.Get(ctx, sessionID, false)
 				if err != nil {
@@ -473,7 +475,7 @@ func TestManagerGetBroadcastNoMissedWakeups(t *testing.T) {
 					return
 				}
 				if c == nil {
-					errCh <- fmt.Errorf("nil caller during broadcast round %d", round)
+					errCh <- errors.Errorf("nil caller during broadcast round %d", round)
 					return
 				}
 				errCh <- nil
@@ -483,8 +485,8 @@ func TestManagerGetBroadcastNoMissedWakeups(t *testing.T) {
 		startWG.Wait()
 		time.Sleep(50 * time.Millisecond)
 
-		_, cleanup := startSessionForTest(t, t.Context(), sm, sessionID, fmt.Sprintf("round-%d", round))
-		for i := 0; i < waiters; i++ {
+		_, cleanup := startSessionForTest(t.Context(), t, sm, sessionID, fmt.Sprintf("round-%d", round))
+		for range waiters {
 			require.NoError(t, <-errCh)
 		}
 		cleanup()
@@ -539,18 +541,14 @@ func TestManagerParallelCreateGetNeedFiveSecondChurn(t *testing.T) {
 
 	dialer := Dialer(testutil.TestStream(testutil.Handler(sm.HandleConn)))
 	deadline := time.Now().Add(5 * time.Second)
-	workers := runtime.GOMAXPROCS(0) * 4
-	if workers < 8 {
-		workers = 8
-	}
+	workers := max(runtime.GOMAXPROCS(0)*4, 8)
 
 	errCh := make(chan error, workers*16)
 	var seq atomic.Int64
 	var wg sync.WaitGroup
 	wg.Add(workers)
 
-	for worker := 0; worker < workers; worker++ {
-		worker := worker
+	for worker := range workers {
 		go func() {
 			defer wg.Done()
 			localCounter := int64(0)
@@ -560,16 +558,16 @@ func TestManagerParallelCreateGetNeedFiveSecondChurn(t *testing.T) {
 				id := fmt.Sprintf("churn-%d-%d", worker, localCounter)
 				sharedKey := "key-" + id
 
-				needCtx, needCancel := context.WithTimeout(t.Context(), 2*time.Second)
+				needCtx, needCancel := context.WithTimeoutCause(t.Context(), 2*time.Second, errors.WithStack(context.DeadlineExceeded))
 				needDone := make(chan error, 1)
 				go func() {
 					c, err := sm.Get(needCtx, id, false)
 					if err != nil {
-						needDone <- fmt.Errorf("need Get failed for %s: %w", id, err)
+						needDone <- errors.Errorf("need Get failed for %s: %v", id, err)
 						return
 					}
 					if c == nil {
-						needDone <- fmt.Errorf("need Get returned nil caller for %s", id)
+						needDone <- errors.Errorf("need Get returned nil caller for %s", id)
 						return
 					}
 					needDone <- nil
@@ -622,17 +620,17 @@ func TestManagerParallelCreateGetNeedFiveSecondChurn(t *testing.T) {
 					case <-time.After(2 * time.Second):
 					}
 					needCancel()
-					errCh <- fmt.Errorf("timed out waiting for need Get on %s", id)
+					errCh <- errors.Errorf("timed out waiting for need Get on %s", id)
 					return
 				}
 				needCancel()
 
-				for i := 0; i < 4; i++ {
+				for i := range 4 {
 					lookupID := id
 					if i%2 == 1 {
 						lookupID = "vertex:" + id
 					}
-					getCtx, getCancel := context.WithTimeout(t.Context(), 2*time.Second)
+					getCtx, getCancel := context.WithTimeoutCause(t.Context(), 2*time.Second, errors.WithStack(context.DeadlineExceeded))
 					c, err := sm.Get(getCtx, lookupID, i%2 == 0)
 					getCancel()
 					if err != nil {
@@ -642,7 +640,7 @@ func TestManagerParallelCreateGetNeedFiveSecondChurn(t *testing.T) {
 						case <-runDone:
 						case <-time.After(2 * time.Second):
 						}
-						errCh <- fmt.Errorf("active Get failed for %s: %w", id, err)
+						errCh <- errors.Errorf("active Get failed for %s: %v", id, err)
 						return
 					}
 					if c == nil {
@@ -652,7 +650,7 @@ func TestManagerParallelCreateGetNeedFiveSecondChurn(t *testing.T) {
 						case <-runDone:
 						case <-time.After(2 * time.Second):
 						}
-						errCh <- fmt.Errorf("active Get returned nil caller for %s", id)
+						errCh <- errors.Errorf("active Get returned nil caller for %s", id)
 						return
 					}
 				}
@@ -674,7 +672,7 @@ func TestManagerParallelCreateGetNeedFiveSecondChurn(t *testing.T) {
 						return
 					}
 				case <-time.After(2 * time.Second):
-					errCh <- fmt.Errorf("session run did not exit in time for %s", id)
+					errCh <- errors.Errorf("session run did not exit in time for %s", id)
 					return
 				}
 
@@ -699,18 +697,14 @@ func TestManagerGetParallelPairsWakeupsHTTPAndRawFiveSeconds(t *testing.T) {
 	httpDialer := httpUpgradeTestDialer(sm)
 
 	deadline := time.Now().Add(5 * time.Second)
-	pairs := runtime.GOMAXPROCS(0) * 3
-	if pairs < 12 {
-		pairs = 12
-	}
+	pairs := max(runtime.GOMAXPROCS(0)*3, 12)
 
 	errCh := make(chan error, pairs*32)
 	var loops atomic.Int64
 	var wg sync.WaitGroup
 	wg.Add(pairs)
 
-	for pairID := 0; pairID < pairs; pairID++ {
-		pairID := pairID
+	for pairID := range pairs {
 		go func() {
 			defer wg.Done()
 			localIter := 0
@@ -721,20 +715,20 @@ func TestManagerGetParallelPairsWakeupsHTTPAndRawFiveSeconds(t *testing.T) {
 
 				waiterStarted := make(chan struct{})
 				waiterErrCh := make(chan error, 1)
-				waiterCtx, waiterCancel := context.WithTimeout(t.Context(), 2*time.Second)
+				waiterCtx, waiterCancel := context.WithTimeoutCause(t.Context(), 2*time.Second, errors.WithStack(context.DeadlineExceeded))
 				go func() {
 					close(waiterStarted)
 					c, err := sm.Get(waiterCtx, sessionID, false)
 					if err != nil {
-						waiterErrCh <- fmt.Errorf("blocking Get failed for %s: %w", sessionID, err)
+						waiterErrCh <- errors.Errorf("blocking Get failed for %s: %v", sessionID, err)
 						return
 					}
 					if c == nil {
-						waiterErrCh <- fmt.Errorf("blocking Get returned nil for %s", sessionID)
+						waiterErrCh <- errors.Errorf("blocking Get returned nil for %s", sessionID)
 						return
 					}
 					if c.SharedKey() != sharedKey {
-						waiterErrCh <- fmt.Errorf("blocking Get shared key mismatch for %s: %q", sessionID, c.SharedKey())
+						waiterErrCh <- errors.Errorf("blocking Get shared key mismatch for %s: %q", sessionID, c.SharedKey())
 						return
 					}
 					waiterErrCh <- nil
@@ -793,7 +787,7 @@ func TestManagerGetParallelPairsWakeupsHTTPAndRawFiveSeconds(t *testing.T) {
 							return
 						}
 					case <-time.After(2 * time.Second):
-						creatorErrCh <- fmt.Errorf("session run did not exit for %s", sessionID)
+						creatorErrCh <- errors.Errorf("session run did not exit for %s", sessionID)
 						return
 					}
 
@@ -804,7 +798,7 @@ func TestManagerGetParallelPairsWakeupsHTTPAndRawFiveSeconds(t *testing.T) {
 				select {
 				case waiterErr = <-waiterErrCh:
 				case <-time.After(2 * time.Second):
-					waiterErr = fmt.Errorf("timeout waiting for blocking Get for %s", sessionID)
+					waiterErr = errors.Errorf("timeout waiting for blocking Get for %s", sessionID)
 				}
 				waiterCancel()
 
@@ -813,7 +807,7 @@ func TestManagerGetParallelPairsWakeupsHTTPAndRawFiveSeconds(t *testing.T) {
 				select {
 				case creatorErr = <-creatorErrCh:
 				case <-time.After(3 * time.Second):
-					creatorErr = fmt.Errorf("timeout waiting for creator cleanup for %s", sessionID)
+					creatorErr = errors.Errorf("timeout waiting for creator cleanup for %s", sessionID)
 				}
 
 				if waiterErr != nil {
@@ -909,7 +903,7 @@ func TestManagerHandleHTTPRequestDoesNotBlockUnrelatedGet(t *testing.T) {
 		writeStarted: make(chan struct{}),
 		releaseWrite: make(chan struct{}),
 	}
-	reqCtx, reqCancel := context.WithTimeout(t.Context(), 250*time.Millisecond)
+	reqCtx, reqCancel := context.WithTimeoutCause(t.Context(), 250*time.Millisecond, errors.WithStack(context.DeadlineExceeded))
 	defer reqCancel()
 	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, "http://session.local/upgrade", nil)
 	require.NoError(t, err)
@@ -929,7 +923,7 @@ func TestManagerHandleHTTPRequestDoesNotBlockUnrelatedGet(t *testing.T) {
 		t.Fatal("timed out waiting for HandleHTTPRequest response write")
 	}
 
-	getCtx, getCancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	getCtx, getCancel := context.WithTimeoutCause(t.Context(), 100*time.Millisecond, errors.WithStack(context.DeadlineExceeded))
 	defer getCancel()
 	getDone := make(chan struct{})
 	var c Caller
@@ -974,7 +968,7 @@ func TestManagerGetDoesNotBlockOnMutexPastDeadline(t *testing.T) {
 	held := <-sm.state
 	defer func() { sm.state <- held }()
 
-	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeoutCause(t.Context(), 100*time.Millisecond, errors.WithStack(context.DeadlineExceeded))
 	defer cancel()
 
 	done := make(chan struct{})


### PR DESCRIPTION
## Summary

This PR refactors `session.Manager` to use simpler, more deterministic concurrency control and removes global condition-variable wakeup behavior that caused unnecessary contention under load.

The implementation replaces shared mutable state guarded by `sync.Mutex` + `sync.Cond` with a single-owner state model and explicit per-session wait coordination.

This is part of the changes we run in our fork, along with https://github.com/moby/buildkit/pull/6630 and https://github.com/moby/buildkit/pull/6632, but broken out into separate PRs to make it easier to review. We have been running this change in our internal fork with no issues.

## Motivation

The previous manager implementation relied on:
- a global mutex around the session map
- broadcast wakeups for all waiters
- lock-heavy create/get paths that could amplify contention during high concurrency

Under churn (many waiters + session creation/cancellation), this could lead to avoidable wakeup storms and poor tail latency for unrelated lookups.

## What Changed

### Session manager concurrency model
- Introduced internal `sessionState` with explicit buckets:
  - `active` sessions
  - `reserved` session IDs (creation in progress)
  - `pending` waiters per session ID
- Added a single-owner state channel (`chan *sessionState`) and helper methods (`withState`, `tryWithState`) for serialized state mutation.
- Replaced global `Cond.Broadcast()` wakeups with targeted per-session waiter notification (`pendingWait` / `notifyPending` / `releasePendingWait`).

### Session lifecycle handling
- Added explicit `reserve -> activate -> remove` lifecycle to prevent duplicate registration races.
- Refactored `HandleHTTPRequest` and `HandleConn` through a shared `runSession` flow with clear setup/session/cleanup phases.
- Kept cleanup robust even on failure paths by ensuring reserved/active state is released.

### `Get` behavior improvements
- Added fast-path non-blocking lookup for active sessions.
- Preserved no-wait semantics (`noWait=true` returns immediately if no active session).
- Added cancellation-aware waiter cleanup so canceled callers do not leak pending wait entries.
- Improved timeout/cancel error context for easier debugging.

## Test Coverage

This PR adds broad test coverage for correctness and concurrency behavior, including:

- `session/manager_test.go`
  - no-wait and prefix lookup behavior
  - cancellation while waiting
  - pending waiter cleanup
  - high concurrency lookup/create scenarios
  - wakeup/broadcast stress cases
  - duplicate session handling and HTTP/raw session paths
  - deadline behavior under lock contention
- `session/manager_concurrency_test.go`
  - thundering-herd contention scenarios
- `session/group_test.go`
  - `Any()` edge cases, callback errors, and high-concurrency access patterns

## Impact

- Reduces global lock contention in session lookup/registration paths.
- Eliminates broad broadcast wakeups in favor of targeted waiter signaling.
- Improves determinism and isolation for concurrent `Get`, `HandleConn`, and `HandleHTTPRequest` operations.
- Makes session manager behavior easier to reason about and safer under heavy parallel workloads.

Fixes https://github.com/moby/buildkit/issues/6633
