### PR TITLE
fix: G118: Goroutine uses context.Background/TODO (gosec)

### DIFF
--- a/cache/manager.go
+++ b/cache/manager.go
@@ -162,12 +162,12 @@ func (cm *cacheManager) GetByBlob(ctx context.Context, desc ocispecs.Descriptor,
 		p = p2.(*immutableRef)
 
 		if err := p.Finalize(ctx); err != nil {
-			p.Release(context.TODO())
+			_ = p.Release(context.WithoutCancel(ctx))
 			return nil, err
 		}
 
 		if p.getChainID() == "" || p.getBlobChainID() == "" {
-			p.Release(context.TODO())
+			_ = p.Release(context.WithoutCancel(ctx))
 			return nil, errors.Errorf("failed to get ref by blob on non-addressable parent")
 		}
 		chainID = imagespecidentity.ChainID([]digest.Digest{p.getChainID(), chainID})
@@ -177,7 +177,7 @@ func (cm *cacheManager) GetByBlob(ctx context.Context, desc ocispecs.Descriptor,
 	releaseParent := false
 	defer func() {
 		if releaseParent || rerr != nil && p != nil {
-			p.Release(context.WithoutCancel(ctx))
+			_ = p.Release(context.WithoutCancel(ctx))
 		}
 	}()
 

--- a/cache/refs.go
+++ b/cache/refs.go
@@ -1508,12 +1508,12 @@ func (cr *cacheRecord) finalize(ctx context.Context) error {
 		ID:   cr.getSnapshotID(),
 		Type: "snapshots/" + cr.cm.Snapshotter.Name(),
 	}); err != nil {
-		cr.cm.LeaseManager.Delete(context.TODO(), leases.Lease{ID: cr.ID()})
+		_ = cr.cm.LeaseManager.Delete(context.WithoutCancel(ctx), leases.Lease{ID: cr.ID()})
 		return errors.Wrapf(err, "failed to add snapshot %s to lease", cr.getSnapshotID())
 	}
 
 	if err := cr.cm.Snapshotter.Commit(ctx, cr.getSnapshotID(), mutable.getSnapshotID()); err != nil {
-		cr.cm.LeaseManager.Delete(context.TODO(), leases.Lease{ID: cr.ID()})
+		_ = cr.cm.LeaseManager.Delete(context.WithoutCancel(ctx), leases.Lease{ID: cr.ID()})
 		return errors.Wrapf(err, "failed to commit %s to %s during finalize", mutable.getSnapshotID(), cr.getSnapshotID())
 	}
 	cr.mountCache = nil

--- a/client/client_image_source_test.go
+++ b/client/client_image_source_test.go
@@ -65,11 +65,11 @@ func testClientGatewayCanceledCredentialsCallbackReturns(t *testing.T, sb integr
 	target, err := url.Parse("http://" + registry)
 	require.NoError(t, err)
 
-	proxy := httputil.NewSingleHostReverseProxy(target)
-	director := proxy.Director
-	proxy.Director = func(req *http.Request) {
-		director(req)
-		req.Host = target.Host
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			pr.SetURL(target)
+			pr.Out.Host = target.Host
+		},
 	}
 
 	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/util/pull/pullprogress/progress.go
+++ b/util/pull/pullprogress/progress.go
@@ -33,7 +33,7 @@ func (p *ProviderWithProgress) ReaderAt(ctx context.Context, desc ocispecs.Descr
 
 	progressCtx, cancel := context.WithCancelCause(context.WithoutCancel(ctx))
 	doneCh := make(chan struct{})
-	go trackProgress(progressCtx, desc, p.Manager, doneCh) //nolint:gosec // Progress tracking is tied to the reader lifetime and canceled by Close.
+	go trackProgress(progressCtx, desc, p.Manager, doneCh) // Progress tracking is tied to the reader lifetime and canceled by Close.
 	return readerAtWithCancel{ReaderAt: ra, cancel: cancel, doneCh: doneCh, logger: bklog.G(ctx)}, nil
 }
 
@@ -67,7 +67,7 @@ func (f *FetcherWithProgress) Fetch(ctx context.Context, desc ocispecs.Descripto
 
 	progressCtx, cancel := context.WithCancelCause(context.WithoutCancel(ctx))
 	doneCh := make(chan struct{})
-	go trackProgress(progressCtx, desc, f.Manager, doneCh) //nolint:gosec // Progress tracking is tied to the reader lifetime and canceled by Close.
+	go trackProgress(progressCtx, desc, f.Manager, doneCh) // Progress tracking is tied to the reader lifetime and canceled by Close.
 	return readerWithCancel{ReadCloser: rc, cancel: cancel, doneCh: doneCh, logger: bklog.G(ctx)}, nil
 }
 
@@ -110,7 +110,7 @@ func trackProgress(ctx context.Context, desc ocispecs.Descriptor, manager PullMa
 		case <-ctx.Done():
 			onFinalStatus = true
 			// we need a context for the manager.Status() calls to pass once. after that this function will exit
-			ctx = context.TODO()
+			ctx = context.WithoutCancel(ctx) //nolint:fatcontext // ignore "nested context in loop"
 		case <-ticker.C:
 		}
 


### PR DESCRIPTION
    cache/manager.go:238:3: G118: Goroutine uses context.Background/TODO while request-scoped context is available (gosec)
            go link.Release(context.TODO())
            ^
    cache/refs.go:1519:2: G118: Goroutine uses context.Background/TODO while request-scoped context is available (gosec)
        go func() {
        ^
    session/testutil/testutil.go:22:3: G118: Goroutine uses context.Background/TODO while request-scoped context is available (gosec)
            go func() {
            ^
    solver/edge.go:975:4: G118: Goroutine uses context.Background/TODO while request-scoped context is available (gosec)
                go results[i].Release(context.TODO())
                ^
    util/leaseutil/manager.go:79:2: G118: Goroutine uses context.Background/TODO while request-scoped context is available (gosec)
        go l.Discard()
        ^