### PR TITLE
Dockerfile: update RootlessKit to v3.0.0

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -120,7 +120,7 @@ jobs:
           - containerd-snapshotter-stargz
           - oci
           - oci-rootless
-          - oci-rootless-slirp4netns-detachnetns
+          - oci-rootless-gvisor-tap-vsock-detachnetns
           - oci-snapshotter-stargz
         pkg: ${{ fromJson(needs.prepare.outputs.pkgs) }}
         kind: ${{ fromJson(needs.prepare.outputs.kinds) }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -459,6 +459,7 @@ RUN --mount=target=/tmp/gen_gpg_test_env.sh,source=hack/fixtures/gen_gpg_test_en
 RUN --mount=target=/tmp/gen_ssh_test_env.sh,source=hack/fixtures/gen_ssh_test_env.sh sh /tmp/gen_ssh_test_env.sh user1 && sh /tmp/gen_ssh_test_env.sh user2
 ENV CGO_ENABLED=0
 ENV GOTESTSUM_FORMAT=standard-verbose
+COPY --link --from=docker-engine / /usr/bin/
 COPY --link --from=gotestsum /out /usr/bin/
 COPY --link --from=minio /usr/bin/minio /usr/bin/
 COPY --link --from=minio-mc /usr/bin/mc /usr/bin/
@@ -470,7 +471,6 @@ COPY --link --from=containerd-alt-17 /out/containerd* /opt/containerd-alt-17/bin
 COPY --link --from=registry /out /usr/bin/
 COPY --link --from=runc /usr/bin/runc /usr/bin/
 COPY --link --from=containerd /out/containerd* /usr/bin/
-COPY --link --from=docker-engine / /usr/bin/
 COPY --link --from=docker-cli / /usr/bin/
 COPY --link --from=docker-buildx /buildx /usr/libexec/docker/cli-plugins/docker-buildx
 COPY --link --from=cni-plugins /opt/cni/bin/bridge /opt/cni/bin/host-local /opt/cni/bin/loopback /opt/cni/bin/firewall /opt/cni/bin/dnsname /opt/cni/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG CONTAINERD_VERSION=v2.2.2
 ARG CONTAINERD_ALT_VERSION_21=v2.1.6
 ARG CONTAINERD_ALT_VERSION_17=v1.7.30
 ARG REGISTRY_VERSION=v2.8.3
-ARG ROOTLESSKIT_VERSION=v2.3.6
+ARG ROOTLESSKIT_VERSION=v3.0.0
 ARG CNI_VERSION=v1.9.1
 ARG STARGZ_SNAPSHOTTER_VERSION=v0.18.2
 ARG NERDCTL_VERSION=v2.2.1
@@ -433,7 +433,7 @@ COPY --link --from=binaries / /
 
 FROM buildkit-base AS integration-tests-base
 ENV BUILDKIT_INTEGRATION_ROOTLESS_IDPAIR="1000:1000"
-RUN apk add --no-cache shadow shadow-uidmap sudo vim iptables ip6tables dnsmasq fuse curl git-daemon openssh-client openssl slirp4netns iproute2 gpg gpg-agent \
+RUN apk add --no-cache shadow shadow-uidmap sudo vim iptables ip6tables dnsmasq fuse curl git-daemon openssh-client openssl iproute2 gpg gpg-agent \
   && useradd --create-home --home-dir /home/user --uid 1000 -s /bin/sh user \
   && echo "XDG_RUNTIME_DIR=/run/user/1000; export XDG_RUNTIME_DIR" >> /home/user/.profile \
   && mkdir -m 0700 -p /run/user/1000 \
@@ -460,6 +460,7 @@ RUN --mount=target=/tmp/gen_ssh_test_env.sh,source=hack/fixtures/gen_ssh_test_en
 ENV CGO_ENABLED=0
 ENV GOTESTSUM_FORMAT=standard-verbose
 COPY --link --from=docker-engine / /usr/bin/
+RUN rm -f /usr/bin/vpnkit
 COPY --link --from=gotestsum /out /usr/bin/
 COPY --link --from=minio /usr/bin/minio /usr/bin/
 COPY --link --from=minio-mc /usr/bin/mc /usr/bin/

--- a/docs/rootless.md
+++ b/docs/rootless.md
@@ -23,8 +23,10 @@ buildctl --addr unix:///run/user/$UID/buildkit/buildkitd.sock build ...
 > [!TIP]
 > To isolate BuildKit daemon's network namespace from the host (recommended):
 > ```bash
-> rootlesskit --net=slirp4netns --copy-up=/etc --disable-host-loopback buildkitd
+> rootlesskit --net=gvisor-tap-vsock --copy-up=/etc --disable-host-loopback buildkitd
 > ```
+>
+> If you use RootlessKit older than v3.0, change `gvisor-tap-vsock` to other network drivers such as `slirp4netns`.
 
 ## Running BuildKit in Rootless mode (containerd worker)
 

--- a/examples/systemd/user/buildkit.service
+++ b/examples/systemd/user/buildkit.service
@@ -5,6 +5,7 @@ Documentation=https://github.com/moby/buildkit
 [Service]
 Type=notify
 NotifyAccess=all
+# TODO: change the network driver from slirp4netns to gvisor-tap-vsock when rootlesskit v3.0 or later is widely used.
 ExecStart=rootlesskit --net=slirp4netns --copy-up=/etc --disable-host-loopback /usr/local/bin/buildkitd --addr unix://%t/buildkit/rootless
 
 [Install]

--- a/util/testutil/workers/oci_unix.go
+++ b/util/testutil/workers/oci_unix.go
@@ -21,8 +21,8 @@ func initOCIWorker() {
 		}
 		if integration.RootlessSupported(uid) {
 			integration.Register(&OCI{ID: "oci-rootless", UID: uid, GID: gid})
-			integration.Register(&OCI{ID: "oci-rootless-slirp4netns-detachnetns", UID: uid, GID: gid,
-				RootlessKitNet: "slirp4netns", RootlessKitDetachNetNS: true})
+			integration.Register(&OCI{ID: "oci-rootless-gvisor-tap-vsock-detachnetns", UID: uid, GID: gid,
+				RootlessKitNet: "gvisor-tap-vsock", RootlessKitDetachNetNS: true})
 		}
 	}
 


### PR DESCRIPTION
slirp4netns is no longer needed, as gvisor-tap-vsock is now embededd in rootlesskit.
https://github.com/rootless-containers/rootlesskit/releases/tag/v3.0.0