### PR TITLE
client: write CDI specs atomically in integration tests

### DIFF
--- a/client/client_cdi_test.go
+++ b/client/client_cdi_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/continuity"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/util/testutil/integration"
 	"github.com/moby/buildkit/util/testutil/workers"
@@ -417,9 +418,12 @@ type cdiSpecFile struct {
 }
 
 func writeCDISpecFile(t *testing.T, sb integration.Sandbox, c *Client, csf ...cdiSpecFile) {
+	t.Helper()
+
+	specDir := sb.CDISpecDir()
 	kinds := make(map[string]struct{})
 	for _, f := range csf {
-		require.NoError(t, os.WriteFile(filepath.Join(sb.CDISpecDir(), f.Name), f.Data, 0600))
+		require.NoError(t, continuity.AtomicWriteFile(filepath.Join(specDir, f.Name), f.Data, 0600))
 		kinds[f.DeviceKind] = struct{}{}
 	}
 


### PR DESCRIPTION
relates to https://github.com/moby/buildkit/actions/runs/24208768555/job/70672691290?pr=6677#step:8:2531

```
=== Failed
=== FAIL: client TestIntegration/TestCDINotAllowed/worker=oci (0.74s)
    client_cdi_test.go:433: 
        	Error Trace:	/src/client/client_cdi_test.go:433
        	            				/src/client/client_cdi_test.go:113
        	            				/src/util/testutil/integration/run.go:105
        	            				/src/util/testutil/integration/run.go:253
        	Error:      	Received unexpected error:
        	            	Unavailable: connection error: desc = "error reading server preface: read unix @->/tmp/bktest_buildkitd784850981/buildkitd.sock: read: connection reset by peer"
        	            	github.com/moby/buildkit/util/stack.Enable
        	            		/src/util/stack/stack.go:82
        	            	github.com/moby/buildkit/util/grpcerrors.FromGRPC
        	            		/src/util/grpcerrors/grpcerrors.go:264
        	            	github.com/moby/buildkit/util/grpcerrors.UnaryClientInterceptor
        	            		/src/util/grpcerrors/intercept.go:41
        	            	google.golang.org/grpc.(*ClientConn).Invoke
        	            		/src/vendor/google.golang.org/grpc/call.go:35
        	            	github.com/moby/buildkit/api/services/control.(*controlClient).ListWorkers
        	            		/src/api/services/control/control_grpc.pb.go:130
        	            	github.com/moby/buildkit/client.(*Client).ListWorkers
        	            		/src/client/workers.go:32
        	            	github.com/moby/buildkit/client.writeCDISpecFile
        	            		/src/client/client_cdi_test.go:432
        	            	github.com/moby/buildkit/client.testCDINotAllowed
        	            		/src/client/client_cdi_test.go:113
        	            	github.com/moby/buildkit/util/testutil/integration.testFunc.Run
        	            		/src/util/testutil/integration/run.go:105
        	            	github.com/moby/buildkit/util/testutil/integration.Run.Run.func2.func4
        	            		/src/util/testutil/integration/run.go:253
        	            	testing.tRunner
        	            		/usr/local/go/src/testing/testing.go:2036
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1771
        	            	failed to list workers
        	            	github.com/moby/buildkit/client.(*Client).ListWorkers
        	            		/src/client/workers.go:34
        	            	github.com/moby/buildkit/client.writeCDISpecFile
        	            		/src/client/client_cdi_test.go:432
        	            	github.com/moby/buildkit/client.testCDINotAllowed
        	            		/src/client/client_cdi_test.go:113
        	            	github.com/moby/buildkit/util/testutil/integration.testFunc.Run
        	            		/src/util/testutil/integration/run.go:105
        	            	github.com/moby/buildkit/util/testutil/integration.Run.Run.func2.func4
        	            		/src/util/testutil/integration/run.go:253
        	            	testing.tRunner
        	            		/usr/local/go/src/testing/testing.go:2036
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1771
        	Test:       	TestIntegration/TestCDINotAllowed/worker=oci
        	Messages:   	failed to list workers
    sandbox.go:202: stderr: /usr/bin/buildkitd --oci-worker=true --containerd-worker=false --oci-worker-gc=false --oci-worker-labels=org.mobyproject.buildkit.worker.sandbox=true --config=/tmp/bktest_config4206214387/buildkitd.toml --root /tmp/bktest_buildkitd784850981 --addr unix:///tmp/bktest_buildkitd784850981/buildkitd.sock --debug
    sandbox.go:205: > StartCmd 2026-04-09 19:29:31.392438389 +0000 UTC m=+28.633039284 /usr/bin/buildkitd --oci-worker=true --containerd-worker=false --oci-worker-gc=false --oci-worker-labels=org.mobyproject.buildkit.worker.sandbox=true --config=/tmp/bktest_config4206214387/buildkitd.toml --root /tmp/bktest_buildkitd784850981 --addr unix:///tmp/bktest_buildkitd784850981/buildkitd.sock --debug
    sandbox.go:205: time="2026-04-09T19:29:31Z" level=debug msg="debug handlers listening at unix:///tmp/bktest_buildkitd784850981/buildkitd-debug.sock"
    sandbox.go:205: time="2026-04-09T19:29:31Z" level=info msg="auto snapshotter: using overlayfs"
    sandbox.go:205: buildkitd: failed to load CDI Spec failed to parse CDI Spec "/tmp/buildkit-integration-cdi967930643/vendor1-device.yaml", no Spec data
    sandbox.go:205: CDI registry initialization failure
    sandbox.go:205: main.getCDIManager
    sandbox.go:205: 	/src/cmd/buildkitd/main.go:1102
    sandbox.go:205: main.ociWorkerInitializer
    sandbox.go:205: 	/src/cmd/buildkitd/main_oci_worker.go:308
    sandbox.go:205: main.newWorkerController
    sandbox.go:205: 	/src/cmd/buildkitd/main.go:904
    sandbox.go:205: main.newController
    sandbox.go:205: 	/src/cmd/buildkitd/main.go:807
    sandbox.go:205: main.main.func3
    sandbox.go:205: 	/src/cmd/buildkitd/main.go:364
    sandbox.go:205: github.com/urfave/cli.HandleAction
    sandbox.go:205: 	/src/vendor/github.com/urfave/cli/app.go:524
    sandbox.go:205: github.com/urfave/cli.(*App).Run
    sandbox.go:205: 	/src/vendor/github.com/urfave/cli/app.go:286
    sandbox.go:205: main.main
    sandbox.go:205: 	/src/cmd/buildkitd/main.go:431
    sandbox.go:205: runtime.main
    sandbox.go:205: 	/usr/local/go/src/runtime/proc.go:290
    sandbox.go:205: runtime.goexit
    sandbox.go:205: 	/usr/local/go/src/runtime/asm_amd64.s:1771
    sandbox.go:205: > stopped 2026-04-09 19:29:31.515444032 +0000 UTC m=+28.756044907 exit status 1 1
    sandbox.go:202: stdout: /usr/bin/buildkitd --oci-worker=true --containerd-worker=false --oci-worker-gc=false --oci-worker-labels=org.mobyproject.buildkit.worker.sandbox=true --config=/tmp/bktest_config4206214387/buildkitd.toml --root /tmp/bktest_buildkitd784850981 --addr unix:///tmp/bktest_buildkitd784850981/buildkitd.sock --debug
    --- FAIL: TestIntegration/TestCDINotAllowed/worker=oci (0.74s)
```

The failing test was racing the CDI file watcher by writing directly into a watched directory, which could make a valid YAML fixture look empty while buildkitd was reading it.