### PR TITLE
github: fix integration tests not running in containerd 2.0

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -116,7 +116,7 @@ jobs:
           - containerd
           - containerd-rootless
           - containerd-1.7
-          - containerd-2.0
+          - containerd-2.1
           - containerd-snapshotter-stargz
           - oci
           - oci-rootless


### PR DESCRIPTION
Integration tests were skipped because config didn't match the worker setup in dockerfile.