### PR TITLE
vendor: github.com/containerd/containerd/v2 v2.2.3, github.com/Microsoft/hcsshim v0.14.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.5.0
 	github.com/Microsoft/go-winio v0.6.2
-	github.com/Microsoft/hcsshim v0.14.0-rc.1
+	github.com/Microsoft/hcsshim v0.14.1
 	github.com/ProtonMail/go-crypto v1.3.0
 	github.com/agext/levenshtein v1.2.3
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/containerd/accelerated-container-image v1.3.0
 	github.com/containerd/console v1.0.5
 	github.com/containerd/containerd/api v1.10.0
-	github.com/containerd/containerd/v2 v2.2.2
+	github.com/containerd/containerd/v2 v2.2.3
 	github.com/containerd/continuity v0.4.5
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/fuse-overlayfs-snapshotter/v2 v2.1.7

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,8 @@ github.com/containerd/console v1.0.5 h1:R0ymNeydRqH2DmakFNdmjR2k0t7UPuiOV/N/27/q
 github.com/containerd/console v1.0.5/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
 github.com/containerd/containerd/api v1.10.0 h1:5n0oHYVBwN4VhoX9fFykCV9dF1/BvAXeg2F8W6UYq1o=
 github.com/containerd/containerd/api v1.10.0/go.mod h1:NBm1OAk8ZL+LG8R0ceObGxT5hbUYj7CzTmR3xh0DlMM=
-github.com/containerd/containerd/v2 v2.2.2 h1:mjVQdtfryzT7lOqs5EYUFZm8ioPVjOpkSoG1GJPxEMY=
-github.com/containerd/containerd/v2 v2.2.2/go.mod h1:5Jhevmv6/2J+Iu/A2xXAdUIdI5Ah/hfyO7okJ4AFIdY=
+github.com/containerd/containerd/v2 v2.2.3 h1:mOBRLaHGvmgy0bRo1Sg6OD8ugMKZIvCoWWMeMMygliA=
+github.com/containerd/containerd/v2 v2.2.3/go.mod h1:ns24cwt+p36mRnuKE3hLRxVBpuSP+a/Y25AMki1t/RY=
 github.com/containerd/continuity v0.4.5 h1:ZRoN1sXq9u7V6QoHMcVWGhOwDFqZ4B9i5H6un1Wh0x4=
 github.com/containerd/continuity v0.4.5/go.mod h1:/lNJvtJKUQStBzpVQ1+rasXO1LAWtUQssk28EZvJ3nE=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/Microsoft/hcsshim v0.14.0-rc.1 h1:qAPXKwGOkVn8LlqgBN8GS0bxZ83hOJpcjxzmlQKxKsQ=
-github.com/Microsoft/hcsshim v0.14.0-rc.1/go.mod h1:hTKFGbnDtQb1wHiOWv4v0eN+7boSWAHyK/tNAaYZL0c=
+github.com/Microsoft/hcsshim v0.14.1 h1:CMuB3fqQVfPdhyXhUqYdUmPUIOhJkmghCx3dJet8Cqs=
+github.com/Microsoft/hcsshim v0.14.1/go.mod h1:VnzvPLyWUhxiPVsJ31P6XadxCcTogTguBFDy/1GR/OM=
 github.com/ProtonMail/go-crypto v1.3.0 h1:ILq8+Sf5If5DCpHQp4PbZdS1J7HDFRXz/+xKBiRGFrw=
 github.com/ProtonMail/go-crypto v1.3.0/go.mod h1:9whxjD8Rbs29b4XWbB8irEcE8KHMqaR2e7GWU1R+/PE=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=

--- a/vendor/github.com/containerd/containerd/v2/core/diff/apply/apply.go
+++ b/vendor/github.com/containerd/containerd/v2/core/diff/apply/apply.go
@@ -18,6 +18,8 @@ package apply
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"time"
@@ -25,6 +27,7 @@ import (
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/diff"
 	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -33,13 +36,22 @@ import (
 // NewFileSystemApplier returns an applier which simply mounts
 // and applies diff onto the mounted filesystem.
 func NewFileSystemApplier(cs content.Provider) diff.Applier {
+	return NewFileSystemApplierWithMountManager(cs, nil)
+}
+
+// NewFileSystemApplierWithMountManager returns an applier which simply mounts and
+// applies diff onto the mounted filesystem.
+// An optional mount manager can be specified and it will take effect when applying.
+func NewFileSystemApplierWithMountManager(cs content.Provider, mm mount.Manager) diff.Applier {
 	return &fsApplier{
 		store: cs,
+		mount: mm,
 	}
 }
 
 type fsApplier struct {
 	store content.Provider
+	mount mount.Manager
 }
 
 var emptyDesc = ocispec.Descriptor{}
@@ -96,6 +108,23 @@ func (s *fsApplier) Apply(ctx context.Context, desc ocispec.Descriptor, mounts [
 	digester := digest.Canonical.Digester()
 	rc := &readCounter{
 		r: io.TeeReader(processor, digester.Hash()),
+	}
+
+	// The number of `mounts` that need to be parsed by the mount manager
+	// will be more than 1 in reality; this is needed to work around some
+	// overlayfs/bind shortcuts in core/diff/apply/apply_linux.go
+	if s.mount != nil && len(mounts) > 1 {
+		var b [3]byte
+		// Ignore read failures, just decreases uniqueness
+		rand.Read(b[:])
+		id := fmt.Sprintf("fs-diffapply-%d-%s", t1.Nanosecond(), base64.URLEncoding.EncodeToString(b[:]))
+		info, err := s.mount.Activate(ctx, id, mounts)
+		if err == nil {
+			defer s.mount.Deactivate(ctx, id)
+			mounts = info.System
+		} else if !errdefs.IsNotImplemented(err) {
+			return emptyDesc, fmt.Errorf("failed to activate mounts: %w", err)
+		}
 	}
 
 	if err := apply(ctx, mounts, rc, config.SyncFs); err != nil {

--- a/vendor/github.com/containerd/containerd/v2/core/unpack/unpacker.go
+++ b/vendor/github.com/containerd/containerd/v2/core/unpack/unpacker.go
@@ -524,6 +524,15 @@ func (u *Unpacker) unpack(
 			case <-fetchC[i-fetchOffset]:
 			}
 
+			// In case of parallel unpack, the parent snapshot isn't provided to the snapshotter.
+			// The overlayfs will return bind mounts for all layers, we need to convert them
+			// to overlay mounts for the applier to perform whiteout conversion correctly.
+			// TODO: this is a temporary workaround until #13053 lands.
+			// See: https://github.com/containerd/containerd/issues/13030
+			if i > 0 && parallel && unpack.SnapshotterKey == "overlayfs" {
+				mounts = bindToOverlay(mounts)
+			}
+
 			diff, err := a.Apply(ctx, desc, mounts, unpack.ApplyOpts...)
 			if err != nil {
 				cleanup.Do(ctx, abort)
@@ -746,4 +755,24 @@ func uniquePart() string {
 	// Ignore read failures, just decreases uniqueness
 	rand.Read(b[:])
 	return fmt.Sprintf("%d-%s", t.Nanosecond(), base64.URLEncoding.EncodeToString(b[:]))
+}
+
+// TODO: this is a temporary workaround until #13053 lands.
+func bindToOverlay(mounts []mount.Mount) []mount.Mount {
+	if len(mounts) != 1 || mounts[0].Type != "bind" {
+		return mounts
+	}
+
+	m := mount.Mount{
+		Type:   "overlay",
+		Source: "overlay",
+	}
+	for _, o := range mounts[0].Options {
+		if o != "rbind" {
+			m.Options = append(m.Options, o)
+		}
+	}
+	m.Options = append(m.Options, "upperdir="+mounts[0].Source)
+
+	return []mount.Mount{m}
 }

--- a/vendor/github.com/containerd/containerd/v2/pkg/archive/tar_unix.go
+++ b/vendor/github.com/containerd/containerd/v2/pkg/archive/tar_unix.go
@@ -80,7 +80,7 @@ func openFile(name string, flag int, perm os.FileMode) (*os.File, error) {
 		return nil, err
 	}
 	// Call chmod to avoid permission mask
-	if err := os.Chmod(name, perm); err != nil {
+	if err := f.Chmod(perm); err != nil {
 		f.Close()
 		return nil, err
 	}

--- a/vendor/github.com/containerd/containerd/v2/pkg/oci/spec_opts.go
+++ b/vendor/github.com/containerd/containerd/v2/pkg/oci/spec_opts.go
@@ -963,7 +963,7 @@ func WithAppendAdditionalGroups(groups ...string) SpecOpts {
 			defer ensureAdditionalGids(s)
 
 			var ugroups []user.Group
-			f, groupErr := root.Open("etc/group")
+			f, groupErr := openUserFile(root, "etc/group")
 			if groupErr == nil {
 				defer f.Close()
 				ugroups, groupErr = user.ParseGroup(f)
@@ -1142,7 +1142,7 @@ func UserFromPath(root string, filter func(user.User) bool) (user.User, error) {
 // UserFromFS inspects the user object using /etc/passwd in the specified fs.FS.
 // filter can be nil.
 func UserFromFS(root fs.FS, filter func(user.User) bool) (user.User, error) {
-	f, err := root.Open("etc/passwd")
+	f, err := openUserFile(root, "etc/passwd")
 	if err != nil {
 		return user.User{}, err
 	}
@@ -1174,7 +1174,7 @@ func GIDFromPath(root string, filter func(user.Group) bool) (gid uint32, err err
 // GIDFromFS inspects the GID using /etc/group in the specified fs.FS.
 // filter can be nil.
 func GIDFromFS(root fs.FS, filter func(user.Group) bool) (gid uint32, err error) {
-	f, err := root.Open("etc/group")
+	f, err := openUserFile(root, "etc/group")
 	if err != nil {
 		return 0, err
 	}
@@ -1191,7 +1191,7 @@ func GIDFromFS(root fs.FS, filter func(user.Group) bool) (gid uint32, err error)
 }
 
 func getSupplementalGroupsFromFS(root fs.FS, filter func(user.Group) bool) ([]uint32, error) {
-	f, err := root.Open("etc/group")
+	f, err := openUserFile(root, "etc/group")
 	if err != nil {
 		return []uint32{}, err
 	}
@@ -1788,4 +1788,44 @@ func WithWindowsNetworkNamespace(ns string) SpecOpts {
 		s.Windows.Network.NetworkNamespace = ns
 		return nil
 	}
+}
+
+// readLinker defines the ReadLink method locally.
+// We keep this shim to ensure compatibility with build environments where
+// the standard library's fs.ReadLinkFS interface is not yet available or recognized.
+type readLinker interface {
+	ReadLink(name string) (string, error)
+}
+
+// openUserFile attempts to open a file within the root fs.
+// It handles cases where the file is an absolute symlink (e.g., NixOS /etc/passwd -> /nix/store/...),
+// which triggers "path escapes from parent" errors in Go 1.24+ due to stricter os.DirFS validation.
+func openUserFile(root fs.FS, name string) (fs.File, error) {
+	f, err := root.Open(name)
+	if err == nil {
+		return f, nil
+	}
+
+	// Check if the FS implements our local ReadLink interface.
+	// We use a local interface instead of fs.ReadLinkFS to avoid strict dependency
+	// issues in some build environments.
+	if lfs, ok := root.(readLinker); ok {
+		if target, lerr := lfs.ReadLink(name); lerr == nil {
+			// Use filepath.IsAbs to handle platform-agnostic absolute path checks
+			if filepath.IsAbs(target) {
+				// Re-anchor the absolute path to the root.
+				// e.g. /nix/store/... becomes nix/store/... (relative to root fs)
+				// We use filepath.Rel to safely strip the leading separator.
+				rel, rerr := filepath.Rel(string(filepath.Separator), target)
+				if rerr == nil {
+					// filepath.Rel might return OS-specific separators (backslashes on Windows).
+					// fs.Open strictly expects forward slashes, so we convert it.
+					return root.Open(filepath.ToSlash(rel))
+				}
+			}
+		}
+	}
+
+	// Return the original error if we couldn't resolve it
+	return nil, err
 }

--- a/vendor/github.com/containerd/containerd/v2/version/version.go
+++ b/vendor/github.com/containerd/containerd/v2/version/version.go
@@ -24,7 +24,7 @@ var (
 	Package = "github.com/containerd/containerd/v2"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "2.2.2+unknown"
+	Version = "2.2.3+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -354,7 +354,7 @@ github.com/containerd/containerd/api/types/runc/options
 github.com/containerd/containerd/api/types/runtimeoptions/v1
 github.com/containerd/containerd/api/types/task
 github.com/containerd/containerd/api/types/transfer
-# github.com/containerd/containerd/v2 v2.2.2
+# github.com/containerd/containerd/v2 v2.2.3
 ## explicit; go 1.24.3
 github.com/containerd/containerd/v2/client
 github.com/containerd/containerd/v2/core/containers

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -88,7 +88,7 @@ github.com/Microsoft/go-winio/internal/stringbuffer
 github.com/Microsoft/go-winio/pkg/bindfilter
 github.com/Microsoft/go-winio/pkg/guid
 github.com/Microsoft/go-winio/vhd
-# github.com/Microsoft/hcsshim v0.14.0-rc.1
+# github.com/Microsoft/hcsshim v0.14.1
 ## explicit; go 1.23.0
 github.com/Microsoft/hcsshim
 github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options


### PR DESCRIPTION
### vendor: github.com/Microsoft/hcsshim v0.14.1

v0.14.0: no diff: same commit, but re-tagged;
https://github.com/microsoft/hcsshim/compare/v0.14.0-rc.1...v0.14.0

v0.14.1: no changes in vendored files; fixes Windows containers when
running with process isolation on Docker

- shim: skip SandboxPlatform validation when platform is not explicitly set
- WCOW: restore support for client-mounted roots

full diff: https://github.com/Microsoft/hcsshim/compare/v0.14.0...v0.14.1

### vendor: github.com/containerd/containerd/v2 v2.2.3

- Fix TOCTOU race bug in tar extraction
- fix(oci): handle absolute symlinks in rootfs user lookup
- fix(oci): apply absolute symlink resolution to /etc/group
- Preserve host cgroup mount options for privileged containers

full diff: https://github.com/containerd/containerd/compare/v2.2.2...v2.2.3

