### PR TITLE
ci(zizmor): enable secrets-outside-env

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,4 +1,0 @@
-# https://docs.zizmor.sh/configuration/
-rules:
-  secrets-outside-env: # FIXME: remove this rule when zizmor 1.24.0 is released, fixing the right persona attached to this rule: https://github.com/zizmorcore/zizmor/pull/1783
-    disable: true


### PR DESCRIPTION
Disabling `secrets-outside-env` rule not needed anymore since Zizmor 1.24.0.