### PR TITLE
source/git: add fetch-by-commit support

### DIFF
--- a/client/llb/source.go
+++ b/client/llb/source.go
@@ -483,6 +483,11 @@ func Git(url, fragment string, opts ...GitOption) State {
 		addCap(&gi.Constraints, pb.CapSourceGitMTime)
 	}
 
+	if gi.FetchByCommit {
+		attrs[pb.AttrGitFetchByCommit] = "true"
+		addCap(&gi.Constraints, pb.CapSourceGitFetchByCommit)
+	}
+
 	addCap(&gi.Constraints, pb.CapSourceGit)
 
 	source := NewSource("git://"+id, attrs, gi.Constraints)
@@ -511,6 +516,7 @@ type GitInfo struct {
 	SubDir           string
 	SkipSubmodules   bool
 	MTime            string
+	FetchByCommit    bool
 }
 
 func GitRef(v string) GitOption {
@@ -574,6 +580,21 @@ func MountSSHSock(sshID string) GitOption {
 func GitChecksum(v string) GitOption {
 	return gitOptionFunc(func(gi *GitInfo) {
 		gi.Checksum = v
+	})
+}
+
+// GitFetchByCommit makes the git source trust the provided checksum as the
+// commit to fetch, without resolving the ref against the remote. The ref, if
+// set, is applied locally after the commit is fetched so that cache keys
+// still depend on it. This is useful when the remote ref may have moved
+// since the original resolution.
+//
+// Unqualified ref names are canonicalized to "refs/heads/<name>" to match
+// the normal path's cache keys for branches. Tags must be passed fully
+// qualified ("refs/tags/<name>").
+func GitFetchByCommit() GitOption {
+	return gitOptionFunc(func(gi *GitInfo) {
+		gi.FetchByCommit = true
 	})
 }
 

--- a/frontend/dockerfile/dfgitutil/git_ref.go
+++ b/frontend/dockerfile/dfgitutil/git_ref.go
@@ -59,6 +59,11 @@ type GitRef struct {
 
 	// MTime controls file modification time policy: "checkout" (default) or "commit".
 	MTime string
+
+	// FetchByCommit, when true, trusts Checksum as the commit and skips comparing
+	// it against the remote ref. The commit is fetched directly and the ref name
+	// (if any) is applied locally.
+	FetchByCommit bool
 }
 
 // ParseGitRef parses a git ref.
@@ -134,7 +139,7 @@ func (gf *GitRef) loadQuery(query url.Values) error {
 		case 0, 1:
 			if len(v) == 0 || v[0] == "" {
 				switch k {
-				case "submodules", "keep-git-dir":
+				case "submodules", "keep-git-dir", "fetch-by-commit":
 					v = nil
 				default:
 					return errors.Errorf("query %q has no value", k)
@@ -192,6 +197,18 @@ func (gf *GitRef) loadQuery(query url.Values) error {
 			default:
 				return errors.Errorf("invalid mtime value: %q (must be \"checkout\" or \"commit\")", v[0])
 			}
+		case "fetch-by-commit":
+			var vv bool
+			if len(v) == 0 {
+				vv = true
+			} else {
+				var err error
+				vv, err = strconv.ParseBool(v[0])
+				if err != nil {
+					return errors.Errorf("invalid fetch-by-commit value: %q", v[0])
+				}
+			}
+			gf.FetchByCommit = vv
 		default:
 			return errors.Errorf("unexpected query %q", k)
 		}

--- a/frontend/dockerfile/dfgitutil/git_ref_test.go
+++ b/frontend/dockerfile/dfgitutil/git_ref_test.go
@@ -235,6 +235,36 @@ func TestParseGitRef(t *testing.T) {
 			err: "invalid mtime value",
 		},
 		{
+			ref: "https://github.com/moby/buildkit.git?fetch-by-commit=true&checksum=deadbeef#refs/heads/branch",
+			expected: &GitRef{
+				Remote:        "https://github.com/moby/buildkit.git",
+				ShortName:     "buildkit",
+				Ref:           "refs/heads/branch",
+				Checksum:      "deadbeef",
+				FetchByCommit: true,
+			},
+		},
+		{
+			ref: "https://github.com/moby/buildkit.git?fetch-by-commit&checksum=deadbeef",
+			expected: &GitRef{
+				Remote:        "https://github.com/moby/buildkit.git",
+				ShortName:     "buildkit",
+				Checksum:      "deadbeef",
+				FetchByCommit: true,
+			},
+		},
+		{
+			ref: "https://github.com/moby/buildkit.git?fetch-by-commit=false",
+			expected: &GitRef{
+				Remote:    "https://github.com/moby/buildkit.git",
+				ShortName: "buildkit",
+			},
+		},
+		{
+			ref: "https://github.com/moby/buildkit.git?fetch-by-commit=invalid",
+			err: "invalid fetch-by-commit value",
+		},
+		{
 			ref: "https://github.com/moby/buildkit.git?invalid=123",
 			err: "unexpected query \"invalid\"",
 		},

--- a/frontend/dockerfile/dockerfile2llb/convert_copy.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_copy.go
@@ -167,6 +167,9 @@ func dispatchCopy(d *dispatchState, cfg copyConfig) error {
 			if gitRef.Submodules != nil && !*gitRef.Submodules {
 				gitOptions = append(gitOptions, llb.GitSkipSubmodules())
 			}
+			if gitRef.FetchByCommit {
+				gitOptions = append(gitOptions, llb.GitFetchByCommit())
+			}
 
 			st := llb.Git(gitRef.Remote, "", gitOptions...)
 			opts := append([]llb.CopyOption{&llb.CopyInfo{

--- a/frontend/dockerui/context.go
+++ b/frontend/dockerui/context.go
@@ -317,6 +317,9 @@ func DetectGitContext(ref string, keepGit *bool, opts ...llb.GitOption) (*llb.St
 	if g.MTime != "" {
 		gitOpts = append(gitOpts, llb.GitMTime(g.MTime))
 	}
+	if g.FetchByCommit {
+		gitOpts = append(gitOpts, llb.GitFetchByCommit())
+	}
 
 	st := llb.Git(g.Remote, "", gitOpts...)
 	return &st, true, nil

--- a/solver/pb/attr.go
+++ b/solver/pb/attr.go
@@ -9,6 +9,7 @@ const AttrMountSSHSock = "git.mountsshsock"
 const AttrGitChecksum = "git.checksum"
 const AttrGitSkipSubmodules = "git.skipsubmodules"
 const AttrGitMTime = "git.mtime"
+const AttrGitFetchByCommit = "git.fetchbycommit"
 
 const AttrGitSignatureVerifyPubKey = "git.sig.pubkey"
 const AttrGitSignatureVerifyRejectExpired = "git.sig.rejectexpired"

--- a/solver/pb/caps.go
+++ b/solver/pb/caps.go
@@ -35,6 +35,7 @@ const (
 	CapSourceGitSkipSubmodules  apicaps.CapID = "source.git.skipsubmodules"
 	CapSourceGitSignatureVerify apicaps.CapID = "source.git.signatureverify"
 	CapSourceGitMTime           apicaps.CapID = "source.git.mtime"
+	CapSourceGitFetchByCommit   apicaps.CapID = "source.git.fetchbycommit"
 
 	CapSourceHTTP         apicaps.CapID = "source.http"
 	CapSourceHTTPAuth     apicaps.CapID = "source.http.auth"
@@ -258,6 +259,12 @@ func init() {
 
 	Caps.Init(apicaps.Cap{
 		ID:      CapSourceGitMTime,
+		Enabled: true,
+		Status:  apicaps.CapStatusExperimental,
+	})
+
+	Caps.Init(apicaps.Cap{
+		ID:      CapSourceGitFetchByCommit,
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})

--- a/source/git/identifier.go
+++ b/source/git/identifier.go
@@ -20,6 +20,7 @@ type GitIdentifier struct {
 	KnownSSHHosts    string
 	SkipSubmodules   bool
 	MTime            string // "checkout" (default) or "commit"
+	FetchByCommit    bool
 
 	VerifySignature *GitSignatureVerifyOptions
 }

--- a/source/git/source.go
+++ b/source/git/source.go
@@ -137,6 +137,8 @@ func (gs *Source) Identifier(scheme, ref string, attrs map[string]string, platfo
 			id.VerifySignature.IgnoreSignedTag = v == "true"
 		case pb.AttrGitMTime:
 			id.MTime = v
+		case pb.AttrGitFetchByCommit:
+			id.FetchByCommit = v == "true"
 		}
 	}
 	if err := validateGitRef(id.Ref); err != nil {
@@ -508,6 +510,29 @@ func (gs *gitSourceHandler) resolveMetadata(ctx context.Context, jobCtx solver.J
 		}, nil
 	}
 
+	if gs.src.FetchByCommit {
+		if gs.src.Checksum == "" {
+			return nil, errors.Errorf("fetch-by-commit requires a checksum or a commit SHA ref")
+		}
+		if !gitutil.IsCommitSHA(gs.src.Checksum) {
+			return nil, errors.Errorf("fetch-by-commit requires a full commit SHA checksum, got %q", gs.src.Checksum)
+		}
+		// Canonicalize unqualified refs so that cache keys match those
+		// produced by the normal path's ls-remote-driven normalization.
+		// Unqualified names are treated as branches (git's preferred
+		// resolution); tags must be passed as "refs/tags/<name>".
+		if gs.src.Ref != "" && !strings.HasPrefix(gs.src.Ref, "refs/") {
+			gs.src.Ref = "refs/heads/" + gs.src.Ref
+		}
+		if gs.src.Ref == "" {
+			gs.src.Ref = gs.src.Checksum
+		}
+		return &Metadata{
+			Ref:      gs.src.Ref,
+			Checksum: gs.src.Checksum,
+		}, nil
+	}
+
 	var g session.Group
 	if jobCtx != nil {
 		g = jobCtx.Session()
@@ -748,6 +773,11 @@ func (gs *gitSourceHandler) remoteFetch(ctx context.Context, jobCtx solver.JobCo
 	}()
 
 	ref := gs.src.Ref
+	// With fetch-by-commit, the user-provided ref is not written into the
+	// bare repo, so resolve the checksum directly.
+	if gs.src.FetchByCommit && gs.src.Checksum != "" {
+		ref = gs.src.Checksum
+	}
 	git := repo.GitCLI
 	if gs.src.Checksum != "" {
 		actualHashBuf, err := repo.Run(ctx, "rev-parse", ref)
@@ -870,10 +900,16 @@ func (gs *gitSourceHandler) tryRemoteFetch(ctx context.Context, g session.Group,
 		}
 		gs.src.Ref = ref
 	}
+	// fetchRef is the identifier used to fetch from the remote. For fetch-by-commit
+	// mode this is the checksum (commit SHA); otherwise it is the ref itself.
+	fetchRef := ref
+	if gs.src.FetchByCommit && gs.src.Checksum != "" {
+		fetchRef = gs.src.Checksum
+	}
 	doFetch := true
-	if gitutil.IsCommitSHA(ref) {
+	if gitutil.IsCommitSHA(fetchRef) {
 		// skip fetch if commit already exists
-		if _, err := git.Run(ctx, "cat-file", "-e", "--", ref+"^{commit}"); err == nil {
+		if _, err := git.Run(ctx, "cat-file", "-e", "--", fetchRef+"^{commit}"); err == nil {
 			doFetch = false
 		}
 	}
@@ -897,7 +933,11 @@ func (gs *gitSourceHandler) tryRemoteFetch(ctx context.Context, g session.Group,
 		gitDirRoot.RemoveAll("shallow.lock")
 
 		args := []string{"fetch"}
-		if !gitutil.IsCommitSHA(ref) { // TODO: find a branch from ls-remote?
+		// For fetch-by-commit, assume the server supports
+		// uploadpack.allowReachableSHA1InWant / allowAnySHA1InWant and
+		// fetch only the requested commit, without the tag/unshallow
+		// fallback used by the generic SHA-ref path.
+		if gs.src.FetchByCommit || !gitutil.IsCommitSHA(fetchRef) { // TODO: find a branch from ls-remote?
 			args = append(args, "--depth=1", "--no-tags")
 		} else {
 			args = append(args, "--tags")
@@ -909,7 +949,7 @@ func (gs *gitSourceHandler) tryRemoteFetch(ctx context.Context, g session.Group,
 		if gitutil.IsCommitSHA(ref) {
 			args = append(args, ref)
 		} else {
-			args = append(args, "--force", "--", ref+":"+targetRef)
+			args = append(args, "--force", "--", fetchRef+":"+targetRef)
 		}
 		if _, err := git.Run(ctx, args...); err != nil {
 			err := errors.Wrapf(err, "failed to fetch remote %s", urlutil.RedactCredentials(gs.src.Remote))
@@ -928,7 +968,7 @@ func (gs *gitSourceHandler) tryRemoteFetch(ctx context.Context, g session.Group,
 		}
 
 		// verify that commit matches the cache key commit
-		dt, err := git.Run(ctx, "rev-parse", ref)
+		dt, err := git.Run(ctx, "rev-parse", fetchRef)
 		if err != nil {
 			return nil, err
 		}
@@ -977,6 +1017,13 @@ func (gs *gitSourceHandler) tryRemoteFetch(ctx context.Context, g session.Group,
 
 func (gs *gitSourceHandler) checkout(ctx context.Context, repo *gitRepo, g session.Group) (_ cache.ImmutableRef, retErr error) {
 	ref := gs.src.Ref
+	// refOrCommit is the identifier to use against the bare repo. For
+	// fetch-by-commit, the user-provided ref is not written into the bare
+	// repo, so fall back to the commit checksum which is always present.
+	refOrCommit := ref
+	if gs.src.FetchByCommit && gs.src.Checksum != "" {
+		refOrCommit = gs.src.Checksum
+	}
 	checkoutRef, err := gs.cache.New(ctx, nil, g, cache.WithRecordType(client.UsageRecordTypeGitCheckout), cache.WithDescription(fmt.Sprintf("git snapshot for %s#%s", urlutil.RedactCredentials(gs.src.Remote), ref)))
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create new mutable for %s", urlutil.RedactCredentials(gs.src.Remote))
@@ -1034,7 +1081,7 @@ func (gs *gitSourceHandler) checkout(ctx context.Context, repo *gitRepo, g sessi
 			return nil, err
 		}
 
-		gitCatFileBuf, err := git.Run(ctx, "cat-file", "-t", ref)
+		gitCatFileBuf, err := git.Run(ctx, "cat-file", "-t", refOrCommit)
 		if err != nil {
 			return nil, err
 		}
@@ -1047,6 +1094,11 @@ func (gs *gitSourceHandler) checkout(ctx context.Context, repo *gitRepo, g sessi
 				targetRef = "refs/tags/" + pullref
 			}
 			pullref += ":" + targetRef
+		} else if gs.src.FetchByCommit && ref != refOrCommit {
+			// Fetch the commit object from the bare repo and save it under the
+			// user-provided ref name in the checkout clone. The ref does not
+			// need to exist in the bare repo.
+			pullref = refOrCommit + ":" + ref
 		} else if gitutil.IsCommitSHA(ref) {
 			pullref = "refs/buildkit/" + identity.NewID()
 			_, err = git.Run(ctx, "update-ref", pullref, ref)
@@ -1084,7 +1136,7 @@ func (gs *gitSourceHandler) checkout(ctx context.Context, repo *gitRepo, g sessi
 			}
 		}
 		checkoutGit := git.New(gitutil.WithWorkTree(cd), gitutil.WithGitDir(gitDir))
-		_, err = checkoutGit.Run(ctx, "checkout", "--no-overlay", ref, "--", ".")
+		_, err = checkoutGit.Run(ctx, "checkout", "--no-overlay", refOrCommit, "--", ".")
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to checkout remote %s", urlutil.RedactCredentials(gs.src.Remote))
 		}
@@ -1139,7 +1191,7 @@ func (gs *gitSourceHandler) checkout(ctx context.Context, repo *gitRepo, g sessi
 	}
 
 	if gs.src.MTime == "commit" {
-		commitTime, err := getCommitTime(ctx, git, ref)
+		commitTime, err := getCommitTime(ctx, git, refOrCommit)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to get commit time for %s", urlutil.RedactCredentials(gs.src.Remote))
 		}

--- a/source/git/source_test.go
+++ b/source/git/source_test.go
@@ -445,6 +445,219 @@ func testFetchUnreferencedRefSha(t *testing.T, ref string, keepGitDir bool, form
 	require.Equal(t, "foo\n", string(dt))
 }
 
+func TestFetchByCommitSHA1(t *testing.T) {
+	testFetchByCommit(t, "sha1", false)
+}
+
+func TestFetchByCommitKeepGitDirSHA1(t *testing.T) {
+	testFetchByCommit(t, "sha1", true)
+}
+
+func TestFetchByCommitSHA256(t *testing.T) {
+	testFetchByCommit(t, "sha256", false)
+}
+
+func TestFetchByCommitKeepGitDirSHA256(t *testing.T) {
+	testFetchByCommit(t, "sha256", true)
+}
+
+// testFetchByCommit exercises the FetchByCommit mode: the branch points to
+// commit A initially, then it is moved to commit B on the remote. A second
+// fetch that asks for commit A via FetchByCommit with the branch ref must
+// still match the first cache key and produce identical content.
+func testFetchByCommit(t *testing.T, format string, keepGitDir bool) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Depends on unimplemented containerd bind-mount support on Windows")
+	}
+
+	t.Parallel()
+	ctx := logProgressStreams(context.Background(), t)
+
+	gs := setupGitSource(t, t.TempDir())
+	repo := setupGitRepo(t, format)
+
+	// Capture the SHA of the current master branch (points at "third").
+	cmd := exec.CommandContext(context.TODO(), "git", "rev-parse", "refs/heads/master")
+	cmd.Dir = repo.mainPath
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	firstSha := strings.TrimSpace(string(out))
+
+	// First fetch: branch "master" at commit firstSha.
+	id := &GitIdentifier{Remote: repo.mainURL, Ref: "master", KeepGitDir: keepGitDir}
+	g, err := gs.Resolve(ctx, id, nil, nil)
+	require.NoError(t, err)
+
+	key1, pin1, _, _, err := g.CacheKey(ctx, nil, 0)
+	require.NoError(t, err)
+	require.Equal(t, firstSha, pin1)
+
+	ref1, err := g.Snapshot(ctx, nil)
+	require.NoError(t, err)
+	defer ref1.Release(context.TODO())
+
+	mount, err := ref1.Mount(ctx, true, nil)
+	require.NoError(t, err)
+	lm := snapshot.LocalMounter(mount)
+	dir, err := lm.Mount()
+	require.NoError(t, err)
+	dt1, err := os.ReadFile(filepath.Join(dir, "def"))
+	require.NoError(t, err)
+	require.Equal(t, "bar\n", string(dt1))
+	if keepGitDir {
+		require.Equal(t, firstSha, gitRevParse(t, dir, "refs/heads/master"))
+	}
+	require.NoError(t, lm.Unmount())
+
+	// Move master on the remote to a different commit.
+	runShell(t, repo.mainPath,
+		"git checkout master",
+		"echo moved > newfile",
+		"git add newfile",
+		"git commit -m moved",
+	)
+	cmd = exec.CommandContext(context.TODO(), "git", "rev-parse", "refs/heads/master")
+	cmd.Dir = repo.mainPath
+	out, err = cmd.Output()
+	require.NoError(t, err)
+	secondSha := strings.TrimSpace(string(out))
+	require.NotEqual(t, firstSha, secondSha)
+
+	// Sanity check: without FetchByCommit, resolving "master" now returns the
+	// new commit, which yields a different cache key.
+	idMoved := &GitIdentifier{Remote: repo.mainURL, Ref: "master", KeepGitDir: keepGitDir}
+	gMoved, err := gs.Resolve(ctx, idMoved, nil, nil)
+	require.NoError(t, err)
+	keyMoved, pinMoved, _, _, err := gMoved.CacheKey(ctx, nil, 0)
+	require.NoError(t, err)
+	require.Equal(t, secondSha, pinMoved)
+	require.NotEqual(t, key1, keyMoved)
+
+	// Without FetchByCommit, passing the old checksum for the now-moved ref
+	// is rejected because the ref resolves to a different commit.
+	idStale := &GitIdentifier{
+		Remote:     repo.mainURL,
+		Ref:        "refs/heads/master",
+		Checksum:   firstSha,
+		KeepGitDir: keepGitDir,
+	}
+	gStale, err := gs.Resolve(ctx, idStale, nil, nil)
+	require.NoError(t, err)
+	_, _, _, _, err = gStale.CacheKey(ctx, nil, 0)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "expected checksum to match")
+
+	// Fetch the old commit by checksum with FetchByCommit and the same
+	// fully-qualified ref name that was originally produced. The cache key
+	// and pin should match the first fetch.
+	idFbc := &GitIdentifier{
+		Remote:        repo.mainURL,
+		Ref:           "refs/heads/master",
+		Checksum:      firstSha,
+		KeepGitDir:    keepGitDir,
+		FetchByCommit: true,
+	}
+	gFbc, err := gs.Resolve(ctx, idFbc, nil, nil)
+	require.NoError(t, err)
+
+	key2, pin2, _, _, err := gFbc.CacheKey(ctx, nil, 0)
+	require.NoError(t, err)
+	require.Equal(t, key1, key2)
+	require.Equal(t, pin1, pin2)
+
+	ref2, err := gFbc.Snapshot(ctx, nil)
+	require.NoError(t, err)
+	defer ref2.Release(context.TODO())
+
+	// Snapshot is reused from the first fetch since the cache key matches.
+	require.Equal(t, ref1.ID(), ref2.ID())
+
+	// Unqualified short refs must be canonicalized to refs/heads/<name> so
+	// that FetchByCommit produces the same cache key as the original fetch,
+	// which used ls-remote-driven normalization. See discussion around
+	// shaToCacheKey and the partialRef/headRef resolution in resolveMetadata.
+	idFbcShort := &GitIdentifier{
+		Remote:        repo.mainURL,
+		Ref:           "master",
+		Checksum:      firstSha,
+		KeepGitDir:    keepGitDir,
+		FetchByCommit: true,
+	}
+	gFbcShort, err := gs.Resolve(ctx, idFbcShort, nil, nil)
+	require.NoError(t, err)
+	keyShort, pinShort, _, _, err := gFbcShort.CacheKey(ctx, nil, 0)
+	require.NoError(t, err)
+	require.Equal(t, key1, keyShort)
+	require.Equal(t, pin1, pinShort)
+
+	// A fresh git source (empty cache) fetching the same commit via
+	// FetchByCommit must produce the same cache key and identical content,
+	// even though no prior snapshot exists to reuse.
+	gsFresh := setupGitSource(t, t.TempDir())
+	gFresh, err := gsFresh.Resolve(ctx, idFbc, nil, nil)
+	require.NoError(t, err)
+
+	key3, pin3, _, _, err := gFresh.CacheKey(ctx, nil, 0)
+	require.NoError(t, err)
+	require.Equal(t, key1, key3)
+	require.Equal(t, pin1, pin3)
+
+	ref3, err := gFresh.Snapshot(ctx, nil)
+	require.NoError(t, err)
+	defer ref3.Release(context.TODO())
+
+	require.NotEqual(t, ref1.ID(), ref3.ID())
+
+	mount, err = ref3.Mount(ctx, true, nil)
+	require.NoError(t, err)
+	lm = snapshot.LocalMounter(mount)
+	dir, err = lm.Mount()
+	require.NoError(t, err)
+	defer lm.Unmount()
+
+	dt3, err := os.ReadFile(filepath.Join(dir, "def"))
+	require.NoError(t, err)
+	require.Equal(t, "bar\n", string(dt3))
+	// File added by the "moved" commit must not be present, since we fetched
+	// the original firstSha rather than the new tip of master.
+	_, err = os.Lstat(filepath.Join(dir, "newfile"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+	if keepGitDir {
+		require.Equal(t, firstSha, gitRevParse(t, dir, "refs/heads/master"))
+	}
+}
+
+func gitRevParse(t *testing.T, workDir, rev string) string {
+	t.Helper()
+	cmd := exec.CommandContext(context.TODO(), "git", "rev-parse", rev)
+	cmd.Dir = workDir
+	out, err := cmd.Output()
+	require.NoError(t, err, "git rev-parse %s in %s", rev, workDir)
+	return strings.TrimSpace(string(out))
+}
+
+func TestFetchByCommitRequiresChecksumSHA1(t *testing.T) {
+	testFetchByCommitRequiresChecksum(t, "sha1")
+}
+
+func testFetchByCommitRequiresChecksum(t *testing.T, format string) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Depends on unimplemented containerd bind-mount support on Windows")
+	}
+
+	t.Parallel()
+	ctx := logProgressStreams(context.Background(), t)
+	gs := setupGitSource(t, t.TempDir())
+	repo := setupGitRepo(t, format)
+
+	id := &GitIdentifier{Remote: repo.mainURL, Ref: "refs/heads/master", FetchByCommit: true}
+	g, err := gs.Resolve(ctx, id, nil, nil)
+	require.NoError(t, err)
+	_, _, _, _, err = g.CacheKey(ctx, nil, 0)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "fetch-by-commit")
+}
+
 func TestFetchByTagSHA1(t *testing.T) {
 	testFetchByTag(t, "lightweight-tag", "third", false, true, false, testChecksumModeNone, "sha1")
 }


### PR DESCRIPTION
Allow git sources to fetch a pinned commit without resolving the ref against the remote tip, while preserving cache keys for canonical branch refs and covering the behavior with tests.