### PR TITLE
session: add timeout for credentialsfunc

### DIFF
--- a/session/auth/auth.go
+++ b/session/auth/auth.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/subtle"
 	"sync"
+	"time"
 
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/util/grpcerrors"
@@ -12,6 +13,8 @@ import (
 	"golang.org/x/crypto/nacl/sign"
 	"google.golang.org/grpc/codes"
 )
+
+const sessionAuthTimeout = 60 * time.Second
 
 var salt []byte
 var saltOnce sync.Once
@@ -27,6 +30,8 @@ func getSalt() []byte {
 
 func CredentialsFunc(ctx context.Context, sm *session.Manager, g session.Group) func(string) (session, username, secret string, err error) {
 	return func(host string) (string, string, string, error) {
+		ctx, cancel := context.WithTimeoutCause(ctx, sessionAuthTimeout, errors.Wrap(context.DeadlineExceeded, "resolving credentials from session"))
+		defer cancel()
 		var sessionID, user, secret string
 		err := sm.Any(ctx, g, func(ctx context.Context, id string, c session.Caller) error {
 			client := NewAuthClient(c.Conn())
@@ -53,6 +58,8 @@ func CredentialsFunc(ctx context.Context, sm *session.Manager, g session.Group) 
 }
 
 func FetchToken(ctx context.Context, req *FetchTokenRequest, sm *session.Manager, g session.Group) (resp *FetchTokenResponse, err error) {
+	ctx, cancel := context.WithTimeoutCause(ctx, sessionAuthTimeout, errors.Wrap(context.DeadlineExceeded, "fetching auth token from session"))
+	defer cancel()
 	err = sm.Any(ctx, g, func(ctx context.Context, id string, c session.Caller) error {
 		client := NewAuthClient(c.Conn())
 
@@ -69,6 +76,8 @@ func FetchToken(ctx context.Context, req *FetchTokenRequest, sm *session.Manager
 }
 
 func VerifyTokenAuthority(ctx context.Context, host string, pubKey *[32]byte, sm *session.Manager, g session.Group) (sessionID string, ok bool, err error) {
+	ctx, cancel := context.WithTimeoutCause(ctx, sessionAuthTimeout, errors.Wrap(context.DeadlineExceeded, "verifying token authority from session"))
+	defer cancel()
 	var verified bool
 	err = sm.Any(ctx, g, func(ctx context.Context, id string, c session.Caller) error {
 		client := NewAuthClient(c.Conn())
@@ -101,6 +110,8 @@ func VerifyTokenAuthority(ctx context.Context, host string, pubKey *[32]byte, sm
 }
 
 func GetTokenAuthority(ctx context.Context, host string, sm *session.Manager, g session.Group) (sessionID string, pubKey *[32]byte, err error) {
+	ctx, cancel := context.WithTimeoutCause(ctx, sessionAuthTimeout, errors.Wrap(context.DeadlineExceeded, "getting token authority from session"))
+	defer cancel()
 	err = sm.Any(ctx, g, func(ctx context.Context, id string, c session.Caller) error {
 		client := NewAuthClient(c.Conn())
 


### PR DESCRIPTION
Ensure build does not appear deadlocked for some
credentials helper issue.

follow-up #6649