### PR TITLE
git: add git bundle source support

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -255,6 +255,8 @@ var allTests = []func(t *testing.T, sb integration.Sandbox){
 	testHTTPResolveMetaReuse,
 	testHTTPResolveMultiBuild,
 	testGitResolveMutatedSource,
+	testGitBundleRoundTrip,
+	testGitBundleRoundTripRegistry,
 	testImageResolveAttestationChainRequiresNetwork,
 	testImageResolveAttestationChainLocal,
 	testImageResolveProvenanceAttestation,
@@ -13669,6 +13671,400 @@ func testGitResolveMutatedSource(t *testing.T, sb integration.Sandbox) {
 	dt, err := os.ReadFile(filepath.Join(dest, "a"))
 	require.NoError(t, err)
 	require.Equal(t, "a\n", string(dt))
+
+	checkAllReleasable(t, c, sb, false)
+}
+
+// testGitBundleRoundTrip exercises the bundle round-trip end to end:
+//
+//  1. Seed a git repo served over HTTP.
+//  2. Build 1 uses GitCheckoutBundle() to export a single-file git bundle.
+//  3. Build 2 imports that bundle via GitBundleURL("oci-layout+blob://...")
+//     against a client-side OCI layout store, once with the sha pinned as ref
+//     and once with a symbolic ref ("master"). Both checkouts must succeed
+//     and produce a worktree matching Build 0 (plain git clone).
+//  4. A KeepGitDir subtest exercises llb.KeepGitDir() + bundle and asserts
+//     no fake refs/buildkit/* namespace leaks into the checkout's .git dir.
+//  5. A provenance subtest enables attest:provenance and asserts both the
+//     git-commit material and the bundle-blob material are recorded.
+func testGitBundleRoundTrip(t *testing.T, sb integration.Sandbox) {
+	workers.CheckFeatureCompat(t, sb, workers.FeatureOCILayout)
+	integration.SkipOnPlatform(t, "windows")
+	ctx := sb.Context()
+	c, err := New(ctx, sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	gitDir := t.TempDir()
+	err = runInDir(gitDir,
+		"git init -b master",
+		"git config --local user.email test@example.com",
+		"git config --local user.name test",
+		"echo hello > file.txt",
+		"git add file.txt",
+		"git commit -m initial",
+		"git update-server-info",
+	)
+	require.NoError(t, err)
+
+	cmd := exec.CommandContext(context.TODO(), "git", "rev-parse", "HEAD")
+	cmd.Dir = gitDir
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	headSha := strings.TrimSpace(string(out))
+
+	server := httptest.NewServer(http.FileServer(http.Dir(filepath.Clean(gitDir))))
+	defer server.Close()
+	repoURL := server.URL + "/.git"
+
+	// Build 1: export a bundle via GitCheckoutBundle.
+	bundleDir := t.TempDir()
+	st := llb.Git(repoURL, "master", llb.GitChecksum(headSha), llb.GitCheckoutBundle())
+	def, err := st.Marshal(ctx)
+	require.NoError(t, err)
+
+	_, err = c.Solve(ctx, def, SolveOpt{
+		Exports: []ExportEntry{{Type: ExporterLocal, OutputDir: bundleDir}},
+	}, nil)
+	require.NoError(t, err)
+
+	bundleBytes, err := os.ReadFile(filepath.Join(bundleDir, "bundle"))
+	require.NoError(t, err)
+	require.NotEmpty(t, bundleBytes)
+	bundleDgst := digest.FromBytes(bundleBytes)
+
+	// Sanity-check the bundle locally: it must contain the commit we pinned,
+	// landing in the natural ref namespace (refs/heads/master).
+	localBare := t.TempDir()
+	err = runInDir(localBare, "git init --bare")
+	require.NoError(t, err)
+	bundlePath := filepath.Join(t.TempDir(), "bundle.pack")
+	require.NoError(t, os.WriteFile(bundlePath, bundleBytes, 0644))
+	err = runInDir(localBare, fmt.Sprintf("git fetch %s +refs/*:refs/*", bundlePath))
+	require.NoError(t, err)
+	//nolint:gosec // Test-controlled temp dir and commit SHA are not attacker input.
+	cmd = exec.CommandContext(context.TODO(), "git", "--git-dir="+localBare, "cat-file", "-e", headSha+"^{commit}")
+	require.NoError(t, cmd.Run(), "bundle does not contain expected commit")
+	//nolint:gosec // Test-controlled temp dir is not attacker input.
+	cmd = exec.CommandContext(context.TODO(), "git", "--git-dir="+localBare, "rev-parse", "--verify", "refs/heads/master")
+	masterOut, err := cmd.CombinedOutput()
+	require.NoError(t, err, "bundle should carry user's ref refs/heads/master; output=%q", string(masterOut))
+	require.Equal(t, headSha, strings.TrimSpace(string(masterOut)))
+
+	// Stage the bundle in a client-side OCI layout store so Build 2 can
+	// resolve it through an oci-layout+blob:// locator.
+	storeDir := t.TempDir()
+	store, err := local.NewStore(storeDir)
+	require.NoError(t, err)
+	err = content.WriteBlob(ctx, store, "bundle-"+bundleDgst.String(), bytes.NewReader(bundleBytes),
+		ocispecs.Descriptor{Digest: bundleDgst, Size: int64(len(bundleBytes))})
+	require.NoError(t, err)
+
+	csID := "git-bundle-oci-store"
+	bundleLocator := fmt.Sprintf("oci-layout+blob://not/real@%s", bundleDgst.String())
+
+	cases := []struct {
+		name string
+		ref  string // value passed as the fragment/ref to llb.Git
+	}{
+		{"sha-ref", headSha},
+		{"symbolic-ref", "master"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			destDir := t.TempDir()
+			st := llb.Git(
+				repoURL,
+				tc.ref,
+				llb.GitChecksum(headSha),
+				llb.GitBundleURL(bundleLocator, llb.GitBundleOCIStore("", csID)),
+			)
+			def, err := st.Marshal(sb.Context())
+			require.NoError(t, err)
+
+			_, err = c.Solve(sb.Context(), def, SolveOpt{
+				Exports: []ExportEntry{{Type: ExporterLocal, OutputDir: destDir}},
+				OCIStores: map[string]content.Store{
+					csID: store,
+				},
+			}, nil)
+			require.NoError(t, err)
+
+			dt, err := os.ReadFile(filepath.Join(destDir, "file.txt"))
+			require.NoError(t, err)
+			require.Equal(t, "hello\n", string(dt))
+		})
+	}
+
+	// KeepGitDir + bundle: the checkout's .git must not contain any leaked
+	// refs/buildkit/* namespace. `.git/refs/heads/*` and `.git/refs/tags/*`
+	// are populated by the plain-git checkout path (it runs its own fetch
+	// into a freshly inited repo), so we only assert no refs/buildkit/
+	// leak — the whole point of Item A is that the bundle no longer uses
+	// that namespace.
+	t.Run("keepgitdir-no-namespace-leak", func(t *testing.T) {
+		destDir := t.TempDir()
+		st := llb.Git(
+			repoURL,
+			"master",
+			llb.GitChecksum(headSha),
+			llb.GitBundleURL(bundleLocator, llb.GitBundleOCIStore("", csID)),
+			llb.KeepGitDir(),
+		)
+		def, err := st.Marshal(sb.Context())
+		require.NoError(t, err)
+
+		_, err = c.Solve(sb.Context(), def, SolveOpt{
+			Exports: []ExportEntry{{Type: ExporterLocal, OutputDir: destDir}},
+			OCIStores: map[string]content.Store{
+				csID: store,
+			},
+		}, nil)
+		require.NoError(t, err)
+
+		// .git dir should be present.
+		st2, err := os.Stat(filepath.Join(destDir, ".git"))
+		require.NoError(t, err)
+		require.True(t, st2.IsDir(), ".git should be a directory")
+
+		// No fake internal namespace anywhere under the checkout's .git.
+		leakRoot := filepath.Join(destDir, ".git", "refs", "buildkit")
+		_, err = os.Stat(leakRoot)
+		require.True(t, os.IsNotExist(err), ".git/refs/buildkit should not exist: %v", err)
+
+		// Also scan packed-refs, which is where cloned/fetched refs may
+		// live on disk after git gc / pack-refs.
+		if pr, err := os.ReadFile(filepath.Join(destDir, ".git", "packed-refs")); err == nil {
+			require.NotContains(t, string(pr), "refs/buildkit/",
+				"packed-refs should not carry refs/buildkit/* entries")
+		}
+
+		// The user's ref name must survive into .git: passing "master" to
+		// llb.Git should produce a checkout whose .git carries
+		// refs/heads/master, either loose or packed.
+		//nolint:gosec // Test-controlled export dir is not attacker input.
+		cmd := exec.CommandContext(context.TODO(), "git",
+			"--git-dir="+filepath.Join(destDir, ".git"),
+			"rev-parse", "--verify", "refs/heads/master")
+		refOut, err := cmd.CombinedOutput()
+		require.NoError(t, err, ".git should carry refs/heads/master; output=%q", string(refOut))
+		require.Equal(t, headSha, strings.TrimSpace(string(refOut)))
+
+		// HEAD must point at the pinned commit.
+		//nolint:gosec // Test-controlled export dir is not attacker input.
+		cmd = exec.CommandContext(context.TODO(), "git",
+			"--git-dir="+filepath.Join(destDir, ".git"),
+			"rev-parse", "HEAD")
+		gotOut, err := cmd.CombinedOutput()
+		require.NoError(t, err, "output=%q", string(gotOut))
+		require.Equal(t, headSha, strings.TrimSpace(string(gotOut)))
+
+		// file.txt content matches.
+		dt, err := os.ReadFile(filepath.Join(destDir, "file.txt"))
+		require.NoError(t, err)
+		require.Equal(t, "hello\n", string(dt))
+	})
+
+	// Provenance subtest: assert that the git-commit material and the
+	// bundle-blob material are both recorded.
+	t.Run("provenance", func(t *testing.T) {
+		workers.CheckFeatureCompat(t, sb, workers.FeatureProvenance)
+		destDir := t.TempDir()
+		st := llb.Scratch().File(
+			llb.Copy(
+				llb.Git(
+					repoURL,
+					"master",
+					llb.GitChecksum(headSha),
+					llb.GitBundleURL(bundleLocator, llb.GitBundleOCIStore("", csID)),
+				),
+				"file.txt",
+				"file.txt",
+			),
+		)
+		def, err := st.Marshal(sb.Context())
+		require.NoError(t, err)
+
+		_, err = c.Solve(sb.Context(), def, SolveOpt{
+			FrontendAttrs: map[string]string{
+				"attest:provenance": "",
+			},
+			Exports: []ExportEntry{{Type: ExporterLocal, OutputDir: destDir}},
+			OCIStores: map[string]content.Store{
+				csID: store,
+			},
+		}, nil)
+		require.NoError(t, err)
+
+		provDt, err := os.ReadFile(filepath.Join(destDir, "provenance.json"))
+		require.NoError(t, err)
+
+		var stmt struct {
+			intoto.StatementHeader
+			Predicate provenancetypes.ProvenancePredicateSLSA1 `json:"predicate"`
+		}
+		require.NoError(t, json.Unmarshal(provDt, &stmt))
+
+		// Bundle-backed git sources emit two materials: the git source
+		// at its raw repository URL (same shape as a non-bundle git
+		// source), and the bundle blob as a purl with a vcs_url
+		// qualifier linking back to the git URL.
+		expectedGitURI := repoURL + "#master"
+		var foundCommit, foundBundle bool
+		for _, m := range stmt.Predicate.BuildDefinition.ResolvedDependencies {
+			if m.URI == expectedGitURI && m.Digest["sha1"] == headSha {
+				foundCommit = true
+			}
+			if strings.HasPrefix(m.URI, "pkg:oci/") && strings.Contains(m.URI, "ref_type=bundle") && strings.Contains(m.URI, "vcs_url=") && m.Digest["sha256"] == bundleDgst.Hex() {
+				foundBundle = true
+			}
+		}
+		require.True(t, foundCommit, "expected git commit material %q with sha1=%s in %+v", expectedGitURI, headSha, stmt.Predicate.BuildDefinition.ResolvedDependencies)
+		require.True(t, foundBundle, "expected bundle blob material (pkg:oci/...?ref_type=bundle) with sha256=%s in %+v", bundleDgst.Hex(), stmt.Predicate.BuildDefinition.ResolvedDependencies)
+	})
+
+	checkAllReleasable(t, c, sb, false)
+}
+
+// testGitBundleRoundTripRegistry mirrors testGitBundleRoundTrip but resolves
+// the bundle blob through a registry using the docker-image+blob:// scheme.
+// The bundle bytes are uploaded directly to the sandbox registry by digest
+// and then re-imported in Build 2.
+func testGitBundleRoundTripRegistry(t *testing.T, sb integration.Sandbox) {
+	workers.CheckFeatureCompat(t, sb, workers.FeatureDirectPush)
+	integration.SkipOnPlatform(t, "windows")
+	requiresLinux(t)
+	ctx := sb.Context()
+	c, err := New(ctx, sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	registry, err := sb.NewRegistry()
+	if errors.Is(err, integration.ErrRequirements) {
+		t.Skip(err.Error())
+	}
+	require.NoError(t, err)
+
+	gitDir := t.TempDir()
+	err = runInDir(gitDir,
+		"git init -b master",
+		"git config --local user.email test@example.com",
+		"git config --local user.name test",
+		"echo hello > file.txt",
+		"git add file.txt",
+		"git commit -m initial",
+		"git update-server-info",
+	)
+	require.NoError(t, err)
+
+	cmd := exec.CommandContext(context.TODO(), "git", "rev-parse", "HEAD")
+	cmd.Dir = gitDir
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	headSha := strings.TrimSpace(string(out))
+
+	server := httptest.NewServer(http.FileServer(http.Dir(filepath.Clean(gitDir))))
+	defer server.Close()
+	repoURL := server.URL + "/.git"
+
+	// Build 1: export a bundle via GitCheckoutBundle.
+	bundleDir := t.TempDir()
+	st := llb.Git(repoURL, "master", llb.GitChecksum(headSha), llb.GitCheckoutBundle())
+	def, err := st.Marshal(ctx)
+	require.NoError(t, err)
+
+	_, err = c.Solve(ctx, def, SolveOpt{
+		Exports: []ExportEntry{{Type: ExporterLocal, OutputDir: bundleDir}},
+	}, nil)
+	require.NoError(t, err)
+
+	bundleBytes, err := os.ReadFile(filepath.Join(bundleDir, "bundle"))
+	require.NoError(t, err)
+	require.NotEmpty(t, bundleBytes)
+	bundleDgst := digest.FromBytes(bundleBytes)
+
+	// Push the bundle as a raw blob into the sandbox registry under a
+	// repository name. The docker registry accepts arbitrary blobs by
+	// digest; the repository exists implicitly once any blob is uploaded
+	// under its name.
+	bundleRepoRef := registry + "/foo/bundle@" + bundleDgst.String()
+	ingester, err := contentutil.IngesterFromRef(bundleRepoRef)
+	require.NoError(t, err)
+	err = content.WriteBlob(ctx, ingester, "bundle-"+bundleDgst.String(), bytes.NewReader(bundleBytes),
+		ocispecs.Descriptor{Digest: bundleDgst, Size: int64(len(bundleBytes))})
+	require.NoError(t, err)
+
+	bundleLocator := "docker-image+blob://" + registry + "/foo/bundle@" + bundleDgst.String()
+
+	t.Run("checkout", func(t *testing.T) {
+		destDir := t.TempDir()
+		st := llb.Git(
+			repoURL,
+			"master",
+			llb.GitChecksum(headSha),
+			llb.GitBundleURL(bundleLocator),
+		)
+		def, err := st.Marshal(sb.Context())
+		require.NoError(t, err)
+
+		_, err = c.Solve(sb.Context(), def, SolveOpt{
+			Exports: []ExportEntry{{Type: ExporterLocal, OutputDir: destDir}},
+		}, nil)
+		require.NoError(t, err)
+
+		dt, err := os.ReadFile(filepath.Join(destDir, "file.txt"))
+		require.NoError(t, err)
+		require.Equal(t, "hello\n", string(dt))
+	})
+
+	t.Run("provenance", func(t *testing.T) {
+		workers.CheckFeatureCompat(t, sb, workers.FeatureProvenance)
+		destDir := t.TempDir()
+		st := llb.Scratch().File(
+			llb.Copy(
+				llb.Git(
+					repoURL,
+					"master",
+					llb.GitChecksum(headSha),
+					llb.GitBundleURL(bundleLocator),
+				),
+				"file.txt",
+				"file.txt",
+			),
+		)
+		def, err := st.Marshal(sb.Context())
+		require.NoError(t, err)
+
+		_, err = c.Solve(sb.Context(), def, SolveOpt{
+			FrontendAttrs: map[string]string{
+				"attest:provenance": "",
+			},
+			Exports: []ExportEntry{{Type: ExporterLocal, OutputDir: destDir}},
+		}, nil)
+		require.NoError(t, err)
+
+		provDt, err := os.ReadFile(filepath.Join(destDir, "provenance.json"))
+		require.NoError(t, err)
+
+		var stmt struct {
+			intoto.StatementHeader
+			Predicate provenancetypes.ProvenancePredicateSLSA1 `json:"predicate"`
+		}
+		require.NoError(t, json.Unmarshal(provDt, &stmt))
+
+		expectedGitURI := repoURL + "#master"
+		var foundCommit, foundBundle bool
+		for _, m := range stmt.Predicate.BuildDefinition.ResolvedDependencies {
+			if m.URI == expectedGitURI && m.Digest["sha1"] == headSha {
+				foundCommit = true
+			}
+			if strings.HasPrefix(m.URI, "pkg:docker/") && strings.Contains(m.URI, "ref_type=bundle") && strings.Contains(m.URI, "vcs_url=") && m.Digest["sha256"] == bundleDgst.Hex() {
+				foundBundle = true
+			}
+		}
+		require.True(t, foundCommit, "expected git commit material %q with sha1=%s in %+v", expectedGitURI, headSha, stmt.Predicate.BuildDefinition.ResolvedDependencies)
+		require.True(t, foundBundle, "expected bundle blob material (pkg:docker/...?ref_type=bundle) with sha256=%s in %+v", bundleDgst.Hex(), stmt.Predicate.BuildDefinition.ResolvedDependencies)
+	})
 
 	checkAllReleasable(t, c, sb, false)
 }

--- a/client/llb/git_test.go
+++ b/client/llb/git_test.go
@@ -69,6 +69,54 @@ func TestGit(t *testing.T) {
 				"git.fullurl":          "https://github.com/foo/bar.git",
 			},
 		},
+		{
+			name: "bundle",
+			st: Git(
+				"github.com/foo/bar.git", "",
+				GitChecksum("1111111111111111111111111111111111111111"),
+				GitBundleURL("docker-image+blob://example.com/repo@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+			),
+			identifier: "git://github.com/foo/bar.git",
+			attrs: map[string]string{
+				"git.authheadersecret": "GIT_AUTH_HEADER",
+				"git.authtokensecret":  "GIT_AUTH_TOKEN",
+				"git.fullurl":          "https://github.com/foo/bar.git",
+				"git.checksum":         "1111111111111111111111111111111111111111",
+				"git.bundle":           "docker-image+blob://example.com/repo@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			},
+		},
+		{
+			name: "bundle oci store",
+			st: Git(
+				"github.com/foo/bar.git", "",
+				GitChecksum("1111111111111111111111111111111111111111"),
+				GitBundleURL(
+					"oci-layout+blob://notreal/repo@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					GitBundleOCIStore("sess1", "store1"),
+				),
+			),
+			identifier: "git://github.com/foo/bar.git",
+			attrs: map[string]string{
+				"git.authheadersecret": "GIT_AUTH_HEADER",
+				"git.authtokensecret":  "GIT_AUTH_TOKEN",
+				"git.fullurl":          "https://github.com/foo/bar.git",
+				"git.checksum":         "1111111111111111111111111111111111111111",
+				"git.bundle":           "oci-layout+blob://notreal/repo@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				"oci.session":          "sess1",
+				"oci.store":            "store1",
+			},
+		},
+		{
+			name:       "checkout bundle",
+			st:         Git("github.com/foo/bar.git", "", GitCheckoutBundle()),
+			identifier: "git://github.com/foo/bar.git",
+			attrs: map[string]string{
+				"git.authheadersecret": "GIT_AUTH_HEADER",
+				"git.authtokensecret":  "GIT_AUTH_TOKEN",
+				"git.fullurl":          "https://github.com/foo/bar.git",
+				"git.checkoutbundle":   "true",
+			},
+		},
 	}
 
 	for _, tc := range tcases {

--- a/client/llb/source.go
+++ b/client/llb/source.go
@@ -487,6 +487,21 @@ func Git(url, fragment string, opts ...GitOption) State {
 		attrs[pb.AttrGitFetchByCommit] = "true"
 		addCap(&gi.Constraints, pb.CapSourceGitFetchByCommit)
 	}
+	if gi.Bundle != "" {
+		attrs[pb.AttrGitBundle] = gi.Bundle
+		addCap(&gi.Constraints, pb.CapSourceGitBundle)
+	}
+	if gi.BundleOCISessionID != "" {
+		attrs[pb.AttrOCILayoutSessionID] = gi.BundleOCISessionID
+	}
+	if gi.BundleOCIStoreID != "" {
+		attrs[pb.AttrOCILayoutStoreID] = gi.BundleOCIStoreID
+	}
+
+	if gi.CheckoutBundle {
+		attrs[pb.AttrGitCheckoutBundle] = "true"
+		addCap(&gi.Constraints, pb.CapSourceGitCheckoutBundle)
+	}
 
 	addCap(&gi.Constraints, pb.CapSourceGit)
 
@@ -505,18 +520,22 @@ func (fn gitOptionFunc) SetGitOption(gi *GitInfo) {
 
 type GitInfo struct {
 	constraintsWrapper
-	KeepGitDir       bool
-	AuthTokenSecret  string
-	AuthHeaderSecret string
-	addAuthCap       bool
-	KnownSSHHosts    string
-	MountSSHSock     string
-	Checksum         string
-	Ref              string
-	SubDir           string
-	SkipSubmodules   bool
-	MTime            string
-	FetchByCommit    bool
+	KeepGitDir         bool
+	AuthTokenSecret    string
+	AuthHeaderSecret   string
+	addAuthCap         bool
+	KnownSSHHosts      string
+	MountSSHSock       string
+	Checksum           string
+	Ref                string
+	SubDir             string
+	SkipSubmodules     bool
+	MTime              string
+	Bundle             string
+	BundleOCISessionID string
+	BundleOCIStoreID   string
+	CheckoutBundle     bool
+	FetchByCommit      bool
 }
 
 func GitRef(v string) GitOption {
@@ -595,6 +614,84 @@ func GitChecksum(v string) GitOption {
 func GitFetchByCommit() GitOption {
 	return gitOptionFunc(func(gi *GitInfo) {
 		gi.FetchByCommit = true
+	})
+}
+
+// GitBundleInfo carries scheme-specific configuration for [GitBundleURL].
+// It is populated by [GitBundleOption] values and consumed by GitBundleURL.
+type GitBundleInfo struct {
+	// OCISessionID pins the OCI-layout bundle fetch to a specific client
+	// session. Only meaningful when the locator uses the
+	// "oci-layout+blob://" scheme.
+	OCISessionID string
+	// OCIStoreID overrides the OCI-layout store name derived from the
+	// bundle locator body. Only meaningful when the locator uses the
+	// "oci-layout+blob://" scheme.
+	OCIStoreID string
+}
+
+// GitBundleOption configures bundle-specific behavior for [GitBundleURL].
+type GitBundleOption interface {
+	SetGitBundleOption(*GitBundleInfo)
+}
+
+type gitBundleOptionFunc func(*GitBundleInfo)
+
+func (fn gitBundleOptionFunc) SetGitBundleOption(bi *GitBundleInfo) {
+	fn(bi)
+}
+
+// GitBundleURL configures the git source to import the commit history from a
+// pre-built git bundle instead of fetching from the upstream Git remote. The
+// locator must use one of the following schemes:
+//
+//	docker-image+blob://<registry-ref>@sha256:<digest>
+//	oci-layout+blob://<ref>@sha256:<digest>
+//
+// [GitChecksum] is required when GitBundleURL is used and the commit it
+// identifies must be reachable from a ref inside the bundle (i.e. the bundle
+// must contain that commit; BuildKit validates this after import). Auth and
+// SSH options are ignored in bundle mode. Submodules, if present, still fetch
+// from their own remotes. See [GitCheckoutBundle] for the checkout side; it
+// is mutually exclusive with [KeepGitDir] and [GitSubDir].
+//
+// Scheme-specific behavior can be tuned via [GitBundleOption] values, e.g.
+// [GitBundleOCIStore] for the "oci-layout+blob://" scheme.
+func GitBundleURL(locator string, opts ...GitBundleOption) GitOption {
+	bi := &GitBundleInfo{}
+	for _, o := range opts {
+		o.SetGitBundleOption(bi)
+	}
+	return gitOptionFunc(func(gi *GitInfo) {
+		gi.Bundle = locator
+		gi.BundleOCISessionID = bi.OCISessionID
+		gi.BundleOCIStoreID = bi.OCIStoreID
+	})
+}
+
+// GitBundleOCIStore configures the OCI-layout session and store id used to
+// resolve a bundle locator with the "oci-layout+blob://" scheme. When unset,
+// the locator body (the part before "@digest") is used as the store id and no
+// session is pinned. This mirrors [ImageBlobOCIStore] for regular OCI-layout
+// blobs.
+//
+// Only meaningful when passed to [GitBundleURL] together with a locator that
+// uses the "oci-layout+blob://" scheme.
+func GitBundleOCIStore(sessionID, storeID string) GitBundleOption {
+	return gitBundleOptionFunc(func(bi *GitBundleInfo) {
+		bi.OCISessionID = sessionID
+		bi.OCIStoreID = storeID
+	})
+}
+
+// GitCheckoutBundle produces a single-file git bundle at the checkout mount
+// root (filename "bundle") containing the resolved commit, instead of a
+// worktree. Mutually exclusive with [KeepGitDir] and [GitSubDir]. Submodules
+// are not included in the bundle. Pair with [GitBundleURL] to re-import the
+// bundle back into a later build.
+func GitCheckoutBundle() GitOption {
+	return gitOptionFunc(func(gi *GitInfo) {
+		gi.CheckoutBundle = true
 	})
 }
 

--- a/solver/llbsolver/provenance/capture.go
+++ b/solver/llbsolver/provenance/capture.go
@@ -152,12 +152,31 @@ func (c *Capture) AddLocal(l provenancetypes.LocalSource) {
 
 func (c *Capture) AddGit(g provenancetypes.GitSource) {
 	g.URL = urlutil.RedactCredentials(g.URL)
+	// Dedupe on the tuple (URL, Bundle.URL). Two records with the same
+	// URL but different bundle identity (e.g. the same repo referenced
+	// once normally and once through a bundle, or through two different
+	// bundle locators) must both be preserved so neither material is
+	// silently dropped from the provenance. Bundle.URL is the canonical
+	// bundle identity: since scheme/ref/digest are derived from it,
+	// different URLs imply different bundle identity.
 	for _, v := range c.Sources.Git {
-		if v.URL == g.URL {
+		if v.URL != g.URL {
+			continue
+		}
+		if bundleKey(v.Bundle) == bundleKey(g.Bundle) {
 			return
 		}
 	}
 	c.Sources.Git = append(c.Sources.Git, g)
+}
+
+// bundleKey returns a comparable identity for dedupe. Nil bundles collapse
+// to the empty key.
+func bundleKey(b *provenancetypes.GitBundle) string {
+	if b == nil {
+		return ""
+	}
+	return b.URL
 }
 
 func (c *Capture) AddHTTP(h provenancetypes.HTTPSource) {

--- a/solver/llbsolver/provenance/capture_test.go
+++ b/solver/llbsolver/provenance/capture_test.go
@@ -95,6 +95,68 @@ func TestCaptureAddGitDedup(t *testing.T) {
 	require.Len(t, c.Sources.Git, 1)
 }
 
+// TestCaptureAddGitBundleDedup pins the dedupe-key behavior: the same URL
+// referenced once without and once with a bundle locator must record two
+// separate materials, because the bundle carries its own identity. Identical
+// bundle locators still dedupe.
+func TestCaptureAddGitBundleDedup(t *testing.T) {
+	t.Parallel()
+
+	url := "https://github.com/moby/buildkit.git#master"
+	bundleDgst := digest.FromString("bundle-content")
+	bundleURL := "docker-image+blob://example.com/ns/repo@" + bundleDgst.String()
+
+	t.Run("same URL, different bundle fields are preserved", func(t *testing.T) {
+		c := &Capture{}
+		c.AddGit(provenancetypes.GitSource{
+			URL:    url,
+			Commit: "abc",
+		})
+		c.AddGit(provenancetypes.GitSource{
+			URL:    url,
+			Commit: "abc",
+			Bundle: &provenancetypes.GitBundle{URL: bundleURL},
+		})
+		require.Len(t, c.Sources.Git, 2)
+		require.Nil(t, c.Sources.Git[0].Bundle)
+		require.NotNil(t, c.Sources.Git[1].Bundle)
+		require.Equal(t, bundleURL, c.Sources.Git[1].Bundle.URL)
+	})
+
+	t.Run("identical bundle tuple still dedupes", func(t *testing.T) {
+		c := &Capture{}
+		mk := func() provenancetypes.GitSource {
+			return provenancetypes.GitSource{
+				URL:    url,
+				Commit: "abc",
+				Bundle: &provenancetypes.GitBundle{URL: bundleURL},
+			}
+		}
+		c.AddGit(mk())
+		c.AddGit(mk())
+		require.Len(t, c.Sources.Git, 1)
+	})
+
+	t.Run("different bundle URLs are preserved", func(t *testing.T) {
+		c := &Capture{}
+		dgst1 := digest.FromString("bundle-1")
+		dgst2 := digest.FromString("bundle-2")
+		c.AddGit(provenancetypes.GitSource{
+			URL: url,
+			Bundle: &provenancetypes.GitBundle{
+				URL: "docker-image+blob://example.com/ns/repo@" + dgst1.String(),
+			},
+		})
+		c.AddGit(provenancetypes.GitSource{
+			URL: url,
+			Bundle: &provenancetypes.GitBundle{
+				URL: "docker-image+blob://example.com/ns/repo@" + dgst2.String(),
+			},
+		})
+		require.Len(t, c.Sources.Git, 2)
+	})
+}
+
 func TestCaptureMerge(t *testing.T) {
 	t.Parallel()
 

--- a/solver/llbsolver/provenance/predicate.go
+++ b/solver/llbsolver/provenance/predicate.go
@@ -9,8 +9,10 @@ import (
 	slsa1 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v1"
 	"github.com/moby/buildkit/frontend/dockerfile/dfgitutil"
 	provenancetypes "github.com/moby/buildkit/solver/llbsolver/provenance/types"
+	srctypes "github.com/moby/buildkit/source/types"
 	"github.com/moby/buildkit/util/purl"
 	"github.com/moby/buildkit/util/urlutil"
+	digest "github.com/opencontainers/go-digest"
 	"github.com/package-url/packageurl-go"
 )
 
@@ -68,9 +70,54 @@ func slsaMaterials(srcs provenancetypes.Sources) ([]slsa.ProvenanceMaterial, err
 	}
 
 	for _, s := range srcs.Git {
+		// Git material URI is always the raw repository URL (same shape
+		// for bundle-backed and normal git sources).
 		out = append(out, slsa.ProvenanceMaterial{
 			URI:    s.URL,
 			Digest: digestSetForCommit(s.Commit),
+		})
+		if s.Bundle == nil {
+			continue
+		}
+
+		// Bundle-backed git source: parse the canonical locator into
+		// its scheme / ref-body / digest components on demand. On parse
+		// failure (shouldn't happen — validateBundleAttrs rejects bad
+		// locators at LLB op construction time) skip bundle material
+		// emission rather than erroring.
+		scheme, refBody, bundleDgst := parseBundleLocatorURL(s.Bundle.URL)
+		if scheme == "" || refBody == "" || bundleDgst == "" {
+			continue
+		}
+
+		bundlePurlType := packageurl.TypeDocker
+		if scheme == srctypes.OCIBlobScheme {
+			bundlePurlType = packageurl.TypeOCI
+		}
+		bundleURI, err := purl.RefToPURL(bundlePurlType, refBody, nil)
+		if err != nil {
+			return nil, err
+		}
+		bundleURI, err = setPURLQualifier(bundleURI, packageurl.Qualifier{
+			Key:   "ref_type",
+			Value: "bundle",
+		})
+		if err != nil {
+			return nil, err
+		}
+		bundleURI, err = setPURLQualifier(bundleURI, packageurl.Qualifier{
+			Key:   "vcs_url",
+			Value: s.URL,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, slsa.ProvenanceMaterial{
+			URI: bundleURI,
+			Digest: slsa.DigestSet{
+				bundleDgst.Algorithm().String(): bundleDgst.Hex(),
+			},
 		})
 	}
 
@@ -84,6 +131,31 @@ func slsaMaterials(srcs provenancetypes.Sources) ([]slsa.ProvenanceMaterial, err
 	}
 
 	return out, nil
+}
+
+// parseBundleLocatorURL parses a "<scheme>://<ref>@<algo>:<hex>" bundle
+// locator into its components. It returns empty values on parse failure; the
+// caller handles that by falling back to the non-bundle emission path.
+//
+// The identifier package has a stricter parseBundleLocator used at LLB op
+// construction time (validateBundleAttrs) that validates the reference and
+// digest algorithm. We intentionally don't import that helper here because
+// the identifier package imports this provenance package. Since the locator
+// has already been validated upstream, the logic here just splits the
+// locator back into its parts for purl emission.
+func parseBundleLocatorURL(raw string) (scheme, refBody string, dgst digest.Digest) {
+	const sep = "://"
+	i := strings.Index(raw, sep)
+	if i <= 0 {
+		return "", "", ""
+	}
+	scheme = raw[:i]
+	body := raw[i+len(sep):]
+	at := strings.LastIndex(body, "@")
+	if at <= 0 {
+		return "", "", ""
+	}
+	return scheme, body[:at], digest.Digest(body[at+1:])
 }
 
 func digestSetForCommit(commit string) slsa.DigestSet {

--- a/solver/llbsolver/provenance/predicate_test.go
+++ b/solver/llbsolver/provenance/predicate_test.go
@@ -1,6 +1,7 @@
 package provenance
 
 import (
+	"strings"
 	"testing"
 
 	provenancetypes "github.com/moby/buildkit/solver/llbsolver/provenance/types"
@@ -61,6 +62,99 @@ func TestSLSAMaterialsOCILayoutBlobPURL(t *testing.T) {
 	q := p.Qualifiers.Map()
 	require.Equal(t, "blob", q["ref_type"])
 	require.Equal(t, dgst.String(), q["digest"])
+}
+
+func TestSLSAMaterialsGitBundlePURL(t *testing.T) {
+	t.Parallel()
+
+	commitHex := "abc123def456abc123def456abc123def456abcd"
+	bundleDgst := digest.FromString("bundle")
+	gitURL := "https://github.com/moby/buildkit.git#master"
+
+	t.Run("registry", func(t *testing.T) {
+		ms, err := slsaMaterials(provenancetypes.Sources{
+			Git: []provenancetypes.GitSource{
+				{
+					URL:    gitURL,
+					Commit: commitHex,
+					Bundle: &provenancetypes.GitBundle{
+						URL: "docker-image+blob://example.com/ns/repo@" + bundleDgst.String(),
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		// one for the git source itself, one for the bundle material
+		require.Len(t, ms, 2)
+
+		// Git material is the raw repository URL (same shape as a
+		// non-bundle git source).
+		gitMaterial := ms[0]
+		require.Equal(t, gitURL, gitMaterial.URI)
+		require.Equal(t, commitHex, gitMaterial.Digest["sha1"])
+
+		// Bundle material is a purl with a vcs_url qualifier pointing
+		// back at the git URL.
+		bundleMaterial := ms[1]
+		require.True(t, strings.HasPrefix(bundleMaterial.URI, "pkg:docker/"),
+			"expected docker purl, got %q", bundleMaterial.URI)
+		bp, err := packageurl.FromString(bundleMaterial.URI)
+		require.NoError(t, err)
+		require.Equal(t, packageurl.TypeDocker, bp.Type)
+		bq := bp.Qualifiers.Map()
+		require.Equal(t, "bundle", bq["ref_type"])
+		require.Equal(t, gitURL, bq["vcs_url"])
+		require.Equal(t, bundleDgst.Hex(), bundleMaterial.Digest[bundleDgst.Algorithm().String()])
+	})
+
+	t.Run("oci-layout", func(t *testing.T) {
+		ms, err := slsaMaterials(provenancetypes.Sources{
+			Git: []provenancetypes.GitSource{
+				{
+					URL:    gitURL,
+					Commit: commitHex,
+					Bundle: &provenancetypes.GitBundle{
+						URL: "oci-layout+blob://example.com/ns/repo@" + bundleDgst.String(),
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, ms, 2)
+
+		// Git material is the raw repository URL.
+		gitMaterial := ms[0]
+		require.Equal(t, gitURL, gitMaterial.URI)
+		require.Equal(t, commitHex, gitMaterial.Digest["sha1"])
+
+		// Bundle material is a pkg:oci purl for an OCI-layout bundle.
+		bundleMaterial := ms[1]
+		require.True(t, strings.HasPrefix(bundleMaterial.URI, "pkg:oci/"),
+			"expected oci purl, got %q", bundleMaterial.URI)
+		bp, err := packageurl.FromString(bundleMaterial.URI)
+		require.NoError(t, err)
+		require.Equal(t, packageurl.TypeOCI, bp.Type)
+		bq := bp.Qualifiers.Map()
+		require.Equal(t, "bundle", bq["ref_type"])
+		require.Equal(t, gitURL, bq["vcs_url"])
+	})
+
+	t.Run("non-bundle git source unchanged", func(t *testing.T) {
+		// A plain git source (no Bundle) should still emit the raw URL
+		// verbatim, not a purl. This guards the non-bundle contract.
+		ms, err := slsaMaterials(provenancetypes.Sources{
+			Git: []provenancetypes.GitSource{
+				{
+					URL:    gitURL,
+					Commit: commitHex,
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, ms, 1)
+		require.Equal(t, gitURL, ms[0].URI)
+		require.Equal(t, commitHex, ms[0].Digest["sha1"])
+	})
 }
 
 func TestFilterArgs(t *testing.T) {

--- a/solver/llbsolver/provenance/types/types.go
+++ b/solver/llbsolver/provenance/types/types.go
@@ -71,6 +71,19 @@ type ImageBlobSource struct {
 type GitSource struct {
 	URL    string
 	Commit string
+	// Bundle, when non-nil, records the bundle blob that the git source
+	// was resolved from. Only present on bundle-backed git sources; nil
+	// for normal remote-backed git sources.
+	Bundle *GitBundle `json:"bundle,omitempty"`
+}
+
+// GitBundle describes the bundle blob a git source was resolved from. URL
+// is the full locator (e.g. "docker-image+blob://example.com/repo@sha256:...")
+// and is the canonical data: scheme, reference body, and digest are all
+// derivable from it and are parsed on demand by consumers (such as the purl
+// emitter in predicate.go).
+type GitBundle struct {
+	URL string `json:"url"`
 }
 
 type HTTPSource struct {

--- a/solver/pb/attr.go
+++ b/solver/pb/attr.go
@@ -10,6 +10,8 @@ const AttrGitChecksum = "git.checksum"
 const AttrGitSkipSubmodules = "git.skipsubmodules"
 const AttrGitMTime = "git.mtime"
 const AttrGitFetchByCommit = "git.fetchbycommit"
+const AttrGitBundle = "git.bundle"
+const AttrGitCheckoutBundle = "git.checkoutbundle"
 
 const AttrGitSignatureVerifyPubKey = "git.sig.pubkey"
 const AttrGitSignatureVerifyRejectExpired = "git.sig.rejectexpired"

--- a/solver/pb/caps.go
+++ b/solver/pb/caps.go
@@ -36,6 +36,8 @@ const (
 	CapSourceGitSignatureVerify apicaps.CapID = "source.git.signatureverify"
 	CapSourceGitMTime           apicaps.CapID = "source.git.mtime"
 	CapSourceGitFetchByCommit   apicaps.CapID = "source.git.fetchbycommit"
+	CapSourceGitBundle          apicaps.CapID = "source.git.bundle"
+	CapSourceGitCheckoutBundle  apicaps.CapID = "source.git.checkoutbundle"
 
 	CapSourceHTTP         apicaps.CapID = "source.http"
 	CapSourceHTTPAuth     apicaps.CapID = "source.http.auth"
@@ -265,6 +267,18 @@ func init() {
 
 	Caps.Init(apicaps.Cap{
 		ID:      CapSourceGitFetchByCommit,
+		Enabled: true,
+		Status:  apicaps.CapStatusExperimental,
+	})
+
+	Caps.Init(apicaps.Cap{
+		ID:      CapSourceGitBundle,
+		Enabled: true,
+		Status:  apicaps.CapStatusExperimental,
+	})
+
+	Caps.Init(apicaps.Cap{
+		ID:      CapSourceGitCheckoutBundle,
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})

--- a/source/containerblob/blobfetch/fetch.go
+++ b/source/containerblob/blobfetch/fetch.go
@@ -1,0 +1,128 @@
+// Package blobfetch provides a shared helper for resolving a single
+// content-addressable blob from either a docker-image registry or an OCI layout
+// content store, identified by its digest. It is factored out of the
+// containerblob source so other consumers (for example the git-bundle flow on
+// the git source) can reuse the same resolution logic without depending on the
+// source implementation.
+package blobfetch
+
+import (
+	"context"
+	"io"
+	"time"
+
+	"github.com/containerd/containerd/v2/core/remotes"
+	"github.com/containerd/containerd/v2/core/remotes/docker"
+	"github.com/moby/buildkit/session"
+	sessioncontent "github.com/moby/buildkit/session/content"
+	srctypes "github.com/moby/buildkit/source/types"
+	"github.com/moby/buildkit/util/iohelper"
+	"github.com/moby/buildkit/util/resolver"
+	digest "github.com/opencontainers/go-digest"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+// FetchOpt describes how to resolve a blob.
+type FetchOpt struct {
+	// Scheme identifies the source kind. Must be one of
+	// srctypes.DockerImageBlobScheme or srctypes.OCIBlobScheme.
+	Scheme string
+	// Ref is the image-ref form of the blob, i.e. "<name>@<digest>" for
+	// registry blobs, or the reference body accepted by the containerd
+	// reference parser for OCI-layout blobs.
+	Ref string
+	// Digest is the blob digest to retrieve.
+	Digest digest.Digest
+	// RegistryHosts is used when Scheme is DockerImageBlobScheme.
+	RegistryHosts docker.RegistryHosts
+	// SessionManager is used to reach the client when Scheme is
+	// OCIBlobScheme.
+	SessionManager *session.Manager
+	// SessionID, if set, pins the OCI-layout fetch to a specific client
+	// session.
+	SessionID string
+	// StoreID is the client-side OCI-layout store name. Required for
+	// Scheme == OCIBlobScheme.
+	StoreID string
+}
+
+// FetchBlob opens a read stream for the requested blob. The caller owns the
+// returned ReadCloser and must Close it. The returned digest is the blob
+// digest from the locator (echoed for convenience).
+func FetchBlob(ctx context.Context, g session.Group, opt FetchOpt) (io.ReadCloser, digest.Digest, error) {
+	if err := opt.Digest.Validate(); err != nil {
+		return nil, "", errors.Wrap(err, "invalid blob digest")
+	}
+	switch opt.Scheme {
+	case srctypes.OCIBlobScheme:
+		if opt.StoreID == "" {
+			return nil, "", errors.Errorf("oci-layout blob source requires store id")
+		}
+		rc, err := fetchFromOCILayoutStore(ctx, g, opt)
+		if err != nil {
+			return nil, "", err
+		}
+		return rc, opt.Digest, nil
+	case srctypes.DockerImageBlobScheme:
+		r := resolver.DefaultPool.GetResolver(opt.RegistryHosts, opt.Ref, resolver.ScopeType{}, opt.SessionManager, g)
+		f, err := r.Fetcher(ctx, opt.Ref)
+		if err != nil {
+			return nil, "", err
+		}
+		fd, ok := f.(remotes.FetcherByDigest)
+		if !ok {
+			return nil, "", errors.Errorf("invalid blob fetcher: %T", f)
+		}
+		rc, _, err := fd.FetchByDigest(ctx, opt.Digest)
+		if err != nil {
+			return nil, "", err
+		}
+		return rc, opt.Digest, nil
+	default:
+		return nil, "", errors.Errorf("unsupported blob scheme %q", opt.Scheme)
+	}
+}
+
+func fetchFromOCILayoutStore(ctx context.Context, g session.Group, opt FetchOpt) (io.ReadCloser, error) {
+	var rc io.ReadCloser
+	err := withOCICaller(ctx, g, opt, func(ctx context.Context, caller session.Caller) error {
+		store := sessioncontent.NewCallerStore(caller, "oci:"+opt.StoreID)
+		info, err := store.Info(ctx, opt.Digest)
+		if err != nil {
+			return err
+		}
+
+		readerAt, err := store.ReaderAt(ctx, ocispecs.Descriptor{
+			Digest: info.Digest,
+			Size:   info.Size,
+		})
+		if err != nil {
+			return err
+		}
+		rc = iohelper.ReadCloser(readerAt)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return rc, nil
+}
+
+func withOCICaller(ctx context.Context, g session.Group, opt FetchOpt, f func(context.Context, session.Caller) error) error {
+	if opt.SessionID != "" {
+		timeoutCtx, cancel := context.WithCancelCause(ctx)
+		timeoutCtx, _ = context.WithTimeoutCause(timeoutCtx, 5*time.Second, errors.WithStack(context.DeadlineExceeded)) //nolint:govet
+		defer func() { cancel(errors.WithStack(context.Canceled)) }()
+
+		caller, err := opt.SessionManager.Get(timeoutCtx, opt.SessionID, false)
+		if err != nil {
+			return err
+		}
+		return f(ctx, caller)
+	}
+
+	return opt.SessionManager.Any(ctx, g, func(ctx context.Context, _ string, caller session.Caller) error {
+		return f(ctx, caller)
+	})
+}

--- a/source/containerblob/pull.go
+++ b/source/containerblob/pull.go
@@ -9,20 +9,15 @@ import (
 	"os"
 	"time"
 
-	"github.com/containerd/containerd/v2/core/remotes"
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/session"
-	sessioncontent "github.com/moby/buildkit/session/content"
 	"github.com/moby/buildkit/snapshot"
 	"github.com/moby/buildkit/solver"
-	srctypes "github.com/moby/buildkit/source/types"
+	"github.com/moby/buildkit/source/containerblob/blobfetch"
 	"github.com/moby/buildkit/source/util/pathutil"
 	"github.com/moby/buildkit/util/contentutil"
-	"github.com/moby/buildkit/util/iohelper"
-	"github.com/moby/buildkit/util/resolver"
 	digest "github.com/opencontainers/go-digest"
-	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -68,83 +63,22 @@ func (p *puller) ensureResolver(ctx context.Context, g session.Group) error {
 		return errors.Wrap(err, "invalid reference digest")
 	}
 
-	var (
-		rc  io.ReadCloser
-		err error
-	)
-	if p.id.Scheme() == srctypes.OCIBlobScheme {
-		rc, err = p.fetchFromOCILayoutStore(ctx, g, dgst)
-		if err != nil {
-			return err
-		}
-	} else {
-		r := resolver.DefaultPool.GetResolver(p.src.RegistryHosts, p.id.Reference.String(), resolver.ScopeType{}, p.SessionManager, g)
-		f, err := r.Fetcher(ctx, p.id.Reference.String())
-		if err != nil {
-			return err
-		}
-
-		fd, ok := f.(remotes.FetcherByDigest)
-		if !ok {
-			return errors.Errorf("invalid blob fetcher: %T", f)
-		}
-
-		rc, _, err = fd.FetchByDigest(ctx, dgst)
-		if err != nil {
-			return err
-		}
+	rc, _, err := blobfetch.FetchBlob(ctx, g, blobfetch.FetchOpt{
+		Scheme:         p.id.Scheme(),
+		Ref:            p.id.Reference.String(),
+		Digest:         dgst,
+		RegistryHosts:  p.src.RegistryHosts,
+		SessionManager: p.SessionManager,
+		SessionID:      p.id.SessionID,
+		StoreID:        p.id.StoreID,
+	})
+	if err != nil {
+		return err
 	}
 
 	p.rc = rc
 	p.dgst = dgst
 	return nil
-}
-
-func (p *puller) fetchFromOCILayoutStore(ctx context.Context, g session.Group, dgst digest.Digest) (io.ReadCloser, error) {
-	if p.id.StoreID == "" {
-		return nil, errors.Errorf("oci-layout blob source requires store id")
-	}
-
-	var rc io.ReadCloser
-	err := p.withOCICaller(ctx, g, func(ctx context.Context, caller session.Caller) error {
-		store := sessioncontent.NewCallerStore(caller, "oci:"+p.id.StoreID)
-		info, err := store.Info(ctx, dgst)
-		if err != nil {
-			return err
-		}
-
-		readerAt, err := store.ReaderAt(ctx, ocispecs.Descriptor{
-			Digest: info.Digest,
-			Size:   info.Size,
-		})
-		if err != nil {
-			return err
-		}
-		rc = iohelper.ReadCloser(readerAt)
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return rc, nil
-}
-
-func (p *puller) withOCICaller(ctx context.Context, g session.Group, f func(context.Context, session.Caller) error) error {
-	if p.id.SessionID != "" {
-		timeoutCtx, cancel := context.WithCancelCause(ctx)
-		timeoutCtx, _ = context.WithTimeoutCause(timeoutCtx, 5*time.Second, errors.WithStack(context.DeadlineExceeded)) //nolint:govet
-		defer func() { cancel(errors.WithStack(context.Canceled)) }()
-
-		caller, err := p.SessionManager.Get(timeoutCtx, p.id.SessionID, false)
-		if err != nil {
-			return err
-		}
-		return f(ctx, caller)
-	}
-
-	return p.SessionManager.Any(ctx, g, func(ctx context.Context, _ string, caller session.Caller) error {
-		return f(ctx, caller)
-	})
 }
 
 func (p *puller) CacheKey(ctx context.Context, jobCtx solver.JobContext, index int) (cacheKey string, imgDigest string, cacheOpts solver.CacheOpts, cacheDone bool, err error) {

--- a/source/git/bundle.go
+++ b/source/git/bundle.go
@@ -1,0 +1,460 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/moby/buildkit/cache"
+	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/snapshot"
+	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/source/containerblob/blobfetch"
+	srctypes "github.com/moby/buildkit/source/types"
+	"github.com/moby/buildkit/util/bklog"
+	"github.com/moby/buildkit/util/gitutil"
+	digest "github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
+)
+
+const (
+	// bundleFileName is the name of the bundle file written at the
+	// checkout mount root when git.checkoutbundle is set. Documented on
+	// the GitCheckoutBundle godoc.
+	bundleFileName = "bundle"
+
+	// bundleImportFileName is the on-disk name of the transient bundle
+	// file streamed in from the blob locator, colocated with the bare
+	// repo and removed once the import completes.
+	bundleImportFileName = "bundle.pack"
+
+	// bundleFallbackRef is the ref name used when the user's ref is empty
+	// or a commit SHA. Bundle creation needs a named ref so the consumer's
+	// fetch refspec has something to land; consumer-side resolution
+	// short-circuits on SHA when Ref is empty/SHA, so the fallback name
+	// is not user-visible.
+	bundleFallbackRef = "refs/heads/main"
+)
+
+// bundleTargetRef normalizes the user's ref into a fully-qualified ref name
+// suitable as the tip ref inside the emitted bundle.
+//
+//   - Empty / commit SHA: falls back to bundleFallbackRef. The consumer
+//     short-circuits on SHA so the chosen branch name is not user-visible,
+//     but bundle creation needs a named ref for the fetch refspec to land.
+//   - "refs/tags/<name>": preserved as a tag ref so a tag-addressed checkout
+//     keeps the tag qualifier on the consumer side.
+//   - Anything else (e.g. "master", "refs/heads/main", "v1"): stripped of a
+//     leading refs/ or heads/ qualifier and re-prefixed with refs/heads/.
+//
+// Design note: refs/tags/<x> is preserved, but a bare "v1" is mapped to
+// refs/heads/v1 rather than refs/tags/v1 because we cannot tell from a
+// symbolic ref alone whether it originated as a tag or a branch; refs/heads/
+// is the safer default for tip placement.
+func bundleTargetRef(ref string) string {
+	if ref == "" || gitutil.IsCommitSHA(ref) {
+		return bundleFallbackRef
+	}
+	if strings.HasPrefix(ref, "refs/tags/") {
+		return ref
+	}
+	name := strings.TrimPrefix(ref, "refs/")
+	name = strings.TrimPrefix(name, "heads/")
+	return "refs/heads/" + name
+}
+
+// stageBundle downloads the bundle blob into an isolated temp bare repo,
+// imports it, and validates that the pinned commit is present. The returned
+// URL (file://<tmpRepoDir>) is suitable for use as a git fetch source (for
+// the main fetch flow) or as the remote URL for an ls-remote call (for
+// metadata resolution), so both paths converge on the same git primitives
+// as a normal origin fetch.
+//
+// The returned cleanup removes the temp dir and must be called once the
+// caller is done with the staged URL.
+func (gs *gitSourceHandler) stageBundle(ctx context.Context, g session.Group) (_ string, _ func() error, retErr error) {
+	scheme, ref, storeID, dgst, err := parseBundleLocator(gs.src.Bundle)
+	if err != nil {
+		return "", nil, err
+	}
+
+	tmpDir, err := os.MkdirTemp("", "buildkit-bundle-")
+	if err != nil {
+		return "", nil, errors.Wrap(err, "failed to create temp dir for bundle")
+	}
+	cleanup := func() error { return os.RemoveAll(tmpDir) }
+	defer func() {
+		if retErr != nil {
+			cleanup()
+		}
+	}()
+
+	if err := gs.downloadBundleToFile(ctx, g, scheme, ref, storeID, dgst, tmpDir, bundleImportFileName); err != nil {
+		return "", nil, err
+	}
+	bundlePath := filepath.Join(tmpDir, bundleImportFileName)
+
+	// Initialize an isolated bare repo in the temp dir and import the
+	// bundle there. This lets us validate the bundle and stage the refs
+	// under their natural names without touching the shared bare repo.
+	tmpRepoDir := filepath.Join(tmpDir, "repo.git")
+	if err := os.Mkdir(tmpRepoDir, 0700); err != nil {
+		return "", nil, errors.Wrap(err, "failed to create temp bare repo dir")
+	}
+	tmpGit := gitCLI(gitutil.WithGitDir(tmpRepoDir))
+	initArgs := []string{"-c", "init.defaultBranch=master", "init", "--bare"}
+	if gs.sha256 {
+		initArgs = append(initArgs, "--object-format=sha256")
+	}
+	if _, err := tmpGit.Run(ctx, initArgs...); err != nil {
+		return "", nil, errors.Wrap(err, "failed to init temp bare repo")
+	}
+
+	if _, err := tmpGit.Run(ctx, "fetch", bundlePath, "+refs/*:refs/*"); err != nil {
+		return "", nil, errors.Wrapf(err, "failed to import git bundle %s into temp", ref)
+	}
+
+	// Confirm the pinned commit is actually present in the bundle. The
+	// subsequent fetch in the main flow would surface a generic "failed to
+	// fetch" error; this check gives a clearer message.
+	if _, err := tmpGit.Run(ctx, "cat-file", "-e", gs.src.Checksum+"^{commit}"); err != nil {
+		return "", nil, errors.Errorf("commit %s not found in bundle %s", gs.src.Checksum, ref)
+	}
+
+	return "file://" + tmpRepoDir, cleanup, nil
+}
+
+// ensureStagedBundle returns the file:// URL of a staged temp bare repo
+// produced from gs.src.Bundle, lazily staging it on first call and reusing
+// the same staging dir on subsequent calls for the lifetime of gs.
+//
+// The call-site contract is: callers may call ensureStagedBundle any number
+// of times and must never run the cleanup themselves. Cleanup is attached to
+// the job via JobContext.Cleanup on the first staging so it fires at
+// end-of-solve regardless of whether Snapshot runs (covering the
+// CacheKey-then-cache-hit path where tryRemoteFetch never executes). If no
+// jobCtx is available (e.g. ResolveMetadata path with a nil jobCtx), the
+// returned cleanup is retained on the handler and teardown must come from a
+// later call that does provide a jobCtx, or from the caller running
+// releaseStagedBundle explicitly.
+//
+// Handler methods run sequentially per solve, so ensureStagedBundle does not
+// guard against concurrent calls.
+func (gs *gitSourceHandler) ensureStagedBundle(ctx context.Context, jobCtx solver.JobContext, g session.Group) (string, error) {
+	if gs.stagedBundleURL != "" {
+		return gs.stagedBundleURL, nil
+	}
+
+	url, cleanup, err := gs.stageBundle(ctx, g)
+	if err != nil {
+		return "", err
+	}
+
+	// Make the cleanup idempotent so it is safe to call from both the
+	// job cleanup path and an explicit releaseStagedBundle (or the
+	// CacheKey fallback path below) without double-removing the temp dir.
+	once := sync.OnceValue(cleanup)
+	gs.stagedBundleURL = url
+	gs.stagedBundleCleanup = once
+
+	if jobCtx != nil {
+		if err := jobCtx.Cleanup(func() error { return once() }); err != nil {
+			// Failed to register the job cleanup — run it synchronously
+			// so we do not leak the temp dir.
+			_ = once()
+			gs.stagedBundleURL = ""
+			gs.stagedBundleCleanup = nil
+			return "", err
+		}
+		// The job cleanup now owns the teardown; clearing the
+		// per-handler pointer avoids a second invocation from any
+		// fallback path. The stored url stays set so repeat callers on
+		// this handler get the cached URL for the remainder of the
+		// solve, before the job cleanup fires.
+		gs.stagedBundleCleanup = nil
+	} else {
+		bklog.G(ctx).Debug("bundle staged without jobCtx; cleanup deferred to handler teardown")
+	}
+
+	return url, nil
+}
+
+// releaseStagedBundle tears down any staged bundle owned by the handler. It
+// is a no-op when the cleanup has already been attached to a JobContext or
+// when nothing was staged. Safe to call multiple times.
+func (gs *gitSourceHandler) releaseStagedBundle() error {
+	cleanup := gs.stagedBundleCleanup
+	gs.stagedBundleCleanup = nil
+	gs.stagedBundleURL = ""
+	if cleanup == nil {
+		return nil
+	}
+	return cleanup()
+}
+
+// downloadBundleToFile streams the bundle blob into a file named bundleName
+// inside bundleDir while verifying its digest against the locator. The file
+// is created via os.Root so a pre-existing symlink at bundleName inside
+// bundleDir cannot redirect the write outside of bundleDir.
+func (gs *gitSourceHandler) downloadBundleToFile(ctx context.Context, g session.Group, scheme, ref, storeID string, expectedDigest digest.Digest, bundleDir, bundleName string) (retErr error) {
+	rc, err := gs.openBundleBlob(ctx, g, scheme, ref, storeID, expectedDigest)
+	if err != nil {
+		return errors.Wrapf(err, "failed to fetch git bundle %s", ref)
+	}
+	defer rc.Close()
+
+	bundleDirRoot, err := os.OpenRoot(bundleDir)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open bundle dir root %s", bundleDir)
+	}
+	defer bundleDirRoot.Close()
+
+	f, err := bundleDirRoot.Create(bundleName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create bundle file %s", bundleName)
+	}
+	defer func() {
+		if retErr != nil {
+			f.Close()
+			bundleDirRoot.Remove(bundleName)
+		}
+	}()
+
+	d := digest.SHA256.Digester()
+	if _, err := io.Copy(io.MultiWriter(f, d.Hash()), rc); err != nil {
+		return errors.Wrapf(err, "failed to download git bundle %s", ref)
+	}
+	if err := f.Close(); err != nil {
+		return errors.Wrapf(err, "failed to close bundle file %s", bundleName)
+	}
+
+	got := d.Digest()
+	if expectedDigest != "" && got != expectedDigest {
+		return errors.Errorf("expected checksum to match %s, got %s", expectedDigest, got)
+	}
+	return nil
+}
+
+// openBundleBlob resolves the blob using blobfetch. storeID is the pre-derived
+// OCI-layout store id (empty for registry blobs).
+func (gs *gitSourceHandler) openBundleBlob(ctx context.Context, g session.Group, scheme, ref, storeID string, dgst digest.Digest) (io.ReadCloser, error) {
+	opt := blobfetch.FetchOpt{
+		Scheme:         scheme,
+		Ref:            ref,
+		Digest:         dgst,
+		RegistryHosts:  gs.registryHosts,
+		SessionManager: gs.sm,
+	}
+	if scheme == srctypes.OCIBlobScheme {
+		opt.SessionID = gs.src.BundleOCISessionID
+		opt.StoreID = storeID
+		if gs.src.BundleOCIStoreID != "" {
+			opt.StoreID = gs.src.BundleOCIStoreID
+		}
+	}
+	rc, _, err := blobfetch.FetchBlob(ctx, g, opt)
+	return rc, err
+}
+
+// resolveBundleMetadata stages the bundle in an isolated temp bare repo and
+// delegates to the shared ls-remote code path using that repo's file:// URL.
+// Bundle mode lands refs in refs/heads/* and refs/tags/* just like a normal
+// origin fetch, so the resolution logic is identical once the URL swap is
+// done — and the resulting Metadata.Ref has the same shape as non-bundle
+// mode (e.g. "refs/heads/master" for symbolic ref "master").
+//
+// For a pinned-commit / empty user ref, short-circuit: the user has already
+// told us the commit, so there is nothing for ls-remote to add and no point
+// downloading the bundle just for metadata resolution. The bundle will still
+// be staged during the Snapshot path if the commit is not already present.
+func (gs *gitSourceHandler) resolveBundleMetadata(ctx context.Context, jobCtx solver.JobContext) (*Metadata, error) {
+	// Bundle mode requires git.checksum; if Ref is empty or a SHA, the
+	// commit is already pinned and no lookup is needed. Report Ref and
+	// Checksum as the commit SHA — same shape as the commit-SHA short
+	// circuit in non-bundle resolveMetadata.
+	if gs.src.Ref == "" || gitutil.IsCommitSHA(gs.src.Ref) {
+		ref := gs.src.Ref
+		if ref == "" {
+			ref = gs.src.Checksum
+		}
+		if gs.src.Checksum != "" && !strings.HasPrefix(ref, gs.src.Checksum) {
+			return nil, errors.Errorf("expected checksum to match %s, got %s", gs.src.Checksum, ref)
+		}
+		return &Metadata{Ref: ref, Checksum: ref}, nil
+	}
+
+	var g session.Group
+	if jobCtx != nil {
+		g = jobCtx.Session()
+	}
+	stagedURL, err := gs.ensureStagedBundle(ctx, jobCtx, g)
+	if err != nil {
+		return nil, err
+	}
+	return gs.resolveMetadataFromURL(ctx, g, stagedURL)
+}
+
+// checkoutAsBundle writes a single-file git bundle at the checkout mount root
+// instead of a worktree. This is the checkout counterpart of bundle import and
+// is used when GitCheckoutBundle() is set on the identifier. Submodules are
+// not included in the bundle.
+func (gs *gitSourceHandler) checkoutAsBundle(ctx context.Context, repo *gitRepo, g session.Group) (_ cache.ImmutableRef, retErr error) {
+	ref := gs.src.Ref
+	commit := gs.src.Checksum
+	if commit == "" {
+		commit = ref
+	}
+
+	checkoutRef, err := gs.cache.New(ctx, nil, g, cache.CachePolicyRetain, cache.WithDescription(fmt.Sprintf("git bundle checkout for %s#%s", gs.src.Remote, ref)))
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create new mutable for bundle checkout")
+	}
+	defer func() {
+		if retErr != nil && checkoutRef != nil {
+			checkoutRef.Release(context.WithoutCancel(ctx))
+		}
+	}()
+
+	mount, err := checkoutRef.Mount(ctx, false, g)
+	if err != nil {
+		return nil, err
+	}
+	lm := snapshot.LocalMounter(mount)
+	checkoutDir, err := lm.Mount()
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if retErr != nil && lm != nil {
+			lm.Unmount()
+		}
+	}()
+
+	// The bundle needs to carry a named ref that points at the target
+	// commit, so `git fetch <bundle> +refs/*:refs/*` on the consumer side
+	// has something to land. We preserve the user's ref name (normalized
+	// into refs/heads/* or refs/tags/*) so the bundle reads as if it were
+	// produced by the upstream remote; no fake internal namespace.
+	targetRef := bundleTargetRef(ref)
+
+	// Stage the bundle in an isolated temp bare repo rather than mutating
+	// the shared bare repo's ref namespace. We fetch the pinned commit
+	// from the shared repo into the temp bare repo and give it the
+	// target-ref name there, so `git bundle create` sees a clean,
+	// self-contained repo with exactly the ref we want in the bundle.
+	tmpDir, err := os.MkdirTemp("", "buildkit-bundle-create-")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create temp dir for bundle creation")
+	}
+	defer os.RemoveAll(tmpDir)
+
+	tmpRepoDir := filepath.Join(tmpDir, "repo.git")
+	if err := os.Mkdir(tmpRepoDir, 0700); err != nil {
+		return nil, errors.Wrap(err, "failed to create temp bare repo dir for bundle creation")
+	}
+	tmpGit := repo.New(gitutil.WithGitDir(tmpRepoDir))
+	initArgs := []string{"-c", "init.defaultBranch=master", "init", "--bare"}
+	if gs.sha256 {
+		initArgs = append(initArgs, "--object-format=sha256")
+	}
+	if _, err := tmpGit.Run(ctx, initArgs...); err != nil {
+		return nil, errors.Wrap(err, "failed to init temp bare repo for bundle creation")
+	}
+
+	// Pull the pinned commit from the shared bare repo into temp, then
+	// point the target ref at it. The shared bare repo maps user refs to
+	// refs/tags/<name> via the main-path fetch refspec, so there is no
+	// natural-name ref to pull; update-ref alone places the tip against
+	// the pinned commit under the target name.
+	sharedURL := "file://" + repo.dir
+	if _, err := tmpGit.Run(ctx, "fetch", sharedURL, commit); err != nil {
+		return nil, errors.Wrapf(err, "failed to fetch commit %s from shared repo for bundle creation", commit)
+	}
+
+	if _, err := tmpGit.Run(ctx, "update-ref", targetRef, commit); err != nil {
+		return nil, errors.Wrapf(err, "failed to create target ref for bundle %s", commit)
+	}
+
+	// Write the bundle under a temp path we fully own, then move it into
+	// the checkout mount through os.OpenRoot so a pre-existing symlink at
+	// <checkoutDir>/bundle cannot redirect the final artifact outside the
+	// mount. git bundle create is an external process that only accepts
+	// path strings, so the only safe landing pattern is: write to a path
+	// outside the mount, then atomically transfer the bytes through an
+	// os.Root-scoped file handle.
+	stagePath := filepath.Join(tmpDir, "out.bundle")
+	if _, err := tmpGit.Run(ctx, "bundle", "create", stagePath, targetRef); err != nil {
+		return nil, errors.Wrapf(err, "failed to create git bundle for %s", commit)
+	}
+
+	if err := writeBundleToMount(checkoutDir, bundleFileName, stagePath); err != nil {
+		return nil, err
+	}
+
+	outPath := filepath.Join(checkoutDir, bundleFileName)
+	if idmap := mount.IdentityMapping(); idmap != nil {
+		uid, gid := idmap.RootPair()
+		if err := os.Lchown(outPath, uid, gid); err != nil {
+			return nil, errors.Wrap(err, "failed to remap git bundle ownership")
+		}
+	}
+
+	lm.Unmount()
+	lm = nil
+
+	snap, err := checkoutRef.Commit(ctx)
+	if err != nil {
+		return nil, err
+	}
+	checkoutRef = nil
+	return snap, nil
+}
+
+// writeBundleToMount copies the bytes at stagePath into
+// <checkoutDir>/<bundleName> via os.OpenRoot, so a symlink at the destination
+// cannot redirect the write outside checkoutDir. The staging file is expected
+// to be a path the caller fully controls (created under its own temp dir),
+// not a path inside checkoutDir.
+func writeBundleToMount(checkoutDir, bundleName, stagePath string) (retErr error) {
+	src, err := os.Open(stagePath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open staged bundle %s", stagePath)
+	}
+	defer src.Close()
+
+	checkoutRoot, err := os.OpenRoot(checkoutDir)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open checkout dir root %s", checkoutDir)
+	}
+	defer checkoutRoot.Close()
+
+	// Remove any pre-existing entry at bundleName. If it's a symlink,
+	// os.Root.Remove deletes the link itself, not the target, so a symlink
+	// planted in the mount cannot redirect the subsequent create.
+	if err := checkoutRoot.Remove(bundleName); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return errors.Wrapf(err, "failed to clear bundle dest %s", bundleName)
+	}
+
+	dst, err := checkoutRoot.Create(bundleName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create bundle file %s", bundleName)
+	}
+	defer func() {
+		if retErr != nil {
+			dst.Close()
+			checkoutRoot.Remove(bundleName)
+		}
+	}()
+
+	if _, err := io.Copy(dst, src); err != nil {
+		return errors.Wrapf(err, "failed to write bundle to %s", bundleName)
+	}
+	if err := dst.Close(); err != nil {
+		return errors.Wrapf(err, "failed to close bundle file %s", bundleName)
+	}
+	return nil
+}

--- a/source/git/bundle.go
+++ b/source/git/bundle.go
@@ -67,6 +67,28 @@ func bundleTargetRef(ref string) string {
 	return "refs/heads/" + name
 }
 
+// detectBundleSHA256 probes a raw git bundle and returns whether it carries
+// sha256 object IDs. git ls-remote reads bundle files directly, so this works
+// before a destination repo exists and lets callers initialize the right object
+// format for a subsequent fetch/import.
+func detectBundleSHA256(ctx context.Context, bundlePath string) (bool, error) {
+	buf, err := gitCLI().Run(ctx, "ls-remote", "--", bundlePath)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to inspect git bundle %s", bundlePath)
+	}
+	for line := range strings.SplitSeq(string(buf), "\n") {
+		if line == "" {
+			continue
+		}
+		sha, _, _ := strings.Cut(line, "\t")
+		if !gitutil.IsCommitSHA(sha) {
+			return false, errors.Errorf("failed to inspect git bundle %s: invalid object ID %q", bundlePath, sha)
+		}
+		return len(sha) == 64, nil
+	}
+	return false, errors.Errorf("failed to inspect git bundle %s: no refs found", bundlePath)
+}
+
 // stageBundle downloads the bundle blob into an isolated temp bare repo,
 // imports it, and validates that the pinned commit is present. The returned
 // URL (file://<tmpRepoDir>) is suitable for use as a git fetch source (for
@@ -97,6 +119,11 @@ func (gs *gitSourceHandler) stageBundle(ctx context.Context, g session.Group) (_
 		return "", nil, err
 	}
 	bundlePath := filepath.Join(tmpDir, bundleImportFileName)
+	sha256, err := detectBundleSHA256(ctx, bundlePath)
+	if err != nil {
+		return "", nil, err
+	}
+	gs.sha256 = sha256
 
 	// Initialize an isolated bare repo in the temp dir and import the
 	// bundle there. This lets us validate the bundle and stage the refs
@@ -107,7 +134,7 @@ func (gs *gitSourceHandler) stageBundle(ctx context.Context, g session.Group) (_
 	}
 	tmpGit := gitCLI(gitutil.WithGitDir(tmpRepoDir))
 	initArgs := []string{"-c", "init.defaultBranch=master", "init", "--bare"}
-	if gs.sha256 {
+	if sha256 {
 		initArgs = append(initArgs, "--object-format=sha256")
 	}
 	if _, err := tmpGit.Run(ctx, initArgs...); err != nil {

--- a/source/git/identifier.go
+++ b/source/git/identifier.go
@@ -1,11 +1,16 @@
 package git
 
 import (
+	"strings"
+
+	"github.com/containerd/containerd/v2/pkg/reference"
 	"github.com/moby/buildkit/solver/llbsolver/provenance"
 	provenancetypes "github.com/moby/buildkit/solver/llbsolver/provenance/types"
 	"github.com/moby/buildkit/source"
 	srctypes "github.com/moby/buildkit/source/types"
 	"github.com/moby/buildkit/util/gitutil"
+	digest "github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
 )
 
 type GitIdentifier struct {
@@ -21,6 +26,23 @@ type GitIdentifier struct {
 	SkipSubmodules   bool
 	MTime            string // "checkout" (default) or "commit"
 	FetchByCommit    bool
+
+	// Bundle, when non-empty, instructs the git source to fetch commits from a
+	// pre-built git bundle stored as a blob instead of fetching from the remote
+	// repository. The locator must use the "docker-image+blob://" or
+	// "oci-layout+blob://" scheme.
+	Bundle string
+	// BundleOCISessionID, when set, pins the OCI-layout bundle fetch to a
+	// specific client session. Only meaningful when Bundle uses the
+	// oci-layout+blob:// scheme.
+	BundleOCISessionID string
+	// BundleOCIStoreID, when set, overrides the OCI-layout store name
+	// derived from the bundle locator. Only meaningful when Bundle uses the
+	// oci-layout+blob:// scheme.
+	BundleOCIStoreID string
+	// CheckoutBundle, when true, produces a single-file git bundle at the
+	// checkout mount root (filename "bundle") instead of a worktree.
+	CheckoutBundle bool
 
 	VerifySignature *GitSignatureVerifyOptions
 }
@@ -56,14 +78,18 @@ func (GitIdentifier) Scheme() string {
 var _ source.Identifier = (*GitIdentifier)(nil)
 
 func (id *GitIdentifier) Capture(c *provenance.Capture, pin string) error {
-	url := id.Remote
+	remoteURL := id.Remote
 	if id.Ref != "" {
-		url += "#" + id.Ref
+		remoteURL += "#" + id.Ref
 	}
-	c.AddGit(provenancetypes.GitSource{
-		URL:    url,
+	gs := provenancetypes.GitSource{
+		URL:    remoteURL,
 		Commit: pin,
-	})
+	}
+	if id.Bundle != "" {
+		gs.Bundle = &provenancetypes.GitBundle{URL: id.Bundle}
+	}
+	c.AddGit(gs)
 	if id.AuthTokenSecret != "" {
 		c.AddSecret(provenancetypes.Secret{
 			ID:       id.AuthTokenSecret,
@@ -83,4 +109,74 @@ func (id *GitIdentifier) Capture(c *provenance.Capture, pin string) error {
 		})
 	}
 	return nil
+}
+
+// validateBundleAttrs enforces the bundle-mode constraints that are statically
+// decidable at identifier parse time.
+func validateBundleAttrs(id *GitIdentifier) error {
+	if id.Bundle != "" {
+		if _, _, _, _, err := parseBundleLocator(id.Bundle); err != nil {
+			return err
+		}
+		if id.Checksum == "" {
+			return errors.Errorf("git.bundle requires git.checksum to be set")
+		}
+		// Reject the pathological "Ref=sha1, Checksum=sha2" case: if both
+		// are set and Ref is itself a commit SHA, the two must agree.
+		// Without this check bundle mode silently overwrites Ref with
+		// Checksum in tryRemoteFetch and the mismatch never surfaces.
+		if id.Ref != "" && gitutil.IsCommitSHA(id.Ref) && !strings.HasPrefix(id.Ref, id.Checksum) {
+			return errors.Errorf("expected checksum to match %s, got %s", id.Checksum, id.Ref)
+		}
+	}
+	if id.CheckoutBundle {
+		if id.KeepGitDir {
+			return errors.Errorf("git.checkoutbundle is incompatible with git.keepgitdir")
+		}
+		if id.Subdir != "" {
+			return errors.Errorf("git.checkoutbundle is incompatible with git.subdir")
+		}
+	}
+	return nil
+}
+
+// splitBundleLocator splits a locator of the form "<scheme>://<body>" into
+// (scheme, body). It returns ("","") if raw does not contain a "://" separator.
+// This avoids net/url for schemes like "oci-layout+blob" whose body contains
+// a colon after '@' (the digest) and confuses url.Parse.
+func splitBundleLocator(raw string) (string, string) {
+	const sep = "://"
+	i := strings.Index(raw, sep)
+	if i < 0 {
+		return "", ""
+	}
+	return raw[:i], raw[i+len(sep):]
+}
+
+// parseBundleLocator extracts the scheme, normalized reference string, the
+// reference locator (i.e. the body before '@digest', used as the OCI-layout
+// store id), and the digest from a bundle locator of the form
+// "<scheme>://<ref>@sha256:<hex>". Only sha256 digests are accepted because
+// downloadBundleToFile hashes with sha256 and would fail to match any other
+// algorithm.
+func parseBundleLocator(raw string) (string, string, string, digest.Digest, error) {
+	scheme, body := splitBundleLocator(raw)
+	if scheme == "" {
+		return "", "", "", "", errors.Errorf("failed to parse git.bundle locator %q: missing scheme", raw)
+	}
+	if scheme != srctypes.DockerImageBlobScheme && scheme != srctypes.OCIBlobScheme {
+		return "", "", "", "", errors.Errorf("git.bundle locator scheme %q is not supported; expected %q or %q", scheme, srctypes.DockerImageBlobScheme, srctypes.OCIBlobScheme)
+	}
+	ref, err := reference.Parse(body)
+	if err != nil {
+		return "", "", "", "", errors.Wrapf(err, "failed to parse git.bundle locator %q", raw)
+	}
+	dgst := ref.Digest()
+	if err := dgst.Validate(); err != nil {
+		return "", "", "", "", errors.Wrapf(err, "failed to parse git.bundle locator %q: invalid digest", raw)
+	}
+	if dgst.Algorithm() != digest.SHA256 {
+		return "", "", "", "", errors.Errorf("git.bundle locator %q: digest algorithm %q not supported, expected %q", raw, dgst.Algorithm(), digest.SHA256)
+	}
+	return scheme, ref.String(), ref.Locator, dgst, nil
 }

--- a/source/git/identifier_test.go
+++ b/source/git/identifier_test.go
@@ -3,6 +3,7 @@ package git
 import (
 	"testing"
 
+	"github.com/moby/buildkit/solver/pb"
 	"github.com/stretchr/testify/require"
 )
 
@@ -177,6 +178,154 @@ func TestNewGitIdentifier(t *testing.T) {
 			gi, err := NewGitIdentifier(tt.url)
 			require.NoError(t, err)
 			require.Equal(t, tt.expected, *gi)
+		})
+	}
+}
+
+// TestIdentifierBundleValidation exercises the attribute-level validation
+// performed by (*Source).Identifier when git.bundle / git.checkoutbundle attrs
+// are present. It covers both positive (should parse cleanly) and negative
+// (should reject with a specific message) cases.
+func TestIdentifierBundleValidation(t *testing.T) {
+	const validBundle = "docker-image+blob://example.com/repo/bundles@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	const validChecksum = "1111111111111111111111111111111111111111"
+
+	tests := []struct {
+		name    string
+		url     string
+		attrs   map[string]string
+		wantErr string
+		assert  func(t *testing.T, id *GitIdentifier)
+	}{
+		{
+			name: "valid bundle+checksum",
+			url:  "https://example.com/repo.git",
+			attrs: map[string]string{
+				pb.AttrGitBundle:   validBundle,
+				pb.AttrGitChecksum: validChecksum,
+			},
+			assert: func(t *testing.T, id *GitIdentifier) {
+				require.Equal(t, validBundle, id.Bundle)
+				require.Equal(t, validChecksum, id.Checksum)
+				require.False(t, id.CheckoutBundle)
+			},
+		},
+		{
+			name: "valid oci-layout bundle",
+			url:  "https://example.com/repo.git",
+			attrs: map[string]string{
+				pb.AttrGitBundle:   "oci-layout+blob://local/bundle@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				pb.AttrGitChecksum: validChecksum,
+			},
+			assert: func(t *testing.T, id *GitIdentifier) {
+				require.Equal(t, "oci-layout+blob://local/bundle@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", id.Bundle)
+			},
+		},
+		{
+			name: "bundle without checksum",
+			url:  "https://example.com/repo.git",
+			attrs: map[string]string{
+				pb.AttrGitBundle: validBundle,
+			},
+			wantErr: "git.bundle requires git.checksum to be set",
+		},
+		{
+			name: "bundle with https scheme",
+			url:  "https://example.com/repo.git",
+			attrs: map[string]string{
+				pb.AttrGitBundle:   "https://example.com/bundle",
+				pb.AttrGitChecksum: validChecksum,
+			},
+			wantErr: `git.bundle locator scheme "https" is not supported`,
+		},
+		{
+			name: "bundle with sha512 digest",
+			url:  "https://example.com/repo.git",
+			attrs: map[string]string{
+				pb.AttrGitBundle:   "docker-image+blob://example.com/repo/bundles@sha512:cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e",
+				pb.AttrGitChecksum: validChecksum,
+			},
+			wantErr: `digest algorithm "sha512" not supported`,
+		},
+		{
+			name: "checkoutbundle with keepgitdir",
+			url:  "https://example.com/repo.git",
+			attrs: map[string]string{
+				pb.AttrGitCheckoutBundle: "true",
+				pb.AttrKeepGitDir:        "true",
+			},
+			wantErr: "git.checkoutbundle is incompatible with git.keepgitdir",
+		},
+		{
+			name: "checkoutbundle with subdir",
+			url:  "https://example.com/repo.git#main:sub",
+			attrs: map[string]string{
+				pb.AttrGitCheckoutBundle: "true",
+			},
+			wantErr: "git.checkoutbundle is incompatible with git.subdir",
+		},
+		{
+			name: "checkoutbundle alone",
+			url:  "https://example.com/repo.git",
+			attrs: map[string]string{
+				pb.AttrGitCheckoutBundle: "true",
+			},
+			assert: func(t *testing.T, id *GitIdentifier) {
+				require.True(t, id.CheckoutBundle)
+				require.Empty(t, id.Bundle)
+			},
+		},
+		{
+			name: "bundle+checkoutbundle",
+			url:  "https://example.com/repo.git",
+			attrs: map[string]string{
+				pb.AttrGitBundle:         validBundle,
+				pb.AttrGitChecksum:       validChecksum,
+				pb.AttrGitCheckoutBundle: "true",
+			},
+			assert: func(t *testing.T, id *GitIdentifier) {
+				require.True(t, id.CheckoutBundle)
+				require.Equal(t, validBundle, id.Bundle)
+			},
+		},
+		{
+			name: "bundle ref-sha mismatches checksum",
+			url:  "https://example.com/repo.git#2222222222222222222222222222222222222222",
+			attrs: map[string]string{
+				pb.AttrGitBundle:   validBundle,
+				pb.AttrGitChecksum: validChecksum,
+			},
+			wantErr: "expected checksum to match 1111111111111111111111111111111111111111",
+		},
+		{
+			name: "bundle ref-sha matches checksum",
+			url:  "https://example.com/repo.git#" + validChecksum,
+			attrs: map[string]string{
+				pb.AttrGitBundle:   validBundle,
+				pb.AttrGitChecksum: validChecksum,
+			},
+			assert: func(t *testing.T, id *GitIdentifier) {
+				require.Equal(t, validChecksum, id.Ref)
+				require.Equal(t, validChecksum, id.Checksum)
+			},
+		},
+	}
+
+	src := &Source{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, err := src.Identifier("git", tt.url, tt.attrs, nil)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			gid, ok := id.(*GitIdentifier)
+			require.True(t, ok)
+			if tt.assert != nil {
+				tt.assert(t, gid)
+			}
 		})
 	}
 }

--- a/source/git/source.go
+++ b/source/git/source.go
@@ -944,12 +944,6 @@ func (gs *gitSourceHandler) tryRemoteFetch(ctx context.Context, jobCtx solver.Jo
 		}
 	}()
 
-	// In bundle mode, derive sha256-ness from the required git.checksum
-	// length. mountRemote uses this only when the bare repo is created fresh.
-	if gs.src.Bundle != "" && len(gs.src.Checksum) == 64 {
-		gs.sha256 = true
-	}
-
 	// Auth args only apply to non-bundle fetches. In bundle mode the
 	// payload comes from a blob fetch, so there is no http remote to
 	// authenticate against.
@@ -963,6 +957,17 @@ func (gs *gitSourceHandler) tryRemoteFetch(ctx context.Context, jobCtx solver.Jo
 		return nil, err
 	}
 	repo.releasers = append(repo.releasers, cleanup)
+
+	// Bundle mode may need to create the shared bare repo before the main
+	// fetch. Stage the bundle first so stageBundle can probe the bundle's
+	// object format via ls-remote and set gs.sha256 for mountRemote.
+	stagedURL := ""
+	if gs.src.Bundle != "" {
+		stagedURL, err = gs.ensureStagedBundle(ctx, jobCtx, g)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	gitDir, unmountGitDir, err := gs.mountRemote(ctx, gs.src.Remote, authArgs, gs.sha256, reset, g)
 	if err != nil {
@@ -1000,14 +1005,10 @@ func (gs *gitSourceHandler) tryRemoteFetch(ctx context.Context, jobCtx solver.Jo
 		// repo (from a prior origin or bundle fetch), skip staging
 		// entirely. The doFetch check below will no-op the fetch.
 		if _, err := repo.Run(ctx, "cat-file", "-e", gs.src.Checksum+"^{commit}"); err != nil {
-			// Reuse the staged bundle if CacheKey already built one via
-			// resolveBundleMetadata. ensureStagedBundle owns the
+			// Reuse the staged bundle if CacheKey or the eager bundle-format
+			// probe above already built one. ensureStagedBundle owns the
 			// teardown (wired to jobCtx.Cleanup on first call), so the
 			// cleanup is intentionally not appended to repo.releasers.
-			stagedURL, err := gs.ensureStagedBundle(ctx, jobCtx, g)
-			if err != nil {
-				return nil, err
-			}
 			fetchSource = stagedURL
 		}
 	}

--- a/source/git/source.go
+++ b/source/git/source.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/containerd/v2/core/remotes/docker"
 	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/identity"
@@ -45,11 +46,16 @@ var defaultBranch = regexp.MustCompile(`refs/heads/(\S+)`)
 
 type Opt struct {
 	CacheAccessor cache.Accessor
+	// RegistryHosts is used to fetch bundle blobs from a docker registry
+	// when a git source uses GitBundleURL("docker-image+blob://...").
+	// Optional: when unset, bundle mode requires oci-layout+blob.
+	RegistryHosts docker.RegistryHosts
 }
 
 type Source struct {
-	cache  cache.Accessor
-	locker *locker.Locker
+	cache         cache.Accessor
+	locker        *locker.Locker
+	registryHosts docker.RegistryHosts
 }
 
 type Metadata struct {
@@ -75,8 +81,9 @@ func Supported() error {
 
 func NewSource(opt Opt) (*Source, error) {
 	gs := &Source{
-		cache:  opt.CacheAccessor,
-		locker: locker.New(),
+		cache:         opt.CacheAccessor,
+		locker:        locker.New(),
+		registryHosts: opt.RegistryHosts,
 	}
 	return gs, nil
 }
@@ -140,9 +147,20 @@ func (gs *Source) Identifier(scheme, ref string, attrs map[string]string, platfo
 			id.MTime = v
 		case pb.AttrGitFetchByCommit:
 			id.FetchByCommit = v == "true"
+		case pb.AttrGitBundle:
+			id.Bundle = v
+		case pb.AttrGitCheckoutBundle:
+			id.CheckoutBundle = v == "true"
+		case pb.AttrOCILayoutSessionID:
+			id.BundleOCISessionID = v
+		case pb.AttrOCILayoutStoreID:
+			id.BundleOCIStoreID = v
 		}
 	}
 	if err := validateGitRef(id.Ref); err != nil {
+		return nil, err
+	}
+	if err := validateBundleAttrs(id); err != nil {
 		return nil, err
 	}
 
@@ -257,6 +275,12 @@ type gitSourceHandler struct {
 	sha256      bool
 	sm          *session.Manager
 	authArgs    []string
+
+	// stagedBundleURL / stagedBundleCleanup cache the temp bundle staging
+	// across resolveBundleMetadata (CacheKey) and tryRemoteFetch (Snapshot)
+	// so the bundle blob is downloaded only once per handler.
+	stagedBundleURL     string
+	stagedBundleCleanup func() error
 }
 
 func (gs *gitSourceHandler) shaToCacheKey(sha, ref string) string {
@@ -276,6 +300,9 @@ func (gs *gitSourceHandler) shaToCacheKey(sha, ref string) string {
 	if gs.src.MTime != "" && gs.src.MTime != "checkout" {
 		key += "(mtime=" + gs.src.MTime + ")"
 	}
+	if gs.src.CheckoutBundle {
+		key += "(bundle)"
+	}
 	return key
 }
 
@@ -285,6 +312,16 @@ func (gs *Source) ResolveMetadata(ctx context.Context, id *GitIdentifier, sm *se
 		Source: gs,
 		sm:     sm,
 	}
+	// The handler is scoped to this call, so any staged bundle it owns
+	// must be released before returning. When a jobCtx is present,
+	// ensureStagedBundle hands ownership to the job and this is a no-op;
+	// without a jobCtx (e.g. direct ResolveMetadata callers) this is the
+	// only hook that frees the temp dir.
+	defer func() {
+		if err := gsh.releaseStagedBundle(); err != nil {
+			bklog.G(ctx).Warnf("failed to release staged git bundle: %v", err)
+		}
+	}()
 	md, err := gsh.resolveMetadata(ctx, jobCtx)
 	if err != nil {
 		return nil, err
@@ -490,16 +527,25 @@ func (gs *gitSourceHandler) remoteKey() string {
 }
 
 func (gs *gitSourceHandler) resolveMetadata(ctx context.Context, jobCtx solver.JobContext) (md *Metadata, retErr error) {
-	remote := gs.src.Remote
-	gs.locker.Lock(remote)
-	defer gs.locker.Unlock(remote)
-
 	if gs.src.Checksum != "" {
 		matched, err := regexp.MatchString("^[a-fA-F0-9]+$", gs.src.Checksum)
 		if err != nil || !matched {
 			return nil, errors.Errorf("invalid checksum %s for Git URL, expected hex commit hash", gs.src.Checksum)
 		}
 	}
+
+	if gs.src.Bundle != "" {
+		// Bundle mode stages the bundle in a temp bare repo and runs the
+		// shared ls-remote code path against its file:// URL so the
+		// resulting Metadata has the same ref shape as the non-bundle
+		// path. Bundle mode does not need the per-remote lock: the temp
+		// bare repo is private to this call.
+		return gs.resolveBundleMetadata(ctx, jobCtx)
+	}
+
+	remote := gs.src.Remote
+	gs.locker.Lock(remote)
+	defer gs.locker.Unlock(remote)
 
 	if gitutil.IsCommitSHA(gs.src.Ref) {
 		if gs.src.Checksum != "" && !strings.HasPrefix(gs.src.Ref, gs.src.Checksum) {
@@ -570,6 +616,14 @@ func (gs *gitSourceHandler) resolveMetadata(ctx context.Context, jobCtx solver.J
 
 	gs.getAuthToken(ctx, g)
 
+	return gs.resolveMetadataFromURL(ctx, g, gs.src.Remote)
+}
+
+// resolveMetadataFromURL runs ls-remote against the given URL and parses the
+// result into a Metadata. The URL may be the user's configured remote (for
+// non-bundle mode) or a file:// URL for a staged bundle. Auth and lock
+// management are the caller's responsibility.
+func (gs *gitSourceHandler) resolveMetadataFromURL(ctx context.Context, g session.Group, remoteURL string) (*Metadata, error) {
 	tmpGit, cleanup, err := gs.emptyGitCli(ctx, g)
 	if err != nil {
 		return nil, err
@@ -578,16 +632,16 @@ func (gs *gitSourceHandler) resolveMetadata(ctx context.Context, jobCtx solver.J
 
 	ref := gs.src.Ref
 	if ref == "" {
-		ref, err = getDefaultBranch(ctx, tmpGit, gs.src.Remote)
+		ref, err = getDefaultBranch(ctx, tmpGit, remoteURL)
 		if err != nil {
 			return nil, err
 		}
 	}
 	// TODO: should we assume that remote tag is immutable? add a timer?
 
-	buf, err := tmpGit.Run(ctx, "ls-remote", "--", gs.src.Remote, ref, ref+"^{}")
+	buf, err := tmpGit.Run(ctx, "ls-remote", "--", remoteURL, ref, ref+"^{}")
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to fetch remote %s", urlutil.RedactCredentials(remote))
+		return nil, errors.Wrapf(err, "failed to fetch remote %s", urlutil.RedactCredentials(remoteURL))
 	}
 	lines := strings.Split(string(buf), "\n")
 
@@ -642,7 +696,7 @@ func (gs *gitSourceHandler) resolveMetadata(ctx context.Context, jobCtx solver.J
 			return nil, errors.Errorf("expected checksum to match %s, got %s", gs.src.Checksum, exp)
 		}
 	}
-	md = &Metadata{
+	md := &Metadata{
 		Ref:      usedRef,
 		Checksum: sha,
 	}
@@ -751,12 +805,12 @@ func (gs *gitSourceHandler) remoteFetch(ctx context.Context, jobCtx solver.JobCo
 		g = jobCtx.Session()
 	}
 
-	repo, err := gs.tryRemoteFetch(ctx, g, false)
+	repo, err := gs.tryRemoteFetch(ctx, jobCtx, g, false)
 	if err != nil {
 		var wce *wouldClobberExistingTagError
 		var ulre *unableToUpdateLocalRefError
 		if errors.As(err, &wce) || errors.As(err, &ulre) {
-			repo, err = gs.tryRemoteFetch(ctx, g, true)
+			repo, err = gs.tryRemoteFetch(ctx, jobCtx, g, true)
 			if err != nil {
 				return nil, err
 			}
@@ -847,7 +901,12 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context, jobCtx solver.JobConte
 	}
 	defer repo.Release()
 
-	ref, err := gs.checkout(ctx, repo, g, compatibilityVersion)
+	var ref cache.ImmutableRef
+	if gs.src.CheckoutBundle {
+		ref, err = gs.checkoutAsBundle(ctx, repo, g)
+	} else {
+		ref, err = gs.checkout(ctx, repo, g, compatibilityVersion)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -875,7 +934,7 @@ func (g *gitRepo) Release() error {
 	return err
 }
 
-func (gs *gitSourceHandler) tryRemoteFetch(ctx context.Context, g session.Group, reset bool) (_ *gitRepo, retErr error) {
+func (gs *gitSourceHandler) tryRemoteFetch(ctx context.Context, jobCtx solver.JobContext, g session.Group, reset bool) (_ *gitRepo, retErr error) {
 	repo := &gitRepo{}
 
 	defer func() {
@@ -885,13 +944,27 @@ func (gs *gitSourceHandler) tryRemoteFetch(ctx context.Context, g session.Group,
 		}
 	}()
 
+	// In bundle mode, derive sha256-ness from the required git.checksum
+	// length. mountRemote uses this only when the bare repo is created fresh.
+	if gs.src.Bundle != "" && len(gs.src.Checksum) == 64 {
+		gs.sha256 = true
+	}
+
+	// Auth args only apply to non-bundle fetches. In bundle mode the
+	// payload comes from a blob fetch, so there is no http remote to
+	// authenticate against.
+	authArgs := gs.authArgs
+	if gs.src.Bundle != "" {
+		authArgs = nil
+	}
+
 	git, cleanup, err := gs.emptyGitCli(ctx, g)
 	if err != nil {
 		return nil, err
 	}
 	repo.releasers = append(repo.releasers, cleanup)
 
-	gitDir, unmountGitDir, err := gs.mountRemote(ctx, gs.src.Remote, gs.authArgs, gs.sha256, reset, g)
+	gitDir, unmountGitDir, err := gs.mountRemote(ctx, gs.src.Remote, authArgs, gs.sha256, reset, g)
 	if err != nil {
 		return nil, err
 	}
@@ -900,6 +973,44 @@ func (gs *gitSourceHandler) tryRemoteFetch(ctx context.Context, g session.Group,
 
 	git = git.New(gitutil.WithGitDir(gitDir))
 	repo.GitCLI = git
+
+	// fetchSource is the URL used in place of the "origin" remote name for
+	// the main fetch. In bundle mode it points at a staged bundle's file://
+	// URL; an empty value means fetch from the configured "origin" remote.
+	fetchSource := ""
+	// Bundle mode: stage the bundle into an isolated temp bare repo and
+	// fetch from it as a file:// remote. The rest of this function runs
+	// unchanged — git accepts a URL anywhere a remote name is expected,
+	// so the fetch flow treats the staged repo like a normal origin.
+	if gs.src.Bundle != "" {
+		// When the user did not supply a symbolic ref, use the pinned
+		// commit as the ref directly. validateBundleAttrs guarantees
+		// Checksum is set.
+		if gs.src.Ref == "" || gitutil.IsCommitSHA(gs.src.Ref) {
+			gs.src.Ref = gs.src.Checksum
+		}
+		// Bundle mode enters tryRemoteFetch from Snapshot. If CacheKey
+		// has not run yet, prime gs.cacheCommit from the pinned checksum
+		// to make the downstream cacheCommit validation a no-op rather
+		// than a spurious mismatch.
+		if gs.cacheCommit == "" {
+			gs.cacheCommit = gs.src.Checksum
+		}
+		// If the pinned commit is already present in the shared bare
+		// repo (from a prior origin or bundle fetch), skip staging
+		// entirely. The doFetch check below will no-op the fetch.
+		if _, err := repo.Run(ctx, "cat-file", "-e", gs.src.Checksum+"^{commit}"); err != nil {
+			// Reuse the staged bundle if CacheKey already built one via
+			// resolveBundleMetadata. ensureStagedBundle owns the
+			// teardown (wired to jobCtx.Cleanup on first call), so the
+			// cleanup is intentionally not appended to repo.releasers.
+			stagedURL, err := gs.ensureStagedBundle(ctx, jobCtx, g)
+			if err != nil {
+				return nil, err
+			}
+			fetchSource = stagedURL
+		}
+	}
 
 	ref := gs.src.Ref
 	if ref == "" {
@@ -941,6 +1052,10 @@ func (gs *gitSourceHandler) tryRemoteFetch(ctx context.Context, g session.Group,
 		// make sure no old lock files have leaked
 		gitDirRoot.RemoveAll("shallow.lock")
 
+		origin := "origin"
+		if fetchSource != "" {
+			origin = fetchSource
+		}
 		args := []string{"fetch"}
 		// For fetch-by-commit, assume the server supports
 		// uploadpack.allowReachableSHA1InWant / allowAnySHA1InWant and
@@ -954,7 +1069,7 @@ func (gs *gitSourceHandler) tryRemoteFetch(ctx context.Context, g session.Group,
 				args = append(args, "--unshallow")
 			}
 		}
-		args = append(args, "origin")
+		args = append(args, origin)
 		if gitutil.IsCommitSHA(ref) {
 			args = append(args, ref)
 		} else {
@@ -1000,7 +1115,7 @@ func (gs *gitSourceHandler) tryRemoteFetch(ctx context.Context, g session.Group,
 				if _, err := gitDirRoot.Lstat("shallow"); err == nil {
 					args = append(args, "--unshallow")
 				}
-				args = append(args, "origin", gs.cacheCommit)
+				args = append(args, origin, gs.cacheCommit)
 				if _, err := git.Run(ctx, args...); err != nil {
 					return nil, errors.Wrapf(err, "failed to fetch remote %s", urlutil.RedactCredentials(gs.src.Remote))
 				}
@@ -1033,7 +1148,18 @@ func (gs *gitSourceHandler) checkout(ctx context.Context, repo *gitRepo, g sessi
 	if gs.src.FetchByCommit && gs.src.Checksum != "" {
 		refOrCommit = gs.src.Checksum
 	}
-	checkoutRef, err := gs.cache.New(ctx, nil, g, cache.WithRecordType(client.UsageRecordTypeGitCheckout), cache.WithDescription(fmt.Sprintf("git snapshot for %s#%s", urlutil.RedactCredentials(gs.src.Remote), ref)))
+	// In bundle mode, if the user did not supply a symbolic Ref (empty or
+	// a SHA), fall back to the pinned checksum so the downstream
+	// `git checkout` / `git fetch` has a valid tip. With a symbolic ref
+	// present, use it as-is: bundle import lands refs in the natural
+	// refs/heads/* / refs/tags/* namespace in the shared bare repo, so
+	// `git checkout <ref>` and `git fetch origin <ref>` resolve it
+	// normally and the resulting .git carries the natural ref name.
+	if gs.src.Bundle != "" && (ref == "" || gitutil.IsCommitSHA(ref)) {
+		ref = gs.src.Checksum
+		refOrCommit = ref
+	}
+	checkoutRef, err := gs.cache.New(ctx, nil, g, cache.WithRecordType(client.UsageRecordTypeGitCheckout), cache.WithDescription(fmt.Sprintf("git snapshot for %s#%s", urlutil.RedactCredentials(gs.src.Remote), gs.src.Ref)))
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create new mutable for %s", urlutil.RedactCredentials(gs.src.Remote))
 	}

--- a/source/git/source_test.go
+++ b/source/git/source_test.go
@@ -2745,6 +2745,65 @@ func TestResetSnapshotMtimes(t *testing.T) {
 	require.Equal(t, "file.txt", linkTarget)
 }
 
+// TestBundleStagedRefShape verifies that the unified metadata-resolution
+// path returns the same ref shape for a bundle as for an origin fetch:
+// resolving the symbolic ref "master" must yield Metadata.Ref ==
+// "refs/heads/master", not "refs/tags/master" (which is what the shared
+// bare repo carries after the main-path fetch maps branches into tags/*).
+func TestBundleStagedRefShape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Depends on unimplemented containerd bind-mount support on Windows")
+	}
+
+	t.Parallel()
+	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx = logProgressStreams(ctx, t)
+
+	// Build a source-of-truth git repo with a single commit on master.
+	seedDir := t.TempDir()
+	runShell(t, seedDir,
+		"git -c init.defaultBranch=master init",
+		"git config --local user.email test@example.com",
+		"git config --local user.name test",
+		"echo hello > file.txt",
+		"git add file.txt",
+		"git commit -m initial",
+	)
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "HEAD")
+	cmd.Dir = seedDir
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	headSha := strings.TrimSpace(string(out))
+
+	// Create a bundle of refs/heads/master, then import it into a fresh
+	// bare repo — emulating stageBundle's output. ls-remote against its
+	// file:// URL should see refs/heads/master.
+	bundlePath := filepath.Join(t.TempDir(), "bundle.pack")
+	cmd = exec.CommandContext(ctx, "git", "bundle", "create", bundlePath, "refs/heads/master")
+	cmd.Dir = seedDir
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err, "bundle create: %s", out)
+
+	stagedRepoDir := filepath.Join(t.TempDir(), "repo.git")
+	require.NoError(t, os.MkdirAll(stagedRepoDir, 0700))
+	runShell(t, stagedRepoDir,
+		"git -c init.defaultBranch=master init --bare",
+		"git fetch "+bundlePath+" +refs/*:refs/*",
+	)
+
+	gs := setupGitSource(t, t.TempDir())
+	gsh := &gitSourceHandler{
+		src:    GitIdentifier{Remote: "https://example.com/repo.git", Ref: "master", Checksum: headSha},
+		Source: gs,
+	}
+
+	md, err := gsh.resolveMetadataFromURL(ctx, nil, "file://"+stagedRepoDir)
+	require.NoError(t, err)
+	require.Equal(t, "refs/heads/master", md.Ref,
+		"bundle-mode resolveMetadataFromURL should return refs/heads/master (parity with origin path)")
+	require.Equal(t, headSha, md.Checksum)
+}
+
 func TestCommitTimeMtimesSHA1(t *testing.T) {
 	testCommitTimeMtimes(t, "sha1", false)
 }

--- a/source/git/source_test.go
+++ b/source/git/source_test.go
@@ -2804,6 +2804,40 @@ func TestBundleStagedRefShape(t *testing.T) {
 	require.Equal(t, headSha, md.Checksum)
 }
 
+func TestDetectBundleSHA256(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Depends on git bundle support exercised via shell helpers")
+	}
+
+	t.Parallel()
+	ctx := logProgressStreams(context.Background(), t)
+
+	for _, format := range []string{"sha1", "sha256"} {
+		t.Run(format, func(t *testing.T) {
+			repo := setupGitRepo(t, format)
+			bundlePath := filepath.Join(t.TempDir(), "bundle.pack")
+			runShell(t, repo.mainPath, "git bundle create "+bundlePath+" refs/heads/master")
+
+			sha256, err := detectBundleSHA256(ctx, bundlePath)
+			require.NoError(t, err)
+			require.Equal(t, format == "sha256", sha256)
+
+			stagedRepoDir := filepath.Join(t.TempDir(), "repo.git")
+			require.NoError(t, os.MkdirAll(stagedRepoDir, 0700))
+
+			initArgs := "git -c init.defaultBranch=master init --bare"
+			if sha256 {
+				initArgs += " --object-format=sha256"
+			}
+			runShell(t, stagedRepoDir,
+				initArgs,
+				"git fetch "+bundlePath+" +refs/*:refs/*",
+				"git cat-file -e refs/heads/master^{commit}",
+			)
+		})
+	}
+}
+
 func TestCommitTimeMtimesSHA1(t *testing.T) {
 	testCommitTimeMtimes(t, "sha1", false)
 }

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -159,6 +159,7 @@ func NewWorker(ctx context.Context, opt WorkerOpt) (*Worker, error) {
 	if err := git.Supported(); err == nil {
 		gs, err := git.NewSource(git.Opt{
 			CacheAccessor: cm,
+			RegistryHosts: opt.RegistryHosts,
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Support importing git sources from OCI or registry-backed bundle blobs and exporting resolved checkouts as single-file git bundles.