### PR TITLE
dockerfile2llb: deep copy cloned image config state

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/convert_test.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_test.go
@@ -114,6 +114,24 @@ RUN ls -l
 	require.NoError(t, err)
 }
 
+func TestCopyFromKeepsStageLabels(t *testing.T) {
+	t.Parallel()
+
+	df := `FROM scratch AS base
+LABEL marker=base
+
+FROM base AS sibling
+LABEL marker=sibling
+
+FROM base AS consumer
+COPY --from=sibling / /
+`
+
+	res, err := Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
+	require.NoError(t, err)
+	require.Equal(t, "base", res.Image.Config.Labels["marker"])
+}
+
 func TestAddEnv(t *testing.T) {
 	// k exists in env as key
 	// override = true

--- a/frontend/dockerfile/dockerfile2llb/image.go
+++ b/frontend/dockerfile/dockerfile2llb/image.go
@@ -1,6 +1,7 @@
 package dockerfile2llb
 
 import (
+	"maps"
 	"slices"
 
 	"github.com/moby/buildkit/util/system"
@@ -15,6 +16,16 @@ func clone(src dockerspec.DockerOCIImage) dockerspec.DockerOCIImage {
 	img.Config.Cmd = slices.Clone(src.Config.Cmd)
 	img.Config.Entrypoint = slices.Clone(src.Config.Entrypoint)
 	img.Config.OnBuild = slices.Clone(src.Config.OnBuild)
+	img.Config.ExposedPorts = maps.Clone(src.Config.ExposedPorts)
+	img.Config.Volumes = maps.Clone(src.Config.Volumes)
+	img.Config.Labels = maps.Clone(src.Config.Labels)
+	img.Config.Shell = slices.Clone(src.Config.Shell)
+	if src.Config.Healthcheck != nil {
+		hc := *src.Config.Healthcheck
+		hc.Test = slices.Clone(src.Config.Healthcheck.Test)
+		img.Config.Healthcheck = &hc
+	}
+	img.History = slices.Clone(src.History)
 	return img
 }
 

--- a/frontend/dockerfile/dockerfile2llb/image_test.go
+++ b/frontend/dockerfile/dockerfile2llb/image_test.go
@@ -1,0 +1,65 @@
+package dockerfile2llb
+
+import (
+	"testing"
+	"time"
+
+	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloneCopiesMutableImageConfig(t *testing.T) {
+	t.Parallel()
+
+	interval := 2 * time.Second
+	src := dockerspec.DockerOCIImage{
+		Image: ocispecs.Image{
+			History: []ocispecs.History{
+				{CreatedBy: "RUN echo base"},
+			},
+		},
+		Config: dockerspec.DockerOCIImageConfig{
+			DockerOCIImageConfigExt: dockerspec.DockerOCIImageConfigExt{
+				Healthcheck: &dockerspec.HealthcheckConfig{
+					Test:     []string{"CMD", "true"},
+					Interval: interval,
+				},
+				OnBuild: []string{"RUN echo base"},
+				Shell:   []string{"/bin/sh", "-c"},
+			},
+		},
+	}
+	src.Config.ExposedPorts = map[string]struct{}{"80/tcp": {}}
+	src.Config.Env = []string{"PATH=/bin"}
+	src.Config.Cmd = []string{"true"}
+	src.Config.Entrypoint = []string{"/entrypoint"}
+	src.Config.Volumes = map[string]struct{}{"/data": {}}
+	src.Config.Labels = map[string]string{"marker": "base"}
+
+	cloned := clone(src)
+
+	cloned.Config.ExposedPorts["443/tcp"] = struct{}{}
+	cloned.Config.Env[0] = "PATH=/usr/bin"
+	cloned.Config.Cmd[0] = "false"
+	cloned.Config.Entrypoint[0] = "/bin/other"
+	cloned.Config.Volumes["/cache"] = struct{}{}
+	cloned.Config.Labels["marker"] = "child"
+	cloned.Config.OnBuild[0] = "RUN echo child"
+	cloned.Config.Shell[0] = "/bin/bash"
+	cloned.Config.Healthcheck.Test[1] = "false"
+	cloned.History[0].CreatedBy = "RUN echo child"
+
+	_, ok := src.Config.ExposedPorts["443/tcp"]
+	require.False(t, ok)
+	require.Equal(t, "PATH=/bin", src.Config.Env[0])
+	require.Equal(t, "true", src.Config.Cmd[0])
+	require.Equal(t, "/entrypoint", src.Config.Entrypoint[0])
+	_, ok = src.Config.Volumes["/cache"]
+	require.False(t, ok)
+	require.Equal(t, "base", src.Config.Labels["marker"])
+	require.Equal(t, "RUN echo base", src.Config.OnBuild[0])
+	require.Equal(t, "/bin/sh", src.Config.Shell[0])
+	require.Equal(t, "true", src.Config.Healthcheck.Test[1])
+	require.Equal(t, "RUN echo base", src.History[0].CreatedBy)
+}


### PR DESCRIPTION
fixes #6712 

This change makes stage image cloning copy the mutable image config fields instead of reusing shared maps, slices, and healthcheck state across stages.

The previous clone behavior was shallow for several mutable config fields, which allowed one stage to mutate image metadata that should have remained isolated to another stage.