### PR TITLE
otlptracegrpc: remove errNoClient instead of a sentinel error

### DIFF
--- a/util/tracing/otlptracegrpc/client.go
+++ b/util/tracing/otlptracegrpc/client.go
@@ -80,7 +80,7 @@ func (c *client) UploadTraces(ctx context.Context, protoSpans []*tracepb.Resourc
 		c.lock.Lock()
 		defer c.lock.Unlock()
 		if c.tracesClient == nil {
-			return errNoClient
+			return errors.New("no client")
 		}
 
 		_, err := c.tracesClient.Export(ctx, &coltracepb.ExportTraceServiceRequest{

--- a/util/tracing/otlptracegrpc/errors.go
+++ b/util/tracing/otlptracegrpc/errors.go
@@ -1,7 +1,0 @@
-package otlptracegrpc
-
-import "errors"
-
-var (
-	errNoClient = errors.New("no client")
-)


### PR DESCRIPTION

Remove the sentinel error in `otlptracegrpc` to use the `github.com/pkg/errors`
package for the stacktrace.

Closes #6494.
