### PR TITLE
docs(dockerfile): clarify WORKDIR does not execute cd(1)

### DIFF
--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -2492,6 +2492,12 @@ the `WORKDIR` may likely be set by the base image you're using.
 
 Therefore, to avoid unintended operations in unknown directories, it's best practice to set your `WORKDIR` explicitly.
 
+`WORKDIR` pivots the working directory that subsequent instructions run in;
+it doesn't execute `cd(1)` inside a shell, so the shell-only variables that
+`cd(1)` maintains are not set or updated. In particular, `$OLDPWD` is not
+set by `WORKDIR`, and `$PWD` is set by the shell from the process's current
+working directory rather than by `WORKDIR` itself.
+
 ## ARG
 
 ```dockerfile


### PR DESCRIPTION
## Description

Users have assumed `WORKDIR` behaves like `cd(1)` and therefore expect shell-only variables like `\$OLDPWD` (and the shell-maintained `\$PWD`) to be set/updated by it. As @tonistiigi and @jedevc confirmed on #6698:

> This is `cd(1)` docs. BuildKit does not use `cd(1)` to set the working directory of a container process.
>
> …the `WORKDIR` just pivots the working directory for the next commands, it doesn't act like `cd`. `PWD` gets set by the shell, which detects it from the process info.

This PR adds a short paragraph to the `WORKDIR` reference entry calling this out explicitly so the next user hitting the same expectation finds the answer in the docs rather than filing an issue.

Docs-only change; no behavior impact.

Refs #6698