### PR TITLE
provenance: include git subdir in configSource

### DIFF
--- a/frontend/dockerfile/dfgitutil/git_ref.go
+++ b/frontend/dockerfile/dfgitutil/git_ref.go
@@ -3,6 +3,7 @@ package dfgitutil
 
 import (
 	"net/url"
+	"path"
 	"strconv"
 	"strings"
 
@@ -240,16 +241,23 @@ func (gf *GitRef) loadQuery(query url.Values) error {
 	return nil
 }
 
-// FragmentFormat returns a simplified git URL in fragment format with only ref.
+// FragmentFormat returns a simplified git URL in fragment format.
 // If the URL cannot be parsed, the original string is returned with false.
-func FragmentFormat(remote string) (string, bool) {
+func FragmentFormat(remote string, withSubdir bool) (string, bool) {
 	gitRef, _, err := ParseGitRef(remote)
 	if err != nil || gitRef == nil {
 		return remote, false
 	}
 	u := gitRef.Remote
-	if gitRef.Ref != "" {
+	subdir := ""
+	if withSubdir {
+		subdir = strings.TrimPrefix(path.Join("/", gitRef.SubDir), "/")
+	}
+	if gitRef.Ref != "" || subdir != "" {
 		u += "#" + gitRef.Ref
+		if subdir != "" {
+			u += ":" + subdir
+		}
 	}
 	return u, true
 }

--- a/frontend/dockerfile/dfgitutil/git_ref_test.go
+++ b/frontend/dockerfile/dfgitutil/git_ref_test.go
@@ -450,7 +450,53 @@ func TestFragmentFormat(t *testing.T) {
 	}
 	for i, tt := range cases {
 		t.Run(fmt.Sprintf("case%d", i+1), func(t *testing.T) {
-			got, ok := FragmentFormat(tt.ref)
+			got, ok := FragmentFormat(tt.ref, false)
+			require.Equal(t, tt.expected, got)
+			require.Equal(t, tt.ok, ok)
+		})
+	}
+}
+
+func TestFragmentFormatWithSubdir(t *testing.T) {
+	cases := []struct {
+		ref      string
+		expected string
+		ok       bool
+	}{
+		{
+			ref:      "https://github.com/foo/bar.git#baz/qux:quux/quuz",
+			expected: "https://github.com/foo/bar.git#baz/qux:quux/quuz",
+			ok:       true,
+		},
+		{
+			ref:      "https://github.com/docker/docker.git#:myfolder",
+			expected: "https://github.com/docker/docker.git#:myfolder",
+			ok:       true,
+		},
+		{
+			ref:      "https://github.com/docker/docker.git?ref=v1.0.0&subdir=/subdir",
+			expected: "https://github.com/docker/docker.git#v1.0.0:subdir",
+			ok:       true,
+		},
+		{
+			ref:      "https://github.com/moby/buildkit.git?subdir=/subdir#v1.0.0",
+			expected: "https://github.com/moby/buildkit.git#v1.0.0:subdir",
+			ok:       true,
+		},
+		{
+			ref:      "git@github.com:moby/buildkit.git?subdir=/subdir#v1.0.0",
+			expected: "git@github.com:moby/buildkit.git#v1.0.0:subdir",
+			ok:       true,
+		},
+		{
+			ref:      "https://github.com/moby/buildkit.git",
+			expected: "https://github.com/moby/buildkit.git",
+			ok:       true,
+		},
+	}
+	for i, tt := range cases {
+		t.Run(fmt.Sprintf("case%d", i+1), func(t *testing.T) {
+			got, ok := FragmentFormat(tt.ref, true)
 			require.Equal(t, tt.expected, got)
 			require.Equal(t, tt.ok, ok)
 		})

--- a/frontend/dockerfile/dockerfile_provenance_test.go
+++ b/frontend/dockerfile/dockerfile_provenance_test.go
@@ -444,7 +444,8 @@ COPY myapp.Dockerfile /
 `)
 			dir := integration.Tmpdir(
 				t,
-				fstest.CreateFile("myapp.Dockerfile", dockerfile, 0600),
+				fstest.CreateDir("src", 0700),
+				fstest.CreateFile("src/myapp.Dockerfile", dockerfile, 0600),
 			)
 
 			initOptions := ""
@@ -455,7 +456,7 @@ COPY myapp.Dockerfile /
 				"git init"+initOptions,
 				"git config --local user.email test",
 				"git config --local user.name test",
-				"git add myapp.Dockerfile",
+				"git add src/myapp.Dockerfile",
 				"git commit -m initial",
 				"git branch v1",
 				"git update-server-info",
@@ -479,7 +480,7 @@ COPY myapp.Dockerfile /
 
 			_, err = f.Solve(sb.Context(), c, client.SolveOpt{
 				FrontendAttrs: map[string]string{
-					"context":           server.URL + "/.git#v1",
+					"context":           server.URL + "/.git#v1:src",
 					"attest:provenance": strings.Join(provArgs, ","),
 					"filename":          "myapp.Dockerfile",
 				},
@@ -532,7 +533,7 @@ COPY myapp.Dockerfile /
 					require.Equal(t, "", pred.BuildDefinition.ExternalParameters.ConfigSource.Path)
 				} else {
 					require.NotEmpty(t, pred.BuildDefinition.ExternalParameters.Request.Frontend)
-					require.Equal(t, expectedURL+"/.git#v1", pred.BuildDefinition.ExternalParameters.ConfigSource.URI)
+					require.Equal(t, expectedURL+"/.git#v1:src", pred.BuildDefinition.ExternalParameters.ConfigSource.URI)
 					require.Equal(t, "myapp.Dockerfile", pred.BuildDefinition.ExternalParameters.ConfigSource.Path)
 				}
 
@@ -587,7 +588,7 @@ COPY myapp.Dockerfile /
 					require.Equal(t, "", pred.Invocation.ConfigSource.EntryPoint)
 				} else {
 					require.NotEmpty(t, pred.Invocation.Parameters.Frontend)
-					require.Equal(t, expectedURL+"/.git#v1", pred.Invocation.ConfigSource.URI)
+					require.Equal(t, expectedURL+"/.git#v1:src", pred.Invocation.ConfigSource.URI)
 					require.Equal(t, "myapp.Dockerfile", pred.Invocation.ConfigSource.EntryPoint)
 				}
 

--- a/solver/llbsolver/provenance/predicate.go
+++ b/solver/llbsolver/provenance/predicate.go
@@ -112,11 +112,15 @@ func setPURLQualifier(uri string, q packageurl.Qualifier) (string, error) {
 }
 
 func findMaterial(srcs provenancetypes.Sources, uri string) (*slsa.ProvenanceMaterial, bool) {
-	uri, _ = dfgitutil.FragmentFormat(uri)
+	configURI := uri
+	if formatted, ok := dfgitutil.FragmentFormat(uri, true); ok {
+		configURI = formatted
+	}
+	uri, _ = dfgitutil.FragmentFormat(uri, false)
 	for _, s := range srcs.Git {
 		if s.URL == uri {
 			return &slsa.ProvenanceMaterial{
-				URI:    s.URL,
+				URI:    configURI,
 				Digest: digestSetForCommit(s.Commit),
 			}, true
 		}

--- a/solver/llbsolver/provenance/predicate_test.go
+++ b/solver/llbsolver/provenance/predicate_test.go
@@ -127,6 +127,7 @@ func TestFindMaterial(t *testing.T) {
 	srcs := provenancetypes.Sources{
 		Git: []provenancetypes.GitSource{
 			{URL: "https://github.com/moby/buildkit.git", Commit: "abc123def456abc123def456abc123def456abcd"},
+			{URL: "https://github.com/moby/buildkit.git#refs/heads/master", Commit: "def123def456abc123def456abc123def456abcd"},
 		},
 		HTTP: []provenancetypes.HTTPSource{
 			{URL: "https://example.com/file.tar.gz", Digest: digest.FromString("data")},
@@ -141,6 +142,56 @@ func TestFindMaterial(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "https://example.com/file.tar.gz", m.URI)
 
+	m, ok = findMaterial(srcs, "https://github.com/moby/buildkit.git?branch=master&subdir=src")
+	require.True(t, ok)
+	require.Equal(t, "https://github.com/moby/buildkit.git#refs/heads/master:src", m.URI)
+	require.Equal(t, "def123def456abc123def456abc123def456abcd", m.Digest["sha1"])
+
 	_, ok = findMaterial(srcs, "https://notfound.com")
 	require.False(t, ok)
+}
+
+func TestNewPredicateGitConfigSourceSubdir(t *testing.T) {
+	t.Parallel()
+
+	commit := "abc123def456abc123def456abc123def456abcd"
+	c := &Capture{
+		Frontend: "dockerfile.v0",
+		Args: map[string]string{
+			"context":  "https://github.com/moby/buildkit.git?branch=master&subdir=src",
+			"filename": "Dockerfile",
+		},
+		Sources: provenancetypes.Sources{
+			Git: []provenancetypes.GitSource{
+				{URL: "https://github.com/moby/buildkit.git#refs/heads/master", Commit: commit},
+			},
+		},
+	}
+
+	pr, err := NewPredicate(c)
+	require.NoError(t, err)
+
+	require.Equal(t, "https://github.com/moby/buildkit.git#refs/heads/master:src", pr.BuildDefinition.ExternalParameters.ConfigSource.URI)
+	require.Equal(t, commit, pr.BuildDefinition.ExternalParameters.ConfigSource.Digest["sha1"])
+	require.Equal(t, "Dockerfile", pr.BuildDefinition.ExternalParameters.ConfigSource.Path)
+	require.Equal(t, "https://github.com/moby/buildkit.git#refs/heads/master", pr.BuildDefinition.ResolvedDependencies[0].URI)
+	require.Equal(t, commit, pr.BuildDefinition.ResolvedDependencies[0].Digest["sha1"])
+}
+
+func TestNewPredicateKeepsContextSubdir(t *testing.T) {
+	t.Parallel()
+
+	c := &Capture{
+		Frontend: "dockerfile.v0",
+		Args: map[string]string{
+			"contextsubdir": "src",
+			"filename":      "Dockerfile",
+		},
+	}
+
+	pr, err := NewPredicate(c)
+	require.NoError(t, err)
+
+	require.Equal(t, "", pr.BuildDefinition.ExternalParameters.ConfigSource.URI)
+	require.Equal(t, "src", pr.BuildDefinition.ExternalParameters.Request.Args["contextsubdir"])
 }


### PR DESCRIPTION
Preserve the git context subdirectory in SLSA configSource while keeping resolved materials scoped to the fetched repository ref.