### PR TITLE
frontend/dockerui: share context load across bake targets

### DIFF
--- a/frontend/dockerui/config.go
+++ b/frontend/dockerui/config.go
@@ -435,20 +435,29 @@ func (bc *Client) MainContext(ctx context.Context, opts ...llb.LocalOption) (*ll
 	}
 
 	sessionID := bc.bopts.SessionID
-	if v, ok := bc.localsSessionIDs[bctx.contextLocalName]; ok {
-		sessionID = v
+	sharedSessionID, sharedSession := bc.localsSessionIDs[bctx.contextLocalName]
+	if sharedSession {
+		sessionID = sharedSessionID
 	}
 
-	opts = append([]llb.LocalOption{
-		llb.SessionID(sessionID),
-		llb.ExcludePatterns(excludes),
-		llb.SharedKeyHint(bctx.contextLocalName),
-		WithInternalName("load build context"),
-	}, opts...)
-
+	opts = mainContextLocalOpts(bctx.contextLocalName, sessionID, excludes, opts, sharedSession)
 	st := llb.Local(bctx.contextLocalName, opts...)
 
 	return &st, nil
+}
+
+func mainContextLocalOpts(name, sessionID string, excludes []string, callerOpts []llb.LocalOption, sharedSession bool) []llb.LocalOption {
+	opts := []llb.LocalOption{
+		llb.SessionID(sessionID),
+		llb.ExcludePatterns(excludes),
+		llb.SharedKeyHint(name),
+		WithInternalName("load build context"),
+	}
+	opts = append(opts, callerOpts...)
+	if sharedSession {
+		opts = append(opts, llb.FollowPaths(nil))
+	}
+	return opts
 }
 
 func (bc *Client) NamedContext(name string, opt ContextOpt) (*NamedContext, error) {

--- a/frontend/dockerui/main_context_test.go
+++ b/frontend/dockerui/main_context_test.go
@@ -1,0 +1,65 @@
+package dockerui
+
+import (
+	"context"
+	"testing"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/stretchr/testify/require"
+)
+
+func findLocalAttr(t *testing.T, def *llb.Definition, attr string) string {
+	t.Helper()
+	for _, dt := range def.Def {
+		var op pb.Op
+		require.NoError(t, op.Unmarshal(dt))
+		src := op.GetSource()
+		if src == nil {
+			continue
+		}
+		if v, ok := src.Attrs[attr]; ok {
+			return v
+		}
+	}
+	return ""
+}
+
+func TestMainContextSharedSessionDropsFollowPaths(t *testing.T) {
+	ctx := context.Background()
+	callerOpts := []llb.LocalOption{
+		llb.FollowPaths([]string{"app/cfg"}),
+	}
+
+	t.Run("non-shared session preserves caller FollowPaths", func(t *testing.T) {
+		opts := mainContextLocalOpts("context", "sess-A", nil, callerOpts, false)
+		st := llb.Local("context", opts...)
+		def, err := st.Marshal(ctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, findLocalAttr(t, def, pb.AttrFollowPaths))
+	})
+
+	t.Run("shared session clears caller FollowPaths", func(t *testing.T) {
+		opts := mainContextLocalOpts("context", "sess-shared", nil, callerOpts, true)
+		st := llb.Local("context", opts...)
+		def, err := st.Marshal(ctx)
+		require.NoError(t, err)
+		require.Empty(t, findLocalAttr(t, def, pb.AttrFollowPaths))
+	})
+
+	t.Run("shared session makes divergent caller FollowPaths identical", func(t *testing.T) {
+		optsA := mainContextLocalOpts("context", "sess-shared", nil,
+			[]llb.LocalOption{llb.FollowPaths([]string{"app/cfg"})}, true)
+		optsB := mainContextLocalOpts("context", "sess-shared", nil,
+			[]llb.LocalOption{llb.FollowPaths([]string{"tools/cfg"})}, true)
+
+		stA := llb.Local("context", optsA...)
+		stB := llb.Local("context", optsB...)
+		defA, err := stA.Marshal(ctx)
+		require.NoError(t, err)
+		defB, err := stB.Marshal(ctx)
+		require.NoError(t, err)
+
+		require.Equal(t, defA.Def, defB.Def)
+	})
+}


### PR DESCRIPTION
When buildx runs a multi-target bake with the same local context, it can pass that context as a shared session with local-sessionid:context. The dockerfile frontend still computes FollowPaths per target from the context files reachable by that target and passes the filter to MainContext.

Small reproducer:

    # Dockerfile
    FROM alpine AS app
    RUN --mount=type=bind,source=app/cfg,target=/cfg cat /cfg

    FROM alpine AS tools
    RUN --mount=type=bind,source=tools/cfg,target=/cfg cat /cfg

    # docker-bake.hcl
    target "app"   { context = "."; target = "app" }
    target "tools" { context = "."; target = "tools" }
    group "default" { targets = ["app", "tools"] }

With app/cfg and tools/cfg present, a bake of both targets can show two separate context-load vertices before this change:

    => [app internal] load build context
    => [tools internal] load build context

The targets compute different FollowPaths values, so the marshaled llb.Local("context") ops differ even though they use the same shared local session.

For shared-session main contexts, clear FollowPaths after applying the caller-provided local options. Non-shared builds keep the existing per-target FollowPaths optimization.

Add a dockerui unit test covering the option behavior: non-shared sessions preserve FollowPaths, while shared sessions clear it and produce identical context source ops for divergent caller filters.

On my real-world - and quite complex - multi-stage Dockerfile this patch significantly improves the build time (times with cold/empty build cache):

Before:
- build time: 1261s
- context transfers: 4

After:
- build time: 870s
- context transfers: 3
