### PR TITLE
trace: treat OTel export failures as non-fatal

### DIFF
--- a/cmd/buildctl/common/trace.go
+++ b/cmd/buildctl/common/trace.go
@@ -2,7 +2,9 @@ package common
 
 import (
 	"context"
+	"errors"
 	"os"
+	"time"
 
 	"github.com/moby/buildkit/util/appcontext"
 	"github.com/moby/buildkit/util/tracing/delegated"
@@ -69,7 +71,13 @@ func AttachAppContext(app *cli.App) error {
 		if span != nil {
 			span.End()
 		}
-		return tp.Shutdown(context.TODO())
+		// Trace export is best-effort: don't block the CLI on a slow or
+		// unreachable OTLP collector, and don't fail the build either.
+		// See https://github.com/moby/buildkit/issues/4616.
+		ctx, cancel := context.WithTimeoutCause(context.Background(), 5*time.Second, errors.New("tracer shutdown timeout"))
+		defer cancel()
+		_ = tp.Shutdown(ctx)
+		return nil
 	}
 	return nil
 }

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/containerd/containerd/v2/core/remotes/docker"
 	"github.com/containerd/containerd/v2/defaults"
@@ -417,13 +418,16 @@ func main() {
 	}
 
 	app.After = func(_ *cli.Context) (err error) {
-		var errs []error
+		// closers are telemetry providers (TracerProvider, MeterProvider).
+		// Failures are non-fatal: an unreachable OTLP collector should
+		// not block daemon shutdown or surface as a process-exit error.
+		// See https://github.com/moby/buildkit/issues/4616.
+		ctx, cancel := context.WithTimeoutCause(context.Background(), 5*time.Second, stderrors.New("telemetry shutdown timeout"))
+		defer cancel()
 		for _, c := range closers {
-			if e := c(context.TODO()); e != nil {
-				errs = append(errs, e)
-			}
+			_ = c(ctx)
 		}
-		return stderrors.Join(errs...)
+		return nil
 	}
 
 	profiler.Attach(app)

--- a/control/control.go
+++ b/control/control.go
@@ -54,9 +54,7 @@ import (
 	tracev1 "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -297,11 +295,17 @@ func (c *Controller) Prune(req *controlapi.PruneRequest, stream controlapi.Contr
 
 func (c *Controller) Export(ctx context.Context, req *tracev1.ExportTraceServiceRequest) (*tracev1.ExportTraceServiceResponse, error) {
 	if c.opt.TraceCollector == nil {
-		return nil, status.Errorf(codes.Unavailable, "trace collector not configured")
+		// Trace collection on the daemon is optional. Returning OK when
+		// it is not configured avoids surfacing a noisy error to clients
+		// that always emit traces. See moby/buildkit#4616.
+		return &tracev1.ExportTraceServiceResponse{}, nil
 	}
-	err := c.opt.TraceCollector.ExportSpans(ctx, transform.Spans(req.GetResourceSpans()))
-	if err != nil {
-		return nil, err
+	// Cap the export so a slow or unreachable downstream collector cannot
+	// stall the gRPC handler (and, by extension, the build).
+	ctx, cancel := context.WithTimeoutCause(ctx, 5*time.Second, errors.New("trace export timeout"))
+	defer cancel()
+	if err := c.opt.TraceCollector.ExportSpans(ctx, transform.Spans(req.GetResourceSpans())); err != nil {
+		bklog.G(ctx).WithError(err).Debug("trace export to collector failed")
 	}
 	return &tracev1.ExportTraceServiceResponse{}, nil
 }

--- a/util/tracing/detect/shutdown_test.go
+++ b/util/tracing/detect/shutdown_test.go
@@ -1,0 +1,76 @@
+package detect_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/moby/buildkit/util/tracing/detect"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+func newTestProvider(t *testing.T) *sdktrace.TracerProvider {
+	t.Helper()
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://192.0.2.1:4317") // RFC 5737 TEST-NET, guaranteed unreachable
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "grpc")
+
+	exp, err := detect.NewSpanExporter(context.Background())
+	if err != nil {
+		t.Fatalf("NewSpanExporter: %v", err)
+	}
+	if detect.IsNoneSpanExporter(exp) {
+		t.Fatal("expected OTLP exporter, got none")
+	}
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithResource(detect.Resource()),
+		sdktrace.WithBatcher(exp),
+	)
+
+	tracer := tp.Tracer("test")
+	_, span := tracer.Start(context.Background(), "test-op")
+	span.End()
+
+	return tp
+}
+
+// TestShutdownStallsWithUnboundedContext reproduces
+// https://github.com/moby/buildkit/issues/4616.
+// Without a deadline on the context, Shutdown blocks until the BSP export
+// timeout expires (default 30 s; reduced here via env for test speed).
+func TestShutdownStallsWithUnboundedContext(t *testing.T) {
+	t.Setenv("OTEL_BSP_EXPORT_TIMEOUT", "2000") // 2 s instead of default 30 s
+
+	tp := newTestProvider(t)
+
+	start := time.Now()
+	_ = tp.Shutdown(context.TODO()) // the buggy call pattern
+	elapsed := time.Since(start)
+
+	// Even with the reduced timeout, shutdown still blocks for the full
+	// export timeout (2 s here, 30 s in production).
+	if elapsed < 1500*time.Millisecond {
+		t.Fatalf("expected stall of ~2s, got %v", elapsed)
+	}
+	t.Logf("Unbounded shutdown stalled for %v (BSP export timeout)", elapsed)
+}
+
+// TestShutdownRespectsDeadline verifies the fix: passing a bounded context
+// makes Shutdown return promptly when the deadline is shorter than the export
+// timeout.
+func TestShutdownRespectsDeadline(t *testing.T) {
+	tp := newTestProvider(t)
+
+	deadline := 500 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), deadline)
+	defer cancel()
+
+	start := time.Now()
+	err := tp.Shutdown(ctx)
+	elapsed := time.Since(start)
+
+	if elapsed > deadline+200*time.Millisecond {
+		t.Fatalf("Shutdown took %v, expected <= %v", elapsed, deadline+200*time.Millisecond)
+	}
+	t.Logf("Bounded shutdown completed in %v (err=%v)", elapsed, err)
+}

--- a/util/tracing/detect/shutdown_test.go
+++ b/util/tracing/detect/shutdown_test.go
@@ -62,7 +62,7 @@ func TestShutdownRespectsDeadline(t *testing.T) {
 	tp := newTestProvider(t)
 
 	deadline := 500 * time.Millisecond
-	ctx, cancel := context.WithTimeout(context.Background(), deadline)
+	ctx, cancel := context.WithTimeoutCause(context.Background(), deadline, nil)
 	defer cancel()
 
 	start := time.Now()


### PR DESCRIPTION
Addresses #6747.

Three call sites pass `context.TODO()` (unbounded) into OTel operations that block on a dead collector:

- `cmd/buildctl/common/trace.go`: `tp.Shutdown` in `app.After`
- `cmd/buildkitd/main.go`: tracer/meter provider closers in `app.After`
- `control/control.go`: `Controller.Export` synchronous span forward

Cap each with a 5-second deadline (`context.WithTimeoutCause`). Errors are non-fatal: discarded in shutdown paths, logged at `Debug` in `Controller.Export`. `Controller.Export` also stops returning `Unavailable` when no downstream collector is configured, since clients that always emit traces would otherwise see a spurious gRPC error.

Regression test in `util/tracing/detect/shutdown_test.go` reproduces the unbounded-context stall and verifies a bounded context returns promptly.
