### PR TITLE
provenance: record request provenance for LLB refs

### DIFF
--- a/frontend/dockerfile/dockerfile_provenance_test.go
+++ b/frontend/dockerfile/dockerfile_provenance_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -51,6 +52,12 @@ var provenanceTests = integration.TestFuncs(
 	testClientFrontendProvenance,
 	testGatewayBuiltinSyntaxSourceProvenance,
 	testClientLLBProvenance,
+	testGatewayProvenanceRootRequest,
+	testGatewayProvenanceSameCallbackInputProducer,
+	testGatewayProvenanceDifferentCallbackInputProducer,
+	testGatewayProvenancePlainLLBInputFallback,
+	testGatewayProvenanceNestedInputProducer,
+	testDockerfileProvenanceInputProducer,
 	testSecretSSHProvenance,
 	testOCILayoutProvenance,
 	testNilProvenance,
@@ -1162,6 +1169,641 @@ func testClientLLBProvenance(t *testing.T, sb integration.Sandbox) {
 	require.Equal(t, 2, len(pred.BuildDefinition.ResolvedDependencies), "%+v", pred.BuildDefinition.ResolvedDependencies)
 	require.Contains(t, pred.BuildDefinition.ResolvedDependencies[0].URI, integration.UnixOrWindows("docker/alpine", "docker/nanoserver"))
 	require.Contains(t, pred.BuildDefinition.ResolvedDependencies[1].URI, "README.md")
+}
+
+// testGatewayProvenanceRootRequest verifies that max provenance keeps the
+// user-facing root build request separate from the frontend solve that produced
+// the exported result.
+func testGatewayProvenanceRootRequest(t *testing.T, sb integration.Sandbox) {
+	integration.SkipOnPlatform(t, "windows")
+	workers.CheckFeatureCompat(t, sb, workers.FeatureDirectPush, workers.FeatureProvenance)
+	ctx := sb.Context()
+
+	c, err := client.New(ctx, sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	registry, err := sb.NewRegistry()
+	if errors.Is(err, integration.ErrRequirements) {
+		t.Skip(err.Error())
+	}
+	require.NoError(t, err)
+	target := registry + "/buildkit/provenance-rootrequest:latest"
+
+	dockerfile := []byte(`
+FROM busybox AS final
+RUN echo root > /foo
+`)
+	dir := integration.Tmpdir(t, fstest.CreateFile("Dockerfile", dockerfile, 0600))
+	f := getFrontend(t, sb)
+
+	frontend := func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
+		return f.SolveGateway(ctx, c, gateway.SolveRequest{
+			FrontendOpt: map[string]string{
+				"target": "final",
+			},
+		})
+	}
+
+	_, err = c.Build(ctx, client.SolveOpt{
+		FrontendAttrs: map[string]string{
+			"attest:provenance": "mode=max",
+			"root-request":      "root-value",
+		},
+		Exports: []client.ExportEntry{{
+			Type: client.ExporterImage,
+			Attrs: map[string]string{
+				"name": target,
+				"push": "true",
+			},
+		}},
+		LocalMounts: map[string]fsutil.FS{
+			dockerui.DefaultLocalNameDockerfile: dir,
+			dockerui.DefaultLocalNameContext:    dir,
+		},
+	}, "", frontend, nil)
+	require.NoError(t, err)
+
+	pred := readNativeProvenancePredicate(ctx, t, target)
+	req := pred.BuildDefinition.ExternalParameters.Request
+	assertFrontendRequest(t, f, &req)
+	require.Equal(t, "final", req.Args["target"])
+	require.NotNil(t, req.Root)
+	require.NotNil(t, req.Root.Request)
+	require.Empty(t, req.Root.Request.Frontend)
+	require.Equal(t, "root-value", req.Root.Request.Args["root-request"])
+}
+
+// testGatewayProvenanceSameCallbackInputProducer verifies that an LLB returned
+// by one solve and consumed by another solve in the same Build callback carries
+// the original producer request into the consumer's provenance.
+func testGatewayProvenanceSameCallbackInputProducer(t *testing.T, sb integration.Sandbox) {
+	integration.SkipOnPlatform(t, "windows")
+	workers.CheckFeatureCompat(t, sb, workers.FeatureDirectPush, workers.FeatureProvenance)
+	ctx := sb.Context()
+
+	c, err := client.New(ctx, sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	registry, err := sb.NewRegistry()
+	if errors.Is(err, integration.ErrRequirements) {
+		t.Skip(err.Error())
+	}
+	require.NoError(t, err)
+	target := registry + "/buildkit/provenance-input-same:latest"
+
+	f := getFrontend(t, sb)
+	dockerfile := provenanceInputDockerfile()
+	dir := integration.Tmpdir(t, fstest.CreateFile("Dockerfile", dockerfile, 0600))
+
+	frontend := func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
+		st, metadata, err := solveProvenanceInputProducer(ctx, c, f)
+		if err != nil {
+			return nil, err
+		}
+		return solveProvenanceInputConsumer(ctx, c, f, st, metadata)
+	}
+
+	_, err = c.Build(ctx, client.SolveOpt{
+		FrontendAttrs: map[string]string{
+			"attest:provenance": "mode=max",
+		},
+		Exports: []client.ExportEntry{{
+			Type: client.ExporterImage,
+			Attrs: map[string]string{
+				"name": target,
+				"push": "true",
+			},
+		}},
+		LocalMounts: map[string]fsutil.FS{
+			dockerui.DefaultLocalNameDockerfile: dir,
+			dockerui.DefaultLocalNameContext:    dir,
+		},
+	}, "", frontend, nil)
+	require.NoError(t, err)
+
+	pred := readNativeProvenancePredicate(ctx, t, target)
+	assertProvenanceInputRequest(t, f, pred)
+}
+
+// testGatewayProvenanceDifferentCallbackInputProducer verifies that producer
+// request provenance is available to a different Build callback while the
+// producer build remains open.
+func testGatewayProvenanceDifferentCallbackInputProducer(t *testing.T, sb integration.Sandbox) {
+	integration.SkipOnPlatform(t, "windows")
+	workers.CheckFeatureCompat(t, sb, workers.FeatureDirectPush, workers.FeatureProvenance)
+	ctx := sb.Context()
+
+	c, err := client.New(ctx, sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	registry, err := sb.NewRegistry()
+	if errors.Is(err, integration.ErrRequirements) {
+		t.Skip(err.Error())
+	}
+	require.NoError(t, err)
+	target := registry + "/buildkit/provenance-input-different:latest"
+
+	f := getFrontend(t, sb)
+	dockerfile := provenanceInputDockerfile()
+	dir := integration.Tmpdir(t, fstest.CreateFile("Dockerfile", dockerfile, 0600))
+
+	var st llb.State
+	var metadata string
+	inputReady := make(chan struct{})
+	releaseProducer := make(chan struct{})
+	firstBuildDone := make(chan error, 1)
+	go func() {
+		_, err := c.Build(ctx, client.SolveOpt{
+			LocalMounts: map[string]fsutil.FS{
+				dockerui.DefaultLocalNameDockerfile: dir,
+				dockerui.DefaultLocalNameContext:    dir,
+			},
+		}, "", func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
+			var err error
+			st, metadata, err = solveProvenanceInputProducer(ctx, c, f)
+			if err != nil {
+				return nil, err
+			}
+			close(inputReady)
+			select {
+			case <-releaseProducer:
+			case <-ctx.Done():
+				return nil, context.Cause(ctx)
+			}
+			return gateway.NewResult(), nil
+		}, nil)
+		firstBuildDone <- err
+	}()
+	select {
+	case <-inputReady:
+	case err := <-firstBuildDone:
+		require.NoError(t, err)
+		require.FailNow(t, "producer build exited before returning an input")
+	}
+	defer func() {
+		close(releaseProducer)
+		require.NoError(t, <-firstBuildDone)
+	}()
+
+	_, err = c.Build(ctx, client.SolveOpt{
+		FrontendAttrs: map[string]string{
+			"attest:provenance": "mode=max",
+		},
+		Exports: []client.ExportEntry{{
+			Type: client.ExporterImage,
+			Attrs: map[string]string{
+				"name": target,
+				"push": "true",
+			},
+		}},
+		LocalMounts: map[string]fsutil.FS{
+			dockerui.DefaultLocalNameDockerfile: dir,
+			dockerui.DefaultLocalNameContext:    dir,
+		},
+	}, "", func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
+		return solveProvenanceInputConsumer(ctx, c, f, st, metadata)
+	}, nil)
+	require.NoError(t, err)
+
+	pred := readNativeProvenancePredicate(ctx, t, target)
+	assertProvenanceInputRequest(t, f, pred)
+}
+
+// testGatewayProvenancePlainLLBInputFallback verifies that plain client-created
+// LLB inputs do not get attributed to a frontend request they did not come from.
+func testGatewayProvenancePlainLLBInputFallback(t *testing.T, sb integration.Sandbox) {
+	integration.SkipOnPlatform(t, "windows")
+	workers.CheckFeatureCompat(t, sb, workers.FeatureDirectPush, workers.FeatureProvenance)
+	ctx := sb.Context()
+
+	c, err := client.New(ctx, sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	registry, err := sb.NewRegistry()
+	if errors.Is(err, integration.ErrRequirements) {
+		t.Skip(err.Error())
+	}
+	require.NoError(t, err)
+	target := registry + "/buildkit/provenance-input-plain:latest"
+
+	f := getFrontend(t, sb)
+	dockerfile := []byte(`
+FROM scratch
+COPY --from=linked /foo /foo
+`)
+	dir := integration.Tmpdir(t, fstest.CreateFile("Dockerfile", dockerfile, 0600))
+	st := llb.Scratch().File(llb.Mkfile("/foo", 0600, []byte("plain")))
+
+	_, err = c.Build(ctx, client.SolveOpt{
+		FrontendAttrs: map[string]string{
+			"attest:provenance": "mode=max",
+		},
+		Exports: []client.ExportEntry{{
+			Type: client.ExporterImage,
+			Attrs: map[string]string{
+				"name": target,
+				"push": "true",
+			},
+		}},
+		LocalMounts: map[string]fsutil.FS{
+			dockerui.DefaultLocalNameDockerfile: dir,
+			dockerui.DefaultLocalNameContext:    dir,
+		},
+	}, "", func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
+		def, err := st.Marshal(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return f.SolveGateway(ctx, c, gateway.SolveRequest{
+			FrontendOpt: map[string]string{
+				"context:linked": "input:plaininput",
+			},
+			FrontendInputs: map[string]*pb.Definition{
+				"plaininput": def.ToPB(),
+			},
+		})
+	}, nil)
+	require.NoError(t, err)
+
+	pred := readNativeProvenancePredicate(ctx, t, target)
+	req := pred.BuildDefinition.ExternalParameters.Request
+	assertFrontendRequest(t, f, &req)
+	require.Equal(t, "input:plaininput", req.Args["context:linked"])
+	require.Empty(t, req.Inputs)
+}
+
+// testGatewayProvenanceNestedInputProducer verifies that main, root, and input
+// requests each keep their own input provenance, including nested input
+// producer requests.
+func testGatewayProvenanceNestedInputProducer(t *testing.T, sb integration.Sandbox) {
+	integration.SkipOnPlatform(t, "windows")
+	workers.CheckFeatureCompat(t, sb, workers.FeatureDirectPush, workers.FeatureProvenance)
+	ctx := sb.Context()
+
+	c, err := client.New(ctx, sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	registry, err := sb.NewRegistry()
+	if errors.Is(err, integration.ErrRequirements) {
+		t.Skip(err.Error())
+	}
+	require.NoError(t, err)
+	target := registry + "/buildkit/provenance-input-nested:latest"
+
+	f := getFrontend(t, sb)
+	dockerfile := []byte(`
+FROM busybox AS seed
+RUN echo -n seed > /seed
+
+FROM busybox AS base
+ARG BASE_TEXT
+COPY --from=inner /seed /innerseed
+RUN echo -n "$BASE_TEXT" > /foo
+
+FROM scratch
+COPY --from=linked /foo /foo
+COPY --from=linked /innerseed /innerseed
+`)
+	dir := integration.Tmpdir(t, fstest.CreateFile("Dockerfile", dockerfile, 0600))
+
+	var rootSt llb.State
+	rootInputReady := make(chan struct{})
+	releaseRootProducer := make(chan struct{})
+	rootProducerDone := make(chan error, 1)
+	go func() {
+		_, err := c.Build(ctx, client.SolveOpt{
+			LocalMounts: map[string]fsutil.FS{
+				dockerui.DefaultLocalNameDockerfile: dir,
+				dockerui.DefaultLocalNameContext:    dir,
+			},
+		}, "", func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
+			var err error
+			rootSt, _, err = solveProvenanceNamedTarget(ctx, c, f, "seed", map[string]string{})
+			if err != nil {
+				return nil, err
+			}
+			close(rootInputReady)
+			select {
+			case <-releaseRootProducer:
+			case <-ctx.Done():
+				return nil, context.Cause(ctx)
+			}
+			return gateway.NewResult(), nil
+		}, nil)
+		rootProducerDone <- err
+	}()
+	select {
+	case <-rootInputReady:
+	case err := <-rootProducerDone:
+		require.NoError(t, err)
+		require.FailNow(t, "root input producer build exited before returning an input")
+	}
+	defer func() {
+		close(releaseRootProducer)
+		require.NoError(t, <-rootProducerDone)
+	}()
+
+	frontend := func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
+		inner, innerMetadata, err := solveProvenanceNamedTarget(ctx, c, f, "seed", map[string]string{})
+		if err != nil {
+			return nil, err
+		}
+		base, baseMetadata, err := solveProvenanceInputProducerWithInner(ctx, c, f, inner, innerMetadata)
+		if err != nil {
+			return nil, err
+		}
+		return solveProvenanceInputConsumer(ctx, c, f, base, baseMetadata)
+	}
+
+	_, err = c.Build(ctx, client.SolveOpt{
+		FrontendAttrs: map[string]string{
+			"attest:provenance": "mode=max",
+			"context:root":      "input:rootinput",
+			"root-request":      "nested-root",
+		},
+		FrontendInputs: map[string]llb.State{
+			"rootinput": rootSt,
+		},
+		Exports: []client.ExportEntry{{
+			Type: client.ExporterImage,
+			Attrs: map[string]string{
+				"name": target,
+				"push": "true",
+			},
+		}},
+		LocalMounts: map[string]fsutil.FS{
+			dockerui.DefaultLocalNameDockerfile: dir,
+			dockerui.DefaultLocalNameContext:    dir,
+		},
+	}, "", frontend, nil)
+	require.NoError(t, err)
+
+	pred := readNativeProvenancePredicate(ctx, t, target)
+	assertProvenanceInputRequest(t, f, pred)
+	req := pred.BuildDefinition.ExternalParameters.Request
+	require.NotNil(t, req.Root)
+	require.NotNil(t, req.Root.Request)
+	require.Equal(t, "input:rootinput", req.Root.Request.Args["context:root"])
+	require.Contains(t, req.Root.Request.Inputs, "rootinput")
+	rootInput := req.Root.Request.Inputs["rootinput"]
+	require.NotNil(t, rootInput.Request)
+	assertFrontendRequest(t, f, rootInput.Request)
+	require.Equal(t, "seed", rootInput.Request.Args["target"])
+	base := pred.BuildDefinition.ExternalParameters.Request.Inputs["baseinput"]
+	require.Contains(t, base.Request.Inputs, "innerinput")
+	inner := base.Request.Inputs["innerinput"]
+	require.NotNil(t, inner.Request)
+	assertFrontendRequest(t, f, inner.Request)
+	require.Equal(t, "seed", inner.Request.Args["target"])
+	require.Nil(t, base.Request.Root)
+}
+
+// testDockerfileProvenanceInputProducer verifies that direct Dockerfile
+// frontend solves consume stored input request provenance without going through
+// the gateway return path.
+func testDockerfileProvenanceInputProducer(t *testing.T, sb integration.Sandbox) {
+	integration.SkipOnPlatform(t, "windows")
+	workers.CheckFeatureCompat(t, sb, workers.FeatureDirectPush, workers.FeatureProvenance)
+	ctx := sb.Context()
+
+	c, err := client.New(ctx, sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	registry, err := sb.NewRegistry()
+	if errors.Is(err, integration.ErrRequirements) {
+		t.Skip(err.Error())
+	}
+	require.NoError(t, err)
+	target := registry + "/buildkit/provenance-input-dockerfile:latest"
+
+	f := getFrontend(t, sb)
+	if _, ok := f.(*builtinFrontend); !ok {
+		t.Skip("direct Dockerfile frontend coverage only")
+	}
+
+	dockerfile := provenanceInputDockerfile()
+	dir := integration.Tmpdir(t, fstest.CreateFile("Dockerfile", dockerfile, 0600))
+
+	var st llb.State
+	var metadata string
+	inputReady := make(chan struct{})
+	releaseProducer := make(chan struct{})
+	producerDone := make(chan error, 1)
+	go func() {
+		_, err := c.Build(ctx, client.SolveOpt{
+			LocalMounts: map[string]fsutil.FS{
+				dockerui.DefaultLocalNameDockerfile: dir,
+				dockerui.DefaultLocalNameContext:    dir,
+			},
+		}, "", func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
+			var err error
+			st, metadata, err = solveProvenanceInputProducer(ctx, c, f)
+			if err != nil {
+				return nil, err
+			}
+			close(inputReady)
+			select {
+			case <-releaseProducer:
+			case <-ctx.Done():
+				return nil, context.Cause(ctx)
+			}
+			return gateway.NewResult(), nil
+		}, nil)
+		producerDone <- err
+	}()
+	select {
+	case <-inputReady:
+	case err := <-producerDone:
+		require.NoError(t, err)
+		require.FailNow(t, "producer build exited before returning an input")
+	}
+	defer func() {
+		close(releaseProducer)
+		require.NoError(t, <-producerDone)
+	}()
+
+	_, err = f.Solve(ctx, c, client.SolveOpt{
+		FrontendAttrs: map[string]string{
+			"attest:provenance":     "mode=max",
+			"context:linked":        "input:baseinput",
+			"input-metadata:linked": metadata,
+		},
+		FrontendInputs: map[string]llb.State{
+			"baseinput": st,
+		},
+		Exports: []client.ExportEntry{{
+			Type: client.ExporterImage,
+			Attrs: map[string]string{
+				"name": target,
+				"push": "true",
+			},
+		}},
+		LocalMounts: map[string]fsutil.FS{
+			dockerui.DefaultLocalNameDockerfile: dir,
+			dockerui.DefaultLocalNameContext:    dir,
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	pred := readNativeProvenancePredicate(ctx, t, target)
+	assertProvenanceInputRequest(t, f, pred)
+}
+
+func provenanceInputDockerfile() []byte {
+	return []byte(`
+FROM busybox AS base
+ARG BASE_TEXT
+RUN echo -n "$BASE_TEXT" > /foo
+
+FROM scratch
+COPY --from=linked /foo /foo
+`)
+}
+
+func solveProvenanceInputProducer(ctx context.Context, c gateway.Client, f frontendGateway) (llb.State, string, error) {
+	return solveProvenanceNamedTarget(ctx, c, f, "base", map[string]string{
+		"build-arg:BASE_TEXT": "from-input",
+	})
+}
+
+func solveProvenanceNamedTarget(ctx context.Context, c gateway.Client, f frontendGateway, target string, opts map[string]string) (llb.State, string, error) {
+	frontendOpt := map[string]string{
+		"target": target,
+	}
+	maps.Copy(frontendOpt, opts)
+	res, err := f.SolveGateway(ctx, c, gateway.SolveRequest{
+		FrontendOpt: frontendOpt,
+	})
+	if err != nil {
+		return llb.State{}, "", err
+	}
+	ref, err := res.SingleRef()
+	if err != nil {
+		return llb.State{}, "", err
+	}
+	st, err := ref.ToState()
+	if err != nil {
+		return llb.State{}, "", err
+	}
+	dt, ok := res.Metadata["containerimage.config"]
+	if !ok {
+		return llb.State{}, "", errors.Errorf("no containerimage.config in metadata")
+	}
+	dt, err = json.Marshal(map[string][]byte{
+		"containerimage.config": dt,
+	})
+	if err != nil {
+		return llb.State{}, "", err
+	}
+	return st, string(dt), nil
+}
+
+func solveProvenanceInputProducerWithInner(ctx context.Context, c gateway.Client, f frontendGateway, inner llb.State, innerMetadata string) (llb.State, string, error) {
+	def, err := inner.Marshal(ctx)
+	if err != nil {
+		return llb.State{}, "", err
+	}
+	res, err := f.SolveGateway(ctx, c, gateway.SolveRequest{
+		FrontendOpt: map[string]string{
+			"target":               "base",
+			"build-arg:BASE_TEXT":  "from-input",
+			"context:inner":        "input:innerinput",
+			"input-metadata:inner": innerMetadata,
+		},
+		FrontendInputs: map[string]*pb.Definition{
+			"innerinput": def.ToPB(),
+		},
+	})
+	if err != nil {
+		return llb.State{}, "", err
+	}
+	ref, err := res.SingleRef()
+	if err != nil {
+		return llb.State{}, "", err
+	}
+	st, err := ref.ToState()
+	if err != nil {
+		return llb.State{}, "", err
+	}
+	dt, ok := res.Metadata["containerimage.config"]
+	if !ok {
+		return llb.State{}, "", errors.Errorf("no containerimage.config in metadata")
+	}
+	dt, err = json.Marshal(map[string][]byte{
+		"containerimage.config": dt,
+	})
+	if err != nil {
+		return llb.State{}, "", err
+	}
+	return st, string(dt), nil
+}
+
+type frontendGateway interface {
+	SolveGateway(context.Context, gateway.Client, gateway.SolveRequest) (*gateway.Result, error)
+}
+
+func solveProvenanceInputConsumer(ctx context.Context, c gateway.Client, f frontendGateway, st llb.State, metadata string) (*gateway.Result, error) {
+	def, err := st.Marshal(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return f.SolveGateway(ctx, c, gateway.SolveRequest{
+		FrontendOpt: map[string]string{
+			"context:linked":        "input:baseinput",
+			"input-metadata:linked": metadata,
+		},
+		FrontendInputs: map[string]*pb.Definition{
+			"baseinput": def.ToPB(),
+		},
+	})
+}
+
+func assertProvenanceInputRequest(t *testing.T, f frontendGateway, pred provenancetypes.ProvenancePredicateSLSA1) {
+	req := pred.BuildDefinition.ExternalParameters.Request
+	assertFrontendRequest(t, f, &req)
+	require.Equal(t, "input:baseinput", req.Args["context:linked"])
+	require.Contains(t, req.Args, "input-metadata:linked")
+	require.Contains(t, req.Inputs, "baseinput")
+
+	in := req.Inputs["baseinput"]
+	require.NotNil(t, in.Request)
+	assertFrontendRequest(t, f, in.Request)
+	require.Equal(t, "base", in.Request.Args["target"])
+	require.Equal(t, "from-input", in.Request.Args["build-arg:BASE_TEXT"])
+	require.Nil(t, in.Request.Root)
+}
+
+func assertFrontendRequest(t *testing.T, f frontendGateway, req *provenancetypes.Parameters) {
+	t.Helper()
+	if _, ok := f.(*gatewayFrontend); ok {
+		require.Equal(t, "gateway.v0", req.Frontend)
+		require.Contains(t, req.Args["source"], "buildkit_test/")
+		return
+	}
+	require.Equal(t, "dockerfile.v0", req.Frontend)
+}
+
+func readNativeProvenancePredicate(ctx context.Context, t *testing.T, target string) provenancetypes.ProvenancePredicateSLSA1 {
+	desc, provider, err := contentutil.ProviderFromRef(target)
+	require.NoError(t, err)
+	imgs, err := testutil.ReadImages(ctx, provider, desc)
+	require.NoError(t, err)
+
+	nativePlatform := platforms.Format(platforms.Normalize(platforms.DefaultSpec()))
+	att := imgs.FindAttestation(nativePlatform)
+	require.NotNil(t, att)
+
+	var stmt struct {
+		Predicate provenancetypes.ProvenancePredicateSLSA1 `json:"predicate"`
+	}
+	require.NoError(t, json.Unmarshal(att.LayersRaw[0], &stmt))
+	return stmt.Predicate
 }
 
 func testSecretSSHProvenance(t *testing.T, sb integration.Sandbox) {

--- a/frontend/dockerfile/dockerfile_provenance_test.go
+++ b/frontend/dockerfile/dockerfile_provenance_test.go
@@ -1251,40 +1251,58 @@ func testGatewayProvenanceSameCallbackInputProducer(t *testing.T, sb integration
 		t.Skip(err.Error())
 	}
 	require.NoError(t, err)
-	target := registry + "/buildkit/provenance-input-same:latest"
-
 	f := getFrontend(t, sb)
 	dockerfile := provenanceInputDockerfile()
 	dir := integration.Tmpdir(t, fstest.CreateFile("Dockerfile", dockerfile, 0600))
 
-	frontend := func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
-		st, metadata, err := solveProvenanceInputProducer(ctx, c, f)
-		if err != nil {
-			return nil, err
-		}
-		return solveProvenanceInputConsumer(ctx, c, f, st, metadata)
+	for _, tc := range []struct {
+		name           string
+		provenanceMode string
+		assert         func(*testing.T, frontendGateway, provenancetypes.ProvenancePredicateSLSA1)
+	}{
+		{
+			name:           "max",
+			provenanceMode: "mode=max",
+			assert:         assertProvenanceInputRequest,
+		},
+		{
+			name:           "min",
+			provenanceMode: "mode=min",
+			assert:         assertMinProvenanceInputRequest,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			target := registry + "/buildkit/provenance-input-same-" + tc.name + ":latest"
+			frontend := func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
+				st, metadata, err := solveProvenanceInputProducer(ctx, c, f)
+				if err != nil {
+					return nil, err
+				}
+				return solveProvenanceInputConsumer(ctx, c, f, st, metadata)
+			}
+
+			_, err = c.Build(ctx, client.SolveOpt{
+				FrontendAttrs: map[string]string{
+					"attest:provenance": tc.provenanceMode,
+				},
+				Exports: []client.ExportEntry{{
+					Type: client.ExporterImage,
+					Attrs: map[string]string{
+						"name": target,
+						"push": "true",
+					},
+				}},
+				LocalMounts: map[string]fsutil.FS{
+					dockerui.DefaultLocalNameDockerfile: dir,
+					dockerui.DefaultLocalNameContext:    dir,
+				},
+			}, "", frontend, nil)
+			require.NoError(t, err)
+
+			pred := readNativeProvenancePredicate(ctx, t, target)
+			tc.assert(t, f, pred)
+		})
 	}
-
-	_, err = c.Build(ctx, client.SolveOpt{
-		FrontendAttrs: map[string]string{
-			"attest:provenance": "mode=max",
-		},
-		Exports: []client.ExportEntry{{
-			Type: client.ExporterImage,
-			Attrs: map[string]string{
-				"name": target,
-				"push": "true",
-			},
-		}},
-		LocalMounts: map[string]fsutil.FS{
-			dockerui.DefaultLocalNameDockerfile: dir,
-			dockerui.DefaultLocalNameContext:    dir,
-		},
-	}, "", frontend, nil)
-	require.NoError(t, err)
-
-	pred := readNativeProvenancePredicate(ctx, t, target)
-	assertProvenanceInputRequest(t, f, pred)
 }
 
 // testGatewayProvenanceDifferentCallbackInputProducer verifies that producer
@@ -1669,6 +1687,7 @@ COPY --from=linked /foo /foo
 func solveProvenanceInputProducer(ctx context.Context, c gateway.Client, f frontendGateway) (llb.State, string, error) {
 	return solveProvenanceNamedTarget(ctx, c, f, "base", map[string]string{
 		"build-arg:BASE_TEXT": "from-input",
+		"label:input":         "from-input",
 	})
 }
 
@@ -1713,6 +1732,7 @@ func solveProvenanceInputProducerWithInner(ctx context.Context, c gateway.Client
 		FrontendOpt: map[string]string{
 			"target":               "base",
 			"build-arg:BASE_TEXT":  "from-input",
+			"label:input":          "from-input",
 			"context:inner":        "input:innerinput",
 			"input-metadata:inner": innerMetadata,
 		},
@@ -1776,6 +1796,24 @@ func assertProvenanceInputRequest(t *testing.T, f frontendGateway, pred provenan
 	assertFrontendRequest(t, f, in.Request)
 	require.Equal(t, "base", in.Request.Args["target"])
 	require.Equal(t, "from-input", in.Request.Args["build-arg:BASE_TEXT"])
+	require.Equal(t, "from-input", in.Request.Args["label:input"])
+	require.Nil(t, in.Request.Root)
+}
+
+func assertMinProvenanceInputRequest(t *testing.T, f frontendGateway, pred provenancetypes.ProvenancePredicateSLSA1) {
+	req := pred.BuildDefinition.ExternalParameters.Request
+	assertFrontendRequest(t, f, &req)
+	require.Equal(t, "input:baseinput", req.Args["context:linked"])
+	require.Contains(t, req.Args, "input-metadata:linked")
+	require.Contains(t, req.Inputs, "baseinput")
+	require.False(t, pred.RunDetails.Metadata.Completeness.Request)
+
+	in := req.Inputs["baseinput"]
+	require.NotNil(t, in.Request)
+	assertFrontendRequest(t, f, in.Request)
+	require.Equal(t, "base", in.Request.Args["target"])
+	require.NotContains(t, in.Request.Args, "build-arg:BASE_TEXT")
+	require.NotContains(t, in.Request.Args, "label:input")
 	require.Nil(t, in.Request.Root)
 }
 

--- a/frontend/gateway/client/client.go
+++ b/frontend/gateway/client/client.go
@@ -3,6 +3,8 @@ package client
 import (
 	"context"
 	"io"
+	"maps"
+	"slices"
 	"syscall"
 
 	"github.com/moby/buildkit/client/llb"
@@ -152,6 +154,40 @@ type SolveRequest struct {
 	FrontendInputs map[string]*pb.Definition
 	CacheImports   []CacheOptionsEntry
 	SourcePolicies []*spb.Policy
+}
+
+// Clone returns a deep copy of the solve request.
+func (r SolveRequest) Clone() SolveRequest {
+	if r.Definition != nil {
+		r.Definition = r.Definition.CloneVT()
+	}
+	r.FrontendOpt = maps.Clone(r.FrontendOpt)
+	if len(r.FrontendInputs) > 0 {
+		inputs := r.FrontendInputs
+		r.FrontendInputs = make(map[string]*pb.Definition, len(inputs))
+		for k, v := range inputs {
+			if v != nil {
+				v = v.CloneVT()
+			}
+			r.FrontendInputs[k] = v
+		}
+	}
+	if len(r.CacheImports) > 0 {
+		r.CacheImports = slices.Clone(r.CacheImports)
+		for i, ci := range r.CacheImports {
+			ci.Attrs = maps.Clone(ci.Attrs)
+			r.CacheImports[i] = ci
+		}
+	}
+	if len(r.SourcePolicies) > 0 {
+		r.SourcePolicies = slices.Clone(r.SourcePolicies)
+		for i, p := range r.SourcePolicies {
+			if p != nil {
+				r.SourcePolicies[i] = p.CloneVT()
+			}
+		}
+	}
+	return r
 }
 
 type CacheOptionsEntry struct {

--- a/frontend/gateway/client/client_test.go
+++ b/frontend/gateway/client/client_test.go
@@ -1,0 +1,41 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSolveRequestCloneCopiesFrontendInputs(t *testing.T) {
+	req := SolveRequest{
+		FrontendOpt: map[string]string{
+			"context:base": "input:base",
+		},
+		FrontendInputs: map[string]*pb.Definition{
+			"base": {
+				Def: [][]byte{[]byte("def")},
+				Metadata: map[string]*pb.OpMetadata{
+					"dgst": {},
+				},
+			},
+			"nil": nil,
+		},
+	}
+
+	clone := req.Clone()
+
+	require.Contains(t, clone.FrontendInputs, "base")
+	require.Contains(t, clone.FrontendInputs, "nil")
+	require.Nil(t, clone.FrontendInputs["nil"])
+	require.NotSame(t, req.FrontendInputs["base"], clone.FrontendInputs["base"])
+	require.Equal(t, req.FrontendInputs["base"], clone.FrontendInputs["base"])
+
+	clone.FrontendOpt["context:base"] = "changed"
+	clone.FrontendInputs["base"].Metadata["dgst"] = &pb.OpMetadata{
+		Description: map[string]string{"name": "changed"},
+	}
+
+	require.Equal(t, "input:base", req.FrontendOpt["context:base"])
+	require.Empty(t, req.FrontendInputs["base"].Metadata["dgst"].Description)
+}

--- a/solver/llbsolver/bridge.go
+++ b/solver/llbsolver/bridge.go
@@ -39,6 +39,7 @@ type llbBridge struct {
 	cms                       map[string]solver.CacheManager
 	cmsMu                     sync.Mutex
 	sm                        *session.Manager
+	provenanceStore           *provenanceStore
 
 	executorOnce sync.Once
 	executorErr  error

--- a/solver/llbsolver/provenance.go
+++ b/solver/llbsolver/provenance.go
@@ -38,12 +38,14 @@ type resultWithBridge struct {
 // provenanceBridge provides scoped access to LLBBridge and captures the request it makes for provenance
 type provenanceBridge struct {
 	*llbBridge
-	mu  sync.Mutex
-	req *frontend.SolveRequest
+	mu      sync.Mutex
+	req     *frontend.SolveRequest
+	rootReq *frontend.SolveRequest
 
-	images     []provenancetypes.ImageSource
-	builds     []resultWithBridge
-	subBridges []*provenanceBridge
+	images                 []provenancetypes.ImageSource
+	builds                 []resultWithBridge
+	subBridges             []*provenanceBridge
+	provenanceRefRecordIDs []string
 }
 
 func (b *provenanceBridge) eachRef(f func(r solver.ResultProxy) error) error {
@@ -165,6 +167,7 @@ func (b *provenanceBridge) ResolveSourceMetadata(ctx context.Context, op *pb.Sou
 }
 
 func (b *provenanceBridge) Solve(ctx context.Context, req frontend.SolveRequest, sid string) (res *frontend.Result, err error) {
+	req = req.Clone()
 	if req.Definition != nil && req.Definition.Def != nil && req.Frontend != "" {
 		return nil, errors.New("cannot solve with both Definition and Frontend specified")
 	}
@@ -180,7 +183,11 @@ func (b *provenanceBridge) Solve(ctx context.Context, req frontend.SolveRequest,
 		if !ok {
 			return nil, errors.Errorf("invalid frontend: %s", req.Frontend)
 		}
-		wb := &provenanceBridge{llbBridge: b.llbBridge, req: &req}
+		rootReq := b.rootReq
+		if !hasRequestProvenance(rootReq) {
+			rootReq = b.req
+		}
+		wb := &provenanceBridge{llbBridge: b.llbBridge, req: &req, rootReq: rootReq}
 		res, err = f.Solve(ctx, wb, b.llbBridge, req.FrontendOpt, req.FrontendInputs, sid, b.sm)
 		if err != nil {
 			fe := errdefs.Frontend{
@@ -201,6 +208,9 @@ func (b *provenanceBridge) Solve(ctx context.Context, req frontend.SolveRequest,
 			_, err := ref.Result(ctx)
 			return err
 		})
+	}
+	if err == nil {
+		err = b.registerProvenanceRefs(res)
 	}
 	return
 }
@@ -671,14 +681,26 @@ func getRefProvenance(ref solver.ResultProxy, br *provenanceBridge) (*provenance
 	if !ok {
 		return nil, errors.Errorf("invalid provenance type %T", p)
 	}
+	pr = pr.Clone()
 
 	if br.req != nil {
 		if pr == nil {
 			return nil, errors.Errorf("missing provenance for %s", ref.ID())
 		}
 
-		pr.Frontend = br.req.Frontend
-		pr.Args = provenance.FilterArgs(br.req.FrontendOpt)
+		pr.Request.Frontend = br.req.Frontend
+		pr.Request.Args = provenance.FilterArgs(br.req.FrontendOpt)
+		pr.Request.Inputs = br.inputProvenance(br.req.FrontendInputs)
+		if root := br.rootRequestProvenance(pr.Sources); root != nil {
+			req := provenance.RequestProvenance(pr.Request.Frontend, pr.Request.Args, pr.Sources)
+			if req.Request == nil {
+				req.Request = &provenancetypes.Parameters{}
+			}
+			req.Request.Inputs = pr.Request.Inputs
+			if !root.Equal(req) {
+				pr.Request.Root = root
+			}
+		}
 		// TODO: should also save some output options like compression
 	}
 

--- a/solver/llbsolver/provenance.go
+++ b/solver/llbsolver/provenance.go
@@ -407,17 +407,9 @@ func NewProvenanceCreator(ctx context.Context, slsaVersion provenancetypes.Prove
 
 	switch mode {
 	case "min":
-		args := make(map[string]string)
-		for k, v := range pr.BuildDefinition.ExternalParameters.Request.Args {
-			if strings.HasPrefix(k, "build-arg:") || strings.HasPrefix(k, "label:") {
-				pr.RunDetails.Metadata.Completeness.Request = false
-				continue
-			}
-			args[k] = v
+		if scrubMinRequest(&pr.BuildDefinition.ExternalParameters.Request) {
+			pr.RunDetails.Metadata.Completeness.Request = false
 		}
-		pr.BuildDefinition.ExternalParameters.Request.Args = args
-		pr.BuildDefinition.ExternalParameters.Request.Secrets = nil
-		pr.BuildDefinition.ExternalParameters.Request.SSH = nil
 	case "max":
 		dgsts, err := provenance.AddBuildConfig(ctx, pr, cp, res, withUsage)
 		if err != nil {
@@ -486,6 +478,41 @@ func NewProvenanceCreator(ctx context.Context, slsaVersion provenancetypes.Prove
 		pc.sampler = usage
 	}
 	return pc, nil
+}
+
+func scrubMinRequest(req *provenancetypes.Parameters) bool {
+	if req == nil {
+		return false
+	}
+
+	var incomplete bool
+	if len(req.Args) > 0 {
+		args := make(map[string]string, len(req.Args))
+		for k, v := range req.Args {
+			if strings.HasPrefix(k, "build-arg:") || strings.HasPrefix(k, "label:") {
+				incomplete = true
+				continue
+			}
+			args[k] = v
+		}
+		req.Args = args
+	}
+	if len(req.Secrets) > 0 {
+		req.Secrets = nil
+	}
+	if len(req.SSH) > 0 {
+		req.SSH = nil
+	}
+
+	for _, in := range req.Inputs {
+		if in != nil && scrubMinRequest(in.Request) {
+			incomplete = true
+		}
+	}
+	if req.Root != nil && scrubMinRequest(req.Root.Request) {
+		incomplete = true
+	}
+	return incomplete
 }
 
 func (p *ProvenanceCreator) PredicateType() string {

--- a/solver/llbsolver/provenance/capture.go
+++ b/solver/llbsolver/provenance/capture.go
@@ -2,6 +2,7 @@ package provenance
 
 import (
 	"cmp"
+	"maps"
 	"slices"
 
 	distreference "github.com/distribution/reference"
@@ -15,14 +16,34 @@ import (
 type Result = result.Result[*Capture]
 
 type Capture struct {
-	Frontend            string
-	Args                map[string]string
+	Request             provenancetypes.Parameters
 	Sources             provenancetypes.Sources
-	Secrets             []provenancetypes.Secret
-	SSH                 []provenancetypes.SSH
 	NetworkAccess       bool
 	IncompleteMaterials bool
 	Samples             map[digest.Digest]*resourcestypes.Samples
+}
+
+func (c *Capture) Clone() *Capture {
+	if c == nil {
+		return nil
+	}
+	out := &Capture{
+		NetworkAccess:       c.NetworkAccess,
+		IncompleteMaterials: c.IncompleteMaterials,
+	}
+	if req := c.Request.Clone(); req != nil {
+		out.Request = *req
+	}
+	out.Sources.Images = append(out.Sources.Images, c.Sources.Images...)
+	out.Sources.ImageBlobs = append(out.Sources.ImageBlobs, c.Sources.ImageBlobs...)
+	out.Sources.Local = append(out.Sources.Local, c.Sources.Local...)
+	out.Sources.Git = append(out.Sources.Git, c.Sources.Git...)
+	out.Sources.HTTP = append(out.Sources.HTTP, c.Sources.HTTP...)
+	if len(c.Samples) > 0 {
+		out.Samples = make(map[digest.Digest]*resourcestypes.Samples, len(c.Samples))
+		maps.Copy(out.Samples, c.Samples)
+	}
+	return out
 }
 
 func (c *Capture) Merge(c2 *Capture) error {
@@ -44,11 +65,15 @@ func (c *Capture) Merge(c2 *Capture) error {
 	for _, h := range c2.Sources.HTTP {
 		c.AddHTTP(h)
 	}
-	for _, s := range c2.Secrets {
-		c.AddSecret(s)
+	for _, s := range c2.Request.Secrets {
+		if s != nil {
+			c.AddSecret(*s)
+		}
 	}
-	for _, s := range c2.SSH {
-		c.AddSSH(s)
+	for _, s := range c2.Request.SSH {
+		if s != nil {
+			c.AddSSH(*s)
+		}
 	}
 	if c2.NetworkAccess {
 		c.NetworkAccess = true
@@ -75,10 +100,10 @@ func (c *Capture) Sort() {
 	slices.SortFunc(c.Sources.HTTP, func(a, b provenancetypes.HTTPSource) int {
 		return cmp.Compare(a.URL, b.URL)
 	})
-	slices.SortFunc(c.Secrets, func(a, b provenancetypes.Secret) int {
+	slices.SortFunc(c.Request.Secrets, func(a, b *provenancetypes.Secret) int {
 		return cmp.Compare(a.ID, b.ID)
 	})
-	slices.SortFunc(c.SSH, func(a, b provenancetypes.SSH) int {
+	slices.SortFunc(c.Request.SSH, func(a, b *provenancetypes.SSH) int {
 		return cmp.Compare(a.ID, b.ID)
 	})
 }
@@ -190,30 +215,30 @@ func (c *Capture) AddHTTP(h provenancetypes.HTTPSource) {
 }
 
 func (c *Capture) AddSecret(s provenancetypes.Secret) {
-	for i, v := range c.Secrets {
+	for i, v := range c.Request.Secrets {
 		if v.ID == s.ID {
 			if !s.Optional {
-				c.Secrets[i].Optional = false
+				c.Request.Secrets[i].Optional = false
 			}
 			return
 		}
 	}
-	c.Secrets = append(c.Secrets, s)
+	c.Request.Secrets = append(c.Request.Secrets, &s)
 }
 
 func (c *Capture) AddSSH(s provenancetypes.SSH) {
 	if s.ID == "" {
 		s.ID = "default"
 	}
-	for i, v := range c.SSH {
+	for i, v := range c.Request.SSH {
 		if v.ID == s.ID {
 			if !s.Optional {
-				c.SSH[i].Optional = false
+				c.Request.SSH[i].Optional = false
 			}
 			return
 		}
 	}
-	c.SSH = append(c.SSH, s)
+	c.Request.SSH = append(c.Request.SSH, &s)
 }
 
 func (c *Capture) AddSamples(dgst digest.Digest, samples *resourcestypes.Samples) {

--- a/solver/llbsolver/provenance/capture_test.go
+++ b/solver/llbsolver/provenance/capture_test.go
@@ -60,8 +60,8 @@ func TestCaptureAddSecretMerge(t *testing.T) {
 	c.AddSecret(provenancetypes.Secret{ID: "mysecret", Optional: true})
 	c.AddSecret(provenancetypes.Secret{ID: "mysecret", Optional: false})
 
-	require.Len(t, c.Secrets, 1)
-	require.False(t, c.Secrets[0].Optional, "non-optional should win")
+	require.Len(t, c.Request.Secrets, 1)
+	require.False(t, c.Request.Secrets[0].Optional, "non-optional should win")
 }
 
 func TestCaptureAddSSHDefault(t *testing.T) {
@@ -69,8 +69,8 @@ func TestCaptureAddSSHDefault(t *testing.T) {
 	c := &Capture{}
 
 	c.AddSSH(provenancetypes.SSH{ID: ""})
-	require.Len(t, c.SSH, 1)
-	require.Equal(t, "default", c.SSH[0].ID)
+	require.Len(t, c.Request.SSH, 1)
+	require.Equal(t, "default", c.Request.SSH[0].ID)
 }
 
 func TestCaptureAddGitRedactsCredentials(t *testing.T) {
@@ -176,7 +176,7 @@ func TestCaptureMerge(t *testing.T) {
 
 	require.Len(t, c1.Sources.Images, 2)
 	require.Len(t, c1.Sources.Git, 1)
-	require.Len(t, c1.Secrets, 1)
+	require.Len(t, c1.Request.Secrets, 1)
 	require.True(t, c1.NetworkAccess)
 	require.True(t, c1.IncompleteMaterials)
 }
@@ -199,8 +199,8 @@ func TestCaptureSort(t *testing.T) {
 
 	require.Equal(t, "alpha", c.Sources.Images[0].Ref)
 	require.Equal(t, "zebra", c.Sources.Images[1].Ref)
-	require.Equal(t, "a", c.Secrets[0].ID)
-	require.Equal(t, "z", c.Secrets[1].ID)
+	require.Equal(t, "a", c.Request.Secrets[0].ID)
+	require.Equal(t, "z", c.Request.Secrets[1].ID)
 }
 
 func TestCaptureOptimizeImageSources(t *testing.T) {

--- a/solver/llbsolver/provenance/predicate.go
+++ b/solver/llbsolver/provenance/predicate.go
@@ -223,39 +223,25 @@ func NewPredicate(c *Capture) (*provenancetypes.ProvenancePredicateSLSA1, error)
 		})
 	}
 
-	args := maps.Clone(c.Args)
-
-	contextKey := "context"
-	if v, ok := args["contextkey"]; ok && v != "" {
-		contextKey = v
-	} else if v, ok := c.Args["input:context"]; ok && v != "" {
-		contextKey = "input:context"
-	}
-
 	ext := provenancetypes.ProvenanceExternalParametersSLSA1{}
-	if v, ok := args[contextKey]; ok && v != "" {
-		if m, ok := findMaterial(c.Sources, v); ok {
-			ext.ConfigSource.URI = m.URI
-			ext.ConfigSource.Digest = m.Digest
-		} else {
-			ext.ConfigSource.URI = v
-		}
-		ext.ConfigSource.URI = urlutil.RedactCredentials(ext.ConfigSource.URI)
-		delete(args, contextKey)
-	}
-
-	if v, ok := args["filename"]; ok && v != "" {
-		ext.ConfigSource.Path = v
-		delete(args, "filename")
-	}
+	reqProv := RequestProvenance(c.Request.Frontend, maps.Clone(c.Request.Args), c.Sources)
+	ext.ConfigSource = reqProv.ConfigSource
 
 	vcs := make(map[string]string)
-	for k, v := range args {
+	req := c.Request.Clone()
+	if req == nil {
+		req = &provenancetypes.Parameters{}
+	}
+	if reqProv.Request != nil {
+		req.Frontend = reqProv.Request.Frontend
+		req.Args = reqProv.Request.Args
+	}
+	for k, v := range req.Args {
 		if strings.HasPrefix(k, "vcs:") {
 			if k == "vcs:source" {
 				v = urlutil.RedactCredentials(v)
 			}
-			delete(args, k)
+			delete(req.Args, k)
 			if v != "" {
 				vcs[strings.TrimPrefix(k, "vcs:")] = v
 			}
@@ -265,27 +251,12 @@ func NewPredicate(c *Capture) (*provenancetypes.ProvenancePredicateSLSA1, error)
 	internal := provenancetypes.ProvenanceInternalParametersSLSA1{}
 	internal.BuilderPlatform = platforms.Format(platforms.Normalize(platforms.DefaultSpec()))
 
-	req := provenancetypes.Parameters{}
-	req.Frontend = c.Frontend
-	req.Args = args
-	for _, s := range c.Secrets {
-		req.Secrets = append(req.Secrets, &provenancetypes.Secret{
-			ID:       s.ID,
-			Optional: s.Optional,
-		})
-	}
-	for _, s := range c.SSH {
-		req.SSH = append(req.SSH, &provenancetypes.SSH{
-			ID:       s.ID,
-			Optional: s.Optional,
-		})
-	}
 	for _, s := range c.Sources.Local {
 		req.Locals = append(req.Locals, &provenancetypes.LocalSource{
 			Name: s.Name,
 		})
 	}
-	ext.Request = req
+	ext.Request = *req
 
 	incompleteMaterials := c.IncompleteMaterials
 	if !incompleteMaterials {
@@ -306,7 +277,7 @@ func NewPredicate(c *Capture) (*provenancetypes.ProvenancePredicateSLSA1, error)
 		RunDetails: provenancetypes.ProvenanceRunDetailsSLSA1{
 			Metadata: &provenancetypes.ProvenanceMetadataSLSA1{
 				Completeness: provenancetypes.BuildKitComplete{
-					Request:              c.Frontend != "",
+					Request:              c.Request.Frontend != "",
 					ResolvedDependencies: !incompleteMaterials,
 				},
 				Hermetic: !incompleteMaterials && !c.NetworkAccess,
@@ -319,6 +290,42 @@ func NewPredicate(c *Capture) (*provenancetypes.ProvenancePredicateSLSA1, error)
 	}
 
 	return pr, nil
+}
+
+func RequestProvenance(frontend string, args map[string]string, srcs provenancetypes.Sources) *provenancetypes.RequestProvenance {
+	args = maps.Clone(args)
+	contextKey := "context"
+	if v, ok := args["contextkey"]; ok && v != "" {
+		contextKey = v
+	} else if v, ok := args["input:context"]; ok && v != "" {
+		contextKey = "input:context"
+	}
+
+	ext := provenancetypes.RequestProvenance{
+		Request: &provenancetypes.Parameters{
+			Frontend: frontend,
+			Args:     args,
+		},
+	}
+	if v, ok := args[contextKey]; ok && v != "" {
+		if m, ok := findMaterial(srcs, v); ok {
+			ext.ConfigSource.URI = m.URI
+			ext.ConfigSource.Digest = m.Digest
+		} else {
+			ext.ConfigSource.URI = v
+		}
+		ext.ConfigSource.URI = urlutil.RedactCredentials(ext.ConfigSource.URI)
+		delete(args, contextKey)
+	}
+
+	if v, ok := args["filename"]; ok && v != "" {
+		ext.ConfigSource.Path = v
+		delete(args, "filename")
+	}
+	if len(args) == 0 {
+		ext.Request.Args = nil
+	}
+	return &ext
 }
 
 func FilterArgs(m map[string]string) map[string]string {

--- a/solver/llbsolver/provenance/predicate_test.go
+++ b/solver/llbsolver/provenance/predicate_test.go
@@ -245,15 +245,60 @@ func TestFindMaterial(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestNewPredicatePreservesRequestSecretsSSHAndInputs(t *testing.T) {
+	t.Parallel()
+
+	c := &Capture{
+		Request: provenancetypes.Parameters{
+			Frontend: "dockerfile.v0",
+			Args: map[string]string{
+				"context":  "https://example.invalid/context.git",
+				"filename": "Dockerfile",
+			},
+			Secrets: []*provenancetypes.Secret{
+				{ID: "mysecret", Optional: true},
+			},
+			SSH: []*provenancetypes.SSH{
+				{ID: "default", Optional: true},
+			},
+			Inputs: map[string]*provenancetypes.RequestProvenance{
+				"base": {
+					Request: &provenancetypes.Parameters{
+						Frontend: "dockerfile.v0",
+						Args:     map[string]string{"target": "base"},
+					},
+				},
+			},
+		},
+	}
+
+	pr, err := NewPredicate(c)
+	require.NoError(t, err)
+
+	req := pr.BuildDefinition.ExternalParameters.Request
+	require.Equal(t, "dockerfile.v0", req.Frontend)
+	require.Nil(t, req.Args)
+	require.Len(t, req.Secrets, 1)
+	require.Equal(t, "mysecret", req.Secrets[0].ID)
+	require.True(t, req.Secrets[0].Optional)
+	require.Len(t, req.SSH, 1)
+	require.Equal(t, "default", req.SSH[0].ID)
+	require.True(t, req.SSH[0].Optional)
+	require.Contains(t, req.Inputs, "base")
+	require.Equal(t, "base", req.Inputs["base"].Request.Args["target"])
+}
+
 func TestNewPredicateGitConfigSourceSubdir(t *testing.T) {
 	t.Parallel()
 
 	commit := "abc123def456abc123def456abc123def456abcd"
 	c := &Capture{
-		Frontend: "dockerfile.v0",
-		Args: map[string]string{
-			"context":  "https://github.com/moby/buildkit.git?branch=master&subdir=src",
-			"filename": "Dockerfile",
+		Request: provenancetypes.Parameters{
+			Frontend: "dockerfile.v0",
+			Args: map[string]string{
+				"context":  "https://github.com/moby/buildkit.git?branch=master&subdir=src",
+				"filename": "Dockerfile",
+			},
 		},
 		Sources: provenancetypes.Sources{
 			Git: []provenancetypes.GitSource{
@@ -276,10 +321,12 @@ func TestNewPredicateKeepsContextSubdir(t *testing.T) {
 	t.Parallel()
 
 	c := &Capture{
-		Frontend: "dockerfile.v0",
-		Args: map[string]string{
-			"contextsubdir": "src",
-			"filename":      "Dockerfile",
+		Request: provenancetypes.Parameters{
+			Frontend: "dockerfile.v0",
+			Args: map[string]string{
+				"contextsubdir": "src",
+				"filename":      "Dockerfile",
+			},
 		},
 	}
 

--- a/solver/llbsolver/provenance/types/types.go
+++ b/solver/llbsolver/provenance/types/types.go
@@ -95,14 +95,38 @@ type LocalSource struct {
 	Name string `json:"name"`
 }
 
+// Equal reports whether the local source matches another local source.
+func (l *LocalSource) Equal(other *LocalSource) bool {
+	if l == nil || other == nil {
+		return l == other
+	}
+	return *l == *other
+}
+
 type Secret struct {
 	ID       string `json:"id"`
 	Optional bool   `json:"optional,omitempty"`
 }
 
+// Equal reports whether the secret matches another secret.
+func (s *Secret) Equal(other *Secret) bool {
+	if s == nil || other == nil {
+		return s == other
+	}
+	return *s == *other
+}
+
 type SSH struct {
 	ID       string `json:"id"`
 	Optional bool   `json:"optional,omitempty"`
+}
+
+// Equal reports whether the SSH mount matches another SSH mount.
+func (s *SSH) Equal(other *SSH) bool {
+	if s == nil || other == nil {
+		return s == other
+	}
+	return *s == *other
 }
 
 type Sources struct {
@@ -170,6 +194,17 @@ type ProvenanceConfigSourceSLSA1 struct {
 	Path   string         `json:"path,omitempty"`
 }
 
+// Clone returns a deep copy of the config source.
+func (c ProvenanceConfigSourceSLSA1) Clone() ProvenanceConfigSourceSLSA1 {
+	c.Digest = maps.Clone(c.Digest)
+	return c
+}
+
+// Equal reports whether the config source matches another config source.
+func (c ProvenanceConfigSourceSLSA1) Equal(other ProvenanceConfigSourceSLSA1) bool {
+	return c.URI == other.URI && c.Path == other.Path && maps.Equal(c.Digest, other.Digest)
+}
+
 type ProvenanceInternalParametersSLSA1 struct {
 	BuildConfig     *BuildConfig `json:"buildConfig,omitempty"`
 	BuilderPlatform string       `json:"builderPlatform"`
@@ -185,13 +220,121 @@ type ProvenanceMetadataSLSA1 struct {
 }
 
 type Parameters struct {
-	Frontend             string            `json:"frontend,omitempty"`
-	Args                 map[string]string `json:"args,omitempty"`
-	Secrets              []*Secret         `json:"secrets,omitempty"`
-	SSH                  []*SSH            `json:"ssh,omitempty"`
-	Locals               []*LocalSource    `json:"locals,omitempty"`
-	CompatibilityVersion int               `json:"compatibilityVersion,omitempty"`
-	// TODO: frontend inputs
+	Frontend             string                        `json:"frontend,omitempty"`
+	Args                 map[string]string             `json:"args,omitempty"`
+	Secrets              []*Secret                     `json:"secrets,omitempty"`
+	SSH                  []*SSH                        `json:"ssh,omitempty"`
+	Locals               []*LocalSource                `json:"locals,omitempty"`
+	Inputs               map[string]*RequestProvenance `json:"inputs,omitempty"`
+	Root                 *RequestProvenance            `json:"root,omitempty"`
+	CompatibilityVersion int                           `json:"compatibilityVersion,omitempty"`
+	// TODO: select export attributes
+}
+
+// Clone returns a deep copy of the request parameters.
+func (p *Parameters) Clone() *Parameters {
+	if p == nil {
+		return nil
+	}
+	out := &Parameters{
+		Frontend:             p.Frontend,
+		Args:                 maps.Clone(p.Args),
+		CompatibilityVersion: p.CompatibilityVersion,
+	}
+	if len(p.Secrets) > 0 {
+		out.Secrets = slices.Clone(p.Secrets)
+		for i, s := range out.Secrets {
+			if s != nil {
+				s2 := *s
+				out.Secrets[i] = &s2
+			}
+		}
+	}
+	if len(p.SSH) > 0 {
+		out.SSH = slices.Clone(p.SSH)
+		for i, s := range out.SSH {
+			if s != nil {
+				s2 := *s
+				out.SSH[i] = &s2
+			}
+		}
+	}
+	if len(p.Locals) > 0 {
+		out.Locals = slices.Clone(p.Locals)
+		for i, l := range out.Locals {
+			if l != nil {
+				l2 := *l
+				out.Locals[i] = &l2
+			}
+		}
+	}
+	if len(p.Inputs) > 0 {
+		out.Inputs = make(map[string]*RequestProvenance, len(p.Inputs))
+		for k, in := range p.Inputs {
+			out.Inputs[k] = in.Clone()
+		}
+	}
+	out.Root = p.Root.Clone()
+	return out
+}
+
+// Equal reports whether the request parameters match another set of parameters.
+func (p *Parameters) Equal(other *Parameters) bool {
+	if p == nil || other == nil {
+		return p == other
+	}
+	if p.Frontend != other.Frontend || p.CompatibilityVersion != other.CompatibilityVersion || !maps.Equal(p.Args, other.Args) {
+		return false
+	}
+	if !slices.EqualFunc(p.Secrets, other.Secrets, func(a, b *Secret) bool {
+		return a.Equal(b)
+	}) {
+		return false
+	}
+	if !slices.EqualFunc(p.SSH, other.SSH, func(a, b *SSH) bool {
+		return a.Equal(b)
+	}) {
+		return false
+	}
+	if !slices.EqualFunc(p.Locals, other.Locals, func(a, b *LocalSource) bool {
+		return a.Equal(b)
+	}) {
+		return false
+	}
+	if len(p.Inputs) != len(other.Inputs) {
+		return false
+	}
+	for k, v := range p.Inputs {
+		v2, ok := other.Inputs[k]
+		if !ok || !v.Equal(v2) {
+			return false
+		}
+	}
+	return p.Root.Equal(other.Root)
+}
+
+type RequestProvenance struct {
+	ConfigSource ProvenanceConfigSourceSLSA1 `json:"configSource"`
+	Request      *Parameters                 `json:"request,omitempty"`
+}
+
+// Clone returns a deep copy of the request provenance.
+func (r *RequestProvenance) Clone() *RequestProvenance {
+	if r == nil {
+		return nil
+	}
+	return &RequestProvenance{
+		ConfigSource: r.ConfigSource.Clone(),
+		Request:      r.Request.Clone(),
+	}
+}
+
+// Equal reports whether the request provenance matches another request provenance.
+func (r *RequestProvenance) Equal(other *RequestProvenance) bool {
+	if r == nil || other == nil {
+		return r == other
+	}
+	return r.ConfigSource.Equal(other.ConfigSource) && r.Request.Equal(other.Request)
 }
 
 type Environment struct {

--- a/solver/llbsolver/provenance_store.go
+++ b/solver/llbsolver/provenance_store.go
@@ -1,0 +1,247 @@
+package llbsolver
+
+import (
+	"slices"
+	"sync"
+
+	"github.com/moby/buildkit/frontend"
+	"github.com/moby/buildkit/identity"
+	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/solver/llbsolver/provenance"
+	provenancetypes "github.com/moby/buildkit/solver/llbsolver/provenance/types"
+	"github.com/moby/buildkit/solver/pb"
+	digest "github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
+)
+
+type provenanceStore struct {
+	mu       sync.Mutex
+	records  map[string]*provenanceRecord
+	byDigest map[digest.Digest]map[string]struct{}
+}
+
+type provenanceRecord struct {
+	defDigest digest.Digest
+	request   *provenancetypes.RequestProvenance
+}
+
+func newProvenanceStore() *provenanceStore {
+	return &provenanceStore{
+		records:  map[string]*provenanceRecord{},
+		byDigest: map[digest.Digest]map[string]struct{}{},
+	}
+}
+
+func (s *provenanceStore) register(def *pb.Definition, req *provenancetypes.RequestProvenance) (string, digest.Digest, error) {
+	if s == nil || def == nil || req == nil {
+		return "", "", nil
+	}
+	dgst, err := definitionHeadDigest(def)
+	if err != nil {
+		return "", "", err
+	}
+	if dgst == "" {
+		return "", "", nil
+	}
+	recordID := identity.NewID()
+	s.mu.Lock()
+	s.records[recordID] = &provenanceRecord{
+		defDigest: dgst,
+		request:   req.Clone(),
+	}
+	if s.byDigest[dgst] == nil {
+		s.byDigest[dgst] = map[string]struct{}{}
+	}
+	s.byDigest[dgst][recordID] = struct{}{}
+	s.mu.Unlock()
+	return recordID, dgst, nil
+}
+
+func (s *provenanceStore) unregister(recordIDs []string) {
+	if s == nil || len(recordIDs) == 0 {
+		return
+	}
+	s.mu.Lock()
+	for _, recordID := range recordIDs {
+		rec := s.records[recordID]
+		delete(s.records, recordID)
+		if rec != nil {
+			delete(s.byDigest[rec.defDigest], recordID)
+			if len(s.byDigest[rec.defDigest]) == 0 {
+				delete(s.byDigest, rec.defDigest)
+			}
+		}
+	}
+	s.mu.Unlock()
+}
+
+func (s *provenanceStore) lookup(def *pb.Definition) (*provenancetypes.RequestProvenance, bool) {
+	if s == nil || def == nil {
+		return nil, false
+	}
+	dgst, err := definitionHeadDigest(def)
+	if err != nil || dgst == "" {
+		return nil, false
+	}
+	s.mu.Lock()
+	records := make([]*provenanceRecord, 0, len(s.byDigest[dgst]))
+	for recordID := range s.byDigest[dgst] {
+		if rec := s.records[recordID]; rec != nil && rec.request != nil {
+			records = append(records, rec)
+		}
+	}
+	s.mu.Unlock()
+	if len(records) == 0 {
+		return nil, false
+	}
+	req := records[0].request.Clone()
+	if req.Request != nil {
+		req.Request.Root = nil
+	}
+	for _, rec := range records[1:] {
+		req2 := rec.request.Clone()
+		if req2.Request != nil {
+			req2.Request.Root = nil
+		}
+		if !req.Equal(req2) {
+			return nil, false
+		}
+	}
+	return req, true
+}
+
+func (b *provenanceBridge) registerProvenanceRefs(res *frontend.Result) error {
+	if b == nil || res == nil {
+		return nil
+	}
+	return res.EachRef(func(ref solver.ResultProxy) error {
+		if ref == nil {
+			return nil
+		}
+		return b.registerProvenanceRef(ref.Definition(), ref)
+	})
+}
+
+func (b *provenanceBridge) registerProvenanceRef(def *pb.Definition, ref solver.ResultProxy) error {
+	if def == nil || ref == nil || b.provenanceStore == nil {
+		return nil
+	}
+	req, ok := b.findByResult(ref)
+	if !ok {
+		return nil
+	}
+	var srcs provenancetypes.Sources
+	if p := ref.Provenance(); p != nil {
+		c, ok := p.(*provenance.Capture)
+		if !ok {
+			return errors.Errorf("invalid provenance type %T", p)
+		}
+		if c != nil {
+			srcs = c.Sources
+		}
+	}
+	reqProv := req.bridge.requestProvenance(srcs)
+	recordID, _, err := b.provenanceStore.register(def, reqProv)
+	if err != nil {
+		return err
+	}
+	if recordID == "" {
+		return nil
+	}
+	b.addProvenanceRefRecordID(recordID)
+	return nil
+}
+
+func (b *provenanceBridge) addProvenanceRefRecordID(recordID string) {
+	if b == nil || recordID == "" {
+		return
+	}
+	b.mu.Lock()
+	b.provenanceRefRecordIDs = append(b.provenanceRefRecordIDs, recordID)
+	b.mu.Unlock()
+}
+
+func (b *provenanceBridge) releaseProvenanceRefs() {
+	if b == nil || b.provenanceStore == nil {
+		return
+	}
+	for _, sb := range b.subBridges {
+		sb.releaseProvenanceRefs()
+	}
+	b.mu.Lock()
+	recordIDs := slices.Clone(b.provenanceRefRecordIDs)
+	b.provenanceRefRecordIDs = nil
+	b.mu.Unlock()
+	b.provenanceStore.unregister(recordIDs)
+}
+
+func (b *provenanceBridge) requestProvenance(srcs provenancetypes.Sources) *provenancetypes.RequestProvenance {
+	if b == nil || b.req == nil {
+		return nil
+	}
+	req := provenance.RequestProvenance(b.req.Frontend, provenance.FilterArgs(b.req.FrontendOpt), srcs)
+	if req.Request == nil {
+		req.Request = &provenancetypes.Parameters{}
+	}
+	if inputs := b.inputProvenance(b.req.FrontendInputs); len(inputs) > 0 {
+		req.Request.Inputs = inputs
+	}
+	if root := b.rootRequestProvenance(srcs); root != nil && !root.Equal(req) {
+		req.Request.Root = root
+	}
+	return req
+}
+
+func (b *provenanceBridge) inputProvenance(inputs map[string]*pb.Definition) map[string]*provenancetypes.RequestProvenance {
+	if len(inputs) == 0 || b == nil || b.provenanceStore == nil {
+		return nil
+	}
+	out := make(map[string]*provenancetypes.RequestProvenance)
+	for name, def := range inputs {
+		if in, ok := b.provenanceStore.lookup(def); ok {
+			out[name] = in
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func (b *provenanceBridge) rootRequestProvenance(srcs provenancetypes.Sources) *provenancetypes.RequestProvenance {
+	if b == nil || !hasRequestProvenance(b.rootReq) {
+		return nil
+	}
+	root := provenance.RequestProvenance(b.rootReq.Frontend, provenance.FilterArgs(b.rootReq.FrontendOpt), srcs)
+	if root.Request == nil {
+		root.Request = &provenancetypes.Parameters{}
+	}
+	if inputs := b.inputProvenance(b.rootReq.FrontendInputs); len(inputs) > 0 {
+		root.Request.Inputs = inputs
+	}
+	if root.Request.Frontend == "" && len(root.Request.Args) == 0 && len(root.Request.Inputs) == 0 {
+		return nil
+	}
+	return root
+}
+
+func hasRequestProvenance(req *frontend.SolveRequest) bool {
+	if req == nil {
+		return false
+	}
+	return req.Frontend != "" || len(req.FrontendOpt) > 0 || len(req.FrontendInputs) > 0
+}
+
+func definitionHeadDigest(def *pb.Definition) (digest.Digest, error) {
+	if def == nil || len(def.Def) == 0 {
+		return "", nil
+	}
+	var op pb.Op
+	if err := op.UnmarshalVT(def.Def[len(def.Def)-1]); err != nil {
+		return "", errors.Wrap(err, "failed to parse llb proto op")
+	}
+	if len(op.Inputs) == 0 {
+		return "", nil
+	}
+	return digest.Digest(op.Inputs[0].Digest), nil
+}

--- a/solver/llbsolver/provenance_store_test.go
+++ b/solver/llbsolver/provenance_store_test.go
@@ -154,3 +154,50 @@ func TestProvenanceStoreAmbiguousDigest(t *testing.T) {
 	_, ok := store.lookup(pbDef)
 	require.False(t, ok)
 }
+
+func TestScrubMinRequestScrubsNestedRequests(t *testing.T) {
+	req := &provenancetypes.Parameters{
+		Args: map[string]string{
+			"build-arg:FOO": "bar",
+			"label:lbl":     "abc",
+			"context":       "input:base",
+		},
+		Secrets: []*provenancetypes.Secret{{ID: "secret"}},
+		SSH:     []*provenancetypes.SSH{{ID: "default"}},
+		Inputs: map[string]*provenancetypes.RequestProvenance{
+			"base": {
+				Request: &provenancetypes.Parameters{
+					Args: map[string]string{
+						"target":              "base",
+						"build-arg:BASE_TEXT": "from-input",
+						"label:input":         "nested",
+					},
+					Secrets: []*provenancetypes.Secret{{ID: "input-secret"}},
+					SSH:     []*provenancetypes.SSH{{ID: "input-ssh"}},
+				},
+			},
+		},
+		Root: &provenancetypes.RequestProvenance{
+			Request: &provenancetypes.Parameters{
+				Args: map[string]string{
+					"source":         "dockerfile.v0",
+					"build-arg:ROOT": "root",
+				},
+			},
+		},
+	}
+
+	require.True(t, scrubMinRequest(req))
+
+	require.Equal(t, map[string]string{"context": "input:base"}, req.Args)
+	require.Nil(t, req.Secrets)
+	require.Nil(t, req.SSH)
+
+	require.Contains(t, req.Inputs, "base")
+	require.Equal(t, map[string]string{"target": "base"}, req.Inputs["base"].Request.Args)
+	require.Nil(t, req.Inputs["base"].Request.Secrets)
+	require.Nil(t, req.Inputs["base"].Request.SSH)
+
+	require.NotNil(t, req.Root)
+	require.Equal(t, map[string]string{"source": "dockerfile.v0"}, req.Root.Request.Args)
+}

--- a/solver/llbsolver/provenance_store_test.go
+++ b/solver/llbsolver/provenance_store_test.go
@@ -1,0 +1,156 @@
+package llbsolver
+
+import (
+	"testing"
+
+	"github.com/moby/buildkit/client/llb"
+	provenancetypes "github.com/moby/buildkit/solver/llbsolver/provenance/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProvenanceStoreLooksUpByDefinitionDigest(t *testing.T) {
+	ctx := t.Context()
+	def, err := llb.Scratch().File(llb.Mkfile("foo", 0600, []byte("foo"))).Marshal(ctx)
+	require.NoError(t, err)
+
+	pbDef := def.ToPB()
+	pbDefBefore := pbDef.CloneVT()
+	store := newProvenanceStore()
+	req := &provenancetypes.RequestProvenance{
+		Request: &provenancetypes.Parameters{
+			Frontend: "dockerfile.v0",
+			Args: map[string]string{
+				"target": "base",
+			},
+		},
+	}
+
+	recordID, _, err := store.register(pbDef, req)
+	require.NoError(t, err)
+	require.NotEmpty(t, recordID)
+	require.Equal(t, pbDefBefore, pbDef)
+
+	in, ok := store.lookup(pbDef)
+	require.True(t, ok)
+	require.NotNil(t, in.Request)
+	require.Equal(t, "dockerfile.v0", in.Request.Frontend)
+	require.Equal(t, "base", in.Request.Args["target"])
+
+	otherDef, err := llb.Scratch().File(llb.Mkfile("bar", 0600, []byte("bar"))).Marshal(ctx)
+	require.NoError(t, err)
+	forged := otherDef.ToPB()
+
+	_, ok = store.lookup(forged)
+	require.False(t, ok)
+}
+
+func TestProvenanceStoreOmitsInputRoot(t *testing.T) {
+	ctx := t.Context()
+	def, err := llb.Scratch().File(llb.Mkfile("foo", 0600, []byte("foo"))).Marshal(ctx)
+	require.NoError(t, err)
+
+	pbDef := def.ToPB()
+	store := newProvenanceStore()
+	req := &provenancetypes.RequestProvenance{
+		Request: &provenancetypes.Parameters{
+			Frontend: "dockerfile.v0",
+			Args:     map[string]string{"target": "base"},
+			Root: &provenancetypes.RequestProvenance{
+				Request: &provenancetypes.Parameters{
+					Frontend: "gateway.v0",
+					Args:     map[string]string{"source": "dockerfile.v0"},
+				},
+			},
+		},
+	}
+
+	recordID, _, err := store.register(pbDef, req)
+	require.NoError(t, err)
+	require.NotEmpty(t, recordID)
+
+	in, ok := store.lookup(pbDef)
+	require.True(t, ok)
+	require.NotNil(t, in.Request)
+	require.Equal(t, "dockerfile.v0", in.Request.Frontend)
+	require.Nil(t, in.Request.Root)
+}
+
+func TestProvenanceStoreLookupAfterDefinitionOpRoundTrip(t *testing.T) {
+	ctx := t.Context()
+	def, err := llb.Scratch().File(llb.Mkfile("foo", 0600, []byte("foo"))).Marshal(ctx)
+	require.NoError(t, err)
+
+	pbDef := def.ToPB()
+	store := newProvenanceStore()
+	req := &provenancetypes.RequestProvenance{
+		Request: &provenancetypes.Parameters{
+			Frontend: "dockerfile.v0",
+			Args:     map[string]string{"target": "base"},
+		},
+	}
+
+	recordID, _, err := store.register(pbDef, req)
+	require.NoError(t, err)
+	require.NotEmpty(t, recordID)
+
+	op, err := llb.NewDefinitionOp(pbDef)
+	require.NoError(t, err)
+	st := llb.NewState(op)
+	roundTripDef, err := st.Marshal(ctx)
+	require.NoError(t, err)
+
+	in, ok := store.lookup(roundTripDef.ToPB())
+	require.True(t, ok)
+	require.Equal(t, "dockerfile.v0", in.Request.Frontend)
+}
+
+func TestProvenanceStoreUnregister(t *testing.T) {
+	ctx := t.Context()
+	def, err := llb.Scratch().File(llb.Mkfile("foo", 0600, []byte("foo"))).Marshal(ctx)
+	require.NoError(t, err)
+
+	pbDef := def.ToPB()
+	store := newProvenanceStore()
+	req := &provenancetypes.RequestProvenance{
+		Request: &provenancetypes.Parameters{
+			Frontend: "dockerfile.v0",
+		},
+	}
+
+	recordID, _, err := store.register(pbDef, req)
+	require.NoError(t, err)
+	require.NotEmpty(t, recordID)
+
+	_, ok := store.lookup(pbDef)
+	require.True(t, ok)
+
+	store.unregister([]string{recordID})
+	_, ok = store.lookup(pbDef)
+	require.False(t, ok)
+}
+
+func TestProvenanceStoreAmbiguousDigest(t *testing.T) {
+	ctx := t.Context()
+	def, err := llb.Scratch().File(llb.Mkfile("foo", 0600, []byte("foo"))).Marshal(ctx)
+	require.NoError(t, err)
+
+	pbDef := def.ToPB()
+	store := newProvenanceStore()
+	_, _, err = store.register(pbDef, &provenancetypes.RequestProvenance{
+		Request: &provenancetypes.Parameters{
+			Frontend: "dockerfile.v0",
+			Args:     map[string]string{"target": "base"},
+		},
+	})
+	require.NoError(t, err)
+	_, _, err = store.register(pbDef, &provenancetypes.RequestProvenance{
+		Request: &provenancetypes.Parameters{
+			Frontend: "dockerfile.v0",
+			Args:     map[string]string{"target": "other"},
+		},
+	})
+	require.NoError(t, err)
+
+	_, ok := store.lookup(pbDef)
+	require.False(t, ok)
+}

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -75,6 +75,7 @@ type Solver struct {
 	history                   *history.Queue
 	sysSampler                *resources.Sampler[*resourcestypes.SysSample]
 	provenanceEnv             map[string]any
+	provenanceStore           *provenanceStore
 }
 
 // Processor defines a processing function to be applied after solving, but
@@ -105,6 +106,7 @@ func New(opt Opt) (*Solver, error) {
 		entitlements:              opt.Entitlements,
 		history:                   opt.HistoryQueue,
 		provenanceEnv:             opt.ProvenanceEnv,
+		provenanceStore:           newProvenanceStore(),
 	}
 
 	sampler, err := resources.NewSysSampler()
@@ -147,6 +149,7 @@ func (s *Solver) bridge(b solver.Builder) *provenanceBridge {
 		resolveCacheImporterFuncs: s.resolveCacheImporterFuncs,
 		cms:                       map[string]solver.CacheManager{},
 		sm:                        s.sm,
+		provenanceStore:           s.provenanceStore,
 	}}
 }
 
@@ -225,6 +228,9 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 	j.SessionID = sessionID
 
 	br := s.bridge(j)
+	defer br.releaseProvenanceRefs()
+	rootReq := req.Clone()
+	br.rootReq = &rootReq
 	var fwd gateway.LLBBridgeForwarder
 	if s.gatewayForwarder != nil && req.Definition == nil && req.Frontend == "" {
 		fwd = gateway.NewBridgeForwarder(ctx, br, br, s.workerController.Infos(), req.FrontendInputs, sessionID, s.sm)


### PR DESCRIPTION
Keep request provenance for solved refs by their LLB digest while the producing build is still active. Use the stored request when another solve later provides the same LLB definition as a frontend input.

This lets max provenance report root and nested input requests for gateway and builtin Dockerfile frontend solves without accepting client-supplied request metadata.