### PR TITLE
gateway: reduce potential lock contention in gateway forwarder

### DIFF
--- a/control/gateway/gateway.go
+++ b/control/gateway/gateway.go
@@ -2,55 +2,36 @@ package gateway
 
 import (
 	"context"
-	"sync"
-	"time"
 
 	"github.com/moby/buildkit/client/buildid"
 	"github.com/moby/buildkit/frontend/gateway"
 	gwapi "github.com/moby/buildkit/frontend/gateway/pb"
 	"github.com/moby/buildkit/solver/errdefs"
+	"github.com/moby/buildkit/util/registrar"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 )
 
 type GatewayForwarder struct {
-	mu         sync.RWMutex
-	updateCond *sync.Cond
-	builds     map[string]gateway.LLBBridgeForwarder
+	registrar *registrar.Registrar[string, gateway.LLBBridgeForwarder]
 }
 
 func NewGatewayForwarder() *GatewayForwarder {
-	gwf := &GatewayForwarder{
-		builds: map[string]gateway.LLBBridgeForwarder{},
+	return &GatewayForwarder{
+		registrar: registrar.New[string, gateway.LLBBridgeForwarder](),
 	}
-	gwf.updateCond = sync.NewCond(gwf.mu.RLocker())
-	return gwf
 }
 
 func (gwf *GatewayForwarder) Register(server *grpc.Server) {
 	gwapi.RegisterLLBBridgeServer(server, gwf)
 }
 
-func (gwf *GatewayForwarder) RegisterBuild(ctx context.Context, id string, bridge gateway.LLBBridgeForwarder) error {
-	gwf.mu.Lock()
-	defer gwf.mu.Unlock()
-
-	if _, ok := gwf.builds[id]; ok {
-		return errors.Errorf("build ID %s exists", id)
-	}
-
-	gwf.builds[id] = bridge
-	gwf.updateCond.Broadcast()
-
-	return nil
+func (gwf *GatewayForwarder) RegisterBuild(ctx context.Context, id string, bridge gateway.LLBBridgeForwarder) {
+	gwf.registrar.Register(id, bridge)
 }
 
 func (gwf *GatewayForwarder) UnregisterBuild(ctx context.Context, id string) {
-	gwf.mu.Lock()
-	defer gwf.mu.Unlock()
-
-	delete(gwf.builds, id)
-	gwf.updateCond.Broadcast()
+	gwf.registrar.Discard(id)
 }
 
 func (gwf *GatewayForwarder) lookupForwarder(ctx context.Context) (gateway.LLBBridgeForwarder, error) {
@@ -59,32 +40,14 @@ func (gwf *GatewayForwarder) lookupForwarder(ctx context.Context) (gateway.LLBBr
 		return nil, errors.New("no buildid found in context")
 	}
 
-	ctx, cancel := context.WithCancelCause(ctx)
-	ctx, _ = context.WithTimeoutCause(ctx, 3*time.Second, errors.WithStack(context.DeadlineExceeded)) //nolint:govet
-	defer func() { cancel(errors.WithStack(context.Canceled)) }()
-
-	go func() {
-		<-ctx.Done()
-		gwf.mu.Lock()
-		gwf.updateCond.Broadcast()
-		gwf.mu.Unlock()
-	}()
-
-	gwf.mu.RLock()
-	defer gwf.mu.RUnlock()
-	for {
-		select {
-		case <-ctx.Done():
-			return nil, errdefs.NewUnknownJobError(bid)
-		default:
+	fwd, err := gwf.registrar.Get(ctx, bid)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil, errors.WithStack(errdefs.NewUnknownJobError(bid))
 		}
-		fwd, ok := gwf.builds[bid]
-		if !ok {
-			gwf.updateCond.Wait()
-			continue
-		}
-		return fwd, nil
+		return nil, err
 	}
+	return fwd, nil
 }
 
 func (gwf *GatewayForwarder) ResolveImageConfig(ctx context.Context, req *gwapi.ResolveImageConfigRequest) (*gwapi.ResolveImageConfigResponse, error) {

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -233,10 +233,8 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 		// s.recordBuildHistory can block for several seconds on
 		// LeaseManager calls, and there is a fixed 3s timeout in
 		// GatewayForwarder on build registration.
-		if err := s.gatewayForwarder.RegisterBuild(ctx, id, fwd); err != nil {
-			return nil, err
-		}
-		defer s.gatewayForwarder.UnregisterBuild(context.WithoutCancel(ctx), id)
+		s.gatewayForwarder.RegisterBuild(ctx, id, fwd)
+		defer s.gatewayForwarder.UnregisterBuild(context.Background(), id)
 	}
 
 	if !internal {

--- a/util/registrar/registrar.go
+++ b/util/registrar/registrar.go
@@ -1,0 +1,110 @@
+package registrar
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+type Registrar[K comparable, V any] struct {
+	mu     sync.Mutex
+	values map[K]*registrarValue[V]
+}
+
+func New[K comparable, V any]() *Registrar[K, V] {
+	return &Registrar[K, V]{
+		values: make(map[K]*registrarValue[V]),
+	}
+}
+
+// Register will register the value with the given id.
+// This value will persist until Discard is called with the same id.
+func (r *Registrar[K, V]) Register(id K, val V) {
+	reg := r.getOrCreateRegistrar(id, nil)
+	reg.Register(val, nil)
+}
+
+// Get will retrieve a registered value and will wait a small time period for that
+// value to appear if it hasn't been registered yet.
+func (r *Registrar[K, V]) Get(ctx context.Context, id K) (v V, _ error) {
+	onCreate := func(reg *registrarValue[V]) {
+		select {
+		case <-reg.notifyCh:
+			return
+		case <-time.After(3 * time.Second):
+			r.Discard(id)
+		}
+	}
+
+	reg := r.getOrCreateRegistrar(id, onCreate)
+
+	select {
+	case <-ctx.Done():
+		return v, context.Cause(ctx)
+	case <-reg.notifyCh:
+		return reg.value, reg.err
+	}
+}
+
+// Discard will remove the given value from the registrar after it has been registered
+// with Register.
+func (r *Registrar[K, V]) Discard(id K) {
+	r.mu.Lock()
+	reg, ok := r.values[id]
+	delete(r.values, id)
+	r.mu.Unlock()
+
+	if ok {
+		var value V
+		reg.Register(value, context.Canceled)
+	}
+}
+
+// getOrCreateRegistrar will create a registrar with the given id to be retrieved at a later time.
+// The same id will return the same registrar.
+//
+// If the registrar is newly created, the onCreate function is invoked in a separate goroutine
+// if it is present. If nil, this function is ignored.
+func (r *Registrar[K, V]) getOrCreateRegistrar(id K, onCreate func(*registrarValue[V])) *registrarValue[V] {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	reg, ok := r.values[id]
+	if !ok {
+		reg = &registrarValue[V]{
+			notifyCh: make(chan struct{}),
+		}
+		r.values[id] = reg
+
+		if onCreate != nil {
+			go onCreate(reg)
+		}
+	}
+	return reg
+}
+
+type registrarValue[V any] struct {
+	// notifyCh is the notification channel that gets closed when
+	// the bridge is registered.
+	notifyCh chan struct{}
+
+	value V
+	err   error
+	isSet bool
+
+	mu sync.Mutex
+}
+
+func (r *registrarValue[V]) Register(value V, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.isSet {
+		return
+	}
+
+	r.value = value
+	r.err = err
+	r.isSet = true
+	close(r.notifyCh)
+}


### PR DESCRIPTION

There's a large potential for a lock contention issue in the gateway
forwarder's logic. The previous iteration of this would keep a global
mapping of the build ids and, when a forwarder for a build id didn't
exist, the forwarder would wait 3 seconds for the build to register.

The issue with lock contention comes after this. Instead of having a
notification channel that a specific build was ready, the forwarder
would wake up all goroutines that were waiting each time a build was
registered. Since each of those builds took a read lock to check whether
its build was present and registering subsequent builds took a write
lock, it was very easy to end up in a lock contention scenario when
starting many builds at the same time. Then it was easy to hit the 3
second timeout especially when the machine itself was under load.

This changes the notification mechanism so the notify happens per build.
Looking up a build id creates a forwarder registrar with a channel that
can be polled for when the registration is complete. A forwarder will
then only be notified and woken when that specific build id is ready by
the go runtime rather than from the sync condition.

Potentially alleviates how often #5171 will happen.
