### PR TITLE
resolver: allow anonymous auth while preserving local image fallback

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -256,6 +256,7 @@ var allTests = []func(t *testing.T, sb integration.Sandbox){
 	testHTTPPruneAfterResolveMeta,
 	testHTTPResolveMetaReuse,
 	testHTTPResolveMultiBuild,
+	testImageResolveConfigDefaultLocalFallback,
 	testGitResolveMutatedSource,
 	testGitBundleRoundTrip,
 	testGitBundleRoundTripRegistry,
@@ -13105,6 +13106,80 @@ func testHTTPResolveSourceMetadata(t *testing.T, sb integration.Sandbox) {
 		return nil, nil
 	}, nil)
 	require.NoError(t, err)
+}
+
+func testImageResolveConfigDefaultLocalFallback(t *testing.T, sb integration.Sandbox) {
+	workers.CheckFeatureCompat(t, sb, workers.FeatureImageExporter)
+
+	cdAddress := sb.ContainerdAddress()
+	if cdAddress == "" {
+		t.Skip("test requires containerd worker")
+	}
+
+	ctx := sb.Context()
+	c, err := New(ctx, sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	cdClient, err := newContainerd(cdAddress)
+	require.NoError(t, err)
+	defer cdClient.Close()
+
+	registry, err := sb.NewRegistry()
+	if errors.Is(err, integration.ErrRequirements) {
+		t.Skip(err.Error())
+	}
+	require.NoError(t, err)
+
+	target := registry + "/buildkit/default-local-fallback:" + identity.NewID()
+	st := integration.UnixOrWindows(
+		llb.Scratch(),
+		llb.Image("nanoserver:latest"),
+	)
+	def, err := st.File(llb.Mkfile("/fallback", 0600, []byte("local"))).Marshal(ctx)
+	require.NoError(t, err)
+
+	_, err = c.Solve(ctx, def, SolveOpt{
+		Exports: []ExportEntry{
+			{
+				Type: ExporterImage,
+				Attrs: map[string]string{
+					"name":  target,
+					"store": "true",
+				},
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	imageService := cdClient.ImageService()
+	imageStoreCtx := namespaces.WithNamespace(ctx, "buildkit")
+	img, err := imageService.Get(imageStoreCtx, target)
+	require.NoError(t, err)
+
+	_, err = c.Build(ctx, SolveOpt{}, "buildkit_test", func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
+		ref, dgst, config, err := c.ResolveImageConfig(ctx, target, sourceresolver.Opt{
+			ImageOpt: &sourceresolver.ResolveImageOpt{
+				ResolveMode: pb.AttrImageResolveModeDefault,
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		require.Equal(t, target, ref)
+		require.Equal(t, img.Target.Digest, dgst)
+		require.NotEmpty(t, config)
+
+		var ociimg ocispecs.Image
+		require.NoError(t, json.Unmarshal(config, &ociimg))
+		require.NotEmpty(t, ociimg.OS)
+		require.NotEmpty(t, ociimg.Architecture)
+
+		return gateway.NewResult(), nil
+	}, nil)
+	require.NoError(t, err)
+
+	checkAllReleasable(t, c, sb, true)
 }
 
 func testImageResolveAttestationChainRequiresNetwork(t *testing.T, sb integration.Sandbox) {

--- a/session/group.go
+++ b/session/group.go
@@ -7,6 +7,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+// ErrNoActiveSessions is returned when a session group does not contain any
+// active session IDs.
+var ErrNoActiveSessions = errors.New("no active sessions")
+
 type Group interface {
 	SessionIterator() Iterator
 }
@@ -69,7 +73,7 @@ func (sm *Manager) Any(ctx context.Context, g Group, f func(context.Context, str
 			if lastErr != nil {
 				return lastErr
 			}
-			return errors.Errorf("no active sessions")
+			return errors.WithStack(ErrNoActiveSessions)
 		}
 
 		timeoutCtx, cancel := context.WithCancelCause(ctx)

--- a/source/containerimage/source.go
+++ b/source/containerimage/source.go
@@ -189,7 +189,18 @@ func (is *Source) ResolveImageMetadata(ctx context.Context, id *ImageIdentifier,
 		res, err := is.gImageRes.Do(ctx, key, func(ctx context.Context) (*resolveImageResult, error) {
 			dgst, dt, err := imageutil.Config(ctx, ref, rslvr, is.ContentStore, is.LeaseManager, opt.Platform)
 			if err != nil {
-				return nil, err
+				if rm != resolver.ResolveModeDefault || is.ImageStore == nil {
+					return nil, err
+				}
+				localRslvr := rslvr.WithImageStore(is.ImageStore, resolver.ResolveModePreferLocal)
+				if _, _, localErr := localRslvr.ResolveLocal(ctx, ref); localErr != nil {
+					return nil, err
+				}
+				localDgst, localDt, localErr := imageutil.Config(ctx, ref, localRslvr, is.ContentStore, is.LeaseManager, opt.Platform)
+				if localErr != nil {
+					return nil, err
+				}
+				dgst, dt = localDgst, localDt
 			}
 			return &resolveImageResult{dgst: dgst, dt: dt}, nil
 		})

--- a/util/resolver/authorizer.go
+++ b/util/resolver/authorizer.go
@@ -48,6 +48,7 @@ func newAuthHandlerNS(sm *session.Manager) *authHandlerNS {
 }
 
 func (a *authHandlerNS) get(ctx context.Context, host string, sm *session.Manager, g session.Group) *authFetcher {
+	hasSession := false
 	if g != nil {
 		if iter := g.SessionIterator(); iter != nil {
 			for {
@@ -55,12 +56,21 @@ func (a *authHandlerNS) get(ctx context.Context, host string, sm *session.Manage
 				if id == "" {
 					break
 				}
+				hasSession = true
 				h, ok := a.fetchers[host+"/"+id]
 				if ok {
 					h.lastUsed = time.Now()
 					return h
 				}
 			}
+		}
+	}
+
+	if !hasSession {
+		h, ok := a.fetchers[host+"/"]
+		if ok {
+			h.lastUsed = time.Now()
+			return h
 		}
 	}
 
@@ -186,12 +196,12 @@ func (a *dockerAuthorizer) AddResponses(ctx context.Context, responses []*http.R
 
 			var username, secret string
 			sessionID, pubKey, err := sessionauth.GetTokenAuthority(ctx, host, a.sm, a.session)
-			if err != nil {
+			if err != nil && !errors.Is(err, session.ErrNoActiveSessions) {
 				return err
 			}
 			if pubKey == nil {
 				sessionID, username, secret, err = a.getCredentials(ctx, host)
-				if err != nil {
+				if err != nil && !errors.Is(err, session.ErrNoActiveSessions) {
 					return err
 				}
 			}

--- a/util/resolver/authorizer_test.go
+++ b/util/resolver/authorizer_test.go
@@ -1,8 +1,16 @@
 package resolver
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
+	"time"
+
+	"github.com/moby/buildkit/session"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseScopes(t *testing.T) {
@@ -52,5 +60,61 @@ func TestParseScopes(t *testing.T) {
 				t.Fatalf("expected %v, got %v", tc.expected, parsed)
 			}
 		})
+	}
+}
+
+func TestBearerAuthFallsBackToAnonymousTokenWithoutSession(t *testing.T) {
+	type tokenRequest struct {
+		authorization string
+		service       string
+		scope         string
+	}
+	tokenRequests := make(chan tokenRequest, 1)
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenRequests <- tokenRequest{
+			authorization: r.Header.Get("Authorization"),
+			service:       r.URL.Query().Get("service"),
+			scope:         r.URL.Query().Get("scope"),
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"token":      "anonymous-token",
+			"expires_in": 60,
+		}); err != nil {
+			t.Errorf("failed to write token response: %v", err)
+		}
+	}))
+	defer tokenServer.Close()
+
+	sm, err := session.NewManager()
+	require.NoError(t, err)
+
+	auth := newDockerAuthorizer(tokenServer.Client(), newAuthHandlerNS(sm), sm, session.NewGroup(""))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://registry.example/v2/library/alpine/manifests/latest", nil)
+	res := &http.Response{
+		StatusCode: http.StatusUnauthorized,
+		Header:     http.Header{},
+		Request:    req,
+	}
+	res.Header.Set("WWW-Authenticate", fmt.Sprintf(
+		`Bearer realm=%q,service="registry.example",scope="repository:library/alpine:pull"`,
+		tokenServer.URL+"/token",
+	))
+
+	require.NoError(t, auth.AddResponses(t.Context(), []*http.Response{res}))
+
+	retryReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://registry.example/v2/library/alpine/manifests/latest", nil)
+	require.NoError(t, auth.Authorize(t.Context(), retryReq))
+	require.Equal(t, "Bearer anonymous-token", retryReq.Header.Get("Authorization"))
+
+	select {
+	case req := <-tokenRequests:
+		require.Empty(t, req.authorization)
+		require.Equal(t, "registry.example", req.service)
+		require.Equal(t, "repository:library/alpine:pull", req.scope)
+	case <-time.After(time.Second):
+		t.Fatal("expected anonymous token request")
 	}
 }

--- a/util/resolver/pool.go
+++ b/util/resolver/pool.go
@@ -230,6 +230,18 @@ func (r *Resolver) WithImageStore(is images.Store, mode ResolveMode) *Resolver {
 	return &r2
 }
 
+// ResolveLocal attempts to resolve the reference from the local image store.
+func (r *Resolver) ResolveLocal(ctx context.Context, ref string) (string, ocispecs.Descriptor, error) {
+	if r.is == nil {
+		return "", ocispecs.Descriptor{}, errors.WithStack(cerrdefs.ErrNotFound)
+	}
+	img, err := getImageByRef(ctx, r.is, ref)
+	if err != nil {
+		return "", ocispecs.Descriptor{}, err
+	}
+	return ref, img.Target, nil
+}
+
 // Fetcher returns a new fetcher for the provided reference.
 func (r *Resolver) Fetcher(ctx context.Context, ref string) (remotes.Fetcher, error) {
 	if r.handler.counter.Load() == 0 {
@@ -241,8 +253,8 @@ func (r *Resolver) Fetcher(ctx context.Context, ref string) (remotes.Fetcher, er
 // Resolve attempts to resolve the reference into a name and descriptor.
 func (r *Resolver) Resolve(ctx context.Context, ref string) (string, ocispecs.Descriptor, error) {
 	if r.mode == ResolveModePreferLocal && r.is != nil {
-		if img, err := getImageByRef(ctx, r.is, ref); err == nil {
-			return ref, img.Target, nil
+		if ref, desc, err := r.ResolveLocal(ctx, ref); err == nil {
+			return ref, desc, nil
 		}
 	}
 
@@ -253,8 +265,8 @@ func (r *Resolver) Resolve(ctx context.Context, ref string) (string, ocispecs.De
 	}
 
 	if r.mode == ResolveModeDefault && r.is != nil {
-		if img, err := getImageByRef(ctx, r.is, ref); err == nil {
-			return ref, img.Target, nil
+		if ref, desc, err := r.ResolveLocal(ctx, ref); err == nil {
+			return ref, desc, nil
 		}
 	}
 


### PR DESCRIPTION
This PR restores anonymous Bearer token resolution from https://github.com/moby/buildkit/pull/6744 when no client session is active and preserves BuildKit's existing default-mode local fallback behavior.

The important clarification from the follow-up discussion is that BuildKit `ResolveModeDefault` is still remote-first. In v0.29, default mode only used the local image store opportunistically when remote `Resolve()` failed, and it returned the original remote error if local lookup also failed: https://github.com/moby/buildkit/blob/8543ce4428265d547cb009e5ad62348284497a88/util/resolver/pool.go#L250-L262

The regression from anonymous auth is that remote `Resolve()` can now succeed without a session, then fail later during image config or platform selection. This PR applies the same opportunistic local fallback at that later failure point, without changing `pull` mode or making BuildKit default mode prefer local.

This is separate from Moby's Docker build semantics. Moby currently maps `PullParent=false` to BuildKit `image-resolve-mode=default` and `PullParent=true` to `pull`: https://github.com/moby/moby/blob/675945d39e1b4dc0e5806b216191e29094e43ec1/daemon/internal/builder-next/builder.go#L350-L354. If Moby wants stronger legacy builder "local parent wins" behavior, that should be handled explicitly in Moby by choosing the appropriate resolve mode, not by changing BuildKit default mode here.