### PR TITLE
registry: add ability to customize the number of concurrent connections to registries

### DIFF
--- a/cache/remotecache/registry/registry.go
+++ b/cache/remotecache/registry/registry.go
@@ -100,7 +100,7 @@ func ResolveCacheExporterFunc(sm *session.Manager, hosts docker.RegistryHosts) r
 	}
 }
 
-func ResolveCacheImporterFunc(sm *session.Manager, cs content.Store, hosts docker.RegistryHosts) remotecache.ResolveCacheImporterFunc {
+func ResolveCacheImporterFunc(sm *session.Manager, cs content.Store, gr *limited.Group, hosts docker.RegistryHosts) remotecache.ResolveCacheImporterFunc {
 	return func(ctx context.Context, g session.Group, attrs map[string]string) (remotecache.Importer, ocispecs.Descriptor, error) {
 		ref, err := canonicalizeRef(attrs[attrRef])
 		if err != nil {
@@ -127,7 +127,7 @@ func ResolveCacheImporterFunc(sm *session.Manager, cs content.Store, hosts docke
 			return nil, ocispecs.Descriptor{}, err
 		}
 		src := &withDistributionSourceLabel{
-			Provider: contentutil.FromFetcher(limited.Default.WrapFetcher(fetcher, refString)),
+			Provider: contentutil.FromFetcher(gr.WrapFetcher(fetcher, refString)),
 			ref:      refString,
 			source:   cs,
 		}

--- a/client/llb/imagemetaresolver/resolver.go
+++ b/client/llb/imagemetaresolver/resolver.go
@@ -12,6 +12,7 @@ import (
 	"github.com/moby/buildkit/client/llb/sourceresolver"
 	"github.com/moby/buildkit/util/contentutil"
 	"github.com/moby/buildkit/util/imageutil"
+	"github.com/moby/buildkit/util/resolver/limited"
 	"github.com/moby/buildkit/util/tracing"
 	"github.com/moby/buildkit/version"
 	"github.com/moby/locker"
@@ -27,7 +28,8 @@ var WithDefault = imageOptionFunc(func(ii *llb.ImageInfo) {
 })
 
 type imageMetaResolverOpts struct {
-	platform *ocispecs.Platform
+	platform         *ocispecs.Platform
+	concurrencyGroup *limited.Group
 }
 
 type ImageMetaResolverOpt func(o *imageMetaResolverOpts)
@@ -35,6 +37,12 @@ type ImageMetaResolverOpt func(o *imageMetaResolverOpts)
 func WithDefaultPlatform(p *ocispecs.Platform) ImageMetaResolverOpt {
 	return func(o *imageMetaResolverOpts) {
 		o.platform = p
+	}
+}
+
+func WithDefaultConcurrencyGroup(gr *limited.Group) ImageMetaResolverOpt {
+	return func(o *imageMetaResolverOpts) {
+		o.concurrencyGroup = gr
 	}
 }
 
@@ -49,10 +57,11 @@ func New(with ...ImageMetaResolverOpt) llb.ImageMetaResolver {
 		resolver: docker.NewResolver(docker.ResolverOptions{
 			Headers: headers,
 		}),
-		platform: opts.platform,
-		buffer:   contentutil.NewBuffer(),
-		cache:    map[string]resolveResult{},
-		locker:   locker.New(),
+		platform:         opts.platform,
+		concurrencyGroup: opts.concurrencyGroup,
+		buffer:           contentutil.NewBuffer(),
+		cache:            map[string]resolveResult{},
+		locker:           locker.New(),
 	}
 }
 
@@ -64,11 +73,12 @@ func Default() llb.ImageMetaResolver {
 }
 
 type imageMetaResolver struct {
-	resolver remotes.Resolver
-	buffer   contentutil.Buffer
-	platform *ocispecs.Platform
-	locker   *locker.Locker
-	cache    map[string]resolveResult
+	resolver         remotes.Resolver
+	buffer           contentutil.Buffer
+	platform         *ocispecs.Platform
+	concurrencyGroup *limited.Group
+	locker           *locker.Locker
+	cache            map[string]resolveResult
 }
 
 type resolveResult struct {
@@ -86,8 +96,14 @@ func (imr *imageMetaResolver) ResolveImageConfig(ctx context.Context, ref string
 	defer imr.locker.Unlock(ref)
 
 	platform := imr.platform
-	if imgOpt := opt.ImageOpt; imgOpt != nil && imgOpt.Platform != nil {
-		platform = imgOpt.Platform
+	concurrencyGroup := imr.concurrencyGroup
+	if imgOpt := opt.ImageOpt; imgOpt != nil {
+		if imgOpt.Platform != nil {
+			platform = imgOpt.Platform
+		}
+		if imgOpt.ConcurrencyGroup != nil {
+			concurrencyGroup = imgOpt.ConcurrencyGroup
+		}
 	}
 
 	k := imr.key(ref, platform)
@@ -96,7 +112,7 @@ func (imr *imageMetaResolver) ResolveImageConfig(ctx context.Context, ref string
 		return ref, res.dgst, res.config, nil
 	}
 
-	dgst, config, err := imageutil.Config(ctx, ref, imr.resolver, imr.buffer, nil, platform)
+	dgst, config, err := imageutil.Config(ctx, ref, imr.resolver, imr.buffer, nil, concurrencyGroup, platform)
 	if err != nil {
 		return "", "", nil, err
 	}

--- a/client/llb/sourceresolver/types.go
+++ b/client/llb/sourceresolver/types.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/moby/buildkit/solver/pb"
 	spb "github.com/moby/buildkit/sourcepolicy/pb"
+	"github.com/moby/buildkit/util/resolver/limited"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -45,6 +46,7 @@ type ResolveImageOpt struct {
 	NoConfig            bool
 	AttestationChain    bool
 	ResolveAttestations []string
+	ConcurrencyGroup    *limited.Group
 }
 
 type ResolveImageResponse struct {

--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -49,6 +49,8 @@ type Config struct {
 	ProvenanceEnvDir string `toml:"provenanceEnvDir"`
 
 	Cache CacheConfig `toml:"cache"`
+
+	Concurrency ConcurrencyConfig `toml:"concurrency"`
 }
 
 type CacheConfig struct {
@@ -220,4 +222,12 @@ type DockerfileFrontendConfig struct {
 type GatewayFrontendConfig struct {
 	Enabled             *bool    `toml:"enabled"`
 	AllowedRepositories []string `toml:"allowedRepositories"`
+}
+
+type ConcurrencyConfig struct {
+	Registry RegistryConcurrencyConfig `toml:"registry"`
+}
+
+type RegistryConcurrencyConfig struct {
+	MaxConnections int `toml:"max-connections"`
 }

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -53,6 +53,7 @@ import (
 	_ "github.com/moby/buildkit/util/grpcutil/encoding/proto"
 	"github.com/moby/buildkit/util/profiler"
 	"github.com/moby/buildkit/util/resolver"
+	"github.com/moby/buildkit/util/resolver/limited"
 	"github.com/moby/buildkit/util/stack"
 	"github.com/moby/buildkit/util/tracing"
 	_ "github.com/moby/buildkit/util/tracing/childprocess"
@@ -92,9 +93,10 @@ func init() {
 var propagators = propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{})
 
 type workerInitializerOpt struct {
-	config         *config.Config
-	sessionManager *session.Manager
-	traceSocket    string
+	config           *config.Config
+	sessionManager   *session.Manager
+	traceSocket      string
+	concurrencyGroup *limited.Group
 }
 
 type workerInitializer struct {
@@ -804,10 +806,12 @@ func newController(ctx context.Context, c *cli.Context, cfg *config.Config) (*co
 		}
 	}
 
+	concurrencyGroup := newConcurrencyGroup(cfg.Concurrency)
 	wc, err := newWorkerController(c, workerInitializerOpt{
-		config:         cfg,
-		sessionManager: sessionManager,
-		traceSocket:    traceSocket,
+		config:           cfg,
+		sessionManager:   sessionManager,
+		traceSocket:      traceSocket,
+		concurrencyGroup: concurrencyGroup,
 	})
 	if err != nil {
 		return nil, err
@@ -857,7 +861,7 @@ func newController(ctx context.Context, c *cli.Context, cfg *config.Config) (*co
 		"azblob":   azblob.ResolveCacheExporterFunc(),
 	}
 	remoteCacheImporterFuncs := map[string]remotecache.ResolveCacheImporterFunc{
-		"registry": registryremotecache.ResolveCacheImporterFunc(sessionManager, w.ContentStore(), resolverFn),
+		"registry": registryremotecache.ResolveCacheImporterFunc(sessionManager, w.ContentStore(), concurrencyGroup, resolverFn),
 		"local":    localremotecache.ResolveCacheImporterFunc(sessionManager),
 		"gha":      gha.ResolveCacheImporterFunc(cfg.Cache.GHA, verifierProvider),
 		"s3":       s3remotecache.ResolveCacheImporterFunc(),
@@ -890,11 +894,21 @@ func newController(ctx context.Context, c *cli.Context, cfg *config.Config) (*co
 		GarbageCollect:            w.GarbageCollect,
 		GracefulStop:              ctx.Done(),
 		ProvenanceEnv:             provenanceEnv,
+		ConcurrencyGroup:          concurrencyGroup,
 	})
 }
 
 func resolverFunc(cfg *config.Config) docker.RegistryHosts {
 	return resolver.NewRegistryConfig(cfg.Registries)
+}
+
+// newConcurrencyGroup returns a limited.Group configured according to cfg.
+// If no value is configured, limited.Default is returned.
+func newConcurrencyGroup(cfg config.ConcurrencyConfig) *limited.Group {
+	if cfg.Registry.MaxConnections <= 0 {
+		return limited.Default
+	}
+	return limited.New(cfg.Registry.MaxConnections)
 }
 
 func newWorkerController(c *cli.Context, wiOpt workerInitializerOpt) (*worker.Controller, error) {

--- a/cmd/buildkitd/main_containerd_worker.go
+++ b/cmd/buildkitd/main_containerd_worker.go
@@ -362,6 +362,7 @@ func containerdWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([
 	opt.GCPolicy = getGCPolicy(cfg.GCConfig, common.config.Root)
 	opt.BuildkitVersion = getBuildkitVersion()
 	opt.RegistryHosts = resolverFunc(common.config)
+	opt.ConcurrencyGroup = common.concurrencyGroup
 
 	if platformsStr := cfg.Platforms; len(platformsStr) != 0 {
 		platforms, err := parsePlatforms(platformsStr)

--- a/cmd/buildkitd/main_oci_worker.go
+++ b/cmd/buildkitd/main_oci_worker.go
@@ -334,6 +334,7 @@ func ociWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([]worker
 	opt.GCPolicy = getGCPolicy(cfg.GCConfig, common.config.Root)
 	opt.BuildkitVersion = getBuildkitVersion()
 	opt.RegistryHosts = hosts
+	opt.ConcurrencyGroup = common.concurrencyGroup
 
 	if platformsStr := cfg.Platforms; len(platformsStr) != 0 {
 		platforms, err := parsePlatforms(platformsStr)

--- a/control/control.go
+++ b/control/control.go
@@ -43,6 +43,7 @@ import (
 	"github.com/moby/buildkit/util/entitlements"
 	"github.com/moby/buildkit/util/imageutil"
 	"github.com/moby/buildkit/util/leaseutil"
+	"github.com/moby/buildkit/util/resolver/limited"
 	"github.com/moby/buildkit/util/throttle"
 	"github.com/moby/buildkit/util/tracing/transform"
 	"github.com/moby/buildkit/version"
@@ -76,6 +77,7 @@ type Opt struct {
 	GarbageCollect            func(context.Context) error
 	GracefulStop              <-chan struct{}
 	ProvenanceEnv             map[string]any
+	ConcurrencyGroup          *limited.Group
 }
 
 type Controller struct { // TODO: ControlService
@@ -117,6 +119,7 @@ func NewController(opt Opt) (*Controller, error) {
 		Entitlements:     opt.Entitlements,
 		HistoryQueue:     hq,
 		ProvenanceEnv:    opt.ProvenanceEnv,
+		ConcurrencyGroup: opt.ConcurrencyGroup,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create solver")

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -432,7 +432,7 @@ func (e *imageExporterInstance) pushImage(ctx context.Context, src *exporter.Sou
 			addAnnotations(annotations, desc)
 		}
 	}
-	return push.Push(ctx, e.opt.SessionManager, sessionID, mprovider, e.opt.ImageWriter.ContentStore(), dgst, targetName, e.insecure, e.opt.RegistryHosts, e.pushByDigest, annotations)
+	return push.Push(ctx, e.opt.SessionManager, sessionID, mprovider, e.opt.ImageWriter.ContentStore(), nil, dgst, targetName, e.insecure, e.opt.RegistryHosts, e.pushByDigest, annotations)
 }
 
 func (e *imageExporterInstance) unpackImage(ctx context.Context, img images.Image, src *exporter.Source, s session.Group) (err0 error) {

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -26,6 +26,7 @@ import (
 	"github.com/moby/buildkit/util/entitlements"
 	"github.com/moby/buildkit/util/leaseutil"
 	"github.com/moby/buildkit/util/progress"
+	"github.com/moby/buildkit/util/resolver/limited"
 	"github.com/moby/buildkit/worker"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
@@ -59,6 +60,7 @@ type Opt struct {
 	HistoryQueue     *history.Queue
 	ResourceMonitor  *resources.Monitor
 	ProvenanceEnv    map[string]any
+	ConcurrencyGroup *limited.Group
 }
 
 type Solver struct {
@@ -74,6 +76,7 @@ type Solver struct {
 	history                   *history.Queue
 	sysSampler                *resources.Sampler[*resourcestypes.SysSample]
 	provenanceEnv             map[string]any
+	concurrencyGroup          *limited.Group
 }
 
 // Processor defines a processing function to be applied after solving, but
@@ -104,6 +107,7 @@ func New(opt Opt) (*Solver, error) {
 		entitlements:              opt.Entitlements,
 		history:                   opt.HistoryQueue,
 		provenanceEnv:             opt.ProvenanceEnv,
+		concurrencyGroup:          opt.ConcurrencyGroup,
 	}
 
 	sampler, err := resources.NewSysSampler()
@@ -347,6 +351,10 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 			return nil, err
 		}
 		exp.Exporters = append(exp.Exporters, exporters...)
+	}
+
+	if s.concurrencyGroup != nil {
+		ctx = limited.WithConcurrencyGroup(ctx, s.concurrencyGroup)
 	}
 
 	var exporterResponse map[string]string

--- a/source/containerimage/source.go
+++ b/source/containerimage/source.go
@@ -30,6 +30,7 @@ import (
 	"github.com/moby/buildkit/util/leaseutil"
 	"github.com/moby/buildkit/util/pull"
 	"github.com/moby/buildkit/util/resolver"
+	"github.com/moby/buildkit/util/resolver/limited"
 	"github.com/moby/buildkit/util/tracing"
 	policyimage "github.com/moby/policy-helpers/image"
 	digest "github.com/opencontainers/go-digest"
@@ -55,7 +56,8 @@ type SourceOpt struct {
 	ImageStore    images.Store // optional
 	RegistryHosts docker.RegistryHosts
 	ResolverType
-	LeaseManager leases.Manager
+	LeaseManager     leases.Manager
+	ConcurrencyGroup *limited.Group
 }
 
 type Source struct {
@@ -135,9 +137,10 @@ func (is *Source) Resolve(ctx context.Context, id source.Identifier, sm *session
 		return nil, errors.Errorf("unknown resolver type: %v", is.ResolverType)
 	}
 	pullerUtil = &pull.Puller{
-		ContentStore: is.ContentStore,
-		Platform:     platform,
-		Src:          ref,
+		ContentStore:     is.ContentStore,
+		Platform:         platform,
+		ConcurrencyGroup: is.ConcurrencyGroup,
+		Src:              ref,
 	}
 	p = &puller{
 		CacheAccessor:  is.CacheAccessor,
@@ -187,7 +190,7 @@ func (is *Source) ResolveImageMetadata(ctx context.Context, id *ImageIdentifier,
 	ret := &sourceresolver.ResolveImageResponse{}
 	if !opt.NoConfig {
 		res, err := is.gImageRes.Do(ctx, key, func(ctx context.Context) (*resolveImageResult, error) {
-			dgst, dt, err := imageutil.Config(ctx, ref, rslvr, is.ContentStore, is.LeaseManager, opt.Platform)
+			dgst, dt, err := imageutil.Config(ctx, ref, rslvr, is.ContentStore, is.LeaseManager, is.ConcurrencyGroup, opt.Platform)
 			if err != nil {
 				return nil, err
 			}
@@ -312,7 +315,7 @@ func (is *Source) ResolveOCILayoutMetadata(ctx context.Context, id *OCIIdentifie
 	key += resolver.ResolveModeForcePull.String()
 
 	res, err := is.gImageRes.Do(ctx, key, func(ctx context.Context) (*resolveImageResult, error) {
-		dgst, dt, err := imageutil.Config(ctx, ref, rslvr, is.ContentStore, is.LeaseManager, opt.Platform)
+		dgst, dt, err := imageutil.Config(ctx, ref, rslvr, is.ContentStore, is.LeaseManager, is.ConcurrencyGroup, opt.Platform)
 		if err != nil {
 			return nil, err
 		}

--- a/util/contentutil/copy.go
+++ b/util/contentutil/copy.go
@@ -31,8 +31,12 @@ func WithReferrers(referrers content.ReferrersProvider) CopyOption {
 }
 
 func Copy(ctx context.Context, ingester content.Ingester, provider content.Provider, desc ocispecs.Descriptor, ref string, logger func([]byte)) error {
+	fetchHandler := limited.FetchHandler(
+		limited.ConcurrencyGroupFromContext(ctx),
+		ingester, &localFetcher{provider}, ref,
+	)
 	ctx = RegisterContentPayloadTypes(ctx)
-	if _, err := retryhandler.New(limited.FetchHandler(ingester, &localFetcher{provider}, ref), logger)(ctx, desc); err != nil {
+	if _, err := retryhandler.New(fetchHandler, logger)(ctx, desc); err != nil {
 		return err
 	}
 	return nil
@@ -110,7 +114,7 @@ func copyChain(ctx context.Context, ingester content.Ingester, provider content.
 	handlers := []images.Handler{
 		annotateDistributionSourceHandler(images.ChildrenHandler(provider), desc.Annotations),
 		filterHandler,
-		retryhandler.New(limited.FetchHandler(ingester, &localFetcher{provider}, ""), func(_ []byte) {}),
+		retryhandler.New(limited.FetchHandler(limited.Default, ingester, &localFetcher{provider}, ""), func(_ []byte) {}),
 	}
 
 	if err := images.Dispatch(ctx, images.Handlers(handlers...), nil, desc); err != nil {

--- a/util/imageutil/config.go
+++ b/util/imageutil/config.go
@@ -60,7 +60,7 @@ func (e ResolveToNonImageError) Error() string {
 	return fmt.Sprintf("ref mutated by policy to non-image: %s://%s -> %s", srctypes.DockerImageScheme, e.Ref, e.Updated)
 }
 
-func Config(ctx context.Context, str string, resolver remotes.Resolver, cache ContentCache, leaseManager leases.Manager, p *ocispecs.Platform) (digest.Digest, []byte, error) {
+func Config(ctx context.Context, str string, resolver remotes.Resolver, cache ContentCache, leaseManager leases.Manager, gr *limited.Group, p *ocispecs.Platform) (digest.Digest, []byte, error) {
 	var platform platforms.MatchComparer
 	if p != nil {
 		platform = platforms.Only(*p)
@@ -130,7 +130,7 @@ func Config(ctx context.Context, str string, resolver remotes.Resolver, cache Co
 	}
 
 	handlers := []images.Handler{
-		retryhandler.New(limited.FetchHandler(cache, fetcher, str), func(_ []byte) {}),
+		retryhandler.New(limited.FetchHandler(gr, cache, fetcher, str), func(_ []byte) {}),
 		dslHandler,
 		children,
 	}

--- a/util/imageutil/config_test.go
+++ b/util/imageutil/config_test.go
@@ -57,7 +57,7 @@ func TestConfigMultiplatform(t *testing.T) {
 		// Now we should be able to get the amd64 config without fetching anything from the remote
 		// If it tries to fetch from the remote this will error out.
 		const ref = "example.com/test:latest"
-		_, dt, err := Config(ctx, ref, r, cc, nil, &pAmd64)
+		_, dt, err := Config(ctx, ref, r, cc, nil, nil, &pAmd64)
 		require.NoError(t, err)
 
 		var cfg ocispecs.Image
@@ -67,7 +67,7 @@ func TestConfigMultiplatform(t *testing.T) {
 
 		// Make sure it doesn't select a non-matching platform
 		pArmv7 := platforms.MustParse("linux/arm/v7")
-		_, _, err = Config(ctx, ref, r, cc, nil, &pArmv7)
+		_, _, err = Config(ctx, ref, r, cc, nil, nil, &pArmv7)
 		require.ErrorIs(t, err, cerrdefs.ErrNotFound)
 	}
 

--- a/util/pull/pull.go
+++ b/util/pull/pull.go
@@ -27,10 +27,11 @@ import (
 type SessionResolver func(g session.Group) remotes.Resolver
 
 type Puller struct {
-	ContentStore content.Store
-	Resolver     remotes.Resolver
-	Src          reference.Spec
-	Platform     ocispecs.Platform
+	ContentStore     content.Store
+	Resolver         remotes.Resolver
+	Src              reference.Spec
+	Platform         ocispecs.Platform
+	ConcurrencyGroup *limited.Group
 
 	g           flightcontrol.Group[struct{}]
 	resolveErr  error
@@ -150,7 +151,7 @@ func (p *Puller) PullManifests(ctx context.Context, getResolver SessionResolver)
 	}
 	handlers = append(handlers,
 		filterLayerBlobs(metadata, &mu),
-		retryhandler.New(limited.FetchHandler(p.ContentStore, fetcher, p.ref), logs.LoggerFromContext(ctx)),
+		retryhandler.New(limited.FetchHandler(p.ConcurrencyGroup, p.ContentStore, fetcher, p.ref), logs.LoggerFromContext(ctx)),
 		childrenHandler,
 		dslHandler,
 	)

--- a/util/push/push.go
+++ b/util/push/push.go
@@ -45,7 +45,7 @@ func Pusher(ctx context.Context, resolver remotes.Resolver, ref string) (remotes
 	return &pusher{Pusher: p}, nil
 }
 
-func Push(ctx context.Context, sm *session.Manager, sid string, provider content.Provider, manager content.Manager, dgst digest.Digest, ref string, insecure bool, hosts docker.RegistryHosts, byDigest bool, annotations map[digest.Digest]map[string]string) error {
+func Push(ctx context.Context, sm *session.Manager, sid string, provider content.Provider, manager content.Manager, gr *limited.Group, dgst digest.Digest, ref string, insecure bool, hosts docker.RegistryHosts, byDigest bool, annotations map[digest.Digest]map[string]string) error {
 	ctx = contentutil.RegisterContentPayloadTypes(ctx)
 	desc := ocispecs.Descriptor{
 		Digest: dgst,
@@ -105,7 +105,7 @@ func Push(ctx context.Context, sm *session.Manager, sid string, provider content
 		}
 	})
 
-	pushHandler := retryhandler.New(limited.PushHandler(pusher, provider, ref), logs.LoggerFromContext(ctx))
+	pushHandler := retryhandler.New(limited.PushHandler(gr, pusher, provider, ref), logs.LoggerFromContext(ctx))
 	pushUpdateSourceHandler, err := updateDistributionSourceHandler(manager, pushHandler, ref)
 	if err != nil {
 		return err

--- a/util/resolver/limited/group.go
+++ b/util/resolver/limited/group.go
@@ -16,9 +16,12 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
-type contextKeyT string
+type contextKeyT int
 
-var contextKey = contextKeyT("buildkit/util/resolver/limited")
+const (
+	contextKey contextKeyT = iota
+	groupKey
+)
 
 // DefaultMaxConcurrency is the default number of concurrent connections per registry.
 var DefaultMaxConcurrency int64 = 4
@@ -87,10 +90,17 @@ func (g *Group) req(ref string) *req {
 }
 
 func (g *Group) WrapFetcher(f remotes.Fetcher, ref string) remotes.Fetcher {
+	if g == nil {
+		g = Default
+	}
 	return &fetcher{Fetcher: f, req: g.req(ref)}
 }
 
 func (g *Group) PushHandler(pusher remotes.Pusher, provider content.Provider, ref string) images.HandlerFunc {
+	if g == nil {
+		g = Default
+	}
+
 	ph := remotes.PushHandler(pusher, provider)
 	req := g.req(ref)
 	return func(ctx context.Context, desc ocispecs.Descriptor) ([]ocispecs.Descriptor, error) {
@@ -160,12 +170,27 @@ func (r *readCloser) close() {
 	r.once.Do(r.release)
 }
 
-func FetchHandler(ingester content.Ingester, fetcher remotes.Fetcher, ref string) images.HandlerFunc {
-	return remotes.FetchHandler(ingester, Default.WrapFetcher(fetcher, ref))
+func FetchHandler(gr *Group, ingester content.Ingester, fetcher remotes.Fetcher, ref string) images.HandlerFunc {
+	return remotes.FetchHandler(ingester, gr.WrapFetcher(fetcher, ref))
 }
 
-func PushHandler(pusher remotes.Pusher, provider content.Provider, ref string) images.HandlerFunc {
-	return Default.PushHandler(pusher, provider, ref)
+func PushHandler(gr *Group, pusher remotes.Pusher, provider content.Provider, ref string) images.HandlerFunc {
+	return gr.PushHandler(pusher, provider, ref)
+}
+
+func WithConcurrencyGroup(ctx context.Context, g *Group) context.Context {
+	return context.WithValue(ctx, groupKey, g)
+}
+
+func ConcurrencyGroupFromContext(ctx context.Context) (gr *Group) {
+	if v := ctx.Value(groupKey); v != nil {
+		gr, _ = v.(*Group)
+	}
+
+	if gr == nil {
+		gr = Default
+	}
+	return gr
 }
 
 func domain(ref string) string {

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -49,6 +49,7 @@ import (
 	"github.com/moby/buildkit/util/network"
 	"github.com/moby/buildkit/util/progress"
 	"github.com/moby/buildkit/util/progress/controller"
+	"github.com/moby/buildkit/util/resolver/limited"
 	"github.com/moby/sys/user"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -86,6 +87,7 @@ type WorkerOpt struct {
 	MountPoolRoot    string
 	ResourceMonitor  *resources.Monitor
 	CDIManager       *cdidevices.Manager
+	ConcurrencyGroup *limited.Group
 }
 
 // Worker is a local worker instance with dedicated snapshotter, cache, and so on.
@@ -130,14 +132,15 @@ func NewWorker(ctx context.Context, opt WorkerOpt) (*Worker, error) {
 	}
 
 	is, err := containerimage.NewSource(containerimage.SourceOpt{
-		Snapshotter:   opt.Snapshotter,
-		ContentStore:  opt.ContentStore,
-		Applier:       opt.Applier,
-		ImageStore:    opt.ImageStore,
-		CacheAccessor: cm,
-		RegistryHosts: opt.RegistryHosts,
-		ResolverType:  containerimage.ResolverTypeRegistry,
-		LeaseManager:  opt.LeaseManager,
+		Snapshotter:      opt.Snapshotter,
+		ContentStore:     opt.ContentStore,
+		Applier:          opt.Applier,
+		ImageStore:       opt.ImageStore,
+		CacheAccessor:    cm,
+		RegistryHosts:    opt.RegistryHosts,
+		ResolverType:     containerimage.ResolverTypeRegistry,
+		LeaseManager:     opt.LeaseManager,
+		ConcurrencyGroup: opt.ConcurrencyGroup,
 	})
 	if err != nil {
 		return nil, err
@@ -187,13 +190,14 @@ func NewWorker(ctx context.Context, opt WorkerOpt) (*Worker, error) {
 	sm.Register(ss)
 
 	os, err := containerimage.NewSource(containerimage.SourceOpt{
-		Snapshotter:   opt.Snapshotter,
-		ContentStore:  opt.ContentStore,
-		Applier:       opt.Applier,
-		ImageStore:    opt.ImageStore,
-		CacheAccessor: cm,
-		ResolverType:  containerimage.ResolverTypeOCILayout,
-		LeaseManager:  opt.LeaseManager,
+		Snapshotter:      opt.Snapshotter,
+		ContentStore:     opt.ContentStore,
+		Applier:          opt.Applier,
+		ImageStore:       opt.ImageStore,
+		CacheAccessor:    cm,
+		ResolverType:     containerimage.ResolverTypeOCILayout,
+		LeaseManager:     opt.LeaseManager,
+		ConcurrencyGroup: opt.ConcurrencyGroup,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION

The current number of concurrent connections to registries is currently
set at 4 and it is unconfigurable. If you want to do more, it's currenly
not possible. This configuration change allows a person to customize the
number of connections that will be allowed concurrently through the new
`concurrency` section of the configuration. At the moment, the only
option there is `concurrency.registry.max-connections` which changes the
maximum number of push/pull operations to registries.

Replaces #6517.
