### PR TITLE
ci: fix deprecated runner value in github builder workflow

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -54,7 +54,7 @@ jobs:
       contents: read # same as global permission
       id-token: write # for signing attestation(s) with GitHub OIDC Token
     with:
-      runner: amd64
+      runner: ubuntu-24.04
       setup-qemu: true
       artifact-name: buildkit-binaries
       artifact-upload: true
@@ -234,7 +234,7 @@ jobs:
       contents: read # same as global permission
       id-token: write # for signing attestation(s) with GitHub OIDC Token
     with:
-      runner: amd64
+      runner: ubuntu-24.04
       setup-qemu: true
       target: image-cross
       cache: true

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -137,7 +137,7 @@ jobs:
       contents: read # same as global permission
       id-token: write # for signing attestation(s) with GitHub OIDC Token
     with:
-      runner: amd64
+      runner: ubuntu-24.04
       setup-qemu: true
       target: frontend-image-cross
       cache: true


### PR DESCRIPTION
follow-up https://github.com/docker/github-builder/pull/188

relates to:

<img width="595" height="353" alt="image" src="https://github.com/user-attachments/assets/95d717e8-27c1-4664-98ca-2f8634bd1967" />
