### PR TITLE
skip pin race test on workers without merge diff support

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -8702,11 +8702,7 @@ func testMergeOp(t *testing.T, sb integration.Sandbox) {
 	}
 
 	var imageTarget string
-	if workers.IsTestDockerdMoby(sb) {
-		// do image export but use a fake url as the image should just end up in moby's
-		// local store
-		imageTarget = "fake.invalid:33333/buildkit/testmergeop:latest"
-	} else if registry != "" {
+	if registry != "" {
 		imageTarget = registry + "/buildkit/testmergeop:latest"
 	}
 
@@ -9193,25 +9189,17 @@ func requireContents(ctx context.Context, t *testing.T, c *Client, sb integratio
 	require.NoError(t, fstest.CheckDirectoryEqualWithApplier(destDir, fstest.Apply(files...)))
 
 	if imageTarget != "" {
-		var exports []ExportEntry
-		if workers.IsTestDockerdMoby(sb) {
-			exports = []ExportEntry{{
-				Type: "moby",
-				Attrs: map[string]string{
-					"name": imageTarget,
-				},
-			}}
-		} else {
-			exports = []ExportEntry{{
+		_, err = c.Solve(ctx, def, SolveOpt{
+			Exports: []ExportEntry{{
 				Type: ExporterImage,
 				Attrs: map[string]string{
 					"name": imageTarget,
 					"push": "true",
 				},
-			}}
-		}
-
-		_, err = c.Solve(ctx, def, SolveOpt{Exports: exports, CacheImports: cacheImports, CacheExports: cacheExports}, nil)
+			}},
+			CacheImports: cacheImports,
+			CacheExports: cacheExports,
+		}, nil)
 		require.NoError(t, err)
 		resetState(t, c, sb)
 		requireContents(ctx, t, c, sb, llb.Image(imageTarget, llb.ResolveModePreferLocal), cacheImports, nil, "", files...)

--- a/client/mergediff_test.go
+++ b/client/mergediff_test.go
@@ -1220,13 +1220,6 @@ func (tc verifyContents) Run(t *testing.T, sb integration.Sandbox) {
 		t.Skip("rootless")
 	}
 
-	switch tc.name {
-	case "TestDiffUpperScratch":
-		if workers.IsTestDockerdMoby(sb) {
-			t.Skip("failed to handle changes: lstat ... no such file or directory: https://github.com/moby/buildkit/pull/2726#issuecomment-1070978499")
-		}
-	}
-
 	requiresLinux(t)
 	cdAddress := sb.ContainerdAddress()
 

--- a/client/pinrace_6731_test.go
+++ b/client/pinrace_6731_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/moby/buildkit/client/llb"
 	gateway "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/moby/buildkit/util/testutil/workers"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -66,6 +67,7 @@ func init() {
 // custom buildkitd build or env-var instrumentation is needed.
 func testPinRaceIgnoreCacheShift(t *testing.T, sb integration.Sandbox) {
 	integration.SkipOnPlatform(t, "windows")
+	workers.CheckFeatureCompat(t, sb, workers.FeatureMergeDiff)
 
 	const fetchDelay = 1500 * time.Millisecond
 	const headStart = 400 * time.Millisecond

--- a/util/testutil/workers/dockerd.go
+++ b/util/testutil/workers/dockerd.go
@@ -33,6 +33,7 @@ func InitDockerdWorker() {
 			FeatureCacheBackendS3,
 			FeatureDirectPush,
 			FeatureImageExporter,
+			FeatureMergeDiff,
 			FeatureMultiCacheExport,
 			FeatureMultiPlatform,
 			FeatureOCIExporter,


### PR DESCRIPTION
relates to https://github.com/moby/moby/actions/runs/25785529458/job/75738374498?pr=52613#step:13:2683

```
=== Failed
=== FAIL: client TestIntegration/TestPinRaceIgnoreCacheShift/worker=dockerd (301.36s)
    sandbox.go:147: sandbox timeout reached, stopping worker
    pinrace_6731_test.go:96: 
        	Error Trace:	/src/client/pinrace_6731_test.go:96
        	            				/src/util/testutil/integration/run.go:105
        	            				/src/util/testutil/integration/run.go:253
        	Error:      	Received unexpected error:
        	            	context canceled
        	            	github.com/moby/buildkit/util/testutil/integration.newSandbox.func3
        	            		/src/util/testutil/integration/sandbox.go:151
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1771
        	Test:       	TestIntegration/TestPinRaceIgnoreCacheShift/worker=dockerd
        	Messages:   	iteration 0
```

Skips the pin race provenance integration test when the selected worker doesn't support merge and diff operations.

This test builds an LLB graph with `llb.Merge`, but Moby classic dockerd graphdriver backend disables `mergeop`: https://github.com/moby/moby/blob/16baa12d9422420024c7b9ebc9ee9ab4216d4651/daemon/internal/builder-next/controller.go#L249-L259, so the test should be gated by worker capability instead of a hard-coded dockerd check.

Tested in https://github.com/moby/moby/pull/52613