### PR TITLE
hack: switch to gomod-updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,6 @@ docs:
 docs-dockerfile:
 	$(BUILDX_CMD) bake docs-dockerfile
 
-.PHONY: mod-outdated
-mod-outdated:
-	$(BUILDX_CMD) bake mod-outdated
+.PHONY: gomod-updates
+gomod-updates:
+	$(BUILDX_CMD) bake gomod-updates

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -428,11 +428,11 @@ target "docs-dockerfile" {
   output = ["./frontend/dockerfile/docs/rules"]
 }
 
-target "mod-outdated" {
+target "gomod-updates" {
   inherits = ["_common"]
   dockerfile = "./hack/dockerfiles/vendor.Dockerfile"
-  target = "outdated"
-  no-cache-filter = ["outdated"]
+  target = "gomod-updates"
+  no-cache-filter = ["gomod-updates"]
   output = ["type=cacheonly"]
 }
 

--- a/hack/dockerfiles/vendor.Dockerfile
+++ b/hack/dockerfiles/vendor.Dockerfile
@@ -2,7 +2,6 @@
 
 ARG GO_VERSION=1.26
 ARG ALPINE_VERSION=3.23
-ARG MODOUTDATED_VERSION=v0.9.0
 
 FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS base
 RUN apk add --no-cache git rsync
@@ -38,11 +37,8 @@ RUN --mount=target=/context \
   fi
 EOT
 
-FROM --platform=linux/amd64 psampaz/go-mod-outdated:${MODOUTDATED_VERSION} AS go-mod-outdated-amd64
-
-FROM go-mod-outdated-amd64 AS go-mod-outdated
-FROM base AS outdated
+FROM base AS gomod-updates
 RUN --mount=target=.,rw \
   --mount=target=/go/pkg/mod,type=cache \
-  --mount=from=go-mod-outdated,source=/usr/bin/go-mod-outdated,target=/usr/bin/go-mod-outdated \
-  go list -mod=mod -u -m -json all | go-mod-outdated -update -direct
+  --mount=from=crazymax/gomod-updates,source=/usr/bin/gomod-updates,target=/usr/bin/gomod-updates \
+  gomod-updates --update --direct --major


### PR DESCRIPTION
Replaces the [go-mod-outdated](https://github.com/psampaz/go-mod-outdated) helper that seems unmaintained with [gomod-updates](https://github.com/crazy-max/gomod-updates) for reporting available Go module updates.

`gomod-updates` provides the same outdated module reporting workflow without the previous `linux/amd64` image-stage limitation, while also surfacing major-version module path candidates. This makes the helper more useful for dependency maintenance.

Example:

```
#16 18.87 +------------------------------------------------------+------------------------------------+------------------------------------+--------+------------------+
#16 18.87 | Module                                               | Version                            | New Version                        | Direct | Valid Timestamps |
#16 18.87 +------------------------------------------------------+------------------------------------+------------------------------------+--------+------------------+
#16 18.87 | github.com/Azure/azure-sdk-for-go/sdk/azcore         | v1.21.0                            | v1.21.1                            | true   | true             |
#16 18.87 | github.com/Azure/azure-sdk-for-go/sdk/storage/azblob | v1.5.0                             | v1.6.4                             | true   | true             |
#16 18.87 | github.com/ProtonMail/go-crypto                      | v1.3.0                             | v1.4.1                             | true   | true             |
#16 18.87 | github.com/aws/aws-sdk-go-v2/feature/s3/manager      | v1.17.10                           | v1.22.18                           | true   | true             |
#16 18.87 | github.com/aws/aws-sdk-go-v2/service/s3              | v1.89.1                            | v1.101.0                           | true   | true             |
#16 18.87 | github.com/containerd/accelerated-container-image    | v1.3.0                             | v1.4.3                             | true   | true             |
#16 18.87 | github.com/containerd/containerd/api                 | v1.10.0                            | v1.11.0                            | true   | true             |
#16 18.87 | github.com/containerd/containerd/v2                  | v2.2.3                             | v2.3.0                             | true   | true             |
#16 18.87 | github.com/containerd/continuity                     | v0.4.5                             | v0.5.0                             | true   | true             |
#16 18.87 | github.com/containerd/nydus-snapshotter              | v0.15.13                           | v0.15.15                           | true   | true             |
#16 18.87 | github.com/containerd/platforms                      | v1.0.0-rc.2                        | v1.0.0-rc.4                        | true   | true             |
#16 18.87 | github.com/opencontainers/selinux                    | v1.13.1                            | v1.14.1                            | true   | true             |
#16 18.87 | github.com/package-url/packageurl-go                 | v0.1.1                             | v0.1.6                             | true   | true             |
#16 18.87 | github.com/pelletier/go-toml/v2                      | v2.2.4                             | v2.3.1                             | true   | true             |
#16 18.87 | github.com/prometheus/procfs                         | v0.17.0                            | v0.20.1                            | true   | true             |
#16 18.87 | github.com/urfave/cli                                | v1.22.17                           | github.com/urfave/cli/v3@v3.9.0    | true   | true             |
#16 18.87 | go.opentelemetry.io/otel/exporters/prometheus        | v0.60.0                            | v0.65.0                            | true   | true             |
#16 18.87 | golang.org/x/crypto                                  | v0.50.0                            | v0.51.0                            | true   | true             |
#16 18.87 | golang.org/x/exp                                     | v0.0.0-20250911091902-df9299821621 | v0.0.0-20260508232706-74f9aab9d74a | true   | true             |
#16 18.87 | golang.org/x/mod                                     | v0.34.0                            | v0.36.0                            | true   | true             |
#16 18.87 | golang.org/x/net                                     | v0.53.0                            | v0.54.0                            | true   | true             |
#16 18.87 | golang.org/x/sys                                     | v0.43.0                            | v0.44.0                            | true   | true             |
#16 18.87 | google.golang.org/genproto/googleapis/rpc            | v0.0.0-20260406210006-6f92a3bedf2d | v0.0.0-20260511170946-3700d4141b60 | true   | true             |
#16 18.87 | google.golang.org/grpc                               | v1.80.0                            | v1.81.0                            | true   | true             |
#16 18.87 +------------------------------------------------------+------------------------------------+------------------------------------+--------+------------------+
```