### PR TITLE
util/resolver/limited: make registry concurrency configurable by the configuration file

### DIFF
--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -62,6 +62,10 @@ type SystemConfig struct {
 	// PlatformCacheMaxAge controls how often supported platforms
 	// are refreshed by rescanning the system.
 	PlatformsCacheMaxAge *Duration `toml:"platformsCacheMaxAge"`
+
+	// MaxRegistryConcurrency sets the maximum number of concurrent
+	// connections per registry.
+	MaxRegistryConcurrency *int `toml:"maxRegistryConcurrency"`
 }
 
 type LogConfig struct {

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -54,6 +54,7 @@ import (
 	_ "github.com/moby/buildkit/util/grpcutil/encoding/proto"
 	"github.com/moby/buildkit/util/profiler"
 	"github.com/moby/buildkit/util/resolver"
+	"github.com/moby/buildkit/util/resolver/limited"
 	"github.com/moby/buildkit/util/stack"
 	"github.com/moby/buildkit/util/tracing"
 	_ "github.com/moby/buildkit/util/tracing/childprocess"
@@ -308,6 +309,12 @@ func main() {
 		if sc := cfg.System; sc != nil {
 			if v := sc.PlatformsCacheMaxAge; v != nil {
 				archutil.CacheMaxAge = v.Duration
+			}
+			if v := sc.MaxRegistryConcurrency; v != nil {
+				if *v <= 0 {
+					return errors.Errorf("maxRegistryConcurrency must be greater than zero; set to %d in the configuration file", *v)
+				}
+				limited.SetMaxConcurrency(*v)
 			}
 		}
 

--- a/docs/buildkitd.toml.md
+++ b/docs/buildkitd.toml.md
@@ -212,6 +212,9 @@ provenanceEnvDir = "/etc/buildkit/provenance.d"
 [system]
   # how often buildkit scans for changes in the supported emulated platforms
   platformsCacheMaxAge = "1h"
+  # maxRegistryConcurrency sets the maximum number of concurrent connections
+  # per registry. If unset, the default concurrency limit is used.
+  maxRegistryConcurrency = 4
 
 
 # optional signed cache configuration for GitHub Actions backend

--- a/util/resolver/limited/group.go
+++ b/util/resolver/limited/group.go
@@ -46,16 +46,7 @@ func (r *req) acquire(ctx context.Context, desc ocispecs.Descriptor) (context.Co
 	// json request get one additional connection
 	highPriority := strings.HasSuffix(desc.MediaType, "+json")
 
-	r.g.mu.Lock()
-	s, ok := r.g.sem[r.ref]
-	if !ok {
-		s = [2]*semaphore.Weighted{
-			semaphore.NewWeighted(int64(r.g.size)),
-			semaphore.NewWeighted(int64(r.g.size + 1)),
-		}
-		r.g.sem[r.ref] = s
-	}
-	r.g.mu.Unlock()
+	s := r.g.getOrInit(r.ref)
 	if !highPriority {
 		if err := s[0].Acquire(ctx, 1); err != nil {
 			return ctx, nil, err
@@ -84,6 +75,26 @@ func New(size int) *Group {
 
 func (g *Group) req(ref string) *req {
 	return &req{g: g, ref: domain(ref)}
+}
+
+func (g *Group) getOrInit(domain string) [2]*semaphore.Weighted {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	s, ok := g.sem[domain]
+	if !ok {
+		s = [2]*semaphore.Weighted{
+			semaphore.NewWeighted(int64(g.size)),
+			semaphore.NewWeighted(int64(g.size + 1)),
+		}
+		g.sem[domain] = s
+	}
+	return s
+}
+
+// SetMaxConcurrency sets the default maximum concurrency for the default group.
+func SetMaxConcurrency(size int) {
+	Default = New(size)
 }
 
 func (g *Group) WrapFetcher(f remotes.Fetcher, ref string) remotes.Fetcher {


### PR DESCRIPTION
Adds a new field to the system configuration that sets the maximum
concurrency for registry connections.

Alternate to #6769.
