### PR TITLE
chore: fix duplicated words in llb, executor and dockerfile_test comments

### DIFF
--- a/client/llb/fileop.go
+++ b/client/llb/fileop.go
@@ -49,7 +49,7 @@ func NewFileOp(s State, action *FileAction, c Constraints) *FileOp {
 }
 
 // CopyInput is either llb.State or *FileActionWithState
-// It is used by [Copy] to to specify the source of the copy operation.
+// It is used by [Copy] to specify the source of the copy operation.
 type CopyInput interface {
 	isFileOpCopyInput()
 }

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -607,7 +607,7 @@ type procHandle struct {
 	ready          chan struct{}
 	ended          chan struct{}
 	shutdown       func(error)
-	// this this only used when the request context is canceled and we need
+	// this only used when the request context is canceled and we need
 	// to kill the in-container process.
 	killer procKiller
 }

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -4356,7 +4356,7 @@ USER nobody
 	require.Equal(t, "nobody", ociimg.Config.User)
 }
 
-// testUserAdditionalGids ensures that that the primary GID is also included in the additional GID list.
+// testUserAdditionalGids ensures that the primary GID is also included in the additional GID list.
 // CVE-2023-25173: https://github.com/advisories/GHSA-hmfx-3pcx-653p
 func testUserAdditionalGids(t *testing.T, sb integration.Sandbox) {
 	integration.SkipOnPlatform(t, "windows", "Tests Unix GID behavior using id command and /etc/passwd, not applicable to Windows")


### PR DESCRIPTION
Three small comment-only typos in source: doubled `to to` in `client/llb/fileop.go`, doubled `this this` in `executor/runcexecutor/executor.go`, and doubled `that that` in `frontend/dockerfile/dockerfile_test.go`. No functional change.