### PR TITLE
runcexecutor: change how the runc executor kills runc processes

### DIFF
--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -643,28 +643,12 @@ func runcProcessHandle(ctx context.Context, killer procKiller) (*procHandle, con
 			}
 		}
 
-		for {
-			select {
-			case <-ctx.Done():
-				killCtx, timeout := context.WithCancelCause(context.WithoutCancel(ctx))                                   //nolint:govet
-				killCtx, _ = context.WithTimeoutCause(killCtx, 7*time.Second, errors.WithStack(context.DeadlineExceeded)) //nolint:govet
-				if err := p.killer.Kill(killCtx); err != nil {
-					select {
-					case <-killCtx.Done():
-						cancel(errors.WithStack(context.Cause(ctx)))
-						return //nolint:govet
-					default:
-					}
-				}
-				timeout(errors.WithStack(context.Canceled))
-				select {
-				case <-time.After(50 * time.Millisecond):
-				case <-p.ended:
-					return
-				}
-			case <-p.ended:
-				return
+		select {
+		case <-ctx.Done():
+			if err := doKillProc(ctx, p); err != nil {
+				cancel(err)
 			}
+		case <-p.ended:
 		}
 	}()
 
@@ -758,4 +742,50 @@ func handleSignals(ctx context.Context, runcProcess *procHandle, signals <-chan 
 			}
 		}
 	}
+}
+
+const killWaitDelay = 50 * time.Millisecond
+
+func doKillProc(ctx context.Context, p *procHandle) error {
+	// Attempt to kill the process normally.
+	for {
+		didSucceed := true
+
+		killCtx, timeout := context.WithTimeoutCause(context.WithoutCancel(ctx), 7*time.Second, errors.WithStack(context.DeadlineExceeded))
+		if err := p.killer.Kill(killCtx); err != nil {
+			if contextErr := context.Cause(ctx); contextErr != nil {
+				timeout()
+				return contextErr
+			}
+			didSucceed = false
+		}
+		timeout()
+
+		if didSucceed {
+			// The kill was successful so exit this for loop.
+			break
+		}
+
+		// The kill did not succeed and the context wasn't canceled.
+		// Either wait for the ended signal or try again in 50 milliseconds.
+		select {
+		case <-p.ended:
+			return nil
+		case <-time.After(killWaitDelay):
+		}
+	}
+
+	// Wait for the process to end. Track how long it takes.
+	start := time.Now()
+	select {
+	case <-p.ended:
+		return nil
+	case <-time.After(killWaitDelay):
+		bklog.G(ctx).Warnf("container id %s is taking a long time to exit after kill", p.killer.id)
+	}
+
+	// We have warned about the slow exit. Just wait for it to exit instead of spamming the logs.
+	<-p.ended
+	bklog.G(ctx).Warnf("container id %s took %s to exit", p.killer.id, time.Since(start))
+	return nil
 }


### PR DESCRIPTION

Change how the runc executor kills runc processes by removing the
previous warning message that occurred every 50 milliseconds with a bit
more precision in how it sends the warning.

The previous version could potentially successfully kill the runc
process and then the runc process could take some time to exit. It would
spam the logs every 50 milliseconds until the process exited and would
attempt to rekill a container that was already marked as killed.

This change makes it so we detect a successful kill. If we detect a
successful kill, we then wait for the process while writing a warning to
the log that the process is taking a long time to end. We print one
message 50 milliseconds after the kill and then an additional one with
the exact time it took to exit after the exit succeeds.

If the kill is not successful, we stay in the same loop as previously
existed.

Related to #4483.
