### PR TITLE
exporter/containerimage: default oci-mediatypes to true in image exporter

### DIFF
--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -77,6 +77,7 @@ func (e *imageExporter) Resolve(ctx context.Context, id int, opt map[string]stri
 			RefCfg: cacheconfig.RefConfig{
 				Compression: compression.New(compression.Default),
 			},
+			OCITypes:                true,
 			ForceInlineAttestations: true,
 		},
 		store: true,


### PR DESCRIPTION
Fixes #6094

The `oci-mediatypes` option should default to `true` per documentation, but the image exporter's `ImageCommitOpts` was not initializing `OCITypes` to `true`. The `parseBoolWithDefault` in `opts.go` only applies the default when the key is present with an empty value, so when the user doesn't pass `--oci-mediatypes` at all, `OCITypes` stays `false` (Go zero value).

This differs from the OCI exporter (`exporter/oci/export.go`) which correctly sets `OCITypes: e.opt.Variant == VariantOCI`.

Signed-off-by: Abdulazez A. <abzaeko@gmail.com>