### PR TITLE
Add docs for `HTTP_AUTH_HEADER_` and `HTTP_AUTH_TOKEN_` secrets.

### DIFF
--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -1502,6 +1502,12 @@ If your URL files are protected using authentication, you need to use `RUN wget`
 `RUN curl` or use another tool from within the container as the `ADD` instruction
 doesn't support authentication.
 
+##### Secrets
+
+You can use the `HTTP_AUTH_HEADER_<host>` and `HTTP_AUTH_TOKEN_<host>` secrets
+to set credentials for remote sources. For more information, see
+[Build secrets](https://docs.docker.com/build/building/secrets/#http-authentication-for-add).
+
 #### Adding files from a Git repository
 
 To use a Git repository as the source for `ADD`, you can reference the


### PR DESCRIPTION
- relates to https://github.com/moby/buildkit/pull/6023
- https://github.com/docker/docs/pull/25092

Just a little follow up on https://github.com/docker/docs/pull/25092 to make it more discoverable, just if of use :-)