### PR TITLE
Prefer WithReadonlyTempMount for diff reads

### DIFF
--- a/util/overlay/overlay_linux.go
+++ b/util/overlay/overlay_linux.go
@@ -123,8 +123,8 @@ func WriteUpperdir(ctx context.Context, w io.Writer, upperdir string, lower []mo
 			Options: []string{fmt.Sprintf("lowerdir=%s", strings.Join([]string{upperdir, emptyLower}, ":"))},
 		},
 	}
-	return mount.WithTempMount(ctx, lower, func(lowerRoot string) error {
-		return mount.WithTempMount(ctx, upperView, func(upperViewRoot string) error {
+	return mount.WithReadonlyTempMount(ctx, lower, func(lowerRoot string) error {
+		return mount.WithReadonlyTempMount(ctx, upperView, func(upperViewRoot string) error {
 			cw := archive.NewChangeWriter(&cancellableWriter{ctx, w}, upperViewRoot)
 			if err := Changes(ctx, cw.HandleChange, upperdir, upperViewRoot, lowerRoot); err != nil {
 				if err2 := cw.Close(); err2 != nil {

--- a/util/overlay/overlay_linux_test.go
+++ b/util/overlay/overlay_linux_test.go
@@ -413,7 +413,7 @@ func collectAndCheckChanges(t *testing.T, base, upperdir string, expected []Test
 			Options: []string{fmt.Sprintf("lowerdir=%s", strings.Join([]string{upperdir, emptyLower}, ":"))},
 		},
 	}
-	return mount.WithTempMount(ctx, upperView, func(upperViewRoot string) error {
+	return mount.WithReadonlyTempMount(ctx, upperView, func(upperViewRoot string) error {
 		if err := Changes(ctx, func(k fs.ChangeKind, p string, f os.FileInfo, err error) error {
 			if err != nil {
 				return err

--- a/util/winlayers/differ.go
+++ b/util/winlayers/differ.go
@@ -70,8 +70,8 @@ func (s *winDiffer) Compare(ctx context.Context, lower, upper []mount.Mount, opt
 	}
 
 	var ocidesc ocispecs.Descriptor
-	if err := mount.WithTempMount(ctx, lower, func(lowerRoot string) error {
-		return mount.WithTempMount(ctx, upper, func(upperRoot string) error {
+	if err := mount.WithReadonlyTempMount(ctx, lower, func(lowerRoot string) error {
+		return mount.WithReadonlyTempMount(ctx, upper, func(upperRoot string) error {
 			var newReference bool
 			if config.Reference == "" {
 				newReference = true


### PR DESCRIPTION
- _maybe_ helps with https://github.com/moby/moby/issues/52431

WriteUpperdir and winDiffer.Compare nest two WithTempMount calls. If the inner mount shares any backing directory with the outer one (e.g. the inner mount's lower is a subset of the outer's lowers), mounting the same upperdir read-write twice concurrently is undefined behavior on overlayfs.

WithReadonlyTempMount strips upperdir/workdir from overlay mounts, so the kernel never sets up the writable side and the two mounts cannot collide.

Also, mounting them read-only better expresses intent and prevents accidental writes from inside the callback.