### PR TITLE
docs: fix COPY --exclude wording

### DIFF
--- a/frontend/dockerfile/docs/reference.md
+++ b/frontend/dockerfile/docs/reference.md
@@ -2068,7 +2068,7 @@ COPY --exclude=*.txt hom* /mydir/
 ```
 
 You can specify the `--exclude` option multiple times for a `COPY` instruction.
-Multiple `--excludes` are files matching its patterns not to be copied,
+Multiple `--exclude` options match files whose patterns should not be copied,
 even if the files paths match the pattern specified in `<src>`.
 To add all files starting with "hom", excluding files with either `.txt` or `.md` extensions:
 


### PR DESCRIPTION
## Summary
Fix the `COPY --exclude` reference docs to use the singular option name consistently.

## Why
The `COPY --exclude` section currently says `--excludes`, but the documented syntax, parser flags, and tests all use `--exclude`.

## Tests
- `git diff --check`
- Verified docs context in `frontend/dockerfile/docs/reference.md`
- Verified parser flag registration uses `AddStrings("exclude")` in `frontend/dockerfile/instructions/parse.go`
