### PR TITLE
disable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 # https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Questions and Discussions
     url: https://github.com/moby/buildkit/discussions/new


### PR DESCRIPTION
Disables blank issues as a global option. This should be paired with enabling only for maintainers.

See [moby/moby](https://gtihub.com/moby/moby/issues) as an example.