### PR TITLE
fix: remove volatile flag in temp mount

### DIFF
--- a/cache/refs.go
+++ b/cache/refs.go
@@ -1808,6 +1808,8 @@ func (sm *sharableMountable) Mount() (_ []mount.Mount, _ func() error, retErr er
 				return nil, nil, err
 			}
 		}
+
+		mounts = mount.RemoveVolatileOption(mounts)
 		if err := mount.All(mounts, dir); err != nil {
 			return nil, nil, err
 		}

--- a/snapshot/localmounter_linux.go
+++ b/snapshot/localmounter_linux.go
@@ -37,6 +37,8 @@ func (lm *localMounter) Mount() (string, error) {
 		}
 	}
 
+	lm.mounts = mount.RemoveVolatileOption(lm.mounts)
+
 	var isFile bool
 	if len(lm.mounts) == 1 && (lm.mounts[0].Type == "bind" || lm.mounts[0].Type == "rbind") {
 		if !lm.forceRemount {


### PR DESCRIPTION
make buildkit can work with containerd volatile
ref https://github.com/moby/moby/pull/51008
