### PR TITLE
Add Dexfile: a buildkit frontend; to Buildkit README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Currently, the following high-level languages have been implemented for LLB:
 -   [r2d4/llb (JSON Gateway)](https://github.com/r2d4/llb)
 -   [Massé](https://github.com/marxarelli/masse)
 -   [DALEC](https://github.com/project-dalec/dalec)
+-   [Dexfile](https://github.com/dexnore/dexfile)
 -   (open a PR to add your own language)
 
 ### Exploring Dockerfiles


### PR DESCRIPTION
Dexfile is a BuildKit frontend built on top of Dockerfile. Every valid Dockerfile is also a valid Dexfile, but Dexfile extends the syntax with powerful new instructions for conditional logic, modularity, and advanced build workflows.

Like Docker, Dexfile allows you to define how images are built through a text-based file. It translates source code into build artifacts in an efficient, expressive, and repeatable way—ideal for modern CI/CD pipelines and platform operators.