### PR TITLE
network: split exec proxy from net mode

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -319,6 +319,15 @@ func testIntegration(t *testing.T, funcs ...func(t *testing.T, sb integration.Sa
 		}),
 	)
 
+	integration.Run(t, integration.TestFuncs(
+		testProxyNetworkModesNoRootless,
+	),
+		mirrors,
+		integration.WithMatrix("netmode", map[string]any{
+			"bridge": proxyBridgeNetwork,
+		}),
+	)
+
 	integration.Run(
 		t,
 		integration.TestFuncs(testBridgeNetworkingDNSNoRootless),
@@ -12740,6 +12749,21 @@ func (*netModeHost) UpdateConfigFile(in string) (string, func() error) {
 	return in + "\n\ninsecure-entitlements = [\"network.host\"]\n", nil
 }
 
+type netModeProxyBridge struct{}
+
+func (*netModeProxyBridge) UpdateConfigFile(in string) (string, func() error) {
+	return in + `
+
+insecure-entitlements = ["network.host"]
+
+[worker.oci]
+networkMode = "bridge"
+
+[worker.containerd]
+networkMode = "bridge"
+`, nil
+}
+
 type netModeDefault struct{}
 
 func (*netModeDefault) UpdateConfigFile(in string) (string, func() error) {
@@ -12765,9 +12789,10 @@ nameservers = ["10.11.0.1"]
 }
 
 var (
-	hostNetwork      integration.ConfigUpdater = &netModeHost{}
-	defaultNetwork   integration.ConfigUpdater = &netModeDefault{}
-	bridgeDNSNetwork integration.ConfigUpdater = &netModeBridgeDNS{}
+	hostNetwork        integration.ConfigUpdater = &netModeHost{}
+	defaultNetwork     integration.ConfigUpdater = &netModeDefault{}
+	proxyBridgeNetwork integration.ConfigUpdater = &netModeProxyBridge{}
+	bridgeDNSNetwork   integration.ConfigUpdater = &netModeBridgeDNS{}
 )
 
 func fixedWriteCloser(wc io.WriteCloser) filesync.FileOutputFunc {

--- a/client/policy_test.go
+++ b/client/policy_test.go
@@ -31,6 +31,7 @@ import (
 	opspb "github.com/moby/buildkit/solver/pb"
 	sourcepolicypb "github.com/moby/buildkit/sourcepolicy/pb"
 	"github.com/moby/buildkit/sourcepolicy/policysession"
+	"github.com/moby/buildkit/util/entitlements"
 	"github.com/moby/buildkit/util/pgpsign"
 	"github.com/moby/buildkit/util/testutil/integration"
 	"github.com/moby/buildkit/util/testutil/workers"
@@ -51,7 +52,7 @@ func testProxyNetworkNoRootless(t *testing.T, sb integration.Sandbox) {
 
 	payload := []byte("buildkit proxy ok\n")
 	convertedPayload := []byte("buildkit proxy converted ok\n")
-	httpSrv, httpURL := newProxyReachableHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	httpSrv, httpURL := newProxyHTTPServer(t, "0.0.0.0", testHostIP(t), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/allowed":
 			_, _ = w.Write(payload)
@@ -64,7 +65,7 @@ func testProxyNetworkNoRootless(t *testing.T, sb integration.Sandbox) {
 	}))
 	defer httpSrv.Close()
 	var leakHit atomic.Int32
-	leakSrv, leakURL := newProxyReachableHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	leakSrv, leakURL := newProxyHTTPServer(t, "0.0.0.0", testHostIP(t), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		leakHit.Add(1)
 		_, _ = w.Write([]byte("host namespace leak\n"))
 	}))
@@ -250,17 +251,126 @@ func testProxyNetworkNoRootless(t *testing.T, sb integration.Sandbox) {
 	require.Equal(t, "unsuccessful_response", materialsErr.Incomplete[0].Reason)
 }
 
-func newProxyReachableHTTPServer(t *testing.T, handler http.Handler) (*httptest.Server, string) {
+func testProxyNetworkModesNoRootless(t *testing.T, sb integration.Sandbox) {
+	integration.SkipOnPlatform(t, "windows")
+	workers.CheckFeatureCompat(t, sb, workers.FeatureCNINetwork)
+	if os.Getenv("BUILDKIT_RUN_NETWORK_INTEGRATION_TESTS") == "" {
+		t.SkipNow()
+	}
+	if sb.Rootless() {
+		t.SkipNow()
+	}
+
+	ctx := sb.Context()
+	c, err := New(ctx, sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	hostPayload := []byte("proxy host ok\n")
+	var hostHit atomic.Int32
+	hostSrv, hostURL := newProxyHTTPServer(t, "127.0.0.1", "127.0.0.1", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hostHit.Add(1)
+		if r.URL.Path != "/host" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write(hostPayload)
+	}))
+	defer hostSrv.Close()
+	hostPath := hostURL + "/host"
+
+	internetURL := "http://example.com/"
+	allowedHost := []string{entitlements.EntitlementNetworkHost.String()}
+
+	// Host mode without the network.host entitlement should be rejected before exec starts.
+	hostWithoutEntitlement := llb.Image("alpine:latest").
+		Run(llb.Shlexf(`wget -q -O- %s`, hostPath), llb.Network(llb.NetModeHost), llb.IgnoreCache).
+		Root()
+	def, err := hostWithoutEntitlement.Marshal(ctx)
+	require.NoError(t, err)
+	_, err = c.Solve(ctx, def, SolveOpt{
+		ProxyNetwork: true,
+	}, nil)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "network.host is not allowed")
+	require.Equal(t, int32(0), hostHit.Load())
+
+	runProxySolve := func(name string, st llb.State, allowedEntitlements []string) (string, error) {
+		t.Helper()
+		def, err := st.Marshal(ctx)
+		require.NoError(t, err, name)
+
+		statusCh := make(chan *SolveStatus)
+		logsCh := make(chan string, 1)
+		go func() {
+			var b strings.Builder
+			for st := range statusCh {
+				for _, l := range st.Logs {
+					b.Write(l.Data)
+				}
+			}
+			logsCh <- b.String()
+		}()
+
+		_, err = c.Solve(ctx, def, SolveOpt{
+			ProxyNetwork:        true,
+			AllowedEntitlements: allowedEntitlements,
+		}, statusCh)
+		return <-logsCh, err
+	}
+
+	// Bridge proxy egress should allow normal external network access.
+	logOutput, err := runProxySolve("bridge internet", llb.Image("alpine:latest").
+		Run(llb.Shlexf(`wget -q -O /tmp/internet %s`, internetURL), llb.IgnoreCache).
+		Root(), nil)
+	require.NoError(t, err)
+	require.Contains(t, logOutput, "proxy network requests:\n- GET "+internetURL+" -> 200")
+	require.Equal(t, int32(0), hostHit.Load())
+
+	// Bridge proxy egress should not reach services bound to buildkitd host loopback.
+	logOutput, err = runProxySolve("bridge host", llb.Image("alpine:latest").
+		// Clear NO_PROXY so the localhost URL is forced through the BuildKit proxy.
+		Run(llb.Shlexf(`sh -c '! env NO_PROXY= no_proxy= wget -T 2 -q -O- %s'`, hostPath), llb.IgnoreCache).
+		Root(), nil)
+	require.NoError(t, err)
+	require.Contains(t, logOutput, "proxy network requests:\n- GET "+hostPath+" -> 502")
+	require.Equal(t, int32(0), hostHit.Load())
+
+	// Host proxy egress is allowed only with the network.host entitlement.
+	logOutput, err = runProxySolve("host allowed", llb.Image("alpine:latest").
+		Run(llb.Shlexf(`sh -c 'env NO_PROXY= no_proxy= wget -q -O- %s | grep "proxy host ok"'`, hostPath), llb.Network(llb.NetModeHost), llb.IgnoreCache).
+		Root(), allowedHost)
+	require.NoError(t, err)
+	require.Contains(t, logOutput, "proxy network requests:\n- GET "+hostPath+" -> 200")
+	require.Equal(t, int32(1), hostHit.Load())
+
+	// None mode should not inject proxy env or allow external network access.
+	logOutput, err = runProxySolve("none internet", llb.Image("alpine:latest").
+		Run(llb.Shlexf(`sh -c '! env | grep -i "^HTTP_PROXY="; ! wget -T 2 -q -O- %s'`, internetURL), llb.Network(llb.NetModeNone), llb.IgnoreCache).
+		Root(), nil)
+	require.NoError(t, err)
+	require.NotContains(t, logOutput, internetURL)
+
+	// None mode should also be unable to reach buildkitd host loopback.
+	logOutput, err = runProxySolve("none host", llb.Image("alpine:latest").
+		Run(llb.Shlexf(`sh -c '! env | grep -i "^HTTP_PROXY="; ! wget -T 2 -q -O- %s'`, hostPath), llb.Network(llb.NetModeNone), llb.IgnoreCache).
+		Root(), nil)
+	require.NoError(t, err)
+	require.NotContains(t, logOutput, hostPath)
+	require.Equal(t, int32(1), hostHit.Load())
+}
+
+func newProxyHTTPServer(t *testing.T, listenHost, urlHost string, handler http.Handler) (*httptest.Server, string) {
 	t.Helper()
 	var lc net.ListenConfig
-	ln, err := lc.Listen(t.Context(), "tcp4", "0.0.0.0:0")
+	ln, err := lc.Listen(t.Context(), "tcp4", net.JoinHostPort(listenHost, "0"))
 	require.NoError(t, err)
 	srv := httptest.NewUnstartedServer(handler)
 	srv.Listener = ln
 	srv.Start()
 	_, port, err := net.SplitHostPort(ln.Addr().String())
 	require.NoError(t, err)
-	return srv, "http://" + net.JoinHostPort(testHostIP(t), port)
+	return srv, "http://" + net.JoinHostPort(urlHost, port)
 }
 
 func testHostIP(t *testing.T) string {

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -1,0 +1,131 @@
+# Build proxy network
+
+BuildKit can run exec network traffic through a BuildKit-owned HTTP(S) proxy.
+
+The proxy network is controlled by solve or daemon configuration. Once proxy is
+enabled for a build, BuildKit applies it to every exec that has network access.
+The exec network mode controls how the proxy itself reaches the network.
+
+## Enabling proxy networking
+
+Enable proxy networking for a single build with `buildctl build`:
+
+```bash
+buildctl build --proxy-network ...
+```
+
+Enable proxy networking by default in `buildkitd.toml`:
+
+```toml
+proxyNetwork = true
+```
+
+Or enable it with the daemon flag:
+
+```bash
+buildkitd --proxy-network
+```
+
+The per-build setting and the daemon setting both enable the same runtime proxy
+behavior. Frontends do not set proxy networking per operation.
+
+## Network mode behavior
+
+The exec network mode describes the network access requested by the build step.
+With proxy networking enabled, BuildKit uses that mode to choose the proxy
+egress path.
+
+| Exec network mode | Proxy behavior |
+| --- | --- |
+| default sandbox | Proxy is injected. The proxy reaches the network through a bridge/CNI-style namespace, not through the `buildkitd` host namespace. This is intended for normal internet access and does not expose host loopback services. |
+| host | Proxy is injected. The proxy reaches the network from the `buildkitd` host namespace. This requires the normal `network.host` entitlement on both the daemon and solve request. |
+| none | Proxy is not injected. The exec has no network access. |
+
+For example, a Dockerfile step using the default network can fetch external
+URLs through the proxy:
+
+```dockerfile
+RUN wget -O- https://example.com/
+```
+
+A step that needs to access a service on the `buildkitd` host network must
+request host networking:
+
+```dockerfile
+RUN --network=host wget -O- http://127.0.0.1:8080/
+```
+
+The build also needs the host network entitlement:
+
+```bash
+buildkitd --proxy-network --allow-insecure-entitlement network.host
+buildctl build --proxy-network --allow network.host ...
+```
+
+`RUN --network=none` remains fully offline:
+
+```dockerfile
+RUN --network=none wget -O- https://example.com/
+```
+
+## What BuildKit injects
+
+For proxied execs, BuildKit injects proxy environment variables into the exec
+process:
+
+```text
+HTTP_PROXY
+HTTPS_PROXY
+http_proxy
+https_proxy
+NO_PROXY
+no_proxy
+```
+
+`NO_PROXY` includes local loopback names and addresses, so direct localhost
+traffic from the process is not sent through the proxy by default. If the
+process clears `NO_PROXY`, localhost requests are sent to the proxy and then
+handled according to the exec network mode.
+
+BuildKit also injects a generated CA certificate into common Linux trust bundle
+locations for the duration of the exec. This lets HTTPS requests using the
+system trust store pass through the BuildKit proxy.
+
+## Request capture and logs
+
+The proxy records network requests made by exec steps. Build output includes a
+summary like:
+
+```text
+proxy network requests:
+- GET https://example.com/ -> 200
+- GET http://127.0.0.1:8080/ -> 502
+```
+
+Successful GET responses can be captured as build materials. When provenance is
+requested, these captured materials are added to the provenance dependency list
+with proxy network metadata. If a GET request cannot be captured completely,
+BuildKit can report it as an incomplete proxy material in provenance metadata.
+
+## Source policy
+
+Proxy requests use BuildKit source policy checks. The proxy evaluates
+proxy-visible HTTP(S) requests as synthesized HTTP source ops, so policy can be
+used to allow, deny, or convert matching proxy GET URLs. Conversion currently
+applies to GET requests where only the URL is changed.
+
+This keeps proxy network access aligned with the same policy model used for
+other BuildKit sources.
+
+## Scope and limitations
+
+The proxy network feature currently applies to exec traffic. It does not replace
+image resolver, Git, HTTP source, or other non-exec fetch paths.
+
+The current implementation is Linux-focused. Rootless workers also have the
+usual rootless networking limitations, where worker networking may behave like
+host networking.
+
+Applications that ignore `HTTP_PROXY` and `HTTPS_PROXY`, use custom trust
+stores, or open raw TCP connections cannot bypass the proxy. That traffic is
+blocked instead of being captured.

--- a/executor/containerdexecutor/executor.go
+++ b/executor/containerdexecutor/executor.go
@@ -33,6 +33,7 @@ type containerdExecutor struct {
 	client           *ctd.Client
 	root             string
 	networkProviders map[pb.NetMode]network.Provider
+	proxyProvider    network.ProxyProvider
 	cgroupParent     string
 	dnsConfig        *oci.DNSConfig
 	running          map[string]*containerState
@@ -70,6 +71,7 @@ type ExecutorOptions struct {
 	Root             string
 	CgroupParent     string
 	NetworkProviders map[pb.NetMode]network.Provider
+	ProxyProvider    network.ProxyProvider
 	DNSConfig        *oci.DNSConfig
 	ApparmorProfile  string
 	Selinux          bool
@@ -90,6 +92,7 @@ func New(executorOpts ExecutorOptions) executor.Executor {
 		client:           executorOpts.Client,
 		root:             executorOpts.Root,
 		networkProviders: executorOpts.NetworkProviders,
+		proxyProvider:    executorOpts.ProxyProvider,
 		cgroupParent:     executorOpts.CgroupParent,
 		dnsConfig:        executorOpts.DNSConfig,
 		running:          make(map[string]*containerState),
@@ -147,9 +150,22 @@ func (w *containerdExecutor) Run(ctx context.Context, id string, root executor.M
 		bklog.G(ctx).Info("enabling HostNetworking")
 	}
 
-	provider, ok := w.networkProviders[meta.NetMode]
-	if !ok {
-		return nil, errors.Errorf("unknown network mode %s", meta.NetMode)
+	proxyConfig := meta.Proxy
+	var provider network.Provider
+	if proxyConfig == nil {
+		var ok bool
+		provider, ok = w.networkProviders[meta.NetMode]
+		if !ok {
+			return nil, errors.Errorf("unknown network mode %s", meta.NetMode)
+		}
+	} else if w.proxyProvider == nil {
+		return nil, errors.New("proxy network provider is not available")
+	} else {
+		proxyConfig = &network.ProxyConfig{
+			Policy:     proxyConfig.Policy,
+			Capture:    proxyConfig.Capture,
+			EgressMode: meta.NetMode,
+		}
 	}
 
 	resolvConf, hostsFile, releasers, err := w.prepareExecutionEnv(ctx, root, mounts, meta, details, meta.NetMode)
@@ -165,10 +181,12 @@ func (w *containerdExecutor) Run(ctx context.Context, id string, root executor.M
 		return nil, err
 	}
 
-	namespace, err := provider.New(ctx, meta.Hostname, network.NamespaceOptions{
-		ProxyPolicy:  meta.ProxyPolicy,
-		ProxyCapture: meta.ProxyCapture,
-	})
+	var namespace network.Namespace
+	if proxyConfig != nil {
+		namespace, err = w.proxyProvider.NewProxy(ctx, proxyConfig)
+	} else {
+		namespace, err = provider.New(ctx, meta.Hostname, network.NamespaceOptions{})
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -29,8 +29,7 @@ type Meta struct {
 	NetMode        pb.NetMode
 	SecurityMode   pb.SecurityMode
 	ValidExitCodes []int
-	ProxyPolicy    network.ProxyPolicy
-	ProxyCapture   *network.ProxyCapture
+	Proxy          *network.ProxyConfig
 
 	RemoveMountStubsRecursive bool
 }

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -59,6 +59,7 @@ type Opt struct {
 	TracingSocket   string
 	ResourceMonitor *resources.Monitor
 	CDIManager      *cdidevices.Manager
+	ProxyProvider   network.ProxyProvider
 }
 
 var defaultCommandCandidates = []string{"buildkit-runc", "runc"}
@@ -69,6 +70,7 @@ type runcExecutor struct {
 	cgroupParent     string
 	rootless         bool
 	networkProviders map[pb.NetMode]network.Provider
+	proxyProvider    network.ProxyProvider
 	processMode      oci.ProcessMode
 	idmap            *user.IdentityMapping
 	noPivot          bool
@@ -137,6 +139,7 @@ func New(opt Opt, networkProviders map[pb.NetMode]network.Provider) (executor.Ex
 		cgroupParent:     opt.DefaultCgroupParent,
 		rootless:         opt.Rootless,
 		networkProviders: networkProviders,
+		proxyProvider:    opt.ProxyProvider,
 		processMode:      opt.ProcessMode,
 		idmap:            opt.IdentityMapping,
 		noPivot:          opt.NoPivot,
@@ -183,14 +186,29 @@ func (w *runcExecutor) Run(ctx context.Context, id string, root executor.Mount, 
 		bklog.G(ctx).Info("enabling HostNetworking")
 	}
 
-	provider, ok := w.networkProviders[meta.NetMode]
-	if !ok {
-		return nil, errors.Errorf("unknown network mode %s", meta.NetMode)
+	proxyConfig := meta.Proxy
+	var provider network.Provider
+	if proxyConfig == nil {
+		var ok bool
+		provider, ok = w.networkProviders[meta.NetMode]
+		if !ok {
+			return nil, errors.Errorf("unknown network mode %s", meta.NetMode)
+		}
+	} else if w.proxyProvider == nil {
+		return nil, errors.New("proxy network provider is not available")
+	} else {
+		proxyConfig = &network.ProxyConfig{
+			Policy:     proxyConfig.Policy,
+			Capture:    proxyConfig.Capture,
+			EgressMode: meta.NetMode,
+		}
 	}
-	namespace, err := provider.New(ctx, meta.Hostname, network.NamespaceOptions{
-		ProxyPolicy:  meta.ProxyPolicy,
-		ProxyCapture: meta.ProxyCapture,
-	})
+	var namespace network.Namespace
+	if proxyConfig != nil {
+		namespace, err = w.proxyProvider.NewProxy(ctx, proxyConfig)
+	} else {
+		namespace, err = provider.New(ctx, meta.Hostname, network.NamespaceOptions{})
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/solver/llbsolver/bridge.go
+++ b/solver/llbsolver/bridge.go
@@ -23,6 +23,7 @@ import (
 	spb "github.com/moby/buildkit/sourcepolicy/pb"
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/entitlements"
+	"github.com/moby/buildkit/util/network"
 	"github.com/moby/buildkit/util/progress"
 	"github.com/moby/buildkit/worker"
 	digest "github.com/opencontainers/go-digest"
@@ -175,14 +176,15 @@ func (b *llbBridge) validateEntitlements(p *executor.ProcessInfo) error {
 	}
 	if b.proxyNetwork {
 		switch p.Meta.NetMode {
-		case pb.NetMode_UNSET:
-			p.Meta.NetMode = pb.NetMode_PROXY
-		case pb.NetMode_NONE, pb.NetMode_PROXY:
+		case pb.NetMode_UNSET, pb.NetMode_HOST:
+			if p.Meta.Proxy == nil {
+				p.Meta.Proxy = &network.ProxyConfig{}
+			}
+		case pb.NetMode_NONE:
+			p.Meta.Proxy = nil
 		default:
 			return errors.Errorf("network mode %s is not allowed when proxy network is enabled", p.Meta.NetMode)
 		}
-	} else if p.Meta.NetMode == pb.NetMode_PROXY {
-		return errors.Errorf("network mode %s requires proxy network to be enabled for the build", p.Meta.NetMode)
 	}
 	v := entitlements.Values{
 		NetworkHost:      p.Meta.NetMode == pb.NetMode_HOST,
@@ -199,8 +201,8 @@ func (b *llbBridge) Run(ctx context.Context, id string, rootfs executor.Mount, m
 	if err != nil {
 		return nil, err
 	}
-	if policy != nil {
-		process.Meta.ProxyPolicy = policy
+	if policy != nil && process.Meta.Proxy != nil {
+		process.Meta.Proxy.Policy = policy
 	}
 
 	if err := b.loadExecutor(); err != nil {
@@ -217,8 +219,8 @@ func (b *llbBridge) Exec(ctx context.Context, id string, process executor.Proces
 	if err != nil {
 		return err
 	}
-	if policy != nil {
-		process.Meta.ProxyPolicy = policy
+	if policy != nil && process.Meta.Proxy != nil {
+		process.Meta.Proxy.Policy = policy
 	}
 
 	if err := b.loadExecutor(); err != nil {

--- a/solver/llbsolver/network.go
+++ b/solver/llbsolver/network.go
@@ -1,6 +1,9 @@
 package llbsolver
 
 import (
+	"context"
+
+	"github.com/moby/buildkit/solver"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/sourcepolicy"
 	spb "github.com/moby/buildkit/sourcepolicy/pb"
@@ -8,30 +11,50 @@ import (
 	"github.com/pkg/errors"
 )
 
-func setProxyNetwork(op *pb.Op, proxyNetwork bool) error {
+const keyProxyNetwork = "llb.proxy-network"
+
+func proxyNetworkForOp(op *pb.Op, proxyNetwork bool) (bool, error) {
 	exec := op.GetExec()
 	if exec == nil {
-		return nil
-	}
-	if !proxyNetwork {
-		if exec.Network == pb.NetMode_PROXY {
-			return errors.Errorf("network mode %s requires proxy network to be enabled for the build", exec.Network)
-		}
-		return nil
+		return false, nil
 	}
 	switch exec.Network {
-	case pb.NetMode_UNSET:
-		exec.Network = pb.NetMode_PROXY
-	case pb.NetMode_NONE, pb.NetMode_PROXY:
-		return nil
+	case pb.NetMode_UNSET, pb.NetMode_HOST:
+		return proxyNetwork, nil
+	case pb.NetMode_NONE:
+		return false, nil
 	default:
-		return errors.Errorf("network mode %s is not allowed when proxy network is enabled", exec.Network)
+		if proxyNetwork {
+			return false, errors.Errorf("network mode %s is not allowed when proxy network is enabled", exec.Network)
+		}
+		return false, nil
 	}
-	return nil
 }
 
 func (b *provenanceBridge) ProxyPolicy() (network.ProxyPolicy, error) {
 	return b.llbBridge.ProxyPolicy()
+}
+
+func (b *provenanceBridge) ProxyNetwork() bool {
+	return b.llbBridge.ProxyNetwork()
+}
+
+func (b *llbBridge) ProxyNetwork() bool {
+	return b.proxyNetwork || loadProxyNetwork(b.builder)
+}
+
+func loadProxyNetwork(b solver.Builder) bool {
+	if b == nil {
+		return false
+	}
+	var proxyNetwork bool
+	_ = b.EachValue(context.TODO(), keyProxyNetwork, func(v any) error {
+		if v, ok := v.(bool); ok {
+			proxyNetwork = proxyNetwork || v
+		}
+		return nil
+	})
+	return proxyNetwork
 }
 
 func (b *llbBridge) ProxyPolicy() (network.ProxyPolicy, error) {

--- a/solver/llbsolver/ops/exec.go
+++ b/solver/llbsolver/ops/exec.go
@@ -51,12 +51,13 @@ type ExecOp struct {
 	rec            resourcestypes.Recorder
 	digest         digest.Digest
 	linuxResources *pb.LinuxResources
+	proxyNetwork   bool
 	proxyCap       *network.ProxyCapture
 }
 
 var _ solver.Op = &ExecOp{}
 
-func NewExecOp(v solver.Vertex, op *pb.Op_Exec, platform *pb.Platform, cm cache.Manager, parallelism *semaphore.Weighted, sm *session.Manager, exec executor.Executor, w worker.Worker, linuxResources *pb.LinuxResources) (*ExecOp, error) {
+func NewExecOp(v solver.Vertex, op *pb.Op_Exec, platform *pb.Platform, cm cache.Manager, parallelism *semaphore.Weighted, sm *session.Manager, exec executor.Executor, w worker.Worker, linuxResources *pb.LinuxResources, proxyNetwork bool) (*ExecOp, error) {
 	if err := opsutils.Validate(&pb.Op{Op: op}); err != nil {
 		return nil, err
 	}
@@ -73,6 +74,7 @@ func NewExecOp(v solver.Vertex, op *pb.Op_Exec, platform *pb.Platform, cm cache.
 		parallelism:    parallelism,
 		digest:         v.Digest(),
 		linuxResources: linuxResources,
+		proxyNetwork:   proxyNetwork,
 	}, nil
 }
 
@@ -476,6 +478,9 @@ func (e *ExecOp) Exec(ctx context.Context, jobCtx solver.JobContext, inputs []so
 		SecurityMode:              e.op.Security,
 		RemoveMountStubsRecursive: e.op.Meta.RemoveMountStubsRecursive,
 	}
+	if e.proxyNetwork {
+		meta.Proxy = &network.ProxyConfig{}
+	}
 
 	if e.op.Meta.ProxyEnv != nil {
 		meta.Env = append(meta.Env, proxyEnvList(e.op.Meta.ProxyEnv)...)
@@ -511,9 +516,9 @@ func (e *ExecOp) Exec(ctx context.Context, jobCtx solver.JobContext, inputs []so
 		}
 	}()
 
-	if e.op.Network == pb.NetMode_PROXY {
+	if e.proxyNetwork {
 		e.proxyCap = network.NewProxyCapture()
-		meta.ProxyCapture = e.proxyCap
+		meta.Proxy.Capture = e.proxyCap
 	}
 
 	rec, execErr := e.exec.Run(ctx, "", p.Root, p.Mounts, executor.ProcessInfo{
@@ -637,4 +642,8 @@ func (e *ExecOp) Samples() (*resourcestypes.Samples, error) {
 
 func (e *ExecOp) ProxyCapture() *network.ProxyCapture {
 	return e.proxyCap
+}
+
+func (e *ExecOp) ProxyNetwork() bool {
+	return e.proxyNetwork
 }

--- a/solver/llbsolver/provenance.go
+++ b/solver/llbsolver/provenance.go
@@ -343,7 +343,7 @@ func captureProvenance(ctx context.Context, res solver.CachedResultWithProvenanc
 			if pr.Network != pb.NetMode_NONE {
 				c.NetworkAccess = true
 			}
-			if pr.Network == pb.NetMode_PROXY {
+			if op.ProxyNetwork() {
 				c.ProxyNetwork = true
 				proxyCap := op.ProxyCapture()
 				if proxyCap != nil {

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -148,7 +148,11 @@ func (s *Solver) resolver() solver.ResolveOpFunc {
 		if err != nil {
 			return nil, err
 		}
-		return w.ResolveOp(v, s.Bridge(b), s.sm)
+		br := s.bridge(b)
+		return w.ResolveOp(v, br, s.sm, worker.ProxyOpt{
+			Network: br.ProxyNetwork(),
+			Policy:  br.ProxyPolicy,
+		})
 	}
 }
 
@@ -241,6 +245,9 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 		return nil, err
 	}
 	j.SetValue(keyEntitlements, set)
+	if proxyNetwork {
+		j.SetValue(keyProxyNetwork, true)
+	}
 
 	if srcPol != nil {
 		if err := validateSourcePolicy(srcPol); err != nil {

--- a/solver/llbsolver/vertex.go
+++ b/solver/llbsolver/vertex.go
@@ -247,7 +247,7 @@ func (dpc *detectPrunedCacheID) Load(op *pb.Op, md *pb.OpMetadata, opt *solver.V
 
 func Load(ctx context.Context, def *pb.Definition, polEngine SourcePolicyEvaluator, opts ...LoadOpt) (solver.Edge, error) {
 	return loadLLB(ctx, def, polEngine, nil, func(dgst digest.Digest, op *op, load func(digest.Digest) (solver.Vertex, error)) (solver.Vertex, error) {
-		vtx, err := newVertex(dgst, op.Op, op.Metadata, load, opts...)
+		vtx, err := newVertex(dgst, op, load, opts...)
 		if err != nil {
 			return nil, err
 		}
@@ -257,7 +257,7 @@ func Load(ctx context.Context, def *pb.Definition, polEngine SourcePolicyEvaluat
 
 func loadWithProxyNetwork(ctx context.Context, def *pb.Definition, polEngine SourcePolicyEvaluator, proxyNetwork bool, opts ...LoadOpt) (solver.Edge, error) {
 	return loadLLB(ctx, def, polEngine, &proxyNetwork, func(dgst digest.Digest, op *op, load func(digest.Digest) (solver.Vertex, error)) (solver.Vertex, error) {
-		vtx, err := newVertex(dgst, op.Op, op.Metadata, load, opts...)
+		vtx, err := newVertex(dgst, op, load, opts...)
 		if err != nil {
 			return nil, err
 		}
@@ -278,21 +278,21 @@ func vertexOptions(opMeta *pb.OpMetadata) solver.VertexOptions {
 	return opt
 }
 
-func newVertex(dgst digest.Digest, op *pb.Op, opMeta *pb.OpMetadata, load func(digest.Digest) (solver.Vertex, error), opts ...LoadOpt) (*vertex, error) {
-	opt := vertexOptions(opMeta)
+func newVertex(dgst digest.Digest, op *op, load func(digest.Digest) (solver.Vertex, error), opts ...LoadOpt) (*vertex, error) {
+	opt := vertexOptions(op.Metadata)
 	for _, fn := range opts {
-		if err := fn(op, opMeta, &opt); err != nil {
+		if err := fn(op.Op, op.Metadata, &opt); err != nil {
 			return nil, err
 		}
 	}
 
-	name, err := llbOpName(op, func(dgst string) (solver.Vertex, error) {
+	name, err := llbOpName(op.Op, func(dgst string) (solver.Vertex, error) {
 		return load(digest.Digest(dgst))
 	})
 	if err != nil {
 		return nil, err
 	}
-	vtx := &vertex{sys: op, options: opt, digest: dgst, name: name}
+	vtx := &vertex{sys: op.Op, options: opt, digest: dgst, name: name}
 	for _, in := range op.Inputs {
 		sub, err := load(digest.Digest(in.Digest))
 		if err != nil {
@@ -330,6 +330,9 @@ func recomputeDigests(ctx context.Context, all map[digest.Digest]*op, visited ma
 	if err != nil {
 		return "", err
 	}
+	if op.ProxyNetwork {
+		dt = append(dt, []byte("\x00buildkit.proxy-network.v0")...)
+	}
 
 	newDgst := digest.FromBytes(dt)
 	if newDgst != dgst {
@@ -343,7 +346,8 @@ func recomputeDigests(ctx context.Context, all map[digest.Digest]*op, visited ma
 // op is a private wrapper around pb.Op that includes its metadata.
 type op struct {
 	*pb.Op
-	Metadata *pb.OpMetadata
+	Metadata     *pb.OpMetadata
+	ProxyNetwork bool
 }
 
 // loadLLB loads LLB.
@@ -376,7 +380,9 @@ func loadLLB(ctx context.Context, def *pb.Definition, polEngine SourcePolicyEval
 
 	if proxyNetwork != nil {
 		for _, op := range allOps {
-			if err := setProxyNetwork(op.Op, *proxyNetwork); err != nil {
+			var err error
+			op.ProxyNetwork, err = proxyNetworkForOp(op.Op, *proxyNetwork)
+			if err != nil {
 				return solver.Edge{}, err
 			}
 		}

--- a/solver/llbsolver/vertex_test.go
+++ b/solver/llbsolver/vertex_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/util/entitlements"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -120,15 +121,13 @@ func TestWithProxyNetworkAffectsVertexDigest(t *testing.T) {
 
 	defaultEdge, err := Load(t.Context(), def, nil)
 	require.NoError(t, err)
-	defaultOp, ok := defaultEdge.Vertex.Sys().(*pb.Op)
-	require.True(t, ok)
+	defaultOp := requireVertexOp(t, defaultEdge.Vertex)
 	require.Equal(t, pb.NetMode_UNSET, defaultOp.GetExec().Network)
 
 	proxyEdge, err := loadWithProxyNetwork(t.Context(), def, nil, true)
 	require.NoError(t, err)
-	proxyOp, ok := proxyEdge.Vertex.Sys().(*pb.Op)
-	require.True(t, ok)
-	require.Equal(t, pb.NetMode_PROXY, proxyOp.GetExec().Network)
+	proxyOp := requireVertexOp(t, proxyEdge.Vertex)
+	require.Equal(t, pb.NetMode_UNSET, proxyOp.GetExec().Network)
 
 	require.NotEqual(t, defaultEdge.Vertex.Digest(), proxyEdge.Vertex.Digest())
 }
@@ -141,21 +140,55 @@ func TestNormalizeRuntimePlatformsDoesNotAffectVertexDigest(t *testing.T) {
 
 	normalizedEdge, err := Load(t.Context(), def, nil, NormalizeRuntimePlatforms())
 	require.NoError(t, err)
-	normalizedOp, ok := normalizedEdge.Vertex.Sys().(*pb.Op)
-	require.True(t, ok)
+	normalizedOp := requireVertexOp(t, normalizedEdge.Vertex)
 	require.NotNil(t, normalizedOp.Platform)
 
 	require.Equal(t, defaultEdge.Vertex.Digest(), normalizedEdge.Vertex.Digest())
 }
 
-func TestWithProxyNetworkRejectsExplicitProxyWhenDisabled(t *testing.T) {
+func TestWithProxyNetworkPreservesNoneMode(t *testing.T) {
 	def := proxyNetworkTestDefinition(t, func(exec *pb.ExecOp) {
-		exec.Network = pb.NetMode_PROXY
+		exec.Network = pb.NetMode_NONE
 	})
 
-	_, err := loadWithProxyNetwork(t.Context(), def, nil, false)
+	defaultEdge, err := Load(t.Context(), def, nil)
+	require.NoError(t, err)
+
+	proxyEdge, err := loadWithProxyNetwork(t.Context(), def, nil, true)
+	require.NoError(t, err)
+	proxyOp := requireVertexOp(t, proxyEdge.Vertex)
+	require.Equal(t, pb.NetMode_NONE, proxyOp.GetExec().Network)
+	require.Equal(t, defaultEdge.Vertex.Digest(), proxyEdge.Vertex.Digest())
+}
+
+func TestWithProxyNetworkPreservesHostMode(t *testing.T) {
+	def := proxyNetworkTestDefinition(t, func(exec *pb.ExecOp) {
+		exec.Network = pb.NetMode_HOST
+	})
+
+	defaultEdge, err := Load(t.Context(), def, nil)
+	require.NoError(t, err)
+
+	proxyEdge, err := loadWithProxyNetwork(t.Context(), def, nil, true)
+	require.NoError(t, err)
+	proxyOp := requireVertexOp(t, proxyEdge.Vertex)
+	require.Equal(t, pb.NetMode_HOST, proxyOp.GetExec().Network)
+	require.NotEqual(t, defaultEdge.Vertex.Digest(), proxyEdge.Vertex.Digest())
+}
+
+func TestWithProxyNetworkHostEgressRequiresEntitlement(t *testing.T) {
+	def := proxyNetworkTestDefinition(t, func(exec *pb.ExecOp) {
+		exec.Network = pb.NetMode_HOST
+	})
+
+	_, err := loadWithProxyNetwork(t.Context(), def, nil, true, ValidateEntitlements(entitlements.Set{}, nil))
 	require.Error(t, err)
-	require.ErrorContains(t, err, "requires proxy network to be enabled")
+	require.ErrorContains(t, err, "network.host is not allowed")
+
+	_, err = loadWithProxyNetwork(t.Context(), def, nil, true, ValidateEntitlements(entitlements.Set{
+		entitlements.EntitlementNetworkHost: nil,
+	}, nil))
+	require.NoError(t, err)
 }
 
 func TestBridgeUsesDefaultProxyNetwork(t *testing.T) {
@@ -205,4 +238,11 @@ func marshalTestOp(t *testing.T, op *pb.Op) (digest.Digest, []byte) {
 	dt, err := op.Marshal()
 	require.NoError(t, err)
 	return digest.FromBytes(dt), dt
+}
+
+func requireVertexOp(t *testing.T, v interface{ Sys() any }) *pb.Op {
+	t.Helper()
+	op, ok := v.Sys().(*pb.Op)
+	require.True(t, ok)
+	return op
 }

--- a/solver/pb/ops.pb.go
+++ b/solver/pb/ops.pb.go
@@ -30,7 +30,6 @@ const (
 	NetMode_UNSET NetMode = 0 // sandbox
 	NetMode_HOST  NetMode = 1
 	NetMode_NONE  NetMode = 2
-	NetMode_PROXY NetMode = 3
 )
 
 // Enum value maps for NetMode.
@@ -39,13 +38,11 @@ var (
 		0: "UNSET",
 		1: "HOST",
 		2: "NONE",
-		3: "PROXY",
 	}
 	NetMode_value = map[string]int32{
 		"UNSET": 0,
 		"HOST":  1,
 		"NONE":  2,
-		"PROXY": 3,
 	}
 )
 
@@ -3845,12 +3842,11 @@ const file_github_com_moby_buildkit_solver_pb_ops_proto_rawDesc = "" +
 	"\x05upper\x18\x02 \x01(\v2\x12.pb.UpperDiffInputR\x05upper\"9\n" +
 	"\rPassthroughOp\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
-	"\aoutputs\x18\x02 \x03(\x03R\aoutputs*3\n" +
+	"\aoutputs\x18\x02 \x03(\x03R\aoutputs*(\n" +
 	"\aNetMode\x12\t\n" +
 	"\x05UNSET\x10\x00\x12\b\n" +
 	"\x04HOST\x10\x01\x12\b\n" +
-	"\x04NONE\x10\x02\x12\t\n" +
-	"\x05PROXY\x10\x03*)\n" +
+	"\x04NONE\x10\x02*)\n" +
 	"\fSecurityMode\x12\v\n" +
 	"\aSANDBOX\x10\x00\x12\f\n" +
 	"\bINSECURE\x10\x01*@\n" +

--- a/solver/pb/ops.proto
+++ b/solver/pb/ops.proto
@@ -83,7 +83,6 @@ enum NetMode {
 	UNSET = 0; // sandbox
 	HOST = 1;
 	NONE = 2;
-	PROXY = 3;
 }
 
 enum SecurityMode {

--- a/util/network/cniprovider/cni_linux.go
+++ b/util/network/cniprovider/cni_linux.go
@@ -2,13 +2,14 @@ package cniprovider
 
 import (
 	"context"
+	"net"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
 
-	"github.com/containernetworking/plugins/pkg/ns"
+	netns "github.com/containernetworking/plugins/pkg/ns"
 	resourcestypes "github.com/moby/buildkit/executor/resources/types"
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/pkg/errors"
@@ -90,7 +91,7 @@ func withDetachedNetNSIfAny(ctx context.Context, fn func(context.Context) error)
 		defer root.Close()
 		if _, err := root.Lstat("netns"); err == nil {
 			detachedNetNS := filepath.Join(stateDir, "netns")
-			return ns.WithNetNSPath(detachedNetNS, func(_ ns.NetNS) error {
+			return netns.WithNetNSPath(detachedNetNS, func(_ netns.NetNS) error {
 				ctx := context.WithValue(ctx, contextKeyDetachedNetNS, detachedNetNS)
 				bklog.G(ctx).Debugf("Entering RootlessKit's detached netns %q", detachedNetNS)
 				err2 := fn(ctx)
@@ -102,4 +103,17 @@ func withDetachedNetNSIfAny(ctx context.Context, fn func(context.Context) error)
 		}
 	}
 	return fn(ctx)
+}
+
+func (ns *cniNS) DialContext(ctx context.Context, networkName, address string) (net.Conn, error) {
+	var conn net.Conn
+	err := netns.WithNetNSPath(ns.nativeID, func(_ netns.NetNS) error {
+		var err error
+		conn, err = (&net.Dialer{}).DialContext(ctx, networkName, address)
+		return err
+	})
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return conn, nil
 }

--- a/util/network/host.go
+++ b/util/network/host.go
@@ -4,6 +4,7 @@ package network
 
 import (
 	"context"
+	"net"
 
 	"github.com/containerd/containerd/v2/pkg/oci"
 	resourcestypes "github.com/moby/buildkit/executor/resources/types"
@@ -38,4 +39,8 @@ func (h *hostNS) Close() error {
 
 func (h *hostNS) Sample() (*resourcestypes.NetworkSample, error) {
 	return nil, nil
+}
+
+func (h *hostNS) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	return (&net.Dialer{}).DialContext(ctx, network, address)
 }

--- a/util/network/netproviders/network.go
+++ b/util/network/netproviders/network.go
@@ -18,27 +18,27 @@ type Opt struct {
 
 // Providers returns the network provider set.
 // When opt.Mode is "auto" or "", resolvedMode is set to either "cni" or "host".
-func Providers(opt Opt) (providers map[pb.NetMode]network.Provider, resolvedMode string, err error) {
+func Providers(opt Opt) (providers map[pb.NetMode]network.Provider, proxyProvider network.ProxyProvider, resolvedMode string, err error) {
 	var defaultProvider network.Provider
 	switch opt.Mode {
 	case "cni":
 		cniProvider, err := cniprovider.New(opt.CNI)
 		if err != nil {
-			return nil, resolvedMode, err
+			return nil, nil, resolvedMode, err
 		}
 		defaultProvider = cniProvider
 		resolvedMode = opt.Mode
 	case "host":
 		hostProvider, ok := getHostProvider()
 		if !ok {
-			return nil, resolvedMode, errors.New("no host network support on this platform")
+			return nil, nil, resolvedMode, errors.New("no host network support on this platform")
 		}
 		defaultProvider = hostProvider
 		resolvedMode = opt.Mode
 	case "bridge":
 		bridgeProvider, err := getBridgeProvider(opt.CNI)
 		if err != nil {
-			return nil, resolvedMode, err
+			return nil, nil, resolvedMode, err
 		}
 		defaultProvider = bridgeProvider
 		resolvedMode = "cni"
@@ -46,14 +46,14 @@ func Providers(opt Opt) (providers map[pb.NetMode]network.Provider, resolvedMode
 		if v, err := strconv.ParseBool(os.Getenv("BUILDKIT_NETWORK_BRIDGE_AUTO")); v && err == nil {
 			bridgeProvider, err := getBridgeProvider(opt.CNI)
 			if err != nil {
-				return nil, resolvedMode, err
+				return nil, nil, resolvedMode, err
 			}
 			defaultProvider = bridgeProvider
 			resolvedMode = "cni"
 		} else if _, err := os.Stat(opt.CNI.ConfigPath); err == nil {
 			cniProvider, err := cniprovider.New(opt.CNI)
 			if err != nil {
-				return nil, resolvedMode, err
+				return nil, nil, resolvedMode, err
 			}
 			defaultProvider = cniProvider
 			resolvedMode = "cni"
@@ -61,7 +61,7 @@ func Providers(opt Opt) (providers map[pb.NetMode]network.Provider, resolvedMode
 			defaultProvider, resolvedMode = getFallback()
 		}
 	default:
-		return nil, resolvedMode, errors.Errorf("invalid network mode: %q", opt.Mode)
+		return nil, nil, resolvedMode, errors.Errorf("invalid network mode: %q", opt.Mode)
 	}
 
 	providers = map[pb.NetMode]network.Provider{
@@ -69,19 +69,31 @@ func Providers(opt Opt) (providers map[pb.NetMode]network.Provider, resolvedMode
 		pb.NetMode_NONE:  network.NewNoneProvider(),
 	}
 	if proxyprovider.Supported() {
-		proxyProvider, err := proxyprovider.New(proxyprovider.Opt{
-			Root:     opt.CNI.Root,
-			PoolSize: opt.CNI.PoolSize,
+		proxyEgressProviders := map[pb.NetMode]network.Provider{}
+		var ownedProxyEgressProviders []network.Provider
+		if resolvedMode == "cni" {
+			proxyEgressProviders[pb.NetMode_UNSET] = defaultProvider
+		} else if bridgeProvider, err := getBridgeProvider(opt.CNI); err == nil {
+			proxyEgressProviders[pb.NetMode_UNSET] = bridgeProvider
+			ownedProxyEgressProviders = append(ownedProxyEgressProviders, bridgeProvider)
+		}
+		if hostProvider, ok := getHostProvider(); ok {
+			proxyEgressProviders[pb.NetMode_HOST] = hostProvider
+		}
+		proxyProvider, err = proxyprovider.New(proxyprovider.Opt{
+			Root:                 opt.CNI.Root,
+			PoolSize:             opt.CNI.PoolSize,
+			EgressProviders:      proxyEgressProviders,
+			OwnedEgressProviders: ownedProxyEgressProviders,
 		})
 		if err != nil {
-			return nil, resolvedMode, err
+			return nil, nil, resolvedMode, err
 		}
-		providers[pb.NetMode_PROXY] = proxyProvider
 	}
 
 	if hostProvider, ok := getHostProvider(); ok {
 		providers[pb.NetMode_HOST] = hostProvider
 	}
 
-	return providers, resolvedMode, nil
+	return providers, proxyProvider, resolvedMode, nil
 }

--- a/util/network/network.go
+++ b/util/network/network.go
@@ -3,6 +3,7 @@ package network
 import (
 	"context"
 	"io"
+	"net"
 
 	resourcestypes "github.com/moby/buildkit/executor/resources/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -14,10 +15,7 @@ type Provider interface {
 	New(ctx context.Context, hostname string, opt NamespaceOptions) (Namespace, error)
 }
 
-type NamespaceOptions struct {
-	ProxyPolicy  ProxyPolicy
-	ProxyCapture *ProxyCapture
-}
+type NamespaceOptions struct{}
 
 // Namespace of network for workers
 type Namespace interface {
@@ -26,4 +24,8 @@ type Namespace interface {
 	Set(*specs.Spec) error
 
 	Sample() (*resourcestypes.NetworkSample, error)
+}
+
+type Dialer interface {
+	DialContext(ctx context.Context, network, address string) (net.Conn, error)
 }

--- a/util/network/proxy.go
+++ b/util/network/proxy.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"io"
 	"slices"
 	"sync"
 
@@ -14,9 +15,21 @@ type ProxyPolicy interface {
 	Evaluate(context.Context, *pb.Op) (bool, error)
 }
 
+type ProxyConfig struct {
+	Policy     ProxyPolicy
+	Capture    *ProxyCapture
+	EgressMode pb.NetMode
+}
+
+type ProxyProvider interface {
+	io.Closer
+	NewProxy(ctx context.Context, cfg *ProxyConfig) (ProxyNamespace, error)
+}
+
 // ProxyNamespace is implemented by network namespaces that expose an internal
 // HTTP(S) proxy to the container.
 type ProxyNamespace interface {
+	Namespace
 	ProxyEnv() []string
 	ProxyCACert() []byte
 }

--- a/util/network/proxyprovider/provider_linux.go
+++ b/util/network/proxyprovider/provider_linux.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"maps"
 	"math/big"
 	"net"
 	"net/http"
@@ -24,7 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strconv"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -55,28 +56,32 @@ const (
 )
 
 type Opt struct {
-	Root     string
-	PoolSize int
+	Root                 string
+	PoolSize             int
+	EgressProviders      map[pb.NetMode]network.Provider
+	OwnedEgressProviders []network.Provider
 }
 
 func Supported() bool {
 	return true
 }
 
-func New(opt Opt) (network.Provider, error) {
+func New(opt Opt) (network.ProxyProvider, error) {
 	cleanOldNamespaces(opt.Root)
 	certPEM, ca, key, err := newCA()
 	if err != nil {
 		return nil, err
 	}
 	p := &provider{
-		root:  opt.Root,
-		caPEM: certPEM,
-		ca:    ca,
-		caKey: key,
-		certs: map[string]*certCacheEntry{},
-		lru:   list.New(),
-		client: &http.Transport{
+		root:                 opt.Root,
+		caPEM:                certPEM,
+		ca:                   ca,
+		caKey:                key,
+		certs:                map[string]*certCacheEntry{},
+		lru:                  list.New(),
+		egressProviders:      maps.Clone(opt.EgressProviders),
+		ownedEgressProviders: slices.Clone(opt.OwnedEgressProviders),
+		transport: &http.Transport{
 			Proxy:              nil,
 			DisableCompression: true,
 		},
@@ -105,7 +110,10 @@ type provider struct {
 	certsMu sync.Mutex
 	certs   map[string]*certCacheEntry
 	lru     *list.List
-	client  *http.Transport
+
+	egressProviders      map[pb.NetMode]network.Provider
+	ownedEgressProviders []network.Provider
+	transport            *http.Transport
 }
 
 type certCacheEntry struct {
@@ -117,11 +125,16 @@ type certCacheEntry struct {
 
 func (p *provider) Close() error {
 	err := p.pool.Close()
-	p.client.CloseIdleConnections()
+	p.transport.CloseIdleConnections()
+	for _, provider := range p.ownedEgressProviders {
+		if e := provider.Close(); e != nil && err == nil {
+			err = e
+		}
+	}
 	return err
 }
 
-func (p *provider) New(ctx context.Context, hostname string, opt network.NamespaceOptions) (_ network.Namespace, retErr error) {
+func (p *provider) NewProxy(ctx context.Context, proxy *network.ProxyConfig) (_ network.ProxyNamespace, retErr error) {
 	ns, err := p.pool.Get(ctx)
 	if err != nil {
 		return nil, err
@@ -131,7 +144,7 @@ func (p *provider) New(ctx context.Context, hostname string, opt network.Namespa
 			_ = p.pool.Discard(ns)
 		}
 	}()
-	if err := ns.startProxy(ctx, opt.ProxyPolicy, opt.ProxyCapture); err != nil {
+	if err := ns.startProxy(ctx, proxy); err != nil {
 		return nil, err
 	}
 	return ns, nil
@@ -154,8 +167,8 @@ func (p *provider) newNS(ctx context.Context) (_ *proxyNS, retErr error) {
 		provider:    p,
 		nsPath:      nsPath,
 		proxyNSPath: proxyNSPath,
-		hostName:    ifName("bkpxh", n),
-		ctrName:     ifName("bkpxc", n),
+		hostName:    ifName("bkpxh", id),
+		ctrName:     ifName("bkpxc", id),
 		hostIP:      proxyHostIP(n),
 		ctrIP:       proxyContainerIP(n),
 		prefix:      proxyPrefix(),
@@ -181,8 +194,10 @@ type proxyNS struct {
 	ctrIP       net.IP
 	prefix      int
 
-	server *http.Server
-	ln     net.Listener
+	server    *http.Server
+	ln        net.Listener
+	egressNS  network.Namespace
+	transport *http.Transport
 }
 
 func (n *proxyNS) Set(s *specs.Spec) error {
@@ -215,6 +230,16 @@ func (n *proxyNS) stopProxy() error {
 	}
 	n.server = nil
 	n.ln = nil
+	if n.transport != nil {
+		n.transport.CloseIdleConnections()
+		n.transport = nil
+	}
+	if n.egressNS != nil {
+		if e := n.egressNS.Close(); e != nil && err == nil {
+			err = e
+		}
+		n.egressNS = nil
+	}
 	return err
 }
 
@@ -347,16 +372,37 @@ func (n *proxyNS) setupVeth() error {
 	return errors.WithStack(h.LinkSetUp(lo))
 }
 
-func (n *proxyNS) startProxy(ctx context.Context, policy network.ProxyPolicy, capture *network.ProxyCapture) error {
+func (n *proxyNS) startProxy(ctx context.Context, proxy *network.ProxyConfig) error {
+	if proxy == nil {
+		return errors.New("proxy network config is required")
+	}
 	ln, err := listenInNetNS(ctx, n.proxyNSPath, "tcp4", net.JoinHostPort(n.hostIP.String(), "0"))
 	if err != nil {
 		return errors.WithStack(err)
 	}
 	n.ln = ln
+	egressNS, err := n.egressNamespace(ctx, proxy.EgressMode)
+	if err != nil {
+		_ = ln.Close()
+		n.ln = nil
+		return err
+	}
+	dialer, ok := egressNS.(network.Dialer)
+	if !ok {
+		_ = egressNS.Close()
+		_ = ln.Close()
+		n.ln = nil
+		return errors.Errorf("proxy egress network mode %s does not support dialing", proxy.EgressMode)
+	}
+	n.egressNS = egressNS
+	transport := n.provider.transport.Clone()
+	transport.DialContext = dialer.DialContext
+	n.transport = transport
 	handler := &proxyHandler{
-		provider: n.provider,
-		policy:   policy,
-		capture:  capture,
+		provider:  n.provider,
+		policy:    proxy.Policy,
+		capture:   proxy.Capture,
+		transport: transport,
 	}
 	n.server = &http.Server{
 		Handler:           handler,
@@ -366,6 +412,18 @@ func (n *proxyNS) startProxy(ctx context.Context, policy network.ProxyPolicy, ca
 		_ = n.server.Serve(ln)
 	}()
 	return nil
+}
+
+func (n *proxyNS) egressNamespace(ctx context.Context, mode pb.NetMode) (network.Namespace, error) {
+	provider, ok := n.provider.egressProviders[mode]
+	if !ok {
+		return nil, errors.Errorf("unknown proxy egress network mode %s", mode)
+	}
+	ns, err := provider.New(ctx, "", network.NamespaceOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return ns, nil
 }
 
 func listenInNetNS(ctx context.Context, nsPath, networkName, address string) (net.Listener, error) {
@@ -437,9 +495,10 @@ func (n *proxyNS) deleteVeth() error {
 }
 
 type proxyHandler struct {
-	provider *provider
-	policy   network.ProxyPolicy
-	capture  *network.ProxyCapture
+	provider  *provider
+	policy    network.ProxyPolicy
+	capture   *network.ProxyCapture
+	transport *http.Transport
 }
 
 func (h *proxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -683,7 +742,7 @@ func (h *proxyHandler) roundTrip(r *http.Request) (*http.Response, error) {
 	stripProxyHeaders(r.Header)
 	r.Header.Del("Accept-Encoding")
 	r.RequestURI = ""
-	return h.provider.client.RoundTrip(r.WithContext(context.WithoutCancel(r.Context())))
+	return h.transport.RoundTrip(r.WithContext(context.WithoutCancel(r.Context())))
 }
 
 func (h *proxyHandler) check(ctx context.Context, method, rawURL string) (*neturl.URL, error) {
@@ -913,8 +972,13 @@ func proxyIP(n uint32, offset byte) net.IP {
 	return net.IPv4(10, 89, byte(block/64), byte((block%64)*4)+offset)
 }
 
-func ifName(prefix string, n uint32) string {
-	return prefix + strconv.FormatUint(uint64(n%1000000000), 10)
+func ifName(prefix, id string) string {
+	const ifNameMaxLen = 15
+	maxIDLen := ifNameMaxLen - len(prefix)
+	if len(id) > maxIDLen {
+		id = id[:maxIDLen]
+	}
+	return prefix + id
 }
 
 func stripPort(hostport string) string {

--- a/util/network/proxyprovider/provider_linux_test.go
+++ b/util/network/proxyprovider/provider_linux_test.go
@@ -85,8 +85,8 @@ func TestProxyHandlerRoundTripIgnoresClientContextCancel(t *testing.T) {
 	pool := x509.NewCertPool()
 	pool.AddCert(upstream.Certificate())
 	handler := newTestProxyHandler(t, nil)
-	handler.provider.client.TLSClientConfig = upstream.Client().Transport.(*http.Transport).TLSClientConfig.Clone()
-	handler.provider.client.TLSClientConfig.RootCAs = pool
+	handler.transport.TLSClientConfig = upstream.Client().Transport.(*http.Transport).TLSClientConfig.Clone()
+	handler.transport.TLSClientConfig.RootCAs = pool
 
 	ctx, cancel := context.WithCancelCause(t.Context())
 	cancel(context.Canceled)
@@ -358,8 +358,9 @@ func newTestProxyHandler(t *testing.T, capture *network.ProxyCapture) *proxyHand
 	tr.DisableCompression = true
 	t.Cleanup(tr.CloseIdleConnections)
 	return &proxyHandler{
-		provider: &provider{client: tr},
-		capture:  capture,
+		provider:  &provider{},
+		capture:   capture,
+		transport: tr,
 	}
 }
 

--- a/util/network/proxyprovider/provider_unsupported.go
+++ b/util/network/proxyprovider/provider_unsupported.go
@@ -3,19 +3,22 @@
 package proxyprovider
 
 import (
+	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/network"
 	"github.com/pkg/errors"
 )
 
 type Opt struct {
-	Root     string
-	PoolSize int
+	Root                 string
+	PoolSize             int
+	EgressProviders      map[pb.NetMode]network.Provider
+	OwnedEgressProviders []network.Provider
 }
 
 func Supported() bool {
 	return false
 }
 
-func New(opt Opt) (network.Provider, error) {
+func New(opt Opt) (network.ProxyProvider, error) {
 	return nil, errors.New("proxy network provider is only supported on linux")
 }

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -51,6 +51,7 @@ import (
 	"github.com/moby/buildkit/util/network"
 	"github.com/moby/buildkit/util/progress"
 	"github.com/moby/buildkit/util/progress/controller"
+	"github.com/moby/buildkit/worker"
 	"github.com/moby/sys/user"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -73,6 +74,7 @@ type WorkerOpt struct {
 	GCPolicy         []client.PruneInfo
 	BuildkitVersion  client.BuildkitVersion
 	NetworkProviders map[pb.NetMode]network.Provider
+	ProxyProvider    network.ProxyProvider
 	Executor         executor.Executor
 	Snapshotter      snapshot.Snapshotter
 	ContentStore     *containerdsnapshot.Store
@@ -247,6 +249,11 @@ func (w *Worker) Close() error {
 	if err := w.MetadataStore.Close(); err != nil {
 		errs = append(errs, err)
 	}
+	if w.ProxyProvider != nil {
+		if err := w.ProxyProvider.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
 	for _, provider := range w.NetworkProviders {
 		if err := provider.Close(); err != nil {
 			errs = append(errs, err)
@@ -356,46 +363,42 @@ func (w *Worker) CacheManager() cache.Manager {
 	return w.CacheMgr
 }
 
-type proxyPolicyProvider interface {
-	ProxyPolicy() (network.ProxyPolicy, error)
-}
-
 type proxyPolicyExecutor struct {
 	executor.Executor
-	provider proxyPolicyProvider
+	getProxyPolicy func() (network.ProxyPolicy, error)
 }
 
 func (e *proxyPolicyExecutor) Run(ctx context.Context, id string, rootfs executor.Mount, mounts []executor.Mount, process executor.ProcessInfo, started chan<- struct{}) (resourcestypes.Recorder, error) {
-	if process.Meta.NetMode == pb.NetMode_PROXY {
+	if process.Meta.Proxy != nil {
 		policy, err := e.proxyPolicy()
 		if err != nil {
 			return nil, err
 		}
-		process.Meta.ProxyPolicy = policy
+		process.Meta.Proxy.Policy = policy
 	}
 	return e.Executor.Run(ctx, id, rootfs, mounts, process, started)
 }
 
 func (e *proxyPolicyExecutor) Exec(ctx context.Context, id string, process executor.ProcessInfo) error {
-	if process.Meta.NetMode == pb.NetMode_PROXY {
+	if process.Meta.Proxy != nil {
 		policy, err := e.proxyPolicy()
 		if err != nil {
 			return err
 		}
-		process.Meta.ProxyPolicy = policy
+		process.Meta.Proxy.Policy = policy
 	}
 	return e.Executor.Exec(ctx, id, process)
 }
 
 func (e *proxyPolicyExecutor) proxyPolicy() (network.ProxyPolicy, error) {
-	policy, err := e.provider.ProxyPolicy()
+	policy, err := e.getProxyPolicy()
 	if err != nil {
 		return nil, err
 	}
 	return policy, nil
 }
 
-func (w *Worker) ResolveOp(v solver.Vertex, s frontend.FrontendLLBBridge, sm *session.Manager) (solver.Op, error) {
+func (w *Worker) ResolveOp(v solver.Vertex, s frontend.FrontendLLBBridge, sm *session.Manager, proxyOpt worker.ProxyOpt) (solver.Op, error) {
 	if baseOp, ok := v.Sys().(*pb.Op); ok {
 		switch op := baseOp.Op.(type) {
 		case *pb.Op_Source:
@@ -406,13 +409,13 @@ func (w *Worker) ResolveOp(v solver.Vertex, s frontend.FrontendLLBBridge, sm *se
 				linuxResources = m.LinuxResources
 			}
 			exec := w.WorkerOpt.Executor
-			if op.Exec != nil && op.Exec.Network == pb.NetMode_PROXY {
-				provider, ok := s.(proxyPolicyProvider)
-				if ok {
-					exec = &proxyPolicyExecutor{Executor: exec, provider: provider}
+			proxyNetwork := proxyOpt.Network && op.Exec.Network != pb.NetMode_NONE
+			if proxyNetwork {
+				if proxyOpt.Policy != nil {
+					exec = &proxyPolicyExecutor{Executor: exec, getProxyPolicy: proxyOpt.Policy}
 				}
 			}
-			return ops.NewExecOp(v, op, baseOp.Platform, w.CacheMgr, w.ParallelismSem, sm, exec, w, linuxResources)
+			return ops.NewExecOp(v, op, baseOp.Platform, w.CacheMgr, w.ParallelismSem, sm, exec, w, linuxResources, proxyNetwork)
 		case *pb.Op_File:
 			return ops.NewFileOp(v, op, w.CacheMgr, w.ParallelismSem, w)
 		case *pb.Op_Build:

--- a/worker/containerd/containerd.go
+++ b/worker/containerd/containerd.go
@@ -79,7 +79,7 @@ func newContainerd(client *ctd.Client, workerOpts WorkerOptions) (base.WorkerOpt
 		return base.WorkerOpt{}, err
 	}
 
-	np, npResolvedMode, err := netproviders.Providers(workerOpts.NetworkOpt)
+	np, proxyProvider, npResolvedMode, err := netproviders.Providers(workerOpts.NetworkOpt)
 	if err != nil {
 		return base.WorkerOpt{}, err
 	}
@@ -151,6 +151,7 @@ func newContainerd(client *ctd.Client, workerOpts WorkerOptions) (base.WorkerOpt
 		Runtime:          workerOpts.Runtime,
 		CDIManager:       workerOpts.CDIManager,
 		NetworkProviders: np,
+		ProxyProvider:    proxyProvider,
 	}
 
 	opt := base.WorkerOpt{
@@ -159,6 +160,7 @@ func newContainerd(client *ctd.Client, workerOpts WorkerOptions) (base.WorkerOpt
 		Labels:           xlabels,
 		MetadataStore:    md,
 		NetworkProviders: np,
+		ProxyProvider:    proxyProvider,
 		Executor:         containerdexecutor.New(executorOpts),
 		Snapshotter:      containerdsnapshot.NewSnapshotter(workerOpts.SnapshotterName, client.SnapshotService(workerOpts.SnapshotterName), workerOpts.Namespace, nil),
 		ContentStore:     cs,

--- a/worker/runc/runc.go
+++ b/worker/runc/runc.go
@@ -47,7 +47,7 @@ func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, proc
 		return opt, err
 	}
 
-	np, npResolvedMode, err := netproviders.Providers(nopt)
+	np, proxyProvider, npResolvedMode, err := netproviders.Providers(nopt)
 	if err != nil {
 		return opt, err
 	}
@@ -80,6 +80,7 @@ func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, proc
 		DefaultCgroupParent: defaultCgroupParent,
 		ResourceMonitor:     rm,
 		CDIManager:          cdiManager,
+		ProxyProvider:       proxyProvider,
 	}, np)
 	if err != nil {
 		return opt, err
@@ -141,6 +142,7 @@ func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, proc
 		Labels:           xlabels,
 		MetadataStore:    md,
 		NetworkProviders: np,
+		ProxyProvider:    proxyProvider,
 		Executor:         exe,
 		Snapshotter:      containerdsnapshot.NewSnapshotter(snFactory.Name, mdb.Snapshotter(snFactory.Name), "buildkit", idmap),
 		ContentStore:     c,

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -16,8 +16,14 @@ import (
 	"github.com/moby/buildkit/solver/llbsolver/cdidevices"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/leaseutil"
+	"github.com/moby/buildkit/util/network"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 )
+
+type ProxyOpt struct {
+	Network bool
+	Policy  func() (network.ProxyPolicy, error)
+}
 
 type Worker interface {
 	io.Closer
@@ -30,7 +36,7 @@ type Worker interface {
 	GCPolicy() []client.PruneInfo
 	LoadRef(ctx context.Context, id string, hidden bool) (cache.ImmutableRef, error)
 	// ResolveOp resolves Vertex.Sys() to Op implementation.
-	ResolveOp(v solver.Vertex, s frontend.FrontendLLBBridge, sm *session.Manager) (solver.Op, error)
+	ResolveOp(v solver.Vertex, s frontend.FrontendLLBBridge, sm *session.Manager, proxyOpt ProxyOpt) (solver.Op, error)
 	ResolveSourceMetadata(ctx context.Context, op *pb.SourceOp, opt sourceresolver.Opt, sm *session.Manager, jobCtx solver.JobContext) (*sourceresolver.MetaResponse, error)
 	DiskUsage(ctx context.Context, opt client.DiskUsageInfo) ([]*client.UsageInfo, error)
 	Exporter(name string, sm *session.Manager) (exporter.Exporter, error)


### PR DESCRIPTION
updates #6740 so that there is no single proxy network mode but proxy works on top of both bridge and host mode. Requests get proxied in both cases but only on host+proxy mode you can access local services (and still entitlement required).