### PR TITLE
solver: fix slow cache error result ownership

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -9499,19 +9499,29 @@ loop0:
 		snapshotterName := sb.Snapshotter()
 		snapshotService := client.SnapshotService(snapshotterName)
 
-		leases, err := client.LeasesService().List(ctx)
-		require.NoError(t, err)
-		count := 0
-		for _, l := range leases {
-			_, isTemp := l.Labels["buildkit/lease.temporary"]
-			_, isExpire := l.Labels["containerd.io/gc.expire"]
-			if isTemp && isExpire {
-				continue
+		checkLeases := func() {
+			leases, err := client.LeasesService().List(ctx)
+			require.NoError(t, err)
+			count := 0
+			for _, l := range leases {
+				_, isTemp := l.Labels["buildkit/lease.temporary"]
+				_, isExpire := l.Labels["containerd.io/gc.expire"]
+				if isTemp && isExpire {
+					continue
+				}
+				resources, err := client.LeasesService().ListResources(ctx, l)
+				require.NoError(t, err)
+				if len(resources) == 0 {
+					continue
+				}
+				count++
+				t.Logf("lease: %v", l)
+				for _, r := range resources {
+					t.Logf("lease resource: %v", r)
+				}
 			}
-			count++
-			t.Logf("lease: %v", l)
+			require.Equal(t, 0, count)
 		}
-		require.Equal(t, 0, count)
 
 		if checkContent {
 			images, err := client.ImageService().List(ctx)
@@ -9539,6 +9549,7 @@ loop0:
 		}
 
 		if !checkContent {
+			checkLeases()
 			return
 		}
 
@@ -9573,6 +9584,8 @@ loop0:
 			retries++
 			time.Sleep(500 * time.Millisecond)
 		}
+
+		checkLeases()
 	}
 }
 

--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -1048,7 +1048,9 @@ func (s *sharedOp) LoadCache(ctx context.Context, rec *CacheRecord) (Result, fun
 // evaluated, hence "slow" cache.
 func (s *sharedOp) CalcSlowCache(ctx context.Context, index Index, p PreprocessFunc, f ResultBasedCacheFunc, res Result) (dgst digest.Digest, err error) {
 	defer func() {
-		err = WrapSlowCache(err, index, NewSharedResult(res).Clone())
+		if err != nil {
+			err = WrapSlowCache(err, index, res.Clone())
+		}
 		err = errdefs.WithOp(err, s.st.vtx.Sys(), s.st.vtx.Options().Description)
 		err = errdefs.WrapVertex(err, s.st.origDigest)
 	}()

--- a/solver/scheduler_test.go
+++ b/solver/scheduler_test.go
@@ -1108,6 +1108,71 @@ func TestSlowCache(t *testing.T) {
 	j1 = nil
 }
 
+func TestSlowCacheErrorResultCloneRelease(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	l := NewSolver(SolverOpt{
+		ResolveOpFunc: testOpResolver,
+	})
+	defer l.Close()
+
+	j, err := l.NewJob("j0")
+	require.NoError(t, err)
+	defer func() {
+		if j != nil {
+			require.NoError(t, j.Discard())
+		}
+	}()
+
+	var releaseCount atomic.Int64
+
+	inputRes := &countedResult{
+		id:           identity.NewID(),
+		value:        "input",
+		releaseCount: &releaseCount,
+	}
+
+	g := Edge{
+		Vertex: vtx(vtxOpt{
+			name:         "v0",
+			cacheKeySeed: "seed0",
+			value:        "result0",
+			inputs: []Edge{
+				{Vertex: vtx(vtxOpt{
+					name:         "v1",
+					cacheKeySeed: "seed1",
+					result:       inputRes,
+				})},
+			},
+			slowCacheCompute: map[int]ResultBasedCacheFunc{
+				0: func(context.Context, Result, session.Group) (digest.Digest, error) {
+					return "", errors.Errorf("slow cache error")
+				},
+			},
+		}),
+	}
+
+	_, err = j.Build(ctx, g)
+	require.Error(t, err)
+
+	var sce *SlowCacheError
+	require.ErrorAs(t, err, &sce)
+	require.NotNil(t, sce.Result)
+
+	require.NoError(t, j.Discard())
+	j = nil
+
+	require.Never(t, func() bool {
+		return releaseCount.Load() != 0
+	}, 100*time.Millisecond, 10*time.Millisecond)
+
+	require.NoError(t, sce.Result.Release(ctx))
+	require.Eventually(t, func() bool {
+		return releaseCount.Load() == 1
+	}, time.Second, 10*time.Millisecond)
+}
+
 // TestParallelInputs validates that inputs are processed in parallel
 func TestParallelInputs(t *testing.T) {
 	t.Parallel()
@@ -3655,6 +3720,7 @@ type vtxOpt struct {
 	execPreFunc      func(context.Context) error
 	inputs           []Edge
 	value            string
+	result           Result
 	slowCacheCompute map[int]ResultBasedCacheFunc
 	selectors        map[int]digest.Digest
 	cacheSource      CacheManager
@@ -3794,6 +3860,9 @@ func (v *vertex) exec(ctx context.Context, inputs []Result) error {
 func (v *vertex) Exec(ctx context.Context, job JobContext, inputs []Result) (outputs []Result, err error) {
 	if err := v.exec(ctx, inputs); err != nil {
 		return nil, err
+	}
+	if v.opt.result != nil {
+		return []Result{v.opt.result}, nil
 	}
 	return []Result{&dummyResult{id: identity.NewID(), value: v.opt.value}}, nil
 }
@@ -3989,6 +4058,28 @@ func (r *dummyResult) ID() string                    { return r.id }
 func (r *dummyResult) Release(context.Context) error { return nil }
 func (r *dummyResult) Sys() any                      { return r }
 func (r *dummyResult) Clone() Result                 { return r }
+
+type countedResult struct {
+	id           string
+	value        string
+	releaseCount *atomic.Int64
+}
+
+func (r *countedResult) ID() string { return r.id }
+func (r *countedResult) Release(context.Context) error {
+	if r.releaseCount != nil {
+		r.releaseCount.Add(1)
+	}
+	return nil
+}
+func (r *countedResult) Sys() any { return &dummyResult{id: r.id, value: r.value} }
+func (r *countedResult) Clone() Result {
+	return &countedResult{
+		id:           r.id,
+		value:        r.value,
+		releaseCount: r.releaseCount,
+	}
+}
 
 func testOpResolver(v Vertex, b Builder) (Op, error) {
 	if op, ok := v.Sys().(Op); ok {


### PR DESCRIPTION
Clone the existing slow-cache input result when wrapping errors instead of creating a separate shared owner. This keeps SlowCacheError.Result tied to the same release chain and avoids releasing the input while the error still holds it.

Update the containerd cleanup check to ignore empty leases while still failing on leases that retain resources, and add a deterministic regression.

This issue caused flaky error in `TestClientGatewaySlowCacheExecError`