### PR TITLE
Fix failed to commit on during finalize error

### DIFF
--- a/cache/refs.go
+++ b/cache/refs.go
@@ -151,8 +151,9 @@ func (p parentRefs) release(ctx context.Context) error {
 	switch {
 	case p.layerParent != nil:
 		p.layerParent.mu.Lock()
-		defer p.layerParent.mu.Unlock()
-		if err := p.layerParent.release(ctx); err != nil {
+		err := p.layerParent.release(ctx)
+		p.layerParent.mu.Unlock()
+		if err != nil {
 			errs = append(errs, err)
 		}
 	case len(p.mergeParents) > 0:
@@ -171,8 +172,9 @@ func (p parentRefs) release(ctx context.Context) error {
 	case p.diffParents != nil:
 		if p.diffParents.lower != nil {
 			p.diffParents.lower.mu.Lock()
-			defer p.diffParents.lower.mu.Unlock()
-			if err := p.diffParents.lower.release(ctx); err != nil {
+			err := p.diffParents.lower.release(ctx)
+			p.diffParents.lower.mu.Unlock()
+			if err != nil {
 				errs = append(errs, err)
 			} else {
 				p.diffParents.lower = nil
@@ -180,8 +182,9 @@ func (p parentRefs) release(ctx context.Context) error {
 		}
 		if p.diffParents.upper != nil {
 			p.diffParents.upper.mu.Lock()
-			defer p.diffParents.upper.mu.Unlock()
-			if err := p.diffParents.upper.release(ctx); err != nil {
+			err := p.diffParents.upper.release(ctx)
+			p.diffParents.upper.mu.Unlock()
+			if err != nil {
 				errs = append(errs, err)
 			} else {
 				p.diffParents.upper = nil

--- a/frontend/gateway/forwarder/forward.go
+++ b/frontend/gateway/forwarder/forward.go
@@ -181,8 +181,17 @@ func (c *BridgeClient) registerResultIDs(results ...solver.Result) (ids []string
 		if !ok {
 			return ids, errors.Errorf("unexpected type for result, got %T", res.Sys())
 		}
-		ids[i] = workerRef.ID()
-		c.workerRefByID[workerRef.ID()] = workerRef
+		id := workerRef.ID()
+		ids[i] = id
+		if existing, ok := c.workerRefByID[id]; ok {
+			if existing != workerRef {
+				if err := workerRef.Release(context.TODO()); err != nil {
+					return ids, errors.WithStack(err)
+				}
+			}
+			continue
+		}
+		c.workerRefByID[id] = workerRef
 	}
 	return ids, nil
 }
@@ -220,7 +229,7 @@ func (c *BridgeClient) discard(err error) {
 	c.discardMounts()
 
 	for id, workerRef := range c.workerRefByID {
-		workerRef.ImmutableRef.Release(context.TODO())
+		workerRef.Release(context.TODO())
 		delete(c.workerRefByID, id)
 	}
 	for _, r := range c.refs {

--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -707,8 +707,17 @@ func (lbf *llbBridgeForwarder) registerResultIDs(results ...solver.Result) (ids 
 		if !ok {
 			return ids, errors.Errorf("unexpected type for result, got %T", res.Sys())
 		}
-		ids[i] = workerRef.ID()
-		lbf.workerRefByID[workerRef.ID()] = workerRef
+		id := workerRef.ID()
+		ids[i] = id
+		if existing, ok := lbf.workerRefByID[id]; ok {
+			if existing != workerRef {
+				if err := workerRef.Release(context.TODO()); err != nil {
+					return ids, errors.WithStack(err)
+				}
+			}
+			continue
+		}
+		lbf.workerRefByID[id] = workerRef
 	}
 	return ids, nil
 }

--- a/solver/llbsolver/ops/exec.go
+++ b/solver/llbsolver/ops/exec.go
@@ -397,7 +397,16 @@ func (e *ExecOp) Exec(ctx context.Context, jobCtx solver.JobContext, inputs []so
 			execMounts := make([]solver.Result, len(e.op.Mounts))
 			copy(execMounts, execInputs)
 			for i, res := range results {
-				execMounts[p.OutputRefs[i].MountIndex] = res
+				// res.Clone() (not res) is required: results[i] is owned by
+				// the caller (and ultimately released via the gateway / job
+				// path), while execMounts[i] is embedded in the ExecError
+				// returned below and released independently by the error
+				// owner. Sharing the same *workerRefResult here would mean
+				// two independent owners holding the same *WorkerRef, so a
+				// Release on one would also free the cache ref held by the
+				// other. See worker/result_test.go for the underlying
+				// ownership invariant.
+				execMounts[p.OutputRefs[i].MountIndex] = res.Clone()
 			}
 			for _, active := range p.Actives {
 				if active.NoCommit {

--- a/solver/llbsolver/ops/file.go
+++ b/solver/llbsolver/ops/file.go
@@ -449,7 +449,9 @@ func (s *FileOpSolver) getInput(ctx context.Context, idx int, inputs []fileoptyp
 				ctx := context.WithoutCancel(ctx)
 				inputRes := make([]solver.Result, len(inputs))
 				for i, input := range inputs {
-					inputRes[i] = worker.NewWorkerRefResult(input.(cache.ImmutableRef), s.w)
+					// Clone so ExecError owns its own counted ref,
+					// independent of the caller's input.
+					inputRes[i] = worker.NewWorkerRefResult(input.(cache.ImmutableRef).Clone(), s.w)
 				}
 
 				outputRes := make([]solver.Result, len(actions))

--- a/worker/result.go
+++ b/worker/result.go
@@ -65,8 +65,12 @@ func (r *workerRefResult) Sys() any {
 
 func (r *workerRefResult) Clone() solver.Result {
 	r2 := *r
-	if r.ImmutableRef != nil {
-		r.ImmutableRef = r.ImmutableRef.Clone()
+	if r.WorkerRef != nil {
+		wr := *r.WorkerRef
+		if wr.ImmutableRef != nil {
+			wr.ImmutableRef = wr.ImmutableRef.Clone()
+		}
+		r2.WorkerRef = &wr
 	}
 	return &r2
 }

--- a/worker/result_test.go
+++ b/worker/result_test.go
@@ -1,0 +1,88 @@
+package worker
+
+import (
+	"testing"
+
+	"github.com/moby/buildkit/cache"
+	"github.com/stretchr/testify/require"
+)
+
+// stubImmutableRef is a minimal cache.ImmutableRef stub for testing
+// workerRefResult ownership semantics. Only ID and Clone are used by these
+// tests; any other method call will panic via the embedded nil interface,
+// which is intentional so accidental usage is loud.
+type stubImmutableRef struct {
+	cache.ImmutableRef
+	id     string
+	parent *stubImmutableRef
+}
+
+func (r *stubImmutableRef) ID() string {
+	return r.id
+}
+
+func (r *stubImmutableRef) Clone() cache.ImmutableRef {
+	return &stubImmutableRef{id: r.id, parent: r}
+}
+
+// TestWorkerRefResultCloneOwnership pins the ownership invariant that
+// workerRefResult.Clone must produce a result with an independent *WorkerRef.
+//
+// This is the structural pre-condition behind the "failed to finalize upper
+// parent during diff: ... snapshot does not exist" snapshot-finalization
+// failure: when multiple owners share the same *WorkerRef they
+// also share the same cache.ImmutableRef, so independent Release/Finalize
+// paths in the gateway forwarder and ExecError decoration end up acting on
+// the same underlying refcount instead of independent clones.
+//
+// The buggy implementation does:
+//
+//	r2 := *r
+//	if r.ImmutableRef != nil {
+//	    r.ImmutableRef = r.ImmutableRef.Clone()
+//	}
+//	return &r2
+//
+// Because workerRefResult embeds *WorkerRef (a pointer), `r2 := *r` copies the
+// pointer, not the WorkerRef struct, so both `r` and `r2` continue to point at
+// the same WorkerRef and the subsequent `r.ImmutableRef = ...` mutates the
+// shared WorkerRef. The fix copies the WorkerRef struct first and assigns the
+// clone to the copy, so the original WorkerRef is untouched.
+func TestWorkerRefResultCloneOwnership(t *testing.T) {
+	orig := &stubImmutableRef{id: "orig"}
+	res := &workerRefResult{&WorkerRef{ImmutableRef: orig}}
+
+	cloned := res.Clone().(*workerRefResult)
+
+	require.NotSame(t, res.WorkerRef, cloned.WorkerRef,
+		"workerRefResult.Clone must produce an independent *WorkerRef so each result owns its own cache ref")
+	require.Same(t, orig, res.ImmutableRef,
+		"workerRefResult.Clone must not mutate the original WorkerRef.ImmutableRef")
+	require.NotNil(t, cloned.ImmutableRef,
+		"cloned workerRefResult must hold a non-nil ImmutableRef")
+	require.NotSame(t, orig, cloned.ImmutableRef,
+		"cloned workerRefResult must hold a freshly cloned ImmutableRef, not the original")
+
+	// Sys() must return the WorkerRef that backs the receiver; this is what
+	// the gateway forwarder reads to populate workerRefByID and what the
+	// exec error decoration walks to find result refs. If Sys() crossed
+	// owners, callers would silently share ownership.
+	require.Same(t, res.WorkerRef, res.Sys().(*WorkerRef),
+		"workerRefResult.Sys must return the result's own WorkerRef")
+	require.Same(t, cloned.WorkerRef, cloned.Sys().(*WorkerRef),
+		"cloned workerRefResult.Sys must return the clone's own WorkerRef")
+}
+
+// TestWorkerRefResultCloneNilRef ensures Clone is safe when there is no
+// ImmutableRef set, which the production code relies on via the early nil
+// check before invoking ImmutableRef.Clone.
+func TestWorkerRefResultCloneNilRef(t *testing.T) {
+	res := &workerRefResult{&WorkerRef{}}
+
+	cloned := res.Clone().(*workerRefResult)
+
+	require.NotSame(t, res.WorkerRef, cloned.WorkerRef,
+		"workerRefResult.Clone must produce an independent *WorkerRef even when ImmutableRef is nil")
+	require.Nil(t, res.ImmutableRef)
+	require.Nil(t, cloned.ImmutableRef)
+}


### PR DESCRIPTION
replaces #6808

Updated fix. Changes:
- Removed the complicated TestExecFailedOutputDoubleOwnerFinalizeRepro as it heavily relies on stubs
- Added similar case for `File` next to `Exec`.

I couldn't get a reasonable integration test but manual POC and analysis is in https://gist.github.com/tonistiigi/fb61083d56f8d70a952f9993a9334d8d that fails for both exec and file case before the patch is fixed by this.

Some other similar fixes in https://github.com/moby/buildkit/pull/6820

@cpuguy83 