### PR TITLE
containerimage: use policyimage.ResolveAttestationStatements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -251,6 +251,8 @@ exclude (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 )
 
+replace github.com/moby/policy-helpers => github.com/smerkviladze/policy-helpers v0.0.0-20260603124614-a22db872ec6f
+
 tool (
 	github.com/planetscale/vtprotobuf/cmd/protoc-gen-go-vtproto
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc

--- a/go.sum
+++ b/go.sum
@@ -434,8 +434,6 @@ github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
 github.com/moby/patternmatcher v0.6.1 h1:qlhtafmr6kgMIJjKJMDmMWq7WLkKIo23hsrpR3x084U=
 github.com/moby/patternmatcher v0.6.1/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
-github.com/moby/policy-helpers v0.0.0-20260507153417-a39d60132186 h1:AA3y9usJgmJyrOX16s8HsgHA3QP0CSvI9EJ9vVmpgGo=
-github.com/moby/policy-helpers v0.0.0-20260507153417-a39d60132186/go.mod h1:AbesLhDyQnWkhYOeG5BjDpfUWuyFlSpwv17zBGc03ag=
 github.com/moby/profiles/seccomp v0.2.3 h1:nrHNSiECQQvq4WjgceCUgJXIXUJBIswVQ133k4Do2mA=
 github.com/moby/profiles/seccomp v0.2.3/go.mod h1:8m3qkkWZXrRsMqlUUN2zyccnYmBf3EAdQYPMVJ3NBhk=
 github.com/moby/sys/capability v0.4.0 h1:4D4mI6KlNtWMCM1Z/K0i7RV1FkX+DBDHKVJpCndZoHk=
@@ -563,6 +561,8 @@ github.com/sigstore/timestamp-authority/v2 v2.0.6/go.mod h1:Nk5ucGBDyH0tXAIMZ0pr
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
+github.com/smerkviladze/policy-helpers v0.0.0-20260603124614-a22db872ec6f h1:9Zd2DrIjNRpRBgHxNeK2NFCwdy7u8XI483FPpsR+IY8=
+github.com/smerkviladze/policy-helpers v0.0.0-20260603124614-a22db872ec6f/go.mod h1:AbesLhDyQnWkhYOeG5BjDpfUWuyFlSpwv17zBGc03ag=
 github.com/spdx/tools-golang v0.5.7 h1:+sWcKGnhwp3vLdMqPcLdA6QK679vd86cK9hQWH3AwCg=
 github.com/spdx/tools-golang v0.5.7/go.mod h1:jg7w0LOpoNAw6OxKEzCoqPC2GCTj45LyTlVmXubDsYw=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=

--- a/source/containerimage/source.go
+++ b/source/containerimage/source.go
@@ -2,7 +2,6 @@ package containerimage
 
 import (
 	"context"
-	"encoding/json"
 	"slices"
 	"strconv"
 	"time"
@@ -265,9 +264,22 @@ func (is *Source) ResolveImageMetadata(ctx context.Context, id *ImageIdentifier,
 					Data:       dt,
 				}
 			}
-			if len(opt.ResolveAttestations) > 0 && ac.AttestationManifest != "" {
-				if err := addAttestationBlobs(ctx, prov, ac, opt.ResolveAttestations); err != nil {
+			// The empty-predicateTypes guard is load-bearing:
+			// ResolveAttestationStatements treats nil/empty as "return all",
+			// but BuildKit only fetches statements the policy verifier
+			// explicitly requested via opt.ResolveAttestations.
+			if len(opt.ResolveAttestations) > 0 && sc != nil && sc.AttestationManifest != nil {
+				stmts, err := policyimage.ResolveAttestationStatements(ctx, sc, opt.ResolveAttestations)
+				if err != nil {
 					return nil, err
+				}
+				for _, b := range stmts {
+					if _, ok := ac.Blobs[b.Descriptor.Digest]; !ok {
+						ac.Blobs[b.Descriptor.Digest] = sourceresolver.Blob{
+							Descriptor: b.Descriptor,
+							Data:       b.Data,
+						}
+					}
 				}
 			}
 			if err := prov.SetGCLabels(ctx, desc); err != nil {
@@ -330,49 +342,6 @@ func (is *Source) ResolveOCILayoutMetadata(ctx context.Context, id *OCIIdentifie
 type resolveImageResult struct {
 	dgst digest.Digest
 	dt   []byte
-}
-
-func addAttestationBlobs(ctx context.Context, prov policyimage.ReferrersProvider, ac *sourceresolver.AttestationChain, predicateTypes []string) error {
-	if ac == nil || ac.AttestationManifest == "" || ac.Blobs == nil || len(predicateTypes) == 0 {
-		return nil
-	}
-	att, ok := ac.Blobs[ac.AttestationManifest]
-	if !ok || len(att.Data) == 0 {
-		return nil
-	}
-	need := map[string]struct{}{}
-	for _, p := range predicateTypes {
-		if p == "" {
-			continue
-		}
-		need[p] = struct{}{}
-	}
-	if len(need) == 0 {
-		return nil
-	}
-	var manifest ocispecs.Manifest
-	if err := json.Unmarshal(att.Data, &manifest); err != nil {
-		return errors.Wrapf(err, "unmarshaling attestation manifest %s", ac.AttestationManifest)
-	}
-
-	for _, layer := range manifest.Layers {
-		predicateType := layer.Annotations["in-toto.io/predicate-type"]
-		if _, ok := need[predicateType]; !ok {
-			continue
-		}
-		if _, ok := ac.Blobs[layer.Digest]; ok {
-			continue
-		}
-		dt, err := policyimage.ReadBlob(ctx, prov, layer)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-		ac.Blobs[layer.Digest] = sourceresolver.Blob{
-			Descriptor: layer,
-			Data:       dt,
-		}
-	}
-	return nil
 }
 
 func (is *Source) registryIdentifier(ref string, attrs map[string]string, platform *pb.Platform) (source.Identifier, error) {

--- a/vendor/github.com/moby/policy-helpers/image/resolve.go
+++ b/vendor/github.com/moby/policy-helpers/image/resolve.go
@@ -237,3 +237,53 @@ func ReadBlob(ctx context.Context, provider content.Provider, desc ocispecs.Desc
 	}
 	return dt, nil
 }
+
+// Blob holds the raw content of a single OCI blob together with its descriptor.
+type Blob struct {
+	Descriptor ocispecs.Descriptor
+	Data       []byte
+}
+
+// ResolveAttestationStatements reads the in-toto statement layers from
+// sc.AttestationManifest, filtered by predicateTypes, and returns each
+// matching layer's descriptor and raw content.
+//
+// If predicateTypes is empty all statement layers are returned.
+// Layers without an "in-toto.io/predicate-type" annotation are always skipped.
+// Returns nil without error if sc has no AttestationManifest.
+func ResolveAttestationStatements(ctx context.Context, sc *SignatureChain, predicateTypes []string) ([]Blob, error) {
+	if sc == nil || sc.AttestationManifest == nil {
+		return nil, nil
+	}
+
+	mfst, err := sc.OCIManifest(ctx, sc.AttestationManifest)
+	if err != nil {
+		return nil, errors.Wrapf(err, "reading attestation manifest %s", sc.AttestationManifest.Digest)
+	}
+
+	filter := make(map[string]struct{}, len(predicateTypes))
+	for _, p := range predicateTypes {
+		if p != "" {
+			filter[p] = struct{}{}
+		}
+	}
+
+	blobs := make([]Blob, 0, len(mfst.Layers))
+	for _, layer := range mfst.Layers {
+		predicateType := layer.Annotations["in-toto.io/predicate-type"]
+		if predicateType == "" {
+			continue
+		}
+		if len(filter) > 0 {
+			if _, ok := filter[predicateType]; !ok {
+				continue
+			}
+		}
+		dt, err := ReadBlob(ctx, sc.Provider, layer)
+		if err != nil {
+			return nil, errors.Wrapf(err, "reading attestation statement %s", layer.Digest)
+		}
+		blobs = append(blobs, Blob{Descriptor: layer, Data: dt})
+	}
+	return blobs, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -810,7 +810,7 @@ github.com/moby/locker
 ## explicit; go 1.19
 github.com/moby/patternmatcher
 github.com/moby/patternmatcher/ignorefile
-# github.com/moby/policy-helpers v0.0.0-20260507153417-a39d60132186
+# github.com/moby/policy-helpers v0.0.0-20260507153417-a39d60132186 => github.com/smerkviladze/policy-helpers v0.0.0-20260603124614-a22db872ec6f
 ## explicit; go 1.25.5
 github.com/moby/policy-helpers
 github.com/moby/policy-helpers/image
@@ -1451,3 +1451,4 @@ tags.cncf.io/container-device-interface/pkg/parser
 # tags.cncf.io/container-device-interface/specs-go v1.1.0
 ## explicit; go 1.19
 tags.cncf.io/container-device-interface/specs-go
+# github.com/moby/policy-helpers => github.com/smerkviladze/policy-helpers v0.0.0-20260603124614-a22db872ec6f


### PR DESCRIPTION
**WIP**

Replaces BuildKit's private `addAttestationBlobs` function in `source/containerimage/source.go` with a call to the shared `ResolveAttestationStatements` function in [moby/policy-helpers/pull/30](https://github.com/moby/policy-helpers/pull/30).

Both functions do the same work: walk the layers of an attestation manifest, filter them by in-toto predicate type, fetch matching blobs, and add them to the attestation chain.

**What changed:**

- Removed `addAttestationBlobs` from `source/containerimage/source.go`;
- Replaced its call site with `policyimage.ResolveAttestationStatements` plus a small loop that merges the result into `ac.Blobs` while preserving the original "skip if already fetched" deduplication.

External behaviour is unchanged.

**Testing:**

This change is covered by existing integration tests:
- `testImageResolveProvenanceAttestation`
- `testImageResolveAttestationChainLocal`
- `testImageResolveAttestationChainRequiresNetwork`