### PR TITLE
test: avoid local source differ release race

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2919,6 +2919,9 @@ func testLocalSourceWithDiffer(t *testing.T, sb integration.Sandbox, d llb.DiffT
 	require.NoError(t, err)
 	require.Equal(t, []byte("foo"), dt)
 
+	// Give some extra time to ensure the resources from first solve are released
+	time.Sleep(500 * time.Millisecond)
+
 	err = os.WriteFile(filepath.Join(dir.Name, "foo"), []byte("bar"), 0600)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Wait before the second solve so previous local source refs can be released before the reuse assertion runs.