### PR TITLE
vendor: update fsutil with umask-aware MkdirAll

### DIFF
--- a/cmd/buildctl/main_unix.go
+++ b/cmd/buildctl/main_unix.go
@@ -4,8 +4,11 @@ package main
 
 import (
 	"syscall"
+
+	copy "github.com/tonistiigi/fsutil/copy"
 )
 
 func init() {
 	syscall.Umask(0)
+	copy.UmaskIsZero = true
 }

--- a/cmd/buildkitd/main_unix.go
+++ b/cmd/buildkitd/main_unix.go
@@ -11,12 +11,14 @@ import (
 	"github.com/containerd/containerd/v2/pkg/sys"
 	"github.com/coreos/go-systemd/v22/activation"
 	"github.com/pkg/errors"
+	copy "github.com/tonistiigi/fsutil/copy"
 )
 
 const socketScheme = "unix://"
 
 func init() {
 	syscall.Umask(0)
+	copy.UmaskIsZero = true
 }
 
 func listenFD(addr string, tlsConfig *tls.Config) (net.Listener, error) {

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -4470,6 +4470,8 @@ RUN mkdir -m 0777 /out
 COPY --chmod=0644 foo /
 COPY --chmod=777 bar /baz
 COPY --chmod=0 foo /foobis
+COPY --chmod=777 foo /parent/foo
+COPY --chmod=770 foo /parent/sub/foo
 
 ARG mode
 COPY --chmod=${mode} foo /footer
@@ -4477,6 +4479,8 @@ COPY --chmod=${mode} foo /footer
 RUN stat -c "%04a" /foo  > /out/fooperm
 RUN stat -c "%04a" /baz  > /out/barperm
 RUN stat -c "%04a" /foobis  > /out/foobisperm
+RUN stat -c "%04a" /parent  > /out/parentperm
+RUN stat -c "%04a" /parent/sub  > /out/subparentperm
 RUN stat -c "%04a" /footer  > /out/footerperm
 FROM scratch
 COPY --from=base /out /
@@ -4524,6 +4528,14 @@ COPY --from=base /out /
 	dt, err = os.ReadFile(filepath.Join(destDir, "foobisperm"))
 	require.NoError(t, err)
 	require.Equal(t, "0000\n", string(dt))
+
+	dt, err = os.ReadFile(filepath.Join(destDir, "parentperm"))
+	require.NoError(t, err)
+	require.Equal(t, "0777\n", string(dt))
+
+	dt, err = os.ReadFile(filepath.Join(destDir, "subparentperm"))
+	require.NoError(t, err)
+	require.Equal(t, "0770\n", string(dt))
 
 	dt, err = os.ReadFile(filepath.Join(destDir, "footerperm"))
 	require.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/spdx/tools-golang v0.5.7
 	github.com/stretchr/testify v1.11.1
 	github.com/tonistiigi/dchapes-mode v0.0.0-20250318174251-73d941a28323
-	github.com/tonistiigi/fsutil v0.0.0-20251211185533-a2aa163d723f
+	github.com/tonistiigi/fsutil v0.0.0-20260603212341-ed540e182f8a
 	github.com/tonistiigi/go-actions-cache v0.0.0-20260120203934-54bc28c26fd2
 	github.com/tonistiigi/go-archvariant v1.0.0
 	github.com/tonistiigi/go-csvvalue v0.0.0-20240814133006-030d3b2625d0

--- a/go.sum
+++ b/go.sum
@@ -600,8 +600,8 @@ github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 h1:e/5i7d4oYZ+C
 github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399/go.mod h1:LdwHTNJT99C5fTAzDz0ud328OgXz+gierycbcIx2fRs=
 github.com/tonistiigi/dchapes-mode v0.0.0-20250318174251-73d941a28323 h1:r0p7fK56l8WPequOaR3i9LBqfPtEdXIQbUTzT55iqT4=
 github.com/tonistiigi/dchapes-mode v0.0.0-20250318174251-73d941a28323/go.mod h1:3Iuxbr0P7D3zUzBMAZB+ois3h/et0shEz0qApgHYGpY=
-github.com/tonistiigi/fsutil v0.0.0-20251211185533-a2aa163d723f h1:Z4NEQ86qFl1mHuCu9gwcE+EYCwDKfXAYXZbdIXyxmEA=
-github.com/tonistiigi/fsutil v0.0.0-20251211185533-a2aa163d723f/go.mod h1:BKdcez7BiVtBvIcef90ZPc6ebqIWr4JWD7+EvLm6J98=
+github.com/tonistiigi/fsutil v0.0.0-20260603212341-ed540e182f8a h1:fouZioB486i05IyehzLIrq4Jcz5LHQbMJsznx6ByJZo=
+github.com/tonistiigi/fsutil v0.0.0-20260603212341-ed540e182f8a/go.mod h1:BKdcez7BiVtBvIcef90ZPc6ebqIWr4JWD7+EvLm6J98=
 github.com/tonistiigi/go-actions-cache v0.0.0-20260120203934-54bc28c26fd2 h1:5p6hffZeB25G4rhBc3HU6x1aIlyDELfib+/Omq+ZfQA=
 github.com/tonistiigi/go-actions-cache v0.0.0-20260120203934-54bc28c26fd2/go.mod h1:cD0SB2270BYw6HYKriFn4H6NRLhGj6ytf48YTpsm8LY=
 github.com/tonistiigi/go-archvariant v1.0.0 h1:5LC1eDWiBNflnTF1prCiX09yfNHIxDC/aukdhCdTyb0=

--- a/vendor/github.com/tonistiigi/fsutil/copy/mkdir.go
+++ b/vendor/github.com/tonistiigi/fsutil/copy/mkdir.go
@@ -6,6 +6,8 @@ import (
 	"time"
 )
 
+var UmaskIsZero = false
+
 // MkdirAll is forked os.MkdirAll
 func MkdirAll(path string, perm os.FileMode, user Chowner, tm *time.Time) ([]string, error) {
 	// Fast path: if we can tell whether path is a directory or file, stop with success or error.
@@ -53,6 +55,16 @@ func MkdirAll(path string, perm os.FileMode, user Chowner, tm *time.Time) ([]str
 			return createdDirs, nil
 		}
 		return nil, err
+	}
+
+	// In general, this code should run with umask unset.
+	// At the same time, there are certain environments where we rely
+	// on this behavior and the umask causes the directory to be created
+	// with the wrong mode.
+	if !UmaskIsZero {
+		if err := os.Chmod(path, perm); err != nil {
+			return nil, err
+		}
 	}
 	createdDirs = append(createdDirs, path)
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1039,7 +1039,7 @@ github.com/theupdateframework/go-tuf/v2/metadata/updater
 # github.com/tonistiigi/dchapes-mode v0.0.0-20250318174251-73d941a28323
 ## explicit; go 1.21
 github.com/tonistiigi/dchapes-mode
-# github.com/tonistiigi/fsutil v0.0.0-20251211185533-a2aa163d723f
+# github.com/tonistiigi/fsutil v0.0.0-20260603212341-ed540e182f8a
 ## explicit; go 1.21
 github.com/tonistiigi/fsutil
 github.com/tonistiigi/fsutil/copy


### PR DESCRIPTION
closes #6801

MkdirAll now chmods each created directory to the requested perm so a non-zero process umask no longer leaves directories with the wrong mode.

buildkitd and buildctl set the umask to 0 at startup, so set the new copy.UmaskIsZero flag in both to skip the now-redundant per-directory chmod.