### PR TITLE
llb: add passthrough op

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -196,6 +196,7 @@ var allTests = []func(t *testing.T, sb integration.Sandbox){
 	testBuildExportZstd,
 	testPullZstdImage,
 	testMergeOp,
+	testPassthroughOp,
 	testMergeOpCacheInline,
 	testMergeOpCacheMin,
 	testMergeOpCacheMax,
@@ -8979,6 +8980,101 @@ func testMergeOp(t *testing.T, sb integration.Sandbox) {
 		File(llb.Mkfile("qaz", 0644, nil)),
 	)
 	// /foo from stateE is not here because it is deleted in stateB, which is part of a submerge of mergeD
+}
+
+func testPassthroughOp(t *testing.T, sb integration.Sandbox) {
+	requiresLinux(t)
+
+	c, err := New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	ctx := sb.Context()
+	busybox := llb.Image("busybox:latest")
+	base := llb.Scratch().File(llb.Mkfile("/base", 0644, []byte("base")))
+
+	t.Run("requires returns receiver and builds non-output dependency", func(t *testing.T) {
+		cacheID := "passthrough-requires-" + identity.NewID()
+		nonOutputDep := busybox.Run(llb.Shlex(`sh -e -c "echo requires-dep-built > /cache/marker; echo should-not-export > /not-output"`))
+		nonOutputDep.AddMount("/cache", llb.Scratch(), llb.AsPersistentCacheDir(cacheID, llb.CacheMountShared))
+
+		outDir := solveStateToLocalDir(ctx, t, c, base.Requires("test.passthrough.requires", nonOutputDep.Root()))
+		requireLocalFile(t, outDir, "base", "base")
+		require.NoFileExists(t, filepath.Join(outDir, "not-output"))
+
+		markerDir := solveStateToLocalDir(ctx, t, c, cacheMountFile(busybox, cacheID, "marker"))
+		requireLocalFile(t, markerDir, "marker", "requires-dep-built\n")
+	})
+
+	t.Run("direct passthrough returns selected outputs and builds non-output input", func(t *testing.T) {
+		cacheID := "passthrough-direct-" + identity.NewID()
+		nonOutputInput := busybox.Run(llb.Shlex(`sh -e -c "echo direct-input-built > /cache/marker; echo should-not-export > /not-output"`))
+		nonOutputInput.AddMount("/cache", llb.Scratch(), llb.AsPersistentCacheDir(cacheID, llb.CacheMountShared))
+
+		pass := llb.NewPassthroughOp("test.passthrough.direct", []llb.PassthroughInput{
+			{State: llb.Scratch().File(llb.Mkfile("/a", 0644, []byte("a"))), Output: true},
+			{State: nonOutputInput.Root()},
+			{State: llb.Scratch().File(llb.Mkfile("/c", 0644, []byte("c"))), Output: true},
+		})
+
+		outA := llb.NewState(pass.Output())
+		outC := llb.NewState(pass.OutputAt(1))
+		out := llb.Scratch().
+			File(llb.Copy(outA, "/a", "/a")).
+			File(llb.Copy(outC, "/c", "/c"))
+
+		outDir := solveStateToLocalDir(ctx, t, c, out)
+		requireLocalFile(t, outDir, "a", "a")
+		requireLocalFile(t, outDir, "c", "c")
+		require.NoFileExists(t, filepath.Join(outDir, "not-output"))
+
+		markerDir := solveStateToLocalDir(ctx, t, c, cacheMountFile(busybox, cacheID, "marker"))
+		requireLocalFile(t, markerDir, "marker", "direct-input-built\n")
+	})
+
+	t.Run("failing non-output dependency fails solve", func(t *testing.T) {
+		fail := busybox.Run(llb.Shlex(`sh -e -c "exit 42"`)).Root()
+		def, err := base.Requires("test.passthrough.fail", fail).Marshal(ctx)
+		require.NoError(t, err)
+		_, err = c.Solve(ctx, def, SolveOpt{
+			Exports: []ExportEntry{{
+				Type:      ExporterLocal,
+				OutputDir: t.TempDir(),
+			}},
+		}, nil)
+		require.Error(t, err)
+	})
+}
+
+func solveStateToLocalDir(ctx context.Context, t *testing.T, c *Client, st llb.State) string {
+	t.Helper()
+
+	def, err := st.Marshal(ctx)
+	require.NoError(t, err)
+
+	outDir := t.TempDir()
+	_, err = c.Solve(ctx, def, SolveOpt{
+		Exports: []ExportEntry{{
+			Type:      ExporterLocal,
+			OutputDir: outDir,
+		}},
+	}, nil)
+	require.NoError(t, err)
+	return outDir
+}
+
+func cacheMountFile(base llb.State, cacheID, name string) llb.State {
+	check := base.Run(llb.Shlexf(`sh -e -c "echo %s >/dev/null; cp /cache/%s /out/%s"`, cacheID, name, name))
+	check.AddMount("/cache", llb.Scratch(), llb.AsPersistentCacheDir(cacheID, llb.CacheMountShared))
+	return check.AddMount("/out", llb.Scratch())
+}
+
+func requireLocalFile(t *testing.T, dir, name, expected string) {
+	t.Helper()
+
+	dt, err := os.ReadFile(filepath.Join(dir, name))
+	require.NoError(t, err)
+	require.Equal(t, expected, string(dt))
 }
 
 func testMergeOpCacheInline(t *testing.T, sb integration.Sandbox) {

--- a/client/llb/passthrough.go
+++ b/client/llb/passthrough.go
@@ -1,0 +1,123 @@
+package llb
+
+import (
+	"context"
+
+	"github.com/moby/buildkit/solver/pb"
+	digest "github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
+)
+
+type PassthroughInput struct {
+	State  State
+	Output bool
+}
+
+type PassthroughOp struct {
+	cache       MarshalCache
+	id          string
+	inputs      []Output
+	outputs     []Output
+	outputMap   []int
+	constraints Constraints
+}
+
+func NewPassthroughOp(id string, inputs []PassthroughInput, opts ...ConstraintsOpt) *PassthroughOp {
+	var c Constraints
+	for _, o := range opts {
+		o.SetConstraintsOption(&c)
+	}
+	addCap(&c, pb.CapPassthroughOp)
+
+	op := &PassthroughOp{id: id, constraints: c}
+	for _, input := range inputs {
+		out := input.State.Output()
+		if out == nil {
+			continue
+		}
+		inputIndex := len(op.inputs)
+		op.inputs = append(op.inputs, out)
+		if input.Output {
+			outputIndex := len(op.outputMap)
+			op.outputMap = append(op.outputMap, inputIndex)
+			op.outputs = append(op.outputs, &output{vertex: op, getIndex: func() (pb.OutputIndex, error) {
+				return pb.OutputIndex(outputIndex), nil
+			}})
+		}
+	}
+	return op
+}
+
+func NewPassthrough(id string, inputs []PassthroughInput, opts ...ConstraintsOpt) State {
+	op := NewPassthroughOp(id, inputs, opts...)
+	return NewState(op.Output())
+}
+
+func (p *PassthroughOp) Validate(context.Context, *Constraints) error {
+	if len(p.inputs) == 0 {
+		return errors.Errorf("passthrough must have at least one input")
+	}
+	if p.id == "" {
+		return errors.Errorf("passthrough requires an id")
+	}
+	if len(p.outputMap) == 0 {
+		return errors.Errorf("passthrough must have at least one output")
+	}
+	for _, input := range p.outputMap {
+		if input < 0 || input >= len(p.inputs) {
+			return errors.Errorf("passthrough output references invalid input %d", input)
+		}
+	}
+	return nil
+}
+
+func (p *PassthroughOp) Marshal(ctx context.Context, constraints *Constraints) (digest.Digest, []byte, *pb.OpMetadata, []*SourceLocation, error) {
+	cache := p.cache.Acquire()
+	defer cache.Release()
+
+	if dgst, dt, md, srcs, err := cache.Load(constraints); err == nil {
+		return dgst, dt, md, srcs, nil
+	}
+
+	if err := p.Validate(ctx, constraints); err != nil {
+		return "", nil, nil, nil, err
+	}
+
+	pop, md := MarshalConstraints(constraints, &p.constraints)
+	pop.Platform = nil
+
+	op := &pb.PassthroughOp{Id: p.id}
+	for _, input := range p.inputs {
+		pbInput, err := input.ToInput(ctx, constraints)
+		if err != nil {
+			return "", nil, nil, nil, err
+		}
+		pop.Inputs = append(pop.Inputs, pbInput)
+	}
+	for _, input := range p.outputMap {
+		op.Outputs = append(op.Outputs, int64(input))
+	}
+	pop.Op = &pb.Op_Passthrough{Passthrough: op}
+
+	dt, err := deterministicMarshal(pop)
+	if err != nil {
+		return "", nil, nil, nil, err
+	}
+
+	return cache.Store(dt, md, p.constraints.SourceLocations, constraints)
+}
+
+func (p *PassthroughOp) Output() Output {
+	return p.OutputAt(0)
+}
+
+func (p *PassthroughOp) OutputAt(index int) Output {
+	if index < 0 || index >= len(p.outputs) {
+		return &output{vertex: p, err: errors.Errorf("invalid passthrough output %d", index)}
+	}
+	return p.outputs[index]
+}
+
+func (p *PassthroughOp) Inputs() []Output {
+	return p.inputs
+}

--- a/client/llb/passthrough_test.go
+++ b/client/llb/passthrough_test.go
@@ -1,0 +1,88 @@
+package llb
+
+import (
+	"testing"
+
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPassthroughRequiresMarshal(t *testing.T) {
+	t.Parallel()
+
+	base := Image("example.com/base:latest")
+	depA := Image("example.com/dep:a")
+	depB := Image("example.com/dep:b")
+
+	def, err := base.Requires("test.requires", depA, depB).Marshal(t.Context())
+	require.NoError(t, err)
+
+	op := requirePassthroughVertex(t, def)
+	require.Len(t, op.Inputs, 3)
+	require.Equal(t, "test.requires", op.GetPassthrough().GetId())
+	require.Equal(t, []int64{0}, op.GetPassthrough().GetOutputs())
+}
+
+func TestPassthroughMultipleOutputsMarshal(t *testing.T) {
+	t.Parallel()
+
+	op := NewPassthroughOp("test.multi", []PassthroughInput{
+		{State: Image("example.com/input:0"), Output: true},
+		{State: Image("example.com/input:1")},
+		{State: Image("example.com/input:2"), Output: true},
+	})
+
+	def, err := NewState(op.OutputAt(1)).Marshal(t.Context())
+	require.NoError(t, err)
+
+	p := requirePassthroughVertex(t, def)
+	require.Len(t, p.Inputs, 3)
+	require.Equal(t, "test.multi", p.GetPassthrough().GetId())
+	require.Equal(t, []int64{0, 2}, p.GetPassthrough().GetOutputs())
+}
+
+func TestPassthroughRequiresNoDeps(t *testing.T) {
+	t.Parallel()
+
+	def, err := Image("example.com/base:latest").Requires("test.empty").Marshal(t.Context())
+	require.NoError(t, err)
+	require.Nil(t, findPassthroughVertex(t, def))
+}
+
+func TestPassthroughRequiresPreservesMetadata(t *testing.T) {
+	t.Parallel()
+
+	st := Image("example.com/base:latest").Dir("/work").Requires("test.metadata", Image("example.com/dep:latest"))
+
+	dir, err := st.GetDir(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "/work", dir)
+}
+
+func TestPassthroughEmptyID(t *testing.T) {
+	t.Parallel()
+
+	_, err := Image("example.com/base:latest").Requires("", Image("example.com/dep:latest")).Marshal(t.Context())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "passthrough requires an id")
+}
+
+func requirePassthroughVertex(t *testing.T, def *Definition) *pb.Op {
+	t.Helper()
+	op := findPassthroughVertex(t, def)
+	require.NotNil(t, op)
+	return op
+}
+
+func findPassthroughVertex(t *testing.T, def *Definition) *pb.Op {
+	t.Helper()
+
+	for _, dt := range def.Def {
+		var op pb.Op
+		require.NoError(t, op.UnmarshalVT(dt))
+		if op.GetPassthrough() != nil {
+			return &op
+		}
+	}
+	return nil
+}

--- a/client/llb/state.go
+++ b/client/llb/state.go
@@ -385,6 +385,18 @@ func (s State) Reset(s2 State) State {
 	return Reset(s2)(s)
 }
 
+func (s State) Requires(id string, deps ...State) State {
+	if len(deps) == 0 {
+		return s
+	}
+	inputs := make([]PassthroughInput, 0, len(deps)+1)
+	inputs = append(inputs, PassthroughInput{State: s, Output: true})
+	for _, dep := range deps {
+		inputs = append(inputs, PassthroughInput{State: dep})
+	}
+	return s.WithOutput(NewPassthroughOp(id, inputs).Output())
+}
+
 // User sets the user for this state.
 // See [User] for more details.
 func (s State) User(v string) State {

--- a/solver/llbsolver/ops/opsutils/validate.go
+++ b/solver/llbsolver/ops/opsutils/validate.go
@@ -10,6 +10,7 @@ func Validate(op *pb.Op) error {
 		return errors.Errorf("invalid nil op")
 	}
 
+	inputCount := len(op.Inputs)
 	switch op := op.Op.(type) {
 	case *pb.Op_Source:
 		if op.Source == nil {
@@ -57,6 +58,21 @@ func Validate(op *pb.Op) error {
 	case *pb.Op_Diff:
 		if op.Diff == nil {
 			return errors.Errorf("invalid nil diff op")
+		}
+	case *pb.Op_Passthrough:
+		if op.Passthrough == nil {
+			return errors.Errorf("invalid nil passthrough op")
+		}
+		if op.Passthrough.Id == "" {
+			return errors.Errorf("invalid passthrough op with no id")
+		}
+		if len(op.Passthrough.Outputs) == 0 {
+			return errors.Errorf("invalid passthrough op with no outputs")
+		}
+		for _, input := range op.Passthrough.Outputs {
+			if input < 0 || inputCount > 0 && input >= int64(inputCount) {
+				return errors.Errorf("invalid passthrough output input index %d", input)
+			}
 		}
 	}
 	return nil

--- a/solver/llbsolver/ops/passthrough.go
+++ b/solver/llbsolver/ops/passthrough.go
@@ -1,0 +1,74 @@
+package ops
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/solver/llbsolver/ops/opsutils"
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/util/cachedigest"
+	digest "github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
+)
+
+const passthroughCacheType = "buildkit.passthrough.v0"
+
+type passthroughOp struct {
+	op         *pb.PassthroughOp
+	inputCount int
+}
+
+func NewPassthroughOp(v solver.Vertex, op *pb.Op_Passthrough) (solver.Op, error) {
+	if err := opsutils.Validate(&pb.Op{Op: op}); err != nil {
+		return nil, err
+	}
+	return &passthroughOp{op: op.Passthrough, inputCount: len(v.Inputs())}, nil
+}
+
+func (p *passthroughOp) CacheMap(context.Context, solver.JobContext, int) (*solver.CacheMap, bool, error) {
+	dt, err := json.Marshal(struct {
+		Type        string
+		Passthrough *pb.PassthroughOp
+	}{
+		Type:        passthroughCacheType,
+		Passthrough: p.op,
+	})
+	if err != nil {
+		return nil, false, err
+	}
+
+	dgst, err := cachedigest.FromBytes(dt, cachedigest.TypeJSON)
+	if err != nil {
+		return nil, false, err
+	}
+
+	cm := &solver.CacheMap{
+		Digest: dgst,
+		Deps: make([]struct {
+			Selector          digest.Digest
+			ComputeDigestFunc solver.ResultBasedCacheFunc
+			PreprocessFunc    solver.PreprocessFunc
+		}, p.inputCount),
+	}
+
+	return cm, true, nil
+}
+
+func (p *passthroughOp) Exec(ctx context.Context, jobCtx solver.JobContext, inputs []solver.Result) ([]solver.Result, error) {
+	outputs := make([]solver.Result, len(p.op.Outputs))
+	for i, inputIndex := range p.op.Outputs {
+		if inputIndex < 0 || inputIndex >= int64(len(inputs)) {
+			return nil, errors.Errorf("invalid passthrough output input index %d", inputIndex)
+		}
+		inp := inputs[inputIndex]
+		if inp != nil {
+			outputs[i] = inp.Clone()
+		}
+	}
+	return outputs, nil
+}
+
+func (p *passthroughOp) Acquire(ctx context.Context) (solver.ReleaseFunc, error) {
+	return func() {}, nil
+}

--- a/solver/llbsolver/vertex.go
+++ b/solver/llbsolver/vertex.go
@@ -497,6 +497,8 @@ func llbOpName(pbOp *pb.Op, load func(string) (solver.Vertex, error)) (string, e
 			upperName = fmt.Sprintf("(%s)", upperVtx.Name())
 		}
 		return "diff " + lowerName + " -> " + upperName, nil
+	case *pb.Op_Passthrough:
+		return "passthrough " + op.Passthrough.Id, nil
 	default:
 		return "unknown", nil
 	}

--- a/solver/pb/caps.go
+++ b/solver/pb/caps.go
@@ -100,8 +100,9 @@ const (
 	CapRemoteCacheS3     apicaps.CapID = "cache.s3"
 	CapRemoteCacheAzBlob apicaps.CapID = "cache.azblob"
 
-	CapMergeOp apicaps.CapID = "mergeop"
-	CapDiffOp  apicaps.CapID = "diffop"
+	CapMergeOp       apicaps.CapID = "mergeop"
+	CapDiffOp        apicaps.CapID = "diffop"
+	CapPassthroughOp apicaps.CapID = "passthroughop"
 
 	CapAnnotations  apicaps.CapID = "exporter.image.annotations"
 	CapAttestations apicaps.CapID = "exporter.image.attestations"
@@ -591,6 +592,12 @@ func init() {
 
 	Caps.Init(apicaps.Cap{
 		ID:      CapDiffOp,
+		Enabled: true,
+		Status:  apicaps.CapStatusExperimental,
+	})
+
+	Caps.Init(apicaps.Cap{
+		ID:      CapPassthroughOp,
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})

--- a/solver/pb/json.go
+++ b/solver/pb/json.go
@@ -5,12 +5,13 @@ import "encoding/json"
 type jsonOp struct {
 	Inputs []*Input `json:"inputs,omitempty"`
 	Op     struct {
-		Exec   *ExecOp   `json:"exec,omitempty"`
-		Source *SourceOp `json:"source,omitempty"`
-		File   *FileOp   `json:"file,omitempty"`
-		Build  *BuildOp  `json:"build,omitempty"`
-		Merge  *MergeOp  `json:"merge,omitempty"`
-		Diff   *DiffOp   `json:"diff,omitempty"`
+		Exec   *ExecOp        `json:"exec,omitempty"`
+		Source *SourceOp      `json:"source,omitempty"`
+		File   *FileOp        `json:"file,omitempty"`
+		Build  *BuildOp       `json:"build,omitempty"`
+		Merge  *MergeOp       `json:"merge,omitempty"`
+		Diff   *DiffOp        `json:"diff,omitempty"`
+		Pass   *PassthroughOp `json:"passthrough,omitempty"`
 	}
 	Platform    *Platform          `json:"platform,omitempty"`
 	Constraints *WorkerConstraints `json:"constraints,omitempty"`
@@ -32,6 +33,8 @@ func (m *Op) MarshalJSON() ([]byte, error) {
 		v.Op.Merge = op.Merge
 	case *Op_Diff:
 		v.Op.Diff = op.Diff
+	case *Op_Passthrough:
+		v.Op.Pass = op.Passthrough
 	}
 	v.Platform = m.Platform
 	v.Constraints = m.Constraints
@@ -58,6 +61,8 @@ func (m *Op) UnmarshalJSON(data []byte) error {
 		m.Op = &Op_Merge{v.Op.Merge}
 	case v.Op.Diff != nil:
 		m.Op = &Op_Diff{v.Op.Diff}
+	case v.Op.Pass != nil:
+		m.Op = &Op_Passthrough{v.Op.Pass}
 	}
 	m.Platform = v.Platform
 	m.Constraints = v.Constraints

--- a/solver/pb/ops.pb.go
+++ b/solver/pb/ops.pb.go
@@ -295,6 +295,7 @@ type Op struct {
 	//	*Op_Build
 	//	*Op_Merge
 	//	*Op_Diff
+	//	*Op_Passthrough
 	Op            isOp_Op            `protobuf_oneof:"op"`
 	Platform      *Platform          `protobuf:"bytes,10,opt,name=platform,proto3" json:"platform,omitempty"`
 	Constraints   *WorkerConstraints `protobuf:"bytes,11,opt,name=constraints,proto3" json:"constraints,omitempty"`
@@ -400,6 +401,15 @@ func (x *Op) GetDiff() *DiffOp {
 	return nil
 }
 
+func (x *Op) GetPassthrough() *PassthroughOp {
+	if x != nil {
+		if x, ok := x.Op.(*Op_Passthrough); ok {
+			return x.Passthrough
+		}
+	}
+	return nil
+}
+
 func (x *Op) GetPlatform() *Platform {
 	if x != nil {
 		return x.Platform
@@ -442,6 +452,10 @@ type Op_Diff struct {
 	Diff *DiffOp `protobuf:"bytes,7,opt,name=diff,proto3,oneof"`
 }
 
+type Op_Passthrough struct {
+	Passthrough *PassthroughOp `protobuf:"bytes,8,opt,name=passthrough,proto3,oneof"`
+}
+
 func (*Op_Exec) isOp_Op() {}
 
 func (*Op_Source) isOp_Op() {}
@@ -453,6 +467,8 @@ func (*Op_Build) isOp_Op() {}
 func (*Op_Merge) isOp_Op() {}
 
 func (*Op_Diff) isOp_Op() {}
+
+func (*Op_Passthrough) isOp_Op() {}
 
 // Platform is github.com/opencontainers/image-spec/specs-go/v1.Platform
 type Platform struct {
@@ -3496,11 +3512,63 @@ func (x *DiffOp) GetUpper() *UpperDiffInput {
 	return nil
 }
 
+type PassthroughOp struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Outputs       []int64                `protobuf:"varint,2,rep,packed,name=outputs,proto3" json:"outputs,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PassthroughOp) Reset() {
+	*x = PassthroughOp{}
+	mi := &file_github_com_moby_buildkit_solver_pb_ops_proto_msgTypes[45]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PassthroughOp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PassthroughOp) ProtoMessage() {}
+
+func (x *PassthroughOp) ProtoReflect() protoreflect.Message {
+	mi := &file_github_com_moby_buildkit_solver_pb_ops_proto_msgTypes[45]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PassthroughOp.ProtoReflect.Descriptor instead.
+func (*PassthroughOp) Descriptor() ([]byte, []int) {
+	return file_github_com_moby_buildkit_solver_pb_ops_proto_rawDescGZIP(), []int{45}
+}
+
+func (x *PassthroughOp) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *PassthroughOp) GetOutputs() []int64 {
+	if x != nil {
+		return x.Outputs
+	}
+	return nil
+}
+
 var File_github_com_moby_buildkit_solver_pb_ops_proto protoreflect.FileDescriptor
 
 const file_github_com_moby_buildkit_solver_pb_ops_proto_rawDesc = "" +
 	"\n" +
-	",github.com/moby/buildkit/solver/pb/ops.proto\x12\x02pb\"\xe8\x02\n" +
+	",github.com/moby/buildkit/solver/pb/ops.proto\x12\x02pb\"\x9f\x03\n" +
 	"\x02Op\x12!\n" +
 	"\x06inputs\x18\x01 \x03(\v2\t.pb.InputR\x06inputs\x12 \n" +
 	"\x04exec\x18\x02 \x01(\v2\n" +
@@ -3511,7 +3579,8 @@ const file_github_com_moby_buildkit_solver_pb_ops_proto_rawDesc = "" +
 	"\x05build\x18\x05 \x01(\v2\v.pb.BuildOpH\x00R\x05build\x12#\n" +
 	"\x05merge\x18\x06 \x01(\v2\v.pb.MergeOpH\x00R\x05merge\x12 \n" +
 	"\x04diff\x18\a \x01(\v2\n" +
-	".pb.DiffOpH\x00R\x04diff\x12(\n" +
+	".pb.DiffOpH\x00R\x04diff\x125\n" +
+	"\vpassthrough\x18\b \x01(\v2\x11.pb.PassthroughOpH\x00R\vpassthrough\x12(\n" +
 	"\bplatform\x18\n" +
 	" \x01(\v2\f.pb.PlatformR\bplatform\x127\n" +
 	"\vconstraints\x18\v \x01(\v2\x15.pb.WorkerConstraintsR\vconstraintsB\x04\n" +
@@ -3773,7 +3842,10 @@ const file_github_com_moby_buildkit_solver_pb_ops_proto_rawDesc = "" +
 	"\x05input\x18\x01 \x01(\x03R\x05input\"\\\n" +
 	"\x06DiffOp\x12(\n" +
 	"\x05lower\x18\x01 \x01(\v2\x12.pb.LowerDiffInputR\x05lower\x12(\n" +
-	"\x05upper\x18\x02 \x01(\v2\x12.pb.UpperDiffInputR\x05upper*3\n" +
+	"\x05upper\x18\x02 \x01(\v2\x12.pb.UpperDiffInputR\x05upper\"9\n" +
+	"\rPassthroughOp\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
+	"\aoutputs\x18\x02 \x03(\x03R\aoutputs*3\n" +
 	"\aNetMode\x12\t\n" +
 	"\x05UNSET\x10\x00\x12\b\n" +
 	"\x04HOST\x10\x01\x12\b\n" +
@@ -3813,7 +3885,7 @@ func file_github_com_moby_buildkit_solver_pb_ops_proto_rawDescGZIP() []byte {
 }
 
 var file_github_com_moby_buildkit_solver_pb_ops_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_github_com_moby_buildkit_solver_pb_ops_proto_msgTypes = make([]protoimpl.MessageInfo, 52)
+var file_github_com_moby_buildkit_solver_pb_ops_proto_msgTypes = make([]protoimpl.MessageInfo, 53)
 var file_github_com_moby_buildkit_solver_pb_ops_proto_goTypes = []any{
 	(NetMode)(0),              // 0: pb.NetMode
 	(SecurityMode)(0),         // 1: pb.SecurityMode
@@ -3865,13 +3937,14 @@ var file_github_com_moby_buildkit_solver_pb_ops_proto_goTypes = []any{
 	(*LowerDiffInput)(nil),    // 47: pb.LowerDiffInput
 	(*UpperDiffInput)(nil),    // 48: pb.UpperDiffInput
 	(*DiffOp)(nil),            // 49: pb.DiffOp
-	nil,                       // 50: pb.SourceOp.AttrsEntry
-	nil,                       // 51: pb.BuildOp.InputsEntry
-	nil,                       // 52: pb.BuildOp.AttrsEntry
-	nil,                       // 53: pb.OpMetadata.DescriptionEntry
-	nil,                       // 54: pb.OpMetadata.CapsEntry
-	nil,                       // 55: pb.Source.LocationsEntry
-	nil,                       // 56: pb.Definition.MetadataEntry
+	(*PassthroughOp)(nil),     // 50: pb.PassthroughOp
+	nil,                       // 51: pb.SourceOp.AttrsEntry
+	nil,                       // 52: pb.BuildOp.InputsEntry
+	nil,                       // 53: pb.BuildOp.AttrsEntry
+	nil,                       // 54: pb.OpMetadata.DescriptionEntry
+	nil,                       // 55: pb.OpMetadata.CapsEntry
+	nil,                       // 56: pb.Source.LocationsEntry
+	nil,                       // 57: pb.Definition.MetadataEntry
 }
 var file_github_com_moby_buildkit_solver_pb_ops_proto_depIdxs = []int32{
 	7,  // 0: pb.Op.inputs:type_name -> pb.Input
@@ -3881,66 +3954,67 @@ var file_github_com_moby_buildkit_solver_pb_ops_proto_depIdxs = []int32{
 	20, // 4: pb.Op.build:type_name -> pb.BuildOp
 	46, // 5: pb.Op.merge:type_name -> pb.MergeOp
 	49, // 6: pb.Op.diff:type_name -> pb.DiffOp
-	6,  // 7: pb.Op.platform:type_name -> pb.Platform
-	33, // 8: pb.Op.constraints:type_name -> pb.WorkerConstraints
-	9,  // 9: pb.ExecOp.meta:type_name -> pb.Meta
-	14, // 10: pb.ExecOp.mounts:type_name -> pb.Mount
-	0,  // 11: pb.ExecOp.network:type_name -> pb.NetMode
-	1,  // 12: pb.ExecOp.security:type_name -> pb.SecurityMode
-	12, // 13: pb.ExecOp.secretenv:type_name -> pb.SecretEnv
-	13, // 14: pb.ExecOp.cdiDevices:type_name -> pb.CDIDevice
-	32, // 15: pb.Meta.proxy_env:type_name -> pb.ProxyEnv
-	10, // 16: pb.Meta.extraHosts:type_name -> pb.HostIP
-	11, // 17: pb.Meta.ulimit:type_name -> pb.Ulimit
-	2,  // 18: pb.Mount.mountType:type_name -> pb.MountType
-	15, // 19: pb.Mount.TmpfsOpt:type_name -> pb.TmpfsOpt
-	16, // 20: pb.Mount.cacheOpt:type_name -> pb.CacheOpt
-	17, // 21: pb.Mount.secretOpt:type_name -> pb.SecretOpt
-	18, // 22: pb.Mount.SSHOpt:type_name -> pb.SSHOpt
-	3,  // 23: pb.Mount.contentCache:type_name -> pb.MountContentCache
-	4,  // 24: pb.CacheOpt.sharing:type_name -> pb.CacheSharingOpt
-	50, // 25: pb.SourceOp.attrs:type_name -> pb.SourceOp.AttrsEntry
-	51, // 26: pb.BuildOp.inputs:type_name -> pb.BuildOp.InputsEntry
-	34, // 27: pb.BuildOp.def:type_name -> pb.Definition
-	52, // 28: pb.BuildOp.attrs:type_name -> pb.BuildOp.AttrsEntry
-	53, // 29: pb.OpMetadata.description:type_name -> pb.OpMetadata.DescriptionEntry
-	29, // 30: pb.OpMetadata.export_cache:type_name -> pb.ExportCache
-	54, // 31: pb.OpMetadata.caps:type_name -> pb.OpMetadata.CapsEntry
-	30, // 32: pb.OpMetadata.progress_group:type_name -> pb.ProgressGroup
-	31, // 33: pb.OpMetadata.linux_resources:type_name -> pb.LinuxResources
-	55, // 34: pb.Source.locations:type_name -> pb.Source.LocationsEntry
-	25, // 35: pb.Source.infos:type_name -> pb.SourceInfo
-	26, // 36: pb.Locations.locations:type_name -> pb.Location
-	34, // 37: pb.SourceInfo.definition:type_name -> pb.Definition
-	27, // 38: pb.Location.ranges:type_name -> pb.Range
-	28, // 39: pb.Range.start:type_name -> pb.Position
-	28, // 40: pb.Range.end:type_name -> pb.Position
-	56, // 41: pb.Definition.metadata:type_name -> pb.Definition.MetadataEntry
-	23, // 42: pb.Definition.Source:type_name -> pb.Source
-	36, // 43: pb.FileOp.actions:type_name -> pb.FileAction
-	37, // 44: pb.FileAction.copy:type_name -> pb.FileActionCopy
-	38, // 45: pb.FileAction.mkfile:type_name -> pb.FileActionMkFile
-	40, // 46: pb.FileAction.mkdir:type_name -> pb.FileActionMkDir
-	41, // 47: pb.FileAction.rm:type_name -> pb.FileActionRm
-	39, // 48: pb.FileAction.symlink:type_name -> pb.FileActionSymlink
-	42, // 49: pb.FileActionCopy.owner:type_name -> pb.ChownOpt
-	42, // 50: pb.FileActionMkFile.owner:type_name -> pb.ChownOpt
-	42, // 51: pb.FileActionSymlink.owner:type_name -> pb.ChownOpt
-	42, // 52: pb.FileActionMkDir.owner:type_name -> pb.ChownOpt
-	43, // 53: pb.ChownOpt.user:type_name -> pb.UserOpt
-	43, // 54: pb.ChownOpt.group:type_name -> pb.UserOpt
-	44, // 55: pb.UserOpt.byName:type_name -> pb.NamedUserOpt
-	45, // 56: pb.MergeOp.inputs:type_name -> pb.MergeInput
-	47, // 57: pb.DiffOp.lower:type_name -> pb.LowerDiffInput
-	48, // 58: pb.DiffOp.upper:type_name -> pb.UpperDiffInput
-	21, // 59: pb.BuildOp.InputsEntry.value:type_name -> pb.BuildInput
-	24, // 60: pb.Source.LocationsEntry.value:type_name -> pb.Locations
-	22, // 61: pb.Definition.MetadataEntry.value:type_name -> pb.OpMetadata
-	62, // [62:62] is the sub-list for method output_type
-	62, // [62:62] is the sub-list for method input_type
-	62, // [62:62] is the sub-list for extension type_name
-	62, // [62:62] is the sub-list for extension extendee
-	0,  // [0:62] is the sub-list for field type_name
+	50, // 7: pb.Op.passthrough:type_name -> pb.PassthroughOp
+	6,  // 8: pb.Op.platform:type_name -> pb.Platform
+	33, // 9: pb.Op.constraints:type_name -> pb.WorkerConstraints
+	9,  // 10: pb.ExecOp.meta:type_name -> pb.Meta
+	14, // 11: pb.ExecOp.mounts:type_name -> pb.Mount
+	0,  // 12: pb.ExecOp.network:type_name -> pb.NetMode
+	1,  // 13: pb.ExecOp.security:type_name -> pb.SecurityMode
+	12, // 14: pb.ExecOp.secretenv:type_name -> pb.SecretEnv
+	13, // 15: pb.ExecOp.cdiDevices:type_name -> pb.CDIDevice
+	32, // 16: pb.Meta.proxy_env:type_name -> pb.ProxyEnv
+	10, // 17: pb.Meta.extraHosts:type_name -> pb.HostIP
+	11, // 18: pb.Meta.ulimit:type_name -> pb.Ulimit
+	2,  // 19: pb.Mount.mountType:type_name -> pb.MountType
+	15, // 20: pb.Mount.TmpfsOpt:type_name -> pb.TmpfsOpt
+	16, // 21: pb.Mount.cacheOpt:type_name -> pb.CacheOpt
+	17, // 22: pb.Mount.secretOpt:type_name -> pb.SecretOpt
+	18, // 23: pb.Mount.SSHOpt:type_name -> pb.SSHOpt
+	3,  // 24: pb.Mount.contentCache:type_name -> pb.MountContentCache
+	4,  // 25: pb.CacheOpt.sharing:type_name -> pb.CacheSharingOpt
+	51, // 26: pb.SourceOp.attrs:type_name -> pb.SourceOp.AttrsEntry
+	52, // 27: pb.BuildOp.inputs:type_name -> pb.BuildOp.InputsEntry
+	34, // 28: pb.BuildOp.def:type_name -> pb.Definition
+	53, // 29: pb.BuildOp.attrs:type_name -> pb.BuildOp.AttrsEntry
+	54, // 30: pb.OpMetadata.description:type_name -> pb.OpMetadata.DescriptionEntry
+	29, // 31: pb.OpMetadata.export_cache:type_name -> pb.ExportCache
+	55, // 32: pb.OpMetadata.caps:type_name -> pb.OpMetadata.CapsEntry
+	30, // 33: pb.OpMetadata.progress_group:type_name -> pb.ProgressGroup
+	31, // 34: pb.OpMetadata.linux_resources:type_name -> pb.LinuxResources
+	56, // 35: pb.Source.locations:type_name -> pb.Source.LocationsEntry
+	25, // 36: pb.Source.infos:type_name -> pb.SourceInfo
+	26, // 37: pb.Locations.locations:type_name -> pb.Location
+	34, // 38: pb.SourceInfo.definition:type_name -> pb.Definition
+	27, // 39: pb.Location.ranges:type_name -> pb.Range
+	28, // 40: pb.Range.start:type_name -> pb.Position
+	28, // 41: pb.Range.end:type_name -> pb.Position
+	57, // 42: pb.Definition.metadata:type_name -> pb.Definition.MetadataEntry
+	23, // 43: pb.Definition.Source:type_name -> pb.Source
+	36, // 44: pb.FileOp.actions:type_name -> pb.FileAction
+	37, // 45: pb.FileAction.copy:type_name -> pb.FileActionCopy
+	38, // 46: pb.FileAction.mkfile:type_name -> pb.FileActionMkFile
+	40, // 47: pb.FileAction.mkdir:type_name -> pb.FileActionMkDir
+	41, // 48: pb.FileAction.rm:type_name -> pb.FileActionRm
+	39, // 49: pb.FileAction.symlink:type_name -> pb.FileActionSymlink
+	42, // 50: pb.FileActionCopy.owner:type_name -> pb.ChownOpt
+	42, // 51: pb.FileActionMkFile.owner:type_name -> pb.ChownOpt
+	42, // 52: pb.FileActionSymlink.owner:type_name -> pb.ChownOpt
+	42, // 53: pb.FileActionMkDir.owner:type_name -> pb.ChownOpt
+	43, // 54: pb.ChownOpt.user:type_name -> pb.UserOpt
+	43, // 55: pb.ChownOpt.group:type_name -> pb.UserOpt
+	44, // 56: pb.UserOpt.byName:type_name -> pb.NamedUserOpt
+	45, // 57: pb.MergeOp.inputs:type_name -> pb.MergeInput
+	47, // 58: pb.DiffOp.lower:type_name -> pb.LowerDiffInput
+	48, // 59: pb.DiffOp.upper:type_name -> pb.UpperDiffInput
+	21, // 60: pb.BuildOp.InputsEntry.value:type_name -> pb.BuildInput
+	24, // 61: pb.Source.LocationsEntry.value:type_name -> pb.Locations
+	22, // 62: pb.Definition.MetadataEntry.value:type_name -> pb.OpMetadata
+	63, // [63:63] is the sub-list for method output_type
+	63, // [63:63] is the sub-list for method input_type
+	63, // [63:63] is the sub-list for extension type_name
+	63, // [63:63] is the sub-list for extension extendee
+	0,  // [0:63] is the sub-list for field type_name
 }
 
 func init() { file_github_com_moby_buildkit_solver_pb_ops_proto_init() }
@@ -3955,6 +4029,7 @@ func file_github_com_moby_buildkit_solver_pb_ops_proto_init() {
 		(*Op_Build)(nil),
 		(*Op_Merge)(nil),
 		(*Op_Diff)(nil),
+		(*Op_Passthrough)(nil),
 	}
 	file_github_com_moby_buildkit_solver_pb_ops_proto_msgTypes[31].OneofWrappers = []any{
 		(*FileAction_Copy)(nil),
@@ -3973,7 +4048,7 @@ func file_github_com_moby_buildkit_solver_pb_ops_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_moby_buildkit_solver_pb_ops_proto_rawDesc), len(file_github_com_moby_buildkit_solver_pb_ops_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   52,
+			NumMessages:   53,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/solver/pb/ops.proto
+++ b/solver/pb/ops.proto
@@ -18,6 +18,7 @@ message Op {
 		BuildOp build = 5;
 		MergeOp merge = 6;
 		DiffOp diff = 7;
+		PassthroughOp passthrough = 8;
 	}
 	Platform platform = 10;
 	WorkerConstraints constraints = 11;
@@ -459,4 +460,9 @@ message UpperDiffInput {
 message DiffOp {
 	LowerDiffInput lower = 1;
 	UpperDiffInput upper = 2;
+}
+
+message PassthroughOp {
+	string id = 1;
+	repeated int64 outputs = 2;
 }

--- a/solver/pb/ops_vtproto.pb.go
+++ b/solver/pb/ops_vtproto.pb.go
@@ -101,6 +101,15 @@ func (m *Op_Diff) CloneVT() isOp_Op {
 	return r
 }
 
+func (m *Op_Passthrough) CloneVT() isOp_Op {
+	if m == nil {
+		return (*Op_Passthrough)(nil)
+	}
+	r := new(Op_Passthrough)
+	r.Passthrough = m.Passthrough.CloneVT()
+	return r
+}
+
 func (m *Platform) CloneVT() *Platform {
 	if m == nil {
 		return (*Platform)(nil)
@@ -1176,6 +1185,28 @@ func (m *DiffOp) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (m *PassthroughOp) CloneVT() *PassthroughOp {
+	if m == nil {
+		return (*PassthroughOp)(nil)
+	}
+	r := new(PassthroughOp)
+	r.Id = m.Id
+	if rhs := m.Outputs; rhs != nil {
+		tmpContainer := make([]int64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.Outputs = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *PassthroughOp) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (this *Op) EqualVT(that *Op) bool {
 	if this == that {
 		return true
@@ -1367,6 +1398,31 @@ func (this *Op_Diff) EqualVT(thatIface isOp_Op) bool {
 		}
 		if q == nil {
 			q = &DiffOp{}
+		}
+		if !p.EqualVT(q) {
+			return false
+		}
+	}
+	return true
+}
+
+func (this *Op_Passthrough) EqualVT(thatIface isOp_Op) bool {
+	that, ok := thatIface.(*Op_Passthrough)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if p, q := this.Passthrough, that.Passthrough; p != q {
+		if p == nil {
+			p = &PassthroughOp{}
+		}
+		if q == nil {
+			q = &PassthroughOp{}
 		}
 		if !p.EqualVT(q) {
 			return false
@@ -3005,6 +3061,34 @@ func (this *DiffOp) EqualMessageVT(thatMsg proto.Message) bool {
 	}
 	return this.EqualVT(that)
 }
+func (this *PassthroughOp) EqualVT(that *PassthroughOp) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.Id != that.Id {
+		return false
+	}
+	if len(this.Outputs) != len(that.Outputs) {
+		return false
+	}
+	for i, vx := range this.Outputs {
+		vy := that.Outputs[i]
+		if vx != vy {
+			return false
+		}
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *PassthroughOp) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*PassthroughOp)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (m *Op) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -3214,6 +3298,29 @@ func (m *Op_Diff) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i = protohelpers.EncodeVarint(dAtA, i, 0)
 		i--
 		dAtA[i] = 0x3a
+	}
+	return len(dAtA) - i, nil
+}
+func (m *Op_Passthrough) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *Op_Passthrough) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Passthrough != nil {
+		size, err := m.Passthrough.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x42
+	} else {
+		i = protohelpers.EncodeVarint(dAtA, i, 0)
+		i--
+		dAtA[i] = 0x42
 	}
 	return len(dAtA) - i, nil
 }
@@ -6132,6 +6239,67 @@ func (m *DiffOp) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *PassthroughOp) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *PassthroughOp) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *PassthroughOp) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Outputs) > 0 {
+		var pksize2 int
+		for _, num := range m.Outputs {
+			pksize2 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize2
+		j1 := i
+		for _, num1 := range m.Outputs {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j1] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j1++
+			}
+			dAtA[j1] = uint8(num)
+			j1++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize2))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Id) > 0 {
+		i -= len(m.Id)
+		copy(dAtA[i:], m.Id)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Id)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *Op) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -6237,6 +6405,20 @@ func (m *Op_Diff) SizeVT() (n int) {
 	_ = l
 	if m.Diff != nil {
 		l = m.Diff.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	} else {
+		n += 3
+	}
+	return n
+}
+func (m *Op_Passthrough) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Passthrough != nil {
+		l = m.Passthrough.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	} else {
 		n += 3
@@ -7412,6 +7594,27 @@ func (m *DiffOp) SizeVT() (n int) {
 	return n
 }
 
+func (m *PassthroughOp) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Id)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.Outputs) > 0 {
+		l = 0
+		for _, e := range m.Outputs {
+			l += protohelpers.SizeOfVarint(uint64(e))
+		}
+		n += 1 + protohelpers.SizeOfVarint(uint64(l)) + l
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *Op) UnmarshalVT(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -7719,6 +7922,47 @@ func (m *Op) UnmarshalVT(dAtA []byte) error {
 					return err
 				}
 				m.Op = &Op_Diff{Diff: v}
+			}
+			iNdEx = postIndex
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Passthrough", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if oneof, ok := m.Op.(*Op_Passthrough); ok {
+				if err := oneof.Passthrough.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				v := &PassthroughOp{}
+				if err := v.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+				m.Op = &Op_Passthrough{Passthrough: v}
 			}
 			iNdEx = postIndex
 		case 10:
@@ -15221,6 +15465,165 @@ func (m *DiffOp) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *PassthroughOp) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: PassthroughOp: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: PassthroughOp: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Id", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Id = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType == 0 {
+				var v int64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					v |= int64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				m.Outputs = append(m.Outputs, v)
+			} else if wireType == 2 {
+				var packedLen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					packedLen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if packedLen < 0 {
+					return protohelpers.ErrInvalidLength
+				}
+				postIndex := iNdEx + packedLen
+				if postIndex < 0 {
+					return protohelpers.ErrInvalidLength
+				}
+				if postIndex > l {
+					return io.ErrUnexpectedEOF
+				}
+				var elementCount int
+				var count int
+				for _, integer := range dAtA[iNdEx:postIndex] {
+					if integer < 128 {
+						count++
+					}
+				}
+				elementCount = count
+				if elementCount != 0 && len(m.Outputs) == 0 {
+					m.Outputs = make([]int64, 0, elementCount)
+				}
+				for iNdEx < postIndex {
+					var v int64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						v |= int64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					m.Outputs = append(m.Outputs, v)
+				}
+			} else {
+				return fmt.Errorf("proto: wrong wireType = %d for field Outputs", wireType)
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -421,6 +421,8 @@ func (w *Worker) ResolveOp(v solver.Vertex, s frontend.FrontendLLBBridge, sm *se
 			return ops.NewMergeOp(v, op, w)
 		case *pb.Op_Diff:
 			return ops.NewDiffOp(v, op, w)
+		case *pb.Op_Passthrough:
+			return ops.NewPassthroughOp(v, op)
 		default:
 			return nil, errors.Errorf("no support for %T", op)
 		}


### PR DESCRIPTION
fixes #6809

Add a passthrough LLB op that builds all inputs and exposes selected inputs as outputs. Add State.Requires as a client shortcut for requiring dependencies without returning their snapshots.