### PR TITLE
archutil: advertise linux/arm/v5 from arm probe

### DIFF
--- a/util/archutil/detect.go
+++ b/util/archutil/detect.go
@@ -92,14 +92,18 @@ func SupportedPlatforms(noCache bool) []ocispecs.Platform {
 	}
 	if p := "arm"; def.Architecture != p {
 		if _, err := armSupported(); err == nil {
-			p := linux("arm")
-			p.Variant = "v6"
-			arr = append(arr, linux("arm"), p)
+			v6 := linux("arm")
+			v6.Variant = "v6"
+			v5 := linux("arm")
+			v5.Variant = "v5"
+			arr = append(arr, linux("arm"), v6, v5)
 		}
 	} else if def.Variant == "" {
-		p := linux("arm")
-		p.Variant = "v6"
-		arr = append(arr, p)
+		v6 := linux("arm")
+		v6.Variant = "v6"
+		v5 := linux("arm")
+		v5.Variant = "v5"
+		arr = append(arr, v6, v5)
 	}
 	return arr
 }


### PR DESCRIPTION
follow-up
* https://github.com/tonistiigi/binfmt/issues/296

QEMU exposes one 32-bit ARM user-mode emulator as `qemu-arm`, and BuildKit maps all `arm` variants to `buildkit-qemu-arm`. The platform variant is OCI metadata and should not be modeled as a separate emulator capability. This change keeps detection aligned with that model while making `linux/arm/v5` visible when ARM32 emulation is available.