### PR TITLE
testutil: match exact platform for mirrored images

### DIFF
--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -344,7 +344,7 @@ func resolveDefaultPlatform(ctx context.Context, provider content.Provider, desc
 	if err != nil {
 		return ocispecs.Descriptor{}, err
 	}
-	matcher := platforms.Default()
+	matcher := platforms.OnlyStrict(platforms.DefaultSpec())
 	for _, c := range children {
 		if c.Platform != nil && matcher.Match(*c.Platform) {
 			return c, nil


### PR DESCRIPTION
resolveDefaultPlatform used platforms.Default(), which also matches sub-platforms (e.g. 386 for amd64, arm for arm64). When an index lists a compatible variant before the host platform, the wrong single-arch manifest could be copied to the local mirror.