### PR TITLE
config: fix a default GC policy filter never matching any record

### DIFF
--- a/cmd/buildkitd/config/gcpolicy.go
+++ b/cmd/buildkitd/config/gcpolicy.go
@@ -78,7 +78,7 @@ func DefaultGCPolicy(cfg GCConfig, dstat disk.DiskStat) []GCPolicy {
 	return []GCPolicy{
 		// if build cache uses more than 512MB delete the most easily reproducible data after it has not been used for 2 days
 		{
-			Filters:      []string{"type==source.local,type==exec.cachemount,type==source.git.checkout"},
+			Filters:      []string{"type==source.local", "type==exec.cachemount", "type==source.git.checkout"},
 			KeepDuration: Duration{Duration: time.Duration(48) * time.Hour}, // 48h
 			MaxUsedSpace: DiskSpace{Bytes: 512 * 1e6},                       // 512MB
 		},

--- a/cmd/buildkitd/config/gcpolicy_test.go
+++ b/cmd/buildkitd/config/gcpolicy_test.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/containerd/containerd/v2/pkg/filters"
+	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/util/disk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultGCPolicyFiltersMatch(t *testing.T) {
+	policies := DefaultGCPolicy(GCConfig{}, disk.DiskStat{Total: 1e12})
+	require.NotEmpty(t, policies)
+
+	rule := policies[0]
+	require.NotEmpty(t, rule.Filters)
+
+	f, err := filters.ParseAll(rule.Filters...)
+	require.NoError(t, err)
+
+	adapt := func(rt client.UsageRecordType) filters.Adaptor {
+		return filters.AdapterFunc(func(fieldpath []string) (string, bool) {
+			if len(fieldpath) == 1 && fieldpath[0] == "type" {
+				return string(rt), rt != ""
+			}
+			return "", false
+		})
+	}
+
+	for _, rt := range []client.UsageRecordType{
+		client.UsageRecordTypeLocalSource,
+		client.UsageRecordTypeCacheMount,
+		client.UsageRecordTypeGitCheckout,
+	} {
+		require.Truef(t, f.Match(adapt(rt)),
+			"first default GC policy should match record type %q", rt)
+	}
+
+	// It must not match unrelated records such as regular build cache.
+	require.Falsef(t, f.Match(adapt(client.UsageRecordTypeRegular)),
+		"first default GC policy should not match record type %q", client.UsageRecordTypeRegular)
+}

--- a/docs/cdi.md
+++ b/docs/cdi.md
@@ -57,7 +57,7 @@ Devices:
 
 GC Policy rule#0:
         All:                    false
-        Filters:                type==source.local,type==exec.cachemount,type==source.git.checkout
+        Filters:                type==source.local type==exec.cachemount type==source.git.checkout
         Keep duration:          48h0m0s
         Maximum used space:     512MB
 GC Policy rule#1:


### PR DESCRIPTION
### Summary

The first default GC policy is meant to prune the most easily reproducible cache (local sources, cache mounts, git checkouts) once the build cache exceeds 512MB and the data has been unused for 48h.

Its filter was written as a single comma-joined string:

```go
Filters: []string{"type==source.local,type==exec.cachemount,type==source.git.checkout"}
```

Each element of `GCPolicy.Filters` is passed to `containerd/filters.ParseAll`. Selectors separated by commas **within a single string** are ANDed together (`ParseAll` only ORs across separate slice elements). Since a record only ever has a single `type`, the expression `type==source.local AND type==exec.cachemount AND type==source.git.checkout` can never be satisfied — so this policy matched nothing and was effectively a no-op. 

### Fix

Split the filter into separate slice elements so they are ORed, matching the documented intent. This is also the form that already works when the array is written in `buildkitd.toml`:

```toml
filters = ["type==source.local", "type==exec.cachemount", "type==source.git.checkout"]
```

A regression test verifies the first default policy's filter matches the three reproducible record types and not regular build cache.
