### PR TITLE
Revert "executor: avoid runc stdin shutdown hangs"

### DIFF
--- a/client/build_test.go
+++ b/client/build_test.go
@@ -53,8 +53,6 @@ func TestClientGatewayIntegration(t *testing.T) {
 		testNoBuildID,
 		testUnknownBuildID,
 		testClientGatewayContainerExecPipe,
-		testClientGatewayContainerExecPipeRelease,
-		testClientGatewayContainerExecPipeSignalKill,
 		testClientGatewayContainerExecStdinCloseRace,
 		testClientGatewayContainerCancelOnRelease,
 		testClientGatewayContainerPID1Fail,
@@ -402,35 +400,6 @@ func testClientGatewayContainerCancelOnRelease(t *testing.T, sb integration.Sand
 // process together all started via `Exec` into the same container.
 // We are mimicing: `echo testing | cat | cat > /tmp/foo && cat /tmp/foo`
 func testClientGatewayContainerExecPipe(t *testing.T, sb integration.Sandbox) {
-	testClientGatewayContainerExecPipeWithCleanup(t, sb, func(ctx context.Context, ctr client.Container, pid1 client.ContainerProcess, stdin *io.PipeWriter) {
-		stdin.Close()
-		pid1.Wait()
-		ctr.Release(context.WithoutCancel(ctx))
-	})
-}
-
-// testClientGatewayContainerExecPipeRelease verifies that releasing the
-// container while pid1 still has an open stdin reader does not leave runc
-// blocked on the stdin copy.
-func testClientGatewayContainerExecPipeRelease(t *testing.T, sb integration.Sandbox) {
-	testClientGatewayContainerExecPipeWithCleanup(t, sb, func(ctx context.Context, ctr client.Container, pid1 client.ContainerProcess, _ *io.PipeWriter) {
-		ctr.Release(context.WithoutCancel(ctx))
-		pid1.Wait()
-	})
-}
-
-// testClientGatewayContainerExecPipeSignalKill verifies that SIGKILL delivered
-// via the process Signal channel unblocks runc when pid1 still has an open
-// stdin reader.
-func testClientGatewayContainerExecPipeSignalKill(t *testing.T, sb integration.Sandbox) {
-	testClientGatewayContainerExecPipeWithCleanup(t, sb, func(ctx context.Context, ctr client.Container, pid1 client.ContainerProcess, _ *io.PipeWriter) {
-		pid1.Signal(ctx, syscall.SIGKILL)
-		pid1.Wait()
-		ctr.Release(context.WithoutCancel(ctx))
-	})
-}
-
-func testClientGatewayContainerExecPipeWithCleanup(t *testing.T, sb integration.Sandbox, cleanup func(ctx context.Context, ctr client.Container, pid1 client.ContainerProcess, stdin *io.PipeWriter)) {
 	requiresLinux(t)
 
 	ctx := sb.Context()
@@ -470,17 +439,19 @@ func testClientGatewayContainerExecPipeWithCleanup(t *testing.T, sb integration.
 		}
 
 		// background pid1 process that starts container
-		pid1StdinR, pid1StdinW := io.Pipe()
 		pid1, err := ctr.Start(ctx, client.StartRequest{
-			Args:  []string{"cat"},
-			Stdin: pid1StdinR,
+			Args: []string{"sleep", "10"},
 		})
 		if err != nil {
 			ctr.Release(context.WithoutCancel(ctx))
 			return nil, err
 		}
 
-		defer cleanup(ctx, ctr, pid1, pid1StdinW)
+		defer func() {
+			// cancel pid1
+			ctr.Release(context.WithoutCancel(ctx))
+			pid1.Wait()
+		}()
 
 		// first part is `echo testing | cat`
 		stdin2 := bytes.NewBuffer([]byte("testing"))
@@ -555,6 +526,9 @@ func testClientGatewayContainerExecPipeWithCleanup(t *testing.T, sb integration.
 // exec receives stdin before EOF and uses the timeout only to catch stuck execs.
 func testClientGatewayContainerExecStdinCloseRace(t *testing.T, sb integration.Sandbox) {
 	requiresLinux(t)
+	if !strings.HasPrefix(sb.Name(), "containerd") {
+		t.Skip("test covers the containerd executor stdin close race")
+	}
 
 	ctx, cancel := context.WithTimeoutCause(sb.Context(), 30*time.Second, errors.WithStack(context.DeadlineExceeded))
 	defer cancel()

--- a/executor/runcexecutor/executor_linux.go
+++ b/executor/runcexecutor/executor_linux.go
@@ -83,34 +83,7 @@ func (w *runcExecutor) callWithIO(ctx context.Context, process executor.ProcessI
 	})
 
 	if !process.Meta.Tty {
-		runcIO := &forwardIO{stdout: process.Stdout, stderr: process.Stderr}
-		if process.Stdin != nil {
-			// Forward stdin through an os.Pipe rather than handing the
-			// caller's io.ReadCloser to runc directly. When cmd.Stdin is
-			// an *os.File, exec.Cmd dup2s it into the child and cmd.Wait
-			// returns as soon as the runc subprocess exits. Otherwise
-			// exec.Cmd spawns an internal goroutine that blocks on the
-			// caller's Reader and prevents cmd.Wait from returning after
-			// the in-container process is killed. Stdin is closed in a
-			// defer after call() returns, matching the tty path and the
-			// natural-exit cleanup.
-			pr, pw, err := os.Pipe()
-			if err != nil {
-				return errors.Wrap(err, "failed to create stdin pipe")
-			}
-			runcIO.stdin = pr
-			defer pr.Close()
-			defer process.Stdin.Close()
-			eg.Go(func() error {
-				defer pw.Close()
-				_, err := io.Copy(pw, process.Stdin)
-				if errors.Is(err, io.ErrClosedPipe) || errors.Is(err, os.ErrClosed) {
-					return nil
-				}
-				return err
-			})
-		}
-		return call(ctx, startedCh, runcIO, killer.pidfile)
+		return call(ctx, startedCh, &forwardIO{stdin: process.Stdin, stdout: process.Stdout, stderr: process.Stderr}, killer.pidfile)
 	}
 
 	ptm, ptsName, err := console.NewPty()


### PR DESCRIPTION
This reverts commit 953437b10276e77a6f907bc60bb0f4ecc4c8e3fa.

After #6815 merged, CI started showing sandbox timeouts in OCI worker jobs, while the matching containerd jobs passed. The hangs we checked were in the runcexecutor and go-runc path, so reverting the change is the conservative move while we investigate whether this is a runc race or an unintended interaction with the stdin forwarding change.