### PR TITLE
sourcepolicy: fix exact match convert ignoring destination

### DIFF
--- a/sourcepolicy/engine_test.go
+++ b/sourcepolicy/engine_test.go
@@ -14,6 +14,7 @@ func TestEngineEvaluate(t *testing.T) {
 	t.Run("Deny All", testDenyAll)
 	t.Run("Allow Deny", testAllowDeny)
 	t.Run("Convert", testConvert)
+	t.Run("Convert exact", testConvertExact)
 	t.Run("Convert Deny", testConvertDeny)
 	t.Run("Allow Convert Deny", testAllowConvertDeny)
 	t.Run("Test convert loop", testConvertLoop)
@@ -378,6 +379,34 @@ func testConvert(t *testing.T) {
 			require.Equal(t, dst, op.Identifier)
 		})
 	}
+}
+
+func testConvertExact(t *testing.T) {
+	src := "docker-image://docker.io/library/busybox:latest"
+	dst := "docker-image://docker.io/library/busybox@sha256:c0d488a800e4127c334ad20d61d7bc21b4097540327217dfab52262adc02380c"
+	op := &pb.SourceOp{
+		Identifier: src,
+	}
+
+	pol := &spb.Policy{
+		Rules: []*spb.Rule{
+			{
+				Action: spb.PolicyAction_CONVERT,
+				Selector: &spb.Selector{
+					Identifier: src,
+					MatchType:  spb.MatchType_EXACT,
+				},
+				Updates: &spb.Update{
+					Identifier: dst,
+				},
+			},
+		},
+	}
+
+	mutated, err := NewEngine([]*spb.Policy{pol}).Evaluate(t.Context(), op)
+	require.True(t, mutated)
+	require.NoError(t, err)
+	require.Equal(t, dst, op.Identifier)
 }
 
 func testAllowDeny(t *testing.T) {

--- a/sourcepolicy/formatter.go
+++ b/sourcepolicy/formatter.go
@@ -39,7 +39,7 @@ func newSelectorCache(sel *spb.Selector) *selectorCache {
 func (s *selectorCache) Format(match, format string) (string, error) {
 	switch s.MatchType {
 	case spb.MatchType_EXACT:
-		return s.Identifier, nil
+		return format, nil
 	case spb.MatchType_REGEX:
 		re, err := s.regex()
 		if err != nil {


### PR DESCRIPTION
### Summary

A `CONVERT` rule whose selector uses `matchType: EXACT` matches the source but silently performs no conversion — the source identifier is left unchanged and no error is returned.

### Root cause

The destination of a `CONVERT` is computed by `selectorCache.Format(match, format)` (`sourcepolicy/formatter.go`), where `format` is the rule's `Updates.Identifier` (the target). Across the three match types:

- `WILDCARD` / `REGEX`: the groups captured from `match` are substituted into the target template (`${1}` / `$1`) — correct.
- `EXACT`: there are no captures, so it should return the target `format` verbatim; instead the old code returned `s.Identifier` (the selector's own identifier, i.e. the matched source).

`mutate()` (`sourcepolicy/mutate.go`) then computed a `dest` equal to the source, so `op.Identifier != dest` was false and it returned `mutated=false` without applying the update — the conversion was silently dropped.

### Impact

Source pinning/substitution done via exact match (`matchType: EXACT`) silently fails. The build still succeeds with no error, but the source is not rewritten as the policy intends.

### Fix

Return the target `format` from the `EXACT` branch instead of the selector's own identifier (one line). The empty-destination case is unaffected: `mutate()` already falls back to `Selector.Identifier` before calling `Format`, so an empty `Updates.Identifier` remains a correct no-op.

### Test

Add `testConvertExact` (`sourcepolicy/engine_test.go`) covering an explicit `MatchType_EXACT` conversion (the existing `testConvert` only exercised the default wildcard path); it asserts the conversion happens and `op.Identifier` is rewritten to the target digest.

Verified by reverting the fix: only `TestEngineEvaluate/Convert_exact` fails while the rest of the package passes; with the fix the package is green.
