### PR TITLE
cniprovider: keep proxy dials in CNI netns

### DIFF
--- a/util/network/cniprovider/cni_linux.go
+++ b/util/network/cniprovider/cni_linux.go
@@ -106,10 +106,44 @@ func withDetachedNetNSIfAny(ctx context.Context, fn func(context.Context) error)
 }
 
 func (ns *cniNS) DialContext(ctx context.Context, networkName, address string) (net.Conn, error) {
+	// WithNetNSPath only pins the calling thread to the namespace, while
+	// net.Dialer runs happy-eyeballs connect attempts and cgo DNS lookups on
+	// separate goroutines that would create their sockets in the host
+	// namespace. A negative FallbackDelay keeps connects serial on the pinned
+	// thread, and the Go resolver with a custom Dial re-enters the namespace
+	// for DNS sockets created on resolver goroutines.
+	dialer := &net.Dialer{
+		FallbackDelay: -1,
+		Resolver: &net.Resolver{
+			PreferGo: true,
+			Dial: func(ctx context.Context, networkName, address string) (net.Conn, error) {
+				d := &net.Dialer{FallbackDelay: -1}
+				if isLoopbackHost(address) {
+					// loopback resolvers (systemd-resolved, Docker embedded
+					// DNS) are only reachable in the host namespace
+					return d.DialContext(ctx, networkName, address)
+				}
+				return ns.dialInNS(ctx, networkName, address, d)
+			},
+		},
+	}
+	return ns.dialInNS(ctx, networkName, address, dialer)
+}
+
+func isLoopbackHost(address string) bool {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		host = address
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func (ns *cniNS) dialInNS(ctx context.Context, networkName, address string, dialer *net.Dialer) (net.Conn, error) {
 	var conn net.Conn
 	err := netns.WithNetNSPath(ns.nativeID, func(_ netns.NetNS) error {
 		var err error
-		conn, err = (&net.Dialer{}).DialContext(ctx, networkName, address)
+		conn, err = dialer.DialContext(ctx, networkName, address)
 		return err
 	})
 	if err != nil {

--- a/util/network/cniprovider/cni_linux.go
+++ b/util/network/cniprovider/cni_linux.go
@@ -112,7 +112,16 @@ func (ns *cniNS) DialContext(ctx context.Context, networkName, address string) (
 	// namespace. A negative FallbackDelay keeps connects serial on the pinned
 	// thread, and the Go resolver with a custom Dial re-enters the namespace
 	// for DNS sockets created on resolver goroutines.
-	dialer := &net.Dialer{
+	resolverNS, err := netns.GetCurrentNS()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	defer resolverNS.Close()
+	return ns.dialInNS(ctx, networkName, address, ns.dialer(resolverNS))
+}
+
+func (ns *cniNS) dialer(resolverNS netns.NetNS) *net.Dialer {
+	return &net.Dialer{
 		FallbackDelay: -1,
 		Resolver: &net.Resolver{
 			PreferGo: true,
@@ -120,14 +129,14 @@ func (ns *cniNS) DialContext(ctx context.Context, networkName, address string) (
 				d := &net.Dialer{FallbackDelay: -1}
 				if isLoopbackHost(address) {
 					// loopback resolvers (systemd-resolved, Docker embedded
-					// DNS) are only reachable in the host namespace
-					return d.DialContext(ctx, networkName, address)
+					// DNS) are only reachable in the namespace that called
+					// DialContext.
+					return dialInNetNS(ctx, resolverNS, networkName, address, d)
 				}
 				return ns.dialInNS(ctx, networkName, address, d)
 			},
 		},
 	}
-	return ns.dialInNS(ctx, networkName, address, dialer)
 }
 
 func isLoopbackHost(address string) bool {
@@ -140,8 +149,17 @@ func isLoopbackHost(address string) bool {
 }
 
 func (ns *cniNS) dialInNS(ctx context.Context, networkName, address string, dialer *net.Dialer) (net.Conn, error) {
+	targetNS, err := netns.GetNS(ns.nativeID)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	defer targetNS.Close()
+	return dialInNetNS(ctx, targetNS, networkName, address, dialer)
+}
+
+func dialInNetNS(ctx context.Context, targetNS netns.NetNS, networkName, address string, dialer *net.Dialer) (net.Conn, error) {
 	var conn net.Conn
-	err := netns.WithNetNSPath(ns.nativeID, func(_ netns.NetNS) error {
+	err := targetNS.Do(func(_ netns.NetNS) error {
 		var err error
 		conn, err = dialer.DialContext(ctx, networkName, address)
 		return err

--- a/util/network/cniprovider/cni_linux_test.go
+++ b/util/network/cniprovider/cni_linux_test.go
@@ -108,6 +108,35 @@ func TestDialContextDialsInsideNetNS(t *testing.T) {
 	conn.Close()
 }
 
+func TestLoopbackDNSUsesCallerNetNS(t *testing.T) {
+	nsPath := createTestNetNS(t)
+
+	ln, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp4", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+	go acceptLoop(ln)
+
+	callerNS, err := netns.GetCurrentNS()
+	require.NoError(t, err)
+	defer callerNS.Close()
+
+	ns := &cniNS{nativeID: nsPath}
+	dialer := ns.dialer(callerNS)
+	require.NotNil(t, dialer.Resolver)
+	require.NotNil(t, dialer.Resolver.Dial)
+
+	var conn net.Conn
+	require.NoError(t, netns.WithNetNSPath(nsPath, func(_ netns.NetNS) error {
+		ctx, cancel := context.WithTimeoutCause(t.Context(), 3*time.Second, nil)
+		defer cancel()
+		var err error
+		conn, err = dialer.Resolver.Dial(ctx, "tcp", ln.Addr().String())
+		return err
+	}))
+	require.NotNil(t, conn)
+	require.NoError(t, conn.Close())
+}
+
 func TestIsLoopbackHost(t *testing.T) {
 	require.True(t, isLoopbackHost("127.0.0.11:53"))
 	require.True(t, isLoopbackHost("127.0.0.53:53"))

--- a/util/network/cniprovider/cni_linux_test.go
+++ b/util/network/cniprovider/cni_linux_test.go
@@ -1,0 +1,118 @@
+//go:build linux
+
+package cniprovider
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	netns "github.com/containernetworking/plugins/pkg/ns"
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+)
+
+func createTestNetNS(t *testing.T) string {
+	t.Helper()
+	if os.Geteuid() != 0 {
+		t.Skip("requires root")
+	}
+	nsPath := filepath.Join(t.TempDir(), "netns")
+	f, err := os.Create(nsPath)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	errCh := make(chan error)
+	go func() {
+		defer close(errCh)
+		runtime.LockOSThread()
+		errCh <- unshareAndMountNetNS(nsPath)
+		// the thread stays locked so the go runtime terminates it
+	}()
+	require.NoError(t, <-errCh)
+	t.Cleanup(func() {
+		require.NoError(t, unmountNetNS(nsPath))
+	})
+	return nsPath
+}
+
+func acceptLoop(ln net.Listener) {
+	for {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		c.Close()
+	}
+}
+
+// Dialing a dual-stack name must not reach listeners in the host namespace.
+// net.Dialer runs happy-eyeballs connect attempts on goroutines that are not
+// pinned to the namespace, so a plain dialer inside WithNetNSPath escapes to
+// the host namespace for any destination that resolves to both families.
+func TestDialContextDoesNotEscapeNetNS(t *testing.T) {
+	ns := &cniNS{nativeID: createTestNetNS(t)}
+
+	ln4, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp4", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln4.Close()
+	_, port, err := net.SplitHostPort(ln4.Addr().String())
+	require.NoError(t, err)
+	ln6, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp6", "[::1]:"+port)
+	if err != nil {
+		t.Skipf("IPv6 loopback unavailable: %v", err)
+	}
+	defer ln6.Close()
+	go acceptLoop(ln4)
+	go acceptLoop(ln6)
+
+	ctx, cancel := context.WithTimeoutCause(t.Context(), 3*time.Second, nil)
+	defer cancel()
+	conn, err := ns.DialContext(ctx, "tcp", "localhost:"+port)
+	if conn != nil {
+		conn.Close()
+	}
+	require.Error(t, err, "dial escaped the network namespace")
+}
+
+func TestDialContextDialsInsideNetNS(t *testing.T) {
+	nsPath := createTestNetNS(t)
+
+	var ln net.Listener
+	require.NoError(t, netns.WithNetNSPath(nsPath, func(_ netns.NetNS) error {
+		lo, err := netlink.LinkByName("lo")
+		if err != nil {
+			return err
+		}
+		if err := netlink.LinkSetUp(lo); err != nil {
+			return err
+		}
+		ln, err = (&net.ListenConfig{}).Listen(t.Context(), "tcp4", "127.0.0.1:0")
+		return err
+	}))
+	defer ln.Close()
+	go acceptLoop(ln)
+	_, port, err := net.SplitHostPort(ln.Addr().String())
+	require.NoError(t, err)
+
+	ns := &cniNS{nativeID: nsPath}
+	ctx, cancel := context.WithTimeoutCause(t.Context(), 3*time.Second, nil)
+	defer cancel()
+	// a hostname destination exercises resolution and the serial
+	// IPv6->IPv4 fallback inside the namespace
+	conn, err := ns.DialContext(ctx, "tcp", "localhost:"+port)
+	require.NoError(t, err)
+	conn.Close()
+}
+
+func TestIsLoopbackHost(t *testing.T) {
+	require.True(t, isLoopbackHost("127.0.0.11:53"))
+	require.True(t, isLoopbackHost("127.0.0.53:53"))
+	require.True(t, isLoopbackHost("[::1]:53"))
+	require.False(t, isLoopbackHost("8.8.8.8:53"))
+	require.False(t, isLoopbackHost("[2001:4860:4860::8888]:53"))
+	require.False(t, isLoopbackHost("example.com:53"))
+}


### PR DESCRIPTION
depends on https://github.com/moby/buildkit/pull/6862

Dialing from a CNI namespace with the standard net.Dialer can escape the
namespace through happy-eyeballs connection attempts or resolver goroutines.

Use a serial dialer and route Go resolver sockets through the target
namespace, while preserving host loopback DNS stubs such as systemd-resolved
and Docker embedded DNS.
