### PR TITLE
fix: add mutex to protect Worker.Platforms from data race

### DIFF
--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/containerd/containerd/v2/core/content"
@@ -103,6 +104,7 @@ type Worker struct {
 	OCILayoutSource *containerimage.Source
 	GitSource       *git.Source
 	HTTPSource      *http.Source
+	platformsMu     sync.Mutex
 }
 
 // NewWorker instantiates a local worker
@@ -288,6 +290,8 @@ func (w *Worker) Labels() map[string]string {
 }
 
 func (w *Worker) Platforms(noCache bool) []ocispecs.Platform {
+	w.platformsMu.Lock()
+	defer w.platformsMu.Unlock()
 	if noCache {
 		matchers := make([]platforms.MatchComparer, len(w.WorkerOpt.Platforms))
 		for i, p := range w.WorkerOpt.Platforms {


### PR DESCRIPTION
When noCache=true, Platforms() appends to w.WorkerOpt.Platforms. Concurrent gRPC calls to ListWorkers (each handled in a separate goroutine) can cause a data race where one goroutine creates matchers with length N, while another appends new platforms, causing the first goroutine's range to exceed matchers bounds:

  panic: runtime error: index out of range [81] with length 81

Add sync.Mutex to serialize access to Platforms().

Fixes #6866