### PR TITLE
gitutil: preserve SUDO_UID for git subprocesses

### DIFF
--- a/util/gitutil/git_cli.go
+++ b/util/gitutil/git_cli.go
@@ -212,6 +212,13 @@ func (cli *GitCLI) Run(ctx context.Context, args ...string) (_ []byte, err error
 				"HOMEPATH",
 				"GIT_CONFIG_GLOBAL",
 				"GIT_CONFIG_SYSTEM",
+				// When git runs as root under sudo it consults SUDO_UID to trust
+				// repositories owned by the user who invoked sudo, so client-side
+				// callers such as `sudo docker build` don't trip git's "detected
+				// dubious ownership" check and silently lose commit provenance.
+				// This mirrors git's own default behavior and does not disable
+				// safe.directory checks. See docker/buildx#3855.
+				"SUDO_UID",
 			} {
 				if v, ok := os.LookupEnv(ev); ok {
 					cmd.Env = append(cmd.Env, ev+"="+v)

--- a/util/gitutil/git_cli_test.go
+++ b/util/gitutil/git_cli_test.go
@@ -25,6 +25,7 @@ func TestGitCLIConfigEnv(t *testing.T) {
 	t.Setenv("HOMEPATH", `\Users\tester`)
 	t.Setenv("GIT_CONFIG_GLOBAL", "/tmp/global-gitconfig")
 	t.Setenv("GIT_CONFIG_SYSTEM", "/tmp/system-gitconfig")
+	t.Setenv("SUDO_UID", "1000")
 
 	t.Run("isolated by default", func(t *testing.T) {
 		var got []string
@@ -41,6 +42,7 @@ func TestGitCLIConfigEnv(t *testing.T) {
 		require.NotContains(t, got, "XDG_CONFIG_HOME=/tmp/xdg")
 		require.NotContains(t, got, "GIT_CONFIG_GLOBAL=/tmp/global-gitconfig")
 		require.NotContains(t, got, "GIT_CONFIG_SYSTEM=/tmp/system-gitconfig")
+		require.NotContains(t, got, "SUDO_UID=1000")
 	})
 
 	t.Run("host git config opt-in", func(t *testing.T) {
@@ -64,5 +66,6 @@ func TestGitCLIConfigEnv(t *testing.T) {
 		require.Contains(t, got, `HOMEPATH=\Users\tester`)
 		require.Contains(t, got, "GIT_CONFIG_GLOBAL=/tmp/global-gitconfig")
 		require.Contains(t, got, "GIT_CONFIG_SYSTEM=/tmp/system-gitconfig")
+		require.Contains(t, got, "SUDO_UID=1000")
 	})
 }


### PR DESCRIPTION
### Description

When git runs as `root` under `sudo`, it consults the `SUDO_UID` environment variable to decide whether a repository's ownership can be trusted, additionally granting access to repositories owned by the user who invoked `sudo`. This is git's own mechanism (see the `safe.directory` documentation) to avoid `detected dubious ownership in repository` errors when a repo is checked out by a regular user but git is later run as root.

`GitCLI` builds a deliberately restricted environment for the git subprocess and did not forward `SUDO_UID`. As a result, commands run via `sudo` (e.g. `sudo docker build`) trip git's dubious-ownership check, and the commit-info inspection (`git rev-parse --is-inside-work-tree`) fails. The build still succeeds, but the commit metadata is dropped and a warning is printed:

```
WARNING: current commit information was not captured by the build: failed to read current commit information with git rev-parse --is-inside-work-tree
```

This change forwards `SUDO_UID` to the git subprocess **only when it is present** in the parent environment, mirroring the existing proxy-variable forwarding.

### Notes

- Only `SUDO_UID` is forwarded — git's ownership check is uid-based and never consults `SUDO_GID`.
- This matches git's own default behavior under sudo: it does **not** disable `safe.directory` checks and is **not** equivalent to `safe.directory=*`. The ownership comparison still runs; it merely adds trust for repositories owned by the invoking user, exactly as native git does when invoked through sudo.
- The rest of the host environment is still withheld.

### Tests

Added `TestGitCLIPreservesSudoUID` and `TestGitCLIDoesNotSetSudoUIDWhenUnset` in `util/gitutil/git_cli_test.go`, using the existing `WithExec` interception helper so no `sudo` or root privileges are needed.

### Related

Fixes the root cause for docker/buildx#3855. buildx inspects the build context through this `GitCLI` (its `util/gitutil` embeds and delegates to it), so buildx picks up the fix via a moby/buildkit dependency bump — no buildx-side code change is required.
