### PR TITLE
util/tracing: remove fallbacks for OTEL_TRACE_PARENT, OTEL_TRACE_STATE

### DIFF
--- a/util/tracing/childprocess/traceenv.go
+++ b/util/tracing/childprocess/traceenv.go
@@ -14,23 +14,13 @@ func init() {
 
 func initContext(ctx context.Context) context.Context {
 	// open-telemetry/opentelemetry-specification#740
-	parent := os.Getenv("TRACEPARENT")
-	state := os.Getenv("TRACESTATE")
+	parent := os.Getenv("TRACEPARENT") // https://www.w3.org/TR/trace-context/#traceparent-header
+	state := os.Getenv("TRACESTATE")   // https://www.w3.org/TR/trace-context/#tracestate-header
 
 	if parent != "" {
 		tc := propagation.TraceContext{}
 		return tc.Extract(ctx, &textMap{parent: parent, state: state})
 	}
 
-	// deprecated: removed in v0.11.0
-	// previously defined in https://github.com/open-telemetry/opentelemetry-swift/blob/4ea467ed4b881d7329bf2254ca7ed7f2d9d6e1eb/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift#L14-L15
-	parent = os.Getenv("OTEL_TRACE_PARENT")
-	state = os.Getenv("OTEL_TRACE_STATE")
-
-	if parent == "" {
-		return ctx
-	}
-
-	tc := propagation.TraceContext{}
-	return tc.Extract(ctx, &textMap{parent: parent, state: state})
+	return ctx
 }

--- a/util/tracing/childprocess/traceexec.go
+++ b/util/tracing/childprocess/traceexec.go
@@ -15,15 +15,6 @@ func Environ(ctx context.Context) []string {
 
 	var env []string
 
-	// deprecated: removed in v0.11.0
-	// previously defined in https://github.com/open-telemetry/opentelemetry-swift/blob/4ea467ed4b881d7329bf2254ca7ed7f2d9d6e1eb/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift#L14-L15
-	if tm.parent != "" {
-		env = append(env, "OTEL_TRACE_PARENT="+tm.parent)
-	}
-	if tm.state != "" {
-		env = append(env, "OTEL_TRACE_STATE="+tm.state)
-	}
-
 	// open-telemetry/opentelemetry-specification#740
 	if tm.parent != "" {
 		env = append(env, "TRACEPARENT="+tm.parent)


### PR DESCRIPTION
Relates to:

- https://github.com/moby/buildkit/pull/2572
- https://github.com/open-telemetry/opentelemetry-specification/issues/740
- https://github.com/open-telemetry/opentelemetry-specification/pull/4454
- https://github.com/open-telemetry/opentelemetry-specification/pull/4961


### util/tracing: remove fallbacks for OTEL_TRACE_PARENT, OTEL_TRACE_STATE

The OTEL_TRACE_PARENT and OTEL_TRACE_STATE environment variables were deprecated in BuildKit v0.10 (f5dbcf6e99b2eee695dce31e2a3515d5269f33f5) because they were deprecated in the OTel specification in favor of the TRACEPARENT and TRACESTATE env-vars, aligning with the [W3C traceparent] and [W3C tracestate] headers.

[W3C traceparent]: https://www.w3.org/TR/trace-context/#traceparent-header
[W3C tracestate]: https://www.w3.org/TR/trace-context/#tracestate-header