### PR TITLE
Dockerfile: update runc binary to v1.3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:master
 
-ARG RUNC_VERSION=v1.3.5
+ARG RUNC_VERSION=v1.3.6
 ARG CONTAINERD_VERSION=v2.2.4
 # CONTAINERD_ALT_VERSION_... defines fallback containerd version for integration tests
 ARG CONTAINERD_ALT_VERSION_21=v2.1.8


### PR DESCRIPTION
This is the sixth patch release of the 1.3.z series of runc. Among some performance improvements and bugfixes, it includes a fix for a low-severity vulnerability ([CVE-2026-41579]) and users are encouraged to update. As it was a low-severity vulnerability and it was reported by multiple people, we decided to release it publicly with NO EMBARGO.

Security

This release includes a fix for the following low-severity security issue:

- CVE-2026-41579 allowed a malicious image with a /dev symlink to have limited write access to the host filesystem in ways that our analysis indicates was too limited to be problematic in practice. This bug was very similar to those fixed in CVE-2025-31133, CVE-2025-52565, CVE-2025-31133 and was simply missed at the time when we hardened the rootfs preparation code. We have conducted a deeper audit and not found any other problematic cases.

Fixed

- A regression in runc v1.3.0 which can result in a stuck runc exec or runc run when the container process runs for a short time.
- Various integration test improvements.

Changed

- When masking directories with maskPaths, runc will now re-use a single tmpfs instance (which is not writable) to reduce the number tmpfs superblocks that need to be reaped when containers die (in particular, Kubernetes applies masks to per-CPU sysfs directories which get expensive quickly).

[CVE-2026-41579]: https://github.com/opencontainers/runc/security/advisories/GHSA-xjvp-4fhw-gc47

full diff: https://github.com/opencontainers/runc/compare/v1.3.5...v1.3.6