### PR TITLE
sbom: add initial CycloneDX format support for attestation layer

### DIFF
--- a/client/client_export_metadata_test.go
+++ b/client/client_export_metadata_test.go
@@ -1906,6 +1906,246 @@ func testSBOMSupplements(t *testing.T, sb integration.Sandbox) {
 	checkAllReleasable(t, c, sb, true)
 }
 
+func testSBOMCycloneDX(t *testing.T, sb integration.Sandbox) {
+	workers.CheckFeatureCompat(t, sb, workers.FeatureDirectPush, workers.FeatureSBOM)
+	requiresLinux(t)
+	c, err := New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	registry, err := sb.NewRegistry()
+	if errors.Is(err, integration.ErrRequirements) {
+		t.Skip(err.Error())
+	}
+	require.NoError(t, err)
+
+	p := platforms.DefaultSpec()
+	pk := platforms.Format(p)
+
+	// Build a CycloneDX scanner image
+	scannerFrontend := func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
+		res := gateway.NewResult()
+
+		st := llb.Image("busybox", llb.Platform(p))
+		def, err := st.Marshal(sb.Context())
+		require.NoError(t, err)
+
+		r, err := c.Solve(ctx, gateway.SolveRequest{
+			Definition: def.ToPB(),
+		})
+		if err != nil {
+			return nil, err
+		}
+		ref, err := r.SingleRef()
+		if err != nil {
+			return nil, err
+		}
+		_, err = ref.ToState()
+		if err != nil {
+			return nil, err
+		}
+		res.AddRef(pk, ref)
+
+		expPlatforms := &exptypes.Platforms{
+			Platforms: []exptypes.Platform{{ID: pk, Platform: p}},
+		}
+		dt, err := json.Marshal(expPlatforms)
+		if err != nil {
+			return nil, err
+		}
+		res.AddMeta(exptypes.ExporterPlatformsKey, dt)
+
+		var img ocispecs.Image
+		cmd := `
+cat <<EOF > $BUILDKIT_SCAN_DESTINATION/cdx.json
+{
+  "_type": "https://in-toto.io/Statement/v0.1",
+  "predicateType": "https://cyclonedx.org/bom",
+  "predicate": {
+	"bomFormat": "CycloneDX",
+	"specVersion": "1.4"
+  }
+}
+EOF
+`
+		img.Config.Cmd = []string{"/bin/sh", "-c", cmd}
+		img.Platform = p
+		config, err := json.Marshal(img)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to marshal image config")
+		}
+		res.AddMeta(fmt.Sprintf("%s/%s", exptypes.ExporterImageConfigKey, pk), config)
+
+		return res, nil
+	}
+
+	scannerTarget := registry + "/buildkit/testcdxscanner:latest"
+	_, err = c.Build(sb.Context(), SolveOpt{
+		Exports: []ExportEntry{
+			{
+				Type: ExporterImage,
+				Attrs: map[string]string{
+					"name": scannerTarget,
+					"push": "true",
+				},
+			},
+		},
+	}, "", scannerFrontend, nil)
+	require.NoError(t, err)
+
+	// makeBaseResult builds a scratch image with a greeting file and platform metadata,
+	// shared by the plain target and the CDX-annotated frontend.
+	makeBaseResult := func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
+		res := gateway.NewResult()
+
+		st := llb.Scratch().File(
+			llb.Mkfile("/greeting", 0600, []byte("hello cyclonedx!")),
+		)
+		def, err := st.Marshal(ctx)
+		if err != nil {
+			return nil, err
+		}
+		r, err := c.Solve(ctx, gateway.SolveRequest{
+			Definition: def.ToPB(),
+		})
+		if err != nil {
+			return nil, err
+		}
+		ref, err := r.SingleRef()
+		if err != nil {
+			return nil, err
+		}
+		if _, err = ref.ToState(); err != nil {
+			return nil, err
+		}
+		res.AddRef(pk, ref)
+
+		expPlatforms := &exptypes.Platforms{
+			Platforms: []exptypes.Platform{{ID: pk, Platform: p}},
+		}
+		dt, err := json.Marshal(expPlatforms)
+		if err != nil {
+			return nil, err
+		}
+		res.AddMeta(exptypes.ExporterPlatformsKey, dt)
+
+		return res, nil
+	}
+
+	// Test CycloneDX fallback scanner
+	target := registry + "/buildkit/testcdx:latest"
+	_, err = c.Build(sb.Context(), SolveOpt{
+		FrontendAttrs: map[string]string{
+			"attest:sbom": "generator=" + scannerTarget,
+		},
+		Exports: []ExportEntry{
+			{
+				Type: ExporterImage,
+				Attrs: map[string]string{
+					"name": target,
+					"push": "true",
+				},
+			},
+		},
+	}, "", makeBaseResult, nil)
+	require.NoError(t, err)
+
+	desc, provider, err := contentutil.ProviderFromRef(target)
+	require.NoError(t, err)
+
+	imgs, err := testutil.ReadImages(sb.Context(), provider, desc)
+	require.NoError(t, err)
+	require.Len(t, imgs.Images, 2, "expected main image + attestation manifest")
+
+	att := imgs.Find("unknown/unknown")
+	require.NotNil(t, att)
+	attest := intoto.Statement{}
+	require.NoError(t, json.Unmarshal(att.LayersRaw[0], &attest))
+	require.Equal(t, intoto.StatementInTotoV1, attest.Type)
+	require.Equal(t, intoto.PredicateCycloneDX, attest.PredicateType)
+	require.NotEmpty(t, attest.Subject)
+	pred, ok := attest.Predicate.(map[string]interface{})
+	require.True(t, ok, "predicate should be a JSON object")
+	require.Equal(t, "CycloneDX", pred["bomFormat"])
+	require.Equal(t, "1.4", pred["specVersion"])
+
+	// Test that HasSBOM recognizes CycloneDX attestations from frontend
+	cdxFrontend := func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
+		res, err := makeBaseResult(ctx, c)
+		if err != nil {
+			return nil, err
+		}
+
+		// Attach a CycloneDX attestation from the frontend
+		st := llb.Scratch().
+			File(llb.Mkfile("/result.cdx", 0600, []byte(`{"bomFormat": "CycloneDX"}`)))
+		def, err := st.Marshal(ctx)
+		if err != nil {
+			return nil, err
+		}
+		r, err := c.Solve(ctx, gateway.SolveRequest{
+			Definition: def.ToPB(),
+		})
+		if err != nil {
+			return nil, err
+		}
+		refAttest, err := r.SingleRef()
+		if err != nil {
+			return nil, err
+		}
+		if _, err = refAttest.ToState(); err != nil {
+			return nil, err
+		}
+
+		res.AddAttestation(pk, gateway.Attestation{
+			Kind: gatewaypb.AttestationKind_InToto,
+			Ref:  refAttest,
+			Path: "/result.cdx",
+			InToto: result.InTotoAttestation{
+				PredicateType: intoto.PredicateCycloneDX,
+			},
+		})
+
+		return res, nil
+	}
+
+	// When frontend provides CycloneDX SBOM, the fallback scanner should be skipped
+	target = registry + "/buildkit/testcdx2:latest"
+	_, err = c.Build(sb.Context(), SolveOpt{
+		FrontendAttrs: map[string]string{
+			"attest:sbom": "",
+		},
+		Exports: []ExportEntry{
+			{
+				Type: ExporterImage,
+				Attrs: map[string]string{
+					"name": target,
+					"push": "true",
+				},
+			},
+		},
+	}, "", cdxFrontend, nil)
+	require.NoError(t, err)
+
+	desc, provider, err = contentutil.ProviderFromRef(target)
+	require.NoError(t, err)
+
+	imgs, err = testutil.ReadImages(sb.Context(), provider, desc)
+	require.NoError(t, err)
+	require.Len(t, imgs.Images, 2, "expected main image + attestation manifest")
+
+	att = imgs.Find("unknown/unknown")
+	require.NotNil(t, att)
+	attest = intoto.Statement{}
+	require.NoError(t, json.Unmarshal(att.LayersRaw[0], &attest))
+	require.Equal(t, intoto.StatementInTotoV1, attest.Type)
+	require.Equal(t, intoto.PredicateCycloneDX, attest.PredicateType)
+	require.NotEmpty(t, attest.Subject)
+	pred, ok = attest.Predicate.(map[string]interface{})
+	require.True(t, ok, "predicate should be a JSON object")
+	require.Equal(t, "CycloneDX", pred["bomFormat"])
+}
+
 func testSourceDateEpochClamp(t *testing.T, sb integration.Sandbox) {
 	workers.CheckFeatureCompat(t, sb, workers.FeatureOCIExporter, workers.FeatureSourceDateEpoch)
 	requiresLinux(t)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -107,6 +107,7 @@ var allTests = []func(t *testing.T, sb integration.Sandbox){
 	testImageResolveAttestationChainLocal,
 	testImageResolveAttestationChainRequiresNetwork,
 	testImageResolveProvenanceAttestation,
+	testSBOMCycloneDX,
 	testSBOMScan,
 	testSBOMScanSingleRef,
 	testSBOMSupplements,

--- a/docs/attestations/sbom-protocol.md
+++ b/docs/attestations/sbom-protocol.md
@@ -13,11 +13,12 @@ The SBOM generator image is expected to follow the rules of the BuildKit SBOM
 generator protocol, defined in this document.
 
 > [!NOTE]
-> Currently, only SBOMs in the [SPDX](https://spdx.dev) JSON format are
-> supported.
+> SBOMs in [SPDX](https://spdx.dev) JSON format and
+> [CycloneDX](https://cyclonedx.org) JSON format are supported.
 >
-> These SBOMs will be attached to the final image as an in-toto attestation
-> with the `https://spdx.dev/Document` predicate type.
+> SPDX SBOMs will be attached as in-toto attestations with the
+> `https://spdx.dev/Document` predicate type. CycloneDX SBOMs will use
+> the `https://cyclonedx.org/bom` predicate type.
 
 ## Implementations
 
@@ -39,7 +40,9 @@ by BuildKit:
 - `BUILDKIT_SCAN_DESTINATION` (required)
 
   This variable specifies the directory where the scanner should write its
-  SBOM data. Scanners should write their SBOMs to `$BUILDKIT_SCAN_DESTINATION/<scan>.spdx.json`
+  SBOM data. Scanners should write their SBOMs to
+  `$BUILDKIT_SCAN_DESTINATION/<scan>.spdx.json` for SPDX format or
+  `$BUILDKIT_SCAN_DESTINATION/<scan>.cdx.json` for CycloneDX format,
   where `<scan>` is the name of an arbitrary scan. A scanner may produce
   multiple scans for a single target - scan names must be unique within a
   target, but should not be considered significant by producers or consumers.
@@ -50,7 +53,8 @@ by BuildKit:
   filesystem of the final build result.
 
   The scanner should scan this filesystem, and write its SBOM result to
-  `$BUILDKIT_SCAN_DESTINATION/$(basename $BUILDKIT_SCAN_SOURCE).spdx.json`.
+  `$BUILDKIT_SCAN_DESTINATION/$(basename $BUILDKIT_SCAN_SOURCE).spdx.json`
+  (or `.cdx.json` for CycloneDX).
 
 - `BUILDKIT_SCAN_SOURCE_EXTRAS` (optional)
 
@@ -59,7 +63,8 @@ by BuildKit:
   a directory that does not exist, then no extras should be scanned.
 
   The scanner should iterate through this directory, and write its SBOM scans
-  to `$BUILDKIT_SCAN_DESTINATION/<scan>.spdx.json`, similar to above.
+  to `$BUILDKIT_SCAN_DESTINATION/<scan>.spdx.json` (or `.cdx.json` for
+  CycloneDX), similar to above.
 
 A scanner must not error if optional parameters are not set.
 

--- a/frontend/attestations/sbom/sbom.go
+++ b/frontend/attestations/sbom/sbom.go
@@ -102,7 +102,10 @@ func CreateSBOMScanner(ctx context.Context, resolver sourceresolver.MetaResolver
 				result.AttestationSBOMCore:  []byte(CoreSBOMName),
 			},
 			InToto: result.InTotoAttestation{
-				PredicateType: intoto.PredicateSPDX,
+				// PredicateType is left empty so that the unbundler
+				// detects the format (SPDX or CycloneDX) from the
+				// predicateType field in the scanner's JSON output.
+				// See exporter/attestation/unbundle.go
 			},
 		}, nil
 	}, nil
@@ -121,10 +124,16 @@ func scannerTmpMount(scannerImage llb.State, platform ocispecs.Platform) (llb.St
 func HasSBOM[T comparable](res *result.Result[T]) bool {
 	for _, as := range res.Attestations {
 		for _, a := range as {
-			if a.InToto.PredicateType == intoto.PredicateSPDX {
+			if IsSBOMPredicateType(a.InToto.PredicateType) {
 				return true
 			}
 		}
 	}
 	return false
+}
+
+// IsSBOMPredicateType returns true if the predicate type represents an SBOM,
+// either SPDX or CycloneDX.
+func IsSBOMPredicateType(predicateType string) bool {
+	return predicateType == intoto.PredicateSPDX || predicateType == intoto.PredicateCycloneDX
 }

--- a/frontend/attestations/sbom/sbom_test.go
+++ b/frontend/attestations/sbom/sbom_test.go
@@ -6,11 +6,14 @@ import (
 	"strings"
 	"testing"
 
+	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/client/llb/sourceresolver"
 	"github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/solver/result"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -130,4 +133,49 @@ func findMount(t *testing.T, exec *pb.ExecOp, dest string) *pb.Mount {
 	}
 	require.FailNow(t, "mount not found", "dest=%s", dest)
 	return nil
+}
+
+func TestIsSBOMPredicateType(t *testing.T) {
+	assert.True(t, IsSBOMPredicateType(intoto.PredicateSPDX))
+	assert.True(t, IsSBOMPredicateType(intoto.PredicateCycloneDX))
+	assert.False(t, IsSBOMPredicateType(""))
+	assert.False(t, IsSBOMPredicateType("https://slsa.dev/provenance/v0.2"))
+	assert.False(t, IsSBOMPredicateType("https://example.com/unknown"))
+}
+
+func TestHasSBOM(t *testing.T) {
+	t.Run("SPDX", func(t *testing.T) {
+		res := &result.Result[int]{}
+		res.Attestations = map[string][]result.Attestation[int]{
+			"linux/amd64": {
+				{InToto: result.InTotoAttestation{PredicateType: intoto.PredicateSPDX}},
+			},
+		}
+		assert.True(t, HasSBOM(res))
+	})
+
+	t.Run("CycloneDX", func(t *testing.T) {
+		res := &result.Result[int]{}
+		res.Attestations = map[string][]result.Attestation[int]{
+			"linux/amd64": {
+				{InToto: result.InTotoAttestation{PredicateType: intoto.PredicateCycloneDX}},
+			},
+		}
+		assert.True(t, HasSBOM(res))
+	})
+
+	t.Run("none", func(t *testing.T) {
+		res := &result.Result[int]{}
+		res.Attestations = map[string][]result.Attestation[int]{
+			"linux/amd64": {
+				{InToto: result.InTotoAttestation{PredicateType: "https://slsa.dev/provenance/v0.2"}},
+			},
+		}
+		assert.False(t, HasSBOM(res))
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		res := &result.Result[int]{}
+		assert.False(t, HasSBOM(res))
+	})
 }


### PR DESCRIPTION
## Initial PR for issue https://github.com/moby/buildkit/issues/6665: "BuildKit + CycloneDX SBOM Integration"

This PR extends the SBOM scanner protocol to support CycloneDX JSON alongside SPDX. Previously, `HasSBOM` and `CreateSBOMScanner` hardcoded `intoto.PredicateSPDX`, which meant CycloneDX output from a scanner would result in an error: `"ERROR: failed to build: failed to solve: bundle entry https://cyclonedx.org/bom does not match required predicate type https://spdx.dev/Document"`

The `PredicateType` in `CreateSBOMScanner` is now left empty so the unbundler can detect the format from the `predicateType` field in the scanner's JSON output and attach the attestation with the correct predicate type (https://spdx.dev/Document or
https://cyclonedx.org/bom). `HasSBOM` is updated via a new `IsSBOMPredicateType` helper to recognize both formats.

Scanners may write `.cdx.json` files to `$BUILDKIT_SCAN_DESTINATION`; the existing `.spdx.json` convention is unchanged.

**Note**: This PR doesn't create parity with SPDX within BuildKit, since there's additional actions BuildKit performs to enhance the SPDX SBOM. However, this PR is meant to be a first "pass-through" step to integrating CycloneDX SBOMs.

## Example

1. Build with SBOM scanning; scanner (can be custom scanner) should generate CycloneDX SBOM. 

```
  docker buildx build \
      --builder custom-buildkit \
      --sbom=generator=[ScannerDockerImage] \
      --build-arg BUILDKIT_SBOM_SCAN_CONTEXT=true \
      --output type=image,name=host.docker.internal:5001/test:sbom,push=true \
     [SampleRepo]
```

2. Inspect using `imagetools`

```
$ docker buildx imagetools inspect localhost:5001/test:sbom   

Name:      localhost:5001/test:sbom
MediaType: application/vnd.oci.image.index.v1+json
Digest:    sha256:01fce5a7dcbeda2fb135a071a5b146dd1c87480aca09405d2b25e0470d5ca449
           
Manifests: 
  Name:        localhost:5001/test:sbom@sha256:840f4796abf11546307bbc3d22e433d1fad85b1f0a3f1934d9a432d7563c9ba8
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    linux/arm64
               
  Name:        localhost:5001/test:sbom@sha256:d7b037748e6d25a94d1d2d5146fc105db1b8809b8438ac3760d999aedb3dc32f
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    unknown/unknown
  Annotations: 
    vnd.docker.reference.type:   attestation-manifest
    vnd.docker.reference.digest: sha256:840f4796abf11546307bbc3d22e433d1fad85b1f0a3f1934d9a432d7563c9ba8
```

3. Inspect using `curl`

```
curl -s -H "Accept: application/vnd.oci.image.manifest.v1+json" "http://localhost:5001/v2/test/manifests/sha256:d7b037748e6d25a94d1d2d5146fc105db1b8809b8438ac3760d999aedb3dc32f" | jq .

{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "config": {
      "mediaType": "application/vnd.oci.image.config.v1+json",
      "digest": "sha256:c8e03515df34e77c8efe510c04db1ee2b354093ad1e7662af915d381efb50999",
      "size": 315
  },
  "layers": [
    {
      "mediaType": "application/vnd.in-toto+json",
      "digest": "sha256:a320d745453d0ced56440b38ecd0ef25becc8c84f2837557f2ee6a17d01f44ea",
      "size": 5935194,
      "annotations": {
        "in-toto.io/predicate-type": "https://cyclonedx.org/bom"
      }
    },
    {
      "mediaType": "application/vnd.in-toto+json",
      "digest": "sha256:a320d745453d0ced56440b38ecd0ef25becc8c84f2837557f2ee6a17d01f44ea",
      "size": 5935194,
      "annotations": {
        "in-toto.io/predicate-type": "https://cyclonedx.org/bom"
      }
    },
    {
      "mediaType": "application/vnd.in-toto+json",
      "digest": "sha256:c7bd9af483756387a7e7e66d4a0130614f71413d9e1daafd8ea690d9344fed9e",
      "size": 1729,
      "annotations": {
        "in-toto.io/predicate-type": "https://slsa.dev/provenance/v1"
      }
    }
  ]
}
```

**Note**: `in-toto.io/predicate-type` is `https://cyclonedx.org/bom`, not `https://spdx.dev/Document`

4. Compare with SPDX SBOM; a `curl` on an image that has a SPDX SBOM attestation layer looks like this

```
$ curl -s -H "Accept: application/vnd.oci.image.manifest.v1+json" "http://localhost:5001/v2/test/manifests/sha256:89209cf7b7b11ce8cb106037d4704b2f5d1f622c740e3f256c930f597c4f9e8a" | jq .

{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "config": {
    "mediaType": "application/vnd.oci.image.config.v1+json",
    "digest": "sha256:5f893ec2bf87fe48524dc373048ce9ddb0f965ce7714e8039d06c42dbc258b04",
    "size": 315
  },
  "layers": [
    {
      "mediaType": "application/vnd.in-toto+json",
      "digest": "sha256:8e1c807efbe9f679bb81bb7d071f1b9c78f14dd99d84a2a9aeecbe4de4ab17e8",
      "size": 12519811,
      "annotations": {
        "in-toto.io/predicate-type": "https://spdx.dev/Document"
      }
    },
    {
      "mediaType": "application/vnd.in-toto+json",
      "digest": "sha256:8e1c807efbe9f679bb81bb7d071f1b9c78f14dd99d84a2a9aeecbe4de4ab17e8",
      "size": 12519811,
      "annotations": {
        "in-toto.io/predicate-type": "https://spdx.dev/Document"
      }
    },
    {
      "mediaType": "application/vnd.in-toto+json",
      "digest": "sha256:7e58ce181478a6e37bb936e870369d06702c3cac02b2359f5e45aaacbef7c32a",
      "size": 2022,
      "annotations": {
        "in-toto.io/predicate-type": "https://slsa.dev/provenance/v1"
      }
    }
  ]
}
```