### PR TITLE
exporter: default attestation manifests to OCI artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Keys supported by image output:
 * `push-by-digest=true`: push unnamed image
 * `registry.insecure=true`: push to insecure HTTP registry
 * `oci-mediatypes=true`: use OCI mediatypes in configuration JSON instead of Docker's
-* `oci-artifact=false`: use OCI artifact format for attestations
+* `oci-artifact=false`: use the legacy image manifest format for attestations instead of the OCI artifact format when OCI mediatypes are enabled
 * `unpack=true`: unpack image after creation (for use with containerd)
 * `dangling-name-prefix=<value>`: name image with `prefix@<digest>`, used for anonymous images
 * `name-canonical=true`: add additional canonical name `name@<digest>`

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -216,6 +216,7 @@ var allTests = []func(t *testing.T, sb integration.Sandbox){
 	testPullWithLayerLimit,
 	testExportAnnotations,
 	testExportAnnotationsMediaTypes,
+	testExportAttestationsOCIArtifactDefault,
 	testExportAttestationsOCIArtifact,
 	testExportAttestationsImageManifest,
 	testExportedImageLabels,
@@ -10869,15 +10870,21 @@ func testExportAnnotationsMediaTypes(t *testing.T, sb integration.Sandbox) {
 	require.Equal(t, ocispecs.MediaTypeImageIndex, imgs2.Index.MediaType)
 }
 
+func testExportAttestationsOCIArtifactDefault(t *testing.T, sb integration.Sandbox) {
+	testExportAttestations(t, sb, nil)
+}
+
 func testExportAttestationsOCIArtifact(t *testing.T, sb integration.Sandbox) {
-	testExportAttestations(t, sb, true)
+	ociArtifact := true
+	testExportAttestations(t, sb, &ociArtifact)
 }
 
 func testExportAttestationsImageManifest(t *testing.T, sb integration.Sandbox) {
-	testExportAttestations(t, sb, false)
+	ociArtifact := false
+	testExportAttestations(t, sb, &ociArtifact)
 }
 
-func testExportAttestations(t *testing.T, sb integration.Sandbox, ociArtifact bool) {
+func testExportAttestations(t *testing.T, sb integration.Sandbox, ociArtifact *bool) {
 	workers.CheckFeatureCompat(t, sb, workers.FeatureDirectPush)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
@@ -10992,15 +10999,18 @@ func testExportAttestations(t *testing.T, sb integration.Sandbox, ociArtifact bo
 			registry + "/buildkit/testattestationsfoo:latest",
 			registry + "/buildkit/testattestationsbar:latest",
 		}
+		attrs := map[string]string{
+			"name": strings.Join(targets, ","),
+			"push": "true",
+		}
+		if ociArtifact != nil {
+			attrs["oci-artifact"] = strconv.FormatBool(*ociArtifact)
+		}
 		_, err = c.Build(sb.Context(), SolveOpt{
 			Exports: []ExportEntry{
 				{
-					Type: ExporterImage,
-					Attrs: map[string]string{
-						"name":         strings.Join(targets, ","),
-						"push":         "true",
-						"oci-artifact": strconv.FormatBool(ociArtifact),
-					},
+					Type:  ExporterImage,
+					Attrs: attrs,
 				},
 			},
 		}, "", frontend, nil)
@@ -11033,7 +11043,7 @@ func testExportAttestations(t *testing.T, sb integration.Sandbox, ociArtifact bo
 			require.Equal(t, bases[i].Desc.Digest.String(), att.Desc.Annotations[attestation.DockerAnnotationReferenceDigest])
 			require.Equal(t, 2, len(att.Layers))
 
-			if ociArtifact {
+			if ociArtifact == nil || *ociArtifact {
 				subject := att.Manifest.Subject
 				require.NotNil(t, subject)
 				require.Equal(t, bases[i].Desc.MediaType, subject.MediaType)

--- a/docs/attestations/attestation-storage.md
+++ b/docs/attestations/attestation-storage.md
@@ -2,14 +2,15 @@
 title: Image attestation storage
 ---
 
-Buildkit supports creating and attaching attestations to build artifacts. These
+BuildKit supports creating and attaching attestations to build artifacts. These
 attestations can provide valuable information from the build process,
 including, but not limited to: [SBOMs](https://en.wikipedia.org/wiki/Software_supply_chain),
 [SLSA Provenance](https://slsa.dev/provenance), build logs, etc.
 
-This document describes the current custom format used to store attestations,
-which is designed to be compatible with current registry implementations today.
-In the future, we may support exporting attestations in additional formats.
+This document describes the storage format used for attestations. When the image
+output uses OCI media types, BuildKit exports attestation manifests as OCI
+artifacts by default. Set the image exporter option `oci-artifact=false` to use
+the legacy image manifest format instead.
 
 Attestations are stored as manifest objects in the image index, similar in
 style to OCI artifacts.

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -234,6 +234,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 	}
 	opts.Annotations = opts.Annotations.Merge(as)
 	opts.SetOCITypesDefault(DefaultOCITypes(buildInfo.CompatibilityVersion, src))
+	opts.SetOCIArtifactDefault(opts.OCITypesEnabled())
 	if err := opts.Validate(); err != nil {
 		return nil, nil, nil, err
 	}

--- a/exporter/containerimage/opts.go
+++ b/exporter/containerimage/opts.go
@@ -16,6 +16,7 @@ type ImageCommitOpts struct {
 	RefCfg      cacheconfig.RefConfig
 	OCITypes    *bool
 	OCIArtifact bool
+	ociArtifact *bool
 	Annotations AnnotationsGroup
 	Epoch       *epoch.Epoch
 
@@ -51,7 +52,10 @@ func (c *ImageCommitOpts) Load(ctx context.Context, opt map[string]string) (map[
 			err = parseBool(&b, k, v)
 			c.OCITypes = &b
 		case exptypes.OptKeyOCIArtifact:
-			err = parseBool(&c.OCIArtifact, k, v)
+			var b bool
+			err = parseBool(&b, k, v)
+			c.OCIArtifact = b
+			c.ociArtifact = &b
 		case exptypes.OptKeyForceInlineAttestations:
 			err = parseBool(&c.ForceInlineAttestations, k, v)
 		case exptypes.OptKeyPreferNondistLayers:
@@ -92,6 +96,12 @@ func (c *ImageCommitOpts) Validate() error {
 func (c *ImageCommitOpts) SetOCITypesDefault(v bool) {
 	if c.OCITypes == nil {
 		c.OCITypes = &v
+	}
+}
+
+func (c *ImageCommitOpts) SetOCIArtifactDefault(v bool) {
+	if c.ociArtifact == nil {
+		c.OCIArtifact = v
 	}
 }
 

--- a/exporter/containerimage/opts_test.go
+++ b/exporter/containerimage/opts_test.go
@@ -1,0 +1,45 @@
+package containerimage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestImageCommitOptsSetOCIArtifactDefault(t *testing.T) {
+	t.Run("defaults to OCI artifact when OCI mediatypes are enabled", func(t *testing.T) {
+		var opts ImageCommitOpts
+		_, err := opts.Load(context.Background(), map[string]string{})
+		require.NoError(t, err)
+
+		opts.SetOCITypesDefault(true)
+		opts.SetOCIArtifactDefault(opts.OCITypesEnabled())
+
+		require.True(t, opts.OCIArtifact)
+	})
+
+	t.Run("keeps explicit OCI artifact opt-out", func(t *testing.T) {
+		var opts ImageCommitOpts
+		_, err := opts.Load(context.Background(), map[string]string{
+			"oci-artifact": "false",
+		})
+		require.NoError(t, err)
+
+		opts.SetOCITypesDefault(true)
+		opts.SetOCIArtifactDefault(opts.OCITypesEnabled())
+
+		require.False(t, opts.OCIArtifact)
+	})
+
+	t.Run("does not enable OCI artifact when OCI mediatypes are disabled", func(t *testing.T) {
+		var opts ImageCommitOpts
+		_, err := opts.Load(context.Background(), map[string]string{})
+		require.NoError(t, err)
+
+		opts.SetOCITypesDefault(false)
+		opts.SetOCIArtifactDefault(opts.OCITypesEnabled())
+
+		require.False(t, opts.OCIArtifact)
+	})
+}

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -148,6 +148,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 	}
 	opts.Annotations = opts.Annotations.Merge(as)
 	opts.SetOCITypesDefault(e.defaultOCITypes(buildInfo.CompatibilityVersion, src))
+	opts.SetOCIArtifactDefault(opts.OCITypesEnabled())
 	if err := opts.Validate(); err != nil {
 		return nil, nil, nil, err
 	}


### PR DESCRIPTION
## Summary

- Default attestation manifests to OCI artifacts whenever the resolved image output uses OCI media types.
- Preserve `oci-artifact=false` as the opt-out path for the legacy attestation image manifest format.
- Add focused option-defaulting coverage and an integration test case for the omitted `oci-artifact` exporter option.
- Update README and attestation storage docs for the new default.

Fixes #6171

## Verification

- `go test ./exporter/containerimage -run TestImageCommitOptsSetOCIArtifactDefault -count=1 -v`
- `go test ./exporter/containerimage ./exporter/oci`
- `go test ./exporter/...`
- `SKIP_INTEGRATION_TESTS=1 go test ./client ./client/...`
- `git diff --check`

Attempted full client package test without skipping integration:

- `go test ./client/... ./exporter/containerimage ./exporter/oci`
- Result: failed before exercising this change because the local macOS test environment is missing the `registry` binary required by the integration mirror setup (`failed to lookup registry binary`). The skipped-integration run above verifies compile/unit coverage for the client packages.

## Second-agent review

Reviewer used: `hermes chat -Q` fallback. `claude -p` was attempted first but failed authentication with a 401.

Result: CLEAN

Reviewer summary: no blocking correctness, regression, security, duplicate/superseded-work, or maintainer-fit issues found. The reviewer called out that the explicit `oci-artifact=false` opt-out is preserved, defaults are applied before validation in both image and OCI exporters, tests cover default/explicit behavior, and the diff matches the direction from #6171/#5573.

Created with: Hermes Agent
