### PR TITLE
ci: tolerate empty test matrix includes

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -88,7 +88,8 @@ jobs:
               core.setOutput('tags', JSON.stringify(matrix));
             });
             await core.group(`Set includes`, async () => {
-              const includes = yaml.load(core.getInput('includes'));
+              const input = core.getInput('includes').trim();
+              const includes = input ? yaml.load(input) : [];
               core.info(JSON.stringify(includes, null, 2));
               core.setOutput('includes', JSON.stringify(includes ?? []));
             });

--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -56,7 +56,7 @@ jobs:
       -
         name: Deps
         run: |
-          npm install js-yaml
+          npm install --no-save js-yaml@5.1.0
       -
         name: Set outputs
         id: set


### PR DESCRIPTION
Unbreak ci https://github.com/moby/buildkit/actions/runs/27922360733/job/82618171093?pr=6889

The reusable test workflow installs js-yaml dynamically during CI. After
js-yaml 5.0.0 was released on 2026-06-20, load("") started throwing
instead of returning undefined.

Callers such as frontend.yml omit the optional includes input, so GitHub
Actions passes an empty string. Guard that value before parsing so omitted
or explicitly empty includes produce an empty JSON matrix while valid YAML
includes continue to work.

Use an explicit js-yaml version in the reusable test workflow so CI does
not silently pick up parser behavior changes from future npm releases.