### PR TITLE
feat: not fail on non-default ports

### DIFF
--- a/util/sshutil/keyscan.go
+++ b/util/sshutil/keyscan.go
@@ -14,6 +14,17 @@ const defaultPort = 22
 
 var errCallbackDone = errors.New("callback failed on purpose")
 
+// knownHostsServerID formats a host identifier for a known_hosts entry. A
+// non-standard port must be rendered as "[host]:port" so that ssh matches the
+// entry when connecting (see the SSH_KNOWN_HOSTS format in sshd(8)); the
+// default port is rendered as a bare hostname.
+func knownHostsServerID(hostname, port string) string {
+	if port == "" || port == strconv.Itoa(defaultPort) {
+		return hostname
+	}
+	return fmt.Sprintf("[%s]:%s", hostname, port)
+}
+
 // addDefaultPort appends a default port if hostport doesn't contain one
 func addDefaultPort(hostport string, defaultPort int) string {
 	_, _, err := net.SplitHostPort(hostport)
@@ -28,11 +39,12 @@ func addDefaultPort(hostport string, defaultPort int) string {
 func SSHKeyScan(server string) (string, error) {
 	var key string
 	KeyScanCallback := func(hostport string, remote net.Addr, pubKey ssh.PublicKey) error {
-		hostname, _, err := net.SplitHostPort(hostport)
+		hostname, port, err := net.SplitHostPort(hostport)
 		if err != nil {
 			return err
 		}
-		key = strings.TrimSpace(fmt.Sprintf("%s %s", hostname, string(ssh.MarshalAuthorizedKey(pubKey))))
+		serverID := knownHostsServerID(hostname, port)
+		key = strings.TrimSpace(fmt.Sprintf("%s %s", serverID, string(ssh.MarshalAuthorizedKey(pubKey))))
 		return errCallbackDone
 	}
 	config := &ssh.ClientConfig{

--- a/util/sshutil/keyscan_test.go
+++ b/util/sshutil/keyscan_test.go
@@ -1,0 +1,25 @@
+package sshutil
+
+import "testing"
+
+func TestKnownHostsServerID(t *testing.T) {
+	tests := []struct {
+		name     string
+		hostname string
+		port     string
+		want     string
+	}{
+		{"default port renders bare host", "github.com", "22", "github.com"},
+		{"empty port treated as default", "github.com", "", "github.com"},
+		{"non-standard port is bracketed", "git.example.com", "2222", "[git.example.com]:2222"},
+		{"ipv6 default port", "::1", "22", "::1"},
+		{"ipv6 non-standard port is bracketed", "::1", "2222", "[::1]:2222"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := knownHostsServerID(tt.hostname, tt.port); got != tt.want {
+				t.Fatalf("knownHostsServerID(%q, %q) = %q, want %q", tt.hostname, tt.port, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description

`SSHKeyScan` builds a `known_hosts` entry from the scanned host key but
discards the port, always emitting a bare hostname:

```go
hostname, _, err := net.SplitHostPort(hostport)
...
key = fmt.Sprintf("%s %s", hostname, ...)
```

For a server reachable on a non-standard port (e.g. `git.example.com:2222`)
this stores the key under `git.example.com`, but `ssh` looks it up under
`[git.example.com]:2222` per the `SSH_KNOWN_HOSTS` format in `sshd(8)`. The
entry never matches, so host-key verification fails for any git source or
SSH endpoint on a non-22 port.

### Fix

Render non-standard ports as `[host]:port`; keep the default port (22) as a
bare hostname (matching `ssh-keyscan` and the known_hosts format). The
formatting is extracted into a small pure helper, `knownHostsServerID`, which
is unit-tested directly (a full SSH handshake is impractical to fake in a
unit test).

### Test

`go test ./util/sshutil/` — new table test covers default port, empty port,
non-standard port, and IPv6 (default and non-standard).
