### PR TITLE
Improve diagnostics in gateway: return os.ErrNotExist for empty ref in file ops

### DIFF
--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -862,7 +862,7 @@ func (lbf *llbBridgeForwarder) Solve(ctx context.Context, req *pb.SolveRequest) 
 	return resp, nil
 }
 
-func (lbf *llbBridgeForwarder) getImmutableRef(ctx context.Context, id string) (cache.ImmutableRef, error) {
+func (lbf *llbBridgeForwarder) getImmutableRef(ctx context.Context, id, path string) (cache.ImmutableRef, error) {
 	lbf.mu.Lock()
 	ref, ok := lbf.refs[id]
 	if !ok {
@@ -878,7 +878,7 @@ func (lbf *llbBridgeForwarder) getImmutableRef(ctx context.Context, id string) (
 	}
 	lbf.mu.Unlock()
 	if ref == nil {
-		return nil, errors.Errorf("empty ref: %s", id)
+		return nil, errors.Wrapf(os.ErrNotExist, "%s (empty ref %s)", path, id)
 	}
 
 	r, err := ref.Result(ctx)
@@ -928,7 +928,7 @@ func (lbf *llbBridgeForwarder) getMount(ctx context.Context, id string, ref cach
 func (lbf *llbBridgeForwarder) ReadFile(ctx context.Context, req *pb.ReadFileRequest) (*pb.ReadFileResponse, error) {
 	ctx = tracing.ContextWithSpanFromContext(ctx, lbf.callCtx)
 
-	ref, err := lbf.getImmutableRef(ctx, req.Ref)
+	ref, err := lbf.getImmutableRef(ctx, req.Ref, req.FilePath)
 	if err != nil {
 		return nil, err
 	}
@@ -958,7 +958,7 @@ func (lbf *llbBridgeForwarder) ReadFile(ctx context.Context, req *pb.ReadFileReq
 func (lbf *llbBridgeForwarder) ReadDir(ctx context.Context, req *pb.ReadDirRequest) (*pb.ReadDirResponse, error) {
 	ctx = tracing.ContextWithSpanFromContext(ctx, lbf.callCtx)
 
-	ref, err := lbf.getImmutableRef(ctx, req.Ref)
+	ref, err := lbf.getImmutableRef(ctx, req.Ref, req.DirPath)
 	if err != nil {
 		return nil, err
 	}
@@ -983,7 +983,7 @@ func (lbf *llbBridgeForwarder) ReadDir(ctx context.Context, req *pb.ReadDirReque
 func (lbf *llbBridgeForwarder) StatFile(ctx context.Context, req *pb.StatFileRequest) (*pb.StatFileResponse, error) {
 	ctx = tracing.ContextWithSpanFromContext(ctx, lbf.callCtx)
 
-	ref, err := lbf.getImmutableRef(ctx, req.Ref)
+	ref, err := lbf.getImmutableRef(ctx, req.Ref, req.Path)
 	if err != nil {
 		return nil, err
 	}
@@ -1003,7 +1003,7 @@ func (lbf *llbBridgeForwarder) StatFile(ctx context.Context, req *pb.StatFileReq
 func (lbf *llbBridgeForwarder) Evaluate(ctx context.Context, req *pb.EvaluateRequest) (*pb.EvaluateResponse, error) {
 	ctx = tracing.ContextWithSpanFromContext(ctx, lbf.callCtx)
 
-	_, err := lbf.getImmutableRef(ctx, req.Ref)
+	_, err := lbf.getImmutableRef(ctx, req.Ref, "/")
 	if err != nil {
 		return nil, err
 	}

--- a/frontend/gateway/getimmutableref_test.go
+++ b/frontend/gateway/getimmutableref_test.go
@@ -1,0 +1,32 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/solver"
+)
+
+// A ref that is registered but resolves to a nil ResultProxy should surface as
+// an os.ErrNotExist that names both the requested path and the ref id, so
+// gateway clients (ReadFile/ReadDir/StatFile) can match on it and users get an
+// actionable message.
+func TestGetImmutableRefEmptyRefIsNotExist(t *testing.T) {
+	lbf := &llbBridgeForwarder{
+		refs: map[string]solver.ResultProxy{"emptyref": nil},
+	}
+
+	_, err := lbf.getImmutableRef(context.Background(), "emptyref", "/foo/bar")
+	if err == nil {
+		t.Fatal("expected an error for an empty ref")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("error should match os.ErrNotExist, got: %v", err)
+	}
+	if msg := err.Error(); !strings.Contains(msg, "/foo/bar") || !strings.Contains(msg, "emptyref") {
+		t.Fatalf("error should name the path and ref id, got: %q", msg)
+	}
+}


### PR DESCRIPTION
Increase the error fidelity - at the moment we can't tell the difference between absent and it was there but there was an error.

---

`ReadFile`/`ReadDir`/`StatFile` resolve a ref via `getImmutableRef`. When the ref is registered but resolves to nil ("empty ref"), they returned an opaque `errors.Errorf("empty ref: %s")` with no machine-detectable not-found signal and no indication of the path being read.

Pass the requested path through and return `errors.Wrap(os.ErrNotExist, "<path> (empty ref <id>)")` so callers can match `errors.Is(err, os.ErrNotExist)` -- letting a frontend handle an optional read cleanly -- and so the message names both the path and the ref id. No proto change; the richer `no such ref` error for an unregistered id is unchanged.

### Test

`TestGetImmutableRefEmptyRefIsNotExist` constructs a forwarder with a nil ref and asserts the error matches `os.ErrNotExist` and names the path and id.
