### PR TITLE
cache/remotecache: normalize object cache layer media types

### DIFF
--- a/cache/remotecache/v1/chains_test.go
+++ b/cache/remotecache/v1/chains_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/containerd/v2/core/images"
 	"github.com/moby/buildkit/solver"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -103,6 +104,60 @@ func TestSimpleMarshal(t *testing.T) {
 
 	require.Equal(t, 2, len(cfg.Layers))
 	require.Equal(t, 4, len(cfg.Records))
+}
+
+func TestMarshalLayerMediaTypes(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		descs    []ocispecs.Descriptor
+		expected map[digest.Digest]string
+	}{
+		{
+			name: "docker",
+			descs: []ocispecs.Descriptor{
+				{Digest: dgst("d0"), MediaType: images.MediaTypeDockerSchema2Layer},
+				{Digest: dgst("d1"), MediaType: images.MediaTypeDockerSchema2LayerGzip},
+				{Digest: dgst("d2"), MediaType: images.MediaTypeDockerSchema2LayerZstd},
+			},
+			expected: map[digest.Digest]string{
+				dgst("d0"): ocispecs.MediaTypeImageLayer,
+				dgst("d1"): ocispecs.MediaTypeImageLayerGzip,
+				dgst("d2"): ocispecs.MediaTypeImageLayerZstd,
+			},
+		},
+		{
+			name: "oci",
+			descs: []ocispecs.Descriptor{
+				{Digest: dgst("d0"), MediaType: ocispecs.MediaTypeImageLayer},
+				{Digest: dgst("d1"), MediaType: ocispecs.MediaTypeImageLayerGzip},
+				{Digest: dgst("d2"), MediaType: ocispecs.MediaTypeImageLayerZstd},
+			},
+			expected: map[digest.Digest]string{
+				dgst("d0"): ocispecs.MediaTypeImageLayer,
+				dgst("d1"): ocispecs.MediaTypeImageLayerGzip,
+				dgst("d2"): ocispecs.MediaTypeImageLayerZstd,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cc := NewCacheChains()
+			_, ok, err := cc.Add(outputKey(dgst("foo"), 0), nil, []solver.CacheExportResult{{
+				CreatedAt: time.Now(),
+				Result: &solver.Remote{
+					Descriptors: tc.descs,
+				},
+			}})
+			require.NoError(t, err)
+			require.True(t, ok)
+
+			_, descPairs, err := cc.Marshal(t.Context())
+			require.NoError(t, err)
+
+			for dgst, mediaType := range tc.expected {
+				require.Equal(t, mediaType, descPairs[dgst].Descriptor.MediaType)
+			}
+		})
+	}
 }
 
 func dgst(s string) digest.Digest {

--- a/cache/remotecache/v1/utils.go
+++ b/cache/remotecache/v1/utils.go
@@ -10,6 +10,7 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	cacheimporttypes "github.com/moby/buildkit/cache/remotecache/v1/types"
 	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/util/compression"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
@@ -152,6 +153,9 @@ func marshalRemote(ctx context.Context, r *solver.Remote, state *marshalState) s
 		parentID = marshalRemote(ctx, r2, state)
 	}
 	desc := r.Descriptors[len(r.Descriptors)-1]
+	if desc.MediaType != "" {
+		desc = compression.ConvertAllLayerMediaTypes(ctx, true, desc)[0]
+	}
 
 	state.descriptors[desc.Digest] = DescriptorProviderPair{
 		Descriptor: desc,


### PR DESCRIPTION
follow-up https://github.com/moby/buildkit/pull/6824

Updates remote cache chain marshaling so layer descriptors are normalized to OCI media types when descriptor media types are recorded.

This makes cache metadata written by the GHA, S3, and Azure Blob cache exporters store OCI layer media types in `CacheLayer.Annotations`. Registry and local cache exporters keep their existing exported manifest behavior through their `oci-mediatypes` option.

This doesn't add a new `compatibility-version` path because the affected cache metadata is internal to the remote cache backends.