### PR TITLE
exporter: default attestations to OCI artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Keys supported by image output:
 * `push-by-digest=true`: push unnamed image
 * `registry.insecure=true`: push to insecure HTTP registry
 * `oci-mediatypes=true`: use OCI mediatypes in configuration JSON instead of Docker's
-* `oci-artifact=false`: use OCI artifact format for attestations
+* `oci-artifact=true`: use OCI artifact format for attestations when OCI media types are enabled. Set to `false` to use the legacy attestation image manifest format.
 * `unpack=true`: unpack image after creation (for use with containerd)
 * `dangling-name-prefix=<value>`: name image with `prefix@<digest>`, used for anonymous images
 * `name-canonical=true`: add additional canonical name `name@<digest>`

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -216,6 +216,7 @@ var allTests = []func(t *testing.T, sb integration.Sandbox){
 	testPullWithLayerLimit,
 	testExportAnnotations,
 	testExportAnnotationsMediaTypes,
+	testExportAttestationsDefaultOCIArtifact,
 	testExportAttestationsOCIArtifact,
 	testExportAttestationsImageManifest,
 	testExportedImageLabels,
@@ -10915,15 +10916,19 @@ func testExportAnnotationsMediaTypes(t *testing.T, sb integration.Sandbox) {
 	require.Equal(t, ocispecs.MediaTypeImageIndex, imgs2.Index.MediaType)
 }
 
+func testExportAttestationsDefaultOCIArtifact(t *testing.T, sb integration.Sandbox) {
+	testExportAttestations(t, sb, false, false)
+}
+
 func testExportAttestationsOCIArtifact(t *testing.T, sb integration.Sandbox) {
-	testExportAttestations(t, sb, true)
+	testExportAttestations(t, sb, true, true)
 }
 
 func testExportAttestationsImageManifest(t *testing.T, sb integration.Sandbox) {
-	testExportAttestations(t, sb, false)
+	testExportAttestations(t, sb, false, true)
 }
 
-func testExportAttestations(t *testing.T, sb integration.Sandbox, ociArtifact bool) {
+func testExportAttestations(t *testing.T, sb integration.Sandbox, ociArtifact bool, setOCIArtifact bool) {
 	workers.CheckFeatureCompat(t, sb, workers.FeatureDirectPush)
 	requiresLinux(t)
 	c, err := New(sb.Context(), sb.Address())
@@ -11034,19 +11039,23 @@ func testExportAttestations(t *testing.T, sb integration.Sandbox, ociArtifact bo
 	}
 
 	t.Run("image", func(t *testing.T) {
+		expectedOCIArtifact := !setOCIArtifact || ociArtifact
 		targets := []string{
 			registry + "/buildkit/testattestationsfoo:latest",
 			registry + "/buildkit/testattestationsbar:latest",
 		}
+		attrs := map[string]string{
+			"name": strings.Join(targets, ","),
+			"push": "true",
+		}
+		if setOCIArtifact {
+			attrs["oci-artifact"] = strconv.FormatBool(ociArtifact)
+		}
 		_, err = c.Build(sb.Context(), SolveOpt{
 			Exports: []ExportEntry{
 				{
-					Type: ExporterImage,
-					Attrs: map[string]string{
-						"name":         strings.Join(targets, ","),
-						"push":         "true",
-						"oci-artifact": strconv.FormatBool(ociArtifact),
-					},
+					Type:  ExporterImage,
+					Attrs: attrs,
 				},
 			},
 		}, "", frontend, nil)
@@ -11079,7 +11088,7 @@ func testExportAttestations(t *testing.T, sb integration.Sandbox, ociArtifact bo
 			require.Equal(t, bases[i].Desc.Digest.String(), att.Desc.Annotations[attestation.DockerAnnotationReferenceDigest])
 			require.Equal(t, 2, len(att.Layers))
 
-			if ociArtifact {
+			if expectedOCIArtifact {
 				subject := att.Manifest.Subject
 				require.NotNil(t, subject)
 				require.Equal(t, bases[i].Desc.MediaType, subject.MediaType)

--- a/docs/attestations/attestation-storage.md
+++ b/docs/attestations/attestation-storage.md
@@ -7,12 +7,12 @@ attestations can provide valuable information from the build process,
 including, but not limited to: [SBOMs](https://en.wikipedia.org/wiki/Software_supply_chain),
 [SLSA Provenance](https://slsa.dev/provenance), build logs, etc.
 
-This document describes the current custom format used to store attestations,
-which is designed to be compatible with current registry implementations today.
-In the future, we may support exporting attestations in additional formats.
+This document describes the formats used to store attestations. BuildKit stores
+attestations as OCI artifacts when OCI media types are enabled. Set the image
+exporter option `oci-artifact=false` to use the legacy attestation image
+manifest format.
 
-Attestations are stored as manifest objects in the image index, similar in
-style to OCI artifacts.
+Attestations are stored as manifest objects in the image index.
 
 ## Properties
 
@@ -21,12 +21,18 @@ style to OCI artifacts.
 Attestation manifests are attached to the root image index object, under a
 separate [OCI image manifest](https://github.com/opencontainers/image-spec/blob/main/manifest.md).
 Each attestation manifest can contain multiple [attestation blobs](#attestation-blob),
-with all the of the attestations in a manifest applying to a single platform
+with all of the attestations in a manifest applying to a single platform
 manifest. All properties of standard OCI and Docker manifests continue to
 apply.
 
-The image `config` descriptor will point to a valid [image config](https://github.com/opencontainers/image-spec/blob/main/config.md),
-however, it will not contain attestation-specific details, and should be
+When OCI artifact storage is enabled, the manifest `artifactType` is set to
+`application/vnd.docker.attestation.manifest.v1+json`, the `subject` descriptor
+points to the target image manifest, and the `config` descriptor uses the OCI
+empty JSON descriptor.
+
+When `oci-artifact=false` is set, the image `config` descriptor will point to a
+valid [image config](https://github.com/opencontainers/image-spec/blob/main/config.md).
+The image config will not contain attestation-specific details, and should be
 ignored as it is only included for compatibility purposes.
 
 Each image layer in `layers` will contain a descriptor for a single
@@ -160,10 +166,12 @@ This attestation manifest contains one attestation that is an in-toto attestatio
 {
   "mediaType": "application/vnd.oci.image.manifest.v1+json",
   "schemaVersion": 2,
+  "artifactType": "application/vnd.docker.attestation.manifest.v1+json",
   "config": {
-    "mediaType": "application/vnd.oci.image.config.v1+json",
-    "digest": "sha256:a781560066f20ec9c28f2115a95a886e5e71c7c7aa9d8fd680678498b82f3ea3",
-    "size": 123
+    "mediaType": "application/vnd.oci.empty.v1+json",
+    "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+    "size": 2,
+    "data": "e30="
   },
   "layers": [
     {
@@ -174,22 +182,11 @@ This attestation manifest contains one attestation that is an in-toto attestatio
         "in-toto.io/predicate-type": "https://spdx.dev/Document"
       }
     }
-  ]
-}
-```
-
-#### Image config (`sha256:a781560066f20ec9c28f2115a95a886e5e71c7c7aa9d8fd680678498b82f3ea3`):
-
-```json
-{
-  "architecture": "unknown",
-  "os": "unknown",
-  "config": {},
-  "rootfs": {
-    "type": "layers",
-    "diff_ids": [
-      "sha256:133ae3f9bcc385295b66c2d83b28c25a9f294ce20954d5cf922dda860429734a"
-    ]
+  ],
+  "subject": {
+    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+    "digest": "sha256:23678f31b3b3586c4fb318aecfe64a96a1f0916ba8faf9b2be2abee63fa9e827",
+    "size": 1234
   }
 }
 ```

--- a/exporter/containerimage/export.go
+++ b/exporter/containerimage/export.go
@@ -234,6 +234,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 	}
 	opts.Annotations = opts.Annotations.Merge(as)
 	opts.SetOCITypesDefault(DefaultOCITypes(buildInfo.CompatibilityVersion, src))
+	opts.SetOCIArtifactDefault(DefaultOCIArtifact(buildInfo.CompatibilityVersion, &opts))
 	if err := opts.Validate(); err != nil {
 		return nil, nil, nil, err
 	}
@@ -588,6 +589,11 @@ func DefaultOCITypes(compatibilityVersion int, src *exporter.Source) bool {
 		return true
 	}
 	return len(src.Attestations) > 0
+}
+
+// DefaultOCIArtifact returns the default attestation manifest format.
+func DefaultOCIArtifact(compatibilityVersion int, opts *ImageCommitOpts) bool {
+	return compatibilityVersion >= compat.CompatibilityVersion031 && opts.OCITypesEnabled()
 }
 
 func NewDescriptorReference(desc ocispecs.Descriptor, release func(context.Context) error) exporter.DescriptorReference {

--- a/exporter/containerimage/opts.go
+++ b/exporter/containerimage/opts.go
@@ -15,7 +15,7 @@ type ImageCommitOpts struct {
 	ImageName   string
 	RefCfg      cacheconfig.RefConfig
 	OCITypes    *bool
-	OCIArtifact bool
+	OCIArtifact *bool
 	Annotations AnnotationsGroup
 	Epoch       *epoch.Epoch
 
@@ -51,7 +51,9 @@ func (c *ImageCommitOpts) Load(ctx context.Context, opt map[string]string) (map[
 			err = parseBool(&b, k, v)
 			c.OCITypes = &b
 		case exptypes.OptKeyOCIArtifact:
-			err = parseBool(&c.OCIArtifact, k, v)
+			var b bool
+			err = parseBool(&b, k, v)
+			c.OCIArtifact = &b
 		case exptypes.OptKeyForceInlineAttestations:
 			err = parseBool(&c.ForceInlineAttestations, k, v)
 		case exptypes.OptKeyPreferNondistLayers:
@@ -83,7 +85,7 @@ func (c *ImageCommitOpts) Validate() error {
 	if c.RefCfg.Compression.Type.OnlySupportOCITypes() && !c.OCITypesEnabled() {
 		return errors.Errorf("exporter option \"compression=%s\" conflicts with \"oci-mediatypes=false\"", c.RefCfg.Compression.Type)
 	}
-	if c.OCIArtifact && !c.OCITypesEnabled() {
+	if c.OCIArtifactEnabled() && !c.OCITypesEnabled() {
 		return errors.New("exporter option \"oci-artifact=true\" conflicts with \"oci-mediatypes=false\"")
 	}
 	return nil
@@ -97,6 +99,16 @@ func (c *ImageCommitOpts) SetOCITypesDefault(v bool) {
 
 func (c *ImageCommitOpts) OCITypesEnabled() bool {
 	return c.OCITypes != nil && *c.OCITypes
+}
+
+func (c *ImageCommitOpts) SetOCIArtifactDefault(v bool) {
+	if c.OCIArtifact == nil {
+		c.OCIArtifact = &v
+	}
+}
+
+func (c *ImageCommitOpts) OCIArtifactEnabled() bool {
+	return c.OCIArtifact != nil && *c.OCIArtifact
 }
 
 func parseBool(dest *bool, key string, value string) error {

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -342,7 +342,7 @@ func (ic *ImageWriter) Commit(ctx context.Context, inp *exporter.Source, session
 				return nil, err
 			}
 
-			desc, err := ic.commitAttestationsManifest(ctx, opts, *desc, stmts, opts.OCIArtifact)
+			desc, err := ic.commitAttestationsManifest(ctx, opts, *desc, stmts, opts.OCIArtifactEnabled())
 			if err != nil {
 				return nil, err
 			}

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -148,6 +148,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source
 	}
 	opts.Annotations = opts.Annotations.Merge(as)
 	opts.SetOCITypesDefault(e.defaultOCITypes(buildInfo.CompatibilityVersion, src))
+	opts.SetOCIArtifactDefault(containerimage.DefaultOCIArtifact(buildInfo.CompatibilityVersion, &opts))
 	if err := opts.Validate(); err != nil {
 		return nil, nil, nil, err
 	}


### PR DESCRIPTION
fixes https://github.com/moby/buildkit/issues/6171

This changes attestation manifests to use the OCI artifact form by default when OCI media types are enabled in the current compatibility version.

The exporter now tracks whether `oci-artifact` was omitted or explicitly set, which preserves `oci-artifact=false` as the opt-out path and keeps explicit `oci-artifact=true` behavior intact. 

OCI artifact storage is now supported across the targeted registries, so the previous opt-in default is no longer buying much except old behavior.