### PR TITLE
solver: fix job value iteration race

### DIFF
--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -354,9 +354,14 @@ func (sb *subBuilder) InContext(ctx context.Context, f func(context.Context, Job
 }
 
 func (sb *subBuilder) EachValue(ctx context.Context, key string, fn func(any) error) error {
-	sb.mu.Lock()
-	defer sb.mu.Unlock()
+	sb.state.mu.Lock()
+	jobs := make([]*Job, 0, len(sb.jobs))
 	for j := range sb.jobs {
+		jobs = append(jobs, j)
+	}
+	sb.state.mu.Unlock()
+
+	for _, j := range jobs {
 		if err := j.EachValue(ctx, key, fn); err != nil {
 			return err
 		}


### PR DESCRIPTION
Snapshot the state's job set under state.mu before walking job values. This matches the lock used by job attach and discard paths and avoids concurrent map iteration when op resolution loads shared job values.

fix #6915

It doesn't actually look v0.31 regression, but is more likely not with the network proxy feature.

@Lunatik-006