### PR TITLE
ci: remove vagrant dependency workaround

### DIFF
--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -198,8 +198,6 @@ jobs:
       - build
     env:
       GOOS: freebsd
-      # https://github.com/hashicorp/vagrant/issues/13652
-      VAGRANT_DISABLE_STRICT_DEPENDENCY_ENFORCEMENT: 1
     steps:
       -
         name: Checkout


### PR DESCRIPTION
relates to: https://github.com/moby/buildkit/actions/runs/28630119054/job/84905246097?pr=6920#step:5:1356

```
Installing the 'vagrant-libvirt' plugin. This can take a few minutes...
/opt/vagrant/embedded/lib/ruby/3.3.0/rubygems/specification.rb:2245:in `raise_if_conflicts': Unable to activate fog-json-1.4.0, because json-2.7.2 conflicts with json (~> 2.19) (Gem::ConflictError)
	from /opt/vagrant/embedded/lib/ruby/3.3.0/rubygems/specification.rb:1383:in `activate'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.9/lib/vagrant/bundler.rb:771:in `block in activate_solution'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.9/lib/vagrant/bundler.rb:768:in `each'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.9/lib/vagrant/bundler.rb:768:in `activate_solution'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.9/lib/vagrant/bundler.rb:608:in `internal_install'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.9/lib/vagrant/bundler.rb:358:in `install'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.9/lib/vagrant/plugin/manager.rb:141:in `block in install_plugin'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.9/lib/vagrant/plugin/manager.rb:151:in `install_plugin'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.9/plugins/commands/plugin/action/install_gem.rb:33:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.9/lib/vagrant/action/warden.rb:38:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.9/lib/vagrant/action/builder.rb:183:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.9/lib/vagrant/action/runner.rb:104:in `block in run'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.9/lib/vagrant/util/busy.rb:22:in `busy'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.9/lib/vagrant/action/runner.rb:104:in `run'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.9/plugins/commands/plugin/command/base.rb:17:in `action'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.9/plugins/commands/plugin/command/install.rb:73:in `block in execute'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.9/plugins/commands/plugin/command/install.rb:72:in `each'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.9/plugins/commands/plugin/command/install.rb:72:in `execute'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.9/plugins/commands/plugin/command/root.rb:69:in `execute'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.9/lib/vagrant/cli.rb:67:in `execute'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.9/lib/vagrant/environment.rb:317:in `cli'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.9/bin/vagrant:238:in `<main>'
```

The previous workaround was added for an older Vagrant resolver issue, but the current failure happens while installing `vagrant-libvirt` with the latest HashiCorp package. Removing the workaround lets Vagrant use its normal dependency enforcement again, which should avoid allowing an incompatible plugin dependency solution.