### PR TITLE
dockerfile: fix CopyIgnoredFile for context root

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/validations.go
+++ b/frontend/dockerfile/dockerfile2llb/validations.go
@@ -15,6 +15,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/moby/buildkit/frontend/dockerfile/shell"
 	"github.com/moby/buildkit/util/suggest"
+	"github.com/moby/patternmatcher"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
@@ -46,6 +47,13 @@ func validateCopySourcePath(src string, cfg *copyConfig) error {
 	}
 
 	src = filepath.ToSlash(filepath.Clean(src))
+	if src == "." || src == "/" {
+		// "." and "/" are context roots, not real paths that can be excluded.
+		// Only keep the warning for patterns that exclude all root entries.
+		if !copySourceRootIgnored(cfg.ignoreMatcher) {
+			return nil
+		}
+	}
 	ok, err := cfg.ignoreMatcher.MatchesOrParentMatches(src)
 	if err != nil {
 		return err
@@ -56,6 +64,19 @@ func validateCopySourcePath(src string, cfg *copyConfig) error {
 	}
 
 	return nil
+}
+
+func copySourceRootIgnored(matcher *patternmatcher.PatternMatcher) bool {
+	for _, pattern := range matcher.Patterns() {
+		if pattern.Exclusion() {
+			continue
+		}
+		switch pattern.String() {
+		case "*", "**", "**/*":
+			return true
+		}
+	}
+	return false
 }
 
 func validateCircularDependency(states []*dispatchState) error {

--- a/frontend/dockerfile/dockerfile_lint_test.go
+++ b/frontend/dockerfile/dockerfile_lint_test.go
@@ -48,6 +48,7 @@ var lintTests = integration.TestFuncs(
 	testInvalidDefaultArgInFrom,
 	testFromPlatformFlagConstDisallowed,
 	testCopyIgnoredFiles,
+	testCopyIgnoredFileContextRoot,
 	testDefinitionDescription,
 	testExposeProtoCasing,
 	testExposeInvalidFormat,
@@ -239,6 +240,41 @@ COPY . .
 	checkLinterWarnings(t, sb, &lintTestParams{
 		Dockerfile:   dockerfile,
 		DockerIgnore: dockerignore,
+	})
+}
+
+func testCopyIgnoredFileContextRoot(t *testing.T, sb integration.Sandbox) {
+	dockerfile := []byte(`
+FROM scratch
+COPY . .
+`)
+
+	t.Run("dotfiles", func(t *testing.T) {
+		checkLinterWarnings(t, sb, &lintTestParams{
+			Dockerfile: dockerfile,
+			DockerIgnore: []byte(`
+.*
+`),
+		})
+	})
+
+	t.Run("wildcard", func(t *testing.T) {
+		checkLinterWarnings(t, sb, &lintTestParams{
+			Dockerfile: dockerfile,
+			DockerIgnore: []byte(`
+*
+`),
+			Warnings: []expectedLintWarning{
+				{
+					RuleName:    "CopyIgnoredFile",
+					Description: "Attempting to Copy file that is excluded by .dockerignore",
+					Detail:      `Attempting to Copy file "." that is excluded by .dockerignore`,
+					URL:         "https://docs.docker.com/go/dockerfile/rule/copy-ignored-file/",
+					Level:       1,
+					Line:        3,
+				},
+			},
+		})
 	})
 }
 


### PR DESCRIPTION
Avoid treating COPY . . as copying an ignored file named "." when .dockerignore excludes dotfiles with patterns such as .*.

Keep the warning for catch-all root patterns like *, where copying the context root would copy only ignored entries.

fix #6926