### PR TITLE
util/compression: use zstd.EncoderLevelFromZstd to map compression levels

### DIFF
--- a/util/compression/zstd.go
+++ b/util/compression/zstd.go
@@ -12,7 +12,11 @@ import (
 
 func (c zstdType) Compress(ctx context.Context, comp Config) (compressorFunc Compressor, finalize Finalizer) {
 	return func(dest io.Writer, _ string) (io.WriteCloser, error) {
-		return zstdWriter(comp)(dest)
+		var opts []zstd.EOption
+		if comp.Level != nil {
+			opts = append(opts, zstd.WithEncoderLevel(zstd.EncoderLevelFromZstd(*comp.Level)))
+		}
+		return zstd.NewWriter(dest, opts...)
 	}, nil
 }
 
@@ -48,29 +52,4 @@ func (c zstdType) MediaType() string {
 
 func (c zstdType) String() string {
 	return "zstd"
-}
-
-func zstdWriter(comp Config) func(io.Writer) (io.WriteCloser, error) {
-	return func(dest io.Writer) (io.WriteCloser, error) {
-		level := zstd.SpeedDefault
-		if comp.Level != nil {
-			level = toZstdEncoderLevel(*comp.Level)
-		}
-		return zstd.NewWriter(dest, zstd.WithEncoderLevel(level))
-	}
-}
-
-func toZstdEncoderLevel(level int) zstd.EncoderLevel {
-	// map zstd compression levels to go-zstd levels
-	// once we also have c based implementation move this to helper pkg
-	if level < 0 {
-		return zstd.SpeedDefault
-	} else if level < 3 {
-		return zstd.SpeedFastest
-	} else if level < 7 {
-		return zstd.SpeedDefault
-	} else if level < 9 {
-		return zstd.SpeedBetterCompression
-	}
-	return zstd.SpeedBestCompression
 }


### PR DESCRIPTION
- relates to https://github.com/moby/buildkit/pull/2591
- possibly relevant upstream changes;
    - https://github.com/klauspost/compress/pull/118
    - https://github.com/klauspost/compress/pull/240
    - https://github.com/klauspost/compress/pull/410
    - https://github.com/klauspost/compress/pull/472


The toZstdEncoderLevel utility was introduced in cab33b1e31b20a2191ef8f5af7addb04399c161a, and has a custom mapping of zstd compressions levels to their go (klauspost/compress) counterparts.

Swap our local implementation for the one in klauspost/compress so that new levels implemented in klauspost/compress will also be mapped if they arrive.

This does change some mappings;

| Input level | Before                 | After                    |
|-------------|------------------------|--------------------------|
| `< 0`       | `SpeedDefault`         | `SpeedFastest`           |
| `6`         | `SpeedDefault`         | `SpeedBetterCompression` |
| `9`         | `SpeedBestCompression` | `SpeedBetterCompression` |

While updating, also slightly refactor;

- use an options slice to skip setting the option if no config was set, and to allow adding additional options.
- inline zstdWriter where used, as it was only used in a single place.


---

Input level | Before (toZstdEncoderLevel) | After (zstd.EncoderLevelFromZstd) | Change
-- | -- | -- | --
< 0 | SpeedDefault | SpeedFastest | ⚠️ Different
0–2 | SpeedFastest | SpeedFastest | ✅ Same
3–5 | SpeedDefault | SpeedDefault | ✅ Same
6 | SpeedDefault | SpeedBetterCompression | ⚠️ Different
7–8 | SpeedBetterCompression | SpeedBetterCompression | ✅ Same
9 | SpeedBestCompression | SpeedBetterCompression | ⚠️ Different
>= 10 | SpeedBestCompression | SpeedBestCompression | ✅ Same

