### PR TITLE
util/compression: enable zstd.WithConcurrentBlocks

### DIFF
--- a/util/compression/zstd.go
+++ b/util/compression/zstd.go
@@ -12,7 +12,11 @@ import (
 
 func (c zstdType) Compress(ctx context.Context, comp Config) (compressorFunc Compressor, finalize Finalizer) {
 	return func(dest io.Writer, _ string) (io.WriteCloser, error) {
-		return zstdWriter(comp)(dest)
+		var opts []zstd.EOption
+		if comp.Level != nil {
+			opts = append(opts, zstd.WithEncoderLevel(zstd.EncoderLevelFromZstd(*comp.Level)))
+		}
+		return zstd.NewWriter(dest, opts...)
 	}, nil
 }
 
@@ -48,29 +52,4 @@ func (c zstdType) MediaType() string {
 
 func (c zstdType) String() string {
 	return "zstd"
-}
-
-func zstdWriter(comp Config) func(io.Writer) (io.WriteCloser, error) {
-	return func(dest io.Writer) (io.WriteCloser, error) {
-		level := zstd.SpeedDefault
-		if comp.Level != nil {
-			level = toZstdEncoderLevel(*comp.Level)
-		}
-		return zstd.NewWriter(dest, zstd.WithEncoderLevel(level))
-	}
-}
-
-func toZstdEncoderLevel(level int) zstd.EncoderLevel {
-	// map zstd compression levels to go-zstd levels
-	// once we also have c based implementation move this to helper pkg
-	if level < 0 {
-		return zstd.SpeedDefault
-	} else if level < 3 {
-		return zstd.SpeedFastest
-	} else if level < 7 {
-		return zstd.SpeedDefault
-	} else if level < 9 {
-		return zstd.SpeedBetterCompression
-	}
-	return zstd.SpeedBestCompression
 }

--- a/util/compression/zstd.go
+++ b/util/compression/zstd.go
@@ -3,6 +3,7 @@ package compression
 import (
 	"context"
 	"io"
+	"runtime"
 
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
@@ -12,7 +13,10 @@ import (
 
 func (c zstdType) Compress(ctx context.Context, comp Config) (compressorFunc Compressor, finalize Finalizer) {
 	return func(dest io.Writer, _ string) (io.WriteCloser, error) {
-		var opts []zstd.EOption
+		opts := []zstd.EOption{
+			zstd.WithEncoderConcurrency(runtime.GOMAXPROCS(0)), // TBD: default is GOMAXPROCS for each writer.
+			zstd.WithConcurrentBlocks(true),
+		}
 		if comp.Level != nil {
 			opts = append(opts, zstd.WithEncoderLevel(zstd.EncoderLevelFromZstd(*comp.Level)))
 		}


### PR DESCRIPTION
- [ ] stacked on https://github.com/moby/buildkit/pull/6933
- [x] depends on https://github.com/moby/buildkit/pull/6934

### util/compression: enable WithConcurrentBlocks

This option was added in klauspost/compress v0.19; https://pkg.go.dev/github.com/klauspost/compress@v1.19.0/zstd#section-readme
> Parallel Stream Compression
>
> For maximum throughput on large streams, use WithConcurrentBlocks(true)
> together with WithEncoderConcurrency(n) where n is the number of CPU cores
> you want to use. This splits the input into large sections (jobs) that are
> compressed simultaneously by multiple goroutines, similar to how the C zstd
> library does multithreaded compression.

Given that BuildKit creates a new Writer for each blob, we may need
to look what the best value is for WithEncoderConcurrency.

Benchmarks as mentioned in upstream;

> | Level   | 1 thread   | 4 threads          | 16 threads          | 1T ratio | 16T ratio |
> |---------|:----------:|:------------------:|:-------------------:|:--------:|:---------:|
> | fastest | 783 MB/s   | 2950 MB/s (3.8×)   | 6939 MB/s (8.9×)    | 12.24%   | 12.26%    |
> | default | 728 MB/s   | 2533 MB/s (3.5×)   | 5340 MB/s (7.3×)    | 10.67%   | 10.68%    |
> | better  | 434 MB/s   | 1105 MB/s (2.5×)   | 2206 MB/s (5.1×)    | 9.14%    | 9.21%     |
> | best    | 129 MB/s   | 367 MB/s (2.8×)    | 884 MB/s (6.8×)     | 8.48%    | 8.63%     |

