### PR TITLE
docs: clarify WORKDIR tilde path behavior

### DIFF
--- a/frontend/dockerfile/docs/rules/workdir-relative-path.md
+++ b/frontend/dockerfile/docs/rules/workdir-relative-path.md
@@ -28,6 +28,12 @@ image built externally is prone to breaking, since working directory may change
 upstream without warning, resulting in a completely different directory
 hierarchy for your build.
 
+> [!NOTE]
+>
+> `WORKDIR` does not perform shell expansion. Paths beginning with `~` or
+> `~username` are treated as literal directory names and are not resolved to a
+> user's home directory.
+
 ## Examples
 
 ❌ Bad: this assumes that `WORKDIR` in the base image is `/`

--- a/frontend/dockerfile/linter/docs/WorkdirRelativePath.md
+++ b/frontend/dockerfile/linter/docs/WorkdirRelativePath.md
@@ -20,6 +20,12 @@ image built externally is prone to breaking, since working directory may change
 upstream without warning, resulting in a completely different directory
 hierarchy for your build.
 
+> [!NOTE]
+>
+> `WORKDIR` does not perform shell expansion. Paths beginning with `~` or
+> `~username` are treated as literal directory names and are not resolved to a
+> user's home directory.
+
 ## Examples
 
 ❌ Bad: this assumes that `WORKDIR` in the base image is `/`


### PR DESCRIPTION
## Description

Adds a note clarifying that `WORKDIR` does not perform shell expansion.

Paths beginning with `~` or `~username` are treated as literal directory names and are not resolved to a user's home directory.

## Related issues

References docker/docs#25512