### PR TITLE
buildctl: revert trace shutdown timeout

### DIFF
--- a/cmd/buildctl/common/trace.go
+++ b/cmd/buildctl/common/trace.go
@@ -3,20 +3,16 @@ package common
 import (
 	"context"
 	"os"
-	"time"
 
 	"github.com/moby/buildkit/util/appcontext"
 	"github.com/moby/buildkit/util/tracing/delegated"
 	"github.com/moby/buildkit/util/tracing/detect"
-	"github.com/pkg/errors"
 	"github.com/urfave/cli/v3"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 )
-
-const exportTimeout = 50 * time.Millisecond
 
 func AttachAppContext(app *cli.Command) error {
 	baseCtx := appcontext.Context()
@@ -79,13 +75,7 @@ func AttachAppContext(app *cli.Command) error {
 			span.End()
 		}
 
-		// Set a rather aggressive timeout for shutting down the tracer provider
-		// to ensure we don't stall on a non-responsive tracing endpoint for too long
-		// on shutdown.
-		ctx, cancel := context.WithTimeoutCause(appcontext.Shutdown(), exportTimeout, errors.WithStack(context.DeadlineExceeded))
-		defer cancel()
-
-		return tp.Shutdown(ctx)
+		return tp.Shutdown(context.TODO())
 	}
 	return nil
 }


### PR DESCRIPTION
fixes https://github.com/moby/buildkit/issues/6912
closes https://github.com/moby/buildkit/pull/6918

This partially reverts the buildctl tracer shutdown change from #6757.

The 50ms shutdown context can expire while delegated traces are flushed over a slow but healthy connhelper transport. Restore the previous buildctl shutdown behavior so that this telemetry cleanup path doesn't fail an otherwise successful command.

Keep the daemon-side telemetry shutdown bounds and trace forwarder changes from #6757 intact.