### PR TITLE
dockerfile: fix Windows SBOM scanner temp mount

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -13,6 +13,7 @@ import (
 	contentapi "github.com/containerd/containerd/api/services/content/v1"
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/plugins/services/content/contentserver"
+	"github.com/containerd/platforms"
 	"github.com/distribution/reference"
 	"github.com/gohugoio/hashstructure"
 	controlapi "github.com/moby/buildkit/api/services/control"
@@ -548,7 +549,11 @@ func (c *Controller) Solve(ctx context.Context, req *controlapi.SolveRequest) (*
 			resolveMode = v
 		}
 
-		procs = append(procs, proc.SBOMProcessor(ref.String(), useCache, resolveMode, params))
+		scannerPlatform := platforms.Normalize(platforms.DefaultSpec())
+		if ps := w.Platforms(false); len(ps) > 0 {
+			scannerPlatform = ps[0]
+		}
+		procs = append(procs, proc.SBOMProcessor(ref.String(), scannerPlatform, useCache, resolveMode, params))
 	}
 
 	if attrs, ok := attests["provenance"]; ok {

--- a/frontend/attestations/sbom/sbom.go
+++ b/frontend/attestations/sbom/sbom.go
@@ -34,7 +34,7 @@ const (
 // attestation.
 type Scanner func(ctx context.Context, name string, ref llb.State, extras map[string]llb.State, opts ...llb.ConstraintsOpt) (result.Attestation[*llb.State], error)
 
-func CreateSBOMScanner(ctx context.Context, resolver sourceresolver.MetaResolver, scanner string, resolveOpt sourceresolver.Opt, params map[string]string) (Scanner, error) {
+func CreateSBOMScanner(ctx context.Context, resolver sourceresolver.MetaResolver, scanner string, scannerPlatform ocispecs.Platform, resolveOpt sourceresolver.Opt, params map[string]string) (Scanner, error) {
 	if scanner == "" {
 		return nil, nil
 	}
@@ -83,8 +83,10 @@ func CreateSBOMScanner(ctx context.Context, resolver sourceresolver.MetaResolver
 			runOpts = append(runOpts, llb.AddEnv(k, v))
 		}
 
-		runscan := llb.Image(scanner).Run(runOpts...)
-		runscan.AddMount("/tmp", llb.Scratch(), llb.Tmpfs())
+		scannerImage := llb.Image(scanner, llb.Platform(scannerPlatform))
+		runscan := scannerImage.Run(runOpts...)
+		tmpState, tmpMountOpt := scannerTmpMount(scannerImage, scannerPlatform)
+		runscan.AddMount("/tmp", tmpState, tmpMountOpt...)
 
 		runscan.AddMount(path.Join(srcDir, "core", CoreSBOMName), ref, llb.Readonly)
 		for k, extra := range extras {
@@ -104,6 +106,16 @@ func CreateSBOMScanner(ctx context.Context, resolver sourceresolver.MetaResolver
 			},
 		}, nil
 	}, nil
+}
+
+func scannerTmpMount(scannerImage llb.State, platform ocispecs.Platform) (llb.State, []llb.MountOption) {
+	if platform.OS == "windows" {
+		return scannerImage.File(llb.Mkdir("/tmp", 0777, llb.WithParents(true))), []llb.MountOption{
+			llb.SourcePath("/tmp"),
+			llb.ForceNoOutput,
+		}
+	}
+	return llb.Scratch(), []llb.MountOption{llb.Tmpfs()}
 }
 
 func HasSBOM[T comparable](res *result.Result[T]) bool {

--- a/frontend/attestations/sbom/sbom_test.go
+++ b/frontend/attestations/sbom/sbom_test.go
@@ -1,0 +1,133 @@
+package sbom
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/client/llb/sourceresolver"
+	"github.com/moby/buildkit/solver/pb"
+	digest "github.com/opencontainers/go-digest"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScannerTmpMount(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	cfg, err := json.Marshal(ocispecs.Image{
+		Config: ocispecs.ImageConfig{
+			Cmd: []string{"scan"},
+		},
+	})
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name          string
+		buildPlatform ocispecs.Platform
+		mountType     pb.MountType
+	}{
+		{
+			name:          "linux",
+			buildPlatform: ocispecs.Platform{OS: "linux", Architecture: "amd64"},
+			mountType:     pb.MountType_TMPFS,
+		},
+		{
+			name:          "windows",
+			buildPlatform: ocispecs.Platform{OS: "windows", Architecture: "amd64"},
+			mountType:     pb.MountType_BIND,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			scanner, err := CreateSBOMScanner(ctx, testMetaResolver{config: cfg}, "example.com/scanner:latest", tc.buildPlatform, sourceresolver.Opt{}, nil)
+			require.NoError(t, err)
+			require.NotNil(t, scanner)
+
+			att, err := scanner(ctx, tc.name, llb.Scratch(), nil)
+			require.NoError(t, err)
+			op := scannerExecOp(t, att.Ref)
+			require.Equal(t, tc.buildPlatform.OS, op.Platform.OS)
+
+			sourceOp := scannerImageSourceOp(t, att.Ref)
+			require.Equal(t, tc.buildPlatform.OS, sourceOp.Platform.OS)
+
+			tmpMount := findMount(t, op.GetExec(), "/tmp")
+			require.Equal(t, tc.mountType, tmpMount.MountType)
+			require.Equal(t, int64(pb.SkipOutput), tmpMount.Output)
+
+			if tc.mountType == pb.MountType_TMPFS {
+				require.NotNil(t, tmpMount.TmpfsOpt)
+				require.Nil(t, tmpMount.CacheOpt)
+			} else {
+				require.Nil(t, tmpMount.TmpfsOpt)
+				require.Nil(t, tmpMount.CacheOpt)
+				require.Equal(t, "/tmp", tmpMount.Selector)
+			}
+		})
+	}
+}
+
+type testMetaResolver struct {
+	config []byte
+}
+
+func (r testMetaResolver) ResolveSourceMetadata(ctx context.Context, op *pb.SourceOp, opt sourceresolver.Opt) (*sourceresolver.MetaResponse, error) {
+	return &sourceresolver.MetaResponse{
+		Op: op,
+		Image: &sourceresolver.ResolveImageResponse{
+			Digest: digest.FromString("scanner"),
+			Config: r.config,
+		},
+	}, nil
+}
+
+func scannerExecOp(t *testing.T, st *llb.State) *pb.Op {
+	t.Helper()
+
+	def, err := st.Marshal(t.Context())
+	require.NoError(t, err)
+
+	for _, dt := range def.Def {
+		var op pb.Op
+		require.NoError(t, op.UnmarshalVT(dt))
+		if op.GetExec() != nil {
+			return &op
+		}
+	}
+	require.FailNow(t, "scanner exec op not found")
+	return nil
+}
+
+func scannerImageSourceOp(t *testing.T, st *llb.State) *pb.Op {
+	t.Helper()
+
+	def, err := st.Marshal(t.Context())
+	require.NoError(t, err)
+
+	for _, dt := range def.Def {
+		var op pb.Op
+		require.NoError(t, op.UnmarshalVT(dt))
+		if src := op.GetSource(); src != nil && strings.HasPrefix(src.Identifier, "docker-image://") {
+			return &op
+		}
+	}
+	require.FailNow(t, "scanner image source op not found")
+	return nil
+}
+
+func findMount(t *testing.T, exec *pb.ExecOp, dest string) *pb.Mount {
+	t.Helper()
+
+	for _, mount := range exec.Mounts {
+		if mount.Dest == dest {
+			return mount
+		}
+	}
+	require.FailNow(t, "mount not found", "dest=%s", dest)
+	return nil
+}

--- a/frontend/dockerfile/builder/build.go
+++ b/frontend/dockerfile/builder/build.go
@@ -118,9 +118,11 @@ func Build(ctx context.Context, c client.Client) (_ *client.Result, err error) {
 	var scanner sbom.Scanner
 	if bc.SBOM != nil {
 		// TODO: scanner should pass policy
-		scanner, err = sbom.CreateSBOMScanner(ctx, c, bc.SBOM.Generator, sourceresolver.Opt{
+		scannerPlatform := bc.BuildPlatforms[0]
+		scanner, err = sbom.CreateSBOMScanner(ctx, c, bc.SBOM.Generator, scannerPlatform, sourceresolver.Opt{
 			ImageOpt: &sourceresolver.ResolveImageOpt{
 				ResolveMode: opts["image-resolve-mode"],
+				Platform:    &scannerPlatform,
 			},
 		}, bc.SBOM.Parameters)
 		if err != nil {

--- a/solver/llbsolver/proc/sbom.go
+++ b/solver/llbsolver/proc/sbom.go
@@ -13,10 +13,11 @@ import (
 	"github.com/moby/buildkit/solver/llbsolver"
 	"github.com/moby/buildkit/solver/result"
 	"github.com/moby/buildkit/util/tracing"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
-func SBOMProcessor(scannerRef string, useCache bool, resolveMode string, params map[string]string) llbsolver.Processor {
+func SBOMProcessor(scannerRef string, scannerPlatform ocispecs.Platform, useCache bool, resolveMode string, params map[string]string) llbsolver.Processor {
 	return func(ctx context.Context, res *llbsolver.Result, s *llbsolver.Solver, j *solver.Job, usage *resources.SysSampler) (*llbsolver.Result, error) {
 		// skip sbom generation if we already have an sbom
 		if sbom.HasSBOM(res.Result) {
@@ -31,9 +32,10 @@ func SBOMProcessor(scannerRef string, useCache bool, resolveMode string, params 
 			return nil, err
 		}
 
-		scanner, err := sbom.CreateSBOMScanner(ctx, s.Bridge(j), scannerRef, sourceresolver.Opt{
+		scanner, err := sbom.CreateSBOMScanner(ctx, s.Bridge(j), scannerRef, scannerPlatform, sourceresolver.Opt{
 			ImageOpt: &sourceresolver.ResolveImageOpt{
 				ResolveMode: resolveMode,
+				Platform:    &scannerPlatform,
 			},
 		}, params)
 		if err != nil {


### PR DESCRIPTION
needed for https://github.com/docker/buildkit-syft-scanner/pull/201
carry and closes https://github.com/moby/buildkit/pull/6093

This carries the intent of https://github.com/moby/buildkit/pull/6093 and closes it with a mount shape that works for the Windows scanner image being added in https://github.com/docker/buildkit-syft-scanner/pull/201. The SBOM scanner still gets writable temp space, but Windows no longer asks BuildKit to create a tmpfs mount that the platform cannot support.