### PR TITLE
Use bolt hashmap freelist for metadata databases

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -79,6 +79,8 @@ linters:
         - unusedwrite
     importas:
       alias:
+        - pkg: go.etcd.io/bbolt
+          alias: bolt
         - pkg: github.com/containerd/errdefs
           alias: cerrdefs
         - pkg: github.com/opencontainers/image-spec/specs-go/v1

--- a/cache/metadata/metadata.go
+++ b/cache/metadata/metadata.go
@@ -41,7 +41,9 @@ func NewStore(dbPath string) (*Store, error) {
 			)
 		}
 	}
-	db, err := boltutil.Open(dbPath, 0600, nil)
+	db, err := boltutil.Open(dbPath, 0600, &bolt.Options{
+		FreelistType: bolt.FreelistMapType,
+	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to open database file %s", dbPath)
 	}

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -70,6 +70,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v3"
+	bolt "go.etcd.io/bbolt"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/prometheus"
@@ -899,7 +900,9 @@ func newController(ctx context.Context, c *cli.Command, cfg *config.Config, mp m
 	}
 	cacheStoreForDebug = cacheStorage
 
-	historyDB, err := boltutil.SafeOpen(filepath.Join(cfg.Root, "history.db"), 0600, nil)
+	historyDB, err := boltutil.SafeOpen(filepath.Join(cfg.Root, "history.db"), 0600, &bolt.Options{
+		FreelistType: bolt.FreelistMapType,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/solver/bboltcachestorage/storage.go
+++ b/solver/bboltcachestorage/storage.go
@@ -26,7 +26,8 @@ type Store struct {
 
 func NewStore(dbPath string) (*Store, error) {
 	db, err := boltutil.SafeOpen(dbPath, 0600, &bolt.Options{
-		NoSync: true,
+		NoSync:       true,
+		FreelistType: bolt.FreelistMapType,
 	})
 	if err != nil {
 		return nil, err

--- a/util/cachedigest/db.go
+++ b/util/cachedigest/db.go
@@ -7,7 +7,7 @@ import (
 
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
-	"go.etcd.io/bbolt"
+	bolt "go.etcd.io/bbolt"
 )
 
 var ErrInvalidEncoding = errors.Errorf("invalid encoding")
@@ -16,7 +16,7 @@ var ErrNotFound = errors.Errorf("not found")
 const bucketName = "byhash"
 
 type DB struct {
-	db *bbolt.DB
+	db *bolt.DB
 	wg sync.WaitGroup
 }
 
@@ -31,7 +31,7 @@ func GetDefaultDB() *DB {
 }
 
 func NewDB(path string) (*DB, error) {
-	db, err := bbolt.Open(path, 0600, nil)
+	db, err := bolt.Open(path, 0600, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func (d *DB) saveFrames(key string, frames []Frame) {
 			// Optionally log error
 			return
 		}
-		_ = d.db.Update(func(tx *bbolt.Tx) error {
+		_ = d.db.Update(func(tx *bolt.Tx) error {
 			b, err := tx.CreateBucketIfNotExists([]byte(bucketName))
 			if err != nil {
 				return err
@@ -94,7 +94,7 @@ func (d *DB) Get(ctx context.Context, dgst string) (Type, []Frame, error) {
 	}
 	var typ Type
 	var resultFrames []Frame
-	err = d.db.View(func(tx *bbolt.Tx) error {
+	err = d.db.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(bucketName))
 		if b == nil {
 			return errors.WithStack(ErrNotFound)
@@ -127,7 +127,7 @@ func (d *DB) All(ctx context.Context, cb func(key string, typ Type, frames []Fra
 	if d.db == nil {
 		return nil
 	}
-	return d.db.View(func(tx *bbolt.Tx) error {
+	return d.db.View(func(tx *bolt.Tx) error {
 		select {
 		case <-ctx.Done():
 			return context.Cause(ctx)

--- a/util/cachedigest/db.go
+++ b/util/cachedigest/db.go
@@ -31,7 +31,9 @@ func GetDefaultDB() *DB {
 }
 
 func NewDB(path string) (*DB, error) {
-	db, err := bolt.Open(path, 0600, nil)
+	db, err := bolt.Open(path, 0600, &bolt.Options{
+		FreelistType: bolt.FreelistMapType,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/worker/runc/runc.go
+++ b/worker/runc/runc.go
@@ -95,7 +95,9 @@ func NewWorkerOpt(root string, snFactory SnapshotterFactory, rootless bool, proc
 		return opt, err
 	}
 
-	db, err := bolt.Open(filepath.Join(root, "containerdmeta.db"), 0644, nil)
+	db, err := bolt.Open(filepath.Join(root, "containerdmeta.db"), 0644, &bolt.Options{
+		FreelistType: bolt.FreelistMapType,
+	})
 	if err != nil {
 		return opt, err
 	}


### PR DESCRIPTION
bolt documents the array freelist as potentially degrading significantly
for large fragmented databases, while the hashmap freelist is faster in
almost all circumstances. From the [DB.FreelistType] GoDoc:

    // FreelistType sets the backend freelist type. There are two options. Array which is simple but endures
    // dramatic performance degradation if database is large and fragmentation in freelist is common.
    // The alternative one is using hashmap, it is faster in almost all circumstances
    // but it doesn't guarantee that it offers the smallest page id available. In normal case it is safe.
    // The default type is array
    FreelistType FreelistType

While the default is still `FreelistArrayType`, the package shows that
the intent is to make `FreelistMapType` the default in future;
https://pkg.go.dev/go.etcd.io/bbolt@v1.5.0#pkg-constants

    // TODO(ahrtr): eventually we should (step by step)
    //  1. default to `FreelistMapType`;
    //  2. remove the `FreelistArrayType`, do not export `FreelistMapType`
    //     and remove field `FreelistType' from both `DB` and `Options`;

This keeps the on-disk format unchanged and only changes the in-memory
freelist implementation used after opening the DB.

[DB.FreelistType]: https://pkg.go.dev/go.etcd.io/bbolt@v1.5.0#DB.FreelistType
