### PR TITLE
dockerfile: use containerd's defaults.DefaultMax{Recv,Send}MsgSize where constants were hardcoded

### DIFF
--- a/frontend/gateway/grpcclient/client.go
+++ b/frontend/gateway/grpcclient/client.go
@@ -14,6 +14,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/containerd/containerd/v2/defaults"
 	distreference "github.com/distribution/reference"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/client/llb/sourceresolver"
@@ -1451,8 +1452,8 @@ func grpcClientConn(ctx context.Context) (context.Context, *grpc.ClientConn, err
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithUnaryInterceptor(grpcerrors.UnaryClientInterceptor),
 		grpc.WithStreamInterceptor(grpcerrors.StreamClientInterceptor),
-		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(16 << 20)),
-		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(16 << 20)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(defaults.DefaultMaxRecvMsgSize)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(defaults.DefaultMaxSendMsgSize)),
 	}
 
 	//nolint:staticcheck // ignore SA1019 NewClient has different behavior and needs to be tested


### PR DESCRIPTION
I am toying with these values while building very large Dockerfiles and noticed that I needed this fix.

Side request: would you be open to provide a configuration option (for buildkit and frontend images) to set both call options? I need these values set to 128MB (set to 16MB today) and surely you wouldn't be too happy with my values.
Maybe that'd be an image build argument?
Thanks