### PR TITLE
solver: reuse cached results when a shared base is held `complete` by a concurrent build

### DIFF
--- a/solver/cachemiss_stale_dep_test.go
+++ b/solver/cachemiss_stale_dep_test.go
@@ -1,0 +1,259 @@
+package solver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCacheMissStaleCompleteSharedDep reproduces the "stale complete
+// shared-dependency" cache miss (moby/buildkit#4674 family) in-process.
+//
+// Graph (identical for every build): a shared leaf "base" and one op "step" on
+// top of it (arrow = "is an input of"):
+//
+//	"base" --> "step"
+//
+// A1 builds step -> base against an empty cache. base executes, and its cache
+// key ends up living only on base's *result*, not on edgeState.keys (a leaf that
+// executed against an empty cache never appended a key, and a completed edge
+// never re-queries). Both base and step are saved. A2 then builds a step with
+// the SAME cache seed on the SAME shared base and should reuse the cached step.
+//
+// A parent learns a completed dep's key one of two ways: (a) probeCache/Query,
+// fed only from the dep's edgeState.keys, or (b) an edge-index merge onto a
+// still-*live* peer edge, which reads result.CacheKeys(). Discarding A1 removes
+// its step edge from the edge index, closing (b) -- so A2's step edge must
+// resolve through the *cache*, not a live peer. (The index is keyed on the cache
+// key, not the vertex digest, so a distinct step digest alone would not close
+// (b); the discard does.)
+//
+// Whether the shared base is reused-complete or recreated-fresh is then decided
+// purely by concurrency:
+//
+//   - No B: after A1 is discarded the base is unreferenced and dropped from
+//     Solver.actives. A2 recreates it fresh; it re-queries the populated cache
+//     and delivers its key via edgeState.keys -> A2 probes -> hit.
+//   - B holds only the base alive: the base stays referenced in Solver.actives,
+//     already `complete`, and is reused by A2. It delivers edgeState.keys=0 while
+//     its result carries the key -- so pre-fix probeCache sees an empty slice,
+//     noCacheMatchPossible latches, and A2 re-executes; post-fix probeResultCache
+//     reads the result key and A2 hits.
+func TestCacheMissStaleCompleteSharedDep(t *testing.T) {
+	t.Parallel()
+
+	// baseEdge builds a leaf "base" vertex with a fixed digest and cache seed so
+	// it is a single shared active vertex across builds. value differs per build
+	// only to prove the returned result came from A1's cache. ignoreCache marks
+	// the base as `--no-cache` (used by the ignore-cache safety subtest).
+	baseEdge := func(value string, ignoreCache bool) Edge {
+		return Edge{Vertex: vtx(vtxOpt{
+			name:         "base",
+			cacheKeySeed: "base-seed",
+			value:        value,
+			ignoreCache:  ignoreCache,
+		})}
+	}
+
+	// stepEdge builds a "step" vertex on top of base. The cache seed is fixed so
+	// every build's step is cache-matchable against A1's saved
+	// record; stepName (hence the vertex digest) is passed in so a build can
+	// either reuse A1's step vertex (same name) or model a separate
+	// build with a distinct step vertex (different name, same seed). ignoreBase
+	// marks the base dependency as `--no-cache`.
+	stepEdge := func(stepName, value, baseValue string, ignoreBase bool) Edge {
+		return Edge{Vertex: vtx(vtxOpt{
+			name:         stepName,
+			cacheKeySeed: "step-seed",
+			value:        value,
+			inputs:       []Edge{baseEdge(baseValue, ignoreBase)},
+		})}
+	}
+
+	// scenario selects which timing / builder-state case run() exercises.
+	type scenario struct {
+		holdBaseAlive  bool // B keeps the shared base referenced across A2 (concurrent hold)
+		sameStepVertex bool // A2 reuses A1's step vertex digest vs. a distinct one
+		warmBase       bool // base's cache record pre-exists, so it cache-hits instead of executing
+		ignoreBase     bool // base carries IgnoreCache (`--no-cache` on the dependency)
+	}
+	run := func(t *testing.T, scenario scenario) (secondExecs int64, secondResult string) {
+		ctx := context.TODO()
+
+		cacheManager := newTrackingCacheManager(NewInMemoryCacheManager())
+		solver := NewSolver(SolverOpt{
+			ResolveOpFunc: testOpResolver,
+			DefaultCache:  cacheManager,
+		})
+		defer solver.Close()
+
+		// warmBase models a WARM builder (scenario 2b): busybox is already
+		// pulled, so base's persistent-cache record already exists before
+		// A1. A throwaway build of base alone (then discarded) Saves that
+		// record. A1's base then cache-HITS its own query -- it does
+		// NOT execute and leaves its key in edgeState.keys -- whereas on a cold
+		// cache base EXECUTES and its key lives only on the result. The warm-up's
+		// distinct value ("base-result-warmup") lets us confirm A1's
+		// base came from the cache rather than executing.
+		if scenario.warmBase {
+			warmJob, err := solver.NewJob("warmup")
+			require.NoError(t, err)
+			_, err = warmJob.Build(ctx, baseEdge("base-result-warmup", scenario.ignoreBase))
+			require.NoError(t, err)
+			require.NoError(t, warmJob.Discard())
+		}
+
+		// A1: build step -> base. Cold cache: both execute and are saved,
+		// base ending `complete` with its key on its result only. Warm cache: base
+		// cache-hits its own query (no exec), only step executes; base's key is in
+		// edgeState.keys.
+		jobA1, err := solver.NewJob("a1")
+		require.NoError(t, err)
+
+		edgeA1 := stepEdge("step", "step-result", "base-result", scenario.ignoreBase)
+		edgeA1.Vertex.(*vertex).setupCallCounters()
+
+		jobA1Result, err := jobA1.Build(ctx, edgeA1)
+		require.NoError(t, err)
+		require.Equal(t, "step-result", unwrap(jobA1Result))
+		// Cold: A1 executed BOTH base and step against the empty
+		// cache. Warm: base cache-hit the warm-up's record, so only step executed.
+		wantA1Execs := int64(2)
+		if scenario.warmBase {
+			wantA1Execs = int64(1)
+		}
+		require.Equal(t, wantA1Execs, *edgeA1.Vertex.(*vertex).execCallCount)
+
+		// Optionally, B keeps ONLY the shared base alive in
+		// Solver.actives across A1's teardown (the unrelated build
+		// that happens to share the base). It must attach to base before
+		// A1 is discarded.
+		var jobB *Job
+		if scenario.holdBaseAlive {
+			jobB, err = solver.NewJob("b")
+			require.NoError(t, err)
+			jobBResult, err := jobB.Build(ctx, baseEdge("base-result-concurrent", scenario.ignoreBase))
+			require.NoError(t, err)
+			// base was reused from A1's completed active edge, so
+			// B sees whatever value that base carries: the value
+			// A1 execed (cold) or the warm-up record it cache-hit (warm).
+			wantBaseValue := "base-result"
+			if scenario.warmBase {
+				wantBaseValue = "base-result-warmup"
+			}
+			require.Equal(t, wantBaseValue, unwrap(jobBResult))
+		}
+
+		// A1 finishes: its step edge leaves the in-memory edge index, so
+		// A2 cannot merge onto it via currentIndexKey. If the base
+		// is held it survives as a reused-complete edge; otherwise it is deleted
+		// and later recreated fresh by A2.
+		require.NoError(t, jobA1.Discard())
+
+		// A2: build a step on top of the same shared base. When
+		// sameStepVertex it reuses A1's step name/digest (rebuilding
+		// the same image); otherwise it uses a distinct name with the same cache
+		// seed (modelling a separate build that computes the same cached step).
+		jobA2, err := solver.NewJob("a2")
+		require.NoError(t, err)
+
+		stepName := "step"
+		if !scenario.sameStepVertex {
+			stepName = "step-second"
+		}
+		edgeA2 := stepEdge(stepName, "step-result-uncached", "base-result-uncached", scenario.ignoreBase)
+		edgeA2.Vertex.(*vertex).setupCallCounters()
+
+		jobA2Result, err := jobA2.Build(ctx, edgeA2)
+		require.NoError(t, err)
+
+		secondExecs = *edgeA2.Vertex.(*vertex).execCallCount
+		secondResult = unwrap(jobA2Result)
+
+		require.NoError(t, jobA2.Discard())
+		if jobB != nil {
+			require.NoError(t, jobB.Discard())
+		}
+		return secondExecs, secondResult
+	}
+
+	// Control: with the base recreated fresh, A2 probes the
+	// populated cache and reuses A1's step result. This confirms the
+	// harness is capable of producing the hit. (sameStepVertex is irrelevant
+	// here: with no B, A1's step edge is gone from the
+	// edge index once discarded either way.)
+	t.Run("FreshBaseHits", func(t *testing.T) {
+		t.Parallel()
+		execs, result := run(t, scenario{sameStepVertex: true})
+		require.Equal(t, int64(0), execs, "A2 step should reuse cache when base is recreated fresh")
+		require.Equal(t, "step-result", result, "A2 should return A1's cached result")
+	})
+
+	// Confidence (scenario 2b): a WARM base. A warm-up build populates base's
+	// cache record before A1, so A1's base cache-HITS
+	// its own query (it does not execute) and leaves its key in edgeState.keys.
+	// When B then holds that base `complete`, the reused base
+	// STILL delivers its key via edgeState.keys, so A2 probes and
+	// hits. This is the healthy warm path, distinct from the cold bug below: it
+	// passes REGARDLESS of the completed-dep result-key probe fix, and is kept to
+	// confirm the fix does not regress the warm case.
+	t.Run("WarmHeldBaseHits", func(t *testing.T) {
+		t.Parallel()
+		execs, result := run(t, scenario{holdBaseAlive: true, sameStepVertex: true, warmBase: true})
+		require.Equal(t, int64(0), execs, "A2 step should reuse cache: a warm held base delivers its key via edgeState.keys even when held complete")
+		require.Equal(t, "step-result", result, "A2 should return A1's cached result")
+	})
+
+	// Bug: with B holding only the base alive, the shared base
+	// is reused already `complete` and delivers edgeState.keys=0 while its result
+	// carries the key. A2 must still reuse the cached step result.
+	// On current code it re-executes; with the completed-dep result-key probe fix
+	// it hits.
+	t.Run("HeldCompleteBaseMisses", func(t *testing.T) {
+		t.Parallel()
+
+		// SameStepVertex models rebuilding the *same* image: A2's
+		// step reuses A1's step name/digest. The base is held
+		// `complete` by B, but A1's Discard() has
+		// already released its step edge from the edge index, so A2's
+		// step edge must resolve through the cache (no live peer to merge
+		// onto).
+		t.Run("SameStepVertex", func(t *testing.T) {
+			t.Parallel()
+			execs, result := run(t, scenario{holdBaseAlive: true, sameStepVertex: true})
+			require.Equal(t, int64(0), execs, "A2 step re-executed instead of reusing cache (stale complete shared-dep)")
+			require.Equal(t, "step-result", result, "A2 should return A1's cached result")
+		})
+
+		// DistinctStepVertex models A2 as a *separate* build: to model it, use a
+		// different step vertex (different name, same cache seed) that resolves to
+		// the same cache id. Like SameStepVertex it relies on A1's
+		// Discard() to release its step edge from the edge index -- the index is
+		// keyed on the cache key, not the vertex digest, so a distinct digest
+		// alone would not close the merge path; the discard does.
+		t.Run("DistinctStepVertex", func(t *testing.T) {
+			t.Parallel()
+			execs, result := run(t, scenario{holdBaseAlive: true})
+			require.Equal(t, int64(0), execs, "A2 step re-executed instead of reusing cache (stale complete shared-dep)")
+			require.Equal(t, "step-result", result, "A2 should return A1's cached result")
+		})
+	})
+
+	// Safety (the ignore-cache guard): `--no-cache` on the *dependency* must
+	// survive the fix. B holds the shared base `complete`, but the base carries
+	// IgnoreCache (as `--no-cache` / `--no-cache-filter=base` would set). An
+	// ignore-cache base still executes and Saves, so its result carries cache
+	// keys -- but probeResultCache must NOT probe them, or step would wrongly
+	// reuse A1's record. So A2's step must RE-EXECUTE.
+	//
+	// This holds with or without the broader fix; it exists to lock in
+	// probeResultCache's dependency-IgnoreCache guard. Remove that guard and A2
+	// reuses the step, dropping execs to 0 -- which is how this test discriminates
+	// it.
+	t.Run("HeldCompleteIgnoreCacheBaseReExecutes", func(t *testing.T) {
+		t.Parallel()
+		execs, _ := run(t, scenario{holdBaseAlive: true, sameStepVertex: true, ignoreBase: true})
+		require.NotEqual(t, int64(0), execs, "A2 step must re-run: base is --no-cache, so its result key must not seed reuse")
+	})
+}

--- a/solver/debug.go
+++ b/solver/debug.go
@@ -311,3 +311,49 @@ func debugSchedulerSkipInputRequestBasedOnDepState(e *edge, dep *dep, desiredSta
 			Debug("skip input request based on dep state")
 	}
 }
+
+// debugSchedulerNoCacheMatchPossible records the moment an edge latches
+// noCacheMatchPossible because a dependency exposed no probeable key
+// (len(dep.keyMap)==0) once past cache-slow. When the dep nonetheless carries a
+// non-empty result cache key (dep_result_keys>0 with dep_keymap==0), that is the
+// stale/complete shared-dependency starvation: the key lives on the result but
+// was never delivered via edgeState.keys, so probeCache/Query never ran.
+func debugSchedulerNoCacheMatchPossible(e *edge, dep *dep, depHasSlowCache bool) {
+	if e.debug {
+		depResultKeys := 0
+		if dep.result != nil {
+			depResultKeys = len(dep.result.CacheKeys())
+		}
+		bklog.G(context.TODO()).
+			WithField("vtx", e.edge.Vertex.Digest()).
+			WithField("dep", dep.index).
+			WithField("dep_state", dep.state).
+			WithField("dep_keys", len(dep.keys)).
+			WithField("dep_keymap", len(dep.keyMap)).
+			WithField("dep_has_slow_cache", depHasSlowCache).
+			WithField("dep_result", dep.result != nil).
+			WithField("dep_result_keys", depResultKeys).
+			Debug("noCacheMatchPossible set: dep yields no probeable cache key")
+	}
+}
+
+// debugSchedulerDepDelivery records what a dependency hands over once it is
+// key-bearing (cache-slow) or terminal (complete). The starvation shows up as a
+// dep that arrives with dep_edgestate_keys=0 while dep_result_keys>0 -- keys on
+// the result but none in edgeState.keys, so probeCache is fed an empty slice.
+func debugSchedulerDepDelivery(e *edge, dep *dep, state *edgeState) {
+	if e.debug {
+		depResultKeys := 0
+		if state.result != nil {
+			depResultKeys = len(state.result.CacheKeys())
+		}
+		bklog.G(context.TODO()).
+			WithField("vtx", e.edge.Vertex.Digest()).
+			WithField("dep", dep.index).
+			WithField("dep_state", state.state).
+			WithField("dep_edgestate_keys", len(state.keys)).
+			WithField("dep_result", state.result != nil).
+			WithField("dep_result_keys", depResultKeys).
+			Debug("dep delivery: edgeState keys vs result keys")
+	}
+}

--- a/solver/edge.go
+++ b/solver/edge.go
@@ -215,6 +215,41 @@ func (e *edge) probeCache(d *dep, depKeys []CacheKeyWithSelector) bool {
 	return found
 }
 
+// probeResultCache handles the stale/complete shared-dependency case
+// (moby/buildkit#4674 family). A dependency that this edge subscribes to
+// *after* it has already reached `complete` -- e.g. a shared base edge kept
+// alive in Solver.actives by a concurrent solve -- can carry its cache key only
+// on its result (dep.result.CacheKeys()). In the cold-execute case its
+// edgeState.keys is empty: a leaf that executed against an empty cache never
+// appended a key, and a completed edge never re-queries. The edgeState.keys-
+// driven probeCache calls therefore see an empty slice, dep.keyMap stays empty,
+// and checkDepMatchPossible latches noCacheMatchPossible -- forcing
+// re-execution despite an intact cached result. Probe the result's cache keys
+// directly so keyMap/Records get populated, mirroring how currentIndexKey reads
+// dep.result.CacheKeys(). Guarded to a no-op unless the dep already carries a
+// result and has no probeable key yet, so healthy edges (result nil while
+// cache-slow, or keyMap already populated -- e.g. a warm base whose key survived
+// on edgeState.keys) are unaffected.
+func (e *edge) probeResultCache(dep *dep) bool {
+	if e.cacheMap == nil || dep.result == nil || len(dep.keyMap) != 0 {
+		return false
+	}
+	// probeCache already honors THIS edge's own IgnoreCache; this guards the
+	// DEPENDENCY's. An ignore-cache dep still executes and Saves, so its result
+	// carries cache keys -- but the normal edgeState.keys path withholds them
+	// (the dep skipped its own Query), starving this edge into re-executing.
+	// Probing the result keys directly would leak them, so skip it to keep
+	// --no-cache working on a dependency.
+	if e.edge.Vertex.Inputs()[dep.index].Vertex.Options().IgnoreCache {
+		return false
+	}
+	found := e.probeCache(dep, withSelector(dep.result.CacheKeys(), e.cacheMap.Deps[dep.index].Selector))
+	if found && e.allDepsHaveKeys(false) {
+		e.keysDidChange = true
+	}
+	return found
+}
+
 // checkDepMatchPossible checks if any cache matches are possible past this point
 func (e *edge) checkDepMatchPossible(dep *dep) {
 	depHasSlowCache := e.cacheMap.Deps[dep.index].ComputeDigestFunc != nil
@@ -611,6 +646,10 @@ func (e *edge) processCacheMapReq() {
 	// probe keys that were loaded before cache map
 	for i, dep := range e.deps {
 		e.probeCache(dep, withSelector(dep.keys, e.cacheMap.Deps[i].Selector))
+		// retry now that the cacheMap is available: a dep may have reached
+		// `complete` before it resolved, delivering 0 edgeState.keys (see
+		// probeResultCache)
+		e.probeResultCache(dep)
 		e.checkDepMatchPossible(dep)
 	}
 	if !e.cacheMapDone {
@@ -678,6 +717,12 @@ func (e *edge) processDepReq(dep *dep) (depChanged bool) {
 	recheck := state.state != dep.state
 
 	dep.edgeState = *state
+
+	// a dep that jumped straight to `complete` delivered 0 edgeState.keys, so the
+	// probe above never ran; probe its result keys instead (see probeResultCache)
+	if e.probeResultCache(dep) {
+		depChanged = true
+	}
 
 	if recheck && e.cacheMap != nil {
 		e.checkDepMatchPossible(dep)

--- a/solver/edge.go
+++ b/solver/edge.go
@@ -220,6 +220,7 @@ func (e *edge) checkDepMatchPossible(dep *dep) {
 	depHasSlowCache := e.cacheMap.Deps[dep.index].ComputeDigestFunc != nil
 	if !e.noCacheMatchPossible && (((!dep.slowCacheFoundKey && dep.slowCacheComplete && depHasSlowCache) || (!depHasSlowCache && dep.state >= edgeStatusCacheSlow)) && len(dep.keyMap) == 0) {
 		e.noCacheMatchPossible = true
+		debugSchedulerNoCacheMatchPossible(e, dep, depHasSlowCache)
 	}
 }
 
@@ -652,6 +653,10 @@ func (e *edge) processDepReq(dep *dep) (depChanged bool) {
 	if !isEdgeState {
 		bklog.G(context.TODO()).Warnf("invalid edgeState value for update: %T", state)
 		return false
+	}
+
+	if state.state >= edgeStatusCacheSlow {
+		debugSchedulerDepDelivery(e, dep, state)
 	}
 
 	if len(dep.keys) < len(state.keys) {


### PR DESCRIPTION
> [!NOTE]
> This is a heavily AI assisted PR. I've used it to both find the issue and add the relevant debug/trace log lines and the fix. I've also used it to try and dig into how a lot of scheduler/graph works for my own understanding, but I will likely still have gaps in my knowledge. I've also used it to bootstrap some of the writeup, but it has been heavily edited by myself for conciseness and clarity. Feel free to not take the PR as is if you think there is a better fix.

## What's wrong

When two `docker build`s run at the same time on one daemon and share a common `FROM` base, a build can needlessly re-run a step it had already cached.

Concretely: a long-running build has a `FROM <base>` stage, and two shorter builds run alongside it sharing that same base. The second short build should reuse the cached step sitting on top of the base — but it re-runs that step every time. Output is still correct; this is **wasted work, not wrong results**. On a cold builder (a fresh CI runner, say) it means expensive `RUN` steps re-execute when they should have been free.

### How did I run into this?

This arose from debugging why image builds for a particular team were taking so long. For each image:
* We do a `docker buildx build . --output type=docker`, that loads it in the daemon and makes it available to be tested.
* Separately at a later time, we publish this to a registry e.g. `docker buildx build . --output type=registry,name=<bla>`. The expectation here is for steps to be cached entirely.

The images being built are quite large and do take a while i.e. installing `pytorch` and `vllm`. The `Dockerfile` is not written in the most efficient form, which does actually help in debugging this issue. The moment you have two sets of images being built at the same time, we run into this.

## Why it happens

A step decides whether it can reuse a cached result by looking at the cache keys its dependency (the base) advertises *while the base is still resolving* — its in-progress keys. Once the base finishes — reaches its terminal `complete` state after executing — its cache key is no longer on that in-progress list; it lives only on the finished result (`result.CacheKeys()`).

Normally that is harmless: with nothing else holding the base, it is discarded the instant the first build ends and rebuilt fresh for the next build, which re-advertises its key the in-progress way. The bug needs a **concurrent** build to keep the shared base alive across the moment the next build resolves it. The next build then inherits the base already-`complete`, sees an empty in-progress list, concludes no cache match is possible, and re-executes — even though the identical result is intact in the cache.

It only bites a plain base (a `FROM` image op, no result-content cache function) that reached `complete` by *executing* on a cold builder. A base that cache-hit its own lookup keeps its key on the in-progress list and is unaffected — which is why there's a hit on a warm daemon.

## The fix

When a dependency is inherited already-`complete`, also probe the cache keys on its finished result, not just its in-progress keys. This is the same source the scheduler's edge-merge path already reads; the fix (`probeResultCache` in `solver/edge.go`) teaches the probe path to read it too.

This appears to be the smallest fix, but it does feel a little brittle. A thought: I wonder whether there's a way to not have the state spread across `result.CacheKeys()` and `edgeState.keys`. What if `result.CacheKeys()` had some indication about how final the state of the cache key is instead of having to reason about which structure to put it in/read it from at what time. That is obviously a bigger change, and I haven't gone through the wide-reaching implications of it, but curious if it makes sense.

## Why it's safe

- The probe only supplies keys that already live on a **committed** result, and it still goes through the normal cache `Query` — so a match is a real persistent-cache record, never a fabricated one.
- Those keys are exactly what a freshly-recreated base would have advertised, so the fix only recovers hits that serial (non-concurrent) builds already get. It cannot invent new ones.
- It is a guarded no-op on healthy edges, and it preserves `--no-cache`: a dependency built with cache ignored is skipped, so it still forces the step to re-run.

## Verifying it

`TestCacheMissStaleCompleteSharedDep` (`solver/cachemiss_stale_dep_test.go`) reproduces the miss in-process and is red without the fix. A seconds-long real-daemon reproducer and a full walk-through of the scheduler mechanics (state ladder, the two key representations, and every timing case) are in the reproducer: https://github.com/felixdesouza/buildkit-4674-reproducer.

Related to moby/buildkit#4674.
