### PR TITLE
detect: read OTEL_IGNORE_ERROR from environment

### DIFF
--- a/util/tracing/detect/detect.go
+++ b/util/tracing/detect/detect.go
@@ -45,7 +45,7 @@ func (fn TraceExporterDetector) DetectMetricExporter() (sdkmetric.Exporter, erro
 }
 
 func detectExporter[T any](envVar string, fn func(d ExporterDetector) (T, bool, error)) (exp T, err error) {
-	ignoreErrors, _ := strconv.ParseBool("OTEL_IGNORE_ERROR")
+	ignoreErrors, _ := strconv.ParseBool(os.Getenv("OTEL_IGNORE_ERROR"))
 
 	if n := os.Getenv(envVar); n != "" {
 		d, ok := detectors[n]

--- a/util/tracing/detect/detect_test.go
+++ b/util/tracing/detect/detect_test.go
@@ -1,0 +1,43 @@
+package detect
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectExporterIgnoreErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		ignoreErrors string
+		wantErr      bool
+	}{
+		{
+			name:    "error by default",
+			wantErr: true,
+		},
+		{
+			name:         "ignore errors",
+			ignoreErrors: "true",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("OTEL_TRACES_EXPORTER", "invalid")
+			t.Setenv("OTEL_METRICS_EXPORTER", "invalid")
+			t.Setenv("OTEL_IGNORE_ERROR", tc.ignoreErrors)
+
+			spanExp, spanErr := NewSpanExporter(context.Background())
+			metricExp, metricErr := NewMetricExporter(context.Background())
+			if tc.wantErr {
+				require.Error(t, spanErr)
+				require.Error(t, metricErr)
+			} else {
+				require.NoError(t, spanErr)
+				require.NoError(t, metricErr)
+			}
+			require.Nil(t, spanExp)
+			require.Nil(t, metricExp)
+		})
+	}
+}


### PR DESCRIPTION
## What this fixes

Commit `228e250d` moved `OTEL_IGNORE_ERROR` handling into `detectExporter`, but the
refactor passed the environment variable name directly to `strconv.ParseBool` instead
of reading its value. Parsing the literal string always fails, so exporter errors cannot
be ignored even when `OTEL_IGNORE_ERROR=true`.

This restores the environment lookup used before that refactor.

## Changes

- read `OTEL_IGNORE_ERROR` from the environment;
- add regression coverage for trace and metric exporters;
- verify both the default error behavior and explicit error suppression.

The test uses an unknown exporter name, so it does not invoke a detector or connect to
an external telemetry backend.

## Validation

```text
go test ./util/tracing/detect/...
go vet ./util/tracing/detect/...
gofmt -l util/tracing/detect/
```

All tests and vet pass, and `gofmt -l` produces no output.

## Behavior note

Operators with `OTEL_IGNORE_ERROR` already enabled will regain the error-suppression
behavior that existed before the refactor.
