### PR TITLE
gitutil: silence git advice hints during checkout

### DIFF
--- a/util/gitutil/git_cli.go
+++ b/util/gitutil/git_cli.go
@@ -150,6 +150,16 @@ func (cli *GitCLI) Run(ctx context.Context, args ...string) (_ []byte, err error
 		"http_proxy", "https_proxy", "no_proxy", "all_proxy",
 	}
 
+	// Silence Git's advice hints (for example the "detached HEAD" advice
+	// printed while checking out a git context) so builds are less noisy.
+	// An operator debugging git behavior can restore the hints by setting
+	// GIT_ADVICE explicitly in buildkitd's environment: when set it is
+	// forwarded as-is instead of being forced off.
+	gitAdvice, adviceOverridden := os.LookupEnv("GIT_ADVICE")
+	if !adviceOverridden {
+		gitAdvice = "0"
+	}
+
 	for {
 		var cmd *exec.Cmd
 		if cli.exec == nil {
@@ -165,6 +175,12 @@ func (cli *GitCLI) Run(ctx context.Context, args ...string) (_ []byte, err error
 
 		// Block sneaky repositories from using repos from the filesystem as submodules.
 		cmd.Args = append(cmd.Args, "-c", "protocol.file.allow=user")
+		if !adviceOverridden {
+			// GIT_ADVICE (below) covers this on Git >= 2.45; older Git
+			// releases predate it, so disable the specific detached-HEAD
+			// advice here to keep checkouts quiet on those versions too.
+			cmd.Args = append(cmd.Args, "-c", "advice.detachedHead=false")
+		}
 		if cli.workTree != "" {
 			cmd.Args = append(cmd.Args, "--work-tree", cli.workTree)
 		}
@@ -200,6 +216,7 @@ func (cli *GitCLI) Run(ctx context.Context, args ...string) (_ []byte, err error
 			"PATH=" + os.Getenv("PATH"),
 			"GIT_TERMINAL_PROMPT=0",
 			"GIT_SSH_COMMAND=" + getGitSSHCommand(cli.sshKnownHosts),
+			"GIT_ADVICE=" + gitAdvice, // Silence advice hints unless overridden for debugging.
 			//	"GIT_TRACE=1",
 			"LC_ALL=C", // Ensure consistent output.
 		}

--- a/util/gitutil/git_cli_test.go
+++ b/util/gitutil/git_cli_test.go
@@ -69,3 +69,35 @@ func TestGitCLIConfigEnv(t *testing.T) {
 		require.Contains(t, got, "SUDO_UID=1000")
 	})
 }
+
+func TestGitCLIAdvice(t *testing.T) {
+	run := func(t *testing.T) (env, args []string) {
+		cli := NewGitCLI(WithExec(func(ctx context.Context, cmd *exec.Cmd) error {
+			env = append([]string(nil), cmd.Env...)
+			args = append([]string(nil), cmd.Args...)
+			return nil
+		}))
+		_, err := cli.Run(context.Background(), "status")
+		require.NoError(t, err)
+		return env, args
+	}
+
+	t.Run("silenced by default", func(t *testing.T) {
+		env, args := run(t)
+		// GIT_ADVICE=0 disables all advice hints on Git >= 2.45.
+		require.Contains(t, env, "GIT_ADVICE=0")
+		// advice.detachedHead=false keeps the detached-HEAD checkout quiet
+		// on older Git releases that predate GIT_ADVICE.
+		require.Contains(t, args, "advice.detachedHead=false")
+	})
+
+	t.Run("restored when GIT_ADVICE is set for debugging", func(t *testing.T) {
+		t.Setenv("GIT_ADVICE", "1")
+		env, args := run(t)
+		require.Contains(t, env, "GIT_ADVICE=1")
+		require.NotContains(t, env, "GIT_ADVICE=0")
+		// The detached-HEAD override is dropped so the operator sees the
+		// full advice output while debugging.
+		require.NotContains(t, args, "advice.detachedHead=false")
+	})
+}


### PR DESCRIPTION
## What

An `ADD` from a git context runs `git checkout FETCH_HEAD`, which prints Git's detached-HEAD advice into the build output (#6963). This silences that advice noise.

## Changes

All git invocations flow through `GitCLI.Run` in `util/gitutil/git_cli.go` (it already centralizes global git settings such as `-c protocol.file.allow=user`), so the fix lands in that one place:

- Set `GIT_ADVICE=0` in the command environment by default — disables all advice hints on Git >= 2.45 (your stated preference in the issue).
- Also pass `-c advice.detachedHead=false` as a fallback for older Git releases that predate `GIT_ADVICE`, keeping the specific detached-HEAD checkout noise quiet there too.
- Debug escape: if an operator sets `GIT_ADVICE` explicitly in buildkitd's environment (e.g. `GIT_ADVICE=1`), it is forwarded as-is and the `advice.detachedHead=false` override is dropped, so full advice output returns.

I deliberately kept this to the two levers you endorsed rather than implementing the broader curated advice-policy table from the issue discussion, to keep the change minimal and avoid a policy decision — happy to extend it if you'd prefer the curated approach.

## Tests

Added `TestGitCLIAdvice` (using the package's existing `WithExec` command-capture pattern): it asserts `GIT_ADVICE=0` and the `advice.detachedHead=false` arg are present by default, and that they are restored/dropped when `GIT_ADVICE` is set for debugging. `go build`, `go vet`, and `go test ./util/gitutil/...` all pass.

Closes #6963.

---

*AI disclosure: this PR was drafted with Claude Code (AI-assisted). Verified with go build / vet / test on the changed package (all pass). DCO sign-off included.*
