### PR TITLE
frontend,client,daemon: bump defaults.DefaultMax{Recv,Send}MsgSize to 128MiB

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -43,8 +43,8 @@ type ClientOpt interface {
 // New returns a new buildkit client. Address can be empty for the system-default address.
 func New(ctx context.Context, address string, opts ...ClientOpt) (*Client, error) {
 	gopts := []grpc.DialOption{
-		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(defaults.DefaultMaxRecvMsgSize)),
-		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(defaults.DefaultMaxSendMsgSize)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(8 * defaults.DefaultMaxRecvMsgSize)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(8 * defaults.DefaultMaxSendMsgSize)),
 	}
 	needDialer := true
 

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -357,8 +357,8 @@ func main() {
 			grpc.StatsHandler(statsHandler),
 			grpc.ChainUnaryInterceptor(unaryInterceptor, grpcerrors.UnaryServerInterceptor),
 			grpc.StreamInterceptor(grpcerrors.StreamServerInterceptor),
-			grpc.MaxRecvMsgSize(defaults.DefaultMaxRecvMsgSize),
-			grpc.MaxSendMsgSize(defaults.DefaultMaxSendMsgSize),
+			grpc.MaxRecvMsgSize(8 * defaults.DefaultMaxRecvMsgSize),
+			grpc.MaxSendMsgSize(8 * defaults.DefaultMaxSendMsgSize),
 		}
 		server := grpc.NewServer(opts...)
 

--- a/cmd/buildkitd/main_oci_worker.go
+++ b/cmd/buildkitd/main_oci_worker.go
@@ -373,8 +373,8 @@ func snapshotterFactory(commonRoot string, cfg config.OCIConfig, sm *session.Man
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 				grpc.WithConnectParams(connParams),
 				grpc.WithContextDialer(dialer.ContextDialer),
-				grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(defaults.DefaultMaxRecvMsgSize)),
-				grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(defaults.DefaultMaxSendMsgSize)),
+				grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(8 * defaults.DefaultMaxRecvMsgSize)),
+				grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(8 * defaults.DefaultMaxSendMsgSize)),
 			}
 			// ignore SA1019 NewClient has different behavior and needs to be tested
 			//nolint:staticcheck

--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -456,8 +456,8 @@ func serveLLBBridgeForwarder(ctx context.Context, llbBridge frontend.FrontendLLB
 	serverOpt := []grpc.ServerOption{
 		grpc.UnaryInterceptor(grpcerrors.UnaryServerInterceptor),
 		grpc.StreamInterceptor(grpcerrors.StreamServerInterceptor),
-		grpc.MaxRecvMsgSize(defaults.DefaultMaxRecvMsgSize),
-		grpc.MaxSendMsgSize(defaults.DefaultMaxSendMsgSize),
+		grpc.MaxRecvMsgSize(8 * defaults.DefaultMaxRecvMsgSize),
+		grpc.MaxSendMsgSize(8 * defaults.DefaultMaxSendMsgSize),
 	}
 	server := grpc.NewServer(serverOpt...)
 	grpc_health_v1.RegisterHealthServer(server, health.NewServer())

--- a/frontend/gateway/grpcclient/client.go
+++ b/frontend/gateway/grpcclient/client.go
@@ -1452,8 +1452,8 @@ func grpcClientConn(ctx context.Context) (context.Context, *grpc.ClientConn, err
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithUnaryInterceptor(grpcerrors.UnaryClientInterceptor),
 		grpc.WithStreamInterceptor(grpcerrors.StreamClientInterceptor),
-		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(defaults.DefaultMaxRecvMsgSize)),
-		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(defaults.DefaultMaxSendMsgSize)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(8 * defaults.DefaultMaxRecvMsgSize)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(8 * defaults.DefaultMaxSendMsgSize)),
 	}
 
 	//nolint:staticcheck // ignore SA1019 NewClient has different behavior and needs to be tested


### PR DESCRIPTION
Related to https://github.com/moby/buildkit/pull/6951 and https://github.com/docker/buildx/pull/3971