### PR TITLE
contentutil: thread context through registry refs

### DIFF
--- a/client/client_export_image_test.go
+++ b/client/client_export_image_test.go
@@ -151,7 +151,7 @@ func testBuildExportScratch(t *testing.T, sb integration.Sandbox) {
 	}, "", makeFrontend([]string{"linux/amd64", "linux/arm64"}), nil)
 	require.NoError(t, err)
 
-	desc, provider, err := contentutil.ProviderFromRef(target)
+	desc, provider, err := contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 	imgs, err := testutil.ReadImages(sb.Context(), provider, desc)
 	require.NoError(t, err)
@@ -160,7 +160,7 @@ func testBuildExportScratch(t *testing.T, sb integration.Sandbox) {
 	require.Empty(t, img.Layers)
 	require.True(t, platforms.Only(platforms.DefaultSpec()).Match(img.Img.Platform))
 
-	desc, provider, err = contentutil.ProviderFromRef(targetMulti)
+	desc, provider, err = contentutil.ProviderFromRef(sb.Context(), targetMulti)
 	require.NoError(t, err)
 	imgs, err = testutil.ReadImages(sb.Context(), provider, desc)
 	require.NoError(t, err)
@@ -1744,10 +1744,10 @@ func testPushByDigest(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	_, _, err = contentutil.ProviderFromRef(name + ":latest")
+	_, _, err = contentutil.ProviderFromRef(sb.Context(), name+":latest")
 	require.Error(t, err)
 
-	desc, _, err := contentutil.ProviderFromRef(name + "@" + resp.ExporterResponse[exptypes.ExporterImageDigestKey])
+	desc, _, err := contentutil.ProviderFromRef(sb.Context(), name+"@"+resp.ExporterResponse[exptypes.ExporterImageDigestKey])
 	require.NoError(t, err)
 
 	require.Equal(t, resp.ExporterResponse[exptypes.ExporterImageDigestKey], desc.Digest.String())

--- a/client/client_export_metadata_test.go
+++ b/client/client_export_metadata_test.go
@@ -162,7 +162,7 @@ func testAttestationBundle(t *testing.T, sb integration.Sandbox) {
 	}, "", frontend, nil)
 	require.NoError(t, err)
 
-	desc, provider, err := contentutil.ProviderFromRef(target)
+	desc, provider, err := contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 
 	imgs, err := testutil.ReadImages(sb.Context(), provider, desc)
@@ -301,7 +301,7 @@ func testAttestationDefaultSubject(t *testing.T, sb integration.Sandbox) {
 	}, "", frontend, nil)
 	require.NoError(t, err)
 
-	desc, provider, err := contentutil.ProviderFromRef(target)
+	desc, provider, err := contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 
 	imgs, err := testutil.ReadImages(sb.Context(), provider, desc)
@@ -439,7 +439,7 @@ func testExportAnnotations(t *testing.T, sb integration.Sandbox) {
 	}, "", frontend, nil)
 	require.NoError(t, err)
 
-	desc, provider, err := contentutil.ProviderFromRef(target)
+	desc, provider, err := contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 	imgs, err := testutil.ReadImages(sb.Context(), provider, desc)
 	require.NoError(t, err)
@@ -634,7 +634,7 @@ func testExportAnnotationsMediaTypes(t *testing.T, sb integration.Sandbox) {
 	}, "", frontend, nil)
 	require.NoError(t, err)
 
-	desc, provider, err := contentutil.ProviderFromRef(target)
+	desc, provider, err := contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 	imgs, err := testutil.ReadImages(sb.Context(), provider, desc)
 	require.NoError(t, err)
@@ -655,7 +655,7 @@ func testExportAnnotationsMediaTypes(t *testing.T, sb integration.Sandbox) {
 	}, "", frontend, nil)
 	require.NoError(t, err)
 
-	desc, provider, err = contentutil.ProviderFromRef(target2)
+	desc, provider, err = contentutil.ProviderFromRef(sb.Context(), target2)
 	require.NoError(t, err)
 	imgs2, err := testutil.ReadImages(sb.Context(), provider, desc)
 	require.NoError(t, err)
@@ -801,7 +801,7 @@ func testExportAttestations(t *testing.T, sb integration.Sandbox, ociArtifact bo
 		}, "", frontend, nil)
 		require.NoError(t, err)
 
-		desc, provider, err := contentutil.ProviderFromRef(targets[0])
+		desc, provider, err := contentutil.ProviderFromRef(sb.Context(), targets[0])
 		require.NoError(t, err)
 
 		imgs, err := testutil.ReadImages(sb.Context(), provider, desc)
@@ -1414,7 +1414,7 @@ EOF
 	}, "", makeTargetFrontend(false), nil)
 	require.NoError(t, err)
 
-	desc, provider, err := contentutil.ProviderFromRef(target)
+	desc, provider, err := contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 
 	imgs, err := testutil.ReadImages(sb.Context(), provider, desc)
@@ -1439,7 +1439,7 @@ EOF
 	}, "", makeTargetFrontend(true), nil)
 	require.NoError(t, err)
 
-	desc, provider, err = contentutil.ProviderFromRef(target)
+	desc, provider, err = contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 
 	imgs, err = testutil.ReadImages(sb.Context(), provider, desc)
@@ -1471,7 +1471,7 @@ EOF
 	}, "", makeTargetFrontend(false), nil)
 	require.NoError(t, err)
 
-	desc, provider, err = contentutil.ProviderFromRef(target)
+	desc, provider, err = contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 
 	imgs, err = testutil.ReadImages(sb.Context(), provider, desc)
@@ -1503,7 +1503,7 @@ EOF
 	}, "", makeTargetFrontend(true), nil)
 	require.NoError(t, err)
 
-	desc, provider, err = contentutil.ProviderFromRef(target)
+	desc, provider, err = contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 
 	imgs, err = testutil.ReadImages(sb.Context(), provider, desc)
@@ -1535,7 +1535,7 @@ EOF
 	}, "", makeTargetFrontend(false), nil)
 	require.NoError(t, err)
 
-	desc, provider, err = contentutil.ProviderFromRef(target)
+	desc, provider, err = contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 
 	imgs, err = testutil.ReadImages(sb.Context(), provider, desc)
@@ -1569,7 +1569,7 @@ EOF
 	}, "", makeTargetFrontend(false), nil)
 	require.NoError(t, err)
 
-	desc, provider, err = contentutil.ProviderFromRef(target)
+	desc, provider, err = contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 
 	imgs, err = testutil.ReadImages(sb.Context(), provider, desc)
@@ -1726,7 +1726,7 @@ EOF
 	}, "", targetFrontend, nil)
 	require.NoError(t, err)
 
-	desc, provider, err := contentutil.ProviderFromRef(target)
+	desc, provider, err := contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 
 	imgs, err := testutil.ReadImages(sb.Context(), provider, desc)
@@ -1880,7 +1880,7 @@ func testSBOMSupplements(t *testing.T, sb integration.Sandbox) {
 	}, "", frontend, nil)
 	require.NoError(t, err)
 
-	desc, provider, err := contentutil.ProviderFromRef(target)
+	desc, provider, err := contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 
 	imgs, err := testutil.ReadImages(sb.Context(), provider, desc)

--- a/client/client_git_source_test.go
+++ b/client/client_git_source_test.go
@@ -350,7 +350,7 @@ func testGitBundleRoundTripRegistry(t *testing.T, sb integration.Sandbox) {
 	// digest; the repository exists implicitly once any blob is uploaded
 	// under its name.
 	bundleRepoRef := registry + "/foo/bundle@" + bundleDgst.String()
-	ingester, err := contentutil.IngesterFromRef(bundleRepoRef)
+	ingester, err := contentutil.IngesterFromRef(sb.Context(), bundleRepoRef)
 	require.NoError(t, err)
 	err = content.WriteBlob(ctx, ingester, "bundle-"+bundleDgst.String(), bytes.NewReader(bundleBytes),
 		ocispecs.Descriptor{Digest: bundleDgst, Size: int64(len(bundleBytes))})

--- a/client/client_oci_source_test.go
+++ b/client/client_oci_source_test.go
@@ -65,7 +65,7 @@ func testImageBlobSource(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 	require.NoError(t, err)
 
-	desc, provider, err := contentutil.ProviderFromRef(name)
+	desc, provider, err := contentutil.ProviderFromRef(sb.Context(), name)
 	require.NoError(t, err)
 
 	imgs, err := testutil.ReadImages(sb.Context(), provider, desc)

--- a/client/compatibility_test.go
+++ b/client/compatibility_test.go
@@ -358,7 +358,7 @@ func createCompatibilityBaseImage(ctx context.Context, t *testing.T, c *Client, 
 	}, nil)
 	require.NoError(t, err)
 
-	desc, provider, err := contentutil.ProviderFromRef(baseRef)
+	desc, provider, err := contentutil.ProviderFromRef(ctx, baseRef)
 	require.NoError(t, err)
 	actual := readCompatibilityActualFromProvider(ctx, t, provider, desc)
 
@@ -452,7 +452,7 @@ func exportCompatibilityImageCase(ctx context.Context, t *testing.T, c *Client, 
 		return compatibilityActual{}, err
 	}
 
-	desc, provider, err := contentutil.ProviderFromRef(target)
+	desc, provider, err := contentutil.ProviderFromRef(ctx, target)
 	if err != nil {
 		return compatibilityActual{}, err
 	}
@@ -655,7 +655,7 @@ func readCompatibilityActualFromProvider(ctx context.Context, t *testing.T, prov
 }
 
 func readImageCompatibilityProvenance(ctx context.Context, ref string) (*provenancetypes.ProvenancePredicateSLSA1, error) {
-	desc, provider, err := contentutil.ProviderFromRef(ref)
+	desc, provider, err := contentutil.ProviderFromRef(ctx, ref)
 	if err != nil {
 		return nil, err
 	}

--- a/frontend/dockerfile/dockerfile_cache_test.go
+++ b/frontend/dockerfile/dockerfile_cache_test.go
@@ -254,7 +254,7 @@ COPY --from=base /arch /
 	}, nil)
 	require.NoError(t, err)
 
-	desc, provider, err := contentutil.ProviderFromRef(target + "-img")
+	desc, provider, err := contentutil.ProviderFromRef(sb.Context(), target+"-img")
 	require.NoError(t, err)
 
 	imgs, err := testutil.ReadImages(sb.Context(), provider, desc)
@@ -299,7 +299,7 @@ COPY --from=base /arch /
 		}, nil)
 		require.NoError(t, err)
 
-		desc2, provider, err := contentutil.ProviderFromRef(target + "-img")
+		desc2, provider, err := contentutil.ProviderFromRef(sb.Context(), target+"-img")
 		require.NoError(t, err)
 
 		require.Equal(t, desc.Digest, desc2.Digest)
@@ -383,7 +383,7 @@ COPY --from=base unique /
 	}, nil)
 	require.NoError(t, err)
 
-	desc, provider, err := contentutil.ProviderFromRef(target)
+	desc, provider, err := contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 	img, err := testutil.ReadImage(sb.Context(), provider, desc)
 	require.NoError(t, err)

--- a/frontend/dockerfile/dockerfile_cmd_test.go
+++ b/frontend/dockerfile/dockerfile_cmd_test.go
@@ -360,7 +360,7 @@ ENTRYPOINT []random string
 	}, nil)
 	require.NoError(t, err)
 
-	desc, provider, err := contentutil.ProviderFromRef(target)
+	desc, provider, err := contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 
 	imgs, err := testutil.ReadImages(sb.Context(), provider, desc)

--- a/frontend/dockerfile/dockerfile_history_test.go
+++ b/frontend/dockerfile/dockerfile_history_test.go
@@ -178,7 +178,7 @@ RUN dir C:\Windows
 	cmd := sb.Cmd(args + " --output type=image,push=true,name=" + target)
 	require.NoError(t, cmd.Run())
 
-	desc, provider, err := contentutil.ProviderFromRef(target)
+	desc, provider, err := contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 
 	imgs, err := testutil.ReadImages(sb.Context(), provider, desc)

--- a/frontend/dockerfile/dockerfile_namedcontext_test.go
+++ b/frontend/dockerfile/dockerfile_namedcontext_test.go
@@ -335,7 +335,7 @@ RUN echo foo>> C:\test
 	}, nil)
 	require.NoError(t, err)
 
-	desc, provider, err := contentutil.ProviderFromRef(target)
+	desc, provider, err := contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 	img, err := testutil.ReadImage(sb.Context(), provider, desc)
 	require.NoError(t, err)
@@ -381,7 +381,7 @@ RUN echo foo>> C:\test
 	}, nil)
 	require.NoError(t, err)
 
-	desc, provider, err = contentutil.ProviderFromRef(targetDerived)
+	desc, provider, err = contentutil.ProviderFromRef(sb.Context(), targetDerived)
 	require.NoError(t, err)
 	imgDerived, err := testutil.ReadImage(sb.Context(), provider, desc)
 	require.NoError(t, err)

--- a/frontend/dockerfile/dockerfile_platform_test.go
+++ b/frontend/dockerfile/dockerfile_platform_test.go
@@ -226,7 +226,7 @@ EOF
 
 	require.NoError(t, err)
 
-	desc, provider, err := contentutil.ProviderFromRef(target)
+	desc, provider, err := contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 
 	info, err := testutil.ReadImages(ctx, provider, desc)
@@ -369,7 +369,7 @@ EOF
 
 	require.NoError(t, err)
 
-	desc, provider, err := contentutil.ProviderFromRef(target)
+	desc, provider, err := contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 
 	info, err := testutil.ReadImages(ctx, provider, desc)
@@ -417,7 +417,7 @@ EOF
 	}, nil)
 	require.NoError(t, err)
 
-	desc, provider, err = contentutil.ProviderFromRef(target2)
+	desc, provider, err = contentutil.ProviderFromRef(sb.Context(), target2)
 	require.NoError(t, err)
 
 	info, err = testutil.ReadImages(ctx, provider, desc)

--- a/frontend/dockerfile/dockerfile_provenance_test.go
+++ b/frontend/dockerfile/dockerfile_provenance_test.go
@@ -137,7 +137,7 @@ RUN echo ok> /foo
 				}, nil)
 				require.NoError(t, err)
 
-				desc, provider, err := contentutil.ProviderFromRef(target)
+				desc, provider, err := contentutil.ProviderFromRef(sb.Context(), target)
 				require.NoError(t, err)
 				imgs, err := testutil.ReadImages(sb.Context(), provider, desc)
 				require.NoError(t, err)
@@ -499,7 +499,7 @@ COPY myapp.Dockerfile /
 			}, nil)
 			require.NoError(t, err)
 
-			desc, provider, err := contentutil.ProviderFromRef(target)
+			desc, provider, err := contentutil.ProviderFromRef(sb.Context(), target)
 			require.NoError(t, err)
 			imgs, err := testutil.ReadImages(sb.Context(), provider, desc)
 			require.NoError(t, err)
@@ -701,7 +701,7 @@ RUN echo "ok-$TARGETARCH" > /foo
 	}, nil)
 	require.NoError(t, err)
 
-	desc, provider, err := contentutil.ProviderFromRef(target)
+	desc, provider, err := contentutil.ProviderFromRef(ctx, target)
 	require.NoError(t, err)
 	imgs, err := testutil.ReadImages(sb.Context(), provider, desc)
 	require.NoError(t, err)
@@ -912,7 +912,7 @@ func testClientFrontendProvenance(t *testing.T, sb integration.Sandbox) {
 	}, "", frontend, nil)
 	require.NoError(t, err)
 
-	desc, provider, err := contentutil.ProviderFromRef(target)
+	desc, provider, err := contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 	imgs, err := testutil.ReadImages(sb.Context(), provider, desc)
 	require.NoError(t, err)
@@ -1058,7 +1058,7 @@ COPY --from=base C:\out C:\Files
 	}, nil)
 	require.NoError(t, err)
 
-	desc, provider, err := contentutil.ProviderFromRef(target)
+	desc, provider, err := contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 	imgs, err := testutil.ReadImages(ctx, provider, desc)
 	require.NoError(t, err)
@@ -1172,7 +1172,7 @@ func testClientLLBProvenance(t *testing.T, sb integration.Sandbox) {
 	}, "", frontend, nil)
 	require.NoError(t, err)
 
-	desc, provider, err := contentutil.ProviderFromRef(target)
+	desc, provider, err := contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 	imgs, err := testutil.ReadImages(sb.Context(), provider, desc)
 	require.NoError(t, err)
@@ -1869,7 +1869,7 @@ func assertFrontendRequest(t *testing.T, f frontendGateway, req *provenancetypes
 }
 
 func readNativeProvenancePredicate(ctx context.Context, t *testing.T, target string) provenancetypes.ProvenancePredicateSLSA1 {
-	desc, provider, err := contentutil.ProviderFromRef(target)
+	desc, provider, err := contentutil.ProviderFromRef(ctx, target)
 	require.NoError(t, err)
 	imgs, err := testutil.ReadImages(ctx, provider, desc)
 	require.NoError(t, err)
@@ -1932,7 +1932,7 @@ RUN --mount=type=secret,id=mysecret --mount=type=secret,id=othersecret --mount=t
 	}, nil)
 	require.NoError(t, err)
 
-	desc, provider, err := contentutil.ProviderFromRef(target)
+	desc, provider, err := contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 	imgs, err := testutil.ReadImages(sb.Context(), provider, desc)
 	require.NoError(t, err)
@@ -2062,7 +2062,7 @@ EOF
 	}, nil)
 	require.NoError(t, err)
 
-	desc, provider, err := contentutil.ProviderFromRef(target)
+	desc, provider, err := contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 	imgs, err := testutil.ReadImages(sb.Context(), provider, desc)
 	require.NoError(t, err)
@@ -2334,7 +2334,7 @@ ADD bar bar`)
 	}, nil)
 	require.NoError(t, err)
 
-	desc, provider, err := contentutil.ProviderFromRef(target)
+	desc, provider, err := contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 	imgs, err := testutil.ReadImages(sb.Context(), provider, desc)
 	require.NoError(t, err)
@@ -2628,7 +2628,7 @@ func testDuplicateLayersProvenance(t *testing.T, sb integration.Sandbox) {
 
 	require.NoError(t, err)
 
-	desc, provider, err := contentutil.ProviderFromRef(target)
+	desc, provider, err := contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 	imgs, err := testutil.ReadImages(sb.Context(), provider, desc)
 	require.NoError(t, err)

--- a/frontend/dockerfile/dockerfile_sbom_test.go
+++ b/frontend/dockerfile/dockerfile_sbom_test.go
@@ -104,7 +104,7 @@ EOF
 	}, nil)
 	require.NoError(t, err)
 
-	desc, provider, err := contentutil.ProviderFromRef(target)
+	desc, provider, err := contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 	imgs, err := testutil.ReadImages(sb.Context(), provider, desc)
 	require.NoError(t, err)
@@ -225,7 +225,7 @@ FROM base
 	}, nil)
 	require.NoError(t, err)
 
-	desc, provider, err := contentutil.ProviderFromRef(target)
+	desc, provider, err := contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 	imgs, err := testutil.ReadImages(sb.Context(), provider, desc)
 	require.NoError(t, err)
@@ -288,7 +288,7 @@ ARG BUILDKIT_SBOM_SCAN_STAGE=true
 	}, nil)
 	require.NoError(t, err)
 
-	desc, provider, err = contentutil.ProviderFromRef(target)
+	desc, provider, err = contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 	imgs, err = testutil.ReadImages(sb.Context(), provider, desc)
 	require.NoError(t, err)
@@ -338,7 +338,7 @@ ARG BUILDKIT_SBOM_SCAN_STAGE=true
 	}, nil)
 	require.NoError(t, err)
 
-	desc, provider, err = contentutil.ProviderFromRef(target)
+	desc, provider, err = contentutil.ProviderFromRef(sb.Context(), target)
 	require.NoError(t, err)
 	imgs, err = testutil.ReadImages(sb.Context(), provider, desc)
 	require.NoError(t, err)

--- a/frontend/dockerfile/dockerfile_source_date_epoch_test.go
+++ b/frontend/dockerfile/dockerfile_source_date_epoch_test.go
@@ -1067,7 +1067,7 @@ func timeMustParse(t *testing.T, layout, value string) time.Time {
 
 //nolint:revive // context-as-argument: context.Context should be the first parameter of a function
 func readImage(t *testing.T, ctx context.Context, ref string) (ocispecs.Descriptor, ocispecs.Manifest, ocispecs.Image) {
-	desc, provider, err := contentutil.ProviderFromRef(ref)
+	desc, provider, err := contentutil.ProviderFromRef(ctx, ref)
 	require.NoError(t, err)
 	dt, err := content.ReadBlob(ctx, provider, desc)
 	require.NoError(t, err)

--- a/frontend/dockerfile/dockerfile_source_date_epoch_test.go
+++ b/frontend/dockerfile/dockerfile_source_date_epoch_test.go
@@ -1065,7 +1065,7 @@ func timeMustParse(t *testing.T, layout, value string) time.Time {
 
 //nolint:revive // context-as-argument: context.Context should be the first parameter of a function
 func readImage(t *testing.T, ctx context.Context, ref string) (ocispecs.Descriptor, ocispecs.Manifest, ocispecs.Image) {
-	desc, provider, err := contentutil.ProviderFromRef(ref)
+	desc, provider, err := contentutil.ProviderFromRef(ctx, ref)
 	require.NoError(t, err)
 	dt, err := content.ReadBlob(ctx, provider, desc)
 	require.NoError(t, err)

--- a/util/contentutil/refs.go
+++ b/util/contentutil/refs.go
@@ -33,7 +33,7 @@ func WithCredentials(c func(string) (string, string, error)) ResolveOptFunc {
 	}
 }
 
-func ProviderFromRef(ref string, opts ...ResolveOptFunc) (ocispecs.Descriptor, content.Provider, error) {
+func ProviderFromRef(ctx context.Context, ref string, opts ...ResolveOptFunc) (ocispecs.Descriptor, content.Provider, error) {
 	headers := http.Header{}
 	headers.Set("User-Agent", version.UserAgent())
 
@@ -52,26 +52,26 @@ func ProviderFromRef(ref string, opts ...ResolveOptFunc) (ocispecs.Descriptor, c
 	}
 	remote := docker.NewResolver(dro)
 
-	name, desc, err := remote.Resolve(context.TODO(), ref)
+	name, desc, err := remote.Resolve(ctx, ref)
 	if err != nil {
 		return ocispecs.Descriptor{}, nil, err
 	}
 
-	fetcher, err := remote.Fetcher(context.TODO(), name)
+	fetcher, err := remote.Fetcher(ctx, name)
 	if err != nil {
 		return ocispecs.Descriptor{}, nil, err
 	}
 	return desc, FromFetcher(fetcher), nil
 }
 
-func IngesterFromRef(ref string) (content.Ingester, error) {
+func IngesterFromRef(ctx context.Context, ref string) (content.Ingester, error) {
 	headers := http.Header{}
 	headers.Set("User-Agent", version.UserAgent())
 	remote := docker.NewResolver(docker.ResolverOptions{
 		Headers: headers,
 	})
 
-	p, err := remote.Pusher(context.TODO(), ref)
+	p, err := remote.Pusher(ctx, ref)
 	if err != nil {
 		return nil, err
 	}

--- a/util/contentutil/refs_test.go
+++ b/util/contentutil/refs_test.go
@@ -1,0 +1,27 @@
+package contentutil
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProviderFromRefUsesContext(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	cancel(context.Canceled)
+
+	ref := strings.TrimPrefix(srv.URL, "http://") + "/buildkit/test:latest"
+	_, _, err := ProviderFromRef(ctx, ref)
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/util/contentutil/refs_test.go
+++ b/util/contentutil/refs_test.go
@@ -1,0 +1,27 @@
+package contentutil
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProviderFromRefUsesContext(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancelCause(t.Context())
+	cancel(context.Canceled)
+
+	ref := strings.TrimPrefix(srv.URL, "http://") + "/buildkit/test:latest"
+	_, _, err := ProviderFromRef(ctx, ref)
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -236,7 +236,7 @@ func Run(t *testing.T, testCases []Test, opt ...TestOpt) {
 						ctx, cancel := context.WithCancelCause(ctx)
 						defer func() { cancel(errors.WithStack(context.Canceled)) }()
 
-						sb, closer, err := newSandbox(ctx, t, br, getMirror(), mv)
+						sb, closer, err := newSandbox(ctx, t, br, getMirror(ctx), mv)
 						require.NoError(t, err)
 						t.Cleanup(func() {
 							if closer != nil {
@@ -268,7 +268,7 @@ func getFunctionName(i any) string {
 var localImageCache map[string]map[string]struct{}
 var localImageCacheMu sync.Mutex
 
-func copyImagesLocal(t *testing.T, host string, images map[string]string) error {
+func copyImagesLocal(ctx context.Context, t *testing.T, host string, images map[string]string) error {
 	localImageCacheMu.Lock()
 	defer localImageCacheMu.Unlock()
 	for to, from := range images {
@@ -284,7 +284,7 @@ func copyImagesLocal(t *testing.T, host string, images map[string]string) error 
 		localImageCache[host][to] = struct{}{}
 
 		// already exists check
-		if _, _, err := docker.NewResolver(docker.ResolverOptions{}).Resolve(t.Context(), host+"/"+to); err == nil {
+		if _, _, err := docker.NewResolver(docker.ResolverOptions{}).Resolve(ctx, host+"/"+to); err == nil {
 			continue
 		}
 
@@ -303,7 +303,7 @@ func copyImagesLocal(t *testing.T, host string, images map[string]string) error 
 		} else {
 			dockerConfig := config.LoadDefaultConfigFile(os.Stderr)
 
-			desc, provider, err = contentutil.ProviderFromRef(from, contentutil.WithCredentials(
+			desc, provider, err = contentutil.ProviderFromRef(ctx, from, contentutil.WithCredentials(
 				func(host string) (string, string, error) {
 					ac, err := dockerConfig.GetAuthConfig(host)
 					if err != nil {
@@ -316,16 +316,16 @@ func copyImagesLocal(t *testing.T, host string, images map[string]string) error 
 			}
 		}
 
-		desc, err = resolveDefaultPlatform(t.Context(), provider, desc)
+		desc, err = resolveDefaultPlatform(ctx, provider, desc)
 		if err != nil {
 			return err
 		}
 
-		ingester, err := contentutil.IngesterFromRef(host + "/" + to)
+		ingester, err := contentutil.IngesterFromRef(ctx, host+"/"+to)
 		if err != nil {
 			return err
 		}
-		if err := contentutil.CopyChain(t.Context(), ingester, provider, desc); err != nil {
+		if err := contentutil.CopyChain(ctx, ingester, provider, desc); err != nil {
 			return err
 		}
 		t.Logf("copied %s to local mirror %s", from, host+"/"+to)
@@ -402,14 +402,14 @@ func WriteConfig(updaters []ConfigUpdater) (_ string, _ func() error, err error)
 	return filepath.Join(tmpdir, buildkitdConfigFile), deferF.F(), nil
 }
 
-func lazyMirrorRunnerFunc(t *testing.T, images map[string]string) func() string {
+func lazyMirrorRunnerFunc(t *testing.T, images map[string]string) func(context.Context) string {
 	var once sync.Once
 	var mirror string
-	return func() string {
+	return func(ctx context.Context) string {
 		once.Do(func() {
 			m, err := RunMirror()
 			require.NoError(t, err)
-			require.NoError(t, m.AddImages(t, images))
+			require.NoError(t, m.AddImages(ctx, t, images))
 			t.Cleanup(func() { _ = m.Close() })
 			mirror = m.Host
 		})
@@ -444,7 +444,7 @@ func (m *Mirror) Close() error {
 	return nil
 }
 
-func (m *Mirror) AddImages(t *testing.T, images map[string]string) (err error) {
+func (m *Mirror) AddImages(ctx context.Context, t *testing.T, images map[string]string) (err error) {
 	lock, err := m.lock()
 	if err != nil {
 		return err
@@ -455,7 +455,7 @@ func (m *Mirror) AddImages(t *testing.T, images map[string]string) (err error) {
 		}
 	}()
 
-	if err := copyImagesLocal(t, m.Host, images); err != nil {
+	if err := copyImagesLocal(ctx, t, m.Host, images); err != nil {
 		return err
 	}
 	return nil

--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -236,7 +236,7 @@ func Run(t *testing.T, testCases []Test, opt ...TestOpt) {
 						ctx, cancel := context.WithCancelCause(ctx)
 						defer func() { cancel(errors.WithStack(context.Canceled)) }()
 
-						sb, closer, err := newSandbox(ctx, t, br, getMirror(), mv)
+						sb, closer, err := newSandbox(ctx, t, br, getMirror(ctx), mv)
 						require.NoError(t, err)
 						t.Cleanup(func() {
 							if closer != nil {
@@ -268,7 +268,7 @@ func getFunctionName(i any) string {
 var localImageCache map[string]map[string]struct{}
 var localImageCacheMu sync.Mutex
 
-func copyImagesLocal(t *testing.T, host string, images map[string]string) error {
+func copyImagesLocal(ctx context.Context, t *testing.T, host string, images map[string]string) error {
 	localImageCacheMu.Lock()
 	defer localImageCacheMu.Unlock()
 	for to, from := range images {
@@ -284,7 +284,7 @@ func copyImagesLocal(t *testing.T, host string, images map[string]string) error 
 		localImageCache[host][to] = struct{}{}
 
 		// already exists check
-		if _, _, err := docker.NewResolver(docker.ResolverOptions{}).Resolve(context.TODO(), host+"/"+to); err == nil {
+		if _, _, err := docker.NewResolver(docker.ResolverOptions{}).Resolve(ctx, host+"/"+to); err == nil {
 			continue
 		}
 
@@ -303,7 +303,7 @@ func copyImagesLocal(t *testing.T, host string, images map[string]string) error 
 		} else {
 			dockerConfig := config.LoadDefaultConfigFile(os.Stderr)
 
-			desc, provider, err = contentutil.ProviderFromRef(from, contentutil.WithCredentials(
+			desc, provider, err = contentutil.ProviderFromRef(ctx, from, contentutil.WithCredentials(
 				func(host string) (string, string, error) {
 					ac, err := dockerConfig.GetAuthConfig(host)
 					if err != nil {
@@ -316,16 +316,16 @@ func copyImagesLocal(t *testing.T, host string, images map[string]string) error 
 			}
 		}
 
-		desc, err = resolveDefaultPlatform(context.TODO(), provider, desc)
+		desc, err = resolveDefaultPlatform(ctx, provider, desc)
 		if err != nil {
 			return err
 		}
 
-		ingester, err := contentutil.IngesterFromRef(host + "/" + to)
+		ingester, err := contentutil.IngesterFromRef(ctx, host+"/"+to)
 		if err != nil {
 			return err
 		}
-		if err := contentutil.CopyChain(context.TODO(), ingester, provider, desc); err != nil {
+		if err := contentutil.CopyChain(ctx, ingester, provider, desc); err != nil {
 			return err
 		}
 		t.Logf("copied %s to local mirror %s", from, host+"/"+to)
@@ -402,14 +402,14 @@ func WriteConfig(updaters []ConfigUpdater) (_ string, _ func() error, err error)
 	return filepath.Join(tmpdir, buildkitdConfigFile), deferF.F(), nil
 }
 
-func lazyMirrorRunnerFunc(t *testing.T, images map[string]string) func() string {
+func lazyMirrorRunnerFunc(t *testing.T, images map[string]string) func(context.Context) string {
 	var once sync.Once
 	var mirror string
-	return func() string {
+	return func(ctx context.Context) string {
 		once.Do(func() {
 			m, err := RunMirror()
 			require.NoError(t, err)
-			require.NoError(t, m.AddImages(t, images))
+			require.NoError(t, m.AddImages(ctx, t, images))
 			t.Cleanup(func() { _ = m.Close() })
 			mirror = m.Host
 		})
@@ -444,7 +444,7 @@ func (m *Mirror) Close() error {
 	return nil
 }
 
-func (m *Mirror) AddImages(t *testing.T, images map[string]string) (err error) {
+func (m *Mirror) AddImages(ctx context.Context, t *testing.T, images map[string]string) (err error) {
 	lock, err := m.lock()
 	if err != nil {
 		return err
@@ -455,7 +455,7 @@ func (m *Mirror) AddImages(t *testing.T, images map[string]string) (err error) {
 		}
 	}()
 
-	if err := copyImagesLocal(t, m.Host, images); err != nil {
+	if err := copyImagesLocal(ctx, t, m.Host, images); err != nil {
 		return err
 	}
 	return nil

--- a/worker/tests/common.go
+++ b/worker/tests/common.go
@@ -38,16 +38,16 @@ func RunMirror() func() error {
 	return func() error { return mirror.Close() }
 }
 
-func mirrorBusybox(t *testing.T) string {
+func mirrorBusybox(ctx context.Context, t *testing.T) string {
 	mirrorMu.Lock()
 	defer mirrorMu.Unlock()
 	require.NotNil(t, mirror, "mirror must be initialized")
-	require.NoError(t, mirror.AddImages(t, integration.OfficialImages("busybox:latest")))
+	require.NoError(t, mirror.AddImages(ctx, t, integration.OfficialImages("busybox:latest")))
 	return mirror.Host + "/library/busybox:latest"
 }
 
 func NewBusyboxSourceSnapshot(ctx context.Context, t *testing.T, w *base.Worker, sm *session.Manager) cache.ImmutableRef {
-	img, err := containerimage.NewImageIdentifier(mirrorBusybox(t))
+	img, err := containerimage.NewImageIdentifier(mirrorBusybox(ctx, t))
 	require.NoError(t, err)
 	src, err := w.SourceManager.Resolve(ctx, img, sm, nil)
 	require.NoError(t, err)


### PR DESCRIPTION
relates to https://github.com/moby/moby/issues/48830

This makes the contentutil registry helpers respect caller cancellation when resolving, fetching, and pushing registry refs. The previous implementation used `context.TODO()` inside the helper, which meant a hung or unresponsive registry request could outlive the test sandbox context and wait for the outer test timeout instead.