### PR TITLE
resolver: retry token fetch on transient network errors

### DIFF
--- a/util/resolver/authorizer.go
+++ b/util/resolver/authorizer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/errutil"
 	"github.com/moby/buildkit/util/flightcontrol"
+	"github.com/moby/buildkit/util/resolver/retryhandler"
 	"github.com/moby/buildkit/version"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -330,6 +331,30 @@ func (ah *authFetcher) doBearerAuth(ctx context.Context, sm *session.Manager, g 
 	return res.token, nil
 }
 
+// retryTokenFetch retries f on transient network errors (e.g. connection
+// reset, EOF, timeouts, 5xx), the same errors that are already retried for
+// blob/manifest fetches by retryhandler, since a token exchange is just as
+// prone to hitting a flaky registry connection.
+func retryTokenFetch[T any](ctx context.Context, f func() (T, error)) (T, error) {
+	backoff := time.Second
+	for {
+		v, err := f()
+		if err == nil {
+			return v, nil
+		}
+		select {
+		case <-ctx.Done():
+			return v, err
+		default:
+		}
+		if !retryhandler.IsErrorRetriable(err) || backoff >= retryhandler.MaxRetryBackoff {
+			return v, err
+		}
+		time.Sleep(backoff)
+		backoff *= 2
+	}
+}
+
 func (ah *authFetcher) fetchToken(ctx context.Context, sm *session.Manager, g session.Group, to auth.TokenOptions) (r *authResult, err error) {
 	var issuedAt time.Time
 	var expires int
@@ -385,7 +410,9 @@ func (ah *authFetcher) fetchToken(ctx context.Context, sm *session.Manager, g se
 		}()
 		// try GET first because Docker Hub does not support POST
 		// switch once support has landed
-		resp, err := auth.FetchToken(ctx, ah.client, nil, to)
+		resp, err := retryTokenFetch(ctx, func() (*auth.FetchTokenResponse, error) {
+			return auth.FetchToken(ctx, ah.client, nil, to)
+		})
 		if err != nil {
 			var errStatus remoteserrors.ErrUnexpectedStatus
 			if errors.As(err, &errStatus) {
@@ -393,7 +420,9 @@ func (ah *authFetcher) fetchToken(ctx context.Context, sm *session.Manager, g se
 				// As of September 2017, GCR is known to return 404.
 				// As of February 2018, JFrog Artifactory is known to return 401.
 				if (errStatus.StatusCode == http.StatusMethodNotAllowed && to.Username != "") || errStatus.StatusCode == http.StatusNotFound || errStatus.StatusCode == http.StatusUnauthorized {
-					resp, err := auth.FetchTokenWithOAuth(ctx, ah.client, hdr, "buildkit-client", to)
+					resp, err := retryTokenFetch(ctx, func() (*auth.OAuthTokenResponse, error) {
+						return auth.FetchTokenWithOAuth(ctx, ah.client, hdr, "buildkit-client", to)
+					})
 					if err != nil {
 						return nil, err
 					}
@@ -419,7 +448,9 @@ func (ah *authFetcher) fetchToken(ctx context.Context, sm *session.Manager, g se
 		return nil, nil
 	}
 	// do request anonymously
-	resp, err := auth.FetchToken(ctx, ah.client, hdr, to)
+	resp, err := retryTokenFetch(ctx, func() (*auth.FetchTokenResponse, error) {
+		return auth.FetchToken(ctx, ah.client, hdr, to)
+	})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to fetch anonymous token")
 	}

--- a/util/resolver/authorizer.go
+++ b/util/resolver/authorizer.go
@@ -331,12 +331,17 @@ func (ah *authFetcher) doBearerAuth(ctx context.Context, sm *session.Manager, g 
 	return res.token, nil
 }
 
+// tokenFetchInitialBackoff is the initial backoff before retrying a failed
+// token fetch. It is a variable so tests can override it to avoid waiting
+// out the real backoff schedule.
+var tokenFetchInitialBackoff = time.Second
+
 // retryTokenFetch retries f on transient network errors (e.g. connection
 // reset, EOF, timeouts, 5xx), the same errors that are already retried for
 // blob/manifest fetches by retryhandler, since a token exchange is just as
 // prone to hitting a flaky registry connection.
 func retryTokenFetch[T any](ctx context.Context, f func() (T, error)) (T, error) {
-	backoff := time.Second
+	backoff := tokenFetchInitialBackoff
 	for {
 		v, err := f()
 		if err == nil {
@@ -350,7 +355,11 @@ func retryTokenFetch[T any](ctx context.Context, f func() (T, error)) (T, error)
 		if !retryhandler.IsErrorRetriable(err) || backoff >= retryhandler.MaxRetryBackoff {
 			return v, err
 		}
-		time.Sleep(backoff)
+		select {
+		case <-ctx.Done():
+			return v, err
+		case <-time.After(backoff):
+		}
 		backoff *= 2
 	}
 }

--- a/util/resolver/authorizer_test.go
+++ b/util/resolver/authorizer_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/containerd/containerd/v2/core/remotes/docker/auth"
 	"github.com/moby/buildkit/session"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -130,9 +131,13 @@ func TestBearerAuthFallsBackToAnonymousTokenWithoutSession(t *testing.T) {
 }
 
 func TestFetchTokenRetriesOnTransientNetworkError(t *testing.T) {
+	old := tokenFetchInitialBackoff
+	tokenFetchInitialBackoff = time.Millisecond
+	defer func() { tokenFetchInitialBackoff = old }()
+
 	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+		assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
 			"token":      "retried-token",
 			"expires_in": 60,
 		}))

--- a/util/resolver/authorizer_test.go
+++ b/util/resolver/authorizer_test.go
@@ -3,15 +3,25 @@ package resolver
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
+	"github.com/containerd/containerd/v2/core/remotes/docker/auth"
 	"github.com/moby/buildkit/session"
 	"github.com/stretchr/testify/require"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func TestParseScopes(t *testing.T) {
 	for _, tc := range []struct {
@@ -117,4 +127,41 @@ func TestBearerAuthFallsBackToAnonymousTokenWithoutSession(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("expected anonymous token request")
 	}
+}
+
+func TestFetchTokenRetriesOnTransientNetworkError(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"token":      "retried-token",
+			"expires_in": 60,
+		}))
+	}))
+	defer tokenServer.Close()
+
+	client := tokenServer.Client()
+	realTransport := client.Transport
+
+	var attempts atomic.Int32
+	client.Transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if attempts.Add(1) == 1 {
+			// simulate the transient connection reset described in
+			// https://github.com/moby/buildkit/issues/6981
+			return nil, &net.OpError{Op: "read", Err: syscall.ECONNRESET}
+		}
+		return realTransport.RoundTrip(req)
+	})
+
+	ah := newAuthFetcher("registry.example", client, auth.BearerAuth, nil, auth.TokenOptions{
+		Realm:   tokenServer.URL,
+		Service: "registry.example",
+	})
+
+	sm, err := session.NewManager()
+	require.NoError(t, err)
+
+	token, err := ah.authorize(t.Context(), sm, session.NewGroup(""))
+	require.NoError(t, err)
+	require.Equal(t, "Bearer retried-token", token)
+	require.EqualValues(t, 2, attempts.Load())
 }

--- a/util/resolver/retryhandler/retry.go
+++ b/util/resolver/retryhandler/retry.go
@@ -28,7 +28,7 @@ func New(f images.HandlerFunc, logger func([]byte)) images.HandlerFunc {
 				case <-ctx.Done():
 					return nil, err
 				default:
-					if !retryError(err) {
+					if !IsErrorRetriable(err) {
 						return nil, err
 					}
 				}
@@ -51,7 +51,9 @@ func New(f images.HandlerFunc, logger func([]byte)) images.HandlerFunc {
 	}
 }
 
-func retryError(err error) bool {
+// IsErrorRetriable reports whether err is a transient error (e.g. connection
+// reset, EOF, timeout, or a 5xx response) that is worth retrying.
+func IsErrorRetriable(err error) bool {
 	// Retry on 5xx errors
 	var errUnexpectedStatus remoteserrors.ErrUnexpectedStatus
 	if errors.As(err, &errUnexpectedStatus) &&


### PR DESCRIPTION
Motivation:
Blob/manifest fetches are retried on transient network errors (EOF,
ECONNRESET, EPIPE, closed connections, temporary net.Error, 5xx) via
util/resolver/retryhandler, with exponential backoff. The registry
auth token exchange in authorizer.go's fetchToken does not get this
treatment: a transient reset while POSTing/GETting the token endpoint
(e.g. auth.docker.io) propagates straight up and fails the whole
build, even though the same class of error on a manifest/blob request
would have been retried and the build would have succeeded.

Approach:
- Export retryhandler's existing retry-error classifier as
  IsErrorRetriable so it can be reused outside that package (pure
  rename, no behavior change).
- Add a small generic retryTokenFetch helper in authorizer.go that
  retries a fetch function with the same backoff schedule as
  retryhandler.New (starting at 1s, doubling, capped at
  retryhandler.MaxRetryBackoff).
- Wrap the three direct registry network calls in fetchToken (the
  GET auth.FetchToken call, its POST auth.FetchTokenWithOAuth
  fallback, and the anonymous auth.FetchToken call) with this helper.
  The session-forwarded token path (sessionauth.FetchToken, used when
  auth is proxied through a client session) is left untouched since
  it isn't a direct registry network call and is out of scope for
  this issue.

This only changes behavior when a token request hits a transient
network error: it is now retried a few times before giving up,
matching existing blob/manifest behavior. Non-transient errors (bad
credentials, 4xx, insufficient_scope, etc.) are returned immediately
as before.

Validation:
  go build ./util/resolver/...
  go test ./util/resolver/... -v
Both pass. Added TestFetchTokenRetriesOnTransientNetworkError, which
installs a RoundTripper that fails the first token request with a
simulated ECONNRESET and succeeds on the second, and asserts the
overall token fetch succeeds after exactly one retry.

Fixes #6981

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>