### PR TITLE
test: avoid local exporter invalid mode integration hang

### DIFF
--- a/client/client_export_local_test.go
+++ b/client/client_export_local_test.go
@@ -181,33 +181,6 @@ func testExportLocalModeDeleteMultiPlatformKeepsAllPlatforms(t *testing.T, sb in
 	testExportLocalModeMultiPlatformKeepsAllPlatforms(t, sb, true)
 }
 
-func testExportLocalModeInvalid(t *testing.T, sb integration.Sandbox) {
-	c, err := New(sb.Context(), sb.Address())
-	require.NoError(t, err)
-	defer c.Close()
-
-	st := llb.Scratch().File(
-		llb.Mkfile("fresh.txt", 0600, []byte("fresh")),
-	)
-	def, err := st.Marshal(sb.Context())
-	require.NoError(t, err)
-
-	destDir := t.TempDir()
-	_, err = c.Solve(sb.Context(), def, SolveOpt{
-		Exports: []ExportEntry{
-			{
-				Type:      ExporterLocal,
-				OutputDir: destDir,
-				Attrs: map[string]string{
-					"mode": "backup",
-				},
-			},
-		},
-	}, nil)
-	require.Error(t, err)
-	require.ErrorContains(t, err, `invalid local exporter mode "backup"`)
-}
-
 func testExportLocalModeMultiPlatformKeepsAllPlatforms(t *testing.T, sb integration.Sandbox, deleteMode bool) {
 	workers.CheckFeatureCompat(t, sb, workers.FeatureOCIExporter, workers.FeatureMultiPlatform)
 	c, err := New(sb.Context(), sb.Address())

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -86,7 +86,6 @@ var allTests = []func(t *testing.T, sb integration.Sandbox){
 	testExportLocalModeCopyMultiPlatformKeepsAllPlatforms,
 	testExportLocalModeDeleteRemovesStaleDestinationFiles,
 	testExportLocalModeDeleteMultiPlatformKeepsAllPlatforms,
-	testExportLocalModeInvalid,
 	testExportLocalNoPlatformSplit,
 	testExportLocalNoPlatformSplitOverwrite,
 	testExporterTargetExists,

--- a/client/solve_test.go
+++ b/client/solve_test.go
@@ -1,0 +1,30 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSolveRejectsInvalidLocalExporterMode(t *testing.T) {
+	st := llb.Scratch().File(
+		llb.Mkfile("fresh.txt", 0600, []byte("fresh")),
+	)
+	def, err := st.Marshal(t.Context())
+	require.NoError(t, err)
+
+	_, err = (&Client{}).Solve(t.Context(), def, SolveOpt{
+		Exports: []ExportEntry{
+			{
+				Type:      ExporterLocal,
+				OutputDir: t.TempDir(),
+				Attrs: map[string]string{
+					"mode": "backup",
+				},
+			},
+		},
+	}, nil)
+	require.Error(t, err)
+	require.ErrorContains(t, err, `invalid local exporter mode "backup"`)
+}


### PR DESCRIPTION
relates to https://github.com/moby/moby/issues/50389#issuecomment-5078810605

This moves the invalid local exporter mode regression check out of the integration test matrix. The `mode=backup` assertion now runs as a regular client unit test through `Client.Solve`.

The invalid mode is rejected by client-side option validation before a real solve needs to happen, so running a full Windows `dockerd-containerd` sandbox for this case adds flake risk without improving coverage.