### PR TITLE
contentutil: retry remote cache config and manifest writes

### DIFF
--- a/cache/remotecache/export.go
+++ b/cache/remotecache/export.go
@@ -1,7 +1,6 @@
 package remotecache
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -244,7 +243,7 @@ func (ce *contentCacheExporter) Finalize(ctx context.Context) (map[string]string
 		MediaType: cacheimporttypes.CacheConfigMediaTypeV0,
 	}
 	configDone := progress.OneOff(ctx, fmt.Sprintf("writing config %s", dgst))
-	if err := content.WriteBlob(ctx, ce.ingester, dgst.String(), bytes.NewReader(dt), desc); err != nil {
+	if err := contentutil.WriteBlob(ctx, ce.ingester, dt, desc, ce.ref, logs.LoggerFromContext(ctx)); err != nil {
 		err = withRemoteCacheErrorDetails(err)
 		return nil, configDone(errors.Wrap(err, "error writing config blob"))
 	}
@@ -269,7 +268,7 @@ func (ce *contentCacheExporter) Finalize(ctx context.Context) (map[string]string
 		mfstLog = fmt.Sprintf("writing cache image manifest %s", dgst)
 	}
 	mfstDone := progress.OneOff(ctx, mfstLog)
-	if err := content.WriteBlob(ctx, ce.ingester, dgst.String(), bytes.NewReader(dt), desc); err != nil {
+	if err := contentutil.WriteBlob(ctx, ce.ingester, dt, desc, ce.ref, logs.LoggerFromContext(ctx)); err != nil {
 		err = withRemoteCacheErrorDetails(err)
 		return nil, mfstDone(errors.Wrap(err, "error writing manifest blob"))
 	}

--- a/util/contentutil/copy.go
+++ b/util/contentutil/copy.go
@@ -1,6 +1,7 @@
 package contentutil
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"slices"
@@ -38,6 +39,31 @@ func Copy(ctx context.Context, ingester content.Ingester, provider content.Provi
 	}
 	return nil
 }
+
+// WriteBlob writes dt to ingester with the same retry and concurrency handling
+// as Copy, so that a remote ingester can recover from a failed request.
+func WriteBlob(ctx context.Context, ingester content.Ingester, dt []byte, desc ocispecs.Descriptor, ref string, logger func([]byte)) error {
+	return Copy(ctx, ingester, bytesProvider{dt}, desc, ref, logger)
+}
+
+// bytesProvider serves dt as the content for any descriptor, so an in-memory
+// payload can be written through Copy. Each call returns a fresh reader, which
+// is what allows a retried write to start over.
+type bytesProvider struct {
+	dt []byte
+}
+
+func (p bytesProvider) ReaderAt(context.Context, ocispecs.Descriptor) (content.ReaderAt, error) {
+	return bytesReaderAt{bytes.NewReader(p.dt)}, nil
+}
+
+// bytesReaderAt adapts *bytes.Reader, which already implements ReadAt and Size,
+// to content.ReaderAt.
+type bytesReaderAt struct {
+	*bytes.Reader
+}
+
+func (bytesReaderAt) Close() error { return nil }
 
 type localFetcher struct {
 	content.Provider

--- a/util/contentutil/copy_test.go
+++ b/util/contentutil/copy_test.go
@@ -3,11 +3,15 @@ package contentutil
 import (
 	"bytes"
 	"context"
+	"net"
+	"os"
+	"syscall"
 	"testing"
 
 	"github.com/containerd/containerd/v2/core/content"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,4 +31,127 @@ func TestCopy(t *testing.T) {
 	dt, err := content.ReadBlob(ctx, b1, ocispecs.Descriptor{Digest: digest.FromBytes([]byte("foobar"))})
 	require.NoError(t, err)
 	require.Equal(t, "foobar", string(dt))
+}
+
+func TestWriteBlob(t *testing.T) {
+	t.Parallel()
+	ctx := context.TODO()
+
+	b := NewBuffer()
+	dt := []byte("foobar")
+	desc := blobDesc(dt)
+
+	require.NoError(t, WriteBlob(ctx, b, dt, desc, "", nil))
+
+	out, err := content.ReadBlob(ctx, b, desc)
+	require.NoError(t, err)
+	require.Equal(t, dt, out)
+}
+
+// TestWriteBlobRetriesTransientCommit verifies a connection dropped on the final
+// commit is retried and the blob is written intact.
+func TestWriteBlobRetriesTransientCommit(t *testing.T) {
+	t.Parallel()
+	ctx := context.TODO()
+
+	b := NewBuffer()
+	dt := []byte("foobar")
+	desc := blobDesc(dt)
+	ing := &flakyIngester{Ingester: b, failures: 2, err: connTimedOut()}
+
+	require.NoError(t, WriteBlob(ctx, ing, dt, desc, "", nil))
+	require.Equal(t, 3, ing.attempts)
+
+	out, err := content.ReadBlob(ctx, b, desc)
+	require.NoError(t, err)
+	require.Equal(t, dt, out)
+}
+
+// TestWriteBlobRetriesAfterPartialWrite verifies dt is re-read from the start
+// after a partial write, so a retry does not commit truncated content.
+func TestWriteBlobRetriesAfterPartialWrite(t *testing.T) {
+	t.Parallel()
+	ctx := context.TODO()
+
+	b := NewBuffer()
+	dt := []byte("foobar")
+	desc := blobDesc(dt)
+	ing := &flakyIngester{Ingester: b, failures: 1, failMidWrite: true, err: syscall.ECONNRESET}
+
+	require.NoError(t, WriteBlob(ctx, ing, dt, desc, "", nil))
+	require.Equal(t, 2, ing.attempts)
+
+	out, err := content.ReadBlob(ctx, b, desc)
+	require.NoError(t, err)
+	require.Equal(t, dt, out)
+}
+
+func TestWriteBlobDoesNotRetryPermanentError(t *testing.T) {
+	t.Parallel()
+	ctx := context.TODO()
+
+	b := NewBuffer()
+	dt := []byte("foobar")
+	ing := &flakyIngester{Ingester: b, failures: 1, err: errors.New("unauthorized")}
+
+	err := WriteBlob(ctx, ing, dt, blobDesc(dt), "", nil)
+	require.ErrorContains(t, err, "unauthorized")
+	require.Equal(t, 1, ing.attempts)
+}
+
+func blobDesc(dt []byte) ocispecs.Descriptor {
+	return ocispecs.Descriptor{Digest: digest.FromBytes(dt), Size: int64(len(dt))}
+}
+
+func connTimedOut() error {
+	return &net.OpError{Op: "read", Net: "tcp", Err: os.NewSyscallError("read", syscall.ETIMEDOUT)}
+}
+
+// flakyIngester fails the first failures writes with err, then delegates.
+type flakyIngester struct {
+	content.Ingester
+	failures     int
+	failMidWrite bool
+	err          error
+	attempts     int
+}
+
+func (f *flakyIngester) Writer(ctx context.Context, opts ...content.WriterOpt) (content.Writer, error) {
+	f.attempts++
+	w, err := f.Ingester.Writer(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+	if f.failures == 0 {
+		return w, nil
+	}
+	f.failures--
+	return &flakyWriter{Writer: w, err: f.err, failMidWrite: f.failMidWrite}, nil
+}
+
+type flakyWriter struct {
+	content.Writer
+	err          error
+	failMidWrite bool
+}
+
+func (w *flakyWriter) Write(p []byte) (int, error) {
+	if !w.failMidWrite {
+		return w.Writer.Write(p)
+	}
+	if len(p) > 1 {
+		p = p[:1]
+	}
+	n, err := w.Writer.Write(p)
+	if err != nil {
+		return n, err
+	}
+	return n, w.err
+}
+
+func (w *flakyWriter) Commit(ctx context.Context, size int64, expected digest.Digest, opts ...content.Opt) error {
+	if w.failMidWrite {
+		return w.Writer.Commit(ctx, size, expected, opts...)
+	}
+	return w.err
 }


### PR DESCRIPTION
### Problem

`contentCacheExporter.Finalize` writes three kinds of blob to the cache ref, but only one of them is retried:

| write | path | retried |
| --- | --- | --- |
| layer blobs | `contentutil.Copy` → `retryhandler.New(limited.FetchHandler(…))` | yes |
| cache config blob | bare `content.WriteBlob` (`cache/remotecache/export.go:247`) | **no** |
| cache manifest blob | bare `content.WriteBlob` (`cache/remotecache/export.go:272`) | **no** |

For the registry backend the ingester is remote — `cache/remotecache/registry/registry.go:99` passes `contentutil.FromPusher(pusher)` — so those two are the only network writes in `Finalize` with no retry, and a single transient error fails the whole export.

Every other non-test `content.WriteBlob` call site in the tree writes to a local content store, so this is specific to the remote cache exporter.

### Impact

Hit on a CI build exporting to ECR. The image itself exported and pushed fine in 1.3s. The cache export then died on a single blob PUT — and because the cache exporter runs as part of the build, the build failed:

```
#36 exporting to image
#36 pushing manifest for <registry>/<repo>@sha256:f8506ee5… 0.3s done
#36 DONE 1.3s
#37 exporting cache to registry
#37 writing layer sha256:18b8de13… 0.1s done
…  (every layer blob 0.1s — the retried path)
#37 writing config sha256:be58586c… 200.7s done
#37 ERROR: error writing config blob: failed commit on ref "sha256:be58586c…":
  failed to do request: Put "https://<registry>/v2/<repo>/blobs/uploads/…":
  read tcp …:45750->…:443: read: connection timed out
```

So a build fails on a cache-export blip even though the artifact it produced was already safely in the registry moments earlier.

### Fix

Add `contentutil.WriteBlob`, which adapts the in-memory payload to a `content.Provider` and delegates to the existing `Copy`, and use it for both writes.

No new retry logic and no new wiring: it goes through exactly the same `retryhandler` + `limited.FetchHandler` as the layer blobs. `*bytes.Reader` already satisfies `ReadAt` and `Size`, so the adapter is one method plus a no-op `Close`.

Since `Copy` re-derives the reader per attempt via the existing `localFetcher`/`rc`, a retry cannot resume mid-stream and commit truncated content.

### Tests

In `util/contentutil/copy_test.go`:

- `TestWriteBlob` — baseline, no failures injected.
- `TestWriteBlobRetriesTransientCommit` — commit fails twice with the error from the report above (a `net.OpError` wrapping `ETIMEDOUT`); asserts 3 attempts and intact content.
- `TestWriteBlobRetriesAfterPartialWrite` — first attempt fails mid-write; asserts the payload is re-read from the start.
- `TestWriteBlobDoesNotRetryPermanentError` — a non-retryable error still fails on the first attempt, so this doesn't mask real failures.

The two retry tests fail if the retry is removed. `TestWriteBlobRetriesAfterPartialWrite` additionally fails if the reader is shared across attempts rather than re-derived, which is the subtle way this fix can be got wrong.

Observed on v0.31.2; both unretried writes are present on `master` unchanged.
