### PR TITLE
llb: don't chown to root group for "user:" with empty group

### DIFF
--- a/client/llb/fileop.go
+++ b/client/llb/fileop.go
@@ -242,6 +242,11 @@ func WithUser(name string) ChownOption {
 				opt.User = &UserOpt{UID: uid}
 			}
 		case 1:
+			if v == "" {
+				// "user:" with no group after the colon means "use the
+				// user's primary group", same as omitting the colon.
+				continue
+			}
 			gid, err := parseUID(v)
 			if err != nil {
 				opt.Group = &UserOpt{Name: v}

--- a/client/llb/fileop_test.go
+++ b/client/llb/fileop_test.go
@@ -631,6 +631,23 @@ func TestFileOwnerWithGroup(t *testing.T) {
 	require.Equal(t, "bar", mkdir.Owner.Group.User.(*pb.UserOpt_ByName).ByName.Name)
 }
 
+func TestFileOwnerWithTrailingColonNoGroup(t *testing.T) {
+	t.Parallel()
+
+	st := Image("foo").File(Mkdir("bar/baz", 0701, WithUser("foo:")))
+	def, err := st.Marshal(t.Context())
+
+	require.NoError(t, err)
+
+	_, arr := parseDef(t, def.Def)
+
+	action := arr[1].Op.(*pb.Op_File).File.Actions[0]
+	mkdir := action.Action.(*pb.FileAction_Mkdir).Mkdir
+
+	require.Equal(t, "foo", mkdir.Owner.User.User.(*pb.UserOpt_ByName).ByName.Name)
+	require.Nil(t, mkdir.Owner.Group)
+}
+
 func TestFileOwnerWithUIDAndGID(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Motivation:

`COPY --chown=<user>:` (a trailing colon with nothing after it, e.g.
`COPY --chown=rust: ./Cargo.toml ./`) is a natural way to write "chown
to <user>, and use that user's primary group", mirroring the Unix
`chown` command. Instead, it silently chowns the copied files to the
root group (GID 0).

This happens because `llb.WithUser` splits "user:" into ["user", ""].
The empty string after the colon fails uid parsing and falls into the
`opt.Group = &UserOpt{Name: v}` branch, producing a Group option with
an empty Name. `UserOpt.marshal` treats an empty Name as "no name
given" and marshals it as `UserOpt_ByID{ByID: 0}` instead of dropping
the field, so the option is not nil and downstream (readUser in
solver/llbsolver/ops/user_linux.go) unconditionally sets the GID to 0,
overwriting the GID it had already resolved from the user's /etc/passwd
entry. No error is raised anywhere, so this is silent and easy to miss.

Note this is a distinct (and more actively harmful) issue than what
was originally reported in #3555: the exact error message quoted in
the issue ("can't find gid for group : no such group:") does not
appear anywhere in buildkit's history and does not currently reproduce;
instead of erroring, current buildkit silently chowns to root group.

`COPY --chown=<user>` (no colon at all) is unaffected — it already
leaves Group nil and correctly defaults to the user's primary group.

Approach:

In `llb.WithUser`, when the group portion of the input is an empty
string, skip setting `opt.Group` entirely, the same as when there is
no colon at all. This lets the existing fallback in readUser use the
GID already resolved from the user's passwd entry.

Validation:

    go build ./...
    go test ./client/llb/...

Both pass. Added TestFileOwnerWithTrailingColonNoGroup, which fails
against the old code (asserting Owner.Group is nil, but the old code
produces a non-nil UserOpt_ByID{0}) and passes with the fix.

Fixes #3555

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>