### PR TITLE
exporter: sanitize platform IDs in path components

### DIFF
--- a/client/client_export_local_test.go
+++ b/client/client_export_local_test.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"testing"
 
@@ -441,6 +442,90 @@ func testExportLocalNoPlatformSplitOverwrite(t *testing.T, sb integration.Sandbo
 	require.Error(t, err)
 	require.ErrorContains(t, err, "cannot overwrite hello-linux from")
 	require.ErrorContains(t, err, "when split option is disabled")
+}
+
+func testExportTarPlatformIDSanitized(t *testing.T, sb integration.Sandbox) {
+	workers.CheckFeatureCompat(t, sb, workers.FeatureOCIExporter, workers.FeatureMultiPlatform)
+	c, err := New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	const platformID = `..\buildkit-outside`
+	platform := platforms.DefaultSpec()
+
+	frontend := func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
+		st := llb.Scratch().File(
+			llb.Mkfile("payload.txt", 0600, []byte("payload")),
+		)
+
+		def, err := st.Marshal(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		r, err := c.Solve(ctx, gateway.SolveRequest{
+			Definition: def.ToPB(),
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		ref, err := r.SingleRef()
+		if err != nil {
+			return nil, err
+		}
+
+		res := gateway.NewResult()
+		res.AddRef(platformID, ref)
+
+		dt, err := json.Marshal(&exptypes.Platforms{
+			Platforms: []exptypes.Platform{{
+				ID:       platformID,
+				Platform: platform,
+			}},
+		})
+		if err != nil {
+			return nil, err
+		}
+		res.AddMeta(exptypes.ExporterPlatformsKey, dt)
+
+		return res, nil
+	}
+
+	outW := bytes.NewBuffer(nil)
+	_, err = c.Build(sb.Context(), SolveOpt{
+		Exports: []ExportEntry{
+			{
+				Type:   ExporterTar,
+				Output: fixedWriteCloser(&iohelper.NopWriteCloser{Writer: outW}),
+			},
+		},
+	}, "", frontend, nil)
+	require.NoError(t, err)
+
+	m, err := testutil.ReadTarToMap(outW.Bytes(), false)
+	require.NoError(t, err)
+
+	for name := range m {
+		require.Falsef(t, strings.HasPrefix(name, "../") ||
+			strings.HasPrefix(name, `..\`) ||
+			strings.Contains(name, `/../`) ||
+			strings.Contains(name, `\..\`) ||
+			strings.Contains(name, `\`) ||
+			strings.Contains(name, ":"),
+			"tar exporter emitted unsafe platform path %q", name)
+	}
+
+	tarPaths := make([]string, 0, len(m))
+	for name := range m {
+		tarPaths = append(tarPaths, name)
+	}
+	sort.Strings(tarPaths)
+
+	expectedPath := path.Join(".._buildkit-outside", integration.UnixOrWindows("payload.txt", "Files/payload.txt"))
+	item := m[expectedPath]
+	require.NotNilf(t, item, "expected sanitized tar path %q in %v", expectedPath, tarPaths)
+	require.Equal(t, "payload", string(item.Data))
 }
 
 func testExporterTargetExists(t *testing.T, sb integration.Sandbox) {

--- a/client/client_export_local_test.go
+++ b/client/client_export_local_test.go
@@ -522,10 +522,25 @@ func testExportTarPlatformIDSanitized(t *testing.T, sb integration.Sandbox) {
 	}
 	sort.Strings(tarPaths)
 
-	expectedPath := path.Join(".._buildkit-outside", integration.UnixOrWindows("payload.txt", "Files/payload.txt"))
-	item := m[expectedPath]
-	require.NotNilf(t, item, "expected sanitized tar path %q in %v", expectedPath, tarPaths)
-	require.Equal(t, "payload", string(item.Data))
+	const platformDir = ".._buildkit-outside"
+	payloadPath := ""
+	for name, item := range m {
+		// The tar can contain directory entries and unrelated files; this test
+		// only verifies that the payload is exported under the sanitized root.
+		if item.Header.Typeflag != tar.TypeReg {
+			continue
+		}
+		if !strings.HasPrefix(name, platformDir+"/") {
+			continue
+		}
+		if path.Base(name) != "payload.txt" {
+			continue
+		}
+		payloadPath = name
+		require.Equal(t, "payload", string(item.Data))
+		break
+	}
+	require.NotEmptyf(t, payloadPath, "expected payload under sanitized tar path %q in %v", platformDir, tarPaths)
 }
 
 func testExporterTargetExists(t *testing.T, sb integration.Sandbox) {

--- a/client/client_export_local_test.go
+++ b/client/client_export_local_test.go
@@ -522,10 +522,23 @@ func testExportTarPlatformIDSanitized(t *testing.T, sb integration.Sandbox) {
 	}
 	sort.Strings(tarPaths)
 
-	expectedPath := path.Join(".._buildkit-outside", integration.UnixOrWindows("payload.txt", "Files/payload.txt"))
-	item := m[expectedPath]
-	require.NotNilf(t, item, "expected sanitized tar path %q in %v", expectedPath, tarPaths)
-	require.Equal(t, "payload", string(item.Data))
+	const platformDir = ".._buildkit-outside"
+	payloadPath := ""
+	for name, item := range m {
+		if item.Header.Typeflag != tar.TypeReg {
+			continue
+		}
+		if !strings.HasPrefix(name, platformDir+"/") {
+			continue
+		}
+		if path.Base(name) != "payload.txt" {
+			continue
+		}
+		payloadPath = name
+		require.Equal(t, "payload", string(item.Data))
+		break
+	}
+	require.NotEmptyf(t, payloadPath, "expected payload under sanitized tar path %q in %v", platformDir, tarPaths)
 }
 
 func testExporterTargetExists(t *testing.T, sb integration.Sandbox) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -88,6 +88,7 @@ var allTests = []func(t *testing.T, sb integration.Sandbox){
 	testExportLocalModeDeleteMultiPlatformKeepsAllPlatforms,
 	testExportLocalNoPlatformSplit,
 	testExportLocalNoPlatformSplitOverwrite,
+	testExportTarPlatformIDSanitized,
 	testExporterTargetExists,
 	testMultipleExporters,
 	testSessionExporter,

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -89,6 +89,7 @@ var allTests = []func(t *testing.T, sb integration.Sandbox){
 	testExportLocalModeDeleteMultiPlatformKeepsAllPlatforms,
 	testExportLocalNoPlatformSplit,
 	testExportLocalNoPlatformSplitOverwrite,
+	testExportTarPlatformIDSanitized,
 	testExporterTargetExists,
 	testMultipleExporters,
 	testSessionExporter,

--- a/exporter/local/export.go
+++ b/exporter/local/export.go
@@ -3,7 +3,6 @@ package local
 import (
 	"context"
 	"os"
-	"strings"
 	"sync"
 	"time"
 
@@ -127,7 +126,7 @@ func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source
 	platformDirStat := func(k string, opt CreateFSOpts) *fstypes.Stat {
 		st := &fstypes.Stat{
 			Mode: uint32(os.ModeDir | 0755),
-			Path: strings.ReplaceAll(k, "/", "_"),
+			Path: PlatformIDToPath(k),
 		}
 		if opt.Epoch != nil && opt.Epoch.Value != nil {
 			st.ModTime = opt.Epoch.Value.UnixNano()

--- a/exporter/local/fs.go
+++ b/exporter/local/fs.go
@@ -199,7 +199,7 @@ func CreateFS(ctx context.Context, sessionID string, k string, ref cache.Immutab
 			if addPlatformToFilename {
 				nameExt := path.Ext(name)
 				namBase := strings.TrimSuffix(name, nameExt)
-				name = fmt.Sprintf("%s.%s%s", namBase, strings.ReplaceAll(k, "/", "_"), nameExt)
+				name = fmt.Sprintf("%s.%s%s", namBase, PlatformIDToPath(k), nameExt)
 			}
 			if _, ok := names[name]; ok {
 				return nil, nil, errors.Errorf("duplicate attestation path name %s", name)

--- a/exporter/local/platform.go
+++ b/exporter/local/platform.go
@@ -1,0 +1,14 @@
+package local
+
+import "strings"
+
+// PlatformIDToPath maps an exporter platform ID to a single path component.
+func PlatformIDToPath(id string) string {
+	id = strings.NewReplacer("/", "_", `\`, "_", ":", "_").Replace(id)
+	switch id {
+	case ".", "..":
+		return strings.Repeat("_", len(id))
+	default:
+		return id
+	}
+}

--- a/exporter/local/platform_test.go
+++ b/exporter/local/platform_test.go
@@ -1,0 +1,50 @@
+package local
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlatformIDToPath(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		id   string
+		want string
+	}{
+		{
+			name: "slashes",
+			id:   "linux/amd64",
+			want: "linux_amd64",
+		},
+		{
+			name: "windows separators",
+			id:   `..\buildkit-outside`,
+			want: ".._buildkit-outside",
+		},
+		{
+			name: "drive separator",
+			id:   `windows/amd64:C`,
+			want: "windows_amd64_C",
+		},
+		{
+			name: "dot",
+			id:   ".",
+			want: "_",
+		},
+		{
+			name: "dot dot",
+			id:   "..",
+			want: "__",
+		},
+		{
+			name: "embedded dots",
+			id:   "linux.v2/amd64",
+			want: "linux.v2_amd64",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, PlatformIDToPath(tc.id))
+		})
+	}
+}

--- a/exporter/tar/export.go
+++ b/exporter/tar/export.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/moby/buildkit/cache"
@@ -109,7 +108,7 @@ func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source
 
 		st := &fstypes.Stat{
 			Mode: uint32(os.ModeDir | 0755),
-			Path: strings.ReplaceAll(k, "/", "_"),
+			Path: local.PlatformIDToPath(k),
 		}
 		if opt.Epoch != nil && opt.Epoch.Value != nil {
 			st.ModTime = opt.Epoch.Value.UnixNano()

--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/spdx/tools-golang v0.5.7
 	github.com/stretchr/testify v1.12.1
 	github.com/tonistiigi/dchapes-mode v0.0.0-20250318174251-73d941a28323
-	github.com/tonistiigi/fsutil v0.0.0-20260717003753-6d9dc2ebad62
+	github.com/tonistiigi/fsutil v0.0.0-20260818132828-ea1b24afbd39
 	github.com/tonistiigi/go-actions-cache v0.0.0-20260120203934-54bc28c26fd2
 	github.com/tonistiigi/go-archvariant v1.0.0
 	github.com/tonistiigi/go-csvvalue v0.0.0-20240814133006-030d3b2625d0

--- a/go.sum
+++ b/go.sum
@@ -584,8 +584,8 @@ github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 h1:e/5i7d4oYZ+C
 github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399/go.mod h1:LdwHTNJT99C5fTAzDz0ud328OgXz+gierycbcIx2fRs=
 github.com/tonistiigi/dchapes-mode v0.0.0-20250318174251-73d941a28323 h1:r0p7fK56l8WPequOaR3i9LBqfPtEdXIQbUTzT55iqT4=
 github.com/tonistiigi/dchapes-mode v0.0.0-20250318174251-73d941a28323/go.mod h1:3Iuxbr0P7D3zUzBMAZB+ois3h/et0shEz0qApgHYGpY=
-github.com/tonistiigi/fsutil v0.0.0-20260717003753-6d9dc2ebad62 h1:uppBiK+tE8tYG6fc0N8VnsC7FMZcWxnXIyaQ9GcUIU8=
-github.com/tonistiigi/fsutil v0.0.0-20260717003753-6d9dc2ebad62/go.mod h1:K5zrLch9UaSGNiek5XHZeqZUf1zPWJHqDfLIcnpquQ4=
+github.com/tonistiigi/fsutil v0.0.0-20260818132828-ea1b24afbd39 h1:g12NNHiPRetQ/siMoRWPGhYnAmfoln1ERSal11ll7Pg=
+github.com/tonistiigi/fsutil v0.0.0-20260818132828-ea1b24afbd39/go.mod h1:K5zrLch9UaSGNiek5XHZeqZUf1zPWJHqDfLIcnpquQ4=
 github.com/tonistiigi/go-actions-cache v0.0.0-20260120203934-54bc28c26fd2 h1:5p6hffZeB25G4rhBc3HU6x1aIlyDELfib+/Omq+ZfQA=
 github.com/tonistiigi/go-actions-cache v0.0.0-20260120203934-54bc28c26fd2/go.mod h1:cD0SB2270BYw6HYKriFn4H6NRLhGj6ytf48YTpsm8LY=
 github.com/tonistiigi/go-archvariant v1.0.0 h1:5LC1eDWiBNflnTF1prCiX09yfNHIxDC/aukdhCdTyb0=

--- a/vendor/github.com/tonistiigi/fsutil/tarwriter.go
+++ b/vendor/github.com/tonistiigi/fsutil/tarwriter.go
@@ -15,7 +15,7 @@ import (
 
 func WriteTar(ctx context.Context, fs FS, w io.Writer) error {
 	tw := tar.NewWriter(w)
-	err := fs.Walk(ctx, "/", func(path string, entry os.DirEntry, err error) error {
+	err := fs.Walk(ctx, "", func(path string, entry os.DirEntry, err error) error {
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
@@ -33,6 +33,7 @@ func WriteTar(ctx context.Context, fs FS, w io.Writer) error {
 			return err
 		}
 
+		// Tar paths use slash separators on the wire.
 		name := filepath.ToSlash(path)
 		if fi.IsDir() && !strings.HasSuffix(name, "/") {
 			name += "/"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1039,7 +1039,7 @@ github.com/theupdateframework/go-tuf/v2/metadata/updater
 # github.com/tonistiigi/dchapes-mode v0.0.0-20250318174251-73d941a28323
 ## explicit; go 1.21
 github.com/tonistiigi/dchapes-mode
-# github.com/tonistiigi/fsutil v0.0.0-20260717003753-6d9dc2ebad62
+# github.com/tonistiigi/fsutil v0.0.0-20260818132828-ea1b24afbd39
 ## explicit; go 1.25.0
 github.com/tonistiigi/fsutil
 github.com/tonistiigi/fsutil/copy


### PR DESCRIPTION
~needs https://github.com/tonistiigi/fsutil/pull/275~

This restores the platform ID path sanitization from https://github.com/moby/buildkit/pull/6910 after it was reverted in https://github.com/moby/buildkit/pull/6935.

The first commit cherry-picks original sanitizer onto the current tree, with the integration test moved into the split client exporter test file. The second commit fixes the regression test by checking that the payload exists under the sanitized platform directory instead of requiring one exact Windows rootfs path.