### PR TITLE
ci: enable all rules for testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -106,6 +106,7 @@ linters:
         - bool-compare
         - len
         - negative-positive
+      enable-all: true
     usetesting:
       context-background: true
       context-todo: true

--- a/cache/contenthash/checksum_test.go
+++ b/cache/contenthash/checksum_test.go
@@ -512,12 +512,10 @@ func TestSymlinksNoFollow(t *testing.T) {
 	require.Equal(t, expectedSym, dgst)
 
 	_, err = cc.Checksum(t.Context(), ref, "foo/ghi", ChecksumOpts{FollowLinks: true, Wildcard: true}, nil) // same because broken symlink
-	require.Error(t, err)
-	require.Equal(t, true, errors.Is(err, errNotFound))
+	require.ErrorIs(t, err, errNotFound)
 
 	_, err = cc.Checksum(t.Context(), ref, "y1", ChecksumOpts{FollowLinks: true, Wildcard: true}, nil)
-	require.Error(t, err)
-	require.Equal(t, true, errors.Is(err, errNotFound))
+	require.ErrorIs(t, err, errNotFound)
 
 	dgst, err = cc.Checksum(t.Context(), ref, "sym", ChecksumOpts{}, nil)
 	require.NoError(t, err)
@@ -611,8 +609,7 @@ func TestChecksumBasicFile(t *testing.T) {
 	require.Equal(t, dgstFileData0, dgst)
 
 	_, err = cc.Checksum(t.Context(), ref, "d0/ghi", ChecksumOpts{FollowLinks: true}, nil)
-	require.Error(t, err)
-	require.Equal(t, true, errors.Is(err, errNotFound))
+	require.ErrorIs(t, err, errNotFound)
 
 	dgst, err = cc.Checksum(t.Context(), ref, "/", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
@@ -1062,12 +1059,10 @@ func TestHandleChange(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = cc.Checksum(t.Context(), ref, "d0", ChecksumOpts{FollowLinks: true}, nil)
-	require.Error(t, err)
-	require.Equal(t, true, errors.Is(err, errNotFound))
+	require.ErrorIs(t, err, errNotFound)
 
 	_, err = cc.Checksum(t.Context(), ref, "d0/abc", ChecksumOpts{FollowLinks: true}, nil)
-	require.Error(t, err)
-	require.Equal(t, true, errors.Is(err, errNotFound))
+	require.ErrorIs(t, err, errNotFound)
 
 	err = ref.Release(t.Context())
 	require.NoError(t, err)

--- a/cache/contenthash/checksum_test.go
+++ b/cache/contenthash/checksum_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/moby/buildkit/util/winlayers"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tonistiigi/fsutil"
 	fstypes "github.com/tonistiigi/fsutil/types"
@@ -459,7 +460,7 @@ func TestChecksumWildcardWithBadMountable(t *testing.T) {
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, snapshotter.Close())
+		assert.NoError(t, snapshotter.Close())
 	})
 
 	cm, cleanup := setupCacheManager(t, tmpdir, "native", snapshotter)
@@ -997,7 +998,7 @@ func TestHandleChange(t *testing.T) {
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, snapshotter.Close())
+		assert.NoError(t, snapshotter.Close())
 	})
 
 	cm, cleanup := setupCacheManager(t, tmpdir, "native", snapshotter)
@@ -1075,7 +1076,7 @@ func TestHandleRecursiveDir(t *testing.T) {
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, snapshotter.Close())
+		assert.NoError(t, snapshotter.Close())
 	})
 
 	cm, cleanup := setupCacheManager(t, tmpdir, "native", snapshotter)
@@ -1126,7 +1127,7 @@ func TestChecksumUnorderedFiles(t *testing.T) {
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, snapshotter.Close())
+		assert.NoError(t, snapshotter.Close())
 	})
 
 	cm, cleanup := setupCacheManager(t, tmpdir, "native", snapshotter)
@@ -1319,7 +1320,7 @@ func TestSymlinkInPathHandleChange(t *testing.T) {
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, snapshotter.Close())
+		assert.NoError(t, snapshotter.Close())
 	})
 
 	cm, cleanup := setupCacheManager(t, tmpdir, "native", snapshotter)
@@ -1438,7 +1439,7 @@ func TestChecksumUpdateDirectory(t *testing.T) {
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, snapshotter.Close())
+		assert.NoError(t, snapshotter.Close())
 	})
 
 	cm, cleanup := setupCacheManager(t, tmpdir, "native", snapshotter)

--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -602,7 +602,7 @@ func TestMissingMaterializedLowerDiffExtract(t *testing.T) {
 		ref, err := cm.GetByBlob(ctx, desc, nil)
 		require.NoError(t, err)
 		t.Cleanup(func() {
-			require.NoError(t, ref.Release(context.WithoutCancel(ctx)))
+			assert.NoError(t, ref.Release(context.WithoutCancel(ctx)))
 		})
 		refs = append(refs, ref)
 	}
@@ -613,7 +613,7 @@ func TestMissingMaterializedLowerDiffExtract(t *testing.T) {
 	diff, err := cm.Diff(ctx, refs[0], refs[1], nil)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, diff.Release(context.WithoutCancel(ctx)))
+		assert.NoError(t, diff.Release(context.WithoutCancel(ctx)))
 	})
 
 	lowerID := refs[0].(*immutableRef).getSnapshotID()

--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -244,8 +244,7 @@ func TestManager(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = cm.GetMutable(ctx, active.ID())
-	require.Error(t, err)
-	require.Equal(t, true, errors.Is(err, ErrLocked))
+	require.ErrorIs(t, err, ErrLocked)
 
 	checkDiskUsage(ctx, t, cm, 1, 0)
 
@@ -255,8 +254,7 @@ func TestManager(t *testing.T) {
 	checkDiskUsage(ctx, t, cm, 1, 0)
 
 	_, err = cm.GetMutable(ctx, active.ID())
-	require.Error(t, err)
-	require.Equal(t, true, errors.Is(err, ErrLocked))
+	require.ErrorIs(t, err, ErrLocked)
 
 	err = snap.Release(ctx)
 	require.NoError(t, err)
@@ -280,12 +278,10 @@ func TestManager(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = cm.GetMutable(ctx, active.ID())
-	require.Error(t, err)
-	require.Equal(t, true, errors.Is(err, errNotFound))
+	require.ErrorIs(t, err, errNotFound)
 
 	_, err = cm.GetMutable(ctx, snap.ID())
-	require.Error(t, err)
-	require.Equal(t, true, errors.Is(err, errInvalid))
+	require.ErrorIs(t, err, errInvalid)
 
 	snap, err = cm.Get(ctx, snap.ID(), nil)
 	require.NoError(t, err)
@@ -1053,8 +1049,7 @@ func TestLazyCommit(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = cm.GetMutable(ctx, active.ID())
-	require.Error(t, err)
-	require.Equal(t, true, errors.Is(err, ErrLocked))
+	require.ErrorIs(t, err, ErrLocked)
 
 	// immutable refs still work
 	snap2, err := cm.Get(ctx, snap.ID(), nil)
@@ -1074,8 +1069,7 @@ func TestLazyCommit(t *testing.T) {
 
 	// active can't be get while immutable is held
 	_, err = cm.GetMutable(ctx, active.ID())
-	require.Error(t, err)
-	require.Equal(t, true, errors.Is(err, ErrLocked))
+	require.ErrorIs(t, err, ErrLocked)
 
 	err = snap.Release(ctx)
 	require.NoError(t, err)
@@ -1087,8 +1081,7 @@ func TestLazyCommit(t *testing.T) {
 
 	// because ref was took mutable old immutable are cleared
 	_, err = cm.Get(ctx, snap.ID(), nil)
-	require.Error(t, err)
-	require.Equal(t, true, errors.Is(err, errNotFound))
+	require.ErrorIs(t, err, errNotFound)
 
 	snap, err = active2.Commit(ctx)
 	require.NoError(t, err)
@@ -1102,8 +1095,7 @@ func TestLazyCommit(t *testing.T) {
 
 	// mutable is gone after finalize
 	_, err = cm.GetMutable(ctx, active2.ID())
-	require.Error(t, err)
-	require.Equal(t, true, errors.Is(err, errNotFound))
+	require.ErrorIs(t, err, errNotFound)
 
 	// immutable still works
 	snap2, err = cm.Get(ctx, snap.ID(), nil)
@@ -1145,8 +1137,7 @@ func TestLazyCommit(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = cm.Get(ctx, snap.ID(), nil)
-	require.Error(t, err)
-	require.Equal(t, true, errors.Is(err, errNotFound))
+	require.ErrorIs(t, err, errNotFound)
 
 	snap, err = active.Commit(ctx)
 	require.NoError(t, err)
@@ -1175,8 +1166,7 @@ func TestLazyCommit(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = cm.GetMutable(ctx, active.ID())
-	require.Error(t, err)
-	require.Equal(t, true, errors.Is(err, errNotFound))
+	require.ErrorIs(t, err, errNotFound)
 }
 
 func TestLoopLeaseContent(t *testing.T) {

--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -53,6 +53,7 @@ import (
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	bolt "go.etcd.io/bbolt"
 	"golang.org/x/sync/errgroup"
@@ -209,7 +210,7 @@ func TestManager(t *testing.T) {
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, snapshotter.Close())
+		assert.NoError(t, snapshotter.Close())
 	})
 
 	co, cleanup, err := newCacheManager(ctx, t, cmOpt{
@@ -745,7 +746,7 @@ func TestSetBlob(t *testing.T) {
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, snapshotter.Close())
+		assert.NoError(t, snapshotter.Close())
 	})
 
 	co, cleanup, err := newCacheManager(ctx, t, cmOpt{
@@ -918,7 +919,7 @@ func TestPrune(t *testing.T) {
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, snapshotter.Close())
+		assert.NoError(t, snapshotter.Close())
 	})
 
 	co, cleanup, err := newCacheManager(ctx, t, cmOpt{
@@ -1030,7 +1031,7 @@ func TestLazyCommit(t *testing.T) {
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, snapshotter.Close())
+		assert.NoError(t, snapshotter.Close())
 	})
 
 	co, cleanup, err := newCacheManager(ctx, t, cmOpt{
@@ -1798,7 +1799,7 @@ func TestGetRemotes(t *testing.T) {
 					case compression.Zstd:
 						require.Equal(t, ocispecs.MediaTypeImageLayerZstd, desc.MediaType)
 					default:
-						require.Fail(t, "unhandled media type", compressionType)
+						t.Errorf("unhandled media type %s", compressionType)
 					}
 					dgst := desc.Digest
 					require.Contains(t, expectedContent, dgst, "for %v", compressionType)
@@ -2310,7 +2311,7 @@ func TestLoadHalfFinalizedRef(t *testing.T) {
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, snapshotter.Close())
+		assert.NoError(t, snapshotter.Close())
 	})
 
 	co, cleanup, err := newCacheManager(ctx, t, cmOpt{
@@ -2457,7 +2458,7 @@ func TestLoadBrokenParents(t *testing.T) {
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, snapshotter.Close())
+		assert.NoError(t, snapshotter.Close())
 	})
 
 	co, cleanup, err := newCacheManager(ctx, t, cmOpt{

--- a/cache/util/fsutil_test.go
+++ b/cache/util/fsutil_test.go
@@ -21,11 +21,10 @@ func TestSetErrorPath(t *testing.T) {
 	// Random path that shouldn't exist.
 	fpath := path.Join(dir, "a/b/c")
 	_, err := fsutil.Stat(fpath)
-	require.Error(t, err)
-
 	require.ErrorContains(t, err, "a/b/c")
+
 	// Set the path in the error to a new path.
 	replaceErrorPath(err, "/my/new/path")
 	require.NotContains(t, err.Error(), "a/b/c")
-	require.Contains(t, err.Error(), "/my/new/path")
+	require.ErrorContains(t, err, "/my/new/path")
 }

--- a/client/client_cache_test.go
+++ b/client/client_cache_test.go
@@ -480,9 +480,7 @@ func testCacheExportCacheDeletedContent(t *testing.T, sb integration.Sandbox) {
 	var runLayer *int
 	for i, l := range cc.Layers {
 		if l.ParentIndex != -1 {
-			if runLayer != nil {
-				t.Fatal("multiple RUN layers")
-			}
+			require.Nil(t, runLayer, "multiple RUN layers")
 			runLayer = &i
 		}
 	}
@@ -720,7 +718,7 @@ func testCacheExportIgnoreError(t *testing.T, sb integration.Sandbox) {
 				} else {
 					require.Error(t, err)
 					for _, errStr := range test.expectedErrors {
-						require.Contains(t, err.Error(), errStr)
+						require.ErrorContains(t, err, errStr)
 					}
 				}
 			})

--- a/client/client_cdi_test.go
+++ b/client/client_cdi_test.go
@@ -146,7 +146,6 @@ devices:
 			},
 		},
 	}, nil)
-	require.Error(t, err)
 	require.ErrorContains(t, err, "requested by the build but not allowed")
 }
 
@@ -455,8 +454,6 @@ func writeCDISpecFile(t *testing.T, sb integration.Sandbox, c *Client, csf ...cd
 			return
 		}
 
-		if now.After(deadline) {
-			t.Fatal("timeout waiting for CDI devices to appear")
-		}
+		require.LessOrEqualf(t, now, deadline, "timeout waiting for CDI devices to appear")
 	}
 }

--- a/client/client_exec_test.go
+++ b/client/client_exec_test.go
@@ -308,7 +308,6 @@ func testRunValidExitCodes(t *testing.T, sb integration.Sandbox) {
 	def, err := out.Marshal(sb.Context())
 	require.NoError(t, err)
 	_, err = c.Solve(sb.Context(), def, SolveOpt{}, nil)
-	require.Error(t, err)
 	require.ErrorContains(t, err, "exit code: 1")
 
 	// empty exit codes, equivalent to [0]
@@ -335,7 +334,6 @@ func testRunValidExitCodes(t *testing.T, sb integration.Sandbox) {
 	def, err = out.Marshal(sb.Context())
 	require.NoError(t, err)
 	_, err = c.Solve(sb.Context(), def, SolveOpt{}, nil)
-	require.Error(t, err)
 	require.ErrorContains(t, err, "exit code: 0")
 }
 
@@ -427,8 +425,7 @@ func testSecurityModeErrors(t *testing.T, sb integration.Sandbox) {
 		_, err = c.Solve(sb.Context(), def, SolveOpt{
 			AllowedEntitlements: []string{entitlements.EntitlementSecurityInsecure.String()},
 		}, nil)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "security.insecure is not allowed")
+		require.ErrorContains(t, err, "security.insecure is not allowed")
 	}
 	if secMode == securityInsecure {
 		st := llb.Image("busybox:latest").
@@ -438,8 +435,7 @@ func testSecurityModeErrors(t *testing.T, sb integration.Sandbox) {
 		require.NoError(t, err)
 
 		_, err = c.Solve(sb.Context(), def, SolveOpt{}, nil)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "security.insecure is not allowed")
+		require.ErrorContains(t, err, "security.insecure is not allowed")
 	}
 
 	st := llb.Image("busybox:latest").
@@ -485,8 +481,7 @@ func testSecurityModeErrors(t *testing.T, sb integration.Sandbox) {
 	require.True(t, foundExec)
 
 	_, err = c.Solve(sb.Context(), def, SolveOpt{}, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid security mode")
+	require.ErrorContains(t, err, "invalid security mode")
 }
 
 func testSecurityModeSysfs(t *testing.T, sb integration.Sandbox) {
@@ -528,9 +523,8 @@ func testSecurityModeSysfs(t *testing.T, sb integration.Sandbox) {
 	}, nil)
 
 	if secMode == securitySandbox {
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "did not complete successfully")
-		require.Contains(t, err.Error(), "mkdir "+cg)
+		require.ErrorContains(t, err, "did not complete successfully")
+		require.ErrorContains(t, err, "mkdir "+cg)
 	} else {
 		require.NoError(t, err)
 	}

--- a/client/client_export_image_test.go
+++ b/client/client_export_image_test.go
@@ -902,21 +902,18 @@ func testExportedImageLabels(t *testing.T, sb integration.Sandbox) {
 
 	// layers should be deleted
 	_, err = store.Info(ctx, mfst.Layers[1].Digest)
-	require.Error(t, err)
-	require.True(t, errors.Is(err, cerrdefs.ErrNotFound))
+	require.ErrorIs(t, err, cerrdefs.ErrNotFound)
 
 	// config should be deleted
 	_, err = store.Info(ctx, mfst.Config.Digest)
-	require.Error(t, err)
-	require.True(t, errors.Is(err, cerrdefs.ErrNotFound))
+	require.ErrorIs(t, err, cerrdefs.ErrNotFound)
 
 	// buildkit contentstore still has the layer because it is multi-ns
 	bkstore := proxy.NewContentStore(c.ContentClient())
 
 	// layer should be deleted as not kept by history
 	_, err = bkstore.Info(ctx, mfst.Layers[1].Digest)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "not found")
+	require.ErrorContains(t, err, "not found")
 
 	// config should still be there
 	_, err = bkstore.Info(ctx, img.Metadata().Target.Digest)
@@ -1606,8 +1603,7 @@ func testPullWithDigestCheck(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 
 	_, err = c.Solve(sb.Context(), def, SolveOpt{}, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("image digest %s for %s does not match expected checksum %s", dgst2, name2, dgst1))
+	require.ErrorContains(t, err, fmt.Sprintf("image digest %s for %s does not match expected checksum %s", dgst2, name2, dgst1))
 }
 
 // testPullZstdImage verifies pulling and re-exporting a Zstd-compressed image.

--- a/client/client_export_local_test.go
+++ b/client/client_export_local_test.go
@@ -677,7 +677,7 @@ func testMultipleExporters(t *testing.T, sb integration.Sandbox) {
 	for {
 		ev, err := history.Recv()
 		if err != nil {
-			require.Equal(t, io.EOF, err)
+			require.ErrorIs(t, err, io.EOF)
 			break
 		}
 		require.Equal(t, ref, ev.Record.Ref)

--- a/client/client_export_local_test.go
+++ b/client/client_export_local_test.go
@@ -439,7 +439,6 @@ func testExportLocalNoPlatformSplitOverwrite(t *testing.T, sb integration.Sandbo
 			},
 		},
 	}, "", frontend, nil)
-	require.Error(t, err)
 	require.ErrorContains(t, err, "cannot overwrite hello-linux from")
 	require.ErrorContains(t, err, "when split option is disabled")
 }

--- a/client/client_export_metadata_test.go
+++ b/client/client_export_metadata_test.go
@@ -459,7 +459,7 @@ func testExportAnnotations(t *testing.T, sb integration.Sandbox) {
 			require.Equal(t, "arm64 manifest descriptor", desc.Annotations["md"])
 			require.Equal(t, "arm64 manifest descriptor opt", desc.Annotations["mdo"])
 		default:
-			require.Fail(t, "unrecognized platform")
+			t.Error("unrecognized platform")
 		}
 	}
 
@@ -548,7 +548,7 @@ func testExportAnnotations(t *testing.T, sb integration.Sandbox) {
 			require.Equal(t, "arm64 manifest opt", mfst.Annotations["mo"])
 			require.Equal(t, "arm64 manifest descriptor opt", desc.Annotations["mdo"])
 		default:
-			require.Fail(t, "unrecognized platform")
+			t.Error("unrecognized platform")
 		}
 	}
 }

--- a/client/client_export_metadata_test.go
+++ b/client/client_export_metadata_test.go
@@ -2090,7 +2090,7 @@ func testSourceDateEpochImageExporter(t *testing.T, sb integration.Sandbox) {
 
 	img, err := client.GetImage(ctx, name)
 	require.NoError(t, err)
-	require.Equal(t, tm, img.Metadata().CreatedAt)
+	require.WithinDuration(t, tm, img.Metadata().CreatedAt, 0)
 
 	err = client.ImageService().Delete(ctx, name, images.SynchronousDelete())
 	require.NoError(t, err)

--- a/client/client_fileop_test.go
+++ b/client/client_fileop_test.go
@@ -52,7 +52,7 @@ func testCopyFromEmptyImage(t *testing.T, sb integration.Sandbox) {
 			"/foo: no such file or directory",
 			winErrMsgs[i],
 		)
-		require.Contains(t, err.Error(), errMsg)
+		require.ErrorContains(t, err, errMsg)
 
 		imgName := integration.UnixOrWindows(
 			"busybox:latest",
@@ -514,7 +514,7 @@ func testFileOpInputSwap(t *testing.T, sb integration.Sandbox) {
 		"bar: no such file",
 		"bar: The system cannot find the file specified",
 	)
-	require.Contains(t, err.Error(), errStr)
+	require.ErrorContains(t, err, errStr)
 }
 
 func testFileOpMkdirMkfile(t *testing.T, sb integration.Sandbox) {
@@ -690,7 +690,7 @@ func testFileOpSymlink(t *testing.T, sb integration.Sandbox) {
 	require.Equal(t, linkGroup, header.Gid)
 
 	// ensure it was timestamped properly
-	require.Equal(t, dummyTime, header.ModTime)
+	require.WithinDuration(t, dummyTime, header.ModTime, 0)
 }
 
 // #2490

--- a/client/client_http_source_test.go
+++ b/client/client_http_source_test.go
@@ -52,8 +52,7 @@ func testBuildHTTPSource(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 
 	_, err = c.Solve(sb.Context(), def, SolveOpt{}, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid response status 404")
+	require.ErrorContains(t, err, "invalid response status 404")
 
 	// first correct request
 	st = llb.HTTP(server.URL + "/foo")
@@ -461,9 +460,7 @@ func testBuildHTTPSourcePGPSignatureVerify(t *testing.T, sb integration.Sandbox)
 				Signature: sigData,
 			}),
 		)
-		err = solve(t, invalidState)
-		require.Error(t, err)
-		require.ErrorContains(t, err, "failed to verify pgp signature")
+		require.ErrorContains(t, solve(t, invalidState), "failed to verify pgp signature")
 	})
 
 	t.Run("concatenated-pubkeys-right-key-second", func(t *testing.T) {
@@ -521,7 +518,6 @@ func testBuildHTTPSourceUnauthorizedChecksumRace(t *testing.T, sb integration.Sa
 				},
 			},
 		}, nil)
-		require.Error(t, err)
 		require.ErrorContains(t, err, "invalid response status 401")
 	}
 }

--- a/client/client_http_source_test.go
+++ b/client/client_http_source_test.go
@@ -460,7 +460,8 @@ func testBuildHTTPSourcePGPSignatureVerify(t *testing.T, sb integration.Sandbox)
 				Signature: sigData,
 			}),
 		)
-		require.ErrorContains(t, solve(t, invalidState), "failed to verify pgp signature")
+		err = solve(t, invalidState)
+		require.ErrorContains(t, err, "failed to verify pgp signature")
 	})
 
 	t.Run("concatenated-pubkeys-right-key-second", func(t *testing.T) {

--- a/client/client_image_source_test.go
+++ b/client/client_image_source_test.go
@@ -204,8 +204,7 @@ func testPullWithLayerLimit(t *testing.T, sb integration.Sandbox) {
 	require.Equal(t, "second", string(dt))
 
 	_, err = os.ReadFile(filepath.Join(destDir, "third"))
-	require.Error(t, err)
-	require.True(t, errors.Is(err, os.ErrNotExist))
+	require.ErrorIs(t, err, os.ErrNotExist)
 
 	dt, err = os.ReadFile(filepath.Join(destDir, "forth"))
 	require.NoError(t, err)
@@ -231,12 +230,10 @@ func testPullWithLayerLimit(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 
 	_, err = os.ReadFile(filepath.Join(destDir, "first"))
-	require.Error(t, err)
-	require.True(t, errors.Is(err, os.ErrNotExist))
+	require.ErrorIs(t, err, os.ErrNotExist)
 
 	_, err = os.ReadFile(filepath.Join(destDir, "second"))
-	require.Error(t, err)
-	require.True(t, errors.Is(err, os.ErrNotExist))
+	require.ErrorIs(t, err, os.ErrNotExist)
 
 	dt, err = os.ReadFile(filepath.Join(destDir, "third"))
 	require.NoError(t, err)
@@ -253,8 +250,7 @@ func testPullWithLayerLimit(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 
 	_, err = c.Solve(sb.Context(), def, SolveOpt{}, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid layer limit")
+	require.ErrorContains(t, err, "invalid layer limit")
 }
 
 func testValidateDigestOrigin(t *testing.T, sb integration.Sandbox) {

--- a/client/client_mergeop_test.go
+++ b/client/client_mergeop_test.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -248,7 +247,7 @@ func testMergeOpCache(t *testing.T, sb integration.Sandbox, mode string) {
 			},
 		}}
 	default:
-		require.Fail(t, fmt.Sprintf("unknown cache mode: %s", mode))
+		t.Errorf("unknown cache mode: %s", mode)
 	}
 
 	_, err = c.Solve(sb.Context(), def, SolveOpt{
@@ -377,7 +376,7 @@ func testMergeOpCache(t *testing.T, sb integration.Sandbox, mode string) {
 			_, err = contentStore.Info(ctx, layer.Digest)
 			require.NoError(t, err)
 		default:
-			require.Fail(t, fmt.Sprintf("unexpected layer index %d", i))
+			t.Errorf("unexpected layer index %d", i)
 		}
 	}
 

--- a/client/client_mount_test.go
+++ b/client/client_mount_test.go
@@ -647,7 +647,7 @@ func testReadonlyRootFS(t *testing.T, sb integration.Sandbox) {
 	// Would prefer to detect more specifically "Read-only file
 	// system" but that isn't exposed here (it is on the stdio
 	// which we don't see).
-	require.Contains(t, err.Error(), "process \"/bin/touch /foo\" did not complete successfully")
+	require.ErrorContains(t, err, "process \"/bin/touch /foo\" did not complete successfully")
 
 	checkAllReleasable(t, c, sb, true)
 }
@@ -976,8 +976,7 @@ func testSSHMount(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 
 	_, err = c.Solve(sb.Context(), def, SolveOpt{}, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "no SSH key ")
+	require.ErrorContains(t, err, "no SSH key ")
 
 	// custom ID not exposed
 	st = llb.Image("busybox:latest").Run(llb.Shlex(`nosuchcmd`), llb.AddSSHSocket(llb.SSHID("customID")))
@@ -987,8 +986,7 @@ func testSSHMount(t *testing.T, sb integration.Sandbox) {
 	_, err = c.Solve(sb.Context(), def, SolveOpt{
 		Session: []session.Attachable{ssh},
 	}, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "unset ssh forward key customID")
+	require.ErrorContains(t, err, "unset ssh forward key customID")
 
 	// missing custom ID ignored on optional
 	st = llb.Image("busybox:latest").Run(llb.Shlex(`ls`), llb.AddSSHSocket(llb.SSHID("customID"), llb.SSHOptional))

--- a/client/client_mount_test.go
+++ b/client/client_mount_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/moby/buildkit/util/testutil"
 	"github.com/moby/buildkit/util/testutil/integration"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh/agent"
 )
@@ -1138,7 +1139,7 @@ func makeSSHAgentSock(t *testing.T, agent agent.Agent) (p string, err error) {
 		return "", err
 	}
 	t.Cleanup(func() {
-		require.NoError(t, l.Close())
+		assert.NoError(t, l.Close())
 	})
 
 	s := &server{l: l}

--- a/client/client_network_test.go
+++ b/client/client_network_test.go
@@ -226,8 +226,7 @@ func testNetworkMode(t *testing.T, sb integration.Sandbox) {
 		// Currently disabled globally by default
 		// AllowedEntitlements: []entitlements.Entitlement{entitlements.EntitlementNetworkHost},
 	}, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "network.host is not allowed")
+	require.ErrorContains(t, err, "network.host is not allowed")
 }
 
 func testProxyEnv(t *testing.T, sb integration.Sandbox) {

--- a/client/client_utils_test.go
+++ b/client/client_utils_test.go
@@ -179,7 +179,7 @@ loop0:
 						t.Logf("data: %+v %q", err, string(dt[:n]))
 					}
 				}
-				require.FailNowf(t, "content still exists", "%+v", infos)
+				t.Fatalf("content still exists: %+v", infos)
 			}
 			retries++
 			time.Sleep(500 * time.Millisecond)

--- a/client/compatibility_test.go
+++ b/client/compatibility_test.go
@@ -638,7 +638,7 @@ func readCompatibilityActualFromProvider(ctx context.Context, t *testing.T, prov
 			return readCompatibilityActualFromProvider(ctx, t, provider, manifestDesc)
 		}
 
-		require.FailNow(t, "missing platform manifest in image index")
+		t.Fatal("missing platform manifest in image index")
 	}
 
 	manifestDT, err := content.ReadBlob(ctx, provider, desc)

--- a/client/connhelper/dockercontainer/dockercontainer_test.go
+++ b/client/connhelper/dockercontainer/dockercontainer_test.go
@@ -19,9 +19,7 @@ func TestSpecFromURL(t *testing.T) {
 	}
 	for s, expected := range cases {
 		u, err := url.Parse(s)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		got, err := SpecFromURL(u)
 		if expected != nil {
 			require.NoError(t, err)

--- a/client/connhelper/kubepod/kubepod_test.go
+++ b/client/connhelper/kubepod/kubepod_test.go
@@ -25,9 +25,7 @@ func TestSpecFromURL(t *testing.T) {
 	}
 	for s, expected := range cases {
 		u, err := url.Parse(s)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		got, err := SpecFromURL(u)
 		if expected != nil {
 			require.NoError(t, err)

--- a/client/connhelper/nerdctlcontainer/nerdctlcontainer_test.go
+++ b/client/connhelper/nerdctlcontainer/nerdctlcontainer_test.go
@@ -16,9 +16,7 @@ func TestSpecFromURL(t *testing.T) {
 	}
 	for s, expected := range cases {
 		u, err := url.Parse(s)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		got, err := SpecFromURL(u)
 		if expected != nil {
 			require.NoError(t, err)

--- a/client/connhelper/podmancontainer/podmancontainer_test.go
+++ b/client/connhelper/podmancontainer/podmancontainer_test.go
@@ -16,9 +16,7 @@ func TestSpecFromURL(t *testing.T) {
 	}
 	for s, expected := range cases {
 		u, err := url.Parse(s)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		got, err := SpecFromURL(u)
 		if expected != nil {
 			require.NoError(t, err)

--- a/client/connhelper/ssh/ssh_test.go
+++ b/client/connhelper/ssh/ssh_test.go
@@ -25,9 +25,7 @@ func TestSpecFromURL(t *testing.T) {
 	}
 	for s, expected := range cases {
 		u, err := url.Parse(s)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		got, err := SpecFromURL(u)
 		if expected != nil {
 			require.NoError(t, err)

--- a/client/gateway_container_exec_test.go
+++ b/client/gateway_container_exec_test.go
@@ -94,8 +94,7 @@ func testClientGatewayContainerCancelExecTty(t *testing.T, sb integration.Sandbo
 	}
 
 	_, err = c.Build(ctx, SolveOpt{}, product, b, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), context.Canceled.Error())
+	require.ErrorContains(t, err, context.Canceled.Error())
 
 	inputW.Close()
 	inputR.Close()
@@ -162,10 +161,10 @@ func testClientGatewayContainerCancelOnRelease(t *testing.T, sb integration.Sand
 
 		ctr.Release(ctx)
 		err = pid1.Wait()
-		require.Contains(t, err.Error(), context.Canceled.Error())
+		require.ErrorContains(t, err, context.Canceled.Error())
 
 		err = pid2.Wait()
-		require.Contains(t, err.Error(), context.Canceled.Error())
+		require.ErrorContains(t, err, context.Canceled.Error())
 
 		return &client.Result{}, nil
 	}
@@ -478,7 +477,6 @@ func testClientGatewayContainerExecTty(t *testing.T, sb integration.Sandbox) {
 	}
 
 	_, err = c.Build(ctx, SolveOpt{}, product, b, nil)
-	require.Error(t, err)
 	var exitError *gatewayapi.ExitError
 	require.ErrorAs(t, err, &exitError)
 	require.Equal(t, uint32(99), exitError.ExitCode)
@@ -555,7 +553,6 @@ func testClientGatewayContainerPID1Exit(t *testing.T, sb integration.Sandbox) {
 	}
 
 	_, err = c.Build(ctx, SolveOpt{}, product, b, nil)
-	require.Error(t, err)
 	var exitError *gatewayapi.ExitError
 	require.ErrorAs(t, err, &exitError)
 	require.Equal(t, uint32(137), exitError.ExitCode)
@@ -880,7 +877,6 @@ func testClientGatewayExecError(t *testing.T, sb integration.Sandbox) {
 					Evaluate:   true,
 					Definition: def.ToPB(),
 				})
-				require.Error(t, solveErr)
 
 				var se *errdefs.SolveError
 				require.ErrorAs(t, solveErr, &se)
@@ -1041,7 +1037,6 @@ func testClientGatewayExecFileActionError(t *testing.T, sb integration.Sandbox) 
 					Evaluate:   true,
 					Definition: def.ToPB(),
 				})
-				require.Error(t, err)
 
 				var se *errdefs.SolveError
 				require.ErrorAs(t, err, &se)
@@ -1155,7 +1150,6 @@ func testClientGatewaySlowCacheExecError(t *testing.T, sb integration.Sandbox) {
 			Evaluate:   true,
 			Definition: def.ToPB(),
 		})
-		require.Error(t, solveErr)
 
 		var se *errdefs.SolveError
 		require.ErrorAs(t, solveErr, &se)

--- a/client/gateway_container_mount_test.go
+++ b/client/gateway_container_mount_test.go
@@ -239,8 +239,7 @@ func testClientGatewayContainerMounts(t *testing.T, sb integration.Sandbox) {
 			}),
 		},
 	}, product, b, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), context.Canceled.Error())
+	require.ErrorContains(t, err, context.Canceled.Error())
 
 	checkAllReleasable(t, c, sb, true)
 }

--- a/client/gateway_container_network_test.go
+++ b/client/gateway_container_network_test.go
@@ -171,8 +171,7 @@ func testClientGatewayContainerHostNetworking(t *testing.T, sb integration.Sandb
 
 		if netMode == pb.NetMode_HOST {
 			if expectFail {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "network.host is not allowed")
+				require.ErrorContains(t, err, "network.host is not allowed")
 			} else {
 				require.NoError(t, err)
 			}

--- a/client/gateway_container_security_test.go
+++ b/client/gateway_container_security_test.go
@@ -78,8 +78,7 @@ func testClientGatewayContainerInvalidSecurityMode(t *testing.T, sb integration.
 	}
 
 	_, err = c.Build(ctx, SolveOpt{}, "buildkit_test", b, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid security mode")
+	require.ErrorContains(t, err, "invalid security mode")
 }
 
 func testClientGatewayContainerSecurityMode(t *testing.T, sb integration.Sandbox, expectFail bool) {
@@ -180,8 +179,7 @@ func testClientGatewayContainerSecurityMode(t *testing.T, sb integration.Sandbox
 		t.Logf("Stderr: %q", stderr.String())
 
 		if expectFail {
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "security.insecure is not allowed")
+			require.ErrorContains(t, err, "security.insecure is not allowed")
 			return nil, err
 		}
 
@@ -201,8 +199,7 @@ func testClientGatewayContainerSecurityMode(t *testing.T, sb integration.Sandbox
 	_, err = c.Build(ctx, solveOpts, product, b, nil)
 
 	if expectFail {
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "security.insecure is not allowed")
+		require.ErrorContains(t, err, "security.insecure is not allowed")
 	} else {
 		require.NoError(t, err)
 	}

--- a/client/gateway_solve_test.go
+++ b/client/gateway_solve_test.go
@@ -104,8 +104,7 @@ func testClientGatewayFailedSolve(t *testing.T, sb integration.Sandbox) {
 	}
 
 	_, err = c.Build(ctx, SolveOpt{}, "", b, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "expected to fail")
+	require.ErrorContains(t, err, "expected to fail")
 }
 
 func testClientGatewayNilResult(t *testing.T, sb integration.Sandbox) {
@@ -296,8 +295,7 @@ func testNoBuildID(t *testing.T, sb integration.Sandbox) {
 
 	g := gatewayapi.NewLLBBridgeClient(c.conn)
 	_, err = g.Ping(ctx, &gatewayapi.PingRequest{})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "no buildid found in context")
+	require.ErrorContains(t, err, "no buildid found in context")
 }
 
 func testUnknownBuildID(t *testing.T, sb integration.Sandbox) {
@@ -311,7 +309,6 @@ func testUnknownBuildID(t *testing.T, sb integration.Sandbox) {
 
 	g := c.gatewayClientForBuild(t.Name() + identity.NewID())
 	_, err = g.Ping(ctx, &gatewayapi.PingRequest{})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "no such job")
+	require.ErrorContains(t, err, "no such job")
 	require.Equal(t, codes.NotFound, grpcerrors.Code(err))
 }

--- a/client/llb/async_test.go
+++ b/client/llb/async_test.go
@@ -25,7 +25,7 @@ func TestAsyncNonBlocking(t *testing.T) {
 	select {
 	case <-time.After(100 * time.Millisecond):
 	case <-ran:
-		require.Fail(t, "callback should not have been called")
+		t.Error("callback should not have been called")
 	}
 
 	def, err := st.Marshal(ctx)

--- a/client/llb/exec_test.go
+++ b/client/llb/exec_test.go
@@ -13,8 +13,7 @@ func TestTmpfsMountError(t *testing.T) {
 	st := Image("foo").Run(Shlex("args")).AddMount("/tmp", Scratch(), Tmpfs())
 	_, err := st.Marshal(t.Context())
 
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "can't be used as a parent")
+	require.ErrorContains(t, err, "can't be used as a parent")
 
 	st = Image("foo").Run(Shlex("args"), AddMount("/tmp", Scratch(), Tmpfs())).Root()
 	_, err = st.Marshal(t.Context())
@@ -22,8 +21,7 @@ func TestTmpfsMountError(t *testing.T) {
 
 	st = Image("foo").Run(Shlex("args"), AddMount("/tmp", Image("bar"), Tmpfs())).Root()
 	_, err = st.Marshal(t.Context())
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "must use scratch")
+	require.ErrorContains(t, err, "must use scratch")
 }
 
 func TestInvalidSecurityModeMarshalError(t *testing.T) {
@@ -33,8 +31,7 @@ func TestInvalidSecurityModeMarshalError(t *testing.T) {
 		Run(Shlex("true"), Security(pb.SecurityMode(2))).Root()
 
 	_, err := st.Marshal(t.Context())
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid security mode")
+	require.ErrorContains(t, err, "invalid security mode")
 }
 
 func TestValidGetMountIndex(t *testing.T) {

--- a/client/llb/passthrough_test.go
+++ b/client/llb/passthrough_test.go
@@ -63,8 +63,7 @@ func TestPassthroughEmptyID(t *testing.T) {
 	t.Parallel()
 
 	_, err := Image("example.com/base:latest").Requires("", Image("example.com/dep:latest")).Marshal(t.Context())
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "passthrough requires an id")
+	require.ErrorContains(t, err, "passthrough requires an id")
 }
 
 func requirePassthroughVertex(t *testing.T, def *Definition) *pb.Op {

--- a/client/llb/state_test.go
+++ b/client/llb/state_test.go
@@ -62,18 +62,15 @@ func TestImageBlobInvalid(t *testing.T) {
 
 	s := ImageBlob("myuser/myrepo:foo@" + string(dgst))
 	_, err := s.Marshal(ctx)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "tagged image reference not allowed")
+	require.ErrorContains(t, err, "tagged image reference not allowed")
 
 	s = ImageBlob("myuser/myrepo")
 	_, err = s.Marshal(ctx)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "checksum required in blob reference")
+	require.ErrorContains(t, err, "checksum required in blob reference")
 
 	s = ImageBlob("myuser/myrepo@sha256:invalid")
 	_, err = s.Marshal(ctx)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid reference format")
+	require.ErrorContains(t, err, "invalid reference format")
 }
 
 func TestImageBlobSource(t *testing.T) {

--- a/client/policy_test.go
+++ b/client/policy_test.go
@@ -975,7 +975,7 @@ func testSourcePolicyParallelSession(t *testing.T, sb integration.Sandbox) {
 					Action: sourcepolicypb.PolicyAction_ALLOW,
 				}, nil, nil
 			default:
-				require.Fail(t, "too many calls for alpine")
+				t.Error("too many calls for alpine")
 			}
 		case "docker-image://docker.io/library/busybox:latest":
 			time.Sleep(200 * time.Millisecond)
@@ -1539,7 +1539,8 @@ func testSourcePolicySessionHTTPChecksumAssist(t *testing.T, sb integration.Sand
 				require.NoError(t, pgpsign.VerifySignatureWithDigest(sig, keyring, responseDigest))
 				// Negative check: tampered digest must fail signature verification.
 				badDigest := tamperDigestHex(responseDigest)
-				require.ErrorContains(t, pgpsign.VerifySignatureWithDigest(sig, keyring, badDigest), "failed to verify signature with checksum digest")
+				err = pgpsign.VerifySignatureWithDigest(sig, keyring, badDigest)
+				require.ErrorContains(t, err, "failed to verify signature with checksum digest")
 				return &policysession.DecisionResponse{
 					Action: sourcepolicypb.PolicyAction_ALLOW,
 				}, nil, nil

--- a/client/policy_test.go
+++ b/client/policy_test.go
@@ -245,7 +245,6 @@ func testProxyNetworkNoRootless(t *testing.T, sb integration.Sandbox) {
 			OutputDir: t.TempDir(),
 		}},
 	}, nil)
-	require.Error(t, err)
 	require.ErrorContains(t, err, "provenance materials are incomplete")
 	require.ErrorContains(t, err, "/missing")
 	var materialsErr *solvererrdefs.ProvenanceMaterialsIncompleteError
@@ -377,7 +376,6 @@ func testProxyNetworkModesNoRootless(t *testing.T, sb integration.Sandbox) {
 	_, err = c.Solve(ctx, def, SolveOpt{
 		ProxyNetwork: true,
 	}, nil)
-	require.Error(t, err)
 	require.ErrorContains(t, err, "network.host is not allowed")
 	require.Equal(t, int32(0), hostHit.Load())
 
@@ -540,7 +538,6 @@ func testProxyNetworkDefaultEgressNoRootless(t *testing.T, sb integration.Sandbo
 		ProxyNetwork:         true,
 		SourcePolicyProvider: denyProvider,
 	})
-	require.Error(t, err)
 	require.ErrorContains(t, err, "exit code: 1")
 	require.Contains(t, logOutput, "HTTP/1.1 403 Forbidden")
 	require.Equal(t, int32(1), checked.Load())
@@ -713,8 +710,7 @@ func testSourcePolicySession(t *testing.T, sb integration.Sandbox) {
 				SourcePolicyProvider: p,
 			}, nil)
 			if tc.expectedError != "" {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.expectedError)
+				require.ErrorContains(t, err, tc.expectedError)
 				return
 			}
 			require.NoError(t, err)
@@ -836,8 +832,7 @@ func testSourceMetaPolicySession(t *testing.T, sb integration.Sandbox) {
 			}, nil)
 
 			if tc.expectedError != "" {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.expectedError)
+				require.ErrorContains(t, err, tc.expectedError)
 				return
 			}
 			require.NoError(t, err)
@@ -1327,8 +1322,7 @@ func testSourcePolicySignedCommit(t *testing.T, sb integration.Sandbox) {
 				SourcePolicyProvider: p,
 			}, nil)
 			if tc.expectedError != "" {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.expectedError)
+				require.ErrorContains(t, err, tc.expectedError)
 				return
 			}
 			require.NoError(t, err)
@@ -1444,8 +1438,7 @@ func testSourcePolicySessionConvert(t *testing.T, sb integration.Sandbox) {
 				SourcePolicyProvider: p,
 			}, nil)
 			if tc.expectedError != "" {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.expectedError)
+				require.ErrorContains(t, err, tc.expectedError)
 				return
 			}
 			require.NoError(t, err)
@@ -1546,9 +1539,7 @@ func testSourcePolicySessionHTTPChecksumAssist(t *testing.T, sb integration.Sand
 				require.NoError(t, pgpsign.VerifySignatureWithDigest(sig, keyring, responseDigest))
 				// Negative check: tampered digest must fail signature verification.
 				badDigest := tamperDigestHex(responseDigest)
-				err = pgpsign.VerifySignatureWithDigest(sig, keyring, badDigest)
-				require.Error(t, err)
-				require.ErrorContains(t, err, "failed to verify signature with checksum digest")
+				require.ErrorContains(t, pgpsign.VerifySignatureWithDigest(sig, keyring, badDigest), "failed to verify signature with checksum digest")
 				return &policysession.DecisionResponse{
 					Action: sourcepolicypb.PolicyAction_ALLOW,
 				}, nil, nil
@@ -1583,7 +1574,6 @@ func testSourcePolicySessionHTTPChecksumAssist(t *testing.T, sb integration.Sand
 		_, err = c.Solve(ctx, def, SolveOpt{
 			SourcePolicyProvider: p,
 		}, nil)
-		require.Error(t, err)
 		require.ErrorContains(t, err, "suffix exceeds max size")
 		require.Equal(t, 1, callCounter)
 	})
@@ -1607,7 +1597,6 @@ func testSourcePolicySessionHTTPChecksumAssist(t *testing.T, sb integration.Sand
 		_, err = c.Solve(ctx, def, SolveOpt{
 			SourcePolicyProvider: p,
 		}, nil)
-		require.Error(t, err)
 		require.ErrorContains(t, err, "unsupported checksum algorithm")
 		require.Equal(t, 1, callCounter)
 	})
@@ -1758,8 +1747,7 @@ func testSourcePolicy(t *testing.T, sb integration.Sandbox) {
 			if tc.expectedErr == "" {
 				require.NoError(t, err)
 			} else {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.expectedErr)
+				require.ErrorContains(t, err, tc.expectedErr)
 			}
 		})
 	}

--- a/client/solve_test.go
+++ b/client/solve_test.go
@@ -25,6 +25,5 @@ func TestSolveRejectsInvalidLocalExporterMode(t *testing.T) {
 			},
 		},
 	}, nil)
-	require.Error(t, err)
 	require.ErrorContains(t, err, `invalid local exporter mode "backup"`)
 }

--- a/client/validation_test.go
+++ b/client/validation_test.go
@@ -60,8 +60,7 @@ func testValidateNullConfig(t *testing.T, sb integration.Sandbox) {
 			},
 		},
 	}, "", b, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid null image config for export")
+	require.ErrorContains(t, err, "invalid null image config for export")
 }
 
 func testValidateInvalidConfig(t *testing.T, sb integration.Sandbox) {
@@ -107,8 +106,7 @@ func testValidateInvalidConfig(t *testing.T, sb integration.Sandbox) {
 			},
 		},
 	}, "", b, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid image config: os and architecture must be specified together")
+	require.ErrorContains(t, err, "invalid image config: os and architecture must be specified together")
 }
 
 func testValidatePlatformsEmpty(t *testing.T, sb integration.Sandbox) {
@@ -146,8 +144,7 @@ func testValidatePlatformsEmpty(t *testing.T, sb integration.Sandbox) {
 			},
 		},
 	}, "", b, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid empty platforms index for exporter")
+	require.ErrorContains(t, err, "invalid empty platforms index for exporter")
 }
 
 func testValidatePlatformsInvalid(t *testing.T, sb integration.Sandbox) {
@@ -214,8 +211,7 @@ func testValidatePlatformsInvalid(t *testing.T, sb integration.Sandbox) {
 					},
 				},
 			}, "", b, nil)
-			require.Error(t, err)
-			require.Contains(t, err.Error(), tc.exp)
+			require.ErrorContains(t, err, tc.exp)
 		})
 	}
 }
@@ -308,13 +304,11 @@ func testValidateSourcePolicy(t *testing.T, sb integration.Sandbox) {
 			_, err = c.Build(ctx, SolveOpt{
 				SourcePolicy: tc.value,
 			}, "", b, nil)
-			require.Error(t, err)
-			require.Contains(t, err.Error(), tc.exp)
+			require.ErrorContains(t, err, tc.exp)
 
 			viaFrontend = true
 			_, err = c.Build(ctx, SolveOpt{}, "", b, nil)
-			require.Error(t, err)
-			require.Contains(t, err.Error(), tc.exp)
+			require.ErrorContains(t, err, tc.exp)
 		})
 	}
 }

--- a/cmd/buildctl/build/exportcache_test.go
+++ b/cmd/buildctl/build/exportcache_test.go
@@ -44,6 +44,7 @@ func TestParseExportCache(t *testing.T) {
 	for _, tc := range testCases {
 		ex, err := ParseExportCache(tc.exportCaches)
 		if tc.expectedErr == "" {
+			require.NoError(t, err)
 			require.Equal(t, tc.expected, ex)
 		} else {
 			require.ErrorContains(t, err, tc.expectedErr)

--- a/cmd/buildctl/build/exportcache_test.go
+++ b/cmd/buildctl/build/exportcache_test.go
@@ -46,8 +46,7 @@ func TestParseExportCache(t *testing.T) {
 		if tc.expectedErr == "" {
 			require.Equal(t, tc.expected, ex)
 		} else {
-			require.Error(t, err)
-			require.Contains(t, err.Error(), tc.expectedErr)
+			require.ErrorContains(t, err, tc.expectedErr)
 		}
 	}
 }

--- a/cmd/buildctl/build/importcache_test.go
+++ b/cmd/buildctl/build/importcache_test.go
@@ -100,8 +100,7 @@ func TestParseImportCache(t *testing.T) {
 		if tc.expectedErr == "" {
 			require.Equal(t, tc.expected, im)
 		} else {
-			require.Error(t, err)
-			require.Contains(t, err.Error(), tc.expectedErr)
+			require.ErrorContains(t, err, tc.expectedErr)
 		}
 	}
 }

--- a/cmd/buildctl/build/importcache_test.go
+++ b/cmd/buildctl/build/importcache_test.go
@@ -98,6 +98,7 @@ func TestParseImportCache(t *testing.T) {
 	for _, tc := range testCases {
 		im, err := ParseImportCache(tc.importCaches)
 		if tc.expectedErr == "" {
+			require.NoError(t, err)
 			require.Equal(t, tc.expected, im)
 		} else {
 			require.ErrorContains(t, err, tc.expectedErr)

--- a/cmd/buildctl/build/opt_test.go
+++ b/cmd/buildctl/build/opt_test.go
@@ -95,10 +95,10 @@ func TestParseOpt(t *testing.T) {
 			opt, err := ParseOpt(tc.opts)
 			if tc.expectedErr != "" {
 				require.EqualError(t, err, tc.expectedErr)
-				return
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, opt)
 			}
-			require.NoError(t, err)
-			require.Equal(t, tc.expected, opt)
 		})
 	}
 }

--- a/cmd/buildctl/build/registryauthtlscontext_test.go
+++ b/cmd/buildctl/build/registryauthtlscontext_test.go
@@ -100,6 +100,7 @@ func TestParseRegistryAuthTLSContext(t *testing.T) {
 	for _, tc := range testCases {
 		im, err := ParseRegistryAuthTLSContext(tc.registryAuthTLSContext)
 		if tc.expectedErr == "" {
+			require.NoError(t, err)
 			require.Equal(t, tc.expected, im)
 		} else {
 			require.ErrorContains(t, err, tc.expectedErr)

--- a/cmd/buildctl/build/registryauthtlscontext_test.go
+++ b/cmd/buildctl/build/registryauthtlscontext_test.go
@@ -102,8 +102,7 @@ func TestParseRegistryAuthTLSContext(t *testing.T) {
 		if tc.expectedErr == "" {
 			require.Equal(t, tc.expected, im)
 		} else {
-			require.Error(t, err)
-			require.Contains(t, err.Error(), tc.expectedErr)
+			require.ErrorContains(t, err, tc.expectedErr)
 		}
 	}
 }

--- a/cmd/buildctl/common/common_test.go
+++ b/cmd/buildctl/common/common_test.go
@@ -23,10 +23,10 @@ func TestResolveTLSFilesFromDir(t *testing.T) {
 		key := writeTempFile(t, dir, "tls.key", "key")
 
 		caOut, certOut, keyOut, err := resolveTLSFilesFromDir(dir)
+		require.NoError(t, err)
 		require.Equal(t, ca, caOut)
 		require.Equal(t, cert, certOut)
 		require.Equal(t, key, keyOut)
-		require.NoError(t, err)
 	})
 
 	t.Run("all files present for pem style", func(t *testing.T) {
@@ -36,10 +36,10 @@ func TestResolveTLSFilesFromDir(t *testing.T) {
 		key := writeTempFile(t, dir, "key.pem", "key")
 
 		caOut, certOut, keyOut, err := resolveTLSFilesFromDir(dir)
+		require.NoError(t, err)
 		require.Equal(t, ca, caOut)
 		require.Equal(t, cert, certOut)
 		require.Equal(t, key, keyOut)
-		require.NoError(t, err)
 	})
 
 	t.Run("mixed set is present", func(t *testing.T) {
@@ -50,10 +50,10 @@ func TestResolveTLSFilesFromDir(t *testing.T) {
 		// ca for cert-manager, cert and key for pem
 
 		caOut, certOut, keyOut, err := resolveTLSFilesFromDir(dir)
+		require.NoError(t, err)
 		require.Equal(t, ca, caOut)
 		require.Equal(t, cert, certOut)
 		require.Equal(t, key, keyOut)
-		require.NoError(t, err)
 	})
 
 	t.Run("all files present for cert-manager and pem styles and pem is chosen", func(t *testing.T) {
@@ -66,9 +66,9 @@ func TestResolveTLSFilesFromDir(t *testing.T) {
 		key := writeTempFile(t, dir, "key.pem", "key-pem")
 
 		caOut, certOut, keyOut, err := resolveTLSFilesFromDir(dir)
+		require.NoError(t, err)
 		require.Equal(t, ca, caOut)
 		require.Equal(t, cert, certOut)
 		require.Equal(t, key, keyOut)
-		require.NoError(t, err)
 	})
 }

--- a/executor/containerdexecutor/executor_test.go
+++ b/executor/containerdexecutor/executor_test.go
@@ -5,12 +5,11 @@ import (
 
 	ctd "github.com/containerd/containerd/v2/client"
 	gatewayapi "github.com/moby/buildkit/frontend/gateway/pb"
+	"github.com/stretchr/testify/require"
 )
 
 func TestContainerdUnknownExitStatus(t *testing.T) {
 	// There are assumptions in the containerd executor that the UnknownExitStatus
 	// used in errdefs.ExitError matches the variable in the containerd package.
-	if ctd.UnknownExitStatus != gatewayapi.UnknownExitStatus {
-		t.Fatal("containerd.UnknownExitStatus != errdefs.UnknownExitStatus")
-	}
+	require.Equalf(t, ctd.UnknownExitStatus, gatewayapi.UnknownExitStatus, "containerd.UnknownExitStatus != errdefs.UnknownExitStatus")
 }

--- a/executor/containerid_test.go
+++ b/executor/containerid_test.go
@@ -1,6 +1,10 @@
 package executor
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestValidContainerID(t *testing.T) {
 	t.Parallel()
@@ -22,11 +26,10 @@ func TestValidContainerID(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			err := ValidContainerID(tc.id)
-			if tc.wantErr && err == nil {
-				t.Fatalf("expected an error for id %q", tc.id)
-			}
-			if !tc.wantErr && err != nil {
-				t.Fatalf("expected no error for id %q, got %v", tc.id, err)
+			if tc.wantErr {
+				require.Errorf(t, err, "expected an error for id %q", tc.id)
+			} else {
+				require.NoErrorf(t, err, "expected no error for id %q", tc.id)
 			}
 		})
 	}

--- a/executor/proxyca_linux_test.go
+++ b/executor/proxyca_linux_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,7 +23,7 @@ func TestInjectProxyCACleanupPreservesContainerChanges(t *testing.T) {
 	root, err := os.OpenRoot(rootfs)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, root.Close())
+		assert.NoError(t, root.Close())
 	})
 	const bundle = "etc/ssl/certs/ca-certificates.crt"
 	require.NoError(t, root.MkdirAll(filepath.Dir(bundle), 0o755))

--- a/exporter/util/epoch/parse_test.go
+++ b/exporter/util/epoch/parse_test.go
@@ -1,19 +1,22 @@
 package epoch
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestParseBuildArgs(t *testing.T) {
 	t.Parallel()
 
-	if v, ok := ParseBuildArgs(map[string]string{frontendSourceDateEpochArg: "1700000601"}); !ok || v != "1700000601" {
-		t.Fatalf("expected numeric SOURCE_DATE_EPOCH to be forwarded, got %q %v", v, ok)
-	}
+	v, ok := ParseBuildArgs(map[string]string{frontendSourceDateEpochArg: "1700000601"})
+	require.Truef(t, ok, "expected numeric SOURCE_DATE_EPOCH to be forwarded")
+	require.Equalf(t, "1700000601", v, "expected numeric SOURCE_DATE_EPOCH to be forwarded")
 
-	if _, ok := ParseBuildArgs(map[string]string{frontendSourceDateEpochArg: "context"}); ok {
-		t.Fatal("expected SOURCE_DATE_EPOCH=context to stay frontend-only")
-	}
+	_, ok = ParseBuildArgs(map[string]string{frontendSourceDateEpochArg: "context"})
+	require.False(t, ok, "expected SOURCE_DATE_EPOCH=context to stay frontend-only")
 
-	if v, ok := ParseBuildArgs(map[string]string{frontendSourceDateEpochArg: ""}); !ok || v != "" {
-		t.Fatalf("expected empty SOURCE_DATE_EPOCH to remain a valid exporter override, got %q %v", v, ok)
-	}
+	v, ok = ParseBuildArgs(map[string]string{frontendSourceDateEpochArg: ""})
+	require.True(t, ok, "expected empty SOURCE_DATE_EPOCH to remain a valid exporter override")
+	require.Empty(t, v, "expected empty SOURCE_DATE_EPOCH to remain a valid exporter override")
 }

--- a/frontend/attestations/sbom/sbom_test.go
+++ b/frontend/attestations/sbom/sbom_test.go
@@ -99,7 +99,7 @@ func scannerExecOp(t *testing.T, st *llb.State) *pb.Op {
 			return &op
 		}
 	}
-	require.FailNow(t, "scanner exec op not found")
+	t.Fatal("scanner exec op not found")
 	return nil
 }
 
@@ -116,7 +116,7 @@ func scannerImageSourceOp(t *testing.T, st *llb.State) *pb.Op {
 			return &op
 		}
 	}
-	require.FailNow(t, "scanner image source op not found")
+	t.Fatal("scanner image source op not found")
 	return nil
 }
 
@@ -128,6 +128,6 @@ func findMount(t *testing.T, exec *pb.ExecOp, dest string) *pb.Mount {
 			return mount
 		}
 	}
-	require.FailNow(t, "mount not found", "dest=%s", dest)
+	t.Fatal("mount not found", "dest=%s", dest)
 	return nil
 }

--- a/frontend/dockerfile/dfgitutil/git_ref_test.go
+++ b/frontend/dockerfile/dfgitutil/git_ref_test.go
@@ -273,8 +273,8 @@ func TestParseGitRef(t *testing.T) {
 		t.Run(fmt.Sprintf("case%d", i+1), func(t *testing.T) {
 			got, _, err := ParseGitRef(tt.ref)
 			if tt.expected == nil {
-				require.Nil(t, got)
 				require.Error(t, err)
+				require.Nil(t, got)
 				if tt.err != "" {
 					require.ErrorContains(t, err, tt.err)
 				}

--- a/frontend/dockerfile/dockerfile_addgit_test.go
+++ b/frontend/dockerfile/dockerfile_addgit_test.go
@@ -240,8 +240,7 @@ RUN [ ! -d /nogitdir/.git ]
 			dockerui.DefaultLocalNameContext:    dir5,
 		},
 	}, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "expected checksum to match")
+	require.ErrorContains(t, err, "expected checksum to match")
 
 	//  checksum is garbage
 	dockerfile6, err := applyTemplate(`
@@ -264,9 +263,8 @@ RUN [ ! -d /nogitdir/.git ]
 			dockerui.DefaultLocalNameContext:    dir6,
 		},
 	}, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid checksum")
-	require.Contains(t, err.Error(), "expected hex commit hash")
+	require.ErrorContains(t, err, "invalid checksum")
+	require.ErrorContains(t, err, "expected hex commit hash")
 }
 
 // testAddGitChecksumCache verifies that adding --checksum to a Git ADD does not
@@ -653,8 +651,7 @@ COPY foo out
 				},
 			}, nil)
 			if tc.expectErr != "" {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.expectErr)
+				require.ErrorContains(t, err, tc.expectErr)
 				return
 			}
 			require.NoError(t, err)
@@ -704,8 +701,7 @@ FROM main
 				},
 			}, nil)
 			if tc.expectErr != "" {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.expectErr)
+				require.ErrorContains(t, err, tc.expectErr)
 				return
 			}
 			require.NoError(t, err)

--- a/frontend/dockerfile/dockerfile_args_test.go
+++ b/frontend/dockerfile/dockerfile_args_test.go
@@ -74,9 +74,7 @@ FROM %s
 			dockerui.DefaultLocalNameContext:    dir,
 		},
 	}, nil)
-	require.Error(t, err)
-
-	require.Contains(t, err.Error(), "FOO: custom error")
+	require.ErrorContains(t, err, "FOO: custom error")
 
 	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
 		FrontendAttrs: map[string]string{
@@ -114,9 +112,7 @@ ARG BAR=${FOO:?"foo missing"}
 			dockerui.DefaultLocalNameContext:    dir,
 		},
 	}, nil)
-	require.Error(t, err)
-
-	require.Contains(t, err.Error(), "FOO: foo missing")
+	require.ErrorContains(t, err, "FOO: foo missing")
 
 	_, err = f.Solve(sb.Context(), c, client.SolveOpt{
 		FrontendAttrs: map[string]string{

--- a/frontend/dockerfile/dockerfile_check_test.go
+++ b/frontend/dockerfile/dockerfile_check_test.go
@@ -1649,8 +1649,8 @@ func checkUnmarshal(t *testing.T, sb integration.Sandbox, lintTest *lintTestPara
 			require.NotNil(t, lintResults.Error)
 			if lintTest.BuildErr != "" {
 				require.Equal(t, lintTest.BuildErr, lintResults.Error.Message)
-			} else if !lintTest.UnmarshalBuildErrRegexp.MatchString(lintResults.Error.Message) {
-				t.Fatalf("error %q does not match %q", lintResults.Error.Message, lintTest.UnmarshalBuildErrRegexp.String())
+			} else {
+				require.Truef(t, lintTest.UnmarshalBuildErrRegexp.MatchString(lintResults.Error.Message), "error %q does not match %q", lintResults.Error.Message, lintTest.UnmarshalBuildErrRegexp.String())
 			}
 			require.Greater(t, lintResults.Error.Location.SourceIndex, int32(-1))
 			require.Less(t, lintResults.Error.Location.SourceIndex, int32(len(lintResults.Sources)))

--- a/frontend/dockerfile/dockerfile_client_test.go
+++ b/frontend/dockerfile/dockerfile_client_test.go
@@ -320,7 +320,6 @@ COPY Dockerfile Dockerfile
 			},
 			Frontend: "dockerfile.v0",
 		})
-		require.Error(t, err)
 		var reqErr *errdefs.UnsupportedSubrequestError
 		require.ErrorAs(t, err, &reqErr)
 		require.Equal(t, "frontend.subrequests.notexist", reqErr.GetName())
@@ -331,7 +330,6 @@ COPY Dockerfile Dockerfile
 			},
 			Frontend: "dockerfile.v0",
 		})
-		require.Error(t, err)
 		var capErr *errdefs.UnsupportedFrontendCapError
 		require.ErrorAs(t, err, &capErr)
 		require.Equal(t, "moby.buildkit.frontend.notexistcap", capErr.GetName())

--- a/frontend/dockerfile/dockerfile_cmd_test.go
+++ b/frontend/dockerfile/dockerfile_cmd_test.go
@@ -116,7 +116,7 @@ ENTRYPOINT my entrypoint
 	err = json.Unmarshal(dt, &ociimg)
 	require.NoError(t, err)
 
-	require.Equal(t, []string(nil), ociimg.Config.Cmd)
+	require.Nil(t, ociimg.Config.Cmd)
 	require.Equal(t, []string{"ls", "my entrypoint"}, ociimg.Config.Entrypoint)
 }
 

--- a/frontend/dockerfile/dockerfile_cmd_test.go
+++ b/frontend/dockerfile/dockerfile_cmd_test.go
@@ -312,8 +312,7 @@ RUN ["echo", "hello"]this is invalid
 			dockerui.DefaultLocalNameContext:    dir,
 		},
 	}, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "this is invalid")
+	require.ErrorContains(t, err, "this is invalid")
 
 	workers.CheckFeatureCompat(t, sb,
 		workers.FeatureDirectPush,
@@ -443,7 +442,6 @@ FNTRYPOINT ["cmd", "/c", "echo invalidinstruction"]
 		},
 	}, nil)
 
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "unknown instruction: FNTRYPOINT")
-	require.Contains(t, err.Error(), "did you mean ENTRYPOINT?")
+	require.ErrorContains(t, err, "unknown instruction: FNTRYPOINT")
+	require.ErrorContains(t, err, "did you mean ENTRYPOINT?")
 }

--- a/frontend/dockerfile/dockerfile_copy_test.go
+++ b/frontend/dockerfile/dockerfile_copy_test.go
@@ -41,7 +41,6 @@ COPY --from=$FOO . .
 			dockerui.DefaultLocalNameContext:    dir,
 		},
 	}, nil)
-	require.Error(t, err)
 	require.ErrorContains(t, err, "variable expansion is not supported for --from, define a new stage with FROM using ARG from global scope as a workaround")
 }
 

--- a/frontend/dockerfile/dockerfile_core_test.go
+++ b/frontend/dockerfile/dockerfile_core_test.go
@@ -860,6 +860,5 @@ COPY --from=build C:\out C:\
 		},
 	}, nil)
 
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "target stage \"bulid\" could not be found (did you mean build?)")
+	require.ErrorContains(t, err, "target stage \"bulid\" could not be found (did you mean build?)")
 }

--- a/frontend/dockerfile/dockerfile_dockerignore_test.go
+++ b/frontend/dockerfile/dockerfile_dockerignore_test.go
@@ -72,20 +72,16 @@ Dockerfile
 	require.Equal(t, "foo-contents", string(dt))
 
 	_, err = os.Stat(filepath.Join(destDir, ".dockerignore"))
-	require.Error(t, err)
-	require.True(t, errors.Is(err, os.ErrNotExist))
+	require.ErrorIs(t, err, os.ErrNotExist)
 
 	_, err = os.Stat(filepath.Join(destDir, "Dockerfile"))
-	require.Error(t, err)
-	require.True(t, errors.Is(err, os.ErrNotExist))
+	require.ErrorIs(t, err, os.ErrNotExist)
 
 	_, err = os.Stat(filepath.Join(destDir, "bar"))
-	require.Error(t, err)
-	require.True(t, errors.Is(err, os.ErrNotExist))
+	require.ErrorIs(t, err, os.ErrNotExist)
 
 	_, err = os.Stat(filepath.Join(destDir, "baz"))
-	require.Error(t, err)
-	require.True(t, errors.Is(err, os.ErrNotExist))
+	require.ErrorIs(t, err, os.ErrNotExist)
 
 	dt, err = os.ReadFile(filepath.Join(destDir, "bay"))
 	require.NoError(t, err)

--- a/frontend/dockerfile/dockerfile_git_http_test.go
+++ b/frontend/dockerfile/dockerfile_git_http_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/util/testutil/httpserver"
 	"github.com/moby/buildkit/util/testutil/integration"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -111,8 +110,7 @@ COPY --from=build foo bar2
 	require.Equal(t, "fromgit", string(dt))
 
 	_, err = os.Stat(filepath.Join(destDir, "bar2"))
-	require.Error(t, err)
-	require.True(t, errors.Is(err, os.ErrNotExist))
+	require.ErrorIs(t, err, os.ErrNotExist)
 
 	// second request from master branch contains both files
 	destDir = t.TempDir()

--- a/frontend/dockerfile/dockerfile_history_test.go
+++ b/frontend/dockerfile/dockerfile_history_test.go
@@ -310,12 +310,9 @@ COPY notexist /foo
 
 		// contains vertex metadata
 		var ve *errdefs.VertexError
-		if errors.As(err, &ve) {
-			_, err := digest.Parse(ve.Digest)
-			require.NoError(t, err)
-		} else {
-			t.Fatal("did not find vertex error")
-		}
+		require.ErrorAs(t, err, &ve, "did not find vertex error")
+		_, perr := digest.Parse(ve.Digest)
+		require.NoError(t, perr)
 
 		// source points to Dockerfile
 		sources := errdefs.Sources(err)

--- a/frontend/dockerfile/dockerfile_mount_test.go
+++ b/frontend/dockerfile/dockerfile_mount_test.go
@@ -128,9 +128,8 @@ RUN --mont=target=/mytmp,type=tmpfs echo 1
 			dockerui.DefaultLocalNameContext:    dir,
 		},
 	}, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "unknown flag: --mont")
-	require.Contains(t, err.Error(), "did you mean mount?")
+	require.ErrorContains(t, err, "unknown flag: --mont")
+	require.ErrorContains(t, err, "did you mean mount?")
 
 	dockerfile = []byte(integration.UnixOrWindows(
 		`
@@ -154,9 +153,8 @@ RUN --mont=target=/mytmp,type=tmpfs echo 1
 			dockerui.DefaultLocalNameContext:    dir,
 		},
 	}, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "unexpected key 'typ'")
-	require.Contains(t, err.Error(), "did you mean type?")
+	require.ErrorContains(t, err, "unexpected key 'typ'")
+	require.ErrorContains(t, err, "did you mean type?")
 
 	dockerfile = []byte(integration.UnixOrWindows(
 		`
@@ -180,9 +178,8 @@ RUN --mont=target=/mytmp,type=tmpfs echo 1
 			dockerui.DefaultLocalNameContext:    dir,
 		},
 	}, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "unsupported mount type \"tmp\"")
-	require.Contains(t, err.Error(), "did you mean tmpfs?")
+	require.ErrorContains(t, err, "unsupported mount type \"tmp\"")
+	require.ErrorContains(t, err, "did you mean tmpfs?")
 }
 
 func testMountRWCache(t *testing.T, sb integration.Sandbox) {
@@ -535,8 +532,7 @@ RUN --mount=from=$ttt,type=cache,target=/tmp dir
 			dockerui.DefaultLocalNameContext:    dir,
 		},
 	}, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "'from' doesn't support variable expansion, define alias stage instead")
+	require.ErrorContains(t, err, "'from' doesn't support variable expansion, define alias stage instead")
 }
 
 func testMountTmpfsSize(t *testing.T, sb integration.Sandbox) {

--- a/frontend/dockerfile/dockerfile_multistage_test.go
+++ b/frontend/dockerfile/dockerfile_multistage_test.go
@@ -191,9 +191,8 @@ FROM target
 				dockerui.DefaultLocalNameContext:    dir,
 			},
 		}, nil)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "cannot copy from stage")
-		require.Contains(t, err.Error(), "needs to be defined before current stage")
+		require.ErrorContains(t, err, "cannot copy from stage")
+		require.ErrorContains(t, err, "needs to be defined before current stage")
 	}
 }
 
@@ -224,6 +223,5 @@ func testEmptyStages(t *testing.T, sb integration.Sandbox) {
 			},
 		},
 	}, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "dockerfile contains no stages to build")
+	require.ErrorContains(t, err, "dockerfile contains no stages to build")
 }

--- a/frontend/dockerfile/dockerfile_namedcontext_test.go
+++ b/frontend/dockerfile/dockerfile_namedcontext_test.go
@@ -516,8 +516,7 @@ COPY --from=base /o* /
 	require.Greater(t, len(dt), 0)
 
 	_, err = os.ReadFile(filepath.Join(destDir, "out2"))
-	require.Error(t, err)
-	require.True(t, errors.Is(err, os.ErrNotExist))
+	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func testNamedOCILayoutContext(t *testing.T, sb integration.Sandbox) {

--- a/frontend/dockerfile/dockerfile_parents_test.go
+++ b/frontend/dockerfile/dockerfile_parents_test.go
@@ -337,15 +337,15 @@ RUN if exist \out\c exit /b 1
 
 	type test struct {
 		target     string
-		errorRegex any
+		errorRegex string
 	}
 
 	tests := []test{
-		{"normal", nil},
-		{"withpivot", nil},
-		{"nonexistentfile", `failed to calculate checksum of ref.*: "/test/nonexistent-file": not found`},
-		{"wildcard-nonexistent", nil},
-		{"wildcard-afterpivot", nil},
+		{target: "normal"},
+		{target: "withpivot"},
+		{target: "nonexistentfile", errorRegex: `failed to calculate checksum of ref.*: "/test/nonexistent-file": not found`},
+		{target: "wildcard-nonexistent"},
+		{target: "wildcard-afterpivot"},
 	}
 
 	for _, tt := range tests {
@@ -360,7 +360,7 @@ RUN if exist \out\c exit /b 1
 			},
 		}, nil)
 
-		if tt.errorRegex != nil {
+		if tt.errorRegex != "" {
 			require.Error(t, err)
 			require.Regexp(t, tt.errorRegex, err.Error())
 		} else {

--- a/frontend/dockerfile/dockerfile_provenance_test.go
+++ b/frontend/dockerfile/dockerfile_provenance_test.go
@@ -2386,9 +2386,8 @@ ADD bar bar`)
 				require.Equal(t, r.Start.Line, r.End.Line, "step %s has range with multiple lines", id)
 
 				idx := r.Start.Line - 1
-				if idx < 0 || int(idx) >= len(lines) {
-					t.Fatalf("step %s has invalid range on line %d", id, idx)
-				}
+				require.GreaterOrEqualf(t, int(idx), 0, "step %s has invalid range on line %d", id, idx)
+				require.Lessf(t, int(idx), len(lines), "step %s has invalid range on line %d", id, idx)
 				lines[idx] = true
 			}
 		}

--- a/frontend/dockerfile/dockerfile_provenance_test.go
+++ b/frontend/dockerfile/dockerfile_provenance_test.go
@@ -1400,7 +1400,7 @@ func testGatewayProvenanceDifferentCallbackInputProducer(t *testing.T, sb integr
 	case <-inputReady:
 	case err := <-firstBuildDone:
 		require.NoError(t, err)
-		require.FailNow(t, "producer build exited before returning an input")
+		t.Fatal("producer build exited before returning an input")
 	}
 	defer func() {
 		close(releaseProducer)
@@ -1560,7 +1560,7 @@ COPY --from=linked /innerseed /innerseed
 	case <-rootInputReady:
 	case err := <-rootProducerDone:
 		require.NoError(t, err)
-		require.FailNow(t, "root input producer build exited before returning an input")
+		t.Fatal("root input producer build exited before returning an input")
 	}
 	defer func() {
 		close(releaseRootProducer)
@@ -1680,7 +1680,7 @@ func testDockerfileProvenanceInputProducer(t *testing.T, sb integration.Sandbox)
 	case <-inputReady:
 	case err := <-producerDone:
 		require.NoError(t, err)
-		require.FailNow(t, "producer build exited before returning an input")
+		t.Fatal("producer build exited before returning an input")
 	}
 	defer func() {
 		close(releaseProducer)
@@ -2517,7 +2517,7 @@ COPY bar bar2
 	for {
 		ev, err := history.Recv()
 		if err != nil {
-			require.Equal(t, io.EOF, err)
+			require.ErrorIs(t, err, io.EOF)
 			break
 		}
 		require.Equal(t, ref, ev.Record.Ref)

--- a/frontend/dockerfile/dockerfile_runnetwork_test.go
+++ b/frontend/dockerfile/dockerfile_runnetwork_test.go
@@ -138,8 +138,7 @@ RUN --network=host nc 127.0.0.1 %s | grep foo
 		require.NoError(t, err)
 	case networkHostDenied:
 		if !workers.IsTestDockerd() {
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "entitlement network.host is not allowed")
+			require.ErrorContains(t, err, "entitlement network.host is not allowed")
 		} else {
 			require.NoError(t, err)
 		}
@@ -189,8 +188,7 @@ RUN --network=none ! nc -z 127.0.0.1 %s
 		require.NoError(t, err)
 	case networkHostDenied:
 		if !workers.IsTestDockerd() {
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "entitlement network.host is not allowed")
+			require.ErrorContains(t, err, "entitlement network.host is not allowed")
 		} else {
 			require.NoError(t, err)
 		}

--- a/frontend/dockerfile/dockerfile_runnetwork_test.go
+++ b/frontend/dockerfile/dockerfile_runnetwork_test.go
@@ -143,7 +143,7 @@ RUN --network=host nc 127.0.0.1 %s | grep foo
 			require.NoError(t, err)
 		}
 	default:
-		require.Fail(t, fmt.Sprintf("unexpected network.host mode %q", hostAllowed))
+		t.Errorf("unexpected network.host mode %q", hostAllowed)
 	}
 }
 
@@ -193,6 +193,6 @@ RUN --network=none ! nc -z 127.0.0.1 %s
 			require.NoError(t, err)
 		}
 	default:
-		require.Fail(t, fmt.Sprintf("unexpected network.host mode %q", hostAllowed))
+		t.Errorf("unexpected network.host mode %q", hostAllowed)
 	}
 }

--- a/frontend/dockerfile/dockerfile_runsecurity_test.go
+++ b/frontend/dockerfile/dockerfile_runsecurity_test.go
@@ -78,7 +78,7 @@ RUN --security=insecure ls -l /dev && dd if=/dev/zero of=disk.img bs=20M count=1
 	case securityInsecureDenied:
 		require.ErrorContains(t, err, "entitlement security.insecure is not allowed")
 	default:
-		require.Fail(t, "unexpected secmode")
+		t.Error("unexpected secmode")
 	}
 }
 
@@ -115,7 +115,7 @@ RUN [ "$(cat /proc/self/status | grep CapBnd)" == "CapBnd:	00000000a80425fb" ]
 	case securityInsecureDenied:
 		require.ErrorContains(t, err, "entitlement security.insecure is not allowed")
 	default:
-		require.Fail(t, "unexpected secmode")
+		t.Error("unexpected secmode")
 	}
 }
 
@@ -178,6 +178,6 @@ RUN [ "$(cat /proc/self/status | grep CapBnd)" == "CapBnd:	00000000a80425fb" ]
 	case securityInsecureDenied:
 		require.ErrorContains(t, err, "entitlement security.insecure is not allowed")
 	default:
-		require.Fail(t, "unexpected secmode")
+		t.Error("unexpected secmode")
 	}
 }

--- a/frontend/dockerfile/dockerfile_runsecurity_test.go
+++ b/frontend/dockerfile/dockerfile_runsecurity_test.go
@@ -76,8 +76,7 @@ RUN --security=insecure ls -l /dev && dd if=/dev/zero of=disk.img bs=20M count=1
 	case securityInsecureGranted:
 		require.NoError(t, err)
 	case securityInsecureDenied:
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "entitlement security.insecure is not allowed")
+		require.ErrorContains(t, err, "entitlement security.insecure is not allowed")
 	default:
 		require.Fail(t, "unexpected secmode")
 	}
@@ -114,8 +113,7 @@ RUN [ "$(cat /proc/self/status | grep CapBnd)" == "CapBnd:	00000000a80425fb" ]
 	case securityInsecureGranted:
 		require.NoError(t, err)
 	case securityInsecureDenied:
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "entitlement security.insecure is not allowed")
+		require.ErrorContains(t, err, "entitlement security.insecure is not allowed")
 	default:
 		require.Fail(t, "unexpected secmode")
 	}
@@ -178,8 +176,7 @@ RUN [ "$(cat /proc/self/status | grep CapBnd)" == "CapBnd:	00000000a80425fb" ]
 	case securityInsecureGranted:
 		require.NoError(t, err)
 	case securityInsecureDenied:
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "entitlement security.insecure is not allowed")
+		require.ErrorContains(t, err, "entitlement security.insecure is not allowed")
 	default:
 		require.Fail(t, "unexpected secmode")
 	}

--- a/frontend/dockerfile/dockerfile_sbom_test.go
+++ b/frontend/dockerfile/dockerfile_sbom_test.go
@@ -309,7 +309,7 @@ ARG BUILDKIT_SBOM_SCAN_STAGE=true
 		case "extra":
 			extraCount++
 		default:
-			require.Fail(t, "unexpected attestation", "%v", att)
+			t.Errorf("unexpected attestation: %v", att)
 		}
 	}
 	require.Equal(t, extraCount, len(att.LayersRaw)-1)

--- a/frontend/dockerfile/dockerfile_secrets_test.go
+++ b/frontend/dockerfile/dockerfile_secrets_test.go
@@ -161,7 +161,7 @@ RUN --mount=type=secret,id=mysecret,env=SECRET_ENV if %SECRET_ENV% NEQ pw (exit 
 	select {
 	case <-done:
 	case <-time.After(10 * time.Second):
-		require.Fail(t, "timed out waiting for status")
+		t.Error("timed out waiting for status")
 	}
 
 	require.True(t, hasStatus)

--- a/frontend/dockerfile/dockerfile_secrets_test.go
+++ b/frontend/dockerfile/dockerfile_secrets_test.go
@@ -92,8 +92,7 @@ func testSecretRequiredWithoutValue(t *testing.T, sb integration.Sandbox) {
 			dockerui.DefaultLocalNameContext:    dir,
 		},
 	}, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "secret mysecret: not found")
+	require.ErrorContains(t, err, "secret mysecret: not found")
 }
 
 // testSecretAsEnviron verifies that a secret injected via env= is accessible

--- a/frontend/dockerfile/dockerfile_ssh_test.go
+++ b/frontend/dockerfile/dockerfile_ssh_test.go
@@ -125,10 +125,7 @@ RUN --mount=type=ssh apk update \
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-	if !found {
-		sshAgentOutput := sshAgentOutputBuf.String()
-		t.Fatalf("ssh-agent failed to start: %s", sshAgentOutput)
-	}
+	require.Truef(t, found, "ssh-agent failed to start: %s", sshAgentOutputBuf.String())
 
 	ssh, err := sshprovider.NewSSHAgentProvider([]sshprovider.AgentConfig{{
 		Paths: []string{sockPath},

--- a/frontend/dockerfile/errors_test.go
+++ b/frontend/dockerfile/errors_test.go
@@ -1,7 +1,6 @@
 package dockerfile
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/containerd/continuity/fs/fstest"
@@ -109,7 +108,7 @@ env bar=baz`,
 						continue next
 					}
 				}
-				require.Fail(t, fmt.Sprintf("line %d not found", l))
+				t.Errorf("line %d not found", l)
 			}
 		})
 	}

--- a/frontend/dockerfile/instructions/bflag_test.go
+++ b/frontend/dockerfile/instructions/bflag_test.go
@@ -4,27 +4,22 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuilderFlags(t *testing.T) {
-	var expected string
-	var err error
-
 	// ---
 
 	bf := NewBFlags()
 	bf.Args = []string{}
-	if err := bf.Parse(); err != nil {
-		t.Fatalf("Test1 of %q was supposed to work: %s", bf.Args, err)
-	}
+	require.NoErrorf(t, bf.Parse(), "Test1 of %q was supposed to work", bf.Args)
 
 	// ---
 
 	bf = NewBFlags()
 	bf.Args = []string{"--"}
-	if err := bf.Parse(); err != nil {
-		t.Fatalf("Test2 of %q was supposed to work: %s", bf.Args, err)
-	}
+	require.NoErrorf(t, bf.Parse(), "Test2 of %q was supposed to work", bf.Args)
 
 	// ---
 
@@ -32,16 +27,10 @@ func TestBuilderFlags(t *testing.T) {
 	flStr1 := bf.AddString("str1", "")
 	flBool1 := bf.AddBool("bool1", false)
 	bf.Args = []string{}
-	if err = bf.Parse(); err != nil {
-		t.Fatalf("Test3 of %q was supposed to work: %s", bf.Args, err)
-	}
+	require.NoErrorf(t, bf.Parse(), "Test3 of %q was supposed to work", bf.Args)
 
-	if flStr1.IsUsed() {
-		t.Fatal("Test3 - str1 was not used!")
-	}
-	if flBool1.IsUsed() {
-		t.Fatal("Test3 - bool1 was not used!")
-	}
+	require.False(t, flStr1.IsUsed(), "Test3 - str1 was not used!")
+	require.False(t, flBool1.IsUsed(), "Test3 - bool1 was not used!")
 
 	// ---
 
@@ -50,22 +39,12 @@ func TestBuilderFlags(t *testing.T) {
 	flBool1 = bf.AddBool("bool1", false)
 	bf.Args = []string{}
 
-	if err = bf.Parse(); err != nil {
-		t.Fatalf("Test4 of %q was supposed to work: %s", bf.Args, err)
-	}
+	require.NoErrorf(t, bf.Parse(), "Test4 of %q was supposed to work", bf.Args)
 
-	if flStr1.Value != "HI" {
-		t.Fatal("Str1 was supposed to default to: HI")
-	}
-	if flBool1.IsTrue() {
-		t.Fatal("Bool1 was supposed to default to: false")
-	}
-	if flStr1.IsUsed() {
-		t.Fatal("Str1 was not used!")
-	}
-	if flBool1.IsUsed() {
-		t.Fatal("Bool1 was not used!")
-	}
+	require.Equal(t, "HI", flStr1.Value, "Str1 was supposed to default to: HI")
+	require.False(t, flBool1.IsTrue(), "Bool1 was supposed to default to: false")
+	require.False(t, flStr1.IsUsed(), "Str1 was not used!")
+	require.False(t, flBool1.IsUsed(), "Bool1 was not used!")
 
 	// ---
 
@@ -73,9 +52,7 @@ func TestBuilderFlags(t *testing.T) {
 	bf.AddString("str1", "HI")
 	bf.Args = []string{"--str1"}
 
-	if err = bf.Parse(); err == nil {
-		t.Fatalf("Test %q was supposed to fail", bf.Args)
-	}
+	require.Errorf(t, bf.Parse(), "Test %q was supposed to fail", bf.Args)
 
 	// ---
 
@@ -83,14 +60,8 @@ func TestBuilderFlags(t *testing.T) {
 	flStr1 = bf.AddString("str1", "HI")
 	bf.Args = []string{"--str1="}
 
-	if err = bf.Parse(); err != nil {
-		t.Fatalf("Test %q was supposed to work: %s", bf.Args, err)
-	}
-
-	expected = ""
-	if flStr1.Value != expected {
-		t.Fatalf("Str1 (%q) should be: %q", flStr1.Value, expected)
-	}
+	require.NoErrorf(t, bf.Parse(), "Test %q was supposed to work", bf.Args)
+	require.Emptyf(t, flStr1.Value, "Str1 (%q) should be: %q", flStr1.Value, "")
 
 	// ---
 
@@ -98,14 +69,8 @@ func TestBuilderFlags(t *testing.T) {
 	flStr1 = bf.AddString("str1", "HI")
 	bf.Args = []string{"--str1=BYE"}
 
-	if err = bf.Parse(); err != nil {
-		t.Fatalf("Test %q was supposed to work: %s", bf.Args, err)
-	}
-
-	expected = "BYE"
-	if flStr1.Value != expected {
-		t.Fatalf("Str1 (%q) should be: %q", flStr1.Value, expected)
-	}
+	require.NoErrorf(t, bf.Parse(), "Test %q was supposed to work", bf.Args)
+	require.Equalf(t, "BYE", flStr1.Value, "Str1 (%q) should be: %q", flStr1.Value, "BYE")
 
 	// ---
 
@@ -113,13 +78,8 @@ func TestBuilderFlags(t *testing.T) {
 	flBool1 = bf.AddBool("bool1", false)
 	bf.Args = []string{"--bool1"}
 
-	if err = bf.Parse(); err != nil {
-		t.Fatalf("Test %q was supposed to work: %s", bf.Args, err)
-	}
-
-	if !flBool1.IsTrue() {
-		t.Fatal("Test-b1 Bool1 was supposed to be true")
-	}
+	require.NoErrorf(t, bf.Parse(), "Test %q was supposed to work", bf.Args)
+	require.True(t, flBool1.IsTrue(), "Test-b1 Bool1 was supposed to be true")
 
 	// ---
 
@@ -127,13 +87,8 @@ func TestBuilderFlags(t *testing.T) {
 	flBool1 = bf.AddBool("bool1", false)
 	bf.Args = []string{"--bool1=true"}
 
-	if err = bf.Parse(); err != nil {
-		t.Fatalf("Test %q was supposed to work: %s", bf.Args, err)
-	}
-
-	if !flBool1.IsTrue() {
-		t.Fatal("Test-b2 Bool1 was supposed to be true")
-	}
+	require.NoErrorf(t, bf.Parse(), "Test %q was supposed to work", bf.Args)
+	require.True(t, flBool1.IsTrue(), "Test-b2 Bool1 was supposed to be true")
 
 	// ---
 
@@ -141,13 +96,8 @@ func TestBuilderFlags(t *testing.T) {
 	flBool1 = bf.AddBool("bool1", false)
 	bf.Args = []string{"--bool1=false"}
 
-	if err = bf.Parse(); err != nil {
-		t.Fatalf("Test %q was supposed to work: %s", bf.Args, err)
-	}
-
-	if flBool1.IsTrue() {
-		t.Fatal("Test-b3 Bool1 was supposed to be false")
-	}
+	require.NoErrorf(t, bf.Parse(), "Test %q was supposed to work", bf.Args)
+	require.False(t, flBool1.IsTrue(), "Test-b3 Bool1 was supposed to be false")
 
 	// ---
 
@@ -155,9 +105,7 @@ func TestBuilderFlags(t *testing.T) {
 	bf.AddBool("bool1", false)
 	bf.Args = []string{"--bool1=false1"}
 
-	if err = bf.Parse(); err == nil {
-		t.Fatalf("Test %q was supposed to fail", bf.Args)
-	}
+	require.Errorf(t, bf.Parse(), "Test %q was supposed to fail", bf.Args)
 
 	// ---
 
@@ -165,9 +113,7 @@ func TestBuilderFlags(t *testing.T) {
 	bf.AddBool("bool1", false)
 	bf.Args = []string{"--bool2"}
 
-	if err = bf.Parse(); err == nil {
-		t.Fatalf("Test %q was supposed to fail", bf.Args)
-	}
+	require.Errorf(t, bf.Parse(), "Test %q was supposed to fail", bf.Args)
 
 	// ---
 
@@ -176,16 +122,9 @@ func TestBuilderFlags(t *testing.T) {
 	flBool1 = bf.AddBool("bool1", false)
 	bf.Args = []string{"--bool1", "--str1=BYE"}
 
-	if err = bf.Parse(); err != nil {
-		t.Fatalf("Test %q was supposed to work: %s", bf.Args, err)
-	}
-
-	if flStr1.Value != "BYE" {
-		t.Fatalf("Test %s, str1 should be BYE", bf.Args)
-	}
-	if !flBool1.IsTrue() {
-		t.Fatalf("Test %s, bool1 should be true", bf.Args)
-	}
+	require.NoErrorf(t, bf.Parse(), "Test %q was supposed to work", bf.Args)
+	require.Equalf(t, "BYE", flStr1.Value, "Test %s, str1 should be BYE", bf.Args)
+	require.Truef(t, flBool1.IsTrue(), "Test %s, bool1 should be true", bf.Args)
 
 	// ---
 
@@ -202,14 +141,9 @@ func TestBuilderFlags(t *testing.T) {
 
 	bf.Args = []string{`--bool2=false`, `--bool3`, `--bool4=true`, `--bool5`, `--str2= `, `--str3=def3`, `--str4=my-val`}
 
-	if err = bf.Parse(); err != nil {
-		t.Fatalf("Test %q was supposed to work: %s", bf.Args, err)
-	}
+	require.NoErrorf(t, bf.Parse(), "Test %q was supposed to work", bf.Args)
 	used := bf.Used()
 	slices.Sort(used)
-	expected = "bool2, bool3, bool4, bool5, str2, str3, str4"
 	actual := strings.Join(used, ", ")
-	if actual != expected {
-		t.Fatalf("Test %s, expected '%s', got '%s'", bf.Args, expected, actual)
-	}
+	require.Equalf(t, "bool2, bool3, bool4, bool5, str2, str3, str4", actual, "Test %s, expected '%s', got '%s'", bf.Args, "bool2, bool3, bool4, bool5, str2, str3, str4", actual)
 }

--- a/frontend/dockerfile/instructions/commands_rundevice_test.go
+++ b/frontend/dockerfile/instructions/commands_rundevice_test.go
@@ -58,7 +58,6 @@ func TestParseDevice(t *testing.T) {
 		t.Run(tt.input, func(t *testing.T) {
 			result, err := ParseDevice(tt.input)
 			if tt.expectedErr != nil {
-				require.Error(t, err)
 				require.EqualError(t, err, tt.expectedErr.Error())
 			} else {
 				require.NoError(t, err)

--- a/frontend/dockerfile/instructions/parse_heredoc_test.go
+++ b/frontend/dockerfile/instructions/parse_heredoc_test.go
@@ -24,13 +24,10 @@ func TestErrorCasesHeredoc(t *testing.T) {
 		r := strings.NewReader(c.dockerfile)
 		ast, err := parser.Parse(r)
 
-		if err != nil {
-			t.Fatalf("Error when parsing Dockerfile: %s", err)
-		}
+		require.NoErrorf(t, err, "Error when parsing Dockerfile")
 		n := ast.AST.Children[0]
 		_, err = ParseInstruction(n)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), c.expectedError)
+		require.ErrorContains(t, err, c.expectedError)
 	}
 }
 

--- a/frontend/dockerfile/instructions/parse_test.go
+++ b/frontend/dockerfile/instructions/parse_test.go
@@ -139,8 +139,7 @@ func TestParseOptInterval(t *testing.T) {
 		Value:    "50ns",
 	}
 	_, err := parseOptInterval(flInterval)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "cannot be less than 1ms")
+	require.ErrorContains(t, err, "cannot be less than 1ms")
 
 	flInterval.Value = "0ms"
 	_, err = parseOptInterval(flInterval)
@@ -250,9 +249,7 @@ func TestErrorCases(t *testing.T) {
 		r := strings.NewReader(c.dockerfile)
 		ast, err := parser.Parse(r)
 
-		if err != nil {
-			t.Fatalf("Error when parsing Dockerfile: %s", err)
-		}
+		require.NoErrorf(t, err, "Error when parsing Dockerfile")
 		n := ast.AST.Children[0]
 		_, err = ParseInstruction(n)
 		require.ErrorContains(t, err, c.expectedError)

--- a/frontend/dockerfile/instructions/support_test.go
+++ b/frontend/dockerfile/instructions/support_test.go
@@ -1,6 +1,10 @@
 package instructions
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 type testCase struct {
 	name       string
@@ -52,14 +56,10 @@ func TestHandleJSONArgs(t *testing.T) {
 	for _, test := range testCases {
 		arguments := handleJSONArgs(test.args, test.attributes)
 
-		if len(arguments) != len(test.expected) {
-			t.Fatalf("In test \"%s\": length of returned slice is incorrect. Expected: %d, got: %d", test.name, len(test.expected), len(arguments))
-		}
+		require.Equalf(t, len(arguments), len(test.expected), "In test \"%s\": length of returned slice is incorrect. Expected: %d, got: %d", test.name, len(test.expected), len(arguments))
 
 		for i := range test.expected {
-			if arguments[i] != test.expected[i] {
-				t.Fatalf("In test \"%s\": element as position %d is incorrect. Expected: %s, got: %s", test.name, i, test.expected[i], arguments[i])
-			}
+			require.Equalf(t, arguments[i], test.expected[i], "In test \"%s\": element as position %d is incorrect. Expected: %s, got: %s", test.name, i, test.expected[i], arguments[i])
 		}
 	}
 }

--- a/frontend/dockerfile/parser/json_test.go
+++ b/frontend/dockerfile/parser/json_test.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"testing"
 
-	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 )
 
 var invalidJSONArraysOfStrings = []string{
@@ -30,28 +30,19 @@ var validJSONArraysOfStrings = map[string][]string{
 
 func TestJSONArraysOfStrings(t *testing.T) {
 	for json, expected := range validJSONArraysOfStrings {
-		if node, _, err := parseJSON(json); err != nil {
-			t.Fatalf("%q should be a valid JSON array of strings, but wasn't! (err: %q)", json, err)
-		} else {
-			i := 0
-			for node != nil {
-				if i >= len(expected) {
-					t.Fatalf("expected result is shorter than parsed result (%d vs %d+) in %q", len(expected), i+1, json)
-				}
-				if node.Value != expected[i] {
-					t.Fatalf("expected %q (not %q) in %q at pos %d", expected[i], node.Value, json, i)
-				}
-				node = node.Next
-				i++
-			}
-			if i != len(expected) {
-				t.Fatalf("expected result is longer than parsed result (%d vs %d) in %q", len(expected), i+1, json)
-			}
+		node, _, err := parseJSON(json)
+		require.NoErrorf(t, err, "%q should be a valid JSON array of strings, but wasn't! (err: %q)", json, err)
+		i := 0
+		for node != nil {
+			require.Lessf(t, i, len(expected), "expected result is shorter than parsed result (%d vs %d+) in %q", len(expected), i+1, json)
+			require.Equalf(t, node.Value, expected[i], "expected %q (not %q) in %q at pos %d", expected[i], node.Value, json, i)
+			node = node.Next
+			i++
 		}
+		require.Equalf(t, len(expected), i, "expected result is longer than parsed result (%d vs %d) in %q", len(expected), i+1, json)
 	}
 	for _, json := range invalidJSONArraysOfStrings {
-		if _, _, err := parseJSON(json); !errors.Is(err, errDockerfileNotStringArray) {
-			t.Fatalf("%q should be an invalid JSON array of strings, but wasn't!", json)
-		}
+		_, _, err := parseJSON(json)
+		require.ErrorIsf(t, err, errDockerfileNotStringArray, "%q should be an invalid JSON array of strings, but wasn't!", json)
 	}
 }

--- a/frontend/dockerfile/shell/lex_test.go
+++ b/frontend/dockerfile/shell/lex_test.go
@@ -116,9 +116,7 @@ func TestShellParser4EnvVars(t *testing.T) {
 		expected := strings.TrimSpace(words[2])
 
 		// Key W=Windows; A=All; U=Unix
-		if platform != "W" && platform != "A" && platform != "U" {
-			t.Fatalf("Invalid tag %s at line %d of %s. Must be W, A or U", platform, lineCount, fn)
-		}
+		require.Falsef(t, platform != "W" && platform != "A" && platform != "U", "Invalid tag %s at line %d of %s. Must be W, A or U", platform, lineCount, fn)
 
 		if ((platform == "W" || platform == "A") && runtime.GOOS == "windows") ||
 			((platform == "U" || platform == "A") && runtime.GOOS != "windows") {
@@ -137,9 +135,7 @@ func TestShellParser4Words(t *testing.T) {
 	fn := "wordsTest"
 
 	file, err := os.Open(fn)
-	if err != nil {
-		t.Fatalf("Can't open '%s': %s", err, fn)
-	}
+	require.NoErrorf(t, err, "Can't open '%s'", fn)
 	defer file.Close()
 
 	const (
@@ -170,9 +166,7 @@ func TestShellParser4Words(t *testing.T) {
 			}
 
 			words := strings.Split(line, "|")
-			if len(words) != 2 {
-				t.Fatalf("Error in '%s'(line %d) - should be exactly one | in: %q", fn, lineNum, line)
-			}
+			require.Equalf(t, 2, len(words), "Error in '%s'(line %d) - should be exactly one | in: %q", fn, lineNum, line)
 			test := strings.TrimSpace(words[0])
 			expected := strings.Split(strings.TrimLeft(words[1], " "), ",")
 
@@ -183,13 +177,9 @@ func TestShellParser4Words(t *testing.T) {
 				result = []string{"error"}
 			}
 
-			if len(result) != len(expected) {
-				t.Fatalf("Error on line %d. %q was suppose to result in %q, but got %q instead", lineNum, test, expected, result)
-			}
+			require.Equalf(t, len(expected), len(result), "Error on line %d. %q was suppose to result in %q, but got %q instead", lineNum, test, expected, result)
 			for i, w := range expected {
-				if w != result[i] {
-					t.Fatalf("Error on line %d. %q was suppose to result in %q, but got %q instead", lineNum, test, expected, result)
-				}
+				require.Equalf(t, w, result[i], "Error on line %d. %q was suppose to result in %q, but got %q instead", lineNum, test, expected, result)
 			}
 		}
 	}
@@ -203,38 +193,24 @@ func TestGetEnv(t *testing.T) {
 		return value
 	}
 	sw.envs = EnvsFromSlice([]string{})
-	if getEnv("foo") != "" {
-		t.Fatal("2 - 'foo' should map to ''")
-	}
+	require.Empty(t, getEnv("foo"), "2 - 'foo' should map to ''")
 
 	sw.envs = EnvsFromSlice([]string{"foo"})
-	if getEnv("foo") != "" {
-		t.Fatal("3 - 'foo' should map to ''")
-	}
+	require.Empty(t, getEnv("foo"), "3 - 'foo' should map to ''")
 
 	sw.envs = EnvsFromSlice([]string{"foo="})
-	if getEnv("foo") != "" {
-		t.Fatal("4 - 'foo' should map to ''")
-	}
+	require.Empty(t, getEnv("foo"), "4 - 'foo' should map to ''")
 
 	sw.envs = EnvsFromSlice([]string{"foo=bar"})
-	if getEnv("foo") != "bar" {
-		t.Fatal("5 - 'foo' should map to 'bar'")
-	}
+	require.Equal(t, "bar", getEnv("foo"), "5 - 'foo' should map to 'bar'")
 
 	sw.envs = EnvsFromSlice([]string{"foo=bar", "car=hat"})
-	if getEnv("foo") != "bar" {
-		t.Fatal("6 - 'foo' should map to 'bar'")
-	}
-	if getEnv("car") != "hat" {
-		t.Fatal("7 - 'car' should map to 'hat'")
-	}
+	require.Equal(t, "bar", getEnv("foo"), "6 - 'foo' should map to 'bar'")
+	require.Equal(t, "hat", getEnv("car"), "7 - 'car' should map to 'hat'")
 
 	// Make sure we grab the last 'car' in the list
 	sw.envs = EnvsFromSlice([]string{"foo=bar", "car=hat", "car=bike"})
-	if getEnv("car") != "bike" {
-		t.Fatal("8 - 'car' should map to 'bike'")
-	}
+	require.Equal(t, "bike", getEnv("car"), "8 - 'car' should map to 'bike'")
 }
 
 func TestProcessWithMatches(t *testing.T) {

--- a/session/sshforward/sshprovider/agentprovider_test.go
+++ b/session/sshforward/sshprovider/agentprovider_test.go
@@ -4,7 +4,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/moby/buildkit/cmd/buildctl/build"
@@ -14,14 +13,9 @@ import (
 
 func TestToAgentSource(t *testing.T) {
 	configs, err := build.ParseSSH([]string{"default"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, err = sshprovider.NewSSHAgentProvider(configs)
-	ok := err == nil || strings.Contains(err.Error(), "invalid empty ssh agent socket")
-	if !ok {
-		t.Fatal(err)
-	}
+	require.ErrorContains(t, err, "invalid empty ssh agent socket")
 
 	_, err = build.ParseSSH([]string{"default=raw=true"})
 	require.ErrorContains(t, err, "raw mode must supply exactly one socket path")

--- a/snapshot/snapshotter_test.go
+++ b/snapshot/snapshotter_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/moby/buildkit/util/leaseutil"
 	overlayutil "github.com/moby/buildkit/util/overlay"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	bolt "go.etcd.io/bbolt"
 	libcap "kernel.org/pub/linux/libs/security/libcap/cap"
@@ -56,7 +57,7 @@ func newSnapshotter(ctx context.Context, t *testing.T, snapshotterName string) (
 		return nil, nil, errors.Errorf("unhandled snapshotter: %s", snapshotterName)
 	}
 	t.Cleanup(func() {
-		require.NoError(t, ctdSnapshotter.Close())
+		assert.NoError(t, ctdSnapshotter.Close())
 	})
 
 	store, err := local.NewStore(tmpdir)
@@ -69,7 +70,7 @@ func newSnapshotter(ctx context.Context, t *testing.T, snapshotterName string) (
 		return nil, nil, err
 	}
 	t.Cleanup(func() {
-		require.NoError(t, db.Close())
+		assert.NoError(t, db.Close())
 	})
 
 	mdb := ctdmetadata.NewDB(db, store, map[string]snapshots.Snapshotter{
@@ -85,7 +86,7 @@ func newSnapshotter(ctx context.Context, t *testing.T, snapshotterName string) (
 		snapshotter.tryCrossSnapshotLink = false
 	}
 	t.Cleanup(func() {
-		require.NoError(t, snapshotter.Close())
+		assert.NoError(t, snapshotter.Close())
 	})
 
 	leaseID := identity.NewID()

--- a/solver/bboltcachestorage/storage_test.go
+++ b/solver/bboltcachestorage/storage_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/moby/buildkit/solver"
 	"github.com/moby/buildkit/solver/testutil"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,7 +17,7 @@ func TestBoltCacheStorage(t *testing.T) {
 		st, err := NewStore(filepath.Join(tmpDir, "cache.db"))
 		require.NoError(t, err)
 		t.Cleanup(func() {
-			require.NoError(t, st.Close())
+			assert.NoError(t, st.Close())
 		})
 
 		return st

--- a/solver/exporter_test.go
+++ b/solver/exporter_test.go
@@ -4,6 +4,8 @@ import (
 	"slices"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestCompareCacheRecord(t *testing.T) {
@@ -28,7 +30,5 @@ func TestCompareCacheRecord(t *testing.T) {
 		got = append(got, names[r])
 	}
 	want := []string{"c", "a", "b", "d", "nil", "nil"}
-	if !slices.Equal(got, want) {
-		t.Fatalf("unexpected order: got %v, want %v", got, want)
-	}
+	require.Truef(t, slices.Equal(got, want), "unexpected order: got %v, want %v", got, want)
 }

--- a/solver/internal/pipe/pipe_test.go
+++ b/solver/internal/pipe/pipe_test.go
@@ -87,6 +87,5 @@ func TestPipeCancel(t *testing.T) {
 	st = p.Receiver.Status()
 	require.Equal(t, true, st.Completed)
 	require.Equal(t, true, st.Canceled)
-	require.Error(t, st.Err)
 	require.ErrorIs(t, st.Err, context.Canceled)
 }

--- a/solver/llbsolver/file/backend_test.go
+++ b/solver/llbsolver/file/backend_test.go
@@ -8,15 +8,13 @@ import (
 	"testing"
 
 	"github.com/moby/buildkit/solver/pb"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
 func TestRmPathNonExistentFileAllowNotFoundFalse(t *testing.T) {
 	root := t.TempDir()
 	err := rmPath(root, "doesnt_exist", false)
-	require.Error(t, err)
-	require.True(t, errors.Is(err, os.ErrNotExist))
+	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func TestRmPathNonExistentFileAllowNotFoundTrue(t *testing.T) {

--- a/solver/llbsolver/history/filter_test.go
+++ b/solver/llbsolver/history/filter_test.go
@@ -133,8 +133,7 @@ func TestHistoryFilters(t *testing.T) {
 		t.Run(tcase.name, func(t *testing.T) {
 			out, err := filterHistoryEvents(testRecords, tcase.filters, tcase.limit)
 			if tcase.err != "" {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tcase.err)
+				require.ErrorContains(t, err, tcase.err)
 				return
 			}
 			require.NoError(t, err)

--- a/solver/llbsolver/metrics_test.go
+++ b/solver/llbsolver/metrics_test.go
@@ -96,9 +96,8 @@ func TestRecordBuildCompletion_Success(t *testing.T) {
 	})
 	require.Equal(t, int64(1), builds.Value)
 	// On success, error_code must not be present at all.
-	if _, ok := builds.Attributes.Value("error_code"); ok {
-		t.Fatal("error_code attribute should be absent on success")
-	}
+	_, ok := builds.Attributes.Value("error_code")
+	require.False(t, ok, "error_code attribute should be absent on success")
 
 	hist, ok := got["buildkit.build.duration"].(metricdata.Histogram[float64])
 	require.True(t, ok, "expected Histogram[float64] for build.duration, got %T", got["buildkit.build.duration"])

--- a/solver/llbsolver/mounts/mount_test.go
+++ b/solver/llbsolver/mounts/mount_test.go
@@ -78,7 +78,7 @@ func newCacheManager(ctx context.Context, t *testing.T, opt cmOpt) (co *cmOut, e
 		return nil, err
 	}
 	t.Cleanup(func() {
-		require.NoError(t, db.Close())
+		assert.NoError(t, db.Close())
 	})
 
 	mdb := ctdmetadata.NewDB(db, store, map[string]snapshots.Snapshotter{
@@ -98,7 +98,7 @@ func newCacheManager(ctx context.Context, t *testing.T, opt cmOpt) (co *cmOut, e
 		return nil, err
 	}
 	t.Cleanup(func() {
-		require.NoError(t, md.Close())
+		assert.NoError(t, md.Close())
 	})
 
 	cm, err := cache.NewManager(cache.ManagerOpt{
@@ -116,7 +116,7 @@ func newCacheManager(ctx context.Context, t *testing.T, opt cmOpt) (co *cmOut, e
 		return nil, err
 	}
 	t.Cleanup(func() {
-		require.NoError(t, cm.Close())
+		assert.NoError(t, cm.Close())
 	})
 
 	return &cmOut{
@@ -144,7 +144,7 @@ func TestCacheMountPrivateRefs(t *testing.T) {
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, snapshotter.Close())
+		assert.NoError(t, snapshotter.Close())
 	})
 
 	co, err := newCacheManager(ctx, t, cmOpt{
@@ -210,7 +210,7 @@ func TestCacheMountSharedRefs(t *testing.T) {
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, snapshotter.Close())
+		assert.NoError(t, snapshotter.Close())
 	})
 
 	co, err := newCacheManager(ctx, t, cmOpt{
@@ -259,7 +259,7 @@ func TestCacheMountLockedRefs(t *testing.T) {
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, snapshotter.Close())
+		assert.NoError(t, snapshotter.Close())
 	})
 
 	co, err := newCacheManager(ctx, t, cmOpt{
@@ -297,7 +297,7 @@ func TestCacheMountLockedRefs(t *testing.T) {
 
 	select {
 	case <-gotRef4:
-		require.FailNow(t, "mount did not lock")
+		t.Fatal("mount did not lock")
 	case <-time.After(500 * time.Millisecond):
 	}
 
@@ -307,7 +307,7 @@ func TestCacheMountLockedRefs(t *testing.T) {
 	select {
 	case <-gotRef4:
 	case <-time.After(2 * time.Second):
-		require.FailNow(t, "mount did not unlock")
+		t.Fatal("mount did not unlock")
 	}
 }
 
@@ -321,7 +321,7 @@ func TestCacheMountSharedRefsDeadlock(t *testing.T) {
 	snapshotter, err := native.NewSnapshotter(filepath.Join(tmpdir, "snapshots"))
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, snapshotter.Close())
+		assert.NoError(t, snapshotter.Close())
 	})
 
 	co, err := newCacheManager(ctx, t, cmOpt{
@@ -368,6 +368,6 @@ func TestCacheMountSharedRefsDeadlock(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(10 * time.Second):
-		require.FailNow(t, "deadlock on releasing while getting new ref")
+		t.Fatal("deadlock on releasing while getting new ref")
 	}
 }

--- a/solver/llbsolver/ops/exec_binfmt_test.go
+++ b/solver/llbsolver/ops/exec_binfmt_test.go
@@ -82,7 +82,7 @@ func TestBinfmtXAttrErrorHandler(t *testing.T) {
 
 			if tt.expectErr {
 				require.Error(t, result, tt.description)
-				require.Equal(t, tt.inputErr, result, "Error should be propagated unchanged")
+				require.ErrorIs(t, result, tt.inputErr, "Error should be propagated unchanged")
 			} else {
 				require.NoError(t, result, tt.description)
 			}

--- a/solver/llbsolver/ops/exec_test.go
+++ b/solver/llbsolver/ops/exec_test.go
@@ -257,8 +257,8 @@ func TestExecOpContentCache(t *testing.T) {
 					require.NotZero(t, dep.ComputeDigestFunc)
 				}
 			} else {
-				require.False(t, ok)
 				require.ErrorContains(t, err, "invalid mount")
+				require.False(t, ok)
 			}
 		})
 	}

--- a/solver/llbsolver/ops/file_test.go
+++ b/solver/llbsolver/ops/file_test.go
@@ -211,8 +211,7 @@ func TestInvalidNoOutput(t *testing.T) {
 	s, rb := newTestFileSolver()
 	outs, err := s.Solve(t.Context(), []fileoptypes.Ref{}, fo.Actions, nil)
 	rb.checkReleased(t, outs)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "no outputs specified")
+	require.ErrorContains(t, err, "no outputs specified")
 }
 
 func TestInvalidDuplicateOutput(t *testing.T) {
@@ -247,8 +246,7 @@ func TestInvalidDuplicateOutput(t *testing.T) {
 
 	s, rb := newTestFileSolver()
 	_, err := s.Solve(t.Context(), []fileoptypes.Ref{}, fo.Actions, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "duplicate output")
+	require.ErrorContains(t, err, "duplicate output")
 	rb.checkReleased(t, nil)
 }
 
@@ -273,8 +271,7 @@ func TestActionInvalidIndex(t *testing.T) {
 
 	s, rb := newTestFileSolver()
 	_, err := s.Solve(t.Context(), []fileoptypes.Ref{}, fo.Actions, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "loop from index")
+	require.ErrorContains(t, err, "loop from index")
 	rb.checkReleased(t, nil)
 }
 
@@ -310,8 +307,7 @@ func TestActionLoop(t *testing.T) {
 
 	s, rb := newTestFileSolver()
 	_, err := s.Solve(t.Context(), []fileoptypes.Ref{}, fo.Actions, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "loop from index")
+	require.ErrorContains(t, err, "loop from index")
 	rb.checkReleased(t, nil)
 }
 

--- a/solver/llbsolver/vertex_test.go
+++ b/solver/llbsolver/vertex_test.go
@@ -181,7 +181,6 @@ func TestWithProxyNetworkHostEgressRequiresEntitlement(t *testing.T) {
 	})
 
 	_, err := loadWithProxyNetwork(t.Context(), def, nil, true, ValidateEntitlements(entitlements.Set{}, nil))
-	require.Error(t, err)
 	require.ErrorContains(t, err, "network.host is not allowed")
 
 	_, err = loadWithProxyNetwork(t.Context(), def, nil, true, ValidateEntitlements(entitlements.Set{

--- a/solver/resolvercache_test.go
+++ b/solver/resolvercache_test.go
@@ -212,9 +212,9 @@ func TestCombinedResolverCache_ErrorHandlingAndRollback(t *testing.T) {
 	combined := combinedResolverCache([]ResolverCache{rc1, rc2})
 	values, release, err := combined.Lock("key")
 
+	require.EqualError(t, err, "rc2 failed")
 	assert.Nil(t, values)
 	assert.Nil(t, release)
-	require.EqualError(t, err, "rc2 failed")
 
 	mu.Lock()
 	assert.Contains(t, released, "rc1", "should rollback acquired locks")

--- a/solver/scheduler_test.go
+++ b/solver/scheduler_test.go
@@ -502,8 +502,7 @@ func TestSingleCancelCache(t *testing.T) {
 	g0.Vertex.(*vertex).setupCallCounters()
 
 	_, err = j0.Build(ctx, g0)
-	require.Error(t, err)
-	require.Equal(t, true, errors.Is(err, context.Canceled))
+	require.ErrorIs(t, err, context.Canceled)
 
 	require.Equal(t, int64(1), *g0.Vertex.(*vertex).cacheCallCount)
 	require.Equal(t, int64(0), *g0.Vertex.(*vertex).execCallCount)
@@ -544,8 +543,7 @@ func TestSingleCancelExec(t *testing.T) {
 	g1.Vertex.(*vertex).setupCallCounters()
 
 	_, err = j1.Build(ctx, g1)
-	require.Error(t, err)
-	require.Equal(t, true, errors.Is(err, context.Canceled))
+	require.ErrorIs(t, err, context.Canceled)
 
 	require.Equal(t, int64(1), *g1.Vertex.(*vertex).cacheCallCount)
 	require.Equal(t, int64(1), *g1.Vertex.(*vertex).execCallCount)
@@ -598,8 +596,7 @@ func TestSingleCancelParallel(t *testing.T) {
 
 		_, err = j.Build(ctx, g)
 		close(firstErrored)
-		require.Error(t, err)
-		require.Equal(t, true, errors.Is(err, context.Canceled))
+		require.ErrorIs(t, err, context.Canceled)
 		return nil
 	})
 
@@ -1272,8 +1269,7 @@ func TestErrorReturns(t *testing.T) {
 	}
 
 	_, err = j0.Build(ctx, g0)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "error-from-test")
+	require.ErrorContains(t, err, "error-from-test")
 
 	require.NoError(t, j0.Discard())
 	j0 = nil
@@ -1313,8 +1309,7 @@ func TestErrorReturns(t *testing.T) {
 	}
 
 	_, err = j1.Build(ctx, g1)
-	require.Error(t, err)
-	require.Equal(t, true, errors.Is(err, context.Canceled))
+	require.ErrorIs(t, err, context.Canceled)
 
 	require.NoError(t, j1.Discard())
 	j1 = nil
@@ -1354,8 +1349,7 @@ func TestErrorReturns(t *testing.T) {
 	}
 
 	_, err = j2.Build(ctx, g2)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "exec-error-from-test")
+	require.ErrorContains(t, err, "exec-error-from-test")
 
 	require.NoError(t, j2.Discard())
 	j1 = nil
@@ -3543,8 +3537,7 @@ func TestUnknownBuildID(t *testing.T) {
 	defer s.Close()
 
 	_, err := s.Get(identity.NewID())
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "no such job")
+	require.ErrorContains(t, err, "no such job")
 }
 
 func TestStaleEdgeMerge(t *testing.T) {

--- a/solver/testutil/cachestorage_testsuite.go
+++ b/solver/testutil/cachestorage_testsuite.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/moby/buildkit/solver"
 	digest "github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -73,7 +72,7 @@ func testResults(t *testing.T, st solver.CacheKeyStorage) {
 	require.True(t, ok)
 	f1, ok := m["foo1"]
 	require.True(t, ok)
-	require.True(t, f0.CreatedAt.Before(f1.CreatedAt), "f0.CreatedAt %v was not Before f1.CreatedAt %v", f0.CreatedAt, f1.CreatedAt)
+	require.Less(t, f0.CreatedAt, f1.CreatedAt, "f0.CreatedAt %v was not Before f1.CreatedAt %v", f0.CreatedAt, f1.CreatedAt)
 
 	m = map[string]solver.CacheResult{}
 	err = st.WalkResults("bar", func(r solver.CacheResult) error {
@@ -99,12 +98,10 @@ func testResults(t *testing.T, st solver.CacheKeyStorage) {
 	require.Equal(t, "foo1", res.ID)
 
 	_, err = st.Load("foo1", "foo1")
-	require.Error(t, err)
-	require.Equal(t, true, errors.Is(err, solver.ErrNotFound))
+	require.ErrorIs(t, err, solver.ErrNotFound)
 
 	_, err = st.Load("foo", "foo2")
-	require.Error(t, err)
-	require.Equal(t, true, errors.Is(err, solver.ErrNotFound))
+	require.ErrorIs(t, err, solver.ErrNotFound)
 }
 
 func testLinks(t *testing.T, st solver.CacheKeyStorage) {

--- a/solver/testutil/cachestorage_testsuite.go
+++ b/solver/testutil/cachestorage_testsuite.go
@@ -87,7 +87,7 @@ func testResults(t *testing.T, st solver.CacheKeyStorage) {
 
 	// empty result
 	err = st.WalkResults("baz", func(r solver.CacheResult) error {
-		require.Fail(t, "unreachable")
+		t.Error("unreachable")
 		return nil
 	})
 	require.NoError(t, err)
@@ -208,7 +208,7 @@ func testResultReleaseSingleLevel(t *testing.T, st solver.CacheKeyStorage) {
 	require.Equal(t, 0, len(m))
 
 	st.Walk(func(id string) error {
-		require.Fail(t, fmt.Sprintf("id %s should have been released", id))
+		t.Errorf("id %s should have been released", id)
 		return nil
 	})
 }
@@ -336,7 +336,7 @@ func testResultReleaseMultiLevel(t *testing.T, st solver.CacheKeyStorage) {
 	require.False(t, st.Exists("foo"))
 
 	st.Walk(func(id string) error {
-		require.Fail(t, fmt.Sprintf("id %s should have been released", id))
+		t.Errorf("id %s should have been released", id)
 		return nil
 	})
 }

--- a/source/git/identifier_test.go
+++ b/source/git/identifier_test.go
@@ -335,8 +335,7 @@ func TestIdentifierBundleValidation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			id, err := src.Identifier("git", tt.url, tt.attrs, nil)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 			require.NoError(t, err)

--- a/source/git/source_test.go
+++ b/source/git/source_test.go
@@ -547,7 +547,6 @@ func testFetchByCommit(t *testing.T, format string, keepGitDir bool) {
 	gStale, err := gs.Resolve(ctx, idStale, nil, nil)
 	require.NoError(t, err)
 	_, _, _, _, err = gStale.CacheKey(ctx, nil, 0)
-	require.Error(t, err)
 	require.ErrorContains(t, err, "expected checksum to match")
 
 	// Fetch the old commit by checksum with FetchByCommit and the same
@@ -657,7 +656,6 @@ func testFetchByCommitRequiresChecksum(t *testing.T, format string) {
 	g, err := gs.Resolve(ctx, id, nil, nil)
 	require.NoError(t, err)
 	_, _, _, _, err = g.CacheKey(ctx, nil, 0)
-	require.Error(t, err)
 	require.ErrorContains(t, err, "fetch-by-commit")
 }
 
@@ -1403,7 +1401,6 @@ func testFetchBranchRemoveRace(t *testing.T, format string, keepGitDir bool) {
 	require.Error(t, err, string(out))
 
 	_, err = g.Snapshot(ctx, nil)
-	require.Error(t, err)
 	require.ErrorContains(t, err, "fetched ref feature does not match expected commit "+shaFeature)
 }
 

--- a/source/http/source_test.go
+++ b/source/http/source_test.go
@@ -214,8 +214,7 @@ func TestHTTPInvalidURL(t *testing.T) {
 	require.NoError(t, err)
 
 	_, _, _, _, err = h.CacheKey(ctx, nil, 0)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid response")
+	require.ErrorContains(t, err, "invalid response")
 }
 
 func TestHTTPCredentialsRedactedInError(t *testing.T) {
@@ -365,7 +364,6 @@ func TestHTTPSignatureVerification(t *testing.T) {
 		h, err := hs.Resolve(ctx, id, nil, nil)
 		require.NoError(t, err)
 		_, _, _, _, err = h.CacheKey(ctx, nil, 0)
-		require.Error(t, err)
 		require.ErrorContains(t, err, "failed to verify pgp signature")
 	})
 
@@ -395,7 +393,6 @@ func TestHTTPSignatureVerification(t *testing.T) {
 		h, err := hs.Resolve(ctx, id, nil, nil)
 		require.NoError(t, err)
 		_, _, _, _, err = h.CacheKey(ctx, nil, 0)
-		require.Error(t, err)
 		require.ErrorContains(t, err, "requires both pubkey and signature")
 	})
 }

--- a/source/http/source_test.go
+++ b/source/http/source_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/moby/buildkit/util/testutil/httpserver"
 	"github.com/moby/buildkit/util/winlayers"
 	digest "github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	bolt "go.etcd.io/bbolt"
 )
@@ -532,7 +533,7 @@ func newCacheManager(t *testing.T) (cache.Manager, error) {
 		return nil, err
 	}
 	t.Cleanup(func() {
-		require.NoError(t, snapshotter.Close())
+		assert.NoError(t, snapshotter.Close())
 	})
 
 	store, err := local.NewStore(tmpdir)
@@ -545,7 +546,7 @@ func newCacheManager(t *testing.T) (cache.Manager, error) {
 		return nil, err
 	}
 	t.Cleanup(func() {
-		require.NoError(t, db.Close())
+		assert.NoError(t, db.Close())
 	})
 
 	mdb := ctdmetadata.NewDB(db, store, map[string]snapshots.Snapshotter{
@@ -557,7 +558,7 @@ func newCacheManager(t *testing.T) (cache.Manager, error) {
 		return nil, err
 	}
 	t.Cleanup(func() {
-		require.NoError(t, md.Close())
+		assert.NoError(t, md.Close())
 	})
 
 	lm := leaseutil.WithNamespace(ctdmetadata.NewLeaseManager(mdb), "buildkit")
@@ -580,7 +581,7 @@ func newCacheManager(t *testing.T) (cache.Manager, error) {
 		return nil, err
 	}
 	t.Cleanup(func() {
-		require.NoError(t, cm.Close())
+		assert.NoError(t, cm.Close())
 	})
 
 	return cm, nil

--- a/sourcepolicy/engine_test.go
+++ b/sourcepolicy/engine_test.go
@@ -135,8 +135,8 @@ func testConvertMultiple(t *testing.T) {
 	e := NewEngine(pol)
 
 	mutated, err := e.Evaluate(ctx, op)
-	require.True(t, mutated)
 	require.NoError(t, err)
+	require.True(t, mutated)
 }
 
 func testConvertWildcard(t *testing.T) {
@@ -165,8 +165,8 @@ func testConvertWildcard(t *testing.T) {
 	e := NewEngine(pol)
 
 	mutated, err := e.Evaluate(ctx, op)
-	require.True(t, mutated)
 	require.NoError(t, err)
+	require.True(t, mutated)
 	require.Equal(t, "docker-image://fakereg.io/library/golang:1.19", op.Identifier)
 }
 
@@ -194,8 +194,8 @@ func testConvertRegex(t *testing.T) {
 	e := NewEngine([]*spb.Policy{pol})
 
 	mutated, err := e.Evaluate(ctx, op)
-	require.True(t, mutated)
 	require.NoError(t, err)
+	require.True(t, mutated)
 	require.Equal(t, "docker-image://fakereg.io/library/golang:1.19", op.Identifier)
 }
 
@@ -222,8 +222,8 @@ func testConvertHTTP(t *testing.T) {
 	e := NewEngine([]*spb.Policy{pol})
 
 	mutated, err := e.Evaluate(ctx, op)
-	require.True(t, mutated)
 	require.NoError(t, err)
+	require.True(t, mutated)
 	require.Equal(t, "https://example.com/foo", op.Identifier)
 }
 
@@ -259,8 +259,8 @@ func testConvertLoop(t *testing.T) {
 	e := NewEngine([]*spb.Policy{pol})
 
 	mutated, err := e.Evaluate(ctx, op)
-	require.True(t, mutated)
 	require.ErrorIs(t, err, ErrTooManyOps)
+	require.True(t, mutated)
 }
 
 func testAllowConvertDeny(t *testing.T) {
@@ -304,8 +304,8 @@ func testAllowConvertDeny(t *testing.T) {
 	e := NewEngine([]*spb.Policy{pol})
 
 	mutated, err := e.Evaluate(ctx, op)
-	require.True(t, mutated)
 	require.ErrorIs(t, err, ErrSourceDenied)
+	require.True(t, mutated)
 	require.Equal(t, "docker-image://docker.io/library/alpine:latest", op.Identifier)
 }
 
@@ -338,8 +338,8 @@ func testConvertDeny(t *testing.T) {
 	e := NewEngine([]*spb.Policy{pol})
 
 	mutated, err := e.Evaluate(ctx, op)
-	require.True(t, mutated)
 	require.ErrorIs(t, err, ErrSourceDenied)
+	require.True(t, mutated)
 	require.Equal(t, "docker-image://docker.io/library/alpine:latest", op.Identifier)
 }
 
@@ -374,8 +374,8 @@ func testConvert(t *testing.T) {
 			e := NewEngine([]*spb.Policy{pol})
 
 			mutated, err := e.Evaluate(ctx, op)
-			require.True(t, mutated)
 			require.NoError(t, err)
+			require.True(t, mutated)
 			require.Equal(t, dst, op.Identifier)
 		})
 	}
@@ -404,8 +404,8 @@ func testConvertExact(t *testing.T) {
 	}
 
 	mutated, err := NewEngine([]*spb.Policy{pol}).Evaluate(t.Context(), op)
-	require.True(t, mutated)
 	require.NoError(t, err)
+	require.True(t, mutated)
 	require.Equal(t, dst, op.Identifier)
 }
 
@@ -442,8 +442,8 @@ func testAllowDeny(t *testing.T) {
 	}
 
 	mutated, err = e.Evaluate(ctx, op)
-	require.False(t, mutated)
 	require.ErrorIs(t, err, ErrSourceDenied)
+	require.False(t, mutated)
 }
 
 func testDenyAll(t *testing.T) {
@@ -474,8 +474,8 @@ func testDenyAll(t *testing.T) {
 			}
 
 			mutated, err := e.Evaluate(ctx, op)
-			require.False(t, mutated)
 			require.ErrorIs(t, err, ErrSourceDenied)
+			require.False(t, mutated)
 		})
 	}
 }

--- a/sourcepolicy/mutate_test.go
+++ b/sourcepolicy/mutate_test.go
@@ -134,6 +134,7 @@ func TestMutate(t *testing.T) {
 			if tc.expectedErr != "" {
 				require.Error(t, err, tc.expectedErr)
 			} else {
+				require.NoError(t, err)
 				require.True(t, proto.Equal(tc.expectedOp, op))
 			}
 		})

--- a/util/cachedigest/db_test.go
+++ b/util/cachedigest/db_test.go
@@ -140,7 +140,6 @@ func TestDecodeFramesInvalid(t *testing.T) {
 	bad[7] = 10
 	copy(bad[8:], []byte{1, 2, 3, 4})
 	_, err = decodeFrames(bad)
-	require.Error(t, err, "should error for length mismatch")
 	require.ErrorIs(t, err, ErrInvalidEncoding, "should return ErrInvalidFrameLength")
 }
 

--- a/util/cond/cond_test.go
+++ b/util/cond/cond_test.go
@@ -4,8 +4,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestCondInitialWaitBlocks(t *testing.T) {
@@ -27,14 +25,14 @@ func TestCondInitialWaitBlocks(t *testing.T) {
 	select {
 	case <-time.After(50 * time.Millisecond):
 	case <-waited:
-		require.Fail(t, "wait should have blocked")
+		t.Error("wait should have blocked")
 	}
 
 	c.Signal()
 
 	select {
 	case <-time.After(300 * time.Millisecond):
-		require.Fail(t, "wait should have resumed")
+		t.Error("wait should have resumed")
 	case <-waited:
 	}
 
@@ -61,7 +59,7 @@ func TestInitialSignalDoesntBlock(t *testing.T) {
 
 	select {
 	case <-time.After(300 * time.Millisecond):
-		require.Fail(t, "wait should have resumed")
+		t.Error("wait should have resumed")
 	case <-waited:
 	}
 
@@ -74,7 +72,7 @@ func TestInitialSignalDoesntBlock(t *testing.T) {
 	select {
 	case <-time.After(50 * time.Millisecond):
 	case <-waited:
-		require.Fail(t, "wait should have blocked")
+		t.Error("wait should have blocked")
 	}
 
 	c.Signal()
@@ -103,7 +101,7 @@ func TestSignalBetweenWaits(t *testing.T) {
 	select {
 	case <-time.After(50 * time.Millisecond):
 	case <-waited:
-		require.Fail(t, "wait should have blocked")
+		t.Error("wait should have blocked")
 	}
 
 	c.Signal()

--- a/util/contentutil/buffer_test.go
+++ b/util/contentutil/buffer_test.go
@@ -10,7 +10,6 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,8 +39,7 @@ func TestReadWrite(t *testing.T) {
 	require.Equal(t, "foo1", string(dt))
 
 	_, err = content.ReadBlob(ctx, b, ocispecs.Descriptor{Digest: digest.FromBytes([]byte("foo3"))})
-	require.Error(t, err)
-	require.Equal(t, true, errors.Is(err, cerrdefs.ErrNotFound))
+	require.ErrorIs(t, err, cerrdefs.ErrNotFound)
 }
 
 func TestReaderAt(t *testing.T) {
@@ -67,8 +65,7 @@ func TestReaderAt(t *testing.T) {
 	buf = make([]byte, 7)
 
 	n, err = rdr.ReadAt(buf, 3)
-	require.Error(t, err)
-	require.Equal(t, err, io.EOF)
+	require.ErrorIs(t, err, io.EOF)
 	require.Equal(t, "bar", string(buf[:n]))
 }
 

--- a/util/contentutil/fetcher_test.go
+++ b/util/contentutil/fetcher_test.go
@@ -43,8 +43,7 @@ func TestFetcher(t *testing.T) {
 	require.Equal(t, "oob", string(buf[:n]))
 
 	n, err = rdr.ReadAt(buf, 5)
-	require.Error(t, err)
-	require.Equal(t, err, io.EOF)
+	require.ErrorIs(t, err, io.EOF)
 	require.Equal(t, "r", string(buf[:n]))
 }
 
@@ -65,8 +64,7 @@ func TestSlowFetch(t *testing.T) {
 	require.Equal(t, "oob", string(buf[:n]))
 
 	n, err = rdr.ReadAt(buf, 5)
-	require.Error(t, err)
-	require.Equal(t, err, io.EOF)
+	require.ErrorIs(t, err, io.EOF)
 	require.Equal(t, "r", string(buf[:n]))
 }
 

--- a/util/contentutil/multiprovider_test.go
+++ b/util/contentutil/multiprovider_test.go
@@ -8,7 +8,6 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,6 +37,5 @@ func TestMultiProvider(t *testing.T) {
 	require.Equal(t, "foo1", string(dt))
 
 	_, err = content.ReadBlob(ctx, mp, ocispecs.Descriptor{Digest: digest.FromBytes([]byte("foo2"))})
-	require.Error(t, err)
-	require.Equal(t, true, errors.Is(err, cerrdefs.ErrNotFound))
+	require.ErrorIs(t, err, cerrdefs.ErrNotFound)
 }

--- a/util/flightcontrol/cached_test.go
+++ b/util/flightcontrol/cached_test.go
@@ -82,7 +82,7 @@ func TestCachedError(t *testing.T) {
 	select {
 	case <-ctx.Done():
 	default:
-		require.Fail(t, "expected context to be done")
+		t.Error("expected context to be done")
 	}
 
 	v, err := g.Do(ctx, "22", func(ctx context.Context) (string, error) {

--- a/util/flightcontrol/cached_test.go
+++ b/util/flightcontrol/cached_test.go
@@ -40,7 +40,6 @@ func TestCached(t *testing.T) {
 		return 0, errors.New("some error")
 	})
 
-	require.Error(t, err)
 	require.ErrorContains(t, err, "some error")
 
 	v, err = g.Do(ctx, "33", func(ctx context.Context) (int, error) {
@@ -60,13 +59,11 @@ func TestCachedError(t *testing.T) {
 	_, err := g.Do(ctx, "11", func(ctx context.Context) (string, error) {
 		return "", errors.New("first error")
 	})
-	require.Error(t, err)
 	require.ErrorContains(t, err, "first error")
 
 	_, err = g.Do(ctx, "11", func(ctx context.Context) (string, error) {
 		return "never-ran", nil
 	})
-	require.Error(t, err)
 	require.ErrorContains(t, err, "first error")
 
 	// context errors are never cached
@@ -80,7 +77,6 @@ func TestCachedError(t *testing.T) {
 			return "", errors.New("unexpected error")
 		}
 	})
-	require.Error(t, err)
 	require.ErrorContains(t, err, "context deadline exceeded")
 
 	select {

--- a/util/flightcontrol/flightcontrol_test.go
+++ b/util/flightcontrol/flightcontrol_test.go
@@ -53,8 +53,7 @@ func TestCancelOne(t *testing.T) {
 	ctx2, cancel := context.WithCancelCause(ctx)
 	eg.Go(func() error {
 		ret1, err := g.Do(ctx2, "foo", f)
-		require.Error(t, err)
-		require.Equal(t, true, errors.Is(err, context.Canceled))
+		require.ErrorIs(t, err, context.Canceled)
 		if err == nil {
 			r1 = ret1
 		}
@@ -134,8 +133,7 @@ func TestCancelRace(t *testing.T) {
 	}()
 
 	_, err := g.Do(ctx, "foo", f)
-	require.Error(t, err)
-	require.Equal(t, true, errors.Is(err, context.Canceled))
+	require.ErrorIs(t, err, context.Canceled)
 	<-wait
 }
 
@@ -150,8 +148,7 @@ func TestCancelBoth(t *testing.T) {
 	ctx3, cancel3 := context.WithCancelCause(ctx)
 	eg.Go(func() error {
 		ret1, err := g.Do(ctx2, "foo", f)
-		require.Error(t, err)
-		require.Equal(t, true, errors.Is(err, context.Canceled))
+		require.ErrorIs(t, err, context.Canceled)
 		if err == nil {
 			r1 = ret1
 		}
@@ -159,8 +156,7 @@ func TestCancelBoth(t *testing.T) {
 	})
 	eg.Go(func() error {
 		ret2, err := g.Do(ctx3, "foo", f)
-		require.Error(t, err)
-		require.Equal(t, true, errors.Is(err, context.Canceled))
+		require.ErrorIs(t, err, context.Canceled)
 		if err == nil {
 			r2 = ret2
 		}

--- a/util/grpcerrors/grpcerrors_test.go
+++ b/util/grpcerrors/grpcerrors_test.go
@@ -216,7 +216,7 @@ func TestToGRPCMessage(t *testing.T) {
 		encoded := grpcerrors.ToGRPC(t.Context(), joined)
 		decoded := grpcerrors.FromGRPC(encoded)
 
-		assert.ErrorContains(t, decoded, wrapped.Error()) //nolint:testifylint // error is not critical
+		require.ErrorContains(t, decoded, wrapped.Error()) //nolint:testifylint // error is not critical
 		assert.ErrorContains(t, decoded, anotherErr.Error())
 	})
 }

--- a/util/grpcerrors/grpcerrors_test.go
+++ b/util/grpcerrors/grpcerrors_test.go
@@ -49,8 +49,7 @@ func TestFromGRPCPreserveUnknownTypes(t *testing.T) {
 	}
 
 	assertErrorProperties := func(t *testing.T, err error) {
-		require.Error(t, err)
-		assert.Equal(t, fmt.Sprintf("%s: %s", errCode, errMessage), err.Error())
+		require.EqualError(t, err, fmt.Sprintf("%s: %s", errCode, errMessage))
 
 		st, ok := status.FromError(err)
 		require.True(t, ok)
@@ -202,7 +201,7 @@ func TestToGRPCMessage(t *testing.T) {
 		t.Parallel()
 		err := errors.New("something")
 		decoded := grpcerrors.FromGRPC(grpcerrors.ToGRPC(t.Context(), err))
-		assert.Equal(t, err.Error(), decoded.Error())
+		assert.EqualError(t, err, decoded.Error())
 	})
 	t.Run("keep extra context", func(t *testing.T) {
 		t.Parallel()
@@ -216,7 +215,7 @@ func TestToGRPCMessage(t *testing.T) {
 		encoded := grpcerrors.ToGRPC(t.Context(), joined)
 		decoded := grpcerrors.FromGRPC(encoded)
 
-		require.ErrorContains(t, decoded, wrapped.Error()) //nolint:testifylint // error is not critical
+		require.ErrorContains(t, decoded, wrapped.Error())
 		assert.ErrorContains(t, decoded, anotherErr.Error())
 	})
 }

--- a/util/network/cniprovider/cni_linux_test.go
+++ b/util/network/cniprovider/cni_linux_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	netns "github.com/containernetworking/plugins/pkg/ns"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 )
@@ -34,7 +35,7 @@ func createTestNetNS(t *testing.T) string {
 	}()
 	require.NoError(t, <-errCh)
 	t.Cleanup(func() {
-		require.NoError(t, unmountNetNS(nsPath))
+		assert.NoError(t, unmountNetNS(nsPath))
 	})
 	return nsPath
 }

--- a/util/network/proxyprovider/provider_linux_test.go
+++ b/util/network/proxyprovider/provider_linux_test.go
@@ -460,7 +460,7 @@ func TestProxyHandlerPolicyRedactsCredentialsInErrors(t *testing.T) {
 	require.ErrorIs(t, err, sourcepolicy.ErrSourceDenied)
 	require.NotContains(t, err.Error(), "user")
 	require.NotContains(t, err.Error(), "pass")
-	require.Contains(t, err.Error(), "https://xxxxx:xxxxx@example.com/path")
+	require.ErrorContains(t, err, "https://xxxxx:xxxxx@example.com/path")
 }
 
 func TestProxyHandlerRejectsConvertedNonGetRequest(t *testing.T) {
@@ -471,8 +471,7 @@ func TestProxyHandlerRejectsConvertedNonGetRequest(t *testing.T) {
 	})
 
 	_, err := handler.check(t.Context(), http.MethodPost, "https://example.com/file")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "conversion is only supported for GET")
+	require.ErrorContains(t, err, "conversion is only supported for GET")
 }
 
 func TestProxyHandlerRejectsConvertedAttrs(t *testing.T) {
@@ -486,8 +485,7 @@ func TestProxyHandlerRejectsConvertedAttrs(t *testing.T) {
 	})
 
 	_, err := handler.check(t.Context(), http.MethodGet, "https://example.com/file")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "proxy conversion only supports URL updates")
+	require.ErrorContains(t, err, "proxy conversion only supports URL updates")
 }
 
 func TestCertForHostUsesCachedValidCertificate(t *testing.T) {

--- a/util/overlay/overlay_linux_test.go
+++ b/util/overlay/overlay_linux_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containerd/continuity/fs"
 	"github.com/containerd/continuity/fs/fstest"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 )
 
 // This test file contains tests that are required in continuity project.
@@ -47,9 +48,7 @@ func TestSimpleDiff(t *testing.T) {
 		Add("/root/.bashrc"),
 	}
 
-	if err := testDiffWithBase(t, l1, l2, diff); err != nil {
-		t.Fatalf("Failed diff with base: %+v", err)
-	}
+	require.NoErrorf(t, testDiffWithBase(t, l1, l2, diff), "Failed diff with base")
 }
 
 func TestRenameDiff(t *testing.T) {
@@ -72,9 +71,7 @@ func TestRenameDiff(t *testing.T) {
 		Add("/dir2/f1"),
 	}
 
-	if err := testDiffWithBase(t, l1, l2, diff, "redirect_dir=off"); err != nil {
-		t.Fatalf("Failed diff with base: %+v", err)
-	}
+	require.NoErrorf(t, testDiffWithBase(t, l1, l2, diff, "redirect_dir=off"), "Failed diff with base")
 }
 
 type applyFn func(root string) error
@@ -107,9 +104,7 @@ func TestEmptyFileDiff(t *testing.T) {
 	l2 := fstest.Apply()
 	diff := []TestChange{}
 
-	if err := testDiffWithBase(t, l1, l2, diff); err != nil {
-		t.Fatalf("Failed diff with base: %+v", err)
-	}
+	require.NoErrorf(t, testDiffWithBase(t, l1, l2, diff), "Failed diff with base")
 }
 
 // TestNestedDeletion is a test ported from
@@ -131,9 +126,7 @@ func TestNestedDeletion(t *testing.T) {
 		Delete("/d1"),
 	}
 
-	if err := testDiffWithBase(t, l1, l2, diff); err != nil {
-		t.Fatalf("Failed diff with base: %+v", err)
-	}
+	require.NoErrorf(t, testDiffWithBase(t, l1, l2, diff), "Failed diff with base")
 }
 
 // TestDirectoryReplace is a test ported from
@@ -156,9 +149,7 @@ func TestDirectoryReplace(t *testing.T) {
 		Modify("/dir1/f2"),
 	}
 
-	if err := testDiffWithBase(t, l1, l2, diff); err != nil {
-		t.Fatalf("Failed diff with base: %+v", err)
-	}
+	require.NoErrorf(t, testDiffWithBase(t, l1, l2, diff), "Failed diff with base")
 }
 
 // TestRemoveDirectoryTree is a test ported from
@@ -177,9 +168,7 @@ func TestRemoveDirectoryTree(t *testing.T) {
 		Delete("/dir1"),
 	}
 
-	if err := testDiffWithBase(t, l1, l2, diff); err != nil {
-		t.Fatalf("Failed diff with base: %+v", err)
-	}
+	require.NoErrorf(t, testDiffWithBase(t, l1, l2, diff), "Failed diff with base")
 }
 
 // TestRemoveDirectoryTreeWithDash is a test ported from
@@ -200,9 +189,7 @@ func TestRemoveDirectoryTreeWithDash(t *testing.T) {
 		Delete("/dir1"),
 	}
 
-	if err := testDiffWithBase(t, l1, l2, diff); err != nil {
-		t.Fatalf("Failed diff with base: %+v", err)
-	}
+	require.NoErrorf(t, testDiffWithBase(t, l1, l2, diff), "Failed diff with base")
 }
 
 // TestFileReplace is a test ported from
@@ -223,9 +210,7 @@ func TestFileReplace(t *testing.T) {
 		Add("/dir1/dir2/f1"),
 	}
 
-	if err := testDiffWithBase(t, l1, l2, diff); err != nil {
-		t.Fatalf("Failed diff with base: %+v", err)
-	}
+	require.NoErrorf(t, testDiffWithBase(t, l1, l2, diff), "Failed diff with base")
 }
 
 // TestParentDirectoryPermission is a test ported from
@@ -252,9 +237,7 @@ func TestParentDirectoryPermission(t *testing.T) {
 		Add("/dir3/f"),
 	}
 
-	if err := testDiffWithBase(t, l1, l2, diff); err != nil {
-		t.Fatalf("Failed diff with base: %+v", err)
-	}
+	require.NoErrorf(t, testDiffWithBase(t, l1, l2, diff), "Failed diff with base")
 }
 
 // TestUpdateWithSameTime is a test ported from
@@ -304,9 +287,7 @@ func TestUpdateWithSameTime(t *testing.T) {
 		Modify("/file-truncated-time-3"),
 	}
 
-	if err := testDiffWithBase(t, l1, l2, diff); err != nil {
-		t.Fatalf("Failed diff with base: %+v", err)
-	}
+	require.NoErrorf(t, testDiffWithBase(t, l1, l2, diff), "Failed diff with base")
 }
 
 // TestLchtimes is a test ported from
@@ -327,9 +308,7 @@ func TestLchtimes(t *testing.T) {
 		)
 		l2 := fstest.Apply() // empty
 		diff := []TestChange{}
-		if err := testDiffWithBase(t, l1, l2, diff); err != nil {
-			t.Fatalf("Failed diff with base: %+v", err)
-		}
+		require.NoErrorf(t, testDiffWithBase(t, l1, l2, diff), "Failed diff with base")
 	}
 }
 

--- a/util/purl/image_test.go
+++ b/util/purl/image_test.go
@@ -77,12 +77,10 @@ func TestRefToPURL(t *testing.T) {
 			purl, err := RefToPURL(packageurl.TypeDocker, tc.ref, tc.platform)
 			if tc.err {
 				require.Error(t, err)
-				return
-			}
-			if err != nil {
+			} else {
 				require.NoError(t, err)
+				require.Equal(t, tc.expected, purl)
 			}
-			require.Equal(t, tc.expected, purl)
 		})
 	}
 }
@@ -141,16 +139,14 @@ func TestPURLToRef(t *testing.T) {
 			ref, platform, err := PURLToRef(tc.purl)
 			if tc.err {
 				require.Error(t, err)
-				return
-			}
-			if err != nil {
-				require.NoError(t, err)
-			}
-			require.Equal(t, tc.expected, ref)
-			if platform == nil {
-				require.Nil(t, tc.platform)
 			} else {
-				require.Equal(t, *tc.platform, *platform)
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, ref)
+				if platform == nil {
+					require.Nil(t, tc.platform)
+				} else {
+					require.Equal(t, *tc.platform, *platform)
+				}
 			}
 		})
 	}

--- a/util/resolvconf/resolvconf_test.go
+++ b/util/resolvconf/resolvconf_test.go
@@ -702,9 +702,7 @@ func BenchmarkGenerate(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
 		_, err := rc.Generate(true)
-		if err != nil {
-			b.Fatal(err)
-		}
+		require.NoError(b, err)
 	}
 }
 

--- a/util/resolver/authorizer_test.go
+++ b/util/resolver/authorizer_test.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"testing"
 	"time"
 
 	"github.com/moby/buildkit/session"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -55,10 +55,7 @@ func TestParseScopes(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			parsed := parseScopes(tc.input)
-			if !reflect.DeepEqual(parsed, tc.expected) {
-				t.Fatalf("expected %v, got %v", tc.expected, parsed)
-			}
+			require.Equal(t, tc.expected, parseScopes(tc.input))
 		})
 	}
 }
@@ -78,12 +75,10 @@ func TestBearerAuthFallsBackToAnonymousTokenWithoutSession(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(map[string]any{
+		assert.NoErrorf(t, json.NewEncoder(w).Encode(map[string]any{
 			"token":      "anonymous-token",
 			"expires_in": 60,
-		}); err != nil {
-			t.Errorf("failed to write token response: %v", err)
-		}
+		}), "failed to write token response")
 	}))
 	defer tokenServer.Close()
 

--- a/util/sshutil/keyscan_test.go
+++ b/util/sshutil/keyscan_test.go
@@ -1,6 +1,10 @@
 package sshutil
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestKnownHostsServerID(t *testing.T) {
 	tests := []struct {
@@ -17,9 +21,7 @@ func TestKnownHostsServerID(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := knownHostsServerID(tt.hostname, tt.port); got != tt.want {
-				t.Fatalf("knownHostsServerID(%q, %q) = %q, want %q", tt.hostname, tt.port, got, tt.want)
-			}
+			require.Equalf(t, tt.want, knownHostsServerID(tt.hostname, tt.port), "knownHostsServerID(%q, %q)", tt.hostname, tt.port)
 		})
 	}
 }

--- a/util/staticfs/merge_test.go
+++ b/util/staticfs/merge_test.go
@@ -52,7 +52,7 @@ func TestMerge(t *testing.T) {
 			require.Equal(t, int64(6), info.Size())
 			require.Equal(t, os.FileMode(0400), info.Mode())
 		default:
-			require.Fail(t, "unexpected path", path)
+			t.Errorf("unexpected path %s", path)
 		}
 		files = append(files, path)
 		return nil

--- a/util/staticfs/static_test.go
+++ b/util/staticfs/static_test.go
@@ -40,7 +40,7 @@ func TestStatic(t *testing.T) {
 			require.Equal(t, int64(9), info.Size())
 			require.Equal(t, os.FileMode(0444), info.Mode())
 		default:
-			require.Fail(t, "unexpected path", path)
+			t.Errorf("unexpected path %s", path)
 		}
 		files = append(files, path)
 		return nil

--- a/util/system/path_test.go
+++ b/util/system/path_test.go
@@ -90,116 +90,77 @@ func TestCheckSystemDriveAndRemoveDriveLetter(t *testing.T) {
 	keepSlash := false
 	// Fails if not C drive.
 	_, err := CheckSystemDriveAndRemoveDriveLetter(`d:\`, "windows", keepSlash)
-	if err == nil || err.Error() != "The specified path is not on the system drive (C:)" {
-		t.Fatal("Expected error for d:")
-	}
+	require.EqualError(t, err, "The specified path is not on the system drive (C:)", "Expected error for d:")
 
 	var path string
 
 	// Single character is unchanged
-	if path, err = CheckSystemDriveAndRemoveDriveLetter("z", "windows", keepSlash); err != nil {
-		t.Fatal("Single character should pass")
-	}
-	if path != "z" {
-		t.Fatal("Single character should be unchanged")
-	}
+	path, err = CheckSystemDriveAndRemoveDriveLetter("z", "windows", keepSlash)
+	require.NoErrorf(t, err, "Single character should pass")
+	require.Equalf(t, "z", path, "Single character should be unchanged")
 
 	// Two characters without colon is unchanged
-	if path, err = CheckSystemDriveAndRemoveDriveLetter("AB", "windows", keepSlash); err != nil {
-		t.Fatal("2 characters without colon should pass")
-	}
-	if path != "AB" {
-		t.Fatal("2 characters without colon should be unchanged")
-	}
+	path, err = CheckSystemDriveAndRemoveDriveLetter("AB", "windows", keepSlash)
+	require.NoErrorf(t, err, "2 characters without colon should pass")
+	require.Equalf(t, "AB", path, "2 characters without colon should be unchanged")
 
 	// Abs path without drive letter
-	if path, err = CheckSystemDriveAndRemoveDriveLetter(`\l`, "windows", keepSlash); err != nil {
-		t.Fatal("abs path no drive letter should pass")
-	}
-	if path != `/l` {
-		t.Fatal("abs path without drive letter should be unchanged")
-	}
+	path, err = CheckSystemDriveAndRemoveDriveLetter(`\l`, "windows", keepSlash)
+	require.NoErrorf(t, err, "abs path no drive letter should pass")
+	require.Equalf(t, `/l`, path, "abs path without drive letter should be unchanged")
 
 	// Abs path without drive letter, linux style
-	if path, err = CheckSystemDriveAndRemoveDriveLetter(`/l`, "windows", keepSlash); err != nil {
-		t.Fatal("abs path no drive letter linux style should pass")
-	}
-	if path != `/l` {
-		t.Fatalf("abs path without drive letter linux failed %s", path)
-	}
+	path, err = CheckSystemDriveAndRemoveDriveLetter(`/l`, "windows", keepSlash)
+	require.NoErrorf(t, err, "abs path no drive letter linux style should pass")
+	require.Equalf(t, `/l`, path, "abs path without drive letter linux failed %s", path)
 
 	// Drive-colon should be stripped
-	if path, err = CheckSystemDriveAndRemoveDriveLetter(`c:\`, "windows", keepSlash); err != nil {
-		t.Fatal("An absolute path should pass")
-	}
-	if path != `/` {
-		t.Fatalf(`An absolute path should have been shortened to \ %s`, path)
-	}
+	path, err = CheckSystemDriveAndRemoveDriveLetter(`c:\`, "windows", keepSlash)
+	require.NoErrorf(t, err, "An absolute path should pass")
+	require.Equalf(t, `/`, path, `An absolute path should have been shortened to \ %s`, path)
 
 	// Verify with a linux-style path
-	if path, err = CheckSystemDriveAndRemoveDriveLetter(`c:/`, "windows", keepSlash); err != nil {
-		t.Fatal("An absolute path should pass")
-	}
-	if path != `/` {
-		t.Fatalf(`A linux style absolute path should have been shortened to \ %s`, path)
-	}
+	path, err = CheckSystemDriveAndRemoveDriveLetter(`c:/`, "windows", keepSlash)
+	require.NoErrorf(t, err, "An absolute path should pass")
+	require.Equalf(t, `/`, path, `A linux style absolute path should have been shortened to \ %s`, path)
 
 	// Failure on c:
-	if path, err = CheckSystemDriveAndRemoveDriveLetter(`c:`, "windows", keepSlash); err == nil {
-		t.Fatal("c: should fail")
-	}
-	if err.Error() != `No relative path specified in "c:"` {
-		t.Fatalf(path, err)
-	}
+	path, err = CheckSystemDriveAndRemoveDriveLetter(`c:`, "windows", keepSlash)
+	require.Errorf(t, err, "c: should fail")
+	require.EqualErrorf(t, err, `No relative path specified in "c:"`, path)
 
 	// Failure on d:
-	if path, err = CheckSystemDriveAndRemoveDriveLetter(`d:`, "windows", keepSlash); err == nil {
-		t.Fatal("c: should fail")
-	}
-	if err.Error() != `No relative path specified in "d:"` {
-		t.Fatalf(path, err)
-	}
+	path, err = CheckSystemDriveAndRemoveDriveLetter(`d:`, "windows", keepSlash)
+	require.Errorf(t, err, "c: should fail")
+	require.EqualErrorf(t, err, `No relative path specified in "d:"`, path)
 
 	// UNC path should fail.
-	if _, err = CheckSystemDriveAndRemoveDriveLetter(`\\.\C$\test`, "windows", keepSlash); err == nil {
-		t.Fatal("UNC path should fail")
-	}
+	_, err = CheckSystemDriveAndRemoveDriveLetter(`\\.\C$\test`, "windows", keepSlash)
+	require.Errorf(t, err, "UNC path should fail")
 
 	// also testing for keepSlash = true
 	keepSlash = true
 	origPath := "\\a\\b\\..\\c\\"
-	if path, err = CheckSystemDriveAndRemoveDriveLetter(origPath, "windows", keepSlash); err != nil {
-		t.Fatal("windows relative paths should be cleaned and should pass")
-	}
+	path, err = CheckSystemDriveAndRemoveDriveLetter(origPath, "windows", keepSlash)
+	require.NoErrorf(t, err, "windows relative paths should be cleaned and should pass")
 	// When input OS is Windows, the path should be properly cleaned
-	if path != "/a/c/" {
-		t.Fatal("Path was not cleaned successfully")
-	}
+	require.Equalf(t, "/a/c/", path, "Path was not cleaned successfully")
 
-	if path, err = CheckSystemDriveAndRemoveDriveLetter(origPath, "windows", false); err != nil {
-		t.Fatal("windows relative paths should be cleaned and should pass [keepSlash = false]")
-	}
+	path, err = CheckSystemDriveAndRemoveDriveLetter(origPath, "windows", false)
+	require.NoErrorf(t, err, "windows relative paths should be cleaned and should pass [keepSlash = false]")
 	// When input OS is Windows, the path should be properly cleaned
-	if path != "/a/c" {
-		t.Fatal("Path was not cleaned successfully [keepSlash = false]")
-	}
+	require.Equalf(t, "/a/c", path, "Path was not cleaned successfully [keepSlash = false]")
 
 	// windows-style relative paths on linux
-	if path, err = CheckSystemDriveAndRemoveDriveLetter(origPath, "linux", keepSlash); err != nil {
-		t.Fatal("windows style relative paths should be considered a valid path element in linux and should pass")
-	}
+	path, err = CheckSystemDriveAndRemoveDriveLetter(origPath, "linux", keepSlash)
+	require.NoErrorf(t, err, "windows style relative paths should be considered a valid path element in linux and should pass")
 	// When input OS is Linux, this is a valid path element name.
-	if path != "\\a\\b\\..\\c\\" {
-		t.Fatal("Path was not cleaned successfully")
-	}
+	require.Equalf(t, "\\a\\b\\..\\c\\", path, "Path was not cleaned successfully")
 
-	if path, err = CheckSystemDriveAndRemoveDriveLetter(origPath, "linux", false); err != nil {
-		t.Fatal("windows style relative paths should be considered a valid path element in linux and should pass")
-	}
+	path, err = CheckSystemDriveAndRemoveDriveLetter(origPath, "linux", false)
+	require.NoErrorf(t, err, "windows style relative paths should be considered a valid path element in linux and should pass")
 	// When input OS is Linux, this is a valid path element name.
-	if path != "\\a\\b\\..\\c\\" {
-		t.Fatal("Path was not cleaned successfully [keepSlash = false]")
-	}
+	require.Equalf(t, "\\a\\b\\..\\c\\", path, "Path was not cleaned successfully [keepSlash = false]")
 }
 
 // TestNormalizeWorkdirWindows tests NormalizeWorkdir

--- a/util/testutil/integration/util.go
+++ b/util/testutil/integration/util.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/containerd/continuity/fs/fstest"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tonistiigi/fsutil"
 	"golang.org/x/sync/errgroup"
@@ -43,7 +44,7 @@ func Tmpdir(t *testing.T, appliers ...fstest.Applier) *TmpDirWithName {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(tmpdir))
+		assert.NoError(t, os.RemoveAll(tmpdir))
 	})
 
 	err = fstest.Apply(appliers...).Apply(tmpdir)

--- a/util/urlutil/redact_test.go
+++ b/util/urlutil/redact_test.go
@@ -1,6 +1,10 @@
 package urlutil
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestRedactCredentials(t *testing.T) {
 	cases := []struct {
@@ -36,9 +40,7 @@ func TestRedactCredentials(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			if g, w := RedactCredentials(tt.url), tt.want; g != w {
-				t.Fatalf("got: %q\nwant: %q", g, w)
-			}
+			require.Equal(t, tt.want, RedactCredentials(tt.url))
 		})
 	}
 }

--- a/version/ua_test.go
+++ b/version/ua_test.go
@@ -1,6 +1,10 @@
 package version
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestUserAgent(t *testing.T) {
 	cases := []struct {
@@ -41,9 +45,7 @@ func TestUserAgent(t *testing.T) {
 					return pver
 				})
 			}
-			if g, w := UserAgent(), tt.want; g != w {
-				t.Fatalf("got: %q\nwant: %q", g, w)
-			}
+			require.Equal(t, tt.want, UserAgent())
 		})
 	}
 }

--- a/worker/tests/common.go
+++ b/worker/tests/common.go
@@ -195,9 +195,9 @@ func TestWorkerExec(t *testing.T, w *base.Worker) {
 		cancel(errors.WithStack(context.Canceled))
 		select {
 		case err = <-waitCh:
-			require.Failf(t, "timed out waiting for pid1 to exit", "pid1 returned after cancellation: %+v", err)
+			t.Errorf("pid1 returned after cancellation: %+v", err)
 		case <-time.After(5 * time.Second):
-			require.FailNow(t, "timed out waiting for pid1 to exit after cancellation")
+			t.Fatal("timed out waiting for pid1 to exit after cancellation")
 		}
 	}
 
@@ -345,11 +345,11 @@ func TestWorkerCancel(t *testing.T, w *base.Worker) {
 
 	pid2Cancel(errors.WithStack(context.Canceled))
 	<-pid2Done
-	require.Contains(t, pid2Err.Error(), "exit code: 137", "pid2 exits with sigkill")
+	require.ErrorContains(t, pid2Err, "exit code: 137", "pid2 exits with sigkill")
 
 	pid1Cancel(errors.WithStack(context.Canceled))
 	<-pid1Done
-	require.Contains(t, pid1Err.Error(), "exit code: 137", "pid1 exits with sigkill")
+	require.ErrorContains(t, pid1Err, "exit code: 137", "pid1 exits with sigkill")
 }
 
 func execMount(m cache.Mountable) executor.Mount {


### PR DESCRIPTION
This refactors and modernizes test assertions replacing older assertion patterns with more expressive and idiomatic ones from the `testify` library. It also updates linter configuration for improved code quality checks.

**Test assertion improvements:**

* Replaced `require.Equal(t, true, errors.Is(...))` with `require.ErrorIs` for clearer error assertion.

**Linter configuration:**

* Updated `.golangci.yml` to enable all `testifylint` checks by default, removing the previous list of disabled checks. This ensures stricter and more consistent test code quality.