### PR TITLE
Refactor error handling to use errors.New for consistency

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -88,6 +88,14 @@ linters:
         - pkg: github.com/opencontainers/go-digest
           alias: digest
       no-unaliased: true
+    revive:
+      enable-all-rules: false
+      enable-default-rules: true
+      rules:
+        - name: errorf
+        - name: if-return
+        - name: unnecessary-format
+        - name: use-errors-new
     staticcheck:
       checks:
         - all
@@ -132,6 +140,7 @@ linters:
     paths:
       - .*\.pb\.go$
       - examples
+    warn-unused: true
 
 formatters:
   enable:

--- a/cache/compression_nydus.go
+++ b/cache/compression_nydus.go
@@ -37,7 +37,7 @@ func MergeNydus(ctx context.Context, ref ImmutableRef, comp compression.Config, 
 	}
 	refs := iref.layerChain()
 	if len(refs) == 0 {
-		return nil, errors.Errorf("refs can't be empty")
+		return nil, errors.New("refs can't be empty")
 	}
 
 	// Extracts nydus bootstrap from nydus format for each layer.

--- a/cache/contenthash/checksum.go
+++ b/cache/contenthash/checksum.go
@@ -28,7 +28,7 @@ import (
 	fstypes "github.com/tonistiigi/fsutil/types"
 )
 
-var errNotFound = errors.Errorf("not found")
+var errNotFound = errors.New("not found")
 
 var (
 	defaultManager     *cacheManager

--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -73,7 +73,7 @@ type cmOut struct {
 func newCacheManager(ctx context.Context, t *testing.T, opt cmOpt) (co *cmOut, cleanup func(), err error) {
 	ns, ok := namespaces.Namespace(ctx)
 	if !ok {
-		return nil, nil, errors.Errorf("namespace required for test")
+		return nil, nil, errors.New("namespace required for test")
 	}
 
 	if opt.snapshotterName == "" {
@@ -1280,7 +1280,7 @@ func TestSharingCompressionVariant(t *testing.T) {
 		}
 	}
 
-	t.Logf("Test cases with possible compression types")
+	t.Log("Test cases with possible compression types")
 	do(func(testCase testCaseSharingCompressionVariant) {
 		testCase.checkPrune = true
 		testSharingCompressionVariant(ctx, t, co, testCase)
@@ -1288,7 +1288,7 @@ func TestSharingCompressionVariant(t *testing.T) {
 		checkDiskUsage(ctx, t, co.manager, 0, 0)
 	})
 
-	t.Logf("Test case with many parallel operation")
+	t.Log("Test case with many parallel operation")
 	eg, egctx := errgroup.WithContext(ctx)
 	do(func(testCase testCaseSharingCompressionVariant) {
 		eg.Go(func() error {

--- a/cache/metadata/metadata.go
+++ b/cache/metadata/metadata.go
@@ -22,7 +22,7 @@ const (
 	externalBucket = "_external"
 )
 
-var errNotFound = errors.Errorf("not found")
+var errNotFound = errors.New("not found")
 
 type Store struct {
 	db db.DB

--- a/cache/remotecache/azblob/exporter.go
+++ b/cache/remotecache/azblob/exporter.go
@@ -76,12 +76,12 @@ func (ce *exporter) Finalize(ctx context.Context) (map[string]string, error) {
 			return nil, errors.Errorf("missing blob %s", l.Blob)
 		}
 		if dgstPair.Descriptor.Annotations == nil {
-			return nil, errors.Errorf("invalid descriptor without annotations")
+			return nil, errors.New("invalid descriptor without annotations")
 		}
 		var diffID digest.Digest
 		v, ok := dgstPair.Descriptor.Annotations[labels.LabelUncompressed]
 		if !ok {
-			return nil, errors.Errorf("invalid descriptor without uncompressed annotation")
+			return nil, errors.New("invalid descriptor without uncompressed annotation")
 		}
 		dgst, err := digest.Parse(v)
 		if err != nil {

--- a/cache/remotecache/gha/gha_test.go
+++ b/cache/remotecache/gha/gha_test.go
@@ -167,7 +167,7 @@ func ensurePruneAll(t *testing.T, c *client.Client, sb integration.Sandbox) {
 		}
 		t.Logf("retrying prune(%d)", i)
 	}
-	t.Fatalf("failed to ensure prune")
+	t.Fatal("failed to ensure prune")
 }
 
 func requiresLinux(t *testing.T) {

--- a/cache/remotecache/v1/cachestorage.go
+++ b/cache/remotecache/v1/cachestorage.go
@@ -47,7 +47,7 @@ func addItemToStorage(k *cacheKeyStorage, it *item, visited map[*item]*itemWithO
 
 	if id, ok := k.byItem[it]; ok {
 		if id == "" {
-			return nil, errors.Errorf("invalid loop")
+			return nil, errors.New("invalid loop")
 		}
 		return k.byID[id], nil
 	}
@@ -256,7 +256,7 @@ type cacheResultStorage struct {
 }
 
 func (cs *cacheResultStorage) Save(res solver.Result, createdAt time.Time) (solver.CacheResult, error) {
-	return solver.CacheResult{}, errors.Errorf("importer is immutable")
+	return solver.CacheResult{}, errors.New("importer is immutable")
 }
 
 func (cs *cacheResultStorage) LoadWithParents(ctx context.Context, res solver.CacheResult) (map[string]solver.Result, error) {

--- a/cache/remotecache/v1/parse.go
+++ b/cache/remotecache/v1/parse.go
@@ -33,7 +33,7 @@ func ParseConfig(config cacheimporttypes.CacheConfig, provider DescriptorProvide
 func parseRecord(cc cacheimporttypes.CacheConfig, idx int, provider DescriptorProvider, t solver.CacheExporterTarget, cache map[int]solver.CacheExporterRecord) (solver.CacheExporterRecord, error) {
 	if r, ok := cache[idx]; ok {
 		if r == nil {
-			return nil, errors.Errorf("invalid looping record")
+			return nil, errors.New("invalid looping record")
 		}
 		return r, nil
 	}
@@ -115,7 +115,7 @@ func parseRecord(cc cacheimporttypes.CacheConfig, idx int, provider DescriptorPr
 
 func getRemoteChain(layers []cacheimporttypes.CacheLayer, idx int, provider DescriptorProvider, visited map[int]struct{}) (*solver.Remote, error) {
 	if _, ok := visited[idx]; ok {
-		return nil, errors.Errorf("invalid looping layer")
+		return nil, errors.New("invalid looping layer")
 	}
 	visited[idx] = struct{}{}
 

--- a/cache/remotecache/v1/utils.go
+++ b/cache/remotecache/v1/utils.go
@@ -215,7 +215,7 @@ func marshalItem(ctx context.Context, it *item, state *marshalState) error {
 		if id != "" {
 			idx, ok := state.chainsByID[id]
 			if !ok {
-				return errors.Errorf("parent chainid not found")
+				return errors.New("parent chainid not found")
 			}
 			rec.Results = append(rec.Results, cacheimporttypes.CacheResult{LayerIndex: idx, CreatedAt: res.CreatedAt})
 		}

--- a/client/client_cdi_test.go
+++ b/client/client_cdi_test.go
@@ -456,7 +456,7 @@ func writeCDISpecFile(t *testing.T, sb integration.Sandbox, c *Client, csf ...cd
 		}
 
 		if now.After(deadline) {
-			t.Fatalf("timeout waiting for CDI devices to appear")
+			t.Fatal("timeout waiting for CDI devices to appear")
 		}
 	}
 }

--- a/client/client_exec_test.go
+++ b/client/client_exec_test.go
@@ -25,7 +25,7 @@ func testCgroupParent(t *testing.T, sb integration.Sandbox) {
 	}
 
 	if _, err := os.Lstat("/sys/fs/cgroup/cgroup.subtree_control"); os.IsNotExist(err) {
-		t.Skipf("test requires cgroup v2")
+		t.Skip("test requires cgroup v2")
 	}
 
 	c, err := New(sb.Context(), sb.Address())
@@ -95,7 +95,7 @@ func testLinuxResources(t *testing.T, sb integration.Sandbox) {
 	}
 
 	if _, err := os.Lstat("/sys/fs/cgroup/cgroup.subtree_control"); os.IsNotExist(err) {
-		t.Skipf("test requires cgroup v2")
+		t.Skip("test requires cgroup v2")
 	}
 
 	c, err := New(sb.Context(), sb.Address())

--- a/client/client_http_source_test.go
+++ b/client/client_http_source_test.go
@@ -566,7 +566,7 @@ func testHTTPPruneAfterCacheKey(t *testing.T, sb integration.Sandbox) {
 						for _, entry := range du {
 							if entry.Description == "http url "+server.URL+"/foo" {
 								if !entry.InUse {
-									t.Logf("entry no longer in use, pruning")
+									t.Log("entry no longer in use, pruning")
 									err = c.Prune(ctx, nil)
 									assert.NoError(t, err)
 

--- a/client/client_utils_test.go
+++ b/client/client_utils_test.go
@@ -84,7 +84,7 @@ loop0:
 				require.Equal(t, 0, count)
 			}
 		}
-		t.Logf("checkAllReleasable: skipping check for exported tars in non-containerd test")
+		t.Log("checkAllReleasable: skipping check for exported tars in non-containerd test")
 		return
 	}
 
@@ -222,7 +222,7 @@ func ensurePruneAll(t *testing.T, c *Client, sb integration.Sandbox) {
 		}
 		t.Logf("retrying prune(%d)", i)
 	}
-	t.Fatalf("failed to ensure prune")
+	t.Fatal("failed to ensure prune")
 }
 
 func fixedWriteCloser(wc io.WriteCloser) filesync.FileOutputFunc {
@@ -282,7 +282,7 @@ func readImageTimestamps(dt []byte) (*imageTimestamps, error) {
 	}
 
 	if _, ok := m["oci-layout"]; !ok {
-		return nil, errors.Errorf("no oci-layout")
+		return nil, errors.New("no oci-layout")
 	}
 
 	var index ocispecs.Index

--- a/client/compatibility_test.go
+++ b/client/compatibility_test.go
@@ -868,11 +868,11 @@ func removeGoldenFileIfExists(t *testing.T, path string) {
 
 func formatCompatibilityDebug(exporterType, caseName string, version int, attrs map[string]string, exp compatibilityActual, actual compatibilityActual, manifestDiff, configDiff string) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "compatibility regression mismatch\n")
+	fmt.Fprint(&b, "compatibility regression mismatch\n")
 	fmt.Fprintf(&b, "case: %s\n", caseName)
 	fmt.Fprintf(&b, "exporter: %s\n", exporterType)
 	fmt.Fprintf(&b, "compatibility-version: %d\n", version)
-	fmt.Fprintf(&b, "attrs:\n")
+	fmt.Fprint(&b, "attrs:\n")
 
 	keys := make([]string, 0, len(attrs))
 	for k := range attrs {
@@ -883,14 +883,14 @@ func formatCompatibilityDebug(exporterType, caseName string, version int, attrs 
 		fmt.Fprintf(&b, "  %s=%s\n", k, attrs[k])
 	}
 
-	fmt.Fprintf(&b, "\nexpected:\n")
+	fmt.Fprint(&b, "\nexpected:\n")
 	fmt.Fprintf(&b, "  manifest=%s\n", exp.ManifestDigest)
 	fmt.Fprintf(&b, "  config=%s\n", exp.ConfigDigest)
 	for i, layer := range exp.Layers {
 		fmt.Fprintf(&b, "  layer[%d]=%s %s\n", i, layer.MediaType, layer.Digest)
 	}
 
-	fmt.Fprintf(&b, "\nactual:\n")
+	fmt.Fprint(&b, "\nactual:\n")
 	fmt.Fprintf(&b, "  manifest=%s\n", actual.ManifestDigest)
 	fmt.Fprintf(&b, "  config=%s\n", actual.ConfigDigest)
 	for i, layer := range actual.Layers {

--- a/client/connhelper/ssh/ssh.go
+++ b/client/connhelper/ssh/ssh.go
@@ -66,7 +66,7 @@ func SpecFromURL(u *url.URL) (*Spec, error) {
 		}
 	}
 	if sp.Host == "" {
-		return nil, errors.Errorf("no host specified")
+		return nil, errors.New("no host specified")
 	}
 	if u.RawQuery != "" {
 		return nil, errors.Errorf("extra query after the host: %q", u.RawQuery)

--- a/client/llb/definition.go
+++ b/client/llb/definition.go
@@ -150,7 +150,7 @@ func (d *DefinitionOp) Validate(context.Context, *Constraints) error {
 	// It is possible for d.index >= len(d.ops[d.dgst]) when depending on scratch
 	// images.
 	if d.index < 0 {
-		return errors.Errorf("invalid definition op with invalid index")
+		return errors.New("invalid definition op with invalid index")
 	}
 
 	return nil
@@ -158,7 +158,7 @@ func (d *DefinitionOp) Validate(context.Context, *Constraints) error {
 
 func (d *DefinitionOp) Marshal(ctx context.Context, c *Constraints) (digest.Digest, []byte, *pb.OpMetadata, []*SourceLocation, error) {
 	if d.dgst == "" {
-		return "", nil, nil, nil, errors.Errorf("cannot marshal empty definition op")
+		return "", nil, nil, nil, errors.New("cannot marshal empty definition op")
 	}
 
 	if err := d.Validate(ctx, c); err != nil {

--- a/client/llb/exec.go
+++ b/client/llb/exec.go
@@ -111,7 +111,7 @@ func (e *ExecOp) Validate(ctx context.Context, c *Constraints) error {
 		return err
 	}
 	if len(args) == 0 {
-		return errors.Errorf("arguments are required")
+		return errors.New("arguments are required")
 	}
 	cwd, err := getDir(e.base)(ctx, c)
 	if err != nil {
@@ -364,7 +364,7 @@ func (e *ExecOp) Marshal(ctx context.Context, c *Constraints) (digest.Digest, []
 		inputIndex := pb.InputIndex(len(pop.Inputs))
 		if m.source != nil {
 			if m.tmpfs {
-				return "", nil, nil, nil, errors.Errorf("tmpfs mounts must use scratch")
+				return "", nil, nil, nil, errors.New("tmpfs mounts must use scratch")
 			}
 			inp, err := m.source.ToInput(ctx, c)
 			if err != nil {

--- a/client/llb/fileop.go
+++ b/client/llb/fileop.go
@@ -703,7 +703,7 @@ func (f *FileOp) Validate(context.Context, *Constraints) error {
 		return nil
 	}
 	if f.action == nil {
-		return errors.Errorf("action is required")
+		return errors.New("action is required")
 	}
 	f.isValidated = true
 	return nil
@@ -805,7 +805,7 @@ func (ms *marshalState) add(fa *FileAction, c *Constraints) (*fileActionState, e
 			}
 			st.input2Relative = &src.target
 		} else {
-			return nil, errors.Errorf("invalid empty source for copy")
+			return nil, errors.New("invalid empty source for copy")
 		}
 	}
 

--- a/client/llb/merge.go
+++ b/client/llb/merge.go
@@ -26,7 +26,7 @@ func NewMerge(inputs []State, c Constraints) *MergeOp {
 
 func (m *MergeOp) Validate(ctx context.Context, constraints *Constraints) error {
 	if len(m.inputs) < 2 {
-		return errors.Errorf("merge must have at least 2 inputs")
+		return errors.New("merge must have at least 2 inputs")
 	}
 	return nil
 }

--- a/client/llb/passthrough.go
+++ b/client/llb/passthrough.go
@@ -55,13 +55,13 @@ func NewPassthrough(id string, inputs []PassthroughInput, opts ...ConstraintsOpt
 
 func (p *PassthroughOp) Validate(context.Context, *Constraints) error {
 	if len(p.inputs) == 0 {
-		return errors.Errorf("passthrough must have at least one input")
+		return errors.New("passthrough must have at least one input")
 	}
 	if p.id == "" {
-		return errors.Errorf("passthrough requires an id")
+		return errors.New("passthrough requires an id")
 	}
 	if len(p.outputMap) == 0 {
-		return errors.Errorf("passthrough must have at least one output")
+		return errors.New("passthrough must have at least one output")
 	}
 	for _, input := range p.outputMap {
 		if input < 0 || input >= len(p.inputs) {

--- a/client/llb/source.go
+++ b/client/llb/source.go
@@ -44,7 +44,7 @@ func (s *SourceOp) Validate(ctx context.Context, c *Constraints) error {
 		return s.err
 	}
 	if s.id == "" {
-		return errors.Errorf("source identifier can't be empty")
+		return errors.New("source identifier can't be empty")
 	}
 	return nil
 }
@@ -140,9 +140,9 @@ func ImageBlob(ref string, opts ...ImageBlobOption) State {
 	r, err := reference.ParseNormalizedNamed(ref)
 	if err == nil {
 		if _, tagged := r.(reference.Tagged); tagged {
-			err = errors.Errorf("tagged image reference not allowed for blob reference")
+			err = errors.New("tagged image reference not allowed for blob reference")
 		} else if ref, ok := r.(reference.Digested); !ok {
-			err = errors.Errorf("checksum required in blob reference")
+			err = errors.New("checksum required in blob reference")
 		} else {
 			digested = ref
 		}
@@ -194,9 +194,9 @@ func OCILayoutBlob(ref string, opts ...ImageBlobOption) State {
 	r, err := reference.ParseNormalizedNamed(ref)
 	if err == nil {
 		if _, tagged := r.(reference.Tagged); tagged {
-			err = errors.Errorf("tagged image reference not allowed for blob reference")
+			err = errors.New("tagged image reference not allowed for blob reference")
 		} else if ref, ok := r.(reference.Digested); !ok {
-			err = errors.Errorf("checksum required in blob reference")
+			err = errors.New("checksum required in blob reference")
 		} else {
 			digested = ref
 		}

--- a/client/solve.go
+++ b/client/solve.go
@@ -121,7 +121,7 @@ func (c *Client) solve(ctx context.Context, def *llb.Definition, runGateway runG
 
 	if s == nil {
 		if opt.SessionPreInitialized {
-			return nil, errors.Errorf("no session provided for preinitialized option")
+			return nil, errors.New("no session provided for preinitialized option")
 		}
 		s, err = session.NewSession(statusContext, opt.SharedKey)
 		if err != nil {

--- a/cmd/buildctl/build/output.go
+++ b/cmd/buildctl/build/output.go
@@ -101,7 +101,7 @@ func resolveExporterDest(exporter, dest string, attrs map[string]string) (filesy
 				return nil, "", errors.Wrapf(err, "invalid destination file: %s", dest)
 			}
 			if err == nil && fi.IsDir() {
-				return nil, "", errors.Errorf("destination file is a directory")
+				return nil, "", errors.New("destination file is a directory")
 			}
 			w, err := os.Create(dest)
 			return wrapWriter(w), "", err

--- a/cmd/buildctl/debug/ctl.go
+++ b/cmd/buildctl/debug/ctl.go
@@ -31,7 +31,7 @@ var CtlCommand = &cli.Command{
 func ctl(clicontext *cli.Command) error {
 	args := clicontext.Args()
 	if args.Len() == 0 {
-		return errors.Errorf("build ref must be specified")
+		return errors.New("build ref must be specified")
 	}
 	ref := args.First()
 
@@ -47,15 +47,15 @@ func ctl(clicontext *cli.Command) error {
 	del := clicontext.Bool("delete")
 
 	if !pin && !unpin && !del {
-		return errors.Errorf("must specify one of --pin, --unpin, --delete")
+		return errors.New("must specify one of --pin, --unpin, --delete")
 	}
 
 	if pin && unpin {
-		return errors.Errorf("cannot specify both --pin and --unpin")
+		return errors.New("cannot specify both --pin and --unpin")
 	}
 
 	if del && (pin || unpin) {
-		return errors.Errorf("cannot specify --delete with --pin or --unpin")
+		return errors.New("cannot specify --delete with --pin or --unpin")
 	}
 
 	_, err = c.ControlClient().UpdateBuildHistory(ctx, &controlapi.UpdateBuildHistoryRequest{

--- a/cmd/buildctl/debug/get.go
+++ b/cmd/buildctl/debug/get.go
@@ -23,7 +23,7 @@ var GetCommand = &cli.Command{
 func get(clicontext *cli.Command) error {
 	args := clicontext.Args()
 	if args.Len() == 0 {
-		return errors.Errorf("blob digest must be specified")
+		return errors.New("blob digest must be specified")
 	}
 
 	dgst, err := digest.Parse(args.First())

--- a/cmd/buildctl/debug/histories.go
+++ b/cmd/buildctl/debug/histories.go
@@ -54,7 +54,7 @@ func histories(clicontext *cli.Command) error {
 			if err := tmpl.Execute(clicontext.Root().Writer, ev); err != nil {
 				return err
 			}
-			if _, err = fmt.Fprintf(clicontext.Root().Writer, "\n"); err != nil {
+			if _, err = fmt.Fprint(clicontext.Root().Writer, "\n"); err != nil {
 				return err
 			}
 		}

--- a/cmd/buildctl/debug/info.go
+++ b/cmd/buildctl/debug/info.go
@@ -38,7 +38,7 @@ func info(clicontext *cli.Command) error {
 		if err := tmpl.Execute(clicontext.Root().Writer, res); err != nil {
 			return err
 		}
-		_, err = fmt.Fprintf(clicontext.Root().Writer, "\n")
+		_, err = fmt.Fprint(clicontext.Root().Writer, "\n")
 		return err
 	}
 

--- a/cmd/buildctl/debug/logs.go
+++ b/cmd/buildctl/debug/logs.go
@@ -37,7 +37,7 @@ var LogsCommand = &cli.Command{
 func logs(clicontext *cli.Command) error {
 	args := clicontext.Args()
 	if args.Len() == 0 {
-		return errors.Errorf("build ref must be specified")
+		return errors.New("build ref must be specified")
 	}
 	ref := args.First()
 

--- a/cmd/buildctl/debug/workers.go
+++ b/cmd/buildctl/debug/workers.go
@@ -61,7 +61,7 @@ func listWorkers(clicontext *cli.Command) error {
 		if err := tmpl.Execute(clicontext.Root().Writer, workers); err != nil {
 			return err
 		}
-		_, err = fmt.Fprintf(clicontext.Root().Writer, "\n")
+		_, err = fmt.Fprint(clicontext.Root().Writer, "\n")
 		return err
 	}
 
@@ -83,7 +83,7 @@ func printWorkersVerbose(tw *tabwriter.Writer, winfo []*client.WorkerInfo) {
 		if wi.BuildkitVersion.DockerfileVersion != "" {
 			fmt.Fprintf(tw, "Dockerfile:\t%s\n", wi.BuildkitVersion.DockerfileVersion)
 		}
-		fmt.Fprintf(tw, "Labels:\n")
+		fmt.Fprint(tw, "Labels:\n")
 		for _, k := range sortedKeys(wi.Labels) {
 			v := wi.Labels[k]
 			fmt.Fprintf(tw, "\t%s:\t%s\n", k, v)
@@ -124,7 +124,7 @@ func printWorkersVerbose(tw *tabwriter.Writer, winfo []*client.WorkerInfo) {
 				fmt.Fprintf(tw, "\tMaximum used space:\t%g\n", units.Bytes(rule.MaxUsedSpace))
 			}
 		}
-		fmt.Fprintf(tw, "\n")
+		fmt.Fprint(tw, "\n")
 	}
 
 	tw.Flush()

--- a/cmd/buildctl/diskusage.go
+++ b/cmd/buildctl/diskusage.go
@@ -58,7 +58,7 @@ func diskUsage(clicontext *cli.Command) error {
 		if err := tmpl.Execute(clicontext.Root().Writer, du); err != nil {
 			return err
 		}
-		_, err = fmt.Fprintf(clicontext.Root().Writer, "\n")
+		_, err = fmt.Fprint(clicontext.Root().Writer, "\n")
 		return err
 	}
 
@@ -103,7 +103,7 @@ func printVerbose(tw *tabwriter.Writer, du []*client.UsageInfo) {
 			printKV(tw, "Type", di.RecordType)
 		}
 
-		fmt.Fprintf(tw, "\n")
+		fmt.Fprint(tw, "\n")
 	}
 
 	tw.Flush()

--- a/cmd/buildctl/prune.go
+++ b/cmd/buildctl/prune.go
@@ -93,7 +93,7 @@ func prune(clicontext *cli.Command) error {
 				if err := tmpl.Execute(clicontext.Root().Writer, du); err != nil {
 					panic(err)
 				}
-				if _, err = fmt.Fprintf(clicontext.Root().Writer, "\n"); err != nil {
+				if _, err = fmt.Fprint(clicontext.Root().Writer, "\n"); err != nil {
 					panic(err)
 				}
 			}

--- a/cmd/buildctl/prunehistories.go
+++ b/cmd/buildctl/prunehistories.go
@@ -68,7 +68,7 @@ func pruneHistories(clicontext *cli.Command) error {
 			if err := tmpl.Execute(clicontext.Root().Writer, ev); err != nil {
 				return err
 			}
-			if _, err = fmt.Fprintf(clicontext.Root().Writer, "\n"); err != nil {
+			if _, err = fmt.Fprint(clicontext.Root().Writer, "\n"); err != nil {
 				return err
 			}
 		}

--- a/contrib/cdisetup/nvidia/nvidia.go
+++ b/contrib/cdisetup/nvidia/nvidia.go
@@ -50,7 +50,7 @@ func (s *setup) Validate() error {
 		return err
 	}
 	if !b {
-		return errors.Errorf("no NVIDIA devices found")
+		return errors.New("no NVIDIA devices found")
 	}
 	return nil
 }
@@ -94,7 +94,7 @@ func (s *setup) Run(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	} else if osr.ID != "debian" && osr.ID != "ubuntu" {
-		return errors.Errorf("NVIDIA setup is currently only supported on Debian/Ubuntu")
+		return errors.New("NVIDIA setup is currently only supported on Debian/Ubuntu")
 	}
 
 	needsDriver := true
@@ -107,9 +107,9 @@ func (s *setup) Run(ctx context.Context) (err error) {
 	}
 	if needsDriver {
 		if hasWSLGPU() {
-			return errors.Errorf("NVIDIA drivers are required for WSL with non PCI-based GPUs")
+			return errors.New("NVIDIA drivers are required for WSL with non PCI-based GPUs")
 		}
-		return errors.Errorf("NVIDIA drivers are required. Try loading NVIDIA kernel module with \"modprobe nvidia\" command")
+		return errors.New("NVIDIA drivers are required. Try loading NVIDIA kernel module with \"modprobe nvidia\" command")
 	}
 
 	var dv string
@@ -151,7 +151,7 @@ func (s *setup) Run(ctx context.Context) (err error) {
 	}
 
 	if len(buf.Bytes()) == 0 {
-		return errors.Errorf("nvidia-ctk output is empty")
+		return errors.New("nvidia-ctk output is empty")
 	}
 
 	if err := os.WriteFile("/etc/cdi/nvidia.yaml", buf.Bytes(), 0644); err != nil {
@@ -200,7 +200,7 @@ func installPackages(ctx context.Context, osr *osrelease, dv string, pw progress
 	keyTarget := "/usr/share/keyrings/nvidia-cuda-keyring.gpg"
 
 	if _, err := os.Stat(keyTarget); err != nil {
-		fmt.Fprintf(newStream(pw, 2, dgst), "Downloading NVIDIA GPG key\n")
+		fmt.Fprint(newStream(pw, 2, dgst), "Downloading NVIDIA GPG key\n")
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, aptURL+"3bf863cc.pub", nil)
 		if err != nil {
@@ -254,7 +254,7 @@ func parseVersion(dt string) (string, error) {
 	re := regexp.MustCompile(`NVIDIA .* Kernel Module(?:[\s\w\d]+)?\s+(\d+\.\d+)`)
 	matches := re.FindStringSubmatch(dt)
 	if len(matches) < 2 {
-		return "", errors.Errorf("could not parse NVIDIA driver version")
+		return "", errors.New("could not parse NVIDIA driver version")
 	}
 	return matches[1], nil
 }
@@ -316,7 +316,7 @@ func getOSRelease() (*osrelease, error) {
 	}
 
 	if id == "" {
-		return nil, errors.Errorf("ID not found in /etc/os-release")
+		return nil, errors.New("ID not found in /etc/os-release")
 	}
 
 	return &osrelease{ID: id, VersionID: versionID}, nil

--- a/contrib/cdisetup/venus/venus_unix.go
+++ b/contrib/cdisetup/venus/venus_unix.go
@@ -38,7 +38,7 @@ func (s *setup) Validate() error {
 	_, err = os.Stat("/dev/dri")
 	if err != nil {
 		if os.IsNotExist(err) {
-			return errors.Errorf("no DRI device found, make you use Docker VMM Hypervisor")
+			return errors.New("no DRI device found, make you use Docker VMM Hypervisor")
 		}
 		return errors.Wrap(err, "failed to check DRI device")
 	}

--- a/docs/generate.go
+++ b/docs/generate.go
@@ -41,7 +41,7 @@ func main() {
 			groups := re.FindStringSubmatch(string(match))
 			stdout := bytes.NewBuffer(nil)
 			fmt.Fprintf(stdout, "<!---GENERATE_START %s-->\n", groups[1])
-			fmt.Fprintf(stdout, "```\n")
+			fmt.Fprint(stdout, "```\n")
 			cmd := exec.Cmd{
 				Path:   "/bin/sh",
 				Args:   []string{"sh", "-c", groups[1]},
@@ -57,8 +57,8 @@ func main() {
 				err = errors.Wrapf(err, "could not run command %s", groups[1])
 				return nil
 			}
-			fmt.Fprintf(stdout, "```\n")
-			fmt.Fprintf(stdout, "<!---GENERATE_END-->\n")
+			fmt.Fprint(stdout, "```\n")
+			fmt.Fprint(stdout, "<!---GENERATE_END-->\n")
 
 			return stdout.Bytes()
 		})

--- a/executor/containerdexecutor/executor.go
+++ b/executor/containerdexecutor/executor.go
@@ -478,7 +478,7 @@ func (w *containerdExecutor) runProcess(ctx context.Context, p ctd.Process, resi
 				cancel(errors.WithStack(context.Canceled))
 			}
 			io.Cancel()
-			return errors.Errorf("failed to kill process on cancel")
+			return errors.New("failed to kill process on cancel")
 		}
 	}
 }

--- a/executor/containerdexecutor/executor_test.go
+++ b/executor/containerdexecutor/executor_test.go
@@ -11,6 +11,6 @@ func TestContainerdUnknownExitStatus(t *testing.T) {
 	// There are assumptions in the containerd executor that the UnknownExitStatus
 	// used in errdefs.ExitError matches the variable in the containerd package.
 	if ctd.UnknownExitStatus != gatewayapi.UnknownExitStatus {
-		t.Fatalf("containerd.UnknownExitStatus != errdefs.UnknownExitStatus")
+		t.Fatal("containerd.UnknownExitStatus != errdefs.UnknownExitStatus")
 	}
 }

--- a/executor/containerid.go
+++ b/executor/containerid.go
@@ -1,6 +1,8 @@
 package executor
 
-import "github.com/pkg/errors"
+import (
+	"github.com/pkg/errors"
+)
 
 // ValidContainerID validates that id is non-empty and contains only ASCII letters and digits.
 func ValidContainerID(id string) error {

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -477,7 +477,7 @@ func (w *runcExecutor) Exec(ctx context.Context, id string, process executor.Pro
 		return err
 	}
 	if _, err := dec.Token(); !errors.Is(err, io.EOF) {
-		return errors.Errorf("unexpected data after JSON spec object")
+		return errors.New("unexpected data after JSON spec object")
 	}
 
 	if process.Meta.User != "" {

--- a/exporter/attestation/unbundle.go
+++ b/exporter/attestation/unbundle.go
@@ -45,7 +45,7 @@ func Unbundle(ctx context.Context, s session.Group, bundled []exporter.Attestati
 					return errors.New("attestation bundle cannot have callback")
 				}
 				if att.Ref == nil {
-					return errors.Errorf("no ref provided for attestation bundle")
+					return errors.New("no ref provided for attestation bundle")
 				}
 
 				mount, err := att.Ref.Mount(ctx, true, s)

--- a/exporter/local/export.go
+++ b/exporter/local/export.go
@@ -100,7 +100,7 @@ func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source
 	isMap := len(inp.Refs) > 0
 
 	if _, ok := inp.Metadata[exptypes.ExporterPlatformsKey]; isMap && !ok {
-		return nil, nil, nil, errors.Errorf("unable to export multiple refs, missing platforms mapping")
+		return nil, nil, nil, errors.New("unable to export multiple refs, missing platforms mapping")
 	}
 	platforms, err := exptypes.ParsePlatforms(inp.Metadata)
 	if err != nil {
@@ -108,7 +108,7 @@ func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source
 	}
 
 	if !isMap && len(platforms.Platforms) > 1 {
-		return nil, nil, nil, errors.Errorf("unable to export multiple platforms without map")
+		return nil, nil, nil, errors.New("unable to export multiple platforms without map")
 	}
 
 	now := time.Now().Truncate(time.Second)

--- a/exporter/oci/export.go
+++ b/exporter/oci/export.go
@@ -132,7 +132,7 @@ func (e *imageExporterInstance) Config() *exporter.Config {
 
 func (e *imageExporterInstance) Export(ctx context.Context, src *exporter.Source, buildInfo exporter.ExportBuildInfo) (_ map[string]string, _ exporter.FinalizeFunc, descref exporter.DescriptorReference, err error) {
 	if e.opt.Variant == VariantDocker && len(src.Refs) > 0 {
-		return nil, nil, nil, errors.Errorf("docker exporter does not currently support exporting manifest lists")
+		return nil, nil, nil, errors.New("docker exporter does not currently support exporting manifest lists")
 	}
 
 	src = src.Clone()

--- a/exporter/tar/export.go
+++ b/exporter/tar/export.go
@@ -122,14 +122,14 @@ func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source
 	}
 
 	if _, ok := inp.Metadata[exptypes.ExporterPlatformsKey]; isMap && !ok {
-		return nil, nil, nil, errors.Errorf("unable to export multiple refs, missing platforms mapping")
+		return nil, nil, nil, errors.New("unable to export multiple refs, missing platforms mapping")
 	}
 	p, err := exptypes.ParsePlatforms(inp.Metadata)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 	if !isMap && len(p.Platforms) > 1 {
-		return nil, nil, nil, errors.Errorf("unable to export multiple platforms without map")
+		return nil, nil, nil, errors.New("unable to export multiple platforms without map")
 	}
 
 	var fs fsutil.FS

--- a/exporter/verifier/platforms.go
+++ b/exporter/verifier/platforms.go
@@ -21,7 +21,7 @@ func CheckInvalidPlatforms[T comparable](ctx context.Context, res *result.Result
 
 	if _, ok := res.Metadata[exptypes.ExporterPlatformsKey]; !ok {
 		if len(res.Refs) > 0 {
-			return nil, errors.Errorf("build result contains multiple refs without platforms mapping")
+			return nil, errors.New("build result contains multiple refs without platforms mapping")
 		} else if res.IsEmpty() {
 			// No results and no exporter key. Don't run this check.
 			return nil, nil

--- a/frontend/dockerfile/dockerfile2llb/convert_norundevice.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_norundevice.go
@@ -10,7 +10,7 @@ import (
 
 func dispatchRunDevices(c *instructions.RunCommand) ([]llb.RunOption, error) {
 	if len(instructions.GetDevices(c)) > 0 {
-		return nil, errors.Errorf("device feature is only supported in Dockerfile frontend 1.14.0-labs or later")
+		return nil, errors.New("device feature is only supported in Dockerfile frontend 1.14.0-labs or later")
 	}
 	return nil, nil
 }

--- a/frontend/dockerfile/dockerfile2llb/convert_secrets.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_secrets.go
@@ -18,7 +18,7 @@ func dispatchSecret(d *dispatchState, m *instructions.Mount, loc []parser.Range)
 
 	if id == "" {
 		if m.Target == "" {
-			return nil, errors.Errorf("one of source, target required")
+			return nil, errors.New("one of source, target required")
 		}
 		id = path.Base(m.Target)
 	}

--- a/frontend/dockerfile/dockerfile2llb/convert_ssh.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_ssh.go
@@ -9,7 +9,7 @@ import (
 
 func dispatchSSH(d *dispatchState, m *instructions.Mount, loc []parser.Range) (llb.RunOption, error) {
 	if m.Source != "" {
-		return nil, errors.Errorf("ssh does not support source")
+		return nil, errors.New("ssh does not support source")
 	}
 
 	id := m.CacheID

--- a/frontend/dockerfile/dockerfile_check_test.go
+++ b/frontend/dockerfile/dockerfile_check_test.go
@@ -1753,17 +1753,17 @@ func checkProgressStream(t *testing.T, sb integration.Sandbox, lintTest *lintTes
 	select {
 	case <-statusDone:
 	case <-time.After(10 * time.Second):
-		t.Fatalf("timed out waiting for statusDone")
+		t.Fatal("timed out waiting for statusDone")
 	}
 
 	if len(lintTest.Warnings) != len(warnings) {
 		t.Logf("expected %d warnings, received:", len(lintTest.Warnings))
-		t.Logf("\texpected:")
+		t.Log("\texpected:")
 		for i, w := range lintTest.Warnings {
 			t.Logf("\t\t%d: %s", i, w.Detail)
 		}
 
-		t.Logf("\treceived:")
+		t.Log("\treceived:")
 		for i, w := range warnings {
 			t.Logf("\t%d: %s", i, w.Short)
 		}
@@ -1845,7 +1845,7 @@ func checkLintWarning(t *testing.T, warning lint.Warning, expected expectedLintW
 func unmarshalLintResults(res *gateway.Result) (*lint.LintResults, error) {
 	dt, ok := res.Metadata["result.json"]
 	if !ok {
-		return nil, errors.Errorf("missing frontend.outline")
+		return nil, errors.New("missing frontend.outline")
 	}
 	var l lint.LintResults
 	if err := json.Unmarshal(dt, &l); err != nil {

--- a/frontend/dockerfile/dockerfile_history_test.go
+++ b/frontend/dockerfile/dockerfile_history_test.go
@@ -314,7 +314,7 @@ COPY notexist /foo
 			_, err := digest.Parse(ve.Digest)
 			require.NoError(t, err)
 		} else {
-			t.Fatalf("did not find vertex error")
+			t.Fatal("did not find vertex error")
 		}
 
 		// source points to Dockerfile

--- a/frontend/dockerfile/dockerfile_namedcontext_test.go
+++ b/frontend/dockerfile/dockerfile_namedcontext_test.go
@@ -871,7 +871,7 @@ COPY --from=build /foo /out /
 
 		dt, ok := res.Metadata["containerimage.config"]
 		if !ok {
-			return nil, errors.Errorf("no containerimage.config in metadata")
+			return nil, errors.New("no containerimage.config in metadata")
 		}
 
 		dt, err = json.Marshal(map[string][]byte{
@@ -1048,7 +1048,7 @@ COPY --from=build /foo /out /
 
 		dt, ok := res.Metadata["containerimage.config/"+platform1]
 		if !ok {
-			return nil, errors.Errorf("no containerimage.config in metadata")
+			return nil, errors.New("no containerimage.config in metadata")
 		}
 		dt, err = json.Marshal(map[string][]byte{
 			"containerimage.config": dt,
@@ -1060,7 +1060,7 @@ COPY --from=build /foo /out /
 
 		dt, ok = res.Metadata["containerimage.config/"+platform2]
 		if !ok {
-			return nil, errors.Errorf("no containerimage.config in metadata")
+			return nil, errors.New("no containerimage.config in metadata")
 		}
 		dt, err = json.Marshal(map[string][]byte{
 			"containerimage.config": dt,

--- a/frontend/dockerfile/dockerfile_outline_test.go
+++ b/frontend/dockerfile/dockerfile_outline_test.go
@@ -465,7 +465,7 @@ COPY Dockerfile Dockerfile
 func unmarshalOutline(res *gateway.Result) (*outline.Outline, error) {
 	dt, ok := res.Metadata["result.json"]
 	if !ok {
-		return nil, errors.Errorf("missing frontend.outline")
+		return nil, errors.New("missing frontend.outline")
 	}
 	var o outline.Outline
 	if err := json.Unmarshal(dt, &o); err != nil {

--- a/frontend/dockerfile/dockerfile_provenance_test.go
+++ b/frontend/dockerfile/dockerfile_provenance_test.go
@@ -1753,7 +1753,7 @@ func solveProvenanceNamedTarget(ctx context.Context, c gateway.Client, f fronten
 	}
 	dt, ok := res.Metadata["containerimage.config"]
 	if !ok {
-		return llb.State{}, "", errors.Errorf("no containerimage.config in metadata")
+		return llb.State{}, "", errors.New("no containerimage.config in metadata")
 	}
 	dt, err = json.Marshal(map[string][]byte{
 		"containerimage.config": dt,
@@ -1794,7 +1794,7 @@ func solveProvenanceInputProducerWithInner(ctx context.Context, c gateway.Client
 	}
 	dt, ok := res.Metadata["containerimage.config"]
 	if !ok {
-		return llb.State{}, "", errors.Errorf("no containerimage.config in metadata")
+		return llb.State{}, "", errors.New("no containerimage.config in metadata")
 	}
 	dt, err = json.Marshal(map[string][]byte{
 		"containerimage.config": dt,
@@ -2452,7 +2452,7 @@ COPY bar bar2
 
 		dt, ok := res.Metadata["containerimage.config"]
 		if !ok {
-			return nil, errors.Errorf("no containerimage.config in metadata")
+			return nil, errors.New("no containerimage.config in metadata")
 		}
 
 		dt, err = json.Marshal(map[string][]byte{

--- a/frontend/dockerfile/dockerfile_resources_test.go
+++ b/frontend/dockerfile/dockerfile_resources_test.go
@@ -108,7 +108,7 @@ func testCgroupParent(t *testing.T, sb integration.Sandbox) {
 	}
 
 	if _, err := os.Lstat("/sys/fs/cgroup/cgroup.subtree_control"); os.IsNotExist(err) {
-		t.Skipf("test requires cgroup v2")
+		t.Skip("test requires cgroup v2")
 	}
 
 	cgroupName := "test." + identity.NewID()
@@ -177,7 +177,7 @@ func testLinuxResources(t *testing.T, sb integration.Sandbox) {
 	}
 
 	if _, err := os.Lstat("/sys/fs/cgroup/cgroup.subtree_control"); os.IsNotExist(err) {
-		t.Skipf("test requires cgroup v2")
+		t.Skip("test requires cgroup v2")
 	}
 
 	f := getFrontend(t, sb)

--- a/frontend/dockerfile/dockerfile_targets_test.go
+++ b/frontend/dockerfile/dockerfile_targets_test.go
@@ -191,7 +191,7 @@ COPY Dockerfile Dockerfile
 func unmarshalTargets(res *gateway.Result) (*targets.List, error) {
 	dt, ok := res.Metadata["result.json"]
 	if !ok {
-		return nil, errors.Errorf("missing frontend.outline")
+		return nil, errors.New("missing frontend.outline")
 	}
 	var l targets.List
 	if err := json.Unmarshal(dt, &l); err != nil {

--- a/frontend/dockerfile/dockerfile_test.go
+++ b/frontend/dockerfile/dockerfile_test.go
@@ -371,7 +371,7 @@ func ensurePruneAll(t *testing.T, c *client.Client, sb integration.Sandbox) {
 		}
 		t.Logf("retrying prune(%d)", i)
 	}
-	t.Fatalf("failed to ensure prune")
+	t.Fatal("failed to ensure prune")
 }
 
 func newContainerd(cdAddress string) (*ctd.Client, error) {

--- a/frontend/dockerfile/instructions/commands_rundevice.go
+++ b/frontend/dockerfile/instructions/commands_rundevice.go
@@ -30,7 +30,7 @@ func runDevicePostHook(cmd *RunCommand, req parseRequest) error {
 func setDeviceState(cmd *RunCommand) error {
 	st := getDeviceState(cmd)
 	if st == nil {
-		return errors.Errorf("no device state")
+		return errors.New("no device state")
 	}
 	devices := make([]*Device, len(st.flag.StringValues))
 	for i, str := range st.flag.StringValues {

--- a/frontend/dockerfile/instructions/commands_runmount.go
+++ b/frontend/dockerfile/instructions/commands_runmount.go
@@ -81,7 +81,7 @@ func runMountPostHook(cmd *RunCommand, req parseRequest) error {
 func setMountState(cmd *RunCommand, expander SingleWordExpander) error {
 	st := getMountState(cmd)
 	if st == nil {
-		return errors.Errorf("no mount state")
+		return errors.New("no mount state")
 	}
 	mounts := make([]*Mount, len(st.flag.StringValues))
 	for i, str := range st.flag.StringValues {
@@ -289,16 +289,16 @@ func parseMount(val string, expander SingleWordExpander) (*Mount, error) {
 
 	if m.Type == MountTypeSecret {
 		if m.From != "" {
-			return nil, errors.Errorf("secret mount should not have a from")
+			return nil, errors.New("secret mount should not have a from")
 		}
 		if m.CacheSharing != "" {
-			return nil, errors.Errorf("secret mount should not define sharing")
+			return nil, errors.New("secret mount should not define sharing")
 		}
 		if m.Source == "" && m.Target == "" && m.CacheID == "" {
-			return nil, errors.Errorf("invalid secret mount. one of source, target required")
+			return nil, errors.New("invalid secret mount. one of source, target required")
 		}
 		if m.Source != "" && m.CacheID != "" {
-			return nil, errors.Errorf("both source and id can't be set")
+			return nil, errors.New("both source and id can't be set")
 		}
 	}
 

--- a/frontend/dockerfile/instructions/commands_runnetwork.go
+++ b/frontend/dockerfile/instructions/commands_runnetwork.go
@@ -40,7 +40,7 @@ func runNetworkPreHook(cmd *RunCommand, req parseRequest) error {
 func runNetworkPostHook(cmd *RunCommand, req parseRequest) error {
 	st := cmd.getExternalValue(networkKey).(*networkState)
 	if st == nil {
-		return errors.Errorf("no network state")
+		return errors.New("no network state")
 	}
 
 	value := st.flag.Value

--- a/frontend/dockerfile/instructions/commands_runsecurity.go
+++ b/frontend/dockerfile/instructions/commands_runsecurity.go
@@ -36,7 +36,7 @@ func runSecurityPreHook(cmd *RunCommand, req parseRequest) error {
 func runSecurityPostHook(cmd *RunCommand, req parseRequest) error {
 	st := cmd.getExternalValue(securityKey).(*securityState)
 	if st == nil {
-		return errors.Errorf("no security state")
+		return errors.New("no security state")
 	}
 
 	value := st.flag.Value

--- a/frontend/dockerfile/parser/parser.go
+++ b/frontend/dockerfile/parser/parser.go
@@ -274,7 +274,7 @@ func (r *Result) PrintWarnings(out io.Writer) {
 		fmt.Fprintf(out, "[WARNING]: %s\n", w.Short)
 	}
 	if len(r.Warnings) > 0 {
-		fmt.Fprintf(out, "[WARNING]: Empty continuation lines will become errors in a future release.\n")
+		fmt.Fprint(out, "[WARNING]: Empty continuation lines will become errors in a future release.\n")
 	}
 }
 

--- a/frontend/dockerui/config.go
+++ b/frontend/dockerui/config.go
@@ -233,7 +233,7 @@ func (bc *Client) init() error {
 			return errors.Errorf("invalid boolean value for multi-platform: %s", v)
 		}
 		if !b && multiPlatform {
-			return errors.Errorf("conflicting config: returning multiple target platforms is not allowed")
+			return errors.New("conflicting config: returning multiple target platforms is not allowed")
 		}
 		multiPlatform = b
 	}
@@ -285,7 +285,7 @@ func (bc *Client) init() error {
 			}
 		}
 		if ref == nil {
-			return errors.Errorf("sbom scanner cannot be empty")
+			return errors.New("sbom scanner cannot be empty")
 		}
 
 		bc.SBOM = &SBOM{

--- a/frontend/gateway/client/attestation.go
+++ b/frontend/gateway/client/attestation.go
@@ -9,7 +9,7 @@ import (
 
 func AttestationToPB[T any](a *result.Attestation[T]) (*pb.Attestation, error) {
 	if a.ContentFunc != nil {
-		return nil, errors.Errorf("attestation callback cannot be sent through gateway")
+		return nil, errors.New("attestation callback cannot be sent through gateway")
 	}
 
 	subjects := make([]*pb.InTotoSubject, len(a.InToto.Subjects))
@@ -32,12 +32,12 @@ func AttestationToPB[T any](a *result.Attestation[T]) (*pb.Attestation, error) {
 
 func AttestationFromPB[T any](a *pb.Attestation) (*result.Attestation[T], error) {
 	if a == nil {
-		return nil, errors.Errorf("invalid nil attestation")
+		return nil, errors.New("invalid nil attestation")
 	}
 	subjects := make([]result.InTotoSubject, len(a.InTotoSubjects))
 	for i, subject := range a.InTotoSubjects {
 		if subject == nil {
-			return nil, errors.Errorf("invalid nil attestation subject")
+			return nil, errors.New("invalid nil attestation subject")
 		}
 		subjects[i] = result.InTotoSubject{
 			Kind:   subject.Kind,

--- a/frontend/gateway/forwarder/forward.go
+++ b/frontend/gateway/forwarder/forward.go
@@ -70,7 +70,7 @@ func (c *BridgeClient) Solve(ctx context.Context, req client.SolveRequest) (*cli
 	for _, atts := range res.Attestations {
 		for _, att := range atts {
 			if att.ContentFunc != nil {
-				return nil, errors.Errorf("attestation callback cannot be sent through gateway")
+				return nil, errors.New("attestation callback cannot be sent through gateway")
 			}
 		}
 	}
@@ -203,7 +203,7 @@ func (c *BridgeClient) toFrontendResult(r *client.Result) (*frontend.Result, err
 	for _, atts := range r.Attestations {
 		for _, att := range atts {
 			if att.ContentFunc != nil {
-				return nil, errors.Errorf("attestation callback cannot be sent through gateway")
+				return nil, errors.New("attestation callback cannot be sent through gateway")
 			}
 		}
 	}

--- a/frontend/gateway/grpcclient/client.go
+++ b/frontend/gateway/grpcclient/client.go
@@ -1117,7 +1117,7 @@ func (ctr *container) Start(ctx context.Context, req client.StartRequest) (clien
 
 	msg, _ := msgs.Recv(ctx)
 	if msg == nil {
-		return nil, errors.Errorf("failed to receive started message")
+		return nil, errors.New("failed to receive started message")
 	}
 	started := msg.GetStarted()
 	if started == nil {
@@ -1378,7 +1378,7 @@ func (r *reference) ToState() (st llb.State, err error) {
 	}
 
 	if r.def == nil {
-		return st, errors.Errorf("gateway did not return reference with definition")
+		return st, errors.New("gateway did not return reference with definition")
 	}
 
 	defop, err := llb.NewDefinitionOp(r.def)

--- a/frontend/subrequests/describe.go
+++ b/frontend/subrequests/describe.go
@@ -55,7 +55,7 @@ func Describe(ctx context.Context, c client.Client) ([]Request, error) {
 
 	dt, ok := res.Metadata["result.json"]
 	if !ok {
-		return nil, errors.Errorf("no result.json metadata in response")
+		return nil, errors.New("no result.json metadata in response")
 	}
 
 	var reqs []Request
@@ -72,7 +72,7 @@ func PrintDescribe(dt []byte, w io.Writer) error {
 	}
 
 	tw := tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
-	fmt.Fprintf(tw, "NAME\tVERSION\tDESCRIPTION\n")
+	fmt.Fprint(tw, "NAME\tVERSION\tDESCRIPTION\n")
 
 	for _, r := range d {
 		fmt.Fprintf(tw, "%s\t%s\t%s\n", strings.TrimPrefix(r.Name, "frontend."), r.Version, r.Description)

--- a/frontend/subrequests/lint/lint.go
+++ b/frontend/subrequests/lint/lint.go
@@ -202,12 +202,12 @@ func (results *LintResults) PrintErrorTo(w io.Writer, scb SourceInfoMap) {
 func (results *LintResults) validateWarnings() error {
 	for _, warning := range results.Warnings {
 		if int(warning.Location.SourceIndex) >= len(results.Sources) {
-			return errors.Errorf("sourceIndex is out of range")
+			return errors.New("sourceIndex is out of range")
 		}
 		if warning.Location.SourceIndex > 0 {
 			warningSource := results.Sources[warning.Location.SourceIndex]
 			if warningSource == nil {
-				return errors.Errorf("sourceIndex points to nil source")
+				return errors.New("sourceIndex points to nil source")
 			}
 		}
 	}

--- a/frontend/subrequests/outline/outline.go
+++ b/frontend/subrequests/outline/outline.go
@@ -106,7 +106,7 @@ func PrintOutline(dt []byte, w io.Writer) error {
 
 	if len(o.Args) > 0 {
 		tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
-		fmt.Fprintf(tw, "BUILD ARG\tVALUE\tDESCRIPTION\n")
+		fmt.Fprint(tw, "BUILD ARG\tVALUE\tDESCRIPTION\n")
 		for _, a := range o.Args {
 			fmt.Fprintf(tw, "%s\t%s\t%s\n", a.Name, a.Value, a.Description)
 		}
@@ -116,7 +116,7 @@ func PrintOutline(dt []byte, w io.Writer) error {
 
 	if len(o.Secrets) > 0 {
 		tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
-		fmt.Fprintf(tw, "SECRET\tREQUIRED\n")
+		fmt.Fprint(tw, "SECRET\tREQUIRED\n")
 		for _, s := range o.Secrets {
 			b := ""
 			if s.Required {
@@ -130,7 +130,7 @@ func PrintOutline(dt []byte, w io.Writer) error {
 
 	if len(o.SSH) > 0 {
 		tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
-		fmt.Fprintf(tw, "SSH\tREQUIRED\n")
+		fmt.Fprint(tw, "SSH\tREQUIRED\n")
 		for _, s := range o.SSH {
 			b := ""
 			if s.Required {

--- a/frontend/subrequests/targets/targets.go
+++ b/frontend/subrequests/targets/targets.go
@@ -66,7 +66,7 @@ func PrintTargets(dt []byte, w io.Writer) error {
 	}
 
 	tw := tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
-	fmt.Fprintf(tw, "TARGET\tDESCRIPTION\n")
+	fmt.Fprint(tw, "TARGET\tDESCRIPTION\n")
 
 	for _, t := range l.Targets {
 		name := t.Name

--- a/session/filesync/filesync_test.go
+++ b/session/filesync/filesync_test.go
@@ -70,7 +70,7 @@ func TestFileSyncIncludePatterns(t *testing.T) {
 		}
 
 		if _, err := os.ReadFile(filepath.Join(destDir, "foo")); err == nil {
-			return errors.Errorf("expected error reading foo")
+			return errors.New("expected error reading foo")
 		}
 
 		dt, err := os.ReadFile(filepath.Join(destDir, "bar"))

--- a/session/grpc.go
+++ b/session/grpc.go
@@ -70,7 +70,7 @@ func grpcClientConn(ctx context.Context, conn net.Conn, opts map[string][]string
 	var dialCount atomic.Int64
 	dialer := grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
 		if c := dialCount.Add(1); c > 1 {
-			return nil, errors.Errorf("only one connection allowed")
+			return nil, errors.New("only one connection allowed")
 		}
 		return conn, nil
 	})

--- a/session/secrets/secrets.go
+++ b/session/secrets/secrets.go
@@ -13,7 +13,7 @@ type SecretStore interface {
 	GetSecret(context.Context, string) ([]byte, error)
 }
 
-var ErrNotFound = errors.Errorf("not found")
+var ErrNotFound = errors.New("not found")
 
 func GetSecret(ctx context.Context, c session.Caller, id string) ([]byte, error) {
 	ctx = c.Context(ctx)

--- a/session/secrets/secretsprovider/store.go
+++ b/session/secrets/secretsprovider/store.go
@@ -19,7 +19,7 @@ func NewStore(files []Source) (secrets.SecretStore, error) {
 	m := map[string]Source{}
 	for _, f := range files {
 		if f.ID == "" {
-			return nil, errors.Errorf("secret missing ID")
+			return nil, errors.New("secret missing ID")
 		}
 		if f.Env == "" && f.FilePath == "" {
 			if _, ok := os.LookupEnv(f.ID); ok {

--- a/session/sshforward/sshprovider/agentprovider.go
+++ b/session/sshforward/sshprovider/agentprovider.go
@@ -139,7 +139,7 @@ func toDialer(paths []string, raw bool) (func(context.Context) (net.Conn, error)
 			continue
 		}
 		if raw {
-			return nil, errors.Errorf("raw mode only supported with socket paths")
+			return nil, errors.New("raw mode only supported with socket paths")
 		}
 
 		f, err := os.Open(p) //nolint:gosec // SSH key paths are explicit user inputs and may intentionally be symlinks.
@@ -159,7 +159,7 @@ func toDialer(paths []string, raw bool) (func(context.Context) (net.Conn, error)
 			// If parsing the file fails, check to see if it kind of looks like socket-shaped.
 			if runtime.GOOS == "windows" && strings.Contains(string(dt), "socket") {
 				if keys {
-					return nil, errors.Errorf("invalid combination of keys and sockets")
+					return nil, errors.New("invalid combination of keys and sockets")
 				}
 				socket = &socketDialer{path: p, dialer: unixSocketDialer}
 				continue
@@ -176,7 +176,7 @@ func toDialer(paths []string, raw bool) (func(context.Context) (net.Conn, error)
 
 	if socket != nil {
 		if keys {
-			return nil, errors.Errorf("invalid combination of keys and sockets")
+			return nil, errors.New("invalid combination of keys and sockets")
 		}
 		if raw {
 			return func(ctx context.Context) (net.Conn, error) {
@@ -203,21 +203,21 @@ type readOnlyAgent struct {
 }
 
 func (a *readOnlyAgent) Add(_ agent.AddedKey) error {
-	return errors.Errorf("adding new keys not allowed by buildkit")
+	return errors.New("adding new keys not allowed by buildkit")
 }
 
 func (a *readOnlyAgent) Remove(_ ssh.PublicKey) error {
-	return errors.Errorf("removing keys not allowed by buildkit")
+	return errors.New("removing keys not allowed by buildkit")
 }
 
 func (a *readOnlyAgent) RemoveAll() error {
-	return errors.Errorf("removing keys not allowed by buildkit")
+	return errors.New("removing keys not allowed by buildkit")
 }
 
 func (a *readOnlyAgent) Lock(_ []byte) error {
-	return errors.Errorf("locking agent not allowed by buildkit")
+	return errors.New("locking agent not allowed by buildkit")
 }
 
 func (a *readOnlyAgent) Extension(_ string, _ []byte) ([]byte, error) {
-	return nil, errors.Errorf("extensions not allowed by buildkit")
+	return nil, errors.New("extensions not allowed by buildkit")
 }

--- a/session/sshforward/sshprovider/agentprovider_unix.go
+++ b/session/sshforward/sshprovider/agentprovider_unix.go
@@ -7,7 +7,7 @@ import (
 )
 
 func getFallbackAgentPath() (string, error) {
-	return "", errors.Errorf("make sure SSH_AUTH_SOCK is set")
+	return "", errors.New("make sure SSH_AUTH_SOCK is set")
 }
 
 func getWindowsPipeDialer(_ string) *socketDialer {

--- a/snapshot/containerd/content.go
+++ b/snapshot/containerd/content.go
@@ -44,7 +44,7 @@ func (c *Store) Walk(ctx context.Context, fn content.WalkFunc, filters ...string
 }
 
 func (c *Store) Delete(ctx context.Context, dgst digest.Digest) error {
-	return errors.Errorf("contentstore.Delete usage is forbidden")
+	return errors.New("contentstore.Delete usage is forbidden")
 }
 
 func (c *Store) Status(ctx context.Context, ref string) (content.Status, error) {

--- a/snapshot/containerd/snapshotter.go
+++ b/snapshot/containerd/snapshotter.go
@@ -60,7 +60,7 @@ func (s *nsSnapshotter) Commit(ctx context.Context, name, key string, opts ...sn
 }
 
 func (s *nsSnapshotter) Remove(ctx context.Context, key string) error {
-	return errors.Errorf("calling snapshotter.Remove is forbidden")
+	return errors.New("calling snapshotter.Remove is forbidden")
 }
 
 func (s *nsSnapshotter) Walk(ctx context.Context, fn snapshots.WalkFunc, filters ...string) error {

--- a/solver/cachestorage.go
+++ b/solver/cachestorage.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var ErrNotFound = errors.Errorf("not found")
+var ErrNotFound = errors.New("not found")
 
 // CacheKeyStorage is interface for persisting cache metadata
 type CacheKeyStorage interface {

--- a/solver/combinedcache.go
+++ b/solver/combinedcache.go
@@ -101,7 +101,7 @@ func (cm *combinedCacheManager) Load(ctx context.Context, rec *CacheRecord) (res
 		}
 	}
 	if len(results) == 0 { // TODO: handle gracefully
-		return nil, errors.Errorf("failed to load deleted cache")
+		return nil, errors.New("failed to load deleted cache")
 	}
 	return results[0].Result, nil
 }
@@ -117,7 +117,7 @@ func (cm *combinedCacheManager) Records(ctx context.Context, ck *CacheKey) ([]*C
 	ck.mu.RLock()
 	if len(ck.ids) == 0 {
 		ck.mu.RUnlock()
-		return nil, errors.Errorf("no results")
+		return nil, errors.New("no results")
 	}
 
 	cms := make([]*cacheManager, 0, len(ck.ids))

--- a/solver/errdefs/source.go
+++ b/solver/errdefs/source.go
@@ -89,7 +89,7 @@ func (s *Source) Print(w io.Writer) error {
 		}
 		fmt.Fprintf(w, " %3d | %s %s\n", i, pfx, lines[i-1])
 	}
-	fmt.Fprintf(w, "--------------------\n")
+	fmt.Fprint(w, "--------------------\n")
 	return nil
 }
 

--- a/solver/llbsolver/file/refmanager.go
+++ b/solver/llbsolver/file/refmanager.go
@@ -66,7 +66,7 @@ func (rm *RefManager) Commit(ctx context.Context, mount fileoptypes.Mount) (file
 		return nil, errors.Errorf("invalid mount type %T", mount)
 	}
 	if m.mr == nil {
-		return nil, errors.Errorf("invalid mount without active ref for commit")
+		return nil, errors.New("invalid mount without active ref for commit")
 	}
 	ref, err := m.mr.Commit(ctx)
 	if err != nil {

--- a/solver/llbsolver/history/buildhistory.go
+++ b/solver/llbsolver/history/buildhistory.go
@@ -335,7 +335,7 @@ func (h *Queue) UpdateRef(ctx context.Context, ref string, upt func(r *controlap
 	br.Generation++
 
 	if br.Ref != ref {
-		return errors.Errorf("invalid ref change")
+		return errors.New("invalid ref change")
 	}
 
 	if err := h.update(ctx, &br); err != nil {

--- a/solver/llbsolver/mounts/mount_test.go
+++ b/solver/llbsolver/mounts/mount_test.go
@@ -46,7 +46,7 @@ type cmOut struct {
 func newCacheManager(ctx context.Context, t *testing.T, opt cmOpt) (co *cmOut, err error) {
 	ns, ok := namespaces.Namespace(ctx)
 	if !ok {
-		return nil, errors.Errorf("namespace required for test")
+		return nil, errors.New("namespace required for test")
 	}
 
 	if opt.snapshotterName == "" {

--- a/solver/llbsolver/ops/build.go
+++ b/solver/llbsolver/ops/build.go
@@ -67,7 +67,7 @@ func (b *BuildOp) CacheMap(ctx context.Context, job solver.JobContext, index int
 
 func (b *BuildOp) Exec(ctx context.Context, job solver.JobContext, inputs []solver.Result) (outputs []solver.Result, retErr error) {
 	if b.op.Builder != int64(pb.LLBBuilder) {
-		return nil, errors.Errorf("only LLB builder is currently allowed")
+		return nil, errors.New("only LLB builder is currently allowed")
 	}
 
 	builderInputs := b.op.Inputs

--- a/solver/llbsolver/ops/file_test.go
+++ b/solver/llbsolver/ops/file_test.go
@@ -568,7 +568,7 @@ type testFileRef struct {
 
 func (r *testFileRef) Release(context.Context) error {
 	if r.refcount == 0 {
-		return errors.Errorf("ref already released")
+		return errors.New("ref already released")
 	}
 	r.refcount--
 	return nil
@@ -611,7 +611,7 @@ func (tm *testMount) Release(ctx context.Context) error {
 		return tm.b.mounts[tm.initID].Release(ctx)
 	}
 	if tm.unmounted {
-		return errors.Errorf("already unmounted")
+		return errors.New("already unmounted")
 	}
 	tm.unmounted = true
 	if tm.active != nil {

--- a/solver/llbsolver/ops/opsutils/validate.go
+++ b/solver/llbsolver/ops/opsutils/validate.go
@@ -7,27 +7,27 @@ import (
 
 func Validate(op *pb.Op) error {
 	if op == nil {
-		return errors.Errorf("invalid nil op")
+		return errors.New("invalid nil op")
 	}
 
 	inputCount := len(op.Inputs)
 	switch op := op.Op.(type) {
 	case *pb.Op_Source:
 		if op.Source == nil {
-			return errors.Errorf("invalid nil source op")
+			return errors.New("invalid nil source op")
 		}
 	case *pb.Op_Exec:
 		if op.Exec == nil {
-			return errors.Errorf("invalid nil exec op")
+			return errors.New("invalid nil exec op")
 		}
 		if op.Exec.Meta == nil {
-			return errors.Errorf("invalid exec op with no meta")
+			return errors.New("invalid exec op with no meta")
 		}
 		if len(op.Exec.Meta.Args) == 0 {
-			return errors.Errorf("invalid exec op with no args")
+			return errors.New("invalid exec op with no args")
 		}
 		if len(op.Exec.Mounts) == 0 {
-			return errors.Errorf("invalid exec op with no mounts")
+			return errors.New("invalid exec op with no mounts")
 		}
 
 		isRoot := false
@@ -38,39 +38,39 @@ func Validate(op *pb.Op) error {
 			}
 		}
 		if !isRoot {
-			return errors.Errorf("invalid exec op with no rootfs")
+			return errors.New("invalid exec op with no rootfs")
 		}
 	case *pb.Op_File:
 		if op.File == nil {
-			return errors.Errorf("invalid nil file op")
+			return errors.New("invalid nil file op")
 		}
 		if len(op.File.Actions) == 0 {
-			return errors.Errorf("invalid file op with no actions")
+			return errors.New("invalid file op with no actions")
 		}
 	case *pb.Op_Build:
 		if op.Build == nil {
-			return errors.Errorf("invalid nil build op")
+			return errors.New("invalid nil build op")
 		}
 	case *pb.Op_Merge:
 		if op.Merge == nil {
-			return errors.Errorf("invalid nil merge op")
+			return errors.New("invalid nil merge op")
 		}
 	case *pb.Op_Diff:
 		if op.Diff == nil {
-			return errors.Errorf("invalid nil diff op")
+			return errors.New("invalid nil diff op")
 		}
 		if op.Diff.Lower == nil || op.Diff.Upper == nil {
-			return errors.Errorf("invalid diff op with nil lower or upper input")
+			return errors.New("invalid diff op with nil lower or upper input")
 		}
 	case *pb.Op_Passthrough:
 		if op.Passthrough == nil {
-			return errors.Errorf("invalid nil passthrough op")
+			return errors.New("invalid nil passthrough op")
 		}
 		if op.Passthrough.Id == "" {
-			return errors.Errorf("invalid passthrough op with no id")
+			return errors.New("invalid passthrough op with no id")
 		}
 		if len(op.Passthrough.Outputs) == 0 {
-			return errors.Errorf("invalid passthrough op with no outputs")
+			return errors.New("invalid passthrough op with no outputs")
 		}
 		for _, input := range op.Passthrough.Outputs {
 			if input < 0 || inputCount > 0 && input >= int64(inputCount) {

--- a/solver/llbsolver/ops/user_linux.go
+++ b/solver/llbsolver/ops/user_linux.go
@@ -29,7 +29,7 @@ func readUser(chopt *pb.ChownOpt, mu, mg snapshot.Mountable) (*copy.User, error)
 		switch u := chopt.User.User.(type) {
 		case *pb.UserOpt_ByName:
 			if mu == nil {
-				return nil, errors.Errorf("invalid missing user mount")
+				return nil, errors.New("invalid missing user mount")
 			}
 
 			lm := snapshot.LocalMounter(mu)
@@ -75,7 +75,7 @@ func readUser(chopt *pb.ChownOpt, mu, mg snapshot.Mountable) (*copy.User, error)
 		switch u := chopt.Group.User.(type) {
 		case *pb.UserOpt_ByName:
 			if mg == nil {
-				return nil, errors.Errorf("invalid missing group mount")
+				return nil, errors.New("invalid missing group mount")
 			}
 
 			lm := snapshot.LocalMounter(mg)

--- a/solver/llbsolver/policy.go
+++ b/solver/llbsolver/policy.go
@@ -86,7 +86,7 @@ func (p *policyEvaluator) evaluate(ctx context.Context, op *pb.Op, max int) (boo
 	for {
 		max--
 		if max < 0 { // TODO: better loop detection
-			return false, errors.Errorf("too many policy requests")
+			return false, errors.New("too many policy requests")
 		}
 		resp, err := verifier.CheckPolicy(ctx, req)
 		if err != nil {
@@ -156,12 +156,12 @@ func (p *policyEvaluator) evaluate(ctx context.Context, op *pb.Op, max int) (boo
 
 		decision := resp.GetDecision()
 		if decision == nil {
-			return false, errors.Errorf("no decision in policy response")
+			return false, errors.New("no decision in policy response")
 		}
 		if decision.Action == spb.PolicyAction_CONVERT {
 			newSrc := decision.Update
 			if newSrc == nil {
-				return false, errors.Errorf("convert action requires updated source")
+				return false, errors.New("convert action requires updated source")
 			}
 			source.Identifier = newSrc.Identifier
 			source.Attrs = newSrc.Attrs
@@ -260,7 +260,7 @@ func loadSourcePolicy(b solver.Builder) (*spb.Policy, error) {
 		}
 		for _, f := range x.Rules {
 			if f == nil {
-				return errors.Errorf("invalid nil policy rule")
+				return errors.New("invalid nil policy rule")
 			}
 			srcPol.Rules = append(srcPol.Rules, f.CloneVT())
 		}

--- a/solver/llbsolver/result.go
+++ b/solver/llbsolver/result.go
@@ -134,7 +134,7 @@ func (rp *resultProxy) Result(ctx context.Context) (res solver.CachedResult, err
 		rp.mu.Lock()
 		if rp.released {
 			rp.mu.Unlock()
-			return nil, errors.Errorf("accessing released result")
+			return nil, errors.New("accessing released result")
 		}
 		if rp.v != nil || rp.err != nil {
 			rp.mu.Unlock()
@@ -157,7 +157,7 @@ func (rp *resultProxy) Result(ctx context.Context) (res solver.CachedResult, err
 				v.Release(context.TODO())
 			}
 			rp.mu.Unlock()
-			return nil, errors.Errorf("evaluating released result")
+			return nil, errors.New("evaluating released result")
 		}
 		if err == nil {
 			var capture *provenance.Capture

--- a/solver/result/result.go
+++ b/solver/result/result.go
@@ -62,7 +62,7 @@ func (r *Result[T]) SingleRef() (T, error) {
 	var zero T
 	if r.Refs != nil && r.Ref == zero {
 		var t T
-		return t, errors.Errorf("invalid map result")
+		return t, errors.New("invalid map result")
 	}
 	return r.Ref, nil
 }

--- a/solver/scheduler_test.go
+++ b/solver/scheduler_test.go
@@ -1147,7 +1147,7 @@ func TestSlowCacheErrorResultCloneRelease(t *testing.T) {
 			},
 			slowCacheCompute: map[int]ResultBasedCacheFunc{
 				0: func(context.Context, Result, session.Group) (digest.Digest, error) {
-					return "", errors.Errorf("slow cache error")
+					return "", errors.New("slow cache error")
 				},
 			},
 		}),
@@ -1259,7 +1259,7 @@ func TestErrorReturns(t *testing.T) {
 					cacheKeySeed: "seed1",
 					value:        "result1",
 					cachePreFunc: func(ctx context.Context) error {
-						return errors.Errorf("error-from-test")
+						return errors.New("error-from-test")
 					},
 				})},
 				{Vertex: vtx(vtxOpt{
@@ -1346,7 +1346,7 @@ func TestErrorReturns(t *testing.T) {
 					cacheKeySeed: "seed3",
 					value:        "result2",
 					execPreFunc: func(ctx context.Context) error {
-						return errors.Errorf("exec-error-from-test")
+						return errors.New("exec-error-from-test")
 					},
 				})},
 			},
@@ -3834,7 +3834,7 @@ func (v *vertex) CacheMap(ctx context.Context, jobCtx JobContext, index int) (*C
 
 func (v *vertex) exec(ctx context.Context, inputs []Result) error {
 	if len(inputs) != len(v.Inputs()) {
-		return errors.Errorf("invalid number of inputs")
+		return errors.New("invalid number of inputs")
 	}
 	if f := v.opt.execPreFunc; f != nil {
 		if err := f(ctx); err != nil {
@@ -4089,7 +4089,7 @@ func testOpResolver(v Vertex, b Builder) (Op, error) {
 		return op, nil
 	}
 
-	return nil, errors.Errorf("invalid vertex")
+	return nil, errors.New("invalid vertex")
 }
 
 func unwrap(res Result) string {
@@ -4133,7 +4133,7 @@ type trackingCacheManager struct {
 func (cm *trackingCacheManager) Load(ctx context.Context, rec *CacheRecord) (Result, error) {
 	atomic.AddInt64(&cm.loadCounter, 1)
 	if cm.forceFail {
-		return nil, errors.Errorf("force fail")
+		return nil, errors.New("force fail")
 	}
 	return cm.CacheManager.Load(ctx, rec)
 }

--- a/source/containerblob/blobfetch/fetch.go
+++ b/source/containerblob/blobfetch/fetch.go
@@ -57,7 +57,7 @@ func FetchBlob(ctx context.Context, g session.Group, opt FetchOpt) (io.ReadClose
 	switch opt.Scheme {
 	case srctypes.OCIBlobScheme:
 		if opt.StoreID == "" {
-			return nil, "", errors.Errorf("oci-layout blob source requires store id")
+			return nil, "", errors.New("oci-layout blob source requires store id")
 		}
 		rc, err := fetchFromOCILayoutStore(ctx, g, opt)
 		if err != nil {

--- a/source/containerblob/source.go
+++ b/source/containerblob/source.go
@@ -78,7 +78,7 @@ func (is *Source) ociLayoutIdentifier(ref string, attrs map[string]string, _ *pb
 		return nil, err
 	}
 	if id.StoreID == "" {
-		return nil, errors.Errorf("oci-layout blob source requires store id")
+		return nil, errors.New("oci-layout blob source requires store id")
 	}
 	return parsed, nil
 }

--- a/source/git/identifier.go
+++ b/source/git/identifier.go
@@ -136,7 +136,7 @@ func validateBundleAttrs(id *GitIdentifier) error {
 			return err
 		}
 		if id.Checksum == "" {
-			return errors.Errorf("git.bundle requires git.checksum to be set")
+			return errors.New("git.bundle requires git.checksum to be set")
 		}
 		// Reject the pathological "Ref=sha1, Checksum=sha2" case: if both
 		// are set and Ref is itself a commit SHA, the two must agree.
@@ -148,10 +148,10 @@ func validateBundleAttrs(id *GitIdentifier) error {
 	}
 	if id.CheckoutBundle {
 		if id.KeepGitDir {
-			return errors.Errorf("git.checkoutbundle is incompatible with git.keepgitdir")
+			return errors.New("git.checkoutbundle is incompatible with git.keepgitdir")
 		}
 		if id.Subdir != "" {
-			return errors.Errorf("git.checkoutbundle is incompatible with git.subdir")
+			return errors.New("git.checkoutbundle is incompatible with git.subdir")
 		}
 	}
 	return nil

--- a/source/http/transport.go
+++ b/source/http/transport.go
@@ -26,7 +26,7 @@ func (h *sessionHandler) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	if req.Method != http.MethodGet {
-		return nil, errors.Errorf("invalid request")
+		return nil, errors.New("invalid request")
 	}
 
 	var resp *http.Response

--- a/sourcepolicy/mutate.go
+++ b/sourcepolicy/mutate.go
@@ -13,7 +13,7 @@ import (
 // If there is no change, then the return value should be false and is not considered an error.
 func mutate(ctx context.Context, op *pb.SourceOp, rule *spb.Rule, selector *selectorCache, ref string) (bool, error) {
 	if rule.Updates == nil {
-		return false, errors.Errorf("missing destination for convert rule")
+		return false, errors.New("missing destination for convert rule")
 	}
 
 	dest := rule.Updates.Identifier

--- a/sourcepolicy/policysession/provider.go
+++ b/sourcepolicy/policysession/provider.go
@@ -26,7 +26,7 @@ func (p *PolicyProvider) CheckPolicy(ctx context.Context, req *CheckPolicyReques
 		return nil, err
 	}
 	if metareq != nil && decision != nil {
-		return nil, errors.Errorf("cannot return both decision and meta request")
+		return nil, errors.New("cannot return both decision and meta request")
 	}
 	resp := &CheckPolicyResponse{}
 	if decision != nil {

--- a/util/archutil/check_unix.go
+++ b/util/archutil/check_unix.go
@@ -56,7 +56,7 @@ func check(arch, bin string) (string, error) {
 
 	// special handling for amd64. Exit code is 64 + amd64 variant
 	if err == nil {
-		return "", errors.Errorf("invalid zero exit code")
+		return "", errors.New("invalid zero exit code")
 	}
 	exitError := &exec.ExitError{}
 	if errors.As(err, &exitError) {

--- a/util/cachedigest/db.go
+++ b/util/cachedigest/db.go
@@ -10,8 +10,8 @@ import (
 	bolt "go.etcd.io/bbolt"
 )
 
-var ErrInvalidEncoding = errors.Errorf("invalid encoding")
-var ErrNotFound = errors.Errorf("not found")
+var ErrInvalidEncoding = errors.New("invalid encoding")
+var ErrNotFound = errors.New("not found")
 
 const bucketName = "byhash"
 

--- a/util/contentutil/buffer.go
+++ b/util/contentutil/buffer.go
@@ -206,7 +206,7 @@ func (w *bufferedWriter) Digest() digest.Digest {
 
 func (w *bufferedWriter) Commit(ctx context.Context, size int64, expected digest.Digest, opt ...content.Opt) error {
 	if w.buffer == nil {
-		return errors.Errorf("can't commit already committed or closed")
+		return errors.New("can't commit already committed or closed")
 	}
 	if s := int64(w.buffer.Len()); size > 0 && size != s {
 		return errors.Errorf("unexpected commit size %d, expected %d", s, size)

--- a/util/contentutil/fetcher.go
+++ b/util/contentutil/fetcher.go
@@ -38,7 +38,7 @@ func (p *fetchedProvider) ReaderAt(ctx context.Context, desc ocispecs.Descriptor
 func (p *fetchedProvider) FetchReferrers(ctx context.Context, dgst digest.Digest, opts ...remotes.FetchReferrersOpt) ([]ocispecs.Descriptor, error) {
 	refs, ok := p.f.(remotes.ReferrersFetcher)
 	if !ok {
-		return nil, errors.Errorf("fetcher does not support referrers")
+		return nil, errors.New("fetcher does not support referrers")
 	}
 	return refs.FetchReferrers(ctx, dgst, opts...)
 }
@@ -61,7 +61,7 @@ func (r *readerAt) ReadAt(b []byte, off int64) (int, error) {
 			if ra, ok := r.Reader.(io.ReaderAt); ok {
 				return ra.ReadAt(b, off)
 			}
-			return 0, errors.Errorf("unsupported offset")
+			return 0, errors.New("unsupported offset")
 		}
 	}
 

--- a/util/flightcontrol/cached_test.go
+++ b/util/flightcontrol/cached_test.go
@@ -37,7 +37,7 @@ func TestCached(t *testing.T) {
 
 	// by default, errors are not cached
 	_, err = g.Do(ctx, "33", func(ctx context.Context) (int, error) {
-		return 0, errors.Errorf("some error")
+		return 0, errors.New("some error")
 	})
 
 	require.Error(t, err)
@@ -58,7 +58,7 @@ func TestCachedError(t *testing.T) {
 	ctx := context.TODO()
 
 	_, err := g.Do(ctx, "11", func(ctx context.Context) (string, error) {
-		return "", errors.Errorf("first error")
+		return "", errors.New("first error")
 	})
 	require.Error(t, err)
 	require.ErrorContains(t, err, "first error")
@@ -77,7 +77,7 @@ func TestCachedError(t *testing.T) {
 		case <-ctx.Done():
 			return "", context.Cause(ctx)
 		case <-time.After(10 * time.Second):
-			return "", errors.Errorf("unexpected error")
+			return "", errors.New("unexpected error")
 		}
 	})
 	require.Error(t, err)

--- a/util/flightcontrol/flightcontrol.go
+++ b/util/flightcontrol/flightcontrol.go
@@ -16,8 +16,8 @@ import (
 // nested progress reporting
 
 var (
-	errRetry        = errors.Errorf("retry")
-	errRetryTimeout = errors.Errorf("exceeded retry timeout")
+	errRetry        = errors.New("retry")
+	errRetryTimeout = errors.New("exceeded retry timeout")
 )
 
 type contextKeyT string

--- a/util/flightcontrol/flightcontrol_test.go
+++ b/util/flightcontrol/flightcontrol_test.go
@@ -230,7 +230,7 @@ func TestMassiveParallel(t *testing.T) {
 	for range 1000 {
 		eg.Go(func() error {
 			_, err := g.Do(ctx, "key", func(ctx context.Context) (string, error) {
-				return "", errors.Errorf("always fail")
+				return "", errors.New("always fail")
 			})
 			if errors.Is(err, errRetryTimeout) {
 				atomic.AddInt64(&retryCount, 1)

--- a/util/gitutil/gitobject/parse.go
+++ b/util/gitutil/gitobject/parse.go
@@ -49,7 +49,7 @@ func Parse(raw []byte) (*GitObject, error) {
 	obj := &GitObject{Headers: make(map[string][]string), Raw: raw}
 	lines := strings.Split(string(raw), "\n")
 	if len(lines) == 0 {
-		return nil, errors.Errorf("invalid empty git object")
+		return nil, errors.New("invalid empty git object")
 	}
 
 	isTag := bytes.HasPrefix(raw, []byte("object "))
@@ -171,7 +171,7 @@ func (obj *GitObject) VerifyChecksum(sha string) error {
 
 func (obj *GitObject) ToCommit() (*Commit, error) {
 	if obj.Type != "commit" {
-		return nil, errors.Errorf("not a commit object")
+		return nil, errors.New("not a commit object")
 	}
 	c := &Commit{}
 	if trees, ok := obj.Headers["tree"]; ok && len(trees) > 0 {
@@ -192,7 +192,7 @@ func (obj *GitObject) ToCommit() (*Commit, error) {
 
 func (obj *GitObject) ToTag() (*Tag, error) {
 	if obj.Type != "tag" {
-		return nil, errors.Errorf("not a tag object")
+		return nil, errors.New("not a tag object")
 	}
 	t := &Tag{}
 	if objects, ok := obj.Headers["object"]; ok && len(objects) > 0 {

--- a/util/gitutil/gitsign/gitsign.go
+++ b/util/gitutil/gitsign/gitsign.go
@@ -79,7 +79,7 @@ func parseSignatureBlock(data []byte) ([]byte, error) {
 		}
 		return block.Bytes, nil
 	}
-	return nil, errors.Errorf("invalid signature format")
+	return nil, errors.New("invalid signature format")
 }
 
 func ParseSignature(data []byte) (*Signature, error) {
@@ -101,5 +101,5 @@ func ParseSignature(data []byte) (*Signature, error) {
 		}
 		return &Signature{SSHSignature: sig}, nil
 	}
-	return nil, errors.Errorf("invalid signature format")
+	return nil, errors.New("invalid signature format")
 }

--- a/util/leaseutil/manager.go
+++ b/util/leaseutil/manager.go
@@ -65,7 +65,7 @@ func (l *LeaseRef) Adopt(ctx context.Context) error {
 	}
 	currentID, ok := leases.FromContext(ctx)
 	if !ok {
-		return errors.Errorf("missing lease requirement for adopt")
+		return errors.New("missing lease requirement for adopt")
 	}
 	for _, r := range l.resources {
 		if err := l.lm.AddResource(ctx, leases.Lease{ID: currentID}, r); err != nil {

--- a/util/pull/pull.go
+++ b/util/pull/pull.go
@@ -93,7 +93,7 @@ func (p *Puller) tryLocalResolve(ctx context.Context) error {
 	}
 
 	if ok, err := contentutil.HasSource(info, p.Src); err != nil || !ok {
-		return errors.Errorf("no matching source")
+		return errors.New("no matching source")
 	}
 
 	desc.Size = info.Size

--- a/util/stack/compress_test.go
+++ b/util/stack/compress_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func testcall1() error {
-	return errors.Errorf("error1")
+	return errors.New("error1")
 }
 
 func testcall2() error {

--- a/util/system/path.go
+++ b/util/system/path.go
@@ -188,7 +188,7 @@ func CheckSystemDriveAndRemoveDriveLetter(path string, inputOS string, keepSlash
 
 	// UNC paths should error out
 	if len(path) >= 2 && ToSlash(path[:2], inputOS) == "//" {
-		return "", errors.Errorf("UNC paths are not supported")
+		return "", errors.New("UNC paths are not supported")
 	}
 
 	parts := strings.SplitN(path, ":", 2)

--- a/util/system/path_test.go
+++ b/util/system/path_test.go
@@ -91,38 +91,38 @@ func TestCheckSystemDriveAndRemoveDriveLetter(t *testing.T) {
 	// Fails if not C drive.
 	_, err := CheckSystemDriveAndRemoveDriveLetter(`d:\`, "windows", keepSlash)
 	if err == nil || err.Error() != "The specified path is not on the system drive (C:)" {
-		t.Fatalf("Expected error for d:")
+		t.Fatal("Expected error for d:")
 	}
 
 	var path string
 
 	// Single character is unchanged
 	if path, err = CheckSystemDriveAndRemoveDriveLetter("z", "windows", keepSlash); err != nil {
-		t.Fatalf("Single character should pass")
+		t.Fatal("Single character should pass")
 	}
 	if path != "z" {
-		t.Fatalf("Single character should be unchanged")
+		t.Fatal("Single character should be unchanged")
 	}
 
 	// Two characters without colon is unchanged
 	if path, err = CheckSystemDriveAndRemoveDriveLetter("AB", "windows", keepSlash); err != nil {
-		t.Fatalf("2 characters without colon should pass")
+		t.Fatal("2 characters without colon should pass")
 	}
 	if path != "AB" {
-		t.Fatalf("2 characters without colon should be unchanged")
+		t.Fatal("2 characters without colon should be unchanged")
 	}
 
 	// Abs path without drive letter
 	if path, err = CheckSystemDriveAndRemoveDriveLetter(`\l`, "windows", keepSlash); err != nil {
-		t.Fatalf("abs path no drive letter should pass")
+		t.Fatal("abs path no drive letter should pass")
 	}
 	if path != `/l` {
-		t.Fatalf("abs path without drive letter should be unchanged")
+		t.Fatal("abs path without drive letter should be unchanged")
 	}
 
 	// Abs path without drive letter, linux style
 	if path, err = CheckSystemDriveAndRemoveDriveLetter(`/l`, "windows", keepSlash); err != nil {
-		t.Fatalf("abs path no drive letter linux style should pass")
+		t.Fatal("abs path no drive letter linux style should pass")
 	}
 	if path != `/l` {
 		t.Fatalf("abs path without drive letter linux failed %s", path)
@@ -130,7 +130,7 @@ func TestCheckSystemDriveAndRemoveDriveLetter(t *testing.T) {
 
 	// Drive-colon should be stripped
 	if path, err = CheckSystemDriveAndRemoveDriveLetter(`c:\`, "windows", keepSlash); err != nil {
-		t.Fatalf("An absolute path should pass")
+		t.Fatal("An absolute path should pass")
 	}
 	if path != `/` {
 		t.Fatalf(`An absolute path should have been shortened to \ %s`, path)
@@ -138,7 +138,7 @@ func TestCheckSystemDriveAndRemoveDriveLetter(t *testing.T) {
 
 	// Verify with a linux-style path
 	if path, err = CheckSystemDriveAndRemoveDriveLetter(`c:/`, "windows", keepSlash); err != nil {
-		t.Fatalf("An absolute path should pass")
+		t.Fatal("An absolute path should pass")
 	}
 	if path != `/` {
 		t.Fatalf(`A linux style absolute path should have been shortened to \ %s`, path)
@@ -146,7 +146,7 @@ func TestCheckSystemDriveAndRemoveDriveLetter(t *testing.T) {
 
 	// Failure on c:
 	if path, err = CheckSystemDriveAndRemoveDriveLetter(`c:`, "windows", keepSlash); err == nil {
-		t.Fatalf("c: should fail")
+		t.Fatal("c: should fail")
 	}
 	if err.Error() != `No relative path specified in "c:"` {
 		t.Fatalf(path, err)
@@ -154,7 +154,7 @@ func TestCheckSystemDriveAndRemoveDriveLetter(t *testing.T) {
 
 	// Failure on d:
 	if path, err = CheckSystemDriveAndRemoveDriveLetter(`d:`, "windows", keepSlash); err == nil {
-		t.Fatalf("c: should fail")
+		t.Fatal("c: should fail")
 	}
 	if err.Error() != `No relative path specified in "d:"` {
 		t.Fatalf(path, err)
@@ -162,43 +162,43 @@ func TestCheckSystemDriveAndRemoveDriveLetter(t *testing.T) {
 
 	// UNC path should fail.
 	if _, err = CheckSystemDriveAndRemoveDriveLetter(`\\.\C$\test`, "windows", keepSlash); err == nil {
-		t.Fatalf("UNC path should fail")
+		t.Fatal("UNC path should fail")
 	}
 
 	// also testing for keepSlash = true
 	keepSlash = true
 	origPath := "\\a\\b\\..\\c\\"
 	if path, err = CheckSystemDriveAndRemoveDriveLetter(origPath, "windows", keepSlash); err != nil {
-		t.Fatalf("windows relative paths should be cleaned and should pass")
+		t.Fatal("windows relative paths should be cleaned and should pass")
 	}
 	// When input OS is Windows, the path should be properly cleaned
 	if path != "/a/c/" {
-		t.Fatalf("Path was not cleaned successfully")
+		t.Fatal("Path was not cleaned successfully")
 	}
 
 	if path, err = CheckSystemDriveAndRemoveDriveLetter(origPath, "windows", false); err != nil {
-		t.Fatalf("windows relative paths should be cleaned and should pass [keepSlash = false]")
+		t.Fatal("windows relative paths should be cleaned and should pass [keepSlash = false]")
 	}
 	// When input OS is Windows, the path should be properly cleaned
 	if path != "/a/c" {
-		t.Fatalf("Path was not cleaned successfully [keepSlash = false]")
+		t.Fatal("Path was not cleaned successfully [keepSlash = false]")
 	}
 
 	// windows-style relative paths on linux
 	if path, err = CheckSystemDriveAndRemoveDriveLetter(origPath, "linux", keepSlash); err != nil {
-		t.Fatalf("windows style relative paths should be considered a valid path element in linux and should pass")
+		t.Fatal("windows style relative paths should be considered a valid path element in linux and should pass")
 	}
 	// When input OS is Linux, this is a valid path element name.
 	if path != "\\a\\b\\..\\c\\" {
-		t.Fatalf("Path was not cleaned successfully")
+		t.Fatal("Path was not cleaned successfully")
 	}
 
 	if path, err = CheckSystemDriveAndRemoveDriveLetter(origPath, "linux", false); err != nil {
-		t.Fatalf("windows style relative paths should be considered a valid path element in linux and should pass")
+		t.Fatal("windows style relative paths should be considered a valid path element in linux and should pass")
 	}
 	// When input OS is Linux, this is a valid path element name.
 	if path != "\\a\\b\\..\\c\\" {
-		t.Fatalf("Path was not cleaned successfully [keepSlash = false]")
+		t.Fatal("Path was not cleaned successfully [keepSlash = false]")
 	}
 }
 

--- a/util/testutil/dockerd/client/request.go
+++ b/util/testutil/dockerd/client/request.go
@@ -1,4 +1,3 @@
-//nolint:forbidigo
 package client
 
 import (

--- a/util/testutil/dockerd/client/request.go
+++ b/util/testutil/dockerd/client/request.go
@@ -4,7 +4,6 @@ package client
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -127,11 +126,11 @@ func (cli *Client) checkResponseErr(serverResp *http.Response) error {
 			return err
 		}
 		if bodyR.N == 0 {
-			return fmt.Errorf("request returned %s with a message (> %d bytes) for API route and version %s, check if the server supports the requested API version", statusMsg, bodyMax, reqURL)
+			return errors.Errorf("request returned %s with a message (> %d bytes) for API route and version %s, check if the server supports the requested API version", statusMsg, bodyMax, reqURL)
 		}
 	}
 	if len(body) == 0 {
-		return fmt.Errorf("request returned %s for API route and version %s, check if the server supports the requested API version", statusMsg, reqURL)
+		return errors.Errorf("request returned %s for API route and version %s, check if the server supports the requested API version", statusMsg, reqURL)
 	}
 
 	var daemonErr error

--- a/util/testutil/integration/registry.go
+++ b/util/testutil/integration/registry.go
@@ -112,5 +112,5 @@ func detectPort(ctx context.Context, rc io.ReadCloser) (string, error) {
 			return "localhost:" + string(res[1]), nil
 		}
 	}
-	return "", errors.Errorf("no listening address found")
+	return "", errors.New("no listening address found")
 }

--- a/util/testutil/integration/sandbox.go
+++ b/util/testutil/integration/sandbox.go
@@ -144,7 +144,7 @@ func newSandbox(ctx context.Context, t *testing.T, w Worker, mirror string, mv m
 		case <-ctx.Done():
 			return
 		default:
-			t.Logf("sandbox timeout reached, stopping worker")
+			t.Log("sandbox timeout reached, stopping worker")
 			if addr := b.DebugAddress(); addr != "" {
 				printBuildkitdDebugLogs(t, addr)
 			}

--- a/worker/workercontroller.go
+++ b/worker/workercontroller.go
@@ -53,7 +53,7 @@ func (c *Controller) List(filterStrings ...string) ([]Worker, error) {
 // GetDefault returns the default local worker
 func (c *Controller) GetDefault() (Worker, error) {
 	if len(c.workers) == 0 {
-		return nil, errors.Errorf("no default worker")
+		return nil, errors.New("no default worker")
 	}
 	return c.workers[0], nil
 }


### PR DESCRIPTION
This primarily refactors error handling across the codebase by replacing `errors.Errorf` with `errors.New` for static error messages, and makes minor improvements to test logging and linter configuration. These changes simplify error creation, improve code consistency, and update linter rules for better code quality.

**Error handling simplification:**

* Replaced `errors.Errorf` with `errors.New` for static error messages. This reduces unnecessary formatting overhead for constant strings and improves code clarity. 

**Test and logging improvements:**

* Updated test logging methods from `t.Logf`/`t.Skipf`/`t.Fatalf` to `t.Log`/`t.Skip`/`t.Fatal` where string formatting is not required, simplifying test output and making it more idiomatic.

* Changed some `fmt.Fprintf` calls to `fmt.Fprint` in test utilities where no formatting is needed, improving performance and readability.

**Linter configuration updates:**

* Enabled the `revive` linter with a selected set of default rules in `.golangci.yml` and set `warn-unused: true` for better code quality assurance.