### PR TITLE
chore: enable and fix several revive rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -91,11 +91,35 @@ linters:
     revive:
       enable-all-rules: false
       enable-default-rules: true
+      max-open-files: 2048
       rules:
+        - name: early-return
+          arguments:
+            - "preserve-scope"
+        - name: empty-block
+          disabled: true
         - name: errorf
+        - name: exported
+          disabled: true
         - name: if-return
+        - name: indent-error-flow
+          arguments:
+            - "preserve-scope"
+        - name: redefines-builtin-id
+          disabled: true
+        - name: unused-parameter
+          disabled: true
         - name: unnecessary-format
+        - name: unnecessary-if
+        - name: unnecessary-stmt
         - name: use-errors-new
+        - name: use-fmt-print
+        - name: useless-break
+        - name: superfluous-else
+          arguments:
+            - "preserve-scope"
+        - name: var-naming
+          disabled: true
     staticcheck:
       checks:
         - all
@@ -113,27 +137,6 @@ linters:
       - legacy
       - std-error-handling
     rules:
-      - linters:
-          - revive
-        text: stutters
-      - linters:
-          - revive
-        text: empty-block
-      - linters:
-          - revive
-        text: superfluous-else
-      - linters:
-          - revive
-        text: unused-parameter
-      - linters:
-          - revive
-        text: redefines-builtin-id
-      - linters:
-          - revive
-        text: if-return
-      - linters:
-          - revive
-        text: var-naming
       - linters:
           - staticcheck
         text: "SA1019: .* is deprecated: .*in-toto/attestation"

--- a/cache/blobs.go
+++ b/cache/blobs.go
@@ -341,11 +341,7 @@ func (sr *immutableRef) setBlob(ctx context.Context, desc ocispecs.Descriptor) (
 	sr.queueMediaType(desc.MediaType)
 	sr.queueBlobSize(desc.Size)
 	sr.appendURLs(desc.URLs)
-	if err := sr.commitMetadata(); err != nil {
-		return err
-	}
-
-	return nil
+	return sr.commitMetadata()
 }
 
 func (sr *immutableRef) computeChainMetadata(ctx context.Context, filter map[string]struct{}) error {
@@ -381,11 +377,11 @@ func (sr *immutableRef) computeChainMetadata(ctx context.Context, filter map[str
 			} else {
 				return errors.Errorf("failed to set chain for reference with non-addressable parent %q", sr.layerParent.GetDescription())
 			}
-			if parentBlobChainID := sr.layerParent.getBlobChainID(); parentBlobChainID != "" {
-				blobChainID = parentBlobChainID
-			} else {
+			parentBlobChainID := sr.layerParent.getBlobChainID()
+			if parentBlobChainID == "" {
 				return errors.Errorf("failed to set blobchain for reference with non-addressable parent %q", sr.layerParent.GetDescription())
 			}
+			blobChainID = parentBlobChainID
 		}
 		diffID := sr.getDiffID()
 		chainID = imagespecidentity.ChainID([]digest.Digest{chainID, diffID})
@@ -426,10 +422,7 @@ func (sr *immutableRef) computeChainMetadata(ctx context.Context, filter map[str
 
 	sr.queueChainID(chainID)
 	sr.queueBlobChainID(blobChainID)
-	if err := sr.commitMetadata(); err != nil {
-		return err
-	}
-	return nil
+	return sr.commitMetadata()
 }
 
 func isTypeWindows(sr *immutableRef) bool {

--- a/cache/manager.go
+++ b/cache/manager.go
@@ -451,20 +451,19 @@ func (cm *cacheManager) getRecord(ctx context.Context, id string, opts ...RefOpt
 			mutable.equalImmutable = &immutableRef{cacheRecord: rec}
 			cm.records[id] = rec
 			return rec, nil
-		} else if IsNotFound(err) {
-			// The equal mutable for this ref is not found, check to see if our snapshot exists
-			if _, statErr := cm.Snapshotter.Stat(ctx, md.getSnapshotID()); statErr != nil {
-				// this ref's snapshot also doesn't exist, just remove this record
-				cm.MetadataStore.Clear(id)
-				return nil, errors.Wrap(errNotFound, id)
-			}
-			// Our snapshot exists, so there may have been a crash while finalizing this ref.
-			// Clear the equal mutable field and continue using this ref.
-			md.clearEqualMutable()
-			md.commitMetadata()
-		} else {
+		} else if !IsNotFound(err) {
 			return nil, err
 		}
+		// The equal mutable for this ref is not found, check to see if our snapshot exists
+		if _, statErr := cm.Snapshotter.Stat(ctx, md.getSnapshotID()); statErr != nil {
+			// this ref's snapshot also doesn't exist, just remove this record
+			cm.MetadataStore.Clear(id)
+			return nil, errors.Wrap(errNotFound, id)
+		}
+		// Our snapshot exists, so there may have been a crash while finalizing this ref.
+		// Clear the equal mutable field and continue using this ref.
+		md.clearEqualMutable()
+		md.commitMetadata()
 	}
 
 	rec := &cacheRecord{

--- a/cache/metadata/metadata.go
+++ b/cache/metadata/metadata.go
@@ -115,27 +115,23 @@ func (s *Store) Search(ctx context.Context, index string, prefix bool) ([]*Stora
 		}
 		c := b.Cursor()
 		k, _ := c.Seek([]byte(index))
-		for {
-			if k != nil && strings.HasPrefix(string(k), index) {
-				idx := strings.LastIndex(string(k), "::")
-				if idx == -1 {
-					continue
-				}
-				itemID := string(k[idx+2:])
-				k, _ = c.Next()
-				b := main.Bucket([]byte(itemID))
-				if b == nil {
-					bklog.G(ctx).Errorf("index pointing to missing record %s", itemID)
-					continue
-				}
-				si, err := newStorageItem(itemID, b, s)
-				if err != nil {
-					return err
-				}
-				out = append(out, si)
-			} else {
-				break
+		for k != nil && strings.HasPrefix(string(k), index) {
+			idx := strings.LastIndex(string(k), "::")
+			if idx == -1 {
+				continue
 			}
+			itemID := string(k[idx+2:])
+			k, _ = c.Next()
+			b := main.Bucket([]byte(itemID))
+			if b == nil {
+				bklog.G(ctx).Errorf("index pointing to missing record %s", itemID)
+				continue
+			}
+			si, err := newStorageItem(itemID, b, s)
+			if err != nil {
+				return err
+			}
+			out = append(out, si)
 		}
 		return nil
 	})

--- a/cache/refs.go
+++ b/cache/refs.go
@@ -1415,10 +1415,7 @@ func (sr *immutableRef) unlazyLayer(ctx context.Context, dhs DescHandlers, pg pr
 	}
 	sr.queueBlobOnly(false)
 	sr.queueSize(sizeUnknown)
-	if err := sr.commitMetadata(); err != nil {
-		return err
-	}
-	return nil
+	return sr.commitMetadata()
 }
 
 func (sr *immutableRef) Release(ctx context.Context) error {

--- a/client/client_fileop_test.go
+++ b/client/client_fileop_test.go
@@ -781,9 +781,8 @@ func testMoveParentDir(t *testing.T, sb integration.Sandbox) {
 			if err == nil && strings.Contains(key, "/wd") {
 				ok = true
 				break
-			} else {
-				ok = false
 			}
+			ok = false
 		}
 		require.True(t, ok)
 
@@ -791,9 +790,8 @@ func testMoveParentDir(t *testing.T, sb integration.Sandbox) {
 			if err == nil && strings.Contains(key, "/foo2/bar") {
 				ok = true
 				break
-			} else {
-				ok = false
 			}
+			ok = false
 		}
 		require.True(t, ok)
 
@@ -801,9 +799,8 @@ func testMoveParentDir(t *testing.T, sb integration.Sandbox) {
 			if err == nil && strings.Contains(key, "/foo2") {
 				ok = true
 				break
-			} else {
-				ok = false
 			}
+			ok = false
 		}
 		require.True(t, ok)
 	case "busybox:latest":

--- a/control/control.go
+++ b/control/control.go
@@ -338,10 +338,7 @@ func (c *Controller) ListenBuildHistory(req *controlapi.BuildHistoryRequest, srv
 		return err
 	}
 	return c.history.Listen(srv.Context(), req, func(h *controlapi.BuildHistoryEvent) error {
-		if err := srv.Send(h); err != nil {
-			return err
-		}
-		return nil
+		return srv.Send(h)
 	})
 }
 

--- a/executor/oci/spec.go
+++ b/executor/oci/spec.go
@@ -163,11 +163,11 @@ func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mou
 	)
 
 	if cdiManager != nil {
-		if cdiOpts, err := generateCDIOpts(cdiManager, meta.CDIDevices); err == nil {
-			opts = append(opts, cdiOpts...)
-		} else {
+		cdiOpts, err := generateCDIOpts(cdiManager, meta.CDIDevices)
+		if err != nil {
 			return nil, nil, err
 		}
+		opts = append(opts, cdiOpts...)
 	}
 
 	s, err := oci.GenerateSpec(ctx, nil, c, opts...)

--- a/exporter/local/export.go
+++ b/exporter/local/export.go
@@ -194,10 +194,7 @@ func (e *localExporterInstance) Export(ctx context.Context, inp *exporter.Source
 
 			progress, closeProgress := NewProgressHandler(ctx, lbl)
 			defer closeProgress()
-			if err := filesync.CopyToCaller(ctx, outputFS, e.id, caller, progress); err != nil {
-				return err
-			}
-			return nil
+			return filesync.CopyToCaller(ctx, outputFS, e.id, caller, progress)
 		}
 	}
 

--- a/frontend/dockerfile/builder/caps.go
+++ b/frontend/dockerfile/builder/caps.go
@@ -25,11 +25,10 @@ func validateCaps(req string) (forward bool, err error) {
 		parts := strings.SplitN(c, "+", 2)
 		if _, ok := enabledCaps[parts[0]]; !ok {
 			err = stack.Enable(grpcerrors.WrapCode(errdefs.NewUnsupportedFrontendCapError(parts[0]), codes.Unimplemented))
-			if strings.Contains(c, "+forward") {
-				forward = true
-			} else {
+			if !strings.Contains(c, "+forward") {
 				return false, err
 			}
+			forward = true
 		}
 	}
 	return

--- a/frontend/dockerfile/instructions/commands.go
+++ b/frontend/dockerfile/instructions/commands.go
@@ -370,10 +370,7 @@ type RunCommand struct {
 }
 
 func (c *RunCommand) Expand(expander SingleWordExpander) error {
-	if err := setMountState(c, expander); err != nil {
-		return err
-	}
-	return nil
+	return setMountState(c, expander)
 }
 
 // CmdCommand sets the default command to run in the container on start.

--- a/frontend/dockerfile/instructions/commands_runmount.go
+++ b/frontend/dockerfile/instructions/commands_runmount.go
@@ -161,9 +161,8 @@ func parseMount(val string, expander SingleWordExpander) (*Mount, error) {
 				if m.Type == MountTypeSecret || m.Type == MountTypeSSH {
 					m.Required = true
 					continue
-				} else {
-					return nil, errors.Errorf("unexpected key '%s' for mount type '%s'", key, m.Type)
 				}
+				return nil, errors.Errorf("unexpected key '%s' for mount type '%s'", key, m.Type)
 			default:
 				// any other option requires a value.
 				return nil, errors.Errorf("invalid field '%s' must be a key=value pair", field)
@@ -212,22 +211,20 @@ func parseMount(val string, expander SingleWordExpander) (*Mount, error) {
 			m.ReadOnly = !rw
 			roAuto = false
 		case "required":
-			if m.Type == MountTypeSecret || m.Type == MountTypeSSH {
-				m.Required, err = strconv.ParseBool(value)
-				if err != nil {
-					return nil, errors.Errorf("invalid value for %s: %s", key, value)
-				}
-			} else {
+			if m.Type != MountTypeSecret && m.Type != MountTypeSSH {
 				return nil, errors.Errorf("unexpected key '%s' for mount type '%s'", key, m.Type)
 			}
+			m.Required, err = strconv.ParseBool(value)
+			if err != nil {
+				return nil, errors.Errorf("invalid value for %s: %s", key, value)
+			}
 		case "size":
-			if m.Type == MountTypeTmpfs {
-				m.SizeLimit, err = units.RAMInBytes(value)
-				if err != nil {
-					return nil, errors.Errorf("invalid value for %s: %s", key, value)
-				}
-			} else {
+			if m.Type != MountTypeTmpfs {
 				return nil, errors.Errorf("unexpected key '%s' for mount type '%s'", key, m.Type)
+			}
+			m.SizeLimit, err = units.RAMInBytes(value)
+			if err != nil {
+				return nil, errors.Errorf("invalid value for %s: %s", key, value)
 			}
 		case "id":
 			m.CacheID = value
@@ -280,11 +277,7 @@ func parseMount(val string, expander SingleWordExpander) (*Mount, error) {
 	}
 
 	if roAuto {
-		if m.Type == MountTypeCache || m.Type == MountTypeTmpfs {
-			m.ReadOnly = false
-		} else {
-			m.ReadOnly = true
-		}
+		m.ReadOnly = m.Type != MountTypeCache && m.Type != MountTypeTmpfs
 	}
 
 	if m.Type == MountTypeSecret {

--- a/session/auth/authprovider/authprovider.go
+++ b/session/auth/authprovider/authprovider.go
@@ -177,11 +177,10 @@ func (ap *authProvider) tlsConfig(host string) (*tls.Config, error) {
 	if len(c.RootCAs) > 0 {
 		systemPool, err := x509.SystemCertPool()
 		if err != nil {
-			if runtime.GOOS == "windows" {
-				systemPool = x509.NewCertPool()
-			} else {
+			if runtime.GOOS != "windows" {
 				return nil, errors.Wrapf(err, "unable to get system cert pool")
 			}
+			systemPool = x509.NewCertPool()
 		}
 		tc.RootCAs = systemPool
 	}

--- a/snapshot/diffapply_linux.go
+++ b/snapshot/diffapply_linux.go
@@ -627,11 +627,11 @@ func (d *differ) doubleWalkingChanges(ctx context.Context, handle func(context.C
 					return errors.Wrapf(err, "failed to join %s and %s", d.upperBindSource, c.subPath)
 				}
 				c.srcPath = srcPath
-				if fi, err := os.Lstat(c.srcPath); err == nil {
-					srcfi = fi
-				} else {
+				fi, err := os.Lstat(c.srcPath)
+				if err != nil {
 					return errors.Wrap(err, "failed to stat underlying file from bind mount")
 				}
+				srcfi = fi
 			case !srcfi.IsDir() && len(d.upperOverlayDirs) > 0:
 				for i := range d.upperOverlayDirs {
 					dir := d.upperOverlayDirs[len(d.upperOverlayDirs)-1-i]
@@ -645,9 +645,8 @@ func (d *differ) doubleWalkingChanges(ctx context.Context, handle func(context.C
 						break
 					} else if errors.Is(err, unix.ENOENT) {
 						continue
-					} else {
-						return errors.Wrap(err, "failed to lstat when finding direct path of overlay file")
 					}
+					return errors.Wrap(err, "failed to lstat when finding direct path of overlay file")
 				}
 			default:
 				srcPath, err := safeJoin(d.upperRoot, subPath)
@@ -655,11 +654,11 @@ func (d *differ) doubleWalkingChanges(ctx context.Context, handle func(context.C
 					return errors.Wrapf(err, "failed to join %s and %s", d.upperRoot, subPath)
 				}
 				c.srcPath = srcPath
-				if fi, err := os.Lstat(c.srcPath); err == nil {
-					srcfi = fi
-				} else {
+				fi, err := os.Lstat(c.srcPath)
+				if err != nil {
 					return errors.Wrap(err, "failed to stat srcPath from differ")
 				}
+				srcfi = fi
 			}
 
 			var ok bool

--- a/snapshot/localmounter_windows.go
+++ b/snapshot/localmounter_windows.go
@@ -79,11 +79,10 @@ func mountWithRetries(m mount.Mount, dir string, retries int) error {
 		if err == nil || i == retries {
 			return err
 		}
-		if strings.Contains(err.Error(), errStr) {
-			time.Sleep(time.Duration(i+1) * backoff)
-		} else {
+		if !strings.Contains(err.Error(), errStr) {
 			return err
 		}
+		time.Sleep(time.Duration(i+1) * backoff)
 	}
 
 	return err

--- a/solver/bboltcachestorage/storage.go
+++ b/solver/bboltcachestorage/storage.go
@@ -163,11 +163,7 @@ func (s *Store) AddResult(id string, res solver.CacheResult) error {
 		if err != nil {
 			return err
 		}
-		if err := b.Put([]byte(id), []byte{}); err != nil {
-			return err
-		}
-
-		return nil
+		return b.Put([]byte(id), []byte{})
 	})
 }
 
@@ -207,12 +203,9 @@ func (s *Store) Release(resultID string) error {
 		if b == nil {
 			return errors.WithStack(solver.ErrNotFound)
 		}
-		if err := b.ForEach(func(k, v []byte) error {
+		return b.ForEach(func(k, v []byte) error {
 			return s.releaseHelper(tx, string(k), resultID)
-		}); err != nil {
-			return err
-		}
-		return nil
+		})
 	})
 }
 
@@ -332,11 +325,7 @@ func (s *Store) AddLink(id string, link solver.CacheInfoLink, target string) err
 			return err
 		}
 
-		if err := b.Put([]byte(id), []byte{}); err != nil {
-			return err
-		}
-
-		return nil
+		return b.Put([]byte(id), []byte{})
 	})
 }
 
@@ -466,12 +455,12 @@ func (s *Store) WalkBacklinks(id string, fn func(id string, link solver.CacheInf
 			return nil
 		}
 
-		if err := b.ForEach(func(bid, v []byte) error {
+		return b.ForEach(func(bid, v []byte) error {
 			b = links.Bucket(bid)
 			if b == nil {
 				return nil
 			}
-			if err := b.ForEach(func(k, v []byte) error {
+			return b.ForEach(func(k, v []byte) error {
 				parts := bytes.Split(k, []byte("@"))
 				if len(parts) == 2 {
 					if string(parts[1]) != id {
@@ -487,15 +476,8 @@ func (s *Store) WalkBacklinks(id string, fn func(id string, link solver.CacheInf
 					outLinks = append(outLinks, l)
 				}
 				return nil
-			}); err != nil {
-				return err
-			}
-			return nil
-		}); err != nil {
-			return err
-		}
-
-		return nil
+			})
+		})
 	}); err != nil {
 		return err
 	}

--- a/solver/exporter.go
+++ b/solver/exporter.go
@@ -151,12 +151,11 @@ func (e *exporter) ExportTo(ctx context.Context, t CacheExporterTarget, opt Cach
 	v := e.record
 	for exportRecord && addRecord {
 		if v == nil {
-			if i < len(records) {
-				v = records[i]
-				i++
-			} else {
+			if i >= len(records) {
 				break
 			}
+			v = records[i]
+			i++
 		}
 		cm := v.cacheManager
 		key := cm.getID(v.key)

--- a/solver/llbsolver/history.go
+++ b/solver/llbsolver/history.go
@@ -315,17 +315,14 @@ func (s *Solver) recordBuildHistory(ctx context.Context, id string, req frontend
 				}
 				defer release()
 
-				if err := s.history.UpdateRef(context.TODO(), id, func(rec *controlapi.BuildHistoryRecord) error {
+				return s.history.UpdateRef(context.TODO(), id, func(rec *controlapi.BuildHistoryRecord) error {
 					rec.Trace = &controlapi.Descriptor{
 						Digest:    string(desc.Digest),
 						MediaType: desc.MediaType,
 						Size:      desc.Size,
 					}
 					return nil
-				}); err != nil {
-					return err
-				}
-				return nil
+				})
 			}(); err != nil {
 				bklog.G(ctx).Errorf("failed to save trace for %s: %+v", id, err)
 			}

--- a/solver/llbsolver/history/migrate.go
+++ b/solver/llbsolver/history/migrate.go
@@ -72,17 +72,13 @@ func (h *Queue) migrateV2() error {
 		return err
 	}
 
-	if err := h.opt.DB.Update(func(tx *bolt.Tx) error {
+	return h.opt.DB.Update(func(tx *bolt.Tx) error {
 		b, err := tx.CreateBucketIfNotExists([]byte(versionBucket))
 		if err != nil {
 			return err
 		}
 		return b.Put([]byte("version"), []byte("2"))
-	}); err != nil {
-		return err
-	}
-
-	return nil
+	})
 }
 
 func (h *Queue) blobRefs(ctx context.Context, dgst digest.Digest, detectSkipLayer bool) ([]digest.Digest, error) {

--- a/solver/llbsolver/mounts/mount.go
+++ b/solver/llbsolver/mounts/mount.go
@@ -131,17 +131,16 @@ func (g *cacheRefGetter) getRefCacheDirNoCache(ctx context.Context, key string, 
 				bklog.G(ctx).WithError(err).Errorf("failed to get reuse ref for cache dir %q: %s", id, si.ID())
 			}
 		}
-		if block && locked {
-			cacheRefsLocker.Unlock(key)
-			select {
-			case <-ctx.Done():
-				cacheRefsLocker.Lock(key)
-				return nil, context.Cause(ctx)
-			case <-time.After(100 * time.Millisecond):
-				cacheRefsLocker.Lock(key)
-			}
-		} else {
+		if !block || !locked {
 			break
+		}
+		cacheRefsLocker.Unlock(key)
+		select {
+		case <-ctx.Done():
+			cacheRefsLocker.Lock(key)
+			return nil, context.Cause(ctx)
+		case <-time.After(100 * time.Millisecond):
+			cacheRefsLocker.Lock(key)
 		}
 	}
 	mRef, err := makeMutable(ref)

--- a/solver/llbsolver/ops/diff.go
+++ b/solver/llbsolver/ops/diff.go
@@ -90,15 +90,15 @@ func (d *diffOp) Exec(ctx context.Context, jobCtx solver.JobContext, inputs []so
 		if curInput >= len(inputs) {
 			return nil, errors.Errorf("invalid upper input index %d for diff op with %d inputs", curInput, len(inputs))
 		}
-		if upperInp := inputs[curInput]; upperInp != nil {
-			wref, ok := upperInp.Sys().(*worker.WorkerRef)
-			if !ok {
-				return nil, errors.Errorf("invalid upper reference for diff op %T", upperInp.Sys())
-			}
-			upperRef = wref.ImmutableRef
-		} else {
+		upperInp := inputs[curInput]
+		if upperInp == nil {
 			return nil, errors.New("invalid nil upper input for diff op")
 		}
+		wref, ok := upperInp.Sys().(*worker.WorkerRef)
+		if !ok {
+			return nil, errors.Errorf("invalid upper reference for diff op %T", upperInp.Sys())
+		}
+		upperRef = wref.ImmutableRef
 	}
 
 	if lowerRef == nil {

--- a/solver/llbsolver/vertex.go
+++ b/solver/llbsolver/vertex.go
@@ -128,8 +128,7 @@ func NormalizeRuntimePlatforms() LoadOpt {
 
 func ValidateEntitlements(ent entitlements.Set, cdiManager *cdidevices.Manager) LoadOpt {
 	return func(op *pb.Op, _ *pb.OpMetadata, opt *solver.VertexOptions) error {
-		switch op := op.Op.(type) {
-		case *pb.Op_Exec:
+		if op, ok := op.Op.(*pb.Op_Exec); ok {
 			v := entitlements.Values{
 				NetworkHost:      op.Exec.Network == pb.NetMode_HOST,
 				SecurityInsecure: op.Exec.Security == pb.SecurityMode_INSECURE,
@@ -224,8 +223,7 @@ func (dpc *detectPrunedCacheID) Load(op *pb.Op, md *pb.OpMetadata, opt *solver.V
 	if md == nil || !md.IgnoreCache {
 		return nil
 	}
-	switch op := op.Op.(type) {
-	case *pb.Op_Exec:
+	if op, ok := op.Op.(*pb.Op_Exec); ok {
 		for _, m := range op.Exec.GetMounts() {
 			if m.MountType == pb.MountType_CACHE {
 				if m.CacheOpt != nil {

--- a/source/git/source.go
+++ b/source/git/source.go
@@ -178,11 +178,7 @@ func (gs *Source) mountRemote(ctx context.Context, remote string, authArgs []str
 
 	var remoteRef cache.MutableRef
 	for _, si := range sis {
-		if reset {
-			if err := si.clearGitRemote(); err != nil {
-				bklog.G(ctx).Warnf("failed to clear git remote metadata for %s %s: %v", urlutil.RedactCredentials(remote), si.ID(), err)
-			}
-		} else {
+		if !reset {
 			remoteRef, err = gs.cache.GetMutable(ctx, si.ID())
 			if err != nil {
 				if errors.Is(err, cache.ErrLocked) {
@@ -193,6 +189,9 @@ func (gs *Source) mountRemote(ctx context.Context, remote string, authArgs []str
 				return "", nil, errors.Wrapf(err, "failed to get mutable ref for %s", urlutil.RedactCredentials(remote))
 			}
 			break
+		}
+		if err := si.clearGitRemote(); err != nil {
+			bklog.G(ctx).Warnf("failed to clear git remote metadata for %s %s: %v", urlutil.RedactCredentials(remote), si.ID(), err)
 		}
 	}
 
@@ -811,12 +810,11 @@ func (gs *gitSourceHandler) remoteFetch(ctx context.Context, jobCtx solver.JobCo
 	if err != nil {
 		var wce *wouldClobberExistingTagError
 		var ulre *unableToUpdateLocalRefError
-		if errors.As(err, &wce) || errors.As(err, &ulre) {
-			repo, err = gs.tryRemoteFetch(ctx, jobCtx, g, true)
-			if err != nil {
-				return nil, err
-			}
-		} else {
+		if !errors.As(err, &wce) && !errors.As(err, &ulre) {
+			return nil, err
+		}
+		repo, err = gs.tryRemoteFetch(ctx, jobCtx, g, true)
+		if err != nil {
 			return nil, err
 		}
 	}
@@ -1127,13 +1125,13 @@ func (gs *gitSourceHandler) tryRemoteFetch(ctx context.Context, jobCtx solver.Jo
 				if err != nil {
 					return nil, errors.Wrapf(err, "failed to expire reflog for remote %s", urlutil.RedactCredentials(gs.src.Remote))
 				}
-				if _, err := git.Run(ctx, "cat-file", "-e", gs.cacheCommit); err == nil {
-					// force the ref to point to the commit that the cache key points to
-					if _, err := git.Run(ctx, "update-ref", uptRef, gs.cacheCommit, "--no-deref"); err != nil {
-						return nil, err
-					}
-				} else {
+				_, err := git.Run(ctx, "cat-file", "-e", gs.cacheCommit)
+				if err != nil {
 					return nil, errors.Errorf("fetched ref %s does not match expected commit %s and commit can not be found in the repository", ref, gs.cacheCommit)
+				}
+				// force the ref to point to the commit that the cache key points to
+				if _, err := git.Run(ctx, "update-ref", uptRef, gs.cacheCommit, "--no-deref"); err != nil {
+					return nil, err
 				}
 			}
 		}

--- a/source/http/source.go
+++ b/source/http/source.go
@@ -869,11 +869,10 @@ func (hs *httpSourceHandler) Snapshot(ctx context.Context, jobCtx solver.JobCont
 
 	if refID != "" {
 		ref, err := hs.cache.Get(ctx, refID, nil)
-		if err != nil {
-			bklog.G(ctx).WithError(err).Warnf("failed to get HTTP snapshot for ref %s (%s)", refID, hs.src.URL)
-		} else {
+		if err == nil {
 			return ref, nil
 		}
+		bklog.G(ctx).WithError(err).Warnf("failed to get HTTP snapshot for ref %s (%s)", refID, hs.src.URL)
 	}
 
 	var g session.Group

--- a/source/local/source.go
+++ b/source/local/source.go
@@ -218,9 +218,8 @@ func (ls *localSourceHandler) snapshot(ctx context.Context, caller session.Calle
 			bklog.G(ctx).Debugf("reusing ref for local: %s", m.ID())
 			mutable = m
 			break
-		} else {
-			bklog.G(ctx).Debugf("not reusing ref %s for local: %v", si.ID(), err)
 		}
+		bklog.G(ctx).Debugf("not reusing ref %s for local: %v", si.ID(), err)
 	}
 
 	if mutable == nil {

--- a/util/contentutil/fetcher.go
+++ b/util/contentutil/fetcher.go
@@ -52,17 +52,17 @@ type readerAt struct {
 
 func (r *readerAt) ReadAt(b []byte, off int64) (int, error) {
 	if r.offset != off {
-		if seeker, ok := r.Reader.(io.Seeker); ok {
-			if _, err := seeker.Seek(off, io.SeekStart); err != nil {
-				return 0, err
-			}
-			r.offset = off
-		} else {
+		seeker, ok := r.Reader.(io.Seeker)
+		if !ok {
 			if ra, ok := r.Reader.(io.ReaderAt); ok {
 				return ra.ReadAt(b, off)
 			}
 			return 0, errors.New("unsupported offset")
 		}
+		if _, err := seeker.Seek(off, io.SeekStart); err != nil {
+			return 0, err
+		}
+		r.offset = off
 	}
 
 	var totalN int

--- a/util/contentutil/pusher.go
+++ b/util/contentutil/pusher.go
@@ -52,8 +52,7 @@ func (i *pushingIngester) Writer(ctx context.Context, opts ...content.WriterOpt)
 			i.mu.Unlock()
 			return nil, errors.Wrapf(cerrdefs.ErrUnavailable, "ref %v locked", wOpts.Desc.Digest)
 		}
-		_, ok := i.active[wOpts.Desc.Digest]
-		if !ok {
+		if _, ok := i.active[wOpts.Desc.Digest]; !ok {
 			break
 		}
 		i.c.Wait()

--- a/util/contentutil/pusher.go
+++ b/util/contentutil/pusher.go
@@ -52,11 +52,11 @@ func (i *pushingIngester) Writer(ctx context.Context, opts ...content.WriterOpt)
 			i.mu.Unlock()
 			return nil, errors.Wrapf(cerrdefs.ErrUnavailable, "ref %v locked", wOpts.Desc.Digest)
 		}
-		if _, ok := i.active[wOpts.Desc.Digest]; ok {
-			i.c.Wait()
-		} else {
+		_, ok := i.active[wOpts.Desc.Digest]
+		if !ok {
 			break
 		}
+		i.c.Wait()
 	}
 
 	i.active[wOpts.Desc.Digest] = struct{}{}

--- a/util/flightcontrol/cached.go
+++ b/util/flightcontrol/cached.go
@@ -31,12 +31,11 @@ func (g *CachedGroup[T]) Do(ctx context.Context, key string, fn func(ctx context
 		g.mu.Lock()
 		if v, ok := g.cache[key]; ok {
 			g.mu.Unlock()
-			if v.err != nil {
-				if g.CacheError {
-					return v.v, v.err
-				}
-			} else {
+			if v.err == nil {
 				return v.v, nil
+			}
+			if g.CacheError {
+				return v.v, v.err
 			}
 		}
 		g.mu.Unlock()

--- a/util/gitutil/gitobject/parse.go
+++ b/util/gitutil/gitobject/parse.go
@@ -87,9 +87,8 @@ func Parse(raw []byte) (*GitObject, error) {
 				if v, ok := strings.CutPrefix(l, " "); ok {
 					sigLines = append(sigLines, v)
 					continue
-				} else {
-					inSig = false
 				}
+				inSig = false
 			}
 			signedDataLines = append(signedDataLines, l)
 			parts := strings.SplitN(l, " ", 2)

--- a/util/pgpsign/pgpsign.go
+++ b/util/pgpsign/pgpsign.go
@@ -126,10 +126,7 @@ func VerifyArmoredDetachedSignature(signedData io.Reader, signatureData, pubKeyD
 	if err := checkEntityUsableForSigning(signer, now, policy); err != nil {
 		return err
 	}
-	if err := checkCreationTime(sig.CreationTime, now); err != nil {
-		return err
-	}
-	return nil
+	return checkCreationTime(sig.CreationTime, now)
 }
 
 // VerifySignatureWithDigest verifies a parsed signature against a digest of

--- a/util/progress/progressui/colors.go
+++ b/util/progress/progressui/colors.go
@@ -116,10 +116,9 @@ func isValidRGB(s []string) bool {
 		ok := isValidRGBValue(num)
 		if ok {
 			continue
-		} else {
-			bklog.L.Warnf("A field in BUILDKIT_COLORS appears to contain an RGB value that is not within the valid range of 0-255: %s", strings.Join(s, ","))
-			return false
 		}
+		bklog.L.Warnf("A field in BUILDKIT_COLORS appears to contain an RGB value that is not within the valid range of 0-255: %s", strings.Join(s, ","))
+		return false
 	}
 	return true
 }

--- a/util/resolver/resolver.go
+++ b/util/resolver/resolver.go
@@ -94,11 +94,10 @@ func loadTLSConfig(c config.RegistryConfig) (*tls.Config, error) {
 	if len(c.RootCAs) > 0 {
 		systemPool, err := x509.SystemCertPool()
 		if err != nil {
-			if runtime.GOOS == "windows" {
-				systemPool = x509.NewCertPool()
-			} else {
+			if runtime.GOOS != "windows" {
 				return nil, errors.Wrapf(err, "unable to get system cert pool")
 			}
+			systemPool = x509.NewCertPool()
 		}
 		tc.RootCAs = systemPool
 	}

--- a/util/resolver/retryhandler/retry.go
+++ b/util/resolver/retryhandler/retry.go
@@ -23,20 +23,19 @@ func New(f images.HandlerFunc, logger func([]byte)) images.HandlerFunc {
 		backoff := time.Second
 		for {
 			descs, err := f(ctx, desc)
-			if err != nil {
-				select {
-				case <-ctx.Done():
-					return nil, err
-				default:
-					if !retryError(err) {
-						return nil, err
-					}
-				}
-				if logger != nil {
-					logger(fmt.Appendf(nil, "error: %v\n", err.Error()))
-				}
-			} else {
+			if err == nil {
 				return descs, nil
+			}
+			select {
+			case <-ctx.Done():
+				return nil, err
+			default:
+				if !retryError(err) {
+					return nil, err
+				}
+			}
+			if logger != nil {
+				logger(fmt.Appendf(nil, "error: %v\n", err.Error()))
 			}
 			// backoff logic
 			if backoff >= MaxRetryBackoff {

--- a/util/stack/compress.go
+++ b/util/stack/compress.go
@@ -51,13 +51,12 @@ func subFrames(a, b []*Frame) int {
 		if j < 0 {
 			break
 		}
-		if a[i].Equal(b[j]) {
-			idx++
-			i--
-			j--
-		} else {
+		if !a[i].Equal(b[j]) {
 			break
 		}
+		idx++
+		i--
+		j--
 	}
 	return idx
 }

--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -455,10 +455,7 @@ func (m *Mirror) AddImages(t *testing.T, images map[string]string) (err error) {
 		}
 	}()
 
-	if err := copyImagesLocal(t, m.Host, images); err != nil {
-		return err
-	}
-	return nil
+	return copyImagesLocal(t, m.Host, images)
 }
 
 func RunMirror() (_ *Mirror, err error) {

--- a/util/testutil/integration/util.go
+++ b/util/testutil/integration/util.go
@@ -138,15 +138,15 @@ func WaitSocket(address string, d time.Duration, cmd *exec.Cmd) error {
 			return errors.Errorf("process exited while waiting for socket %s after %s: %s", address, time.Since(started), cmd.String())
 		}
 
-		if conn, err := dialPipe(address); err == nil {
+		conn, err := dialPipe(address)
+		if err == nil {
 			conn.Close()
 			if cmd != nil {
 				fmt.Fprintf(cmd.Stderr, "> socket ready %s after=%s %v %+v\n", address, time.Since(started), time.Now(), cmd.String())
 			}
 			break
-		} else {
-			lastErr = err
 		}
+		lastErr = err
 		i++
 		if time.Duration(i)*step > d {
 			return errors.Errorf("failed dialing socket %s after %s: %v", address, time.Since(started), lastErr)


### PR DESCRIPTION
This introduces a variety of code quality improvements, bug fixes, and refactorings across several packages. The main themes include simplifying code by returning errors directly, improving error handling logic, refining linter configurations, and correcting control flow to enhance maintainability and reliability.

**Code simplification and error handling improvements:**

* Refactored many functions to return errors directly from called functions instead of using intermediate variables and redundant return statements, reducing code verbosity and improving readability .
* Improved error handling and control flow in several places, such as ensuring errors are returned when appropriate and removing unreachable or unnecessary branches .

**Bug fixes and logic corrections:**

* Fixed logic in mount parsing to ensure only valid keys are accepted for specific mount types and improved handling of read-only defaults .
* Corrected parent blob chain ID assignment logic to handle non-addressable parents properly.
* Fixed logic in capability validation to properly set forwarding based on the presence of "+forward".

**Linter and code quality configuration:**

* Enhanced `.golangci.yml` by adding and customizing the `revive` linter configuration, enabling default rules, disabling specific rules, and setting resource limits. Also, removed redundant `revive` rule entries from the rules section and enabled `warn-unused`.

**Performance and correctness improvements:**

* Optimized search logic in metadata store by simplifying loop conditions and removing unnecessary branches.

**Other minor improvements:**

* Improved test code by removing redundant else branches and clarifying assignment logic.
* Improved logic for cache ref locking and unlocking to avoid unnecessary blocking.

These changes collectively improve code clarity, maintainability, and reliability across the codebase.