### PR TITLE
buildctl: read a valueless build-arg from the environment

### DIFF
--- a/cmd/buildctl/build/opt.go
+++ b/cmd/buildctl/build/opt.go
@@ -1,10 +1,34 @@
 package build
 
-import "maps"
+import (
+	"maps"
+	"os"
+	"strings"
+)
+
+const buildArgPrefix = "build-arg:"
 
 func ParseOpt(opts []string) (map[string]string, error) {
 	m := loadOptEnv()
-	m2, err := attrMap(opts)
+
+	// A build arg given without a value, e.g. "build-arg:FOO", takes its value
+	// from the client environment, matching "docker build --build-arg FOO".
+	// Variables that are not set in the environment are left out entirely, so
+	// the default from the Dockerfile still applies. Resolved args keep their
+	// position in the list so that the last of two duplicates still wins.
+	resolved := make([]string, 0, len(opts))
+	for _, opt := range opts {
+		if name, ok := strings.CutPrefix(opt, buildArgPrefix); ok && name != "" && !strings.Contains(name, "=") {
+			v, ok := os.LookupEnv(name)
+			if !ok {
+				continue
+			}
+			opt += "=" + v
+		}
+		resolved = append(resolved, opt)
+	}
+
+	m2, err := attrMap(resolved)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/buildctl/build/opt_test.go
+++ b/cmd/buildctl/build/opt_test.go
@@ -1,0 +1,104 @@
+package build
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseOpt(t *testing.T) {
+	type testCase struct {
+		name        string
+		opts        []string // --opt
+		env         map[string]string
+		expected    map[string]string
+		expectedErr string
+	}
+	testCases := []testCase{
+		{
+			name:     "values are taken as given",
+			opts:     []string{"target=foo", "build-arg:FOO=bar"},
+			expected: map[string]string{"target": "foo", "build-arg:FOO": "bar"},
+		},
+		{
+			name:     "a build arg without a value is read from the environment",
+			opts:     []string{"build-arg:IMAGE"},
+			env:      map[string]string{"IMAGE": "alpine"},
+			expected: map[string]string{"build-arg:IMAGE": "alpine"},
+		},
+		{
+			name:     "a build arg missing from the environment is dropped",
+			opts:     []string{"build-arg:IMAGE"},
+			expected: map[string]string{},
+		},
+		{
+			name:     "an empty environment variable is kept",
+			opts:     []string{"build-arg:IMAGE"},
+			env:      map[string]string{"IMAGE": ""},
+			expected: map[string]string{"build-arg:IMAGE": ""},
+		},
+		{
+			name:     "an explicit value wins over the environment",
+			opts:     []string{"build-arg:IMAGE=busybox"},
+			env:      map[string]string{"IMAGE": "alpine"},
+			expected: map[string]string{"build-arg:IMAGE": "busybox"},
+		},
+		{
+			name:     "an explicit empty value is kept",
+			opts:     []string{"build-arg:IMAGE="},
+			env:      map[string]string{"IMAGE": "alpine"},
+			expected: map[string]string{"build-arg:IMAGE": ""},
+		},
+		{
+			name:     "the last of two build args wins, valueless last",
+			opts:     []string{"build-arg:IMAGE=busybox", "build-arg:IMAGE"},
+			env:      map[string]string{"IMAGE": "alpine"},
+			expected: map[string]string{"build-arg:IMAGE": "alpine"},
+		},
+		{
+			name:     "the last of two build args wins, valueless first",
+			opts:     []string{"build-arg:IMAGE", "build-arg:IMAGE=busybox"},
+			env:      map[string]string{"IMAGE": "alpine"},
+			expected: map[string]string{"build-arg:IMAGE": "busybox"},
+		},
+		{
+			name:     "a valueless build arg missing from the environment does not clear an earlier value",
+			opts:     []string{"build-arg:IMAGE=busybox", "build-arg:IMAGE"},
+			expected: map[string]string{"build-arg:IMAGE": "busybox"},
+		},
+		{
+			name:        "other options still require a value",
+			opts:        []string{"target"},
+			expectedErr: "invalid value target",
+		},
+		{
+			name:        "a build arg with no name still requires a value",
+			opts:        []string{"build-arg:"},
+			expectedErr: "invalid value build-arg:",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// SOURCE_DATE_EPOCH is propagated by loadOptEnv, and the cases
+			// below expect IMAGE to be unset unless the case sets it. Clear
+			// both so an ambient value cannot leak into the expectations.
+			for _, k := range []string{"SOURCE_DATE_EPOCH", "IMAGE"} {
+				if v, ok := os.LookupEnv(k); ok {
+					require.NoError(t, os.Unsetenv(k))
+					t.Cleanup(func() { os.Setenv(k, v) })
+				}
+			}
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+			opt, err := ParseOpt(tc.opts)
+			if tc.expectedErr != "" {
+				require.EqualError(t, err, tc.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, opt)
+		})
+	}
+}

--- a/docs/reference/buildctl.md
+++ b/docs/reference/buildctl.md
@@ -175,6 +175,7 @@ In the above example, we define two:
 
 * `--opt target=foo` - build only until the dockerfile target stage `foo`, the equivalent of `docker buildx build --target=foo`.
 * `--opt build-arg:foo=bar` - set the build argument `foo` to `bar`.
+* `--opt build-arg:foo` - set the build argument `foo` to the value of `$foo` in the environment, the equivalent of `docker buildx build --build-arg foo`. If `foo` is not set in the environment the build argument is left unset, so any default given in the Dockerfile applies.
 
 In addition, the dockerfile front-end supports additional build contexts. These allow you to "alias" an image reference or name
 with something else entirely.


### PR DESCRIPTION
Closes #7028

`--opt build-arg:FOO` failed the whole build with `invalid opt: invalid value build-arg:FOO` instead of taking `FOO` from the client environment, so callers had to spell out `--opt build-arg:FOO=$FOO`.

### Why this is a consistency fix rather than a new feature

`buildctl` already sources a build arg from the environment: `loadOptEnv` (`cmd/buildctl/build/util.go`) propagates `SOURCE_DATE_EPOCH` into `build-arg:SOURCE_DATE_EPOCH`. `docker buildx build --build-arg FOO` reads the environment as well. The valueless `--opt build-arg:FOO` was the only form that did not.

### Scope

The change is in `ParseOpt`, not in `attrMap`. `attrMap` is shared with `ParseLocal`, where `--local name` without a value should keep failing, so relaxing it there would be too broad. There is a second, unrelated copy of `attrMap` at `cmd/buildkitd/main.go:1003` that parses daemon flags; it is deliberately untouched.

Only the `build-arg:` prefix is affected. A bare `--opt target` still errors, and so does `--opt build-arg:` with no name.

A variable that is not present in the environment is left out of the frontend attributes entirely rather than sent as an empty string, so a default in the Dockerfile still applies. That matches buildx.

### Verification

New unit tests in `cmd/buildctl/build/opt_test.go`, 8 cases. The 3 that cover the new behaviour fail on master with exactly the reported error; the 5 regression cases pass on both.

End to end against a real `buildkitd` (`moby/buildkit:latest` in a container, reached over `docker-container://`), using the reporter's Dockerfile:

```console
$ printf 'ARG IMAGE\nFROM $IMAGE\nRUN echo working\n' > Dockerfile
$ export IMAGE=alpine

$ buildctl-master build --frontend dockerfile.v0 --local dockerfile=. --local context=. --opt build-arg:IMAGE
error: invalid opt: invalid value build-arg:IMAGE

$ buildctl-fixed build --frontend dockerfile.v0 --local dockerfile=. --local context=. --opt build-arg:IMAGE
#5 [2/2] RUN echo working
#5 0.118 working
#5 DONE 0.1s
```

And the unset case, confirming the Dockerfile default is what applies rather than an empty value:

```console
$ printf 'ARG IMAGE=busybox\nFROM $IMAGE\nRUN echo default-applied\n' > Dockerfile
$ unset IMAGE

$ buildctl-fixed build --frontend dockerfile.v0 --local dockerfile=. --local context=. --opt build-arg:IMAGE
#5 [2/2] RUN echo default-applied
#5 0.141 default-applied
#5 DONE 0.2s
```

`gofmt -s`, `go vet` and `go test ./cmd/buildctl/build/` are clean.

Docs updated in `docs/reference/buildctl.md`.
