### PR TITLE
executor: clean finalized runc mount stubs

### DIFF
--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -277,7 +277,6 @@ func (w *runcExecutor) Run(ctx context.Context, id string, root executor.Mount, 
 	}
 	defer mount.Unmount(rootFSPath, 0)
 
-	defer executor.MountStubsCleaner(context.WithoutCancel(ctx), rootFSPath, mounts, meta.RemoveMountStubsRecursive)()
 	if proxyNS, ok := namespace.(network.ProxyNamespace); ok {
 		cleanProxyCA, err := executor.InjectProxyCA(rootFSPath, proxyNS.ProxyCACert())
 		if err != nil {
@@ -339,6 +338,8 @@ func (w *runcExecutor) Run(ctx context.Context, id string, root executor.Mount, 
 			return nil, err
 		}
 	}
+
+	defer executor.MountStubsCleanerForSpec(context.WithoutCancel(ctx), rootFSPath, spec.Mounts, meta.RemoveMountStubsRecursive)()
 
 	if err := json.NewEncoder(f).Encode(spec); err != nil {
 		return nil, errors.WithStack(err)

--- a/executor/stubs_spec_linux.go
+++ b/executor/stubs_spec_linux.go
@@ -1,0 +1,18 @@
+//go:build linux
+
+package executor
+
+import (
+	"context"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// MountStubsCleanerForSpec cleans stubs for mounts in a finalized OCI spec.
+func MountStubsCleanerForSpec(ctx context.Context, dir string, mounts []specs.Mount, recursive bool) func() {
+	cleanupMounts := make([]Mount, len(mounts))
+	for i, m := range mounts {
+		cleanupMounts[i].Dest = m.Destination
+	}
+	return MountStubsCleaner(ctx, dir, cleanupMounts, recursive)
+}

--- a/executor/stubs_spec_linux_test.go
+++ b/executor/stubs_spec_linux_test.go
@@ -1,0 +1,34 @@
+//go:build linux
+
+package executor
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func TestMountStubsCleanerForSpec(t *testing.T) {
+	root := t.TempDir()
+	clean := MountStubsCleanerForSpec(context.Background(), root, []specs.Mount{
+		{Destination: "/proc"},
+	}, true)
+
+	for _, path := range []string{"proc", "sys"} {
+		if err := os.MkdirAll(filepath.Join(root, path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	clean()
+
+	if _, err := os.Lstat(filepath.Join(root, "proc")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("runtime-created /proc survived cleanup: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "sys")); err != nil {
+		t.Fatalf("rootless user-owned /sys was removed: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #6686

BuildKit currently decides which mount stubs to clean before rootless conversion finishes changing the mount list, which can leave rootful and rootless builds with different empty directories in the image.

This change registers cleanup after rootless conversion, when the mount list is final, and uses that list for cleanup.

The regression test covers the rootless case.
