### PR TITLE
cache: restore missing materialized snapshots

### DIFF
--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -68,6 +68,9 @@ type cmOut struct {
 	manager Manager
 	lm      leases.Manager
 	cs      content.Store
+	// testSnapshotter bypasses the namespaced wrapper and must only be used by
+	// tests that need to simulate out-of-band snapshotter changes.
+	testSnapshotter snapshots.Snapshotter
 }
 
 func newCacheManager(ctx context.Context, t *testing.T, opt cmOpt) (co *cmOut, cleanup func(), err error) {
@@ -144,8 +147,9 @@ func newCacheManager(ctx context.Context, t *testing.T, opt cmOpt) (co *cmOut, c
 		return md.Close()
 	})
 
+	metadataSnapshotter := mdb.Snapshotter(opt.snapshotterName)
 	cm, err := NewManager(ManagerOpt{
-		Snapshotter:    snapshot.FromContainerdSnapshotter(opt.snapshotterName, containerdsnapshot.NSSnapshotter(ns, mdb.Snapshotter(opt.snapshotterName)), nil),
+		Snapshotter:    snapshot.FromContainerdSnapshotter(opt.snapshotterName, containerdsnapshot.NSSnapshotter(ns, metadataSnapshotter), nil),
 		MetadataStore:  md,
 		ContentStore:   store,
 		LeaseManager:   lm,
@@ -163,9 +167,10 @@ func newCacheManager(ctx context.Context, t *testing.T, opt cmOpt) (co *cmOut, c
 	})
 
 	return &cmOut{
-		manager: cm,
-		lm:      lm,
-		cs:      store,
+		manager:         cm,
+		lm:              lm,
+		cs:              store,
+		testSnapshotter: metadataSnapshotter,
 	}, cleanup, nil
 }
 
@@ -572,6 +577,56 @@ func TestSnapshotExtract(t *testing.T) {
 	require.Equal(t, 0, len(dirs))
 
 	checkNumBlobs(ctx, t, co.cs, 0)
+}
+
+func TestMissingMaterializedLowerDiffExtract(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Depends on unimplemented containerd bind-mount support on Windows")
+	}
+
+	t.Parallel()
+	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+
+	co, cleanup, err := newCacheManager(ctx, t, cmOpt{})
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+	cm := co.manager
+
+	var refs []ImmutableRef
+	for i, files := range []map[string]string{
+		{"lower": "lower"},
+		{"upper": "upper"},
+	} {
+		blob, desc, err := mapToBlob(files, true)
+		require.NoError(t, err)
+		require.NoError(t, content.WriteBlob(ctx, co.cs, fmt.Sprintf("missing-snapshot-%d", i), bytes.NewBuffer(blob), desc))
+
+		ref, err := cm.GetByBlob(ctx, desc, nil)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, ref.Release(context.WithoutCancel(ctx)))
+		})
+		refs = append(refs, ref)
+	}
+
+	require.NoError(t, refs[0].Extract(ctx, nil))
+	require.NoError(t, refs[1].Extract(ctx, nil))
+	require.False(t, refs[0].(*immutableRef).getBlobOnly())
+	diff, err := cm.Diff(ctx, refs[0], refs[1], nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, diff.Release(context.WithoutCancel(ctx)))
+	})
+
+	lowerID := refs[0].(*immutableRef).getSnapshotID()
+	require.NoError(t, co.testSnapshotter.Remove(ctx, lowerID))
+
+	_, err = co.testSnapshotter.Stat(ctx, lowerID)
+	require.ErrorIs(t, err, cerrdefs.ErrNotFound)
+
+	require.NoError(t, diff.Extract(ctx, nil))
+	_, err = co.testSnapshotter.Stat(ctx, lowerID)
+	require.NoError(t, err)
 }
 
 func TestExtractOnMutable(t *testing.T) {

--- a/cache/refs.go
+++ b/cache/refs.go
@@ -1311,7 +1311,17 @@ func (sr *immutableRef) unlazyDiffMerge(ctx context.Context, dhs DescHandlers, p
 // should be called within sizeG.Do call for this ref's ID
 func (sr *immutableRef) unlazyLayer(ctx context.Context, dhs DescHandlers, pg progress.Controller, s session.Group, ensureContentStore bool) (rerr error) {
 	if !sr.getBlobOnly() {
-		return nil
+		// unlazy may reach this path because either the snapshot or content is
+		// missing. Recheck the snapshot to distinguish these cases. If the snapshot
+		// disappeared but the blob remains, re-extract it from the blob.
+		if _, err := sr.cm.Snapshotter.Stat(ctx, sr.getSnapshotID()); err == nil {
+			return nil
+		} else if !cerrdefs.IsNotFound(err) {
+			return errors.Wrapf(err, "failed to stat snapshot %s", sr.getSnapshotID())
+		}
+		if sr.getBlob() == "" {
+			return errors.Errorf("failed to restore missing snapshot %s: no blob available", sr.getSnapshotID())
+		}
 	}
 
 	if sr.cm.Applier == nil {

--- a/client/mergediff_test.go
+++ b/client/mergediff_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/continuity/fs/fstest"
 	cerrdefs "github.com/containerd/errdefs"
@@ -1134,8 +1135,115 @@ func diffOpTestCases() (tests []integration.Test) {
 			},
 		}
 	}()...)
+	tests = append(tests, integration.TestFuncs(testMissingMaterializedLowerSnapshot)...)
 
 	return tests
+}
+
+func testMissingMaterializedLowerSnapshot(t *testing.T, sb integration.Sandbox) {
+	requiresLinux(t)
+	workers.CheckFeatureCompat(t, sb, workers.FeatureMergeDiff)
+
+	containerdAddress := sb.ContainerdAddress()
+	if containerdAddress == "" {
+		t.Skip("test requires a containerd worker")
+	}
+
+	ctx := namespaces.WithNamespace(sb.Context(), "buildkit")
+	ctd, err := newContainerd(containerdAddress)
+	require.NoError(t, err)
+	defer ctd.Close()
+
+	c, err := New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	workerInfos, err := c.ListWorkers(sb.Context())
+	require.NoError(t, err)
+	require.Len(t, workerInfos, 1)
+	snapshotterName := workerInfos[0].Labels["org.mobyproject.buildkit.worker.snapshotter"]
+	require.NotEmpty(t, snapshotterName)
+	snapshotter := ctd.SnapshotService(snapshotterName)
+	before, err := snapshotInfoMap(ctx, snapshotter)
+	require.NoError(t, err)
+
+	lower := llb.Image("busybox:latest")
+	upper := llb.Image("alpine:latest")
+	materializedLower := lower.File(llb.Mkfile("/issue6977", 0o644, []byte("materialize lower")))
+	def, err := materializedLower.Marshal(sb.Context())
+	require.NoError(t, err)
+	_, err = c.Solve(sb.Context(), def, SolveOpt{}, nil)
+	require.NoError(t, err)
+
+	afterLower, err := snapshotInfoMap(ctx, snapshotter)
+	require.NoError(t, err)
+	lowerSnapshot := newCommittedRootSnapshot(t, before, afterLower)
+
+	// Simulate the inconsistent state from #6977: BuildKit still has the cache
+	// metadata and layer blob, but containerd has lost the materialized snapshot.
+	require.NoError(t, removeSnapshotTree(ctx, snapshotter, lowerSnapshot))
+	_, err = snapshotter.Stat(ctx, lowerSnapshot)
+	require.ErrorIs(t, err, cerrdefs.ErrNotFound)
+
+	solveStateToLocalDir(sb.Context(), t, c, llb.Diff(lower, upper))
+	_, err = snapshotter.Stat(ctx, lowerSnapshot)
+	require.NoError(t, err)
+}
+
+func snapshotInfoMap(ctx context.Context, snapshotter snapshots.Snapshotter) (map[string]snapshots.Info, error) {
+	infos := map[string]snapshots.Info{}
+	err := snapshotter.Walk(ctx, func(ctx context.Context, info snapshots.Info) error {
+		infos[info.Name] = info
+		return nil
+	})
+	return infos, errors.WithStack(err)
+}
+
+func newCommittedRootSnapshot(t *testing.T, before, after map[string]snapshots.Info) string {
+	t.Helper()
+
+	newSnapshots := map[string]snapshots.Info{}
+	for name, info := range after {
+		if _, ok := before[name]; ok || info.Kind != snapshots.KindCommitted {
+			continue
+		}
+		newSnapshots[name] = info
+	}
+
+	var roots []string
+	for name, info := range newSnapshots {
+		if _, parentIsNew := newSnapshots[info.Parent]; !parentIsNew {
+			roots = append(roots, name)
+		}
+	}
+	require.Len(t, roots, 1, "expected one newly materialized root snapshot")
+	return roots[0]
+}
+
+func removeSnapshotTree(ctx context.Context, snapshotter snapshots.Snapshotter, name string) error {
+	infos, err := snapshotInfoMap(ctx, snapshotter)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	children := map[string][]string{}
+	for child, info := range infos {
+		children[info.Parent] = append(children[info.Parent], child)
+	}
+
+	var remove func(string) error
+	remove = func(name string) error {
+		for _, child := range children[name] {
+			if err := remove(child); err != nil {
+				return err
+			}
+		}
+		if err := snapshotter.Remove(ctx, name); err != nil && !cerrdefs.IsNotFound(err) {
+			return errors.WithStack(err)
+		}
+		return nil
+	}
+	return remove(name)
 }
 
 // contents lets you create fstest.Appliers using the sandbox, which


### PR DESCRIPTION
Re-extract materialized layers from retained blobs when their snapshots are missing instead of failing diff and merge operations.

fix https://github.com/moby/buildkit/issues/6977