### PR TITLE
ci: allow OIDC login in buildx-image workflow

### DIFF
--- a/.github/workflows/buildx-image.yml
+++ b/.github/workflows/buildx-image.yml
@@ -37,6 +37,9 @@ env:
 jobs:
   create:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read # same as global permission
+      id-token: write # for logging in to Docker Hub with GitHub OIDC
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
relates to https://github.com/moby/buildkit/actions/runs/31600529025/job/94126506419#step:3:10

```
Error: Error message: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
```

Oversight from https://github.com/moby/buildkit/pull/7021