### PR TITLE
remotecache: rebind registry cache sessions

### DIFF
--- a/cache/remotecache/registry/registry.go
+++ b/cache/remotecache/registry/registry.go
@@ -122,29 +122,43 @@ func ResolveCacheImporterFunc(sm *session.Manager, cs content.Store, hosts docke
 		if err != nil {
 			return nil, ocispecs.Descriptor{}, err
 		}
-		fetcher, err := remote.Fetcher(ctx, xref)
-		if err != nil {
-			return nil, ocispecs.Descriptor{}, err
-		}
-		src := &withDistributionSourceLabel{
-			Provider: contentutil.FromFetcher(limited.Default.WrapFetcher(fetcher, refString)),
+		src := &registryCacheProvider{
+			resolver: remote,
 			ref:      refString,
+			xref:     xref,
 			source:   cs,
 		}
 		return remotecache.NewImporter(src), desc, nil
 	}
 }
 
-type withDistributionSourceLabel struct {
-	content.Provider
-	ref    string
-	source content.Manager
+type registryCacheProvider struct {
+	resolver *resolver.Resolver
+	ref      string
+	xref     string
+	source   content.Manager
 }
 
-var _ remotecache.DistributionSourceLabelSetter = &withDistributionSourceLabel{}
+var _ remotecache.DistributionSourceLabelSetter = &registryCacheProvider{}
 
-func (dsl *withDistributionSourceLabel) SetDistributionSourceLabel(ctx context.Context, dgst digest.Digest) error {
-	hf, err := docker.AppendDistributionSourceLabel(dsl.source, dsl.ref)
+// ProviderForSession prevents cache providers shared across Solves from using
+// the credentials of the Solve that originally imported the cache manifest.
+func (p *registryCacheProvider) ProviderForSession(g session.Group) content.Provider {
+	p2 := *p
+	p2.resolver = p.resolver.WithSession(g)
+	return &p2
+}
+
+func (p *registryCacheProvider) ReaderAt(ctx context.Context, desc ocispecs.Descriptor) (content.ReaderAt, error) {
+	fetcher, err := p.resolver.Fetcher(ctx, p.xref)
+	if err != nil {
+		return nil, err
+	}
+	return contentutil.FromFetcher(limited.Default.WrapFetcher(fetcher, p.ref)).ReaderAt(ctx, desc)
+}
+
+func (p *registryCacheProvider) SetDistributionSourceLabel(ctx context.Context, dgst digest.Digest) error {
+	hf, err := docker.AppendDistributionSourceLabel(p.source, p.ref)
 	if err != nil {
 		return err
 	}
@@ -152,15 +166,15 @@ func (dsl *withDistributionSourceLabel) SetDistributionSourceLabel(ctx context.C
 	return err
 }
 
-func (dsl *withDistributionSourceLabel) SetDistributionSourceAnnotation(desc ocispecs.Descriptor) ocispecs.Descriptor {
+func (p *registryCacheProvider) SetDistributionSourceAnnotation(desc ocispecs.Descriptor) ocispecs.Descriptor {
 	if desc.Annotations == nil {
 		desc.Annotations = map[string]string{}
 	}
-	desc.Annotations["containerd.io/distribution.source.ref"] = dsl.ref
+	desc.Annotations["containerd.io/distribution.source.ref"] = p.ref
 	return desc
 }
 
-func (dsl *withDistributionSourceLabel) SnapshotLabels(descs []ocispecs.Descriptor, index int) map[string]string {
+func (p *registryCacheProvider) SnapshotLabels(descs []ocispecs.Descriptor, index int) map[string]string {
 	if len(descs) < index {
 		return nil
 	}
@@ -168,8 +182,8 @@ func (dsl *withDistributionSourceLabel) SnapshotLabels(descs []ocispecs.Descript
 	if labels == nil {
 		labels = make(map[string]string)
 	}
-	maps.Copy(labels, estargz.SnapshotLabels(dsl.ref, descs, index))
-	labels[snapshotters.TargetRefLabel] = dsl.ref
+	maps.Copy(labels, estargz.SnapshotLabels(p.ref, descs, index))
+	labels[snapshotters.TargetRefLabel] = p.ref
 	return labels
 }
 

--- a/cache/remotecache/registry/registry_test.go
+++ b/cache/remotecache/registry/registry_test.go
@@ -1,0 +1,130 @@
+package registry
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/remotes/docker"
+	"github.com/docker/cli/cli/config/configfile"
+	"github.com/docker/cli/cli/config/types"
+	cacheimport "github.com/moby/buildkit/cache/remotecache/v1"
+	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/session/auth/authprovider"
+	"github.com/moby/buildkit/util/contentutil"
+	"github.com/moby/buildkit/util/resolver"
+	digest "github.com/opencontainers/go-digest"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistryCacheProviderUsesCurrentSession(t *testing.T) {
+	layer := []byte("a lazily fetched cache layer")
+	desc := ocispecs.Descriptor{Digest: digest.FromBytes(layer), Size: int64(len(layer))}
+
+	var tokenURL string
+	registry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			username, password, ok := r.BasicAuth()
+			if !ok || username != "session-b" || password != "password-b" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			_, _ = io.WriteString(w, `{"token":"token-b","expires_in":300}`)
+		case "/v2/":
+			w.WriteHeader(http.StatusOK)
+		case "/v2/test/blobs/" + desc.Digest.String():
+			if r.Header.Get("Authorization") != "Bearer token-b" {
+				w.Header().Set("WWW-Authenticate", `Bearer realm="`+tokenURL+`",service="repro",scope="repository:test:pull"`)
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			_, _ = w.Write(layer)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer registry.Close()
+	tokenURL = registry.URL + "/token"
+
+	u, err := url.Parse(registry.URL)
+	require.NoError(t, err)
+	hosts := func(string) ([]docker.RegistryHost, error) {
+		return []docker.RegistryHost{{
+			Client:       registry.Client(),
+			Host:         u.Host,
+			Scheme:       u.Scheme,
+			Path:         "/v2",
+			Capabilities: docker.HostCapabilityPull | docker.HostCapabilityResolve,
+		}}, nil
+	}
+
+	sm, err := session.NewManager()
+	require.NoError(t, err)
+	sessionA := startAuthSession(t, sm, u.Host, "session-a", "password-a")
+	ref := u.Host + "/test:latest"
+	provider := &registryCacheProvider{
+		resolver: resolver.NewPool().GetResolver(hosts, ref, resolver.ScopeType{}, sm, session.NewGroup(sessionA.ID())),
+		ref:      ref,
+		xref:     ref,
+	}
+	pair := cacheimport.DescriptorProviderPair{Descriptor: desc, Provider: provider}
+	multiProvider := contentutil.NewMultiProvider(pair)
+	multiProvider.Add(desc.Digest, pair)
+
+	oldSessionID := sessionA.ID()
+	require.NoError(t, sessionA.Close())
+	waitForSessionRemoval(t, sm, oldSessionID)
+
+	sessionB := startAuthSession(t, sm, u.Host, "session-b", "password-b")
+	defer sessionB.Close()
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	currentProvider := contentutil.ProviderForSession(multiProvider, session.NewGroup(sessionB.ID()))
+	got, err := content.ReadBlob(ctx, currentProvider, desc)
+	require.NoError(t, err)
+	require.Equal(t, layer, got)
+}
+
+func startAuthSession(t *testing.T, sm *session.Manager, host, username, password string) *session.Session {
+	t.Helper()
+	s, err := session.NewSession(t.Context(), "registry-cache-session-test")
+	require.NoError(t, err)
+	s.Allow(authprovider.NewDockerAuthProvider(authprovider.DockerAuthProviderConfig{
+		AuthConfigProvider: authprovider.LoadAuthConfig(&configfile.ConfigFile{AuthConfigs: map[string]types.AuthConfig{
+			host: {Username: username, Password: password},
+		}}),
+	}))
+	go func() {
+		_ = s.Run(t.Context(), func(ctx context.Context, _ string, meta map[string][]string) (net.Conn, error) {
+			client, server := net.Pipe()
+			go func() {
+				_ = sm.HandleConn(ctx, server, meta)
+				_ = server.Close()
+			}()
+			return client, nil
+		})
+	}()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	_, err = sm.Get(ctx, s.ID(), false)
+	require.NoError(t, err)
+	return s
+}
+
+func waitForSessionRemoval(t *testing.T, sm *session.Manager, id string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		caller, err := sm.Get(t.Context(), id, true)
+		return err == nil && caller == nil
+	}, time.Second, 10*time.Millisecond)
+}

--- a/cache/remotecache/registry/registry_test.go
+++ b/cache/remotecache/registry/registry_test.go
@@ -85,7 +85,7 @@ func TestRegistryCacheProviderUsesCurrentSession(t *testing.T) {
 
 	sessionB := startAuthSession(t, sm, u.Host, "session-b", "password-b")
 	defer sessionB.Close()
-	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	ctx, cancel := context.WithTimeoutCause(t.Context(), time.Second, nil)
 	defer cancel()
 
 	currentProvider := contentutil.ProviderForSession(multiProvider, session.NewGroup(sessionB.ID()))
@@ -114,7 +114,7 @@ func startAuthSession(t *testing.T, sm *session.Manager, host, username, passwor
 		})
 	}()
 
-	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	ctx, cancel := context.WithTimeoutCause(t.Context(), time.Second, nil)
 	defer cancel()
 	_, err = sm.Get(ctx, s.ID(), false)
 	require.NoError(t, err)

--- a/cache/remotecache/v1/chains.go
+++ b/cache/remotecache/v1/chains.go
@@ -14,6 +14,7 @@ import (
 	cacheimporttypes "github.com/moby/buildkit/cache/remotecache/v1/types"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/util/contentutil"
 	digest "github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -241,6 +242,11 @@ type DescriptorProviderPair struct {
 
 func (p DescriptorProviderPair) ReaderAt(ctx context.Context, desc ocispecs.Descriptor) (content.ReaderAt, error) {
 	return p.Provider.ReaderAt(ctx, desc)
+}
+
+func (p DescriptorProviderPair) ProviderForSession(g session.Group) content.Provider {
+	p.Provider = contentutil.ProviderForSession(p.Provider, g)
+	return p
 }
 
 func (p DescriptorProviderPair) Info(ctx context.Context, dgst digest.Digest) (content.Info, error) {

--- a/util/contentutil/multiprovider.go
+++ b/util/contentutil/multiprovider.go
@@ -20,6 +20,18 @@ func NewMultiProvider(base content.InfoReaderProvider) *MultiProvider {
 	}
 }
 
+type sessionProvider interface {
+	ProviderForSession(session.Group) content.Provider
+}
+
+// ProviderForSession provides a session-bound content provider when supported.
+func ProviderForSession(p content.Provider, g session.Group) content.Provider {
+	if sp, ok := p.(sessionProvider); ok {
+		return sp.ProviderForSession(g)
+	}
+	return p
+}
+
 // MultiProvider is a provider backed by a mutable map of providers
 type MultiProvider struct {
 	mu   sync.RWMutex
@@ -84,6 +96,28 @@ func (mp *MultiProvider) Add(dgst digest.Digest, p content.InfoReaderProvider) {
 	mp.mu.Lock()
 	defer mp.mu.Unlock()
 	mp.sub[dgst] = p
+}
+
+func (mp *MultiProvider) ProviderForSession(g session.Group) content.Provider {
+	return &multiProviderForSession{MultiProvider: mp, g: g}
+}
+
+type multiProviderForSession struct {
+	*MultiProvider
+	g session.Group
+}
+
+func (p *multiProviderForSession) ReaderAt(ctx context.Context, desc ocispecs.Descriptor) (content.ReaderAt, error) {
+	p.mu.RLock()
+	provider, ok := p.sub[desc.Digest]
+	if !ok {
+		provider = p.base
+	}
+	p.mu.RUnlock()
+	if provider == nil {
+		return nil, errors.Wrapf(cerrdefs.ErrNotFound, "content %v", desc.Digest)
+	}
+	return ProviderForSession(provider, p.g).ReaderAt(ctx, desc)
 }
 
 func (mp *MultiProvider) UnlazySession(desc ocispecs.Descriptor) session.Group {

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -48,6 +48,7 @@ import (
 	"github.com/moby/buildkit/source/local"
 	"github.com/moby/buildkit/util/archutil"
 	"github.com/moby/buildkit/util/bklog"
+	"github.com/moby/buildkit/util/contentutil"
 	"github.com/moby/buildkit/util/leaseutil"
 	"github.com/moby/buildkit/util/network"
 	"github.com/moby/buildkit/util/progress"
@@ -661,7 +662,9 @@ func (w *Worker) FromRemote(ctx context.Context, remote *solver.Remote) (ref cac
 	}
 
 	descHandler := &cache.DescHandler{
-		Provider: func(session.Group) content.Provider { return remote.Provider },
+		Provider: func(g session.Group) content.Provider {
+			return contentutil.ProviderForSession(remote.Provider, g)
+		},
 		Progress: pg,
 	}
 	snapshotLabels := func([]ocispecs.Descriptor, int) map[string]string { return nil }


### PR DESCRIPTION
## Summary

Registry cache imports keep layer content lazy, but their resolver and fetcher were bound to the session that originally read the cache manifest. BuildKit can share identical active vertices between concurrent Solves and deduplicate cache managers for the same registry ref. If build A owns the retained provider and exits before build B materializes a lazy layer, B asks for credentials through A's inactive session and fails with:

```text
httpReadSeeker: failed open: no active session for <session>: context deadline exceeded
```

This change:

- makes registry cache providers rebindable to a `session.Group`;
- preserves that behavior through descriptor pairs and multi-providers;
- makes `Worker.FromRemote` use the session supplied by the lazy-read caller; and
- recreates the registry fetcher from `Resolver.WithSession` for that group.

Direct cache-export behavior is intentionally unchanged.

The regression test uses an authenticated registry with distinct credentials for sessions A and B. It closes A after constructing the lazy provider, then verifies the blob can only be fetched through B.

This is the registry-cache variant of the session-specific lazy-cache problem described in #3229. Related to #6422.

## Test plan

```text
go test -count=1 -timeout=2m ./cache/remotecache/registry ./cache/remotecache/v1 ./util/contentutil ./worker/base
ok  github.com/moby/buildkit/cache/remotecache/registry
ok  github.com/moby/buildkit/cache/remotecache/v1
ok  github.com/moby/buildkit/util/contentutil
ok  github.com/moby/buildkit/worker/base


go test -race -count=1 -timeout=2m ./cache/remotecache/registry ./cache/remotecache/v1 ./util/contentutil ./worker/base
ok  github.com/moby/buildkit/cache/remotecache/registry
ok  github.com/moby/buildkit/cache/remotecache/v1
ok  github.com/moby/buildkit/util/contentutil
ok  github.com/moby/buildkit/worker/base


go test ./cache/remotecache/registry -run TestRegistryCacheProviderUsesCurrentSession -count=100 -timeout=30s
ok  github.com/moby/buildkit/cache/remotecache/registry


go vet ./cache/remotecache/registry ./cache/remotecache/v1 ./util/contentutil ./worker/base
# passed


go build ./cmd/buildkitd ./cmd/buildctl
# passed
```

`make validate-all` was not run locally because this host does not have Docker/registry test binaries or mount privileges required by the integration framework.

_written using codex_
