### PR TITLE
Disable build history when maxEntries is zero

### DIFF
--- a/client/client_control_test.go
+++ b/client/client_control_test.go
@@ -54,6 +54,37 @@ func testClientCustomGRPCOpts(t *testing.T, sb integration.Sandbox) {
 	require.Contains(t, interceptedMethods, "/moby.buildkit.v1.Control/Solve")
 }
 
+func testBuildHistoryDisabled(t *testing.T, sb integration.Sandbox) {
+	c, err := New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	successRef := identity.NewID()
+	successDef, err := llb.Scratch().File(llb.Mkfile("file", 0o644, nil)).Marshal(sb.Context())
+	require.NoError(t, err)
+	_, err = c.Solve(sb.Context(), successDef, SolveOpt{Ref: successRef}, nil)
+	require.NoError(t, err)
+	requireNoBuildHistory(t, c, sb, successRef)
+
+	failureRef := identity.NewID()
+	failureDef, err := llb.Scratch().File(llb.Rm("missing")).Marshal(sb.Context())
+	require.NoError(t, err)
+	_, err = c.Solve(sb.Context(), failureDef, SolveOpt{Ref: failureRef}, nil)
+	require.Error(t, err)
+	requireNoBuildHistory(t, c, sb, failureRef)
+}
+
+func requireNoBuildHistory(t *testing.T, c *Client, sb integration.Sandbox, ref string) {
+	t.Helper()
+	history, err := c.ControlClient().ListenBuildHistory(sb.Context(), &controlapi.BuildHistoryRequest{
+		Ref:       ref,
+		EarlyExit: true,
+	})
+	require.NoError(t, err)
+	_, err = history.Recv()
+	require.ErrorIs(t, err, io.EOF)
+}
+
 func testListenBuildHistoryExcludesSoftDeletedRecords(t *testing.T, sb integration.Sandbox) {
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -127,4 +158,10 @@ func testListenBuildHistoryExcludesSoftDeletedRecords(t *testing.T, sb integrati
 			break
 		}
 	}
+}
+
+type historyDisabled struct{}
+
+func (*historyDisabled) UpdateConfigFile(in string) (string, func() error) {
+	return in + "\n\n[history]\n  maxEntries = 0\n", nil
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -319,6 +319,12 @@ func testIntegration(t *testing.T, funcs ...func(t *testing.T, sb integration.Sa
 	tests = append(tests, diffOpTestCases()...)
 	integration.Run(t, tests, mirrors)
 
+	integration.Run(t, integration.TestFuncs(
+		testBuildHistoryDisabled,
+	), mirrors, integration.WithMatrix("history", map[string]any{
+		"disabled": &historyDisabled{},
+	}))
+
 	// the rest of the tests are meant for non-Windows, skipping on Windows.
 	integration.SkipOnPlatform(t, "windows")
 

--- a/docs/buildkitd.toml.md
+++ b/docs/buildkitd.toml.md
@@ -65,6 +65,7 @@ provenanceEnvDir = "/etc/buildkit/provenance.d"
   # maxAge is the maximum age of history entries to keep, in seconds.
   maxAge = 172800
   # maxEntries is the maximum number of history entries to keep.
+  # Setting this value to 0 disables build history.
   maxEntries = 50
 
 [worker.oci]

--- a/solver/llbsolver/history/buildhistory.go
+++ b/solver/llbsolver/history/buildhistory.go
@@ -77,6 +77,12 @@ type StatusImportResult struct {
 	NumWarnings       int
 }
 
+// Enabled reports whether completed build history should be recorded.
+// A configured maximum of zero disables history recording entirely.
+func (h *Queue) Enabled() bool {
+	return h.opt.CleanConfig.MaxEntries != 0
+}
+
 func NewQueue(opt QueueOpt) (*Queue, error) {
 	if opt.CleanConfig == nil {
 		opt.CleanConfig = &config.HistoryConfig{

--- a/solver/llbsolver/history/buildhistory_test.go
+++ b/solver/llbsolver/history/buildhistory_test.go
@@ -1,0 +1,27 @@
+package history
+
+import (
+	"testing"
+
+	"github.com/moby/buildkit/cmd/buildkitd/config"
+)
+
+func TestQueueEnabled(t *testing.T) {
+	tests := []struct {
+		name       string
+		maxEntries int64
+		want       bool
+	}{
+		{name: "disabled", maxEntries: 0, want: false},
+		{name: "enabled", maxEntries: 50, want: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			q := &Queue{opt: QueueOpt{CleanConfig: &config.HistoryConfig{MaxEntries: tc.maxEntries}}}
+			if got := q.Enabled(); got != tc.want {
+				t.Fatalf("Enabled() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/solver/llbsolver/solver.go
+++ b/solver/llbsolver/solver.go
@@ -281,7 +281,7 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 		defer s.gatewayForwarder.UnregisterBuild(context.Background(), id)
 	}
 
-	if !internal {
+	if !internal && s.history.Enabled() {
 		rec, err1 := s.recordBuildHistory(ctx, id, req, exp, j, usage)
 		if err1 != nil {
 			defer j.CloseProgress()
@@ -290,6 +290,8 @@ func (s *Solver) Solve(ctx context.Context, id string, sessionID string, req fro
 		defer func() {
 			err = rec(context.WithoutCancel(ctx), resProv, descrefs, err)
 		}()
+	} else if !internal {
+		defer j.CloseProgress()
 	}
 
 	if fwd != nil {


### PR DESCRIPTION
Closes #3798.

## What changed

- Treat `history.maxEntries = 0` as an explicit request to disable build history.
- Bypass the `recordBuildHistory` path instead of creating START/COMPLETE records, provenance blobs, and trace data that GC deletes shortly afterward.
- Keep the solver progress lifecycle closed for both successful and failed builds when history is disabled.
- Document the zero-value behavior in the example `buildkitd.toml`.

Because the solver now bypasses `recordBuildHistory` entirely in this mode, the build-completion metrics currently emitted from that history finalizer are also disabled. This matches the issue's request to completely ignore the History API; if those metrics should remain independent of history, they can be separated from the history-record path in a follow-up.

## Validation

- `go test -mod=vendor -buildvcs=false ./solver/llbsolver/history -count=1`
- `go test -mod=vendor -buildvcs=false -vet=off ./solver/llbsolver -count=1`
- `go vet -mod=vendor -buildvcs=false ./solver/llbsolver/history`
- `go build -mod=vendor -buildvcs=false ./cmd/buildkitd ./cmd/buildctl`
- `TESTPKGS=./client TESTFLAGS='--run /TestBuildHistoryDisabled -v' ./hack/test integration`
  - Exercised successful and intentionally failed solves.
  - Confirmed neither ref was returned by `ListenBuildHistory`.
  - Passed on all 9 generated workers: OCI, rootless OCI, gVisor/tap/vsock/detached-netns OCI, stargz OCI, containerd, containerd 1.7, containerd 2.2, rootless containerd, and stargz containerd.

Broader `go vet ./solver/llbsolver/... ./control ./client` still reports three existing lost-cancel warnings in `solver/llbsolver/export.go` and `solver/llbsolver/history.go`; this change does not modify those call sites.

## AI assistance

OpenAI Codex assisted with implementation and test development. I reviewed the resulting diff and ran the checks listed above.
