### PR TITLE
lint: enable usetesting linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,7 @@ linters:
     - testifylint
     - unused
     - usestdlibvars
+    - usetesting
     - whitespace
   settings:
     depguard:
@@ -105,6 +106,9 @@ linters:
         - bool-compare
         - len
         - negative-positive
+    usetesting:
+      context-background: true
+      context-todo: true
   exclusions:
     generated: lax
     presets:

--- a/cache/contenthash/checksum_test.go
+++ b/cache/contenthash/checksum_test.go
@@ -62,7 +62,7 @@ func TestChecksumSymlinkNoParentScan(t *testing.T) {
 	cc, err := newCacheContext(ref)
 	require.NoError(t, err)
 
-	dgst, err := cc.Checksum(context.TODO(), ref, "aa/ln/bb/cc/dd", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err := cc.Checksum(t.Context(), ref, "aa/ln/bb/cc/dd", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstFileData0, dgst)
 
@@ -140,7 +140,7 @@ func TestNeedScanChecksumRegression(t *testing.T) {
 	require.NoError(t, err)
 
 	// Checksumming /aa/bb while following links will result in /aa being scanned.
-	_, err = cc.Checksum(context.TODO(), ref, "/bb", ChecksumOpts{FollowLinks: true}, nil)
+	_, err = cc.Checksum(t.Context(), ref, "/bb", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 
 	root := cc.tree.Root()
@@ -174,17 +174,17 @@ func TestNeedScanChecksumRegression(t *testing.T) {
 
 	// Make sure trying to checksum a subpath results in no further scans.
 	initialScanCounter := scanCounter.Load()
-	_, err = cc.Checksum(context.TODO(), ref, "/bb/cc", ChecksumOpts{FollowLinks: true}, nil)
+	_, err = cc.Checksum(t.Context(), ref, "/bb/cc", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, initialScanCounter, scanCounter.Load())
-	_, err = cc.Checksum(context.TODO(), ref, "/bb/non-existent", ChecksumOpts{FollowLinks: true}, nil)
+	_, err = cc.Checksum(t.Context(), ref, "/bb/non-existent", ChecksumOpts{FollowLinks: true}, nil)
 	require.Error(t, err)
 	require.Equal(t, initialScanCounter, scanCounter.Load())
 
 	// Looking up a non-existent path in / will checksum the whole tree. See
 	// <https://github.com/moby/buildkit/issues/5042> for more information.
 	// This means that needsScan will return true for any path.
-	_, err = cc.Checksum(context.TODO(), ref, "/non-existent", ChecksumOpts{FollowLinks: true}, nil)
+	_, err = cc.Checksum(t.Context(), ref, "/non-existent", ChecksumOpts{FollowLinks: true}, nil)
 	require.Error(t, err)
 	fullScanCounter := scanCounter.Load()
 	require.NotEqual(t, fullScanCounter, initialScanCounter)
@@ -204,16 +204,16 @@ func TestNeedScanChecksumRegression(t *testing.T) {
 
 	// Looking up any more paths should not result in any more scans because we
 	// already know / was scanned.
-	_, err = cc.Checksum(context.TODO(), ref, "/non-existent", ChecksumOpts{FollowLinks: true}, nil)
+	_, err = cc.Checksum(t.Context(), ref, "/non-existent", ChecksumOpts{FollowLinks: true}, nil)
 	require.Error(t, err)
 	require.Equal(t, fullScanCounter, scanCounter.Load())
-	_, err = cc.Checksum(context.TODO(), ref, "/different/non/existent", ChecksumOpts{FollowLinks: true}, nil)
+	_, err = cc.Checksum(t.Context(), ref, "/different/non/existent", ChecksumOpts{FollowLinks: true}, nil)
 	require.Error(t, err)
 	require.Equal(t, fullScanCounter, scanCounter.Load())
-	_, err = cc.Checksum(context.TODO(), ref, "/aa/root/aa/non-exist", ChecksumOpts{FollowLinks: true}, nil)
+	_, err = cc.Checksum(t.Context(), ref, "/aa/root/aa/non-exist", ChecksumOpts{FollowLinks: true}, nil)
 	require.Error(t, err)
 	require.Equal(t, fullScanCounter, scanCounter.Load())
-	_, err = cc.Checksum(context.TODO(), ref, "/aa/root/bb/cc", ChecksumOpts{FollowLinks: true}, nil)
+	_, err = cc.Checksum(t.Context(), ref, "/aa/root/bb/cc", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, fullScanCounter, scanCounter.Load())
 }
@@ -264,7 +264,7 @@ func TestChecksumNonLexicalSymlinks(t *testing.T) {
 		"link3/target_file",
 		"link3/target/file",
 	} {
-		dgst, err := cc.Checksum(context.TODO(), ref, path, ChecksumOpts{FollowLinks: true}, nil)
+		dgst, err := cc.Checksum(t.Context(), ref, path, ChecksumOpts{FollowLinks: true}, nil)
 		require.NoErrorf(t, err, "Checksum(%q)", path)
 		require.Equalf(t, dgstFileData0, dgst, "Checksum(%q)", path)
 	}
@@ -280,20 +280,20 @@ func TestChecksumNonLexicalSymlinks(t *testing.T) {
 		"link2/link1_abs/target_dir_abs/file",
 		"link3/target/file",
 	} {
-		dgst, err := cc.Checksum(context.TODO(), ref, path, ChecksumOpts{FollowLinks: false}, nil)
+		dgst, err := cc.Checksum(t.Context(), ref, path, ChecksumOpts{FollowLinks: false}, nil)
 		require.NoErrorf(t, err, "Checksum(%q)", path)
 		require.Equalf(t, dgstFileData0, dgst, "Checksum(%q)", path)
 	}
 
-	dgstLink1TargetFile, err := cc.Checksum(context.TODO(), ref, "link1/target_file", ChecksumOpts{FollowLinks: false}, nil)
+	dgstLink1TargetFile, err := cc.Checksum(t.Context(), ref, "link1/target_file", ChecksumOpts{FollowLinks: false}, nil)
 	require.NoError(t, err)
 	require.NotEqual(t, dgstFileData0, dgstLink1TargetFile)
 
-	dgstLink1TargetFileAbs, err := cc.Checksum(context.TODO(), ref, "link1/target_file_abs", ChecksumOpts{FollowLinks: false}, nil)
+	dgstLink1TargetFileAbs, err := cc.Checksum(t.Context(), ref, "link1/target_file_abs", ChecksumOpts{FollowLinks: false}, nil)
 	require.NoError(t, err)
 	require.NotEqual(t, dgstFileData0, dgstLink1TargetFileAbs)
 
-	dgstLink3TargetFile, err := cc.Checksum(context.TODO(), ref, "link3/target_file", ChecksumOpts{FollowLinks: false}, nil)
+	dgstLink3TargetFile, err := cc.Checksum(t.Context(), ref, "link3/target_file", ChecksumOpts{FollowLinks: false}, nil)
 	require.NoError(t, err)
 	require.NotEqual(t, dgstFileData0, dgstLink3TargetFile)
 
@@ -309,7 +309,7 @@ func TestChecksumNonLexicalSymlinks(t *testing.T) {
 		{"link2/link1_abs/target_file_abs", dgstLink1TargetFileAbs},
 		{"link3/target_file", dgstLink3TargetFile},
 	} {
-		dgst, err := cc.Checksum(context.TODO(), ref, test.path, ChecksumOpts{FollowLinks: false}, nil)
+		dgst, err := cc.Checksum(t.Context(), ref, test.path, ChecksumOpts{FollowLinks: false}, nil)
 		require.NoErrorf(t, err, "Checksum(%q)", test.path)
 		require.NotEqualf(t, dgstFileData0, dgst, "Checksum(%q)", test.path)
 		require.Equalf(t, test.expectedDgst, dgst, "Checksum(%q)", test.path)
@@ -337,15 +337,15 @@ func TestChecksumHardlinks(t *testing.T) {
 	cc, err := newCacheContext(ref)
 	require.NoError(t, err)
 
-	dgst, err := cc.Checksum(context.TODO(), ref, "abc/foo", ChecksumOpts{}, nil)
+	dgst, err := cc.Checksum(t.Context(), ref, "abc/foo", ChecksumOpts{}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstFileData0, dgst)
 
-	dgst, err = cc.Checksum(context.TODO(), ref, "ln", ChecksumOpts{}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "ln", ChecksumOpts{}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstFileData0, dgst)
 
-	dgst, err = cc.Checksum(context.TODO(), ref, "ln2", ChecksumOpts{}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "ln2", ChecksumOpts{}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstFileData0, dgst)
 
@@ -358,15 +358,15 @@ func TestChecksumHardlinks(t *testing.T) {
 	err = emit(cc2.HandleChange, changeStream(ch))
 	require.NoError(t, err)
 
-	dgst, err = cc2.Checksum(context.TODO(), ref, "abc/foo", ChecksumOpts{}, nil)
+	dgst, err = cc2.Checksum(t.Context(), ref, "abc/foo", ChecksumOpts{}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstFileData0, dgst)
 
-	dgst, err = cc2.Checksum(context.TODO(), ref, "ln", ChecksumOpts{}, nil)
+	dgst, err = cc2.Checksum(t.Context(), ref, "ln", ChecksumOpts{}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstFileData0, dgst)
 
-	dgst, err = cc2.Checksum(context.TODO(), ref, "ln2", ChecksumOpts{}, nil)
+	dgst, err = cc2.Checksum(t.Context(), ref, "ln2", ChecksumOpts{}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstFileData0, dgst)
 
@@ -384,15 +384,15 @@ func TestChecksumHardlinks(t *testing.T) {
 
 	data1Expected := "sha256:c2b5e234f5f38fc5864da7def04782f82501a40d46192e4207d5b3f0c3c4732b"
 
-	dgst, err = cc2.Checksum(context.TODO(), ref, "abc/foo", ChecksumOpts{}, nil)
+	dgst, err = cc2.Checksum(t.Context(), ref, "abc/foo", ChecksumOpts{}, nil)
 	require.NoError(t, err)
 	require.Equal(t, data1Expected, string(dgst))
 
-	dgst, err = cc2.Checksum(context.TODO(), ref, "ln", ChecksumOpts{}, nil)
+	dgst, err = cc2.Checksum(t.Context(), ref, "ln", ChecksumOpts{}, nil)
 	require.NoError(t, err)
 	require.Equal(t, data1Expected, string(dgst))
 
-	dgst, err = cc2.Checksum(context.TODO(), ref, "ln2", ChecksumOpts{}, nil)
+	dgst, err = cc2.Checksum(t.Context(), ref, "ln2", ChecksumOpts{}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstFileData0, dgst)
 }
@@ -424,31 +424,31 @@ func TestChecksumWildcardOrFilter(t *testing.T) {
 	cc, err := newCacheContext(ref)
 	require.NoError(t, err)
 
-	dgst, err := cc.Checksum(context.TODO(), ref, "f*o", ChecksumOpts{Wildcard: true}, nil)
+	dgst, err := cc.Checksum(t.Context(), ref, "f*o", ChecksumOpts{Wildcard: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, digest.FromBytes(append([]byte{0}, append([]byte("foo"), []byte(dgstFileData0)...)...)), dgst)
 
 	expFoos := digest.Digest("sha256:0b6731924f0a32a812bf8a729202e55e54ded331f9e4ff2397f681e43694e086")
 
-	dgst, err = cc.Checksum(context.TODO(), ref, "f*", ChecksumOpts{Wildcard: true}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "f*", ChecksumOpts{Wildcard: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, expFoos, dgst)
 
-	dgst, err = cc.Checksum(context.TODO(), ref, "x/d?", ChecksumOpts{Wildcard: true}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "x/d?", ChecksumOpts{Wildcard: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstDirD0FileByFile, dgst)
 
-	dgst, err = cc.Checksum(context.TODO(), ref, "x/d?/def", ChecksumOpts{FollowLinks: true, Wildcard: true}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "x/d?/def", ChecksumOpts{FollowLinks: true, Wildcard: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstFileData0, dgst)
 
 	expFoos2 := digest.Digest("sha256:982153600b9653a1decb0f961e09e2bc1be335cfcaac9b39dbd1120b65fdf92c")
 
-	dgst, err = cc.Checksum(context.TODO(), ref, "y*", ChecksumOpts{FollowLinks: true, Wildcard: true}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "y*", ChecksumOpts{FollowLinks: true, Wildcard: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, expFoos2, dgst)
 
-	err = ref.Release(context.TODO())
+	err = ref.Release(t.Context())
 	require.NoError(t, err)
 }
 
@@ -470,7 +470,7 @@ func TestChecksumWildcardWithBadMountable(t *testing.T) {
 	cc, err := newCacheContext(ref)
 	require.NoError(t, err)
 
-	_, err = cc.Checksum(context.TODO(), newBadMountable(), "*", ChecksumOpts{Wildcard: true}, nil)
+	_, err = cc.Checksum(t.Context(), newBadMountable(), "*", ChecksumOpts{Wildcard: true}, nil)
 	require.Error(t, err)
 }
 
@@ -499,56 +499,56 @@ func TestSymlinksNoFollow(t *testing.T) {
 
 	expectedSym := digest.Digest("sha256:a2ba571981f48ec34eb79c9a3ab091b6491e825c2f7e9914ea86e8e958be7fae")
 
-	dgst, err := cc.Checksum(context.TODO(), ref, "sym", ChecksumOpts{Wildcard: true}, nil)
+	dgst, err := cc.Checksum(t.Context(), ref, "sym", ChecksumOpts{Wildcard: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, expectedSym, dgst)
 
-	dgst, err = cc.Checksum(context.TODO(), ref, "sym2", ChecksumOpts{Wildcard: true}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "sym2", ChecksumOpts{Wildcard: true}, nil)
 	require.NoError(t, err)
 	require.NotEqual(t, expectedSym, dgst)
 
-	dgst, err = cc.Checksum(context.TODO(), ref, "foo/ghi", ChecksumOpts{Wildcard: true}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "foo/ghi", ChecksumOpts{Wildcard: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, expectedSym, dgst)
 
-	_, err = cc.Checksum(context.TODO(), ref, "foo/ghi", ChecksumOpts{FollowLinks: true, Wildcard: true}, nil) // same because broken symlink
+	_, err = cc.Checksum(t.Context(), ref, "foo/ghi", ChecksumOpts{FollowLinks: true, Wildcard: true}, nil) // same because broken symlink
 	require.Error(t, err)
 	require.Equal(t, true, errors.Is(err, errNotFound))
 
-	_, err = cc.Checksum(context.TODO(), ref, "y1", ChecksumOpts{FollowLinks: true, Wildcard: true}, nil)
+	_, err = cc.Checksum(t.Context(), ref, "y1", ChecksumOpts{FollowLinks: true, Wildcard: true}, nil)
 	require.Error(t, err)
 	require.Equal(t, true, errors.Is(err, errNotFound))
 
-	dgst, err = cc.Checksum(context.TODO(), ref, "sym", ChecksumOpts{}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "sym", ChecksumOpts{}, nil)
 	require.NoError(t, err)
 	require.Equal(t, expectedSym, dgst)
 
-	dgst, err = cc.Checksum(context.TODO(), ref, "foo/ghi", ChecksumOpts{}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "foo/ghi", ChecksumOpts{}, nil)
 	require.NoError(t, err)
 	require.Equal(t, expectedSym, dgst)
 
 	expectedSym = digest.Digest("sha256:9b761577efcb1239cf4be971914c5d7404914dd32ff436401af1764dc5446b83")
 
 	// Broken symlink is not followed in subdirectory.
-	dgst, err = cc.Checksum(context.TODO(), ref, "foo", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "foo", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, expectedSym, dgst)
 
 	expectedSym = digest.Digest("sha256:2797e710c6d1a89ff2d91c834b828b1dc500f2982430a58241df8e146f4c4bb4")
 
 	// Same with wildcard used.
-	dgst, err = cc.Checksum(context.TODO(), ref, "fo?", ChecksumOpts{FollowLinks: true, Wildcard: true}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "fo?", ChecksumOpts{FollowLinks: true, Wildcard: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, expectedSym, dgst)
 
 	expectedSym = digest.Digest("sha256:9b761577efcb1239cf4be971914c5d7404914dd32ff436401af1764dc5446b83")
 
 	// Still works with exclude pattern.
-	dgst, err = cc.Checksum(context.TODO(), ref, "foo", ChecksumOpts{FollowLinks: true, ExcludePatterns: []string{"*.git"}}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "foo", ChecksumOpts{FollowLinks: true, ExcludePatterns: []string{"*.git"}}, nil)
 	require.NoError(t, err)
 	require.Equal(t, expectedSym, dgst)
 
-	err = ref.Release(context.TODO())
+	err = ref.Release(t.Context())
 	require.NoError(t, err)
 }
 
@@ -578,53 +578,53 @@ func TestChecksumBasicFile(t *testing.T) {
 	cc, err := newCacheContext(ref)
 	require.NoError(t, err)
 
-	_, err = cc.Checksum(context.TODO(), ref, "nosuch", ChecksumOpts{FollowLinks: true}, nil)
+	_, err = cc.Checksum(t.Context(), ref, "nosuch", ChecksumOpts{FollowLinks: true}, nil)
 	require.Error(t, err)
 
-	dgst, err := cc.Checksum(context.TODO(), ref, "foo", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err := cc.Checksum(t.Context(), ref, "foo", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, dgstFileData0, dgst)
 
 	// second file returns different hash
-	dgst, err = cc.Checksum(context.TODO(), ref, "bar", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "bar", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, digest.Digest("sha256:c2b5e234f5f38fc5864da7def04782f82501a40d46192e4207d5b3f0c3c4732b"), dgst)
 
 	// same file inside a directory
-	dgst, err = cc.Checksum(context.TODO(), ref, "d0/abc", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "d0/abc", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, dgstFileData0, dgst)
 
 	// repeat because codepath is different
-	dgst, err = cc.Checksum(context.TODO(), ref, "d0/abc", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "d0/abc", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, dgstFileData0, dgst)
 
 	// symlink to the same file is followed, returns same hash
-	dgst, err = cc.Checksum(context.TODO(), ref, "d0/def", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "d0/def", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, dgstFileData0, dgst)
 
-	_, err = cc.Checksum(context.TODO(), ref, "d0/ghi", ChecksumOpts{FollowLinks: true}, nil)
+	_, err = cc.Checksum(t.Context(), ref, "d0/ghi", ChecksumOpts{FollowLinks: true}, nil)
 	require.Error(t, err)
 	require.Equal(t, true, errors.Is(err, errNotFound))
 
-	dgst, err = cc.Checksum(context.TODO(), ref, "/", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "/", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, digest.Digest("sha256:427c9cf9ae98c0f81fb57a3076b965c7c149b6b0a85625ad4e884236649a42c6"), dgst)
 
-	dgst, err = cc.Checksum(context.TODO(), ref, "d0", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "d0", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, dgstDirD0, dgst)
 
-	err = ref.Release(context.TODO())
+	err = ref.Release(t.Context())
 	require.NoError(t, err)
 
 	// this is same directory as previous d0
@@ -639,12 +639,12 @@ func TestChecksumBasicFile(t *testing.T) {
 	cc, err = newCacheContext(ref)
 	require.NoError(t, err)
 
-	dgst, err = cc.Checksum(context.TODO(), ref, "/", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "/", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, dgstDirD0, dgst)
 
-	err = ref.Release(context.TODO())
+	err = ref.Release(t.Context())
 	require.NoError(t, err)
 
 	// test that removing broken symlink changes hash even though symlink itself can't be checksummed
@@ -658,13 +658,13 @@ func TestChecksumBasicFile(t *testing.T) {
 	cc, err = newCacheContext(ref)
 	require.NoError(t, err)
 
-	dgst, err = cc.Checksum(context.TODO(), ref, "/", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "/", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, dgstDirD0Modified, dgst)
 	require.NotEqual(t, dgstDirD0, dgst)
 
-	err = ref.Release(context.TODO())
+	err = ref.Release(t.Context())
 	require.NoError(t, err)
 
 	// test multiple scans, get checksum of nested file first
@@ -684,19 +684,19 @@ func TestChecksumBasicFile(t *testing.T) {
 	cc, err = newCacheContext(ref)
 	require.NoError(t, err)
 
-	dgst, err = cc.Checksum(context.TODO(), ref, "abc/aa/foo", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "abc/aa/foo", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, digest.Digest("sha256:1c67653c3cf95b12a0014e2c4cd1d776b474b3218aee54155d6ae27b9b999c54"), dgst)
 	require.NotEqual(t, dgstDirD0, dgst)
 
 	// this will force rescan
-	dgst, err = cc.Checksum(context.TODO(), ref, "d0", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "d0", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, dgstDirD0, dgst)
 
-	err = ref.Release(context.TODO())
+	err = ref.Release(t.Context())
 	require.NoError(t, err)
 }
 
@@ -736,40 +736,40 @@ func testChecksumIncludeExclude(t *testing.T, wildcard bool) {
 		return opts
 	}
 
-	dgstFoo, err := cc.Checksum(context.TODO(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"foo"}}), nil)
+	dgstFoo, err := cc.Checksum(t.Context(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"foo"}}), nil)
 	require.NoError(t, err)
 	require.NotEqual(t, digest.FromBytes([]byte{}), dgstFoo)
 
-	dgstFooBar, err := cc.Checksum(context.TODO(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"foo", "bar"}}), nil)
+	dgstFooBar, err := cc.Checksum(t.Context(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"foo", "bar"}}), nil)
 	require.NoError(t, err)
 	require.NotEqual(t, digest.FromBytes([]byte{}), dgstFooBar)
 
 	require.NotEqual(t, dgstFoo, dgstFooBar)
 
-	dgstD0, err := cc.Checksum(context.TODO(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"d0"}}), nil)
+	dgstD0, err := cc.Checksum(t.Context(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"d0"}}), nil)
 	require.NoError(t, err)
 	require.NotEqual(t, digest.FromBytes([]byte{}), dgstD0)
-	dgstD1, err := cc.Checksum(context.TODO(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"d1"}}), nil)
+	dgstD1, err := cc.Checksum(t.Context(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"d1"}}), nil)
 	require.NoError(t, err)
 	require.NotEqual(t, digest.FromBytes([]byte{}), dgstD1)
 
-	dgstD0Star, err := cc.Checksum(context.TODO(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"d0/*"}}), nil)
+	dgstD0Star, err := cc.Checksum(t.Context(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"d0/*"}}), nil)
 	require.NoError(t, err)
 	require.NotEqual(t, digest.FromBytes([]byte{}), dgstD0Star)
-	dgstD0AStar, err := cc.Checksum(context.TODO(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"d0/a*"}}), nil)
+	dgstD0AStar, err := cc.Checksum(t.Context(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"d0/a*"}}), nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstD0Star, dgstD0AStar)
-	dgstD1Star, err := cc.Checksum(context.TODO(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"d1/*"}}), nil)
+	dgstD1Star, err := cc.Checksum(t.Context(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"d1/*"}}), nil)
 	require.NoError(t, err)
 	require.NotEqual(t, digest.FromBytes([]byte{}), dgstD1Star)
 
 	// Nothing matches pattern, but d2's metadata should be captured in the
 	// checksum if d2 exists
-	dgstD2Foo, err := cc.Checksum(context.TODO(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"d2/foo"}}), nil)
+	dgstD2Foo, err := cc.Checksum(t.Context(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"d2/foo"}}), nil)
 	require.NoError(t, err)
 	require.Equal(t, digest.FromBytes([]byte{}), dgstD2Foo)
 
-	err = ref.Release(context.TODO())
+	err = ref.Release(t.Context())
 	require.NoError(t, err)
 
 	// add some files
@@ -790,54 +790,54 @@ func testChecksumIncludeExclude(t *testing.T, wildcard bool) {
 	cc, err = newCacheContext(ref)
 	require.NoError(t, err)
 
-	dgstFoo2, err := cc.Checksum(context.TODO(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"foo"}}), nil)
+	dgstFoo2, err := cc.Checksum(t.Context(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"foo"}}), nil)
 	require.NoError(t, err)
-	dgstFooBar2, err := cc.Checksum(context.TODO(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"foo", "bar"}}), nil)
+	dgstFooBar2, err := cc.Checksum(t.Context(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"foo", "bar"}}), nil)
 	require.NoError(t, err)
 
 	require.Equal(t, dgstFoo, dgstFoo2)
 	require.Equal(t, dgstFooBar, dgstFooBar2)
 
-	dgstD02, err := cc.Checksum(context.TODO(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"d0"}}), nil)
+	dgstD02, err := cc.Checksum(t.Context(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"d0"}}), nil)
 	require.NoError(t, err)
 	require.NotEqual(t, dgstD0, dgstD02)
 	require.NotEqual(t, digest.FromBytes([]byte{}), dgstD02)
 
-	dgstD12, err := cc.Checksum(context.TODO(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"d1"}}), nil)
+	dgstD12, err := cc.Checksum(t.Context(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"d1"}}), nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstD1, dgstD12)
 
-	dgstD0Star2, err := cc.Checksum(context.TODO(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"d0/*"}}), nil)
+	dgstD0Star2, err := cc.Checksum(t.Context(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"d0/*"}}), nil)
 	require.NoError(t, err)
 	require.NotEqual(t, dgstD0Star, dgstD0Star2)
 
-	dgstD0AStar2, err := cc.Checksum(context.TODO(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"d0/a*"}}), nil)
+	dgstD0AStar2, err := cc.Checksum(t.Context(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"d0/a*"}}), nil)
 	require.NoError(t, err)
 	// new file does not match the include pattern, so the digest should stay the same
 	require.Equal(t, dgstD0AStar, dgstD0AStar2)
 	require.NotEqual(t, digest.FromBytes([]byte{}), dgstD0AStar2)
 
-	dgstStarStarABC, err := cc.Checksum(context.TODO(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"**/abc"}}), nil)
+	dgstStarStarABC, err := cc.Checksum(t.Context(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"**/abc"}}), nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstD0AStar, dgstStarStarABC)
 
-	dgstD1Star2, err := cc.Checksum(context.TODO(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"d1/*"}}), nil)
+	dgstD1Star2, err := cc.Checksum(t.Context(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"d1/*"}}), nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstD1Star, dgstD1Star2)
 
-	dgstD0StarExclude, err := cc.Checksum(context.TODO(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"d0/*"}, ExcludePatterns: []string{"d0/xyz"}}), nil)
+	dgstD0StarExclude, err := cc.Checksum(t.Context(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"d0/*"}, ExcludePatterns: []string{"d0/xyz"}}), nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstD0Star, dgstD0StarExclude)
 
-	dgstD2Foo2, err := cc.Checksum(context.TODO(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"d2/foo"}}), nil)
+	dgstD2Foo2, err := cc.Checksum(t.Context(), ref, "", opts(ChecksumOpts{IncludePatterns: []string{"d2/foo"}}), nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstD2Foo, dgstD2Foo2)
 
-	dgstD2Foo3, err := cc.Checksum(context.TODO(), ref, "d2", opts(ChecksumOpts{IncludePatterns: []string{"foo"}}), nil)
+	dgstD2Foo3, err := cc.Checksum(t.Context(), ref, "d2", opts(ChecksumOpts{IncludePatterns: []string{"foo"}}), nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstD2Foo, dgstD2Foo3)
 
-	err = ref.Release(context.TODO())
+	err = ref.Release(t.Context())
 	require.NoError(t, err)
 }
 
@@ -862,13 +862,13 @@ func TestChecksumIncludeDoubleStar(t *testing.T) {
 	cc, err := newCacheContext(ref)
 	require.NoError(t, err)
 
-	dgst, err := cc.Checksum(context.TODO(), ref, "prefix/a", ChecksumOpts{IncludePatterns: []string{"**/foo/**"}}, nil)
+	dgst, err := cc.Checksum(t.Context(), ref, "prefix/a", ChecksumOpts{IncludePatterns: []string{"**/foo/**"}}, nil)
 	require.NoError(t, err)
 	// Nothing included
 	require.Equal(t, digest.FromBytes([]byte{}), dgst)
 
 	// Same, with Wildcard = true
-	dgst, err = cc.Checksum(context.TODO(), ref, "prefix/a", ChecksumOpts{IncludePatterns: []string{"**/foo/**"}, Wildcard: true}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "prefix/a", ChecksumOpts{IncludePatterns: []string{"**/foo/**"}, Wildcard: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, digest.FromBytes([]byte{}), dgst)
 
@@ -886,23 +886,23 @@ func TestChecksumIncludeDoubleStar(t *testing.T) {
 	cc, err = newCacheContext(ref)
 	require.NoError(t, err)
 
-	dgst, err = cc.Checksum(context.TODO(), ref, "prefix/a", ChecksumOpts{IncludePatterns: []string{"**/foo/**", "**/report"}}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "prefix/a", ChecksumOpts{IncludePatterns: []string{"**/foo/**", "**/report"}}, nil)
 	require.NoError(t, err)
 	// Now there is a file included
 	require.Equal(t, dgstDoubleStar, dgst)
 
 	// Same, with Wildcard = true
-	dgst, err = cc.Checksum(context.TODO(), ref, "prefix/a", ChecksumOpts{IncludePatterns: []string{"**/foo/**", "**/report"}, Wildcard: true}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "prefix/a", ChecksumOpts{IncludePatterns: []string{"**/foo/**", "**/report"}, Wildcard: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstDoubleStar, dgst)
 
 	// **/... pattern (https://github.com/moby/moby/issues/41433)
-	dgst, err = cc.Checksum(context.TODO(), ref, "prefix/a", ChecksumOpts{IncludePatterns: []string{"**/foo", "**/report"}}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "prefix/a", ChecksumOpts{IncludePatterns: []string{"**/foo", "**/report"}}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstDoubleStar, dgst)
 
 	// Same, with Wildcard = true
-	dgst, err = cc.Checksum(context.TODO(), ref, "prefix/a", ChecksumOpts{IncludePatterns: []string{"**/foo", "**/report"}, Wildcard: true}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "prefix/a", ChecksumOpts{IncludePatterns: []string{"**/foo", "**/report"}, Wildcard: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstDoubleStar, dgst)
 }
@@ -932,63 +932,63 @@ func TestChecksumIncludeSymlink(t *testing.T) {
 	cc, err := newCacheContext(ref)
 	require.NoError(t, err)
 
-	dgstD0, err := cc.Checksum(context.TODO(), ref, "data/d0", ChecksumOpts{IncludePatterns: []string{"**/foo"}}, nil)
+	dgstD0, err := cc.Checksum(t.Context(), ref, "data/d0", ChecksumOpts{IncludePatterns: []string{"**/foo"}}, nil)
 	require.NoError(t, err)
 	// File should be included
 	require.NotEqual(t, digest.FromBytes([]byte{}), dgstD0)
 
-	dgstD0Wildcard, err := cc.Checksum(context.TODO(), ref, "data/d*", ChecksumOpts{IncludePatterns: []string{"**/foo"}, Wildcard: true}, nil)
+	dgstD0Wildcard, err := cc.Checksum(t.Context(), ref, "data/d*", ChecksumOpts{IncludePatterns: []string{"**/foo"}, Wildcard: true}, nil)
 	require.NoError(t, err)
 	// File should be included
 	require.NotEqual(t, dgstD0Wildcard, digest.FromBytes([]byte{}), dgstD0Wildcard)
 
-	dgstMntD0, err := cc.Checksum(context.TODO(), ref, "mnt/data/d0", ChecksumOpts{IncludePatterns: []string{"**/foo"}}, nil)
+	dgstMntD0, err := cc.Checksum(t.Context(), ref, "mnt/data/d0", ChecksumOpts{IncludePatterns: []string{"**/foo"}}, nil)
 	require.NoError(t, err)
 	// File should be included despite symlink
 	require.Equal(t, dgstD0, dgstMntD0)
 
-	dgstD2, err := cc.Checksum(context.TODO(), ref, "data/d0/d1/d2", ChecksumOpts{IncludePatterns: []string{"**/foo"}}, nil)
+	dgstD2, err := cc.Checksum(t.Context(), ref, "data/d0/d1/d2", ChecksumOpts{IncludePatterns: []string{"**/foo"}}, nil)
 	require.NoError(t, err)
 	// File should be included
 	require.NotEqual(t, digest.FromBytes([]byte{}), dgstD2)
 
-	dgstD2Wildcard, err := cc.Checksum(context.TODO(), ref, "data/d0/d1/d*", ChecksumOpts{IncludePatterns: []string{"**/foo"}, Wildcard: true}, nil)
+	dgstD2Wildcard, err := cc.Checksum(t.Context(), ref, "data/d0/d1/d*", ChecksumOpts{IncludePatterns: []string{"**/foo"}, Wildcard: true}, nil)
 	require.NoError(t, err)
 	// File should be included
 	require.NotEqual(t, digest.FromBytes([]byte{}), dgstD2)
 
-	dgstD2InnerWildcard, err := cc.Checksum(context.TODO(), ref, "mnt/data/d0/d*/d2", ChecksumOpts{IncludePatterns: []string{"**/foo"}, Wildcard: true}, nil)
+	dgstD2InnerWildcard, err := cc.Checksum(t.Context(), ref, "mnt/data/d0/d*/d2", ChecksumOpts{IncludePatterns: []string{"**/foo"}, Wildcard: true}, nil)
 	require.NoError(t, err)
 	// File should be included
 	require.NotEqual(t, digest.FromBytes([]byte{}), dgstD2)
 
-	dgstMntD2, err := cc.Checksum(context.TODO(), ref, "mnt/data/d0/d1/d2", ChecksumOpts{IncludePatterns: []string{"**/foo"}}, nil)
+	dgstMntD2, err := cc.Checksum(t.Context(), ref, "mnt/data/d0/d1/d2", ChecksumOpts{IncludePatterns: []string{"**/foo"}}, nil)
 	require.NoError(t, err)
 	// File should be included despite symlink
 	require.Equal(t, dgstD2, dgstMntD2)
 
 	// Same, with Wildcard = true
-	dgstMntD0Wildcard, err := cc.Checksum(context.TODO(), ref, "mnt/data/d0", ChecksumOpts{IncludePatterns: []string{"**/foo"}, Wildcard: true}, nil)
+	dgstMntD0Wildcard, err := cc.Checksum(t.Context(), ref, "mnt/data/d0", ChecksumOpts{IncludePatterns: []string{"**/foo"}, Wildcard: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstD0, dgstMntD0Wildcard)
 
-	dgstMntD0Wildcard2, err := cc.Checksum(context.TODO(), ref, "mnt/data/d*", ChecksumOpts{IncludePatterns: []string{"**/foo"}, Wildcard: true}, nil)
+	dgstMntD0Wildcard2, err := cc.Checksum(t.Context(), ref, "mnt/data/d*", ChecksumOpts{IncludePatterns: []string{"**/foo"}, Wildcard: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstD0Wildcard, dgstMntD0Wildcard2)
 
-	dgstMntD2Wildcard, err := cc.Checksum(context.TODO(), ref, "mnt/data/d0/d1/d2", ChecksumOpts{IncludePatterns: []string{"**/foo"}, Wildcard: true}, nil)
+	dgstMntD2Wildcard, err := cc.Checksum(t.Context(), ref, "mnt/data/d0/d1/d2", ChecksumOpts{IncludePatterns: []string{"**/foo"}, Wildcard: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstD2, dgstMntD2Wildcard)
 
-	dgstMntD2Wildcard2, err := cc.Checksum(context.TODO(), ref, "mnt/data/d0/d1/d*", ChecksumOpts{IncludePatterns: []string{"**/foo"}, Wildcard: true}, nil)
+	dgstMntD2Wildcard2, err := cc.Checksum(t.Context(), ref, "mnt/data/d0/d1/d*", ChecksumOpts{IncludePatterns: []string{"**/foo"}, Wildcard: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstD2Wildcard, dgstMntD2Wildcard2)
 
-	dgstMntInnerWildcard, err := cc.Checksum(context.TODO(), ref, "mnt/data/d0/d*/d2", ChecksumOpts{IncludePatterns: []string{"**/foo"}, Wildcard: true}, nil)
+	dgstMntInnerWildcard, err := cc.Checksum(t.Context(), ref, "mnt/data/d0/d*/d2", ChecksumOpts{IncludePatterns: []string{"**/foo"}, Wildcard: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstD2InnerWildcard, dgstMntInnerWildcard)
 
-	dgstMntInnerWildcard2, err := cc.Checksum(context.TODO(), ref, "mnt/data/symlink-to-d0/d*/d2", ChecksumOpts{IncludePatterns: []string{"**/foo"}, Wildcard: true}, nil)
+	dgstMntInnerWildcard2, err := cc.Checksum(t.Context(), ref, "mnt/data/symlink-to-d0/d*/d2", ChecksumOpts{IncludePatterns: []string{"**/foo"}, Wildcard: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstD2InnerWildcard, dgstMntInnerWildcard2)
 }
@@ -1026,19 +1026,19 @@ func TestHandleChange(t *testing.T) {
 	err = emit(cc.HandleChange, changeStream(ch))
 	require.NoError(t, err)
 
-	dgstFoo, err := cc.Checksum(context.TODO(), ref, "foo", ChecksumOpts{FollowLinks: true}, nil)
+	dgstFoo, err := cc.Checksum(t.Context(), ref, "foo", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, dgstFileData0, dgstFoo)
 
 	// symlink to the same file is followed, returns same hash
-	dgst, err := cc.Checksum(context.TODO(), ref, "d0/def", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err := cc.Checksum(t.Context(), ref, "d0/def", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, dgstFoo, dgst)
 
 	// symlink to the same file is followed, returns same hash
-	dgst, err = cc.Checksum(context.TODO(), ref, "d0", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "d0", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, dgstDirD0, dgst)
@@ -1050,7 +1050,7 @@ func TestHandleChange(t *testing.T) {
 	err = emit(cc.HandleChange, changeStream(ch))
 	require.NoError(t, err)
 
-	dgst, err = cc.Checksum(context.TODO(), ref, "d0", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "d0", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstDirD0Modified, dgst)
 
@@ -1061,15 +1061,15 @@ func TestHandleChange(t *testing.T) {
 	err = emit(cc.HandleChange, changeStream(ch))
 	require.NoError(t, err)
 
-	_, err = cc.Checksum(context.TODO(), ref, "d0", ChecksumOpts{FollowLinks: true}, nil)
+	_, err = cc.Checksum(t.Context(), ref, "d0", ChecksumOpts{FollowLinks: true}, nil)
 	require.Error(t, err)
 	require.Equal(t, true, errors.Is(err, errNotFound))
 
-	_, err = cc.Checksum(context.TODO(), ref, "d0/abc", ChecksumOpts{FollowLinks: true}, nil)
+	_, err = cc.Checksum(t.Context(), ref, "d0/abc", ChecksumOpts{FollowLinks: true}, nil)
 	require.Error(t, err)
 	require.Equal(t, true, errors.Is(err, errNotFound))
 
-	err = ref.Release(context.TODO())
+	err = ref.Release(t.Context())
 	require.NoError(t, err)
 }
 
@@ -1104,7 +1104,7 @@ func TestHandleRecursiveDir(t *testing.T) {
 	err = emit(cc.HandleChange, changeStream(ch))
 	require.NoError(t, err)
 
-	dgst, err := cc.Checksum(context.TODO(), ref, "d0/foo/bar", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err := cc.Checksum(t.Context(), ref, "d0/foo/bar", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 
 	ch = []string{
@@ -1116,11 +1116,11 @@ func TestHandleRecursiveDir(t *testing.T) {
 	err = emit(cc.HandleChange, changeStream(ch))
 	require.NoError(t, err)
 
-	dgst2, err := cc.Checksum(context.TODO(), ref, "d1", ChecksumOpts{FollowLinks: true}, nil)
+	dgst2, err := cc.Checksum(t.Context(), ref, "d1", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgst2, dgst)
 
-	_, err = cc.Checksum(context.TODO(), ref, "", ChecksumOpts{FollowLinks: true}, nil)
+	_, err = cc.Checksum(t.Context(), ref, "", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 }
 
@@ -1153,7 +1153,7 @@ func TestChecksumUnorderedFiles(t *testing.T) {
 	err = emit(cc.HandleChange, changeStream(ch))
 	require.NoError(t, err)
 
-	dgst, err := cc.Checksum(context.TODO(), ref, "d0", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err := cc.Checksum(t.Context(), ref, "d0", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, digest.Digest("sha256:14276c302c940a80f82ca5477bf766c98a24702d6a9948ee71bb277cdad3ae05"), dgst)
@@ -1173,7 +1173,7 @@ func TestChecksumUnorderedFiles(t *testing.T) {
 	err = emit(cc.HandleChange, changeStream(ch))
 	require.NoError(t, err)
 
-	dgst2, err := cc.Checksum(context.TODO(), ref, "d0", ChecksumOpts{FollowLinks: true}, nil)
+	dgst2, err := cc.Checksum(t.Context(), ref, "d0", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 
 	require.NotEqual(t, dgst, dgst2)
@@ -1196,15 +1196,15 @@ func TestSymlinkInPathScan(t *testing.T) {
 	}
 	ref := createRef(t, cm, ch)
 
-	dgst, err := Checksum(context.TODO(), ref, "d0/def/foo", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err := Checksum(t.Context(), ref, "d0/def/foo", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstFileData0, dgst)
 
-	dgst, err = Checksum(context.TODO(), ref, "d0/def/foo", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err = Checksum(t.Context(), ref, "d0/def/foo", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstFileData0, dgst)
 
-	err = ref.Release(context.TODO())
+	err = ref.Release(t.Context())
 	require.NoError(t, err)
 }
 
@@ -1228,14 +1228,14 @@ func TestSymlinkNeedsScan(t *testing.T) {
 	ref := createRef(t, cm, ch)
 
 	// scan the d0 path containing the symlink that doesn't get followed
-	_, err = Checksum(context.TODO(), ref, "d0/d1", ChecksumOpts{FollowLinks: true}, nil)
+	_, err = Checksum(t.Context(), ref, "d0/d1", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 
-	dgst, err := Checksum(context.TODO(), ref, "d0/d1/def/foo", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err := Checksum(t.Context(), ref, "d0/d1/def/foo", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstFileData0, dgst)
 
-	err = ref.Release(context.TODO())
+	err = ref.Release(t.Context())
 	require.NoError(t, err)
 }
 
@@ -1256,11 +1256,11 @@ func TestSymlinkAbsDirSuffix(t *testing.T) {
 	}
 	ref := createRef(t, cm, ch)
 
-	dgst, err := Checksum(context.TODO(), ref, "link/foo", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err := Checksum(t.Context(), ref, "link/foo", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstFileData0, dgst)
 
-	err = ref.Release(context.TODO())
+	err = ref.Release(t.Context())
 	require.NoError(t, err)
 }
 
@@ -1289,31 +1289,31 @@ func TestSymlinkThroughParent(t *testing.T) {
 	}
 	ref := createRef(t, cm, ch)
 
-	dgst, err := Checksum(context.TODO(), ref, "link1/sub/foo", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err := Checksum(t.Context(), ref, "link1/sub/foo", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstFileData0, dgst)
 
-	dgst, err = Checksum(context.TODO(), ref, "link2/sub/foo", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err = Checksum(t.Context(), ref, "link2/sub/foo", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstFileData0, dgst)
 
-	dgst, err = Checksum(context.TODO(), ref, "link3/sub/foo", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err = Checksum(t.Context(), ref, "link3/sub/foo", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstFileData0, dgst)
 
-	dgst, err = Checksum(context.TODO(), ref, "link4/sub/foo", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err = Checksum(t.Context(), ref, "link4/sub/foo", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstFileData0, dgst)
 
-	dgst, err = Checksum(context.TODO(), ref, "link5/sub/foo", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err = Checksum(t.Context(), ref, "link5/sub/foo", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstFileData0, dgst)
 
-	dgst, err = Checksum(context.TODO(), ref, "link1/sub/link/sub/foo", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err = Checksum(t.Context(), ref, "link1/sub/link/sub/foo", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstFileData0, dgst)
 
-	err = ref.Release(context.TODO())
+	err = ref.Release(t.Context())
 	require.NoError(t, err)
 }
 
@@ -1354,31 +1354,31 @@ func TestSymlinkInPathHandleChange(t *testing.T) {
 	err = emit(cc.HandleChange, changeStream(ch))
 	require.NoError(t, err)
 
-	dgst, err := cc.Checksum(context.TODO(), ref, "d1/def/foo", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err := cc.Checksum(t.Context(), ref, "d1/def/foo", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstFileData0, dgst)
 
-	dgst, err = cc.Checksum(context.TODO(), ref, "d1/def/bar/abc", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err = cc.Checksum(t.Context(), ref, "d1/def/bar/abc", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstFileData0, dgst)
 
-	dgstFileData0, err := cc.Checksum(context.TODO(), ref, "sub/d0", ChecksumOpts{FollowLinks: true}, nil)
+	dgstFileData0, err := cc.Checksum(t.Context(), ref, "sub/d0", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstDirD0, dgstFileData0)
 
-	dgstFileData0, err = cc.Checksum(context.TODO(), ref, "d1/def/baz", ChecksumOpts{FollowLinks: true}, nil)
+	dgstFileData0, err = cc.Checksum(t.Context(), ref, "d1/def/baz", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstDirD0, dgstFileData0)
 
-	dgstFileData0, err = cc.Checksum(context.TODO(), ref, "d1/def/bay", ChecksumOpts{FollowLinks: true}, nil)
+	dgstFileData0, err = cc.Checksum(t.Context(), ref, "d1/def/bay", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstDirD0, dgstFileData0)
 
-	dgstFileData0, err = cc.Checksum(context.TODO(), ref, "link", ChecksumOpts{FollowLinks: true}, nil)
+	dgstFileData0, err = cc.Checksum(t.Context(), ref, "link", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstDirD0, dgstFileData0)
 
-	err = ref.Release(context.TODO())
+	err = ref.Release(t.Context())
 	require.NoError(t, err)
 }
 
@@ -1403,21 +1403,21 @@ func TestPersistence(t *testing.T) {
 	ref := createRef(t, cm, ch)
 	id := ref.ID()
 
-	dgst, err := Checksum(context.TODO(), ref, "foo", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err := Checksum(t.Context(), ref, "foo", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstFileData0, dgst)
 
-	err = ref.Release(context.TODO())
+	err = ref.Release(t.Context())
 	require.NoError(t, err)
 
-	ref, err = cm.Get(context.TODO(), id, nil)
+	ref, err = cm.Get(t.Context(), id, nil)
 	require.NoError(t, err)
 
-	dgst, err = Checksum(context.TODO(), ref, "foo", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err = Checksum(t.Context(), ref, "foo", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstFileData0, dgst)
 
-	err = ref.Release(context.TODO())
+	err = ref.Release(t.Context())
 	require.NoError(t, err)
 
 	time.Sleep(100 * time.Millisecond) // saving happens on the background
@@ -1428,10 +1428,10 @@ func TestPersistence(t *testing.T) {
 	cm, cleanup = setupCacheManager(t, tmpdir, "native", snapshotter)
 	t.Cleanup(cleanup)
 
-	ref, err = cm.Get(context.TODO(), id, nil)
+	ref, err = cm.Get(t.Context(), id, nil)
 	require.NoError(t, err)
 
-	dgst, err = Checksum(context.TODO(), ref, "foo", ChecksumOpts{FollowLinks: true}, nil)
+	dgst, err = Checksum(t.Context(), ref, "foo", ChecksumOpts{FollowLinks: true}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dgstFileData0, dgst)
 }
@@ -1466,11 +1466,11 @@ func TestChecksumUpdateDirectory(t *testing.T) {
 	err = emit(cc.HandleChange, changeStream(ch))
 	require.NoError(t, err)
 
-	fooDgst1, err := cc.Checksum(context.TODO(), ref, "d0/foo", ChecksumOpts{}, nil)
+	fooDgst1, err := cc.Checksum(t.Context(), ref, "d0/foo", ChecksumOpts{}, nil)
 	require.NoError(t, err)
 	require.Equal(t, digest.Digest("sha256:e76717544f71725bd759a981554ca17c286b3d222598f46a671b983fd2b8172d"), fooDgst1)
 
-	barDgst1, err := cc.Checksum(context.TODO(), ref, "d0/foo/bar", ChecksumOpts{}, nil)
+	barDgst1, err := cc.Checksum(t.Context(), ref, "d0/foo/bar", ChecksumOpts{}, nil)
 	require.NoError(t, err)
 	require.Equal(t, digest.Digest("sha256:cd8e75bca50f2d695f220d0cb0997d8ead387e4f926e8669a92d7f104cc9885b"), barDgst1)
 
@@ -1486,13 +1486,13 @@ func TestChecksumUpdateDirectory(t *testing.T) {
 	require.NoError(t, err)
 
 	// d0/foo should have a different digest now
-	fooDgst2, err := cc.Checksum(context.TODO(), ref, "d0/foo", ChecksumOpts{}, nil)
+	fooDgst2, err := cc.Checksum(t.Context(), ref, "d0/foo", ChecksumOpts{}, nil)
 	require.NoError(t, err)
 	require.NotEqual(t, fooDgst1, fooDgst2)
 	require.Equal(t, digest.Digest("sha256:3a729f6ba0d3d74c6ade7d118b08b46e37e447afdad7fc6e258dbba12fa80141"), fooDgst2)
 
 	// but files under the dir should be the same as before
-	barDgst2, err := cc.Checksum(context.TODO(), ref, "d0/foo/bar", ChecksumOpts{}, nil)
+	barDgst2, err := cc.Checksum(t.Context(), ref, "d0/foo/bar", ChecksumOpts{}, nil)
 	require.NoError(t, err)
 	require.Equal(t, barDgst1, barDgst2)
 
@@ -1503,14 +1503,14 @@ func TestChecksumUpdateDirectory(t *testing.T) {
 	require.NoError(t, err)
 
 	// d0/foo should again have a different digest now
-	fooDgst3, err := cc.Checksum(context.TODO(), ref, "d0/foo", ChecksumOpts{}, nil)
+	fooDgst3, err := cc.Checksum(t.Context(), ref, "d0/foo", ChecksumOpts{}, nil)
 	require.NoError(t, err)
 	require.NotEqual(t, fooDgst1, fooDgst3)
 	require.NotEqual(t, fooDgst2, fooDgst3)
 	require.Equal(t, digest.Digest("sha256:1c67653c3cf95b12a0014e2c4cd1d776b474b3218aee54155d6ae27b9b999c54"), fooDgst3)
 
 	// files under the old dir should not exist anymore
-	_, err = cc.Checksum(context.TODO(), ref, "d0/foo/bar", ChecksumOpts{}, nil)
+	_, err = cc.Checksum(t.Context(), ref, "d0/foo/bar", ChecksumOpts{}, nil)
 	require.ErrorContains(t, err, "not found")
 }
 
@@ -1535,11 +1535,11 @@ func TestChecksumIdenticalWithNoopExclude(t *testing.T) {
 
 	expectedDgst := "sha256:8f36dfd60011a21345427f4d3177b1223e11fbb732c18dd07cd8b2a27a0b53ca"
 
-	dgst, err := cc.Checksum(context.TODO(), ref, "test", ChecksumOpts{}, nil)
+	dgst, err := cc.Checksum(t.Context(), ref, "test", ChecksumOpts{}, nil)
 	require.NoError(t, err)
 	require.Equal(t, expectedDgst, string(dgst))
 
-	dgst, err = cc.Checksum(context.TODO(), ref, "test", ChecksumOpts{
+	dgst, err = cc.Checksum(t.Context(), ref, "test", ChecksumOpts{
 		ExcludePatterns: []string{"*.git"},
 	}, nil)
 	require.NoError(t, err)
@@ -1552,10 +1552,10 @@ func createRef(t *testing.T, cm cache.Manager, files []string) cache.ImmutableRe
 		t.Skip("Depends on unimplemented containerd bind-mount support on Windows")
 	}
 
-	mref, err := cm.New(context.TODO(), nil, nil, cache.CachePolicyRetain)
+	mref, err := cm.New(t.Context(), nil, nil, cache.CachePolicyRetain)
 	require.NoError(t, err)
 
-	mounts, err := mref.Mount(context.TODO(), false, nil)
+	mounts, err := mref.Mount(t.Context(), false, nil)
 	require.NoError(t, err)
 
 	lm := snapshot.LocalMounter(mounts)
@@ -1567,7 +1567,7 @@ func createRef(t *testing.T, cm cache.Manager, files []string) cache.ImmutableRe
 	lm.Unmount()
 	require.NoError(t, err)
 
-	ref, err := mref.Commit(context.TODO())
+	ref, err := mref.Commit(t.Context())
 	require.NoError(t, err)
 
 	return ref

--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -126,7 +126,7 @@ func newCacheManager(ctx context.Context, t *testing.T, opt cmOpt) (co *cmOut, c
 	mdb := ctdmetadata.NewDB(db, store, map[string]snapshots.Snapshotter{
 		opt.snapshotterName: opt.snapshotter,
 	})
-	if err := mdb.Init(context.TODO()); err != nil {
+	if err := mdb.Init(t.Context()); err != nil {
 		return nil, nil, err
 	}
 
@@ -171,14 +171,15 @@ func newCacheManager(ctx context.Context, t *testing.T, opt cmOpt) (co *cmOut, c
 
 func TestSharableMountPoolCleanup(t *testing.T) {
 	t.Parallel()
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 
 	tmpdir := t.TempDir()
 
 	// Emulate the situation where the pool dir is dirty
 	mountPoolDir := filepath.Join(tmpdir, "cachemounts")
 	require.NoError(t, os.MkdirAll(mountPoolDir, 0700))
-	_, err := os.MkdirTemp(mountPoolDir, "buildkit")
+	// not using t.TempDir() here because the dir must be created inside mountPoolDir
+	_, err := os.MkdirTemp(mountPoolDir, "buildkit") //nolint:usetesting
 	require.NoError(t, err)
 
 	// Initialize cache manager and check if pool is cleaned up
@@ -196,7 +197,7 @@ func TestSharableMountPoolCleanup(t *testing.T) {
 func TestManager(t *testing.T) {
 	t.Parallel()
 
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 
 	tmpdir := t.TempDir()
 
@@ -329,7 +330,7 @@ func TestManager(t *testing.T) {
 
 func TestLazyGetByBlob(t *testing.T) {
 	t.Parallel()
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 
 	tmpdir := t.TempDir()
 
@@ -372,7 +373,7 @@ func TestLazyGetByBlob(t *testing.T) {
 
 func TestMergeBlobchainID(t *testing.T) {
 	t.Parallel()
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 
 	tmpdir := t.TempDir()
 
@@ -443,7 +444,7 @@ func TestSnapshotExtract(t *testing.T) {
 	}
 
 	t.Parallel()
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 
 	tmpdir := t.TempDir()
 
@@ -518,7 +519,7 @@ func TestSnapshotExtract(t *testing.T) {
 
 	id := snap.ID()
 
-	err = snap.Release(context.TODO())
+	err = snap.Release(t.Context())
 	require.NoError(t, err)
 
 	buf = pruneResultBuffer()
@@ -537,7 +538,7 @@ func TestSnapshotExtract(t *testing.T) {
 
 	checkDiskUsage(ctx, t, cm, 2, 0)
 
-	err = snap2.Release(context.TODO())
+	err = snap2.Release(t.Context())
 	require.NoError(t, err)
 
 	checkDiskUsage(ctx, t, cm, 1, 1)
@@ -557,7 +558,7 @@ func TestSnapshotExtract(t *testing.T) {
 
 	checkNumBlobs(ctx, t, co.cs, 1)
 
-	err = snap.Release(context.TODO())
+	err = snap.Release(t.Context())
 	require.NoError(t, err)
 
 	buf = pruneResultBuffer()
@@ -580,7 +581,7 @@ func TestExtractOnMutable(t *testing.T) {
 	}
 
 	t.Parallel()
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 
 	tmpdir := t.TempDir()
 
@@ -621,7 +622,7 @@ func TestExtractOnMutable(t *testing.T) {
 	require.NoError(t, err)
 
 	err = snap.(*immutableRef).setBlob(leaseCtx, desc)
-	done(context.TODO())
+	done(t.Context())
 	require.NoError(t, err)
 	err = snap.(*immutableRef).computeChainMetadata(leaseCtx, map[string]struct{}{snap.ID(): {}})
 	require.NoError(t, err)
@@ -629,7 +630,7 @@ func TestExtractOnMutable(t *testing.T) {
 	snap2, err := cm.GetByBlob(ctx, desc2, snap)
 	require.NoError(t, err)
 
-	err = snap.Release(context.TODO())
+	err = snap.Release(t.Context())
 	require.NoError(t, err)
 
 	require.Equal(t, false, !snap2.(*immutableRef).getBlobOnly())
@@ -663,7 +664,7 @@ func TestExtractOnMutable(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 2, len(dirs))
 
-	err = snap2.Release(context.TODO())
+	err = snap2.Release(t.Context())
 	require.NoError(t, err)
 
 	checkDiskUsage(ctx, t, cm, 0, 2)
@@ -686,7 +687,7 @@ func TestExtractOnMutable(t *testing.T) {
 
 func TestSetBlob(t *testing.T) {
 	t.Parallel()
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 
 	tmpdir := t.TempDir()
 
@@ -705,7 +706,7 @@ func TestSetBlob(t *testing.T) {
 
 	ctx, done, err := leaseutil.WithLease(ctx, co.lm, leaseutil.MakeTemporary)
 	require.NoError(t, err)
-	defer done(context.TODO())
+	defer done(t.Context())
 
 	cm := co.manager
 
@@ -724,7 +725,7 @@ func TestSetBlob(t *testing.T) {
 
 	ctx, clean, err := leaseutil.WithLease(ctx, co.lm)
 	require.NoError(t, err)
-	defer clean(context.TODO())
+	defer clean(t.Context())
 
 	b, desc, err := mapToBlob(map[string]string{"foo": "bar"}, true)
 	require.NoError(t, err)
@@ -852,14 +853,14 @@ func TestSetBlob(t *testing.T) {
 	}, snap3)
 	require.Error(t, err)
 
-	clean(context.TODO())
+	clean(t.Context())
 
 	// snap.SetBlob()
 }
 
 func TestPrune(t *testing.T) {
 	t.Parallel()
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 
 	tmpdir := t.TempDir()
 
@@ -971,7 +972,7 @@ func TestPrune(t *testing.T) {
 func TestLazyCommit(t *testing.T) {
 	t.Parallel()
 
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 
 	tmpdir := t.TempDir()
 
@@ -1130,7 +1131,7 @@ func TestLoopLeaseContent(t *testing.T) {
 		t.Skipf("unsupported GOOS: %s", runtime.GOOS)
 	}
 
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 
 	tmpdir := t.TempDir()
 
@@ -1245,7 +1246,7 @@ func TestSharingCompressionVariant(t *testing.T) {
 		t.Skipf("unsupported GOOS: %s", runtime.GOOS)
 	}
 
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 
 	tmpdir := t.TempDir()
 
@@ -1511,7 +1512,7 @@ func TestConversion(t *testing.T) {
 		t.Skipf("unsupported GOOS: %s", runtime.GOOS)
 	}
 
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 
 	tmpdir := t.TempDir()
 
@@ -1606,7 +1607,7 @@ func TestGetRemotes(t *testing.T) {
 		t.Skipf("unsupported GOOS: %s", runtime.GOOS)
 	}
 
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 
 	tmpdir := t.TempDir()
 
@@ -1623,7 +1624,7 @@ func TestGetRemotes(t *testing.T) {
 
 	ctx, done, err := leaseutil.WithLease(ctx, co.lm, leaseutil.MakeTemporary)
 	require.NoError(t, err)
-	defer done(context.TODO())
+	defer done(t.Context())
 
 	contentBuffer := contentutil.NewBuffer()
 
@@ -1908,7 +1909,7 @@ func checkVariantsCoverage(ctx context.Context, t *testing.T, variants idxToVari
 func TestNondistributableBlobs(t *testing.T) {
 	t.Parallel()
 
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 
 	tmpdir := t.TempDir()
 
@@ -1926,7 +1927,7 @@ func TestNondistributableBlobs(t *testing.T) {
 
 	ctx, done, err := leaseutil.WithLease(ctx, co.lm, leaseutil.MakeTemporary)
 	require.NoError(t, err)
-	defer done(context.TODO())
+	defer done(t.Context())
 
 	contentBuffer := contentutil.NewBuffer()
 	descHandlers := DescHandlers(map[digest.Digest]*DescHandler{})
@@ -2037,7 +2038,7 @@ func TestMergeOp(t *testing.T) {
 	// Tests for the fs merge logic are in client_test and snapshotter_test.
 	t.Parallel()
 
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 
 	tmpdir := t.TempDir()
 
@@ -2155,7 +2156,7 @@ func TestDiffOp(t *testing.T) {
 	// Tests for the fs diff logic are in client_test and snapshotter_test.
 	t.Parallel()
 
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 
 	tmpdir := t.TempDir()
 
@@ -2257,7 +2258,7 @@ func TestLoadHalfFinalizedRef(t *testing.T) {
 	// removed and the immutable ref will continue to be usable.
 	t.Parallel()
 
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 
 	tmpdir := t.TempDir()
 
@@ -2338,7 +2339,7 @@ func TestMountReadOnly(t *testing.T) {
 		t.Skipf("unsupported GOOS: %s", runtime.GOOS)
 	}
 
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 
 	tmpdir := t.TempDir()
 
@@ -2404,7 +2405,7 @@ func TestLoadBrokenParents(t *testing.T) {
 	// of other parent refs
 	t.Parallel()
 
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 
 	tmpdir := t.TempDir()
 
@@ -2775,7 +2776,7 @@ func mapToSystemTarBlob(t *testing.T, m map[string]string) ([]byte, ocispecs.Des
 		}
 	}
 
-	cmd := exec.CommandContext(context.TODO(), "tar", "-C", tmpdir, "-c", ".")
+	cmd := exec.CommandContext(t.Context(), "tar", "-C", tmpdir, "-c", ".")
 	tarout, err := cmd.Output()
 	if err != nil {
 		return nil, ocispecs.Descriptor{}, err

--- a/cache/metadata/metadata_test.go
+++ b/cache/metadata/metadata_test.go
@@ -1,7 +1,6 @@
 package metadata
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 
@@ -141,7 +140,7 @@ func TestIndexes(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	sis, err := s.Search(ctx, "tag:baz", false)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(sis))

--- a/cache/remotecache/v1/chains_test.go
+++ b/cache/remotecache/v1/chains_test.go
@@ -1,7 +1,6 @@
 package cacheimport
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -46,7 +45,7 @@ func TestSimpleMarshal(t *testing.T) {
 
 	addRecords()
 
-	cfg, _, err := cc.Marshal(context.TODO())
+	cfg, _, err := cc.Marshal(t.Context())
 	require.NoError(t, err)
 
 	require.Equal(t, 2, len(cfg.Layers))
@@ -78,7 +77,7 @@ func TestSimpleMarshal(t *testing.T) {
 	// adding same info again doesn't produce anything extra
 	addRecords()
 
-	cfg2, descPairs, err := cc.Marshal(context.TODO())
+	cfg2, descPairs, err := cc.Marshal(t.Context())
 	require.NoError(t, err)
 
 	require.Equal(t, cfg, cfg2)
@@ -91,7 +90,7 @@ func TestSimpleMarshal(t *testing.T) {
 	err = Parse(dt, descPairs, newChains)
 	require.NoError(t, err)
 
-	cfg3, _, err := cc.Marshal(context.TODO())
+	cfg3, _, err := cc.Marshal(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, cfg, cfg3)
 
@@ -99,7 +98,7 @@ func TestSimpleMarshal(t *testing.T) {
 	_, ok, err := cc.Add(outputKey(dgst("bay"), 0), nil, nil)
 	require.NoError(t, err)
 	require.True(t, ok)
-	cfg, _, err = cc.Marshal(context.TODO())
+	cfg, _, err = cc.Marshal(t.Context())
 	require.NoError(t, err)
 
 	require.Equal(t, 2, len(cfg.Layers))

--- a/client/client_export_image_test.go
+++ b/client/client_export_image_test.go
@@ -366,7 +366,7 @@ func testBuildExportWithUncompressed(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 
 	allCompressedTarget := registry + "/buildkit/build/exporter:withallcompressed"
-	_, err = c.Solve(context.TODO(), def, SolveOpt{
+	_, err = c.Solve(t.Context(), def, SolveOpt{
 		Exports: []ExportEntry{
 			{
 				Type: ExporterImage,

--- a/client/client_export_local_test.go
+++ b/client/client_export_local_test.go
@@ -483,7 +483,7 @@ func testMultipleExporters(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 	defer c.Close()
 
-	def, err := llb.Scratch().File(llb.Mkfile("foo.txt", 0o755, nil)).Marshal(context.TODO())
+	def, err := llb.Scratch().File(llb.Mkfile("foo.txt", 0o755, nil)).Marshal(t.Context())
 	require.NoError(t, err)
 
 	destDir, destDir2 := t.TempDir(), t.TempDir()
@@ -605,7 +605,7 @@ func testMultipleExporters(t *testing.T, sb integration.Sandbox) {
 func testSessionExporter(t *testing.T, sb integration.Sandbox) {
 	integration.SkipOnPlatform(t, "windows", "This test passed locally on windows, but failed on github action")
 	workers.CheckFeatureCompat(t, sb, workers.FeatureOCIExporter, workers.FeatureOCILayout)
-	c, err := New(context.TODO(), sb.Address())
+	c, err := New(t.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
 

--- a/client/client_export_metadata_test.go
+++ b/client/client_export_metadata_test.go
@@ -1935,9 +1935,7 @@ func testSourceDateEpochClamp(t *testing.T, sb integration.Sandbox) {
 	def, err := busybox.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(destDir)
+	destDir := t.TempDir()
 
 	out := filepath.Join(destDir, "out.tar")
 	outW, err := os.Create(out)
@@ -2120,9 +2118,7 @@ func testSourceDateEpochLayerTimestamps(t *testing.T, sb integration.Sandbox) {
 	def, err := st.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(destDir)
+	destDir := t.TempDir()
 
 	out := filepath.Join(destDir, "out.tar")
 	outW, err := os.Create(out)
@@ -2180,9 +2176,7 @@ func testSourceDateEpochLocalExporter(t *testing.T, sb integration.Sandbox) {
 	def, err := st.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(destDir)
+	destDir := t.TempDir()
 
 	tm := time.Date(2015, time.October, 21, 7, 28, 0, 0, time.UTC)
 
@@ -2231,9 +2225,7 @@ func testSourceDateEpochReset(t *testing.T, sb integration.Sandbox) {
 	def, err := st.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(destDir)
+	destDir := t.TempDir()
 
 	out := filepath.Join(destDir, "out.tar")
 	outW, err := os.Create(out)
@@ -2295,9 +2287,7 @@ func testSourceDateEpochTarExporter(t *testing.T, sb integration.Sandbox) {
 	def, err := st.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(destDir)
+	destDir := t.TempDir()
 
 	out := filepath.Join(destDir, "out.tar")
 	outW, err := os.Create(out)

--- a/client/client_git_source_test.go
+++ b/client/client_git_source_test.go
@@ -65,7 +65,7 @@ func testGitBundleRoundTrip(t *testing.T, sb integration.Sandbox) {
 	)
 	require.NoError(t, err)
 
-	cmd := exec.CommandContext(context.TODO(), "git", "rev-parse", "HEAD")
+	cmd := exec.CommandContext(t.Context(), "git", "rev-parse", "HEAD")
 	cmd.Dir = gitDir
 	out, err := cmd.Output()
 	require.NoError(t, err)
@@ -105,10 +105,10 @@ func testGitBundleRoundTrip(t *testing.T, sb integration.Sandbox) {
 	err = runInDir(localBare, fmt.Sprintf("git fetch %s +refs/*:refs/*", bundlePath))
 	require.NoError(t, err)
 	//nolint:gosec // Test-controlled temp dir and commit SHA are not attacker input.
-	cmd = exec.CommandContext(context.TODO(), "git", "--git-dir="+localBare, "cat-file", "-e", headSha+"^{commit}")
+	cmd = exec.CommandContext(t.Context(), "git", "--git-dir="+localBare, "cat-file", "-e", headSha+"^{commit}")
 	require.NoError(t, cmd.Run(), "bundle does not contain expected commit")
 	//nolint:gosec // Test-controlled temp dir is not attacker input.
-	cmd = exec.CommandContext(context.TODO(), "git", "--git-dir="+localBare, "rev-parse", "--verify", "refs/heads/master")
+	cmd = exec.CommandContext(t.Context(), "git", "--git-dir="+localBare, "rev-parse", "--verify", "refs/heads/master")
 	masterOut, err := cmd.CombinedOutput()
 	require.NoError(t, err, "bundle should carry user's ref refs/heads/master; output=%q", string(masterOut))
 	require.Equal(t, headSha, strings.TrimSpace(string(masterOut)))
@@ -205,7 +205,7 @@ func testGitBundleRoundTrip(t *testing.T, sb integration.Sandbox) {
 		// llb.Git should produce a checkout whose .git carries
 		// refs/heads/master, either loose or packed.
 		//nolint:gosec // Test-controlled export dir is not attacker input.
-		cmd := exec.CommandContext(context.TODO(), "git",
+		cmd := exec.CommandContext(t.Context(), "git",
 			"--git-dir="+filepath.Join(destDir, ".git"),
 			"rev-parse", "--verify", "refs/heads/master")
 		refOut, err := cmd.CombinedOutput()
@@ -214,7 +214,7 @@ func testGitBundleRoundTrip(t *testing.T, sb integration.Sandbox) {
 
 		// HEAD must point at the pinned commit.
 		//nolint:gosec // Test-controlled export dir is not attacker input.
-		cmd = exec.CommandContext(context.TODO(), "git",
+		cmd = exec.CommandContext(t.Context(), "git",
 			"--git-dir="+filepath.Join(destDir, ".git"),
 			"rev-parse", "HEAD")
 		gotOut, err := cmd.CombinedOutput()
@@ -319,7 +319,7 @@ func testGitBundleRoundTripRegistry(t *testing.T, sb integration.Sandbox) {
 	)
 	require.NoError(t, err)
 
-	cmd := exec.CommandContext(context.TODO(), "git", "rev-parse", "HEAD")
+	cmd := exec.CommandContext(t.Context(), "git", "rev-parse", "HEAD")
 	cmd.Dir = gitDir
 	out, err := cmd.Output()
 	require.NoError(t, err)
@@ -456,13 +456,13 @@ func testGitResolveMutatedSource(t *testing.T, sb integration.Sandbox) {
 	err = runInDir(gitDir, gitCommands...)
 	require.NoError(t, err)
 
-	cmd := exec.CommandContext(context.TODO(), "git", "rev-parse", "v0.1")
+	cmd := exec.CommandContext(t.Context(), "git", "rev-parse", "v0.1")
 	cmd.Dir = gitDir
 	out, err := cmd.Output()
 	require.NoError(t, err)
 	commitTag := strings.TrimSpace(string(out))
 
-	cmd = exec.CommandContext(context.TODO(), "git", "rev-parse", "v0.1^{commit}")
+	cmd = exec.CommandContext(t.Context(), "git", "rev-parse", "v0.1^{commit}")
 	cmd.Dir = gitDir
 	out, err = cmd.Output()
 	require.NoError(t, err)
@@ -567,19 +567,19 @@ func testGitResolveSourceMetadata(t *testing.T, sb integration.Sandbox) {
 	err = runInDir(gitDir, gitCommands...)
 	require.NoError(t, err)
 
-	cmd := exec.CommandContext(context.TODO(), "git", "rev-parse", "HEAD")
+	cmd := exec.CommandContext(t.Context(), "git", "rev-parse", "HEAD")
 	cmd.Dir = gitDir
 	out, err := cmd.Output()
 	require.NoError(t, err)
 	commitHEAD := strings.TrimSpace(string(out))
 
-	cmd = exec.CommandContext(context.TODO(), "git", "rev-parse", "v0.1")
+	cmd = exec.CommandContext(t.Context(), "git", "rev-parse", "v0.1")
 	cmd.Dir = gitDir
 	out, err = cmd.Output()
 	require.NoError(t, err)
 	commitTag := strings.TrimSpace(string(out))
 
-	cmd = exec.CommandContext(context.TODO(), "git", "rev-parse", "v0.1^{commit}")
+	cmd = exec.CommandContext(t.Context(), "git", "rev-parse", "v0.1^{commit}")
 	cmd.Dir = gitDir
 	out, err = cmd.Output()
 	require.NoError(t, err)

--- a/client/client_local_source_test.go
+++ b/client/client_local_source_test.go
@@ -27,7 +27,7 @@ func testLocalSourceDiffer(t *testing.T, sb integration.Sandbox) {
 }
 
 func testLocalSourceWithDiffer(t *testing.T, sb integration.Sandbox, d llb.DiffType) {
-	c, err := New(context.TODO(), sb.Address())
+	c, err := New(t.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
 
@@ -43,12 +43,12 @@ func testLocalSourceWithDiffer(t *testing.T, sb integration.Sandbox, d llb.DiffT
 
 	st := llb.Local("mylocal"+string(d), llb.Differ(d, false))
 
-	def, err := st.Marshal(context.TODO())
+	def, err := st.Marshal(t.Context())
 	require.NoError(t, err)
 
 	destDir := t.TempDir()
 
-	_, err = c.Solve(context.TODO(), def, SolveOpt{
+	_, err = c.Solve(t.Context(), def, SolveOpt{
 		Exports: []ExportEntry{
 			{
 				Type:      ExporterLocal,
@@ -74,7 +74,7 @@ func testLocalSourceWithDiffer(t *testing.T, sb integration.Sandbox, d llb.DiffT
 	err = syscall.UtimesNano(filepath.Join(dir.Name, "foo"), []syscall.Timespec{tv, tv})
 	require.NoError(t, err)
 
-	_, err = c.Solve(context.TODO(), def, SolveOpt{
+	_, err = c.Solve(t.Context(), def, SolveOpt{
 		Exports: []ExportEntry{
 			{
 				Type:      ExporterLocal,
@@ -100,7 +100,7 @@ func testLocalSourceWithDiffer(t *testing.T, sb integration.Sandbox, d llb.DiffT
 // moby/buildkit#4831
 func testLocalSourceWithHardlinksFilter(t *testing.T, sb integration.Sandbox) {
 	requiresLinux(t)
-	c, err := New(context.TODO(), sb.Address())
+	c, err := New(t.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
 
@@ -113,12 +113,12 @@ func testLocalSourceWithHardlinksFilter(t *testing.T, sb integration.Sandbox) {
 
 	st := llb.Local("mylocal", llb.FollowPaths([]string{"foo*"}))
 
-	def, err := st.Marshal(context.TODO())
+	def, err := st.Marshal(t.Context())
 	require.NoError(t, err)
 
 	destDir := t.TempDir()
 
-	_, err = c.Solve(context.TODO(), def, SolveOpt{
+	_, err = c.Solve(t.Context(), def, SolveOpt{
 		Exports: []ExportEntry{
 			{
 				Type:      ExporterLocal,

--- a/client/client_mount_test.go
+++ b/client/client_mount_test.go
@@ -492,7 +492,7 @@ func testRawSocketMount(t *testing.T, sb integration.Sandbox) {
 	dir := t.TempDir()
 	sockPath := filepath.Join(dir, "test.sock")
 	listener := net.ListenConfig{}
-	l, err := listener.Listen(context.TODO(), "unix", sockPath)
+	l, err := listener.Listen(t.Context(), "unix", sockPath)
 	require.NoError(t, err)
 	defer l.Close()
 
@@ -1050,7 +1050,7 @@ func makeSSHAgentSock(t *testing.T, agent agent.Agent) (p string, err error) {
 	sockPath := filepath.Join(tmpDir.Name, "ssh_auth_sock")
 
 	listener := net.ListenConfig{}
-	l, err := listener.Listen(context.TODO(), "unix", sockPath)
+	l, err := listener.Listen(t.Context(), "unix", sockPath)
 	if err != nil {
 		return "", err
 	}

--- a/client/client_network_test.go
+++ b/client/client_network_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"context"
 	"net"
 	"os"
 	"path/filepath"
@@ -67,7 +66,7 @@ func testBridgeNetworkingDNSNoRootless(t *testing.T, sb integration.Sandbox) {
 		Marshal(sb.Context())
 	require.NoError(t, err)
 
-	eg, ctx := errgroup.WithContext(context.Background())
+	eg, ctx := errgroup.WithContext(t.Context())
 	eg.Go(func() error {
 		_, err := c.Solve(ctx, server, SolveOpt{}, nil)
 		return err

--- a/client/client_oci_source_test.go
+++ b/client/client_oci_source_test.go
@@ -150,9 +150,7 @@ func testNoTarOCIIndexMediaType(t *testing.T, sb integration.Sandbox) {
 	def, err := st.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(destDir)
+	destDir := t.TempDir()
 
 	outDir := filepath.Join(destDir, "out.d")
 	require.NoError(t, err)
@@ -197,9 +195,7 @@ func testOCIIndexMediatype(t *testing.T, sb integration.Sandbox) {
 	def, err := st.Marshal(sb.Context())
 	require.NoError(t, err)
 
-	destDir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(destDir)
+	destDir := t.TempDir()
 
 	out := filepath.Join(destDir, "out.tar")
 	outW, err := os.Create(out)
@@ -339,7 +335,7 @@ func testOCILayoutBlobSource(t *testing.T, sb integration.Sandbox) {
 func testOCILayoutPlatformSource(t *testing.T, sb integration.Sandbox) {
 	workers.CheckFeatureCompat(t, sb, workers.FeatureOCIExporter, workers.FeatureOCILayout)
 	requiresLinux(t)
-	c, err := New(context.TODO(), sb.Address())
+	c, err := New(t.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
 
@@ -502,7 +498,7 @@ func testOCILayoutPlatformSource(t *testing.T, sb integration.Sandbox) {
 
 func testOCILayoutSource(t *testing.T, sb integration.Sandbox) {
 	workers.CheckFeatureCompat(t, sb, workers.FeatureOCIExporter, workers.FeatureOCILayout)
-	c, err := New(context.TODO(), sb.Address())
+	c, err := New(t.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
 
@@ -577,12 +573,12 @@ func testOCILayoutSource(t *testing.T, sb integration.Sandbox) {
 	csID := "my-content-store"
 	st = llb.OCILayout(fmt.Sprintf("not/real@%s", digest), llb.OCIStore("", csID))
 
-	def, err = st.Marshal(context.TODO())
+	def, err = st.Marshal(t.Context())
 	require.NoError(t, err)
 
 	destDir := t.TempDir()
 
-	_, err = c.Solve(context.TODO(), def, SolveOpt{
+	_, err = c.Solve(t.Context(), def, SolveOpt{
 		Exports: []ExportEntry{
 			{
 				Type:      ExporterLocal,

--- a/client/llb/async_test.go
+++ b/client/llb/async_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAsyncNonBlocking(t *testing.T) {
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	wait := make(chan struct{})
 	ran := make(chan struct{})

--- a/client/llb/exec_test.go
+++ b/client/llb/exec_test.go
@@ -1,7 +1,6 @@
 package llb
 
 import (
-	"context"
 	"testing"
 
 	"github.com/moby/buildkit/solver/pb"
@@ -12,17 +11,17 @@ func TestTmpfsMountError(t *testing.T) {
 	t.Parallel()
 
 	st := Image("foo").Run(Shlex("args")).AddMount("/tmp", Scratch(), Tmpfs())
-	_, err := st.Marshal(context.TODO())
+	_, err := st.Marshal(t.Context())
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "can't be used as a parent")
 
 	st = Image("foo").Run(Shlex("args"), AddMount("/tmp", Scratch(), Tmpfs())).Root()
-	_, err = st.Marshal(context.TODO())
+	_, err = st.Marshal(t.Context())
 	require.NoError(t, err)
 
 	st = Image("foo").Run(Shlex("args"), AddMount("/tmp", Image("bar"), Tmpfs())).Root()
-	_, err = st.Marshal(context.TODO())
+	_, err = st.Marshal(t.Context())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "must use scratch")
 }
@@ -33,7 +32,7 @@ func TestInvalidSecurityModeMarshalError(t *testing.T) {
 	st := Image("busybox:latest").
 		Run(Shlex("true"), Security(pb.SecurityMode(2))).Root()
 
-	_, err := st.Marshal(context.TODO())
+	_, err := st.Marshal(t.Context())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid security mode")
 }
@@ -76,7 +75,7 @@ func TestLinuxResourcesMarshal(t *testing.T) {
 			CpusetMems("0"),
 		).Root()
 
-	def, err := st.Marshal(context.TODO())
+	def, err := st.Marshal(t.Context())
 	require.NoError(t, err)
 
 	// Resources should be in OpMetadata (not in the Op bytes / cache key)
@@ -110,13 +109,13 @@ func TestLinuxResourcesNotInCacheKey(t *testing.T) {
 	st3 := Image("busybox:latest").
 		Run(Shlex("echo hello")).Root()
 
-	def1, err := st1.Marshal(context.TODO())
+	def1, err := st1.Marshal(t.Context())
 	require.NoError(t, err)
 
-	def2, err := st2.Marshal(context.TODO())
+	def2, err := st2.Marshal(t.Context())
 	require.NoError(t, err)
 
-	def3, err := st3.Marshal(context.TODO())
+	def3, err := st3.Marshal(t.Context())
 	require.NoError(t, err)
 
 	// All three should produce the same definition bytes (same cache key)
@@ -135,7 +134,7 @@ func TestLinuxResourcesMerge(t *testing.T) {
 			CPUShares(512),
 		).Root()
 
-	def, err := st.Marshal(context.TODO())
+	def, err := st.Marshal(t.Context())
 	require.NoError(t, err)
 
 	for _, md := range def.Metadata {
@@ -162,7 +161,7 @@ func TestExecOpMarshalConsistency(t *testing.T) {
 		).AddMount("/a", Scratch().File(Mkfile("file2", 0644, []byte("file2 contents"))))
 
 	for range 100 {
-		def, err := st.Marshal(context.TODO())
+		def, err := st.Marshal(t.Context())
 		require.NoError(t, err)
 
 		if prevDef != nil {

--- a/client/llb/git_test.go
+++ b/client/llb/git_test.go
@@ -1,7 +1,6 @@
 package llb
 
 import (
-	"context"
 	"testing"
 
 	"github.com/moby/buildkit/solver/pb"
@@ -122,7 +121,7 @@ func TestGit(t *testing.T) {
 	for _, tc := range tcases {
 		t.Run(tc.name, func(t *testing.T) {
 			st := tc.st
-			def, err := st.Marshal(context.TODO())
+			def, err := st.Marshal(t.Context())
 
 			require.NoError(t, err)
 

--- a/client/llb/llbbuild/llbbuild_test.go
+++ b/client/llb/llbbuild/llbbuild_test.go
@@ -13,7 +13,7 @@ import (
 func TestMarshal(t *testing.T) {
 	t.Parallel()
 	b := NewBuildOp(newDummyOutput("foobar"), WithFilename("myfilename"))
-	dgst, dt, opMeta, _, err := b.Marshal(context.TODO(), &llb.Constraints{})
+	dgst, dt, opMeta, _, err := b.Marshal(t.Context(), &llb.Constraints{})
 	_ = opMeta
 	require.NoError(t, err)
 

--- a/client/llb/llbtest/platform_test.go
+++ b/client/llb/llbtest/platform_test.go
@@ -1,7 +1,6 @@
 package llbtest
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -24,10 +23,10 @@ func TestCustomPlatform(t *testing.T) {
 		Run(llb.Shlex("bax"), llb.Windows).
 		Run(llb.Shlex("bay"))
 
-	def, err := s.Marshal(context.TODO())
+	def, err := s.Marshal(t.Context())
 	require.NoError(t, err)
 
-	e, err := llbsolver.Load(context.TODO(), def.ToPB(), nil)
+	e, err := llbsolver.Load(t.Context(), def.ToPB(), nil)
 	require.NoError(t, err)
 
 	require.Equal(t, 5, depth(e))
@@ -53,10 +52,10 @@ func TestDefaultPlatform(t *testing.T) {
 
 	s := llb.Image("foo").Run(llb.Shlex("bar"))
 
-	def, err := s.Marshal(context.TODO())
+	def, err := s.Marshal(t.Context())
 	require.NoError(t, err)
 
-	e, err := llbsolver.Load(context.TODO(), def.ToPB(), nil)
+	e, err := llbsolver.Load(t.Context(), def.ToPB(), nil)
 	require.NoError(t, err)
 
 	require.Equal(t, 2, depth(e))
@@ -77,10 +76,10 @@ func TestPlatformOnMarshal(t *testing.T) {
 
 	s := llb.Image("image1").Run(llb.Shlex("bar"))
 
-	def, err := s.Marshal(context.TODO(), llb.Windows)
+	def, err := s.Marshal(t.Context(), llb.Windows)
 	require.NoError(t, err)
 
-	e, err := llbsolver.Load(context.TODO(), def.ToPB(), nil)
+	e, err := llbsolver.Load(t.Context(), def.ToPB(), nil)
 	require.NoError(t, err)
 
 	expected := ocispecs.Platform{OS: "windows", Architecture: "amd64"}
@@ -97,10 +96,10 @@ func TestPlatformMixed(t *testing.T) {
 	s2 := llb.Image("image2", llb.LinuxArmel).Run(llb.Shlex("cmd-sub"))
 	s1.AddMount("/mnt", s2.Root())
 
-	def, err := s1.Marshal(context.TODO(), llb.LinuxAmd64)
+	def, err := s1.Marshal(t.Context(), llb.LinuxAmd64)
 	require.NoError(t, err)
 
-	e, err := llbsolver.Load(context.TODO(), def.ToPB(), nil)
+	e, err := llbsolver.Load(t.Context(), def.ToPB(), nil)
 	require.NoError(t, err)
 
 	require.Equal(t, 4, depth(e))
@@ -127,9 +126,9 @@ func TestFallbackPath(t *testing.T) {
 
 	// With no caps we expect no PATH but also no requirement for
 	// the cap.
-	def, err := llb.Scratch().Run(llb.Shlex("cmd")).Marshal(context.TODO(), llb.LinuxAmd64)
+	def, err := llb.Scratch().Run(llb.Shlex("cmd")).Marshal(t.Context(), llb.LinuxAmd64)
 	require.NoError(t, err)
-	e, err := llbsolver.Load(context.TODO(), def.ToPB(), nil)
+	e, err := llbsolver.Load(t.Context(), def.ToPB(), nil)
 	require.NoError(t, err)
 	require.False(t, def.Metadata[e.Vertex.Digest()].Caps[pb.CapExecMetaSetsDefaultPath])
 	_, ok := getenv(e, "PATH")
@@ -139,9 +138,9 @@ func TestFallbackPath(t *testing.T) {
 	// no requirement for the cap.
 	cs := pb.Caps.CapSet(nil)
 	require.Error(t, cs.Supports(pb.CapExecMetaSetsDefaultPath))
-	def, err = llb.Scratch().Run(llb.Shlex("cmd")).Marshal(context.TODO(), llb.LinuxAmd64, llb.WithCaps(cs))
+	def, err = llb.Scratch().Run(llb.Shlex("cmd")).Marshal(t.Context(), llb.LinuxAmd64, llb.WithCaps(cs))
 	require.NoError(t, err)
-	e, err = llbsolver.Load(context.TODO(), def.ToPB(), nil)
+	e, err = llbsolver.Load(t.Context(), def.ToPB(), nil)
 	require.NoError(t, err)
 	require.False(t, def.Metadata[e.Vertex.Digest()].Caps[pb.CapExecMetaSetsDefaultPath])
 	v, ok := getenv(e, "PATH")
@@ -153,9 +152,9 @@ func TestFallbackPath(t *testing.T) {
 	// present and empty), but also require the cap.
 	cs = pb.Caps.CapSet(pb.Caps.All())
 	require.NoError(t, cs.Supports(pb.CapExecMetaSetsDefaultPath))
-	def, err = llb.Scratch().Run(llb.Shlex("cmd")).Marshal(context.TODO(), llb.LinuxAmd64, llb.WithCaps(cs))
+	def, err = llb.Scratch().Run(llb.Shlex("cmd")).Marshal(t.Context(), llb.LinuxAmd64, llb.WithCaps(cs))
 	require.NoError(t, err)
-	e, err = llbsolver.Load(context.TODO(), def.ToPB(), nil)
+	e, err = llbsolver.Load(t.Context(), def.ToPB(), nil)
 	require.NoError(t, err)
 	require.True(t, def.Metadata[e.Vertex.Digest()].Caps[pb.CapExecMetaSetsDefaultPath])
 	_, ok = getenv(e, "PATH")
@@ -169,9 +168,9 @@ func TestFallbackPath(t *testing.T) {
 		{llb.WithCaps(pb.Caps.CapSet(nil))},
 		{llb.WithCaps(pb.Caps.CapSet(pb.Caps.All()))},
 	} {
-		def, err = llb.Scratch().AddEnv("PATH", "foo").Run(llb.Shlex("cmd")).Marshal(context.TODO(), append(cos, llb.LinuxAmd64)...)
+		def, err = llb.Scratch().AddEnv("PATH", "foo").Run(llb.Shlex("cmd")).Marshal(t.Context(), append(cos, llb.LinuxAmd64)...)
 		require.NoError(t, err)
-		e, err = llbsolver.Load(context.TODO(), def.ToPB(), nil)
+		e, err = llbsolver.Load(t.Context(), def.ToPB(), nil)
 		require.NoError(t, err)
 		// pb.CapExecMetaSetsDefaultPath setting is irrelevant (and variable).
 		v, ok = getenv(e, "PATH")

--- a/client/llb/meta_test.go
+++ b/client/llb/meta_test.go
@@ -1,7 +1,6 @@
 package llb
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,7 +26,7 @@ func TestRelativeWd(t *testing.T) {
 
 func getDirHelper(t *testing.T, s State) string {
 	t.Helper()
-	v, err := s.GetDir(context.TODO())
+	v, err := s.GetDir(t.Context())
 	require.NoError(t, err)
 	return v
 }

--- a/client/llb/resolver_test.go
+++ b/client/llb/resolver_test.go
@@ -23,7 +23,7 @@ func TestImageMetaResolver(t *testing.T) {
 
 	require.Equal(t, false, tr.called)
 
-	def, err := st.Marshal(context.TODO(), LinuxPpc64le)
+	def, err := st.Marshal(t.Context(), LinuxPpc64le)
 	require.NoError(t, err)
 
 	require.Equal(t, true, tr.called)
@@ -38,7 +38,7 @@ func TestImageMetaResolver(t *testing.T) {
 
 	require.Equal(t, "docker-image://docker.io/library/alpine:latest", arr[0].Op.(*pb.Op_Source).Source.GetIdentifier())
 
-	d, err := st.GetDir(context.TODO())
+	d, err := st.GetDir(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, "/bar", d)
 }
@@ -51,7 +51,7 @@ func TestImageResolveDigest(t *testing.T) {
 		dir:    "/foo",
 	}), ResolveDigest(true))
 
-	def, err := st.Marshal(context.TODO())
+	def, err := st.Marshal(t.Context())
 	require.NoError(t, err)
 
 	m, arr := parseDef(t, def.Def)
@@ -63,7 +63,7 @@ func TestImageResolveDigest(t *testing.T) {
 
 	require.Equal(t, "docker-image://docker.io/library/alpine:latest@"+string(digest.FromBytes([]byte("bar"))), arr[0].Op.(*pb.Op_Source).Source.GetIdentifier())
 
-	d, err := st.GetDir(context.TODO())
+	d, err := st.GetDir(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, "/foo", d)
 }

--- a/client/llb/state_test.go
+++ b/client/llb/state_test.go
@@ -1,7 +1,6 @@
 package llb
 
 import (
-	"context"
 	"testing"
 
 	"github.com/moby/buildkit/solver/pb"
@@ -57,7 +56,7 @@ func TestFormattingPatterns(t *testing.T) {
 
 func TestImageBlobInvalid(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	dgst := digest.FromBytes([]byte("foo"))
 
@@ -79,7 +78,7 @@ func TestImageBlobInvalid(t *testing.T) {
 
 func TestImageBlobSource(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	blobDgst := digest.FromBytes([]byte("foo"))
 
@@ -106,7 +105,7 @@ func TestImageBlobSource(t *testing.T) {
 
 func TestOCILayoutBlobSource(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	blobDgst := digest.FromBytes([]byte("foo"))
 
@@ -146,7 +145,7 @@ func TestStateSourceMapMarshal(t *testing.T) {
 		sm1.Location([]*pb.Range{{Start: &pb.Position{Line: 9}}}),
 	)
 
-	def, err := s.Marshal(context.TODO())
+	def, err := s.Marshal(t.Context())
 	require.NoError(t, err)
 
 	require.Equal(t, 2, len(def.Def))
@@ -183,7 +182,7 @@ func TestStateSourceMapMarshal(t *testing.T) {
 	s = Merge([]State{s, Image("myimage",
 		sm1.Location([]*pb.Range{{Start: &pb.Position{Line: 10}}}),
 	)})
-	def, err = s.Marshal(context.TODO())
+	def, err = s.Marshal(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, 3, len(def.Def))
 	dgst = digest.FromBytes(def.Def[0])
@@ -229,7 +228,7 @@ func TestPlatformFromImage(t *testing.T) {
 
 	dest := Image("destimage").File(Copy(s, "/", "/")).Run(Args([]string{"afterfile"}))
 
-	def, err := dest.Marshal(context.TODO(), LinuxPpc64le)
+	def, err := dest.Marshal(t.Context(), LinuxPpc64le)
 	require.NoError(t, err)
 
 	m, arr := parseDef(t, def.Def)
@@ -303,7 +302,7 @@ func TestPlatformFromImageWithMerge(t *testing.T) {
 
 	dest := Merge([]State{s, s2}).Run(Args([]string{"aftermerge"}))
 
-	def, err := dest.Marshal(context.TODO(), LinuxPpc64le)
+	def, err := dest.Marshal(t.Context(), LinuxPpc64le)
 	require.NoError(t, err)
 
 	m, arr := parseDef(t, def.Def)
@@ -347,7 +346,7 @@ func TestPlatformFromImageWithMerge(t *testing.T) {
 
 func getEnvHelper(t *testing.T, s State, k string) (string, bool) {
 	t.Helper()
-	v, ok, err := s.GetEnv(context.TODO(), k)
+	v, ok, err := s.GetEnv(t.Context(), k)
 	require.NoError(t, err)
 	return v, ok
 }

--- a/cmd/buildctl/build_test.go
+++ b/cmd/buildctl/build_test.go
@@ -109,7 +109,7 @@ func testBuildContainerdExporter(t *testing.T, sb integration.Sandbox) {
 	require.NoError(t, err)
 	defer client.Close()
 
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit")
 
 	img, err := client.GetImage(ctx, imageName)
 	require.NoError(t, err)
@@ -184,7 +184,7 @@ func testBuildMetadataFile(t *testing.T, sb integration.Sandbox) {
 		require.NoError(t, err)
 		defer client.Close()
 
-		ctx := namespaces.WithNamespace(context.Background(), "buildkit")
+		ctx := namespaces.WithNamespace(t.Context(), "buildkit")
 
 		img, err := client.GetImage(ctx, imageName)
 		require.NoError(t, err)

--- a/cmd/buildkitd/main_test.go
+++ b/cmd/buildkitd/main_test.go
@@ -37,5 +37,5 @@ func runApplyMainFlags(t *testing.T, args []string, cfg *config.Config) error {
 			return applyMainFlags(cmd, cfg, nil)
 		},
 	}
-	return cmd.Run(context.Background(), append([]string{"buildkitd"}, args...))
+	return cmd.Run(t.Context(), append([]string{"buildkitd"}, args...))
 }

--- a/frontend/attestations/sbom/sbom_test.go
+++ b/frontend/attestations/sbom/sbom_test.go
@@ -17,7 +17,7 @@ import (
 func TestScannerTmpMount(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	cfg, err := json.Marshal(ocispecs.Image{
 		Config: ocispecs.ImageConfig{
 			Cmd: []string{"scan"},

--- a/frontend/dockerfile/dockerfile2llb/convert_test.go
+++ b/frontend/dockerfile/dockerfile2llb/convert_test.go
@@ -2,7 +2,6 @@ package dockerfile2llb
 
 import (
 	"bytes"
-	"context"
 	"maps"
 	"testing"
 	"time"
@@ -110,7 +109,7 @@ RUN ls -l
 	res, err := Dockerfile2LLB(appcontext.Context(), []byte(df), ConvertOpt{})
 	require.NoError(t, err)
 
-	_, err = res.State.Marshal(context.TODO())
+	_, err = res.State.Marshal(t.Context())
 	require.NoError(t, err)
 }
 
@@ -304,18 +303,18 @@ func TestResolveSourceDateEpochValue(t *testing.T) {
 	globalArgs := &llb.EnvList{}
 	shlex := shell.NewLex('\\')
 
-	tm, err := resolveSourceDateEpochValue(context.Background(), "1700000501", ConvertOpt{}, nil, globalArgs, shlex)
+	tm, err := resolveSourceDateEpochValue(t.Context(), "1700000501", ConvertOpt{}, nil, globalArgs, shlex)
 	require.NoError(t, err)
 	require.NotNil(t, tm)
 	assert.Equal(t, time.Unix(1700000501, 0).UTC(), *tm)
 	assert.Equal(t, "1700000501", formatSourceDateEpochValue(tm))
 
-	tm, err = resolveSourceDateEpochValue(context.Background(), "context", ConvertOpt{}, nil, globalArgs, shlex)
+	tm, err = resolveSourceDateEpochValue(t.Context(), "context", ConvertOpt{}, nil, globalArgs, shlex)
 	require.NoError(t, err)
 	assert.Nil(t, tm)
 	assert.Empty(t, formatSourceDateEpochValue(tm))
 
-	_, err = resolveSourceDateEpochValue(context.Background(), "not-a-timestamp", ConvertOpt{}, nil, globalArgs, shlex)
+	_, err = resolveSourceDateEpochValue(t.Context(), "not-a-timestamp", ConvertOpt{}, nil, globalArgs, shlex)
 	require.ErrorContains(t, err, "invalid SOURCE_DATE_EPOCH")
 }
 
@@ -336,7 +335,7 @@ FROM scratch
 	require.NoError(t, err)
 
 	globalArgs := (&llb.EnvList{}).AddOrReplace("SOURCE_DATE_EPOCH", "mysource")
-	_, err = resolveSourceDateEpochValue(context.Background(), "mysource", ConvertOpt{}, stages, globalArgs, shell.NewLex('\\'))
+	_, err = resolveSourceDateEpochValue(t.Context(), "mysource", ConvertOpt{}, stages, globalArgs, shell.NewLex('\\'))
 	require.ErrorContains(t, err, "SOURCE_DATE_EPOCH stage does not meet source-only requirements")
 }
 
@@ -359,7 +358,7 @@ ADD $URL /
 	state, err := sourceDateEpochStageSource(stages[0], nil, &llb.EnvList{}, shell.NewLex('\\'))
 	require.NoError(t, err)
 	require.NotNil(t, state)
-	sourceOp, err := sourceOpFromState(context.Background(), state)
+	sourceOp, err := sourceOpFromState(t.Context(), state)
 	require.NoError(t, err)
 	require.NotNil(t, sourceOp)
 	assert.Equal(t, "src.tar", sourceOp.Attrs["http.filename"])
@@ -389,7 +388,7 @@ func TestSourceOpFromStateWrappedCopy(t *testing.T) {
 
 	st := llb.Scratch().File(llb.Copy(llb.HTTP("https://example.com/src.tar"), "src.tar", "/foo"))
 
-	sourceOp, err := sourceOpFromState(context.Background(), &st)
+	sourceOp, err := sourceOpFromState(t.Context(), &st)
 	require.NoError(t, err)
 	require.NotNil(t, sourceOp)
 	assert.Equal(t, "https://example.com/src.tar", sourceOp.Identifier)
@@ -402,7 +401,7 @@ func TestSourceOpFromStateMultipleSourcesIgnored(t *testing.T) {
 		File(llb.Copy(llb.HTTP("https://example.com/src1.tar"), "src1.tar", "/foo")).
 		File(llb.Copy(llb.HTTP("https://example.com/src2.tar"), "src2.tar", "/bar"))
 
-	sourceOp, err := sourceOpFromState(context.Background(), &st)
+	sourceOp, err := sourceOpFromState(t.Context(), &st)
 	require.NoError(t, err)
 	assert.Nil(t, sourceOp)
 }
@@ -412,12 +411,12 @@ func TestSourceStateFromSourceOpWrappedCopy(t *testing.T) {
 
 	st := llb.Scratch().File(llb.Copy(llb.HTTP("https://example.com/src.tar", llb.Filename("src.tar")), "src.tar", "/foo"))
 
-	sourceOp, err := sourceOpFromState(context.Background(), &st)
+	sourceOp, err := sourceOpFromState(t.Context(), &st)
 	require.NoError(t, err)
 	require.NotNil(t, sourceOp)
 
 	sourceState := llb.NewState(llb.NewSource(sourceOp.Identifier, maps.Clone(sourceOp.Attrs), llb.Constraints{}).Output())
-	rewrittenSourceOp, err := sourceOpFromState(context.Background(), &sourceState)
+	rewrittenSourceOp, err := sourceOpFromState(t.Context(), &sourceState)
 	require.NoError(t, err)
 	require.NotNil(t, rewrittenSourceOp)
 	assert.Equal(t, sourceOp.Identifier, rewrittenSourceOp.Identifier)

--- a/frontend/dockerfile/dockerfile_addgit_test.go
+++ b/frontend/dockerfile/dockerfile_addgit_test.go
@@ -2,7 +2,6 @@ package dockerfile
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -54,9 +53,7 @@ func testAddGit(t *testing.T, sb integration.Sandbox, format string) {
 	integration.SkipOnPlatform(t, "windows", "Git source handler submodule update not supported on Windows")
 	f := getFrontend(t, sb)
 
-	gitDir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(gitDir)
+	gitDir := t.TempDir()
 	initOptions := ""
 	if format == "sha256" {
 		initOptions = " --object-format=sha256"
@@ -78,16 +75,16 @@ func testAddGit(t *testing.T, sb integration.Sandbox, format string) {
 	gitCommands = append(gitCommands, makeCommit("v0.0.2")...)
 	gitCommands = append(gitCommands, makeCommit("v0.0.3")...)
 	gitCommands = append(gitCommands, "git update-server-info")
-	err = runShell(gitDir, gitCommands...)
+	err := runShell(gitDir, gitCommands...)
 	require.NoError(t, err)
 
-	revParseCmd := exec.CommandContext(context.TODO(), "git", "rev-parse", "v0.0.2")
+	revParseCmd := exec.CommandContext(t.Context(), "git", "rev-parse", "v0.0.2")
 	revParseCmd.Dir = gitDir
 	commitHashB, err := revParseCmd.Output()
 	require.NoError(t, err)
 	commitHashV2 := strings.TrimSpace(string(commitHashB))
 
-	revParseCmd = exec.CommandContext(context.TODO(), "git", "rev-parse", "v0.0.3")
+	revParseCmd = exec.CommandContext(t.Context(), "git", "rev-parse", "v0.0.3")
 	revParseCmd.Dir = gitDir
 	commitHashB, err = revParseCmd.Output()
 	require.NoError(t, err)
@@ -282,9 +279,7 @@ func testAddGitChecksumCache(t *testing.T, sb integration.Sandbox) {
 	integration.SkipOnPlatform(t, "windows", "Git source handler submodule update not supported on Windows")
 	f := getFrontend(t, sb)
 
-	gitDir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(gitDir)
+	gitDir := t.TempDir()
 	gitCommands := []string{
 		"git init",
 		"git config --local user.email test",
@@ -301,10 +296,10 @@ func testAddGitChecksumCache(t *testing.T, sb integration.Sandbox) {
 	gitCommands = append(gitCommands, makeCommit("v0.0.1")...)
 	gitCommands = append(gitCommands, makeCommit("v0.0.2")...)
 	gitCommands = append(gitCommands, "git update-server-info")
-	err = runShell(gitDir, gitCommands...)
+	err := runShell(gitDir, gitCommands...)
 	require.NoError(t, err)
 
-	revParseCmd := exec.CommandContext(context.TODO(), "git", "rev-parse", "v0.0.2")
+	revParseCmd := exec.CommandContext(t.Context(), "git", "rev-parse", "v0.0.2")
 	revParseCmd.Dir = gitDir
 	commitHashB, err := revParseCmd.Output()
 	require.NoError(t, err)
@@ -458,7 +453,7 @@ COPY foo out
 	require.NoError(t, err)
 
 	// get commit SHA for v0.0.2
-	cmd := exec.CommandContext(context.TODO(), "git", "rev-parse", "v0.0.2")
+	cmd := exec.CommandContext(t.Context(), "git", "rev-parse", "v0.0.2")
 	cmd.Dir = gitDir
 	dt, err := cmd.CombinedOutput()
 	require.NoError(t, err)
@@ -466,7 +461,7 @@ COPY foo out
 	require.Len(t, commitHashV2, 40)
 
 	// get commit SHA for latest
-	cmd = exec.CommandContext(context.TODO(), "git", "rev-parse", "latest")
+	cmd = exec.CommandContext(t.Context(), "git", "rev-parse", "latest")
 	cmd.Dir = gitDir
 	dt, err = cmd.CombinedOutput()
 	require.NoError(t, err)

--- a/frontend/dockerfile/dockerfile_check_test.go
+++ b/frontend/dockerfile/dockerfile_check_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
-	"os"
 	"regexp"
 	"runtime"
 	"slices"
@@ -1618,10 +1617,6 @@ EXPOSE 127.0.0.1:80:80 [::1]:8080:8080 5000:5000 8000
 }
 
 func checkUnmarshal(t *testing.T, sb integration.Sandbox, lintTest *lintTestParams) {
-	destDir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(destDir)
-
 	var warnings []expectedLintWarning
 	if lintTest.UnmarshalWarnings != nil {
 		warnings = lintTest.UnmarshalWarnings
@@ -1682,7 +1677,7 @@ func checkUnmarshal(t *testing.T, sb integration.Sandbox, lintTest *lintTestPara
 		return nil, nil
 	}
 
-	_, err = lintTest.Client.Build(sb.Context(), client.SolveOpt{
+	_, err := lintTest.Client.Build(sb.Context(), client.SolveOpt{
 		LocalMounts: map[string]fsutil.FS{
 			dockerui.DefaultLocalNameDockerfile: lintTest.TmpDir,
 			dockerui.DefaultLocalNameContext:    lintTest.TmpDir,

--- a/frontend/dockerfile/dockerfile_outline_test.go
+++ b/frontend/dockerfile/dockerfile_outline_test.go
@@ -3,7 +3,6 @@ package dockerfile
 import (
 	"context"
 	"encoding/json"
-	"os"
 	"testing"
 
 	"github.com/containerd/continuity/fs/fstest"
@@ -108,10 +107,6 @@ FROM second
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
-
-	destDir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(destDir)
 
 	called := false
 	frontend := func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
@@ -257,10 +252,6 @@ FROM second
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(destDir)
-
 	called := false
 	frontend := func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
 		res, err := c.Solve(ctx, gateway.SolveRequest{
@@ -351,10 +342,6 @@ ARG INFOO=${INFOO}456${INBAR}
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
-
-	destDir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(destDir)
 
 	called := false
 	frontend := func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {

--- a/frontend/dockerfile/dockerfile_provenance_test.go
+++ b/frontend/dockerfile/dockerfile_provenance_test.go
@@ -466,7 +466,7 @@ COPY myapp.Dockerfile /
 			)
 			require.NoError(t, err)
 
-			cmd := exec.CommandContext(context.TODO(), "git", "rev-parse", "v1")
+			cmd := exec.CommandContext(t.Context(), "git", "rev-parse", "v1")
 			cmd.Dir = dir.Name
 			expectedGitSHA, err := cmd.Output()
 			require.NoError(t, err)

--- a/frontend/dockerfile/dockerfile_source_date_epoch_test.go
+++ b/frontend/dockerfile/dockerfile_source_date_epoch_test.go
@@ -51,9 +51,7 @@ COPY Dockerfile .
 	require.NoError(t, err)
 	defer c.Close()
 
-	destDir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(destDir)
+	destDir := t.TempDir()
 
 	out := filepath.Join(destDir, "out.tar")
 	outW, err := os.Create(out)

--- a/frontend/dockerfile/dockerfile_ssh_test.go
+++ b/frontend/dockerfile/dockerfile_ssh_test.go
@@ -105,7 +105,7 @@ RUN --mount=type=ssh apk update \
 	defer c.Close()
 
 	// not using t.TempDir() here because the path ends up longer than the unix socket max length
-	tmpDir, err := os.MkdirTemp("", "buildkit-ssh-test-")
+	tmpDir, err := os.MkdirTemp("", "buildkit-ssh-test-") //nolint:usetesting // see comment above
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		os.RemoveAll(tmpDir)

--- a/frontend/dockerfile/dockerfile_targets_test.go
+++ b/frontend/dockerfile/dockerfile_targets_test.go
@@ -3,7 +3,6 @@ package dockerfile
 import (
 	"context"
 	"encoding/json"
-	"os"
 	"testing"
 
 	"github.com/containerd/continuity/fs/fstest"
@@ -58,10 +57,6 @@ FROM second AS binary
 	c, err := client.New(sb.Context(), sb.Address())
 	require.NoError(t, err)
 	defer c.Close()
-
-	destDir, err := os.MkdirTemp("", "buildkit")
-	require.NoError(t, err)
-	defer os.RemoveAll(destDir)
 
 	called := false
 	frontend := func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {

--- a/session/content/content_test.go
+++ b/session/content/content_test.go
@@ -1,7 +1,6 @@
 package content
 
 import (
-	"context"
 	"testing"
 
 	"github.com/containerd/containerd/v2/core/content"
@@ -16,7 +15,7 @@ import (
 )
 
 func TestContentAttachable(t *testing.T) {
-	ctx := context.TODO()
+	ctx := t.Context()
 	t.Parallel()
 	ids := []string{"store-id-0", "store-id-1"}
 	attachableStores := make(map[string]content.Store)

--- a/session/context_test.go
+++ b/session/context_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestContextWithCaller(t *testing.T) {
 	t.Run("caller close cancels derived context", func(t *testing.T) {
-		callerCtx, callerCancel := context.WithCancelCause(context.Background())
-		ctx := contextWithCaller(context.Background(), callerCtx)
+		callerCtx, callerCancel := context.WithCancelCause(t.Context())
+		ctx := contextWithCaller(t.Context(), callerCtx)
 
 		callerCancel(context.DeadlineExceeded)
 
@@ -24,8 +24,8 @@ func TestContextWithCaller(t *testing.T) {
 	})
 
 	t.Run("request close cancels derived context", func(t *testing.T) {
-		baseCtx, cancel := context.WithCancelCause(context.Background())
-		ctx := contextWithCaller(baseCtx, context.Background())
+		baseCtx, cancel := context.WithCancelCause(t.Context())
+		ctx := contextWithCaller(baseCtx, t.Context())
 		cancel(context.Canceled)
 
 		select {

--- a/session/sshforward/sshprovider/agentprovider_test.go
+++ b/session/sshforward/sshprovider/agentprovider_test.go
@@ -1,7 +1,6 @@
 package sshprovider_test
 
 import (
-	"context"
 	"net"
 	"os"
 	"path/filepath"
@@ -41,7 +40,7 @@ func TestToAgentSource(t *testing.T) {
 
 	sockPath := filepath.Join(dir, "test.sock")
 	listener := net.ListenConfig{}
-	l, err := listener.Listen(context.TODO(), "unix", sockPath)
+	l, err := listener.Listen(t.Context(), "unix", sockPath)
 	require.NoError(t, err)
 	defer l.Close()
 

--- a/session/sshforward/sshprovider/raw_provider_test.go
+++ b/session/sshforward/sshprovider/raw_provider_test.go
@@ -98,7 +98,7 @@ func TestRawProvider(t *testing.T) {
 
 	client := sshforward.NewSSHClient(c)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	_, err = client.CheckAgent(ctx, &sshforward.CheckAgentRequest{ID: "does-not-exist"})
 	require.ErrorContains(t, err, "does-not-exis")

--- a/snapshot/snapshotter_test.go
+++ b/snapshot/snapshotter_test.go
@@ -75,7 +75,7 @@ func newSnapshotter(ctx context.Context, t *testing.T, snapshotterName string) (
 	mdb := ctdmetadata.NewDB(db, store, map[string]snapshots.Snapshotter{
 		snapshotterName: ctdSnapshotter,
 	})
-	if err := mdb.Init(context.TODO()); err != nil {
+	if err := mdb.Init(t.Context()); err != nil {
 		return nil, nil, err
 	}
 
@@ -112,7 +112,7 @@ func TestMerge(t *testing.T) {
 				requireRoot(t)
 			}
 
-			ctx, sn, err := newSnapshotter(context.Background(), t, snName)
+			ctx, sn, err := newSnapshotter(t.Context(), t, snName)
 			require.NoError(t, err)
 
 			ts := time.Unix(0, 0)
@@ -315,7 +315,7 @@ func TestHardlinks(t *testing.T) {
 				requireRoot(t)
 			}
 
-			ctx, sn, err := newSnapshotter(context.Background(), t, snName)
+			ctx, sn, err := newSnapshotter(t.Context(), t, snName)
 			require.NoError(t, err)
 
 			base1Snap := committedKey(ctx, t, sn, identity.NewID(), "",
@@ -377,7 +377,7 @@ func TestMergeFileCapabilities(t *testing.T) {
 		t.Run(snName, func(t *testing.T) {
 			t.Parallel()
 
-			ctx, sn, err := newSnapshotter(context.Background(), t, snName)
+			ctx, sn, err := newSnapshotter(t.Context(), t, snName)
 			require.NoError(t, err)
 
 			setCaps := "cap_net_bind_service=+ep"
@@ -413,7 +413,7 @@ func TestUsage(t *testing.T) {
 				requireRoot(t)
 			}
 
-			ctx, sn, err := newSnapshotter(context.Background(), t, snName)
+			ctx, sn, err := newSnapshotter(t.Context(), t, snName)
 			require.NoError(t, err)
 
 			const direntByteSize = 4096

--- a/solver/llbsolver/file/backend_windows_test.go
+++ b/solver/llbsolver/file/backend_windows_test.go
@@ -3,7 +3,6 @@
 package file
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,7 +11,7 @@ import (
 )
 
 func TestPlatformCopy_RootOnlyProtectedExcludes(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	srcRoot := t.TempDir()
 	destRoot := t.TempDir()

--- a/solver/llbsolver/metrics_test.go
+++ b/solver/llbsolver/metrics_test.go
@@ -1,7 +1,6 @@
 package llbsolver
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -32,7 +31,7 @@ func newTestMetrics(t *testing.T) (*buildMetrics, *sdkmetric.ManualReader) {
 func collect(t *testing.T, reader *sdkmetric.ManualReader) map[string]metricdata.Aggregation {
 	t.Helper()
 	var rm metricdata.ResourceMetrics
-	require.NoError(t, reader.Collect(context.Background(), &rm))
+	require.NoError(t, reader.Collect(t.Context(), &rm))
 	out := map[string]metricdata.Aggregation{}
 	for _, sm := range rm.ScopeMetrics {
 		for _, m := range sm.Metrics {
@@ -83,7 +82,7 @@ func TestRecordBuildCompletion_Success(t *testing.T) {
 		NumWarnings:       1,
 	}
 
-	bm.recordBuildCompletion(context.Background(), rec)
+	bm.recordBuildCompletion(t.Context(), rec)
 	got := collect(t, reader)
 
 	builds := findCounterPoint(t, got["buildkit.builds"], map[string]string{
@@ -123,7 +122,7 @@ func TestRecordBuildCompletion_FailureGRPCCodes(t *testing.T) {
 				CompletedAt: timestamppb.New(start.Add(time.Second)),
 				Error:       &rpcstatus.Status{Code: int32(tc.code), Message: "ignored: must not appear as a label"},
 			}
-			bm.recordBuildCompletion(context.Background(), rec)
+			bm.recordBuildCompletion(t.Context(), rec)
 
 			builds := findCounterPoint(t, collect(t, reader)["buildkit.builds"], map[string]string{
 				"status":     "failure",
@@ -145,7 +144,7 @@ func TestRecordBuildCompletion_StepCounters(t *testing.T) {
 		NumTotalSteps:     10,
 		NumWarnings:       2,
 	}
-	bm.recordBuildCompletion(context.Background(), rec)
+	bm.recordBuildCompletion(t.Context(), rec)
 
 	steps := collect(t, reader)["buildkit.builds.steps"]
 	for kind, want := range map[string]int64{
@@ -164,12 +163,12 @@ func TestRecordBuildCompletion_NilSafe(t *testing.T) {
 	// at solver/llbsolver/history.go do not have to guard the call.
 	var bm *buildMetrics
 	require.NotPanics(t, func() {
-		bm.recordBuildCompletion(context.Background(), &controlapi.BuildHistoryRecord{})
+		bm.recordBuildCompletion(t.Context(), &controlapi.BuildHistoryRecord{})
 	})
 
 	bm, _ = newTestMetrics(t)
 	require.NotPanics(t, func() {
-		bm.recordBuildCompletion(context.Background(), nil)
+		bm.recordBuildCompletion(t.Context(), nil)
 	})
 }
 
@@ -181,7 +180,7 @@ func TestNewBuildMetrics_NilProviderUsesNoop(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, bm)
 	require.NotPanics(t, func() {
-		bm.recordBuildCompletion(context.Background(), &controlapi.BuildHistoryRecord{
+		bm.recordBuildCompletion(t.Context(), &controlapi.BuildHistoryRecord{
 			CreatedAt:   timestamppb.Now(),
 			CompletedAt: timestamppb.Now(),
 		})

--- a/solver/llbsolver/mounts/mount_test.go
+++ b/solver/llbsolver/mounts/mount_test.go
@@ -84,7 +84,7 @@ func newCacheManager(ctx context.Context, t *testing.T, opt cmOpt) (co *cmOut, e
 	mdb := ctdmetadata.NewDB(db, store, map[string]snapshots.Snapshotter{
 		opt.snapshotterName: opt.snapshotter,
 	})
-	if err := mdb.Init(context.TODO()); err != nil {
+	if err := mdb.Init(t.Context()); err != nil {
 		return nil, err
 	}
 
@@ -137,7 +137,7 @@ func newRefGetter(m cache.Manager, shared *cacheRefs) *cacheRefGetter {
 
 func TestCacheMountPrivateRefs(t *testing.T) {
 	t.Parallel()
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 
 	tmpdir := t.TempDir()
 
@@ -180,7 +180,7 @@ func TestCacheMountPrivateRefs(t *testing.T) {
 	require.NotEqual(t, ref.ID(), ref4.ID())
 
 	// releasing one of two refs still keeps first ID private
-	ref.Release(context.TODO())
+	ref.Release(t.Context())
 
 	ref5, err := g3.getRefCacheDir(ctx, nil, "foo", pb.CacheSharingOpt_PRIVATE)
 	require.NoError(t, err)
@@ -188,7 +188,7 @@ func TestCacheMountPrivateRefs(t *testing.T) {
 	require.NotEqual(t, ref4.ID(), ref5.ID())
 
 	// releasing all refs releases ID to be reused
-	ref3.Release(context.TODO())
+	ref3.Release(t.Context())
 
 	ref5, err = g4.getRefCacheDir(ctx, nil, "foo", pb.CacheSharingOpt_PRIVATE)
 	require.NoError(t, err)
@@ -203,7 +203,7 @@ func TestCacheMountPrivateRefs(t *testing.T) {
 
 func TestCacheMountSharedRefs(t *testing.T) {
 	t.Parallel()
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 
 	tmpdir := t.TempDir()
 
@@ -252,7 +252,7 @@ func TestCacheMountSharedRefs(t *testing.T) {
 
 func TestCacheMountLockedRefs(t *testing.T) {
 	t.Parallel()
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 
 	tmpdir := t.TempDir()
 
@@ -314,7 +314,7 @@ func TestCacheMountLockedRefs(t *testing.T) {
 // moby/buildkit#1322
 func TestCacheMountSharedRefsDeadlock(t *testing.T) {
 	// not parallel
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 
 	tmpdir := t.TempDir()
 
@@ -348,10 +348,10 @@ func TestCacheMountSharedRefsDeadlock(t *testing.T) {
 		cacheRefReleaseHijack = nil
 		cacheRefCloneHijack = nil
 	}()
-	eg, _ := errgroup.WithContext(context.TODO())
+	eg, _ := errgroup.WithContext(t.Context())
 
 	eg.Go(func() error {
-		return ref.Release(context.TODO())
+		return ref.Release(t.Context())
 	})
 	eg.Go(func() error {
 		_, err := g2.getRefCacheDir(ctx, nil, "foo", pb.CacheSharingOpt_SHARED)

--- a/solver/llbsolver/ops/exec_test.go
+++ b/solver/llbsolver/ops/exec_test.go
@@ -2,7 +2,6 @@ package ops
 
 import (
 	"bytes"
-	"context"
 	"net/http"
 	"strings"
 	"testing"
@@ -134,7 +133,7 @@ func TestExecOpCacheMap(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -218,7 +217,7 @@ func TestExecOpContentCache(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/solver/llbsolver/vertex_test.go
+++ b/solver/llbsolver/vertex_test.go
@@ -1,7 +1,6 @@
 package llbsolver
 
 import (
-	"context"
 	_ "embed"
 	"fmt"
 	"testing"
@@ -45,7 +44,7 @@ func TestRecomputeDigests(t *testing.T) {
 	}
 	visited := map[digest.Digest]digest.Digest{oldDigest: newDigest}
 
-	updated, err := recomputeDigests(context.Background(), all, visited, op2Digest)
+	updated, err := recomputeDigests(t.Context(), all, visited, op2Digest)
 	require.NoError(t, err)
 	require.Len(t, visited, 2)
 	require.Len(t, all, 2)
@@ -101,7 +100,7 @@ func TestIngestDigest(t *testing.T) {
 	fmt.Println(all, lastDgst)
 
 	visited := map[digest.Digest]digest.Digest{}
-	newDgst, err := recomputeDigests(context.Background(), all, visited, lastDgst)
+	newDgst, err := recomputeDigests(t.Context(), all, visited, lastDgst)
 	require.NoError(t, err)
 	require.Len(t, visited, 2)
 	require.Equal(t, op2Digest, newDgst)

--- a/source/git/source_test.go
+++ b/source/git/source_test.go
@@ -74,7 +74,7 @@ func testRepeatedFetch(t *testing.T, keepGitDir bool, format string) {
 	}
 
 	t.Parallel()
-	ctx := logProgressStreams(context.Background(), t)
+	ctx := logProgressStreams(t.Context(), t)
 
 	gs := setupGitSource(t, t.TempDir())
 
@@ -104,7 +104,7 @@ func testRepeatedFetch(t *testing.T, keepGitDir bool, format string) {
 
 	ref1, err := g.Snapshot(ctx, nil)
 	require.NoError(t, err)
-	defer ref1.Release(context.TODO())
+	defer ref1.Release(t.Context())
 
 	mount, err := ref1.Mount(ctx, true, nil)
 	require.NoError(t, err)
@@ -139,7 +139,7 @@ func testRepeatedFetch(t *testing.T, keepGitDir bool, format string) {
 
 	ref2, err := g.Snapshot(ctx, nil)
 	require.NoError(t, err)
-	defer ref2.Release(context.TODO())
+	defer ref2.Release(t.Context())
 
 	require.Equal(t, ref1.ID(), ref2.ID())
 
@@ -155,7 +155,7 @@ func testRepeatedFetch(t *testing.T, keepGitDir bool, format string) {
 
 	ref3, err := g.Snapshot(ctx, nil)
 	require.NoError(t, err)
-	defer ref3.Release(context.TODO())
+	defer ref3.Release(t.Context())
 
 	mount, err = ref3.Mount(ctx, true, nil)
 	require.NoError(t, err)
@@ -192,7 +192,7 @@ func testFetchAfterSubmoduleRemoval(t *testing.T, format string) {
 	}
 
 	t.Parallel()
-	ctx := logProgressStreams(context.Background(), t)
+	ctx := logProgressStreams(t.Context(), t)
 
 	gs := setupGitSource(t, t.TempDir())
 	repo := setupGitRepo(t, format)
@@ -208,7 +208,7 @@ func testFetchAfterSubmoduleRemoval(t *testing.T, format string) {
 
 	ref1, err := g.Snapshot(ctx, nil)
 	require.NoError(t, err)
-	defer ref1.Release(context.TODO())
+	defer ref1.Release(t.Context())
 
 	runShell(t, repo.mainPath,
 		"git checkout feature",
@@ -228,7 +228,7 @@ func testFetchAfterSubmoduleRemoval(t *testing.T, format string) {
 
 	ref2, err := g.Snapshot(ctx, nil)
 	require.NoError(t, err)
-	defer ref2.Release(context.TODO())
+	defer ref2.Release(t.Context())
 
 	mount, err := ref2.Mount(ctx, true, nil)
 	require.NoError(t, err)
@@ -265,14 +265,14 @@ func testFetchBySHA(t *testing.T, format string, keepGitDir bool) {
 	}
 
 	t.Parallel()
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 	ctx = logProgressStreams(ctx, t)
 
 	gs := setupGitSource(t, t.TempDir())
 
 	repo := setupGitRepo(t, format)
 
-	cmd := exec.CommandContext(context.TODO(), "git", "rev-parse", "feature")
+	cmd := exec.CommandContext(t.Context(), "git", "rev-parse", "feature")
 	cmd.Dir = repo.mainPath
 
 	out, err := cmd.Output()
@@ -311,7 +311,7 @@ func testFetchBySHA(t *testing.T, format string, keepGitDir bool) {
 
 	ref1, err := g.Snapshot(ctx, nil)
 	require.NoError(t, err)
-	defer ref1.Release(context.TODO())
+	defer ref1.Release(t.Context())
 
 	mount, err := ref1.Mount(ctx, true, nil)
 	require.NoError(t, err)
@@ -387,14 +387,14 @@ func testFetchUnreferencedRefSha(t *testing.T, ref string, keepGitDir bool, form
 	}
 
 	t.Parallel()
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 	ctx = logProgressStreams(ctx, t)
 
 	gs := setupGitSource(t, t.TempDir())
 
 	repo := setupGitRepo(t, format)
 
-	cmd := exec.CommandContext(context.TODO(), "git", "rev-parse", ref)
+	cmd := exec.CommandContext(t.Context(), "git", "rev-parse", ref)
 	cmd.Dir = repo.mainPath
 
 	out, err := cmd.Output()
@@ -432,7 +432,7 @@ func testFetchUnreferencedRefSha(t *testing.T, ref string, keepGitDir bool, form
 
 	ref1, err := g.Snapshot(ctx, nil)
 	require.NoError(t, err)
-	defer ref1.Release(context.TODO())
+	defer ref1.Release(t.Context())
 
 	mount, err := ref1.Mount(ctx, true, nil)
 	require.NoError(t, err)
@@ -474,13 +474,13 @@ func testFetchByCommit(t *testing.T, format string, keepGitDir bool) {
 	}
 
 	t.Parallel()
-	ctx := logProgressStreams(context.Background(), t)
+	ctx := logProgressStreams(t.Context(), t)
 
 	gs := setupGitSource(t, t.TempDir())
 	repo := setupGitRepo(t, format)
 
 	// Capture the SHA of the current master branch (points at "third").
-	cmd := exec.CommandContext(context.TODO(), "git", "rev-parse", "refs/heads/master")
+	cmd := exec.CommandContext(t.Context(), "git", "rev-parse", "refs/heads/master")
 	cmd.Dir = repo.mainPath
 	out, err := cmd.Output()
 	require.NoError(t, err)
@@ -497,7 +497,7 @@ func testFetchByCommit(t *testing.T, format string, keepGitDir bool) {
 
 	ref1, err := g.Snapshot(ctx, nil)
 	require.NoError(t, err)
-	defer ref1.Release(context.TODO())
+	defer ref1.Release(t.Context())
 
 	mount, err := ref1.Mount(ctx, true, nil)
 	require.NoError(t, err)
@@ -519,7 +519,7 @@ func testFetchByCommit(t *testing.T, format string, keepGitDir bool) {
 		"git add newfile",
 		"git commit -m moved",
 	)
-	cmd = exec.CommandContext(context.TODO(), "git", "rev-parse", "refs/heads/master")
+	cmd = exec.CommandContext(t.Context(), "git", "rev-parse", "refs/heads/master")
 	cmd.Dir = repo.mainPath
 	out, err = cmd.Output()
 	require.NoError(t, err)
@@ -570,7 +570,7 @@ func testFetchByCommit(t *testing.T, format string, keepGitDir bool) {
 
 	ref2, err := gFbc.Snapshot(ctx, nil)
 	require.NoError(t, err)
-	defer ref2.Release(context.TODO())
+	defer ref2.Release(t.Context())
 
 	// Snapshot is reused from the first fetch since the cache key matches.
 	require.Equal(t, ref1.ID(), ref2.ID())
@@ -607,7 +607,7 @@ func testFetchByCommit(t *testing.T, format string, keepGitDir bool) {
 
 	ref3, err := gFresh.Snapshot(ctx, nil)
 	require.NoError(t, err)
-	defer ref3.Release(context.TODO())
+	defer ref3.Release(t.Context())
 
 	require.NotEqual(t, ref1.ID(), ref3.ID())
 
@@ -632,7 +632,7 @@ func testFetchByCommit(t *testing.T, format string, keepGitDir bool) {
 
 func gitRevParse(t *testing.T, workDir, rev string) string {
 	t.Helper()
-	cmd := exec.CommandContext(context.TODO(), "git", "rev-parse", rev)
+	cmd := exec.CommandContext(t.Context(), "git", "rev-parse", rev)
 	cmd.Dir = workDir
 	out, err := cmd.Output()
 	require.NoError(t, err, "git rev-parse %s in %s", rev, workDir)
@@ -649,7 +649,7 @@ func testFetchByCommitRequiresChecksum(t *testing.T, format string) {
 	}
 
 	t.Parallel()
-	ctx := logProgressStreams(context.Background(), t)
+	ctx := logProgressStreams(t.Context(), t)
 	gs := setupGitSource(t, t.TempDir())
 	repo := setupGitRepo(t, format)
 
@@ -796,7 +796,7 @@ func testFetchByTag(t *testing.T, tag, expectedCommitSubject string, isAnnotated
 	}
 
 	t.Parallel()
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 	ctx = logProgressStreams(ctx, t)
 
 	gs := setupGitSource(t, t.TempDir())
@@ -806,7 +806,7 @@ func testFetchByTag(t *testing.T, tag, expectedCommitSubject string, isAnnotated
 	id := &GitIdentifier{Remote: repo.mainURL, Ref: tag, KeepGitDir: keepGitDir}
 
 	if checksumMode != testChecksumModeNone {
-		cmd := exec.CommandContext(context.TODO(), "git", "rev-parse", tag)
+		cmd := exec.CommandContext(t.Context(), "git", "rev-parse", tag)
 		cmd.Dir = repo.mainPath
 
 		out, err := cmd.Output()
@@ -860,7 +860,7 @@ func testFetchByTag(t *testing.T, tag, expectedCommitSubject string, isAnnotated
 
 	ref1, err := g.Snapshot(ctx, nil)
 	require.NoError(t, err)
-	defer ref1.Release(context.TODO())
+	defer ref1.Release(t.Context())
 
 	mount, err := ref1.Mount(ctx, true, nil)
 	require.NoError(t, err)
@@ -946,11 +946,11 @@ func testFetchAnnotatedTagAfterClone(t *testing.T, format string) {
 	}
 
 	t.Parallel()
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 	ctx = logProgressStreams(ctx, t)
 
 	repo := setupGitRepo(t, format)
-	cmd := exec.CommandContext(context.TODO(), "git", "rev-parse", "HEAD")
+	cmd := exec.CommandContext(t.Context(), "git", "rev-parse", "HEAD")
 	cmd.Dir = repo.mainPath
 
 	out, err := cmd.Output()
@@ -979,7 +979,7 @@ func testFetchAnnotatedTagAfterClone(t *testing.T, format string) {
 
 	ref, err := g.Snapshot(ctx, nil)
 	require.NoError(t, err)
-	ref.Release(context.TODO())
+	ref.Release(t.Context())
 
 	id = &GitIdentifier{Remote: repo.mainURL, Ref: "refs/tags/v1.2.3", KeepGitDir: true}
 	g, err = gs.Resolve(ctx, id, nil, nil)
@@ -994,7 +994,7 @@ func testFetchAnnotatedTagAfterClone(t *testing.T, format string) {
 
 	ref, err = g.Snapshot(ctx, nil)
 	require.NoError(t, err)
-	ref.Release(context.TODO())
+	ref.Release(t.Context())
 }
 
 func TestFetchAnnotatedTagChecksumsSHA1(t *testing.T) {
@@ -1019,11 +1019,11 @@ func testFetchAnnotatedTagChecksums(t *testing.T, format string, keepGitDir bool
 	}
 
 	t.Parallel()
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 	ctx = logProgressStreams(ctx, t)
 
 	repo := setupGitRepo(t, format)
-	cmd := exec.CommandContext(context.TODO(), "git", "rev-parse", "v1.2.3")
+	cmd := exec.CommandContext(t.Context(), "git", "rev-parse", "v1.2.3")
 	cmd.Dir = repo.mainPath
 
 	out, err := cmd.Output()
@@ -1037,7 +1037,7 @@ func testFetchAnnotatedTagChecksums(t *testing.T, format string, keepGitDir bool
 	require.Equal(t, expLen, len(shaTag))
 
 	// make sure this is an annotated tag
-	cmd = exec.CommandContext(context.TODO(), "git", "cat-file", "-t", shaTag)
+	cmd = exec.CommandContext(t.Context(), "git", "cat-file", "-t", shaTag)
 	cmd.Dir = repo.mainPath
 
 	out, err = cmd.Output()
@@ -1045,7 +1045,7 @@ func testFetchAnnotatedTagChecksums(t *testing.T, format string, keepGitDir bool
 	require.Equal(t, "tag\n", string(out))
 
 	// get commit that the tag points to
-	cmd = exec.CommandContext(context.TODO(), "git", "rev-parse", "v1.2.3^{}")
+	cmd = exec.CommandContext(t.Context(), "git", "rev-parse", "v1.2.3^{}")
 	cmd.Dir = repo.mainPath
 
 	out, err = cmd.Output()
@@ -1091,7 +1091,7 @@ func testFetchAnnotatedTagChecksums(t *testing.T, format string, keepGitDir bool
 
 		ref, err := g.Snapshot(ctx, nil)
 		require.NoError(t, err)
-		ref.Release(context.TODO())
+		ref.Release(t.Context())
 
 		if keepGitDir {
 			mountable, err := ref.Mount(ctx, true, nil)
@@ -1102,14 +1102,14 @@ func testFetchAnnotatedTagChecksums(t *testing.T, format string, keepGitDir bool
 			require.NoError(t, err)
 			defer lm1.Unmount()
 
-			cmd = exec.CommandContext(context.TODO(), "git", "tag", "--points-at", "HEAD")
+			cmd = exec.CommandContext(t.Context(), "git", "tag", "--points-at", "HEAD")
 			cmd.Dir = dir
 
 			out, err = cmd.Output()
 			require.NoError(t, err)
 			require.Equal(t, "v1.2.3\n", string(out))
 
-			cmd = exec.CommandContext(context.TODO(), "git", "rev-parse", "v1.2.3")
+			cmd = exec.CommandContext(t.Context(), "git", "rev-parse", "v1.2.3")
 			cmd.Dir = dir
 
 			out, err = cmd.Output()
@@ -1142,7 +1142,7 @@ func testFetchTagChangeRace(t *testing.T, format string, keepGitDir bool) {
 		t.Skip("Depends on unimplemented containerd bind-mount support on Windows")
 	}
 	repo := setupGitRepo(t, format)
-	cmd := exec.CommandContext(context.TODO(), "git", "rev-parse", "v1.2.3")
+	cmd := exec.CommandContext(t.Context(), "git", "rev-parse", "v1.2.3")
 	cmd.Dir = repo.mainPath
 
 	out, err := cmd.Output()
@@ -1155,7 +1155,7 @@ func testFetchTagChangeRace(t *testing.T, format string, keepGitDir bool) {
 	shaTag := strings.TrimSpace(string(out))
 	require.Equal(t, expLen, len(shaTag))
 
-	cmd = exec.CommandContext(context.TODO(), "git", "rev-parse", "v1.2.3^{}")
+	cmd = exec.CommandContext(t.Context(), "git", "rev-parse", "v1.2.3^{}")
 	cmd.Dir = repo.mainPath
 
 	out, err = cmd.Output()
@@ -1180,7 +1180,7 @@ func testFetchTagChangeRace(t *testing.T, format string, keepGitDir bool) {
 		require.Equal(t, shaTagCommit, key1)
 	}
 
-	cmd = exec.CommandContext(context.TODO(), "git", "rev-parse", "v1.2.3-special")
+	cmd = exec.CommandContext(t.Context(), "git", "rev-parse", "v1.2.3-special")
 	cmd.Dir = repo.mainPath
 	out, err = cmd.Output()
 	require.NoError(t, err)
@@ -1188,20 +1188,20 @@ func testFetchTagChangeRace(t *testing.T, format string, keepGitDir bool) {
 	require.NotEqual(t, shaTag, shaTagNew)
 
 	// delete tag v1.2.3
-	cmd = exec.CommandContext(context.TODO(), "git", "tag", "-d", "v1.2.3")
+	cmd = exec.CommandContext(t.Context(), "git", "tag", "-d", "v1.2.3")
 	cmd.Dir = repo.mainPath
 	out, err = cmd.CombinedOutput()
 	require.NoError(t, err, string(out))
 
 	// recreate tag v1.2.3 to point to another commit
-	cmd = exec.CommandContext(context.TODO(), "git", "tag", "v1.2.3", shaTagNew)
+	cmd = exec.CommandContext(t.Context(), "git", "tag", "v1.2.3", shaTagNew)
 	cmd.Dir = repo.mainPath
 	out, err = cmd.CombinedOutput()
 	require.NoError(t, err, string(out))
 
 	ref, err := g.Snapshot(ctx, nil)
 	require.NoError(t, err)
-	ref.Release(context.TODO())
+	ref.Release(t.Context())
 
 	mount, err := ref.Mount(ctx, true, nil)
 	require.NoError(t, err)
@@ -1218,7 +1218,7 @@ func testFetchTagChangeRace(t *testing.T, format string, keepGitDir bool) {
 
 	if keepGitDir {
 		// read current HEAD commit
-		cmd = exec.CommandContext(context.TODO(), "git", "rev-parse", "HEAD")
+		cmd = exec.CommandContext(t.Context(), "git", "rev-parse", "HEAD")
 		cmd.Dir = dir
 
 		out, err = cmd.Output()
@@ -1250,7 +1250,7 @@ func testFetchBranchChangeRace(t *testing.T, format string, keepGitDir bool) {
 		t.Skip("Depends on unimplemented containerd bind-mount support on Windows")
 	}
 	repo := setupGitRepo(t, format)
-	cmd := exec.CommandContext(context.TODO(), "git", "rev-parse", "master")
+	cmd := exec.CommandContext(t.Context(), "git", "rev-parse", "master")
 	cmd.Dir = repo.mainPath
 
 	out, err := cmd.Output()
@@ -1280,7 +1280,7 @@ func testFetchBranchChangeRace(t *testing.T, format string, keepGitDir bool) {
 		require.Equal(t, shaMaster, key1)
 	}
 
-	cmd = exec.CommandContext(context.TODO(), "git", "rev-parse", "feature")
+	cmd = exec.CommandContext(t.Context(), "git", "rev-parse", "feature")
 	cmd.Dir = repo.mainPath
 	out, err = cmd.Output()
 	require.NoError(t, err)
@@ -1288,14 +1288,14 @@ func testFetchBranchChangeRace(t *testing.T, format string, keepGitDir bool) {
 	require.NotEqual(t, shaMaster, shaFeature)
 
 	// checkout feature as master
-	cmd = exec.CommandContext(context.TODO(), "git", "checkout", "-B", "master", "feature")
+	cmd = exec.CommandContext(t.Context(), "git", "checkout", "-B", "master", "feature")
 	cmd.Dir = repo.mainPath
 	out, err = cmd.CombinedOutput()
 	require.NoError(t, err, string(out))
 
 	ref, err := g.Snapshot(ctx, nil)
 	require.NoError(t, err)
-	ref.Release(context.TODO())
+	ref.Release(t.Context())
 
 	mount, err := ref.Mount(ctx, true, nil)
 	require.NoError(t, err)
@@ -1312,7 +1312,7 @@ func testFetchBranchChangeRace(t *testing.T, format string, keepGitDir bool) {
 
 	if keepGitDir {
 		// read current HEAD commit
-		cmd = exec.CommandContext(context.TODO(), "git", "rev-parse", "HEAD")
+		cmd = exec.CommandContext(t.Context(), "git", "rev-parse", "HEAD")
 		cmd.Dir = dir
 
 		out, err = cmd.Output()
@@ -1344,7 +1344,7 @@ func testFetchBranchRemoveRace(t *testing.T, format string, keepGitDir bool) {
 		t.Skip("Depends on unimplemented containerd bind-mount support on Windows")
 	}
 	repo := setupGitRepo(t, format)
-	cmd := exec.CommandContext(context.TODO(), "git", "rev-parse", "feature")
+	cmd := exec.CommandContext(t.Context(), "git", "rev-parse", "feature")
 	cmd.Dir = repo.mainPath
 
 	out, err := cmd.Output()
@@ -1374,7 +1374,7 @@ func testFetchBranchRemoveRace(t *testing.T, format string, keepGitDir bool) {
 		require.Equal(t, shaFeature, key1)
 	}
 
-	cmd = exec.CommandContext(context.TODO(), "git", "rev-parse", "master")
+	cmd = exec.CommandContext(t.Context(), "git", "rev-parse", "master")
 	cmd.Dir = repo.mainPath
 	out, err = cmd.Output()
 	require.NoError(t, err)
@@ -1382,22 +1382,22 @@ func testFetchBranchRemoveRace(t *testing.T, format string, keepGitDir bool) {
 	require.NotEqual(t, shaMaster, shaFeature)
 
 	// change feature to point to master
-	cmd = exec.CommandContext(context.TODO(), "git", "branch", "-f", "feature", "master")
+	cmd = exec.CommandContext(t.Context(), "git", "branch", "-f", "feature", "master")
 	cmd.Dir = repo.mainPath
 	out, err = cmd.CombinedOutput()
 	require.NoError(t, err, string(out))
 
-	cmd = exec.CommandContext(context.TODO(), "git", "reflog", "expire", "--expire-unreachable=now", "--expire=now", "--all")
+	cmd = exec.CommandContext(t.Context(), "git", "reflog", "expire", "--expire-unreachable=now", "--expire=now", "--all")
 	cmd.Dir = repo.mainPath
 	out, err = cmd.CombinedOutput()
 	require.NoError(t, err, string(out))
 
-	cmd = exec.CommandContext(context.TODO(), "git", "gc", "--prune=now", "--aggressive")
+	cmd = exec.CommandContext(t.Context(), "git", "gc", "--prune=now", "--aggressive")
 	cmd.Dir = repo.mainPath
 	out, err = cmd.CombinedOutput()
 	require.NoError(t, err, string(out))
 
-	cmd = exec.CommandContext(context.TODO(), "git", "cat-file", "-t", shaFeature)
+	cmd = exec.CommandContext(t.Context(), "git", "cat-file", "-t", shaFeature)
 	cmd.Dir = repo.mainPath
 	out, err = cmd.CombinedOutput()
 	require.Error(t, err, string(out))
@@ -1429,7 +1429,7 @@ func testFetchMutatedTag(t *testing.T, format string, keepGitDir bool) {
 		t.Skip("Depends on unimplemented containerd bind-mount support on Windows")
 	}
 	repo := setupGitRepo(t, format)
-	cmd := exec.CommandContext(context.TODO(), "git", "rev-parse", "v1.2.3")
+	cmd := exec.CommandContext(t.Context(), "git", "rev-parse", "v1.2.3")
 	cmd.Dir = repo.mainPath
 
 	out, err := cmd.Output()
@@ -1454,16 +1454,16 @@ func testFetchMutatedTag(t *testing.T, format string, keepGitDir bool) {
 
 	ref, err := g.Snapshot(ctx, nil)
 	require.NoError(t, err)
-	ref.Release(context.TODO())
+	ref.Release(t.Context())
 
 	// mutate the tag to point to another commit
-	cmd = exec.CommandContext(context.TODO(), "git", "tag", "-f", "v1.2.3", "feature")
+	cmd = exec.CommandContext(t.Context(), "git", "tag", "-f", "v1.2.3", "feature")
 	cmd.Dir = repo.mainPath
 	out, err = cmd.CombinedOutput()
 	require.NoError(t, err, string(out))
 
 	// verify that the tag now points to a different commit
-	cmd = exec.CommandContext(context.TODO(), "git", "rev-parse", "v1.2.3")
+	cmd = exec.CommandContext(t.Context(), "git", "rev-parse", "v1.2.3")
 	cmd.Dir = repo.mainPath
 
 	out, err = cmd.Output()
@@ -1488,7 +1488,7 @@ func testFetchMutatedTag(t *testing.T, format string, keepGitDir bool) {
 
 	ref, err = g.Snapshot(ctx, nil)
 	require.NoError(t, err)
-	ref.Release(context.TODO())
+	ref.Release(t.Context())
 }
 
 func TestFetchMutatedBranchSHA1(t *testing.T) {
@@ -1515,7 +1515,7 @@ func testFetchMutatedBranch(t *testing.T, format string, keepGitDir bool) {
 		t.Skip("Depends on unimplemented containerd bind-mount support on Windows")
 	}
 	repo := setupGitRepo(t, format)
-	cmd := exec.CommandContext(context.TODO(), "git", "rev-parse", "feature")
+	cmd := exec.CommandContext(t.Context(), "git", "rev-parse", "feature")
 	cmd.Dir = repo.mainPath
 
 	out, err := cmd.Output()
@@ -1540,15 +1540,15 @@ func testFetchMutatedBranch(t *testing.T, format string, keepGitDir bool) {
 
 	ref, err := g.Snapshot(ctx, nil)
 	require.NoError(t, err)
-	ref.Release(context.TODO())
+	ref.Release(t.Context())
 
 	// mutate the branch to point to become parent dir
-	cmd = exec.CommandContext(context.TODO(), "git", "branch", "-D", "feature")
+	cmd = exec.CommandContext(t.Context(), "git", "branch", "-D", "feature")
 	cmd.Dir = repo.mainPath
 	out, err = cmd.CombinedOutput()
 	require.NoError(t, err, string(out))
 
-	cmd = exec.CommandContext(context.TODO(), "git", "branch", "feature/new", shaBranch)
+	cmd = exec.CommandContext(t.Context(), "git", "branch", "feature/new", shaBranch)
 	cmd.Dir = repo.mainPath
 	out, err = cmd.CombinedOutput()
 	require.NoError(t, err, string(out))
@@ -1571,7 +1571,7 @@ func testFetchMutatedBranch(t *testing.T, format string, keepGitDir bool) {
 
 	ref, err = g.Snapshot(ctx, nil)
 	require.NoError(t, err)
-	ref.Release(context.TODO())
+	ref.Release(t.Context())
 }
 
 func TestMultipleTagAccessKeepGitDirSHA1(t *testing.T) {
@@ -1596,7 +1596,7 @@ func testMultipleTagAccess(t *testing.T, keepGitDir bool, format string) {
 	}
 
 	t.Parallel()
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 	ctx = logProgressStreams(ctx, t)
 
 	gs := setupGitSource(t, t.TempDir())
@@ -1628,7 +1628,7 @@ func testMultipleTagAccess(t *testing.T, keepGitDir bool, format string) {
 
 	ref1, err := g.Snapshot(ctx, nil)
 	require.NoError(t, err)
-	defer ref1.Release(context.TODO())
+	defer ref1.Release(t.Context())
 
 	id2 := &GitIdentifier{Remote: repo.mainURL, KeepGitDir: keepGitDir, Ref: "a/v1.2.3-same"}
 	g2, err := gs.Resolve(ctx, id2, nil, nil)
@@ -1653,7 +1653,7 @@ func testMultipleTagAccess(t *testing.T, keepGitDir bool, format string) {
 
 	ref2, err := g2.Snapshot(ctx, nil)
 	require.NoError(t, err)
-	defer ref1.Release(context.TODO())
+	defer ref1.Release(t.Context())
 
 	mount1, err := ref2.Mount(ctx, true, nil)
 	require.NoError(t, err)
@@ -1707,7 +1707,7 @@ func testResolveMetadataObject(t *testing.T, keepGitDir bool, format string) {
 	}
 
 	t.Parallel()
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 	ctx = logProgressStreams(ctx, t)
 
 	gs := setupGitSource(t, t.TempDir())
@@ -1793,7 +1793,7 @@ func testMultipleRepos(t *testing.T, keepGitDir bool, format string) {
 	}
 
 	t.Parallel()
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 	ctx = logProgressStreams(ctx, t)
 
 	gs := setupGitSource(t, t.TempDir())
@@ -1855,7 +1855,7 @@ func testMultipleRepos(t *testing.T, keepGitDir bool, format string) {
 
 	ref1, err := g.Snapshot(ctx, nil)
 	require.NoError(t, err)
-	defer ref1.Release(context.TODO())
+	defer ref1.Release(t.Context())
 
 	mount, err := ref1.Mount(ctx, true, nil)
 	require.NoError(t, err)
@@ -1867,7 +1867,7 @@ func testMultipleRepos(t *testing.T, keepGitDir bool, format string) {
 
 	ref2, err := g2.Snapshot(ctx, nil)
 	require.NoError(t, err)
-	defer ref2.Release(context.TODO())
+	defer ref2.Release(t.Context())
 
 	mount, err = ref2.Mount(ctx, true, nil)
 	require.NoError(t, err)
@@ -1894,7 +1894,7 @@ func TestCredentialRedaction(t *testing.T) {
 	}
 
 	t.Parallel()
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 	ctx = logProgressStreams(ctx, t)
 
 	gs := setupGitSource(t, t.TempDir())
@@ -1931,7 +1931,7 @@ func testSubmoduleSubdir(t *testing.T, keepGitDir bool, format string) {
 		t.Skip("Depends on unimplemented containerd bind-mount support on Windows")
 	}
 	t.Parallel()
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 	ctx = logProgressStreams(ctx, t)
 
 	gs := setupGitSource(t, t.TempDir())
@@ -1958,7 +1958,7 @@ func testSubmoduleSubdir(t *testing.T, keepGitDir bool, format string) {
 
 	ref1, err := g.Snapshot(ctx, nil)
 	require.NoError(t, err)
-	defer ref1.Release(context.TODO())
+	defer ref1.Release(t.Context())
 
 	mount, err := ref1.Mount(ctx, true, nil)
 	require.NoError(t, err)
@@ -1996,7 +1996,7 @@ func testCheckSignatures(t *testing.T, keepGitDir bool, format string) {
 	}
 	t.Parallel()
 	requireSignFixtures(t)
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 	ctx = logProgressStreams(ctx, t)
 
 	gs := setupGitSource(t, t.TempDir())
@@ -2102,7 +2102,7 @@ func testVerifySignatures(t *testing.T, keepGitDir bool, format string) {
 	}
 	t.Parallel()
 	requireSignFixtures(t)
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 	ctx = logProgressStreams(ctx, t)
 
 	gs := setupGitSource(t, t.TempDir())
@@ -2311,7 +2311,7 @@ func testSubdir(t *testing.T, keepGitDir bool) {
 
 	t.Parallel()
 
-	ctx := logProgressStreams(context.Background(), t)
+	ctx := logProgressStreams(t.Context(), t)
 
 	gs := setupGitSource(t, t.TempDir())
 
@@ -2349,7 +2349,7 @@ func testSubdir(t *testing.T, keepGitDir bool) {
 
 	ref1, err := g.Snapshot(ctx, nil)
 	require.NoError(t, err)
-	defer ref1.Release(context.TODO())
+	defer ref1.Release(t.Context())
 
 	mount, err := ref1.Mount(ctx, true, nil)
 	require.NoError(t, err)
@@ -2444,7 +2444,7 @@ func gitSnapshotMode(ctx context.Context, t *testing.T, gs *Source, id *GitIdent
 
 	ref, err := g.Snapshot(ctx, jobCtx)
 	require.NoError(t, err)
-	defer ref.Release(context.TODO())
+	defer ref.Release(t.Context())
 
 	mount, err := ref.Mount(ctx, true, nil)
 	require.NoError(t, err)
@@ -2610,7 +2610,7 @@ func serveGitRepo(t *testing.T, root string) string {
 	t.Helper()
 	gitpath, err := exec.LookPath("git")
 	require.NoError(t, err)
-	gitversion, _ := exec.CommandContext(context.TODO(), gitpath, "version").CombinedOutput()
+	gitversion, _ := exec.CommandContext(t.Context(), gitpath, "version").CombinedOutput()
 	t.Logf("%s", gitversion) // E.g. "git version 2.30.2"
 
 	// Serve all repositories under root using the Smart HTTP protocol so
@@ -2658,9 +2658,9 @@ func runShellEnv(t *testing.T, dir string, env []string, cmds ...string) {
 	for _, args := range cmds {
 		var cmd *exec.Cmd
 		if runtime.GOOS == "windows" {
-			cmd = exec.CommandContext(context.TODO(), "powershell", "-command", args)
+			cmd = exec.CommandContext(t.Context(), "powershell", "-command", args)
 		} else {
-			cmd = exec.CommandContext(context.TODO(), "sh", "-c", args)
+			cmd = exec.CommandContext(t.Context(), "sh", "-c", args)
 		}
 		cmd.Dir = dir
 		cmd.Env = append(os.Environ(), env...)
@@ -2767,7 +2767,7 @@ func TestBundleStagedRefShape(t *testing.T) {
 	}
 
 	t.Parallel()
-	ctx := namespaces.WithNamespace(context.Background(), "buildkit-test")
+	ctx := namespaces.WithNamespace(t.Context(), "buildkit-test")
 	ctx = logProgressStreams(ctx, t)
 
 	// Build a source-of-truth git repo with a single commit on master.
@@ -2894,7 +2894,7 @@ func TestDetectBundleSHA256(t *testing.T) {
 	}
 
 	t.Parallel()
-	ctx := logProgressStreams(context.Background(), t)
+	ctx := logProgressStreams(t.Context(), t)
 
 	for _, format := range []string{"sha1", "sha256"} {
 		t.Run(format, func(t *testing.T) {
@@ -2944,7 +2944,7 @@ func TestCompatibility014FileModes(t *testing.T) {
 	}
 
 	t.Parallel()
-	ctx := logProgressStreams(context.Background(), t)
+	ctx := logProgressStreams(t.Context(), t)
 
 	gs := setupGitSource(t, t.TempDir())
 	repo := setupGitRepo(t, "sha1")
@@ -2963,7 +2963,7 @@ func testCommitTimeMtimes(t *testing.T, format string, keepGitDir bool) {
 	}
 
 	t.Parallel()
-	ctx := logProgressStreams(context.Background(), t)
+	ctx := logProgressStreams(t.Context(), t)
 
 	gs := setupGitSource(t, t.TempDir())
 	repo := setupGitRepo(t, format)
@@ -2997,7 +2997,7 @@ func testCommitTimeMtimes(t *testing.T, format string, keepGitDir bool) {
 
 	refCommit, err := gCommit.Snapshot(ctx, nil)
 	require.NoError(t, err)
-	defer refCommit.Release(context.TODO())
+	defer refCommit.Release(t.Context())
 
 	mount, err := refCommit.Mount(ctx, true, nil)
 	require.NoError(t, err)

--- a/source/http/source_test.go
+++ b/source/http/source_test.go
@@ -33,7 +33,7 @@ const signFixturesPathEnv = "BUILDKIT_TEST_SIGN_FIXTURES"
 
 func TestHTTPSource(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	hs, err := newHTTPSource(t)
 	require.NoError(t, err)
@@ -77,7 +77,7 @@ func TestHTTPSource(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, dt, []byte("content1"))
 
-	ref.Release(context.TODO())
+	ref.Release(t.Context())
 	ref = nil
 
 	// repeat, should use the etag
@@ -105,7 +105,7 @@ func TestHTTPSource(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, dt, []byte("content1"))
 
-	ref.Release(context.TODO())
+	ref.Release(t.Context())
 	ref = nil
 
 	resp2 := &httpserver.Response{
@@ -144,13 +144,13 @@ func TestHTTPSource(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, dt, []byte("content2"))
 
-	ref.Release(context.TODO())
+	ref.Release(t.Context())
 	ref = nil
 }
 
 func TestHTTPDefaultName(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	hs, err := newHTTPSource(t)
 	require.NoError(t, err)
@@ -194,13 +194,13 @@ func TestHTTPDefaultName(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, dt, []byte("content1"))
 
-	ref.Release(context.TODO())
+	ref.Release(t.Context())
 	ref = nil
 }
 
 func TestHTTPInvalidURL(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	hs, err := newHTTPSource(t)
 	require.NoError(t, err)
@@ -220,7 +220,7 @@ func TestHTTPInvalidURL(t *testing.T) {
 
 func TestHTTPChecksum(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	hs, err := newHTTPSource(t)
 	require.NoError(t, err)
@@ -294,13 +294,13 @@ func TestHTTPChecksum(t *testing.T) {
 	require.Equal(t, 2, server.Stats("/foo").AllRequests)
 	require.Equal(t, 0, server.Stats("/foo").CachedRequests)
 
-	ref.Release(context.TODO())
+	ref.Release(t.Context())
 	ref = nil
 }
 
 func TestHTTPSignatureVerification(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	fixturesPath, ok := os.LookupEnv(signFixturesPathEnv)
 	if !ok {
@@ -385,7 +385,7 @@ func TestHTTPSignatureVerification(t *testing.T) {
 
 func TestPruneAfterCacheKey(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	cm, err := newCacheManager(t)
 	require.NoError(t, err)
@@ -440,7 +440,7 @@ func TestPruneAfterCacheKey(t *testing.T) {
 
 	ref, err := h.Snapshot(ctx, jc)
 	require.NoError(t, err)
-	ref.Release(context.TODO())
+	ref.Release(t.Context())
 
 	dt, err := readFile(ctx, ref, "foo")
 	require.NoError(t, err)

--- a/sourcepolicy/mutate_test.go
+++ b/sourcepolicy/mutate_test.go
@@ -1,7 +1,6 @@
 package sourcepolicy
 
 import (
-	"context"
 	"testing"
 
 	"github.com/moby/buildkit/solver/pb"
@@ -125,7 +124,7 @@ func TestMutate(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	for _, tc := range testCases {
 		op := tc.op
 		t.Run(op.String(), func(t *testing.T) {

--- a/util/cachedigest/db_test.go
+++ b/util/cachedigest/db_test.go
@@ -1,7 +1,6 @@
 package cachedigest
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"slices"
@@ -38,7 +37,7 @@ func TestFromBytesAndGet(t *testing.T) {
 
 	db.Wait()
 
-	gotType, frames, err := db.Get(context.Background(), dgst.String())
+	gotType, frames, err := db.Get(t.Context(), dgst.String())
 	require.NoError(t, err)
 	require.Equal(t, typ, gotType)
 
@@ -51,7 +50,7 @@ func TestFromBytesAndGet(t *testing.T) {
 	}
 	require.True(t, foundData, "should find data frame")
 
-	_, _, err = db.Get(context.Background(), digest.FromBytes([]byte("notfound")).String())
+	_, _, err = db.Get(t.Context(), digest.FromBytes([]byte("notfound")).String())
 	require.ErrorIs(t, err, ErrNotFound)
 }
 
@@ -83,7 +82,7 @@ func TestNewHashAndGet(t *testing.T) {
 	expectedHash := digest.FromBytes(expectedConcat)
 	require.Equal(t, expectedHash, sum, "digest sum should match expected value")
 
-	gotType, frames, err := db.Get(context.Background(), sum.String())
+	gotType, frames, err := db.Get(t.Context(), sum.String())
 	require.NoError(t, err)
 	require.Equal(t, TypeStringList, gotType)
 
@@ -171,7 +170,7 @@ func TestAll(t *testing.T) {
 		frames []Frame
 	})
 
-	err := db.All(context.TODO(), func(key string, typ Type, frames []Frame) error {
+	err := db.All(t.Context(), func(key string, typ Type, frames []Frame) error {
 		found[key] = struct {
 			typ    Type
 			frames []Frame

--- a/util/contentutil/buffer_test.go
+++ b/util/contentutil/buffer_test.go
@@ -2,7 +2,6 @@ package contentutil
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"testing"
 
@@ -17,7 +16,7 @@ import (
 
 func TestReadWrite(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	b := NewBuffer()
 
@@ -47,7 +46,7 @@ func TestReadWrite(t *testing.T) {
 
 func TestReaderAt(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	b := NewBuffer()
 
@@ -75,7 +74,7 @@ func TestReaderAt(t *testing.T) {
 
 func TestLabels(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	b := NewBuffer()
 

--- a/util/contentutil/copy_test.go
+++ b/util/contentutil/copy_test.go
@@ -2,7 +2,6 @@ package contentutil
 
 import (
 	"bytes"
-	"context"
 	"testing"
 
 	"github.com/containerd/containerd/v2/core/content"
@@ -13,7 +12,7 @@ import (
 
 func TestCopy(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	b0 := NewBuffer()
 	b1 := NewBuffer()

--- a/util/contentutil/fetcher_test.go
+++ b/util/contentutil/fetcher_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestFetcher(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	b0 := NewBuffer()
 
@@ -50,7 +50,7 @@ func TestFetcher(t *testing.T) {
 
 func TestSlowFetch(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	f := &dummySlowFetcher{}
 	p := FromFetcher(f)

--- a/util/contentutil/multiprovider_test.go
+++ b/util/contentutil/multiprovider_test.go
@@ -2,7 +2,6 @@ package contentutil
 
 import (
 	"bytes"
-	"context"
 	"testing"
 
 	"github.com/containerd/containerd/v2/core/content"
@@ -15,7 +14,7 @@ import (
 
 func TestMultiProvider(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	b0 := NewBuffer()
 	b1 := NewBuffer()

--- a/util/flightcontrol/cached_test.go
+++ b/util/flightcontrol/cached_test.go
@@ -12,7 +12,7 @@ import (
 func TestCached(t *testing.T) {
 	var g CachedGroup[int]
 
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	v, err := g.Do(ctx, "11", func(ctx context.Context) (int, error) {
 		return 1, nil
@@ -55,7 +55,7 @@ func TestCachedError(t *testing.T) {
 	var g CachedGroup[string]
 	g.CacheError = true
 
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	_, err := g.Do(ctx, "11", func(ctx context.Context) (string, error) {
 		return "", errors.New("first error")
@@ -70,7 +70,7 @@ func TestCachedError(t *testing.T) {
 	require.ErrorContains(t, err, "first error")
 
 	// context errors are never cached
-	ctx, cancel := context.WithTimeoutCause(context.TODO(), 10*time.Millisecond, nil)
+	ctx, cancel := context.WithTimeoutCause(t.Context(), 10*time.Millisecond, nil)
 	defer cancel()
 	_, err = g.Do(ctx, "22", func(ctx context.Context) (string, error) {
 		select {

--- a/util/flightcontrol/flightcontrol_test.go
+++ b/util/flightcontrol/flightcontrol_test.go
@@ -16,7 +16,7 @@ import (
 func TestNoCancel(t *testing.T) {
 	t.Parallel()
 	g := &Group[string]{}
-	eg, ctx := errgroup.WithContext(context.Background())
+	eg, ctx := errgroup.WithContext(t.Context())
 	var r1, r2 string
 	var counter int64
 	f := testFunc(100*time.Millisecond, "bar", &counter)
@@ -46,7 +46,7 @@ func TestNoCancel(t *testing.T) {
 func TestCancelOne(t *testing.T) {
 	t.Parallel()
 	g := &Group[string]{}
-	eg, ctx := errgroup.WithContext(context.Background())
+	eg, ctx := errgroup.WithContext(t.Context())
 	var r1, r2 string
 	var counter int64
 	f := testFunc(100*time.Millisecond, "bar", &counter)
@@ -88,7 +88,7 @@ func TestCancelRace(t *testing.T) {
 	// t.Parallel() // disabled for better timing consistency. works with parallel as well
 
 	g := &Group[struct{}]{}
-	ctx, cancel := context.WithCancelCause(context.Background())
+	ctx, cancel := context.WithCancelCause(t.Context())
 
 	kick := make(chan struct{})
 	wait := make(chan struct{})
@@ -129,7 +129,7 @@ func TestCancelRace(t *testing.T) {
 		<-kick
 		cancel(errors.WithStack(context.Canceled))
 		time.Sleep(5 * time.Millisecond)
-		_, err := g.Do(context.Background(), "foo", f)
+		_, err := g.Do(t.Context(), "foo", f)
 		assert.NoError(t, err)
 	}()
 
@@ -142,7 +142,7 @@ func TestCancelRace(t *testing.T) {
 func TestCancelBoth(t *testing.T) {
 	t.Parallel()
 	g := &Group[string]{}
-	eg, ctx := errgroup.WithContext(context.Background())
+	eg, ctx := errgroup.WithContext(t.Context())
 	var r1, r2 string
 	var counter int64
 	f := testFunc(200*time.Millisecond, "bar", &counter)
@@ -189,11 +189,11 @@ func TestCancelBoth(t *testing.T) {
 	assert.Equal(t, "", r1)
 	assert.Equal(t, "", r2)
 	assert.Equal(t, int64(1), counter)
-	ret1, err := g.Do(context.TODO(), "foo", f)
+	ret1, err := g.Do(t.Context(), "foo", f)
 	require.NoError(t, err)
 	assert.Equal(t, "bar", ret1)
 
-	ret1, err = g.Do(context.TODO(), "abc", f)
+	ret1, err = g.Do(t.Context(), "abc", f)
 	require.NoError(t, err)
 	assert.Equal(t, "bar", ret1)
 
@@ -211,7 +211,7 @@ func TestContention(t *testing.T) {
 
 	for range threads {
 		for range perthread {
-			_, err := g.Do(context.TODO(), "foo", func(ctx context.Context) (int, error) {
+			_, err := g.Do(t.Context(), "foo", func(ctx context.Context) (int, error) {
 				time.Sleep(time.Microsecond)
 				return 0, nil
 			})
@@ -226,7 +226,7 @@ func TestContention(t *testing.T) {
 func TestMassiveParallel(t *testing.T) {
 	var retryCount int64
 	g := &Group[string]{}
-	eg, ctx := errgroup.WithContext(context.Background())
+	eg, ctx := errgroup.WithContext(t.Context())
 	for range 1000 {
 		eg.Go(func() error {
 			_, err := g.Do(ctx, "key", func(ctx context.Context) (string, error) {

--- a/util/gitutil/git_cli_test.go
+++ b/util/gitutil/git_cli_test.go
@@ -33,7 +33,7 @@ func TestGitCLIConfigEnv(t *testing.T) {
 			got = append([]string(nil), cmd.Env...)
 			return nil
 		}))
-		_, err := cli.Run(context.Background(), "status")
+		_, err := cli.Run(t.Context(), "status")
 		require.NoError(t, err)
 		require.Contains(t, got, "GIT_CONFIG_NOSYSTEM=1")
 		require.Contains(t, got, "HOME="+os.DevNull)
@@ -54,7 +54,7 @@ func TestGitCLIConfigEnv(t *testing.T) {
 				return nil
 			}),
 		)
-		_, err := cli.Run(context.Background(), "status")
+		_, err := cli.Run(t.Context(), "status")
 		require.NoError(t, err)
 		require.NotContains(t, got, "GIT_CONFIG_NOSYSTEM=1")
 		require.NotContains(t, got, "HOME="+os.DevNull)

--- a/util/imageutil/config_test.go
+++ b/util/imageutil/config_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestConfigMultiplatform(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	cc := &testCache{}
 

--- a/util/overlay/overlay_linux_test.go
+++ b/util/overlay/overlay_linux_test.go
@@ -3,7 +3,6 @@
 package overlay
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -344,7 +343,7 @@ func testDiffWithBase(t *testing.T, base, diff fstest.Applier, expected []TestCh
 	tupper := t.TempDir()
 	workdir := t.TempDir()
 
-	return mount.WithTempMount(context.Background(), []mount.Mount{
+	return mount.WithTempMount(t.Context(), []mount.Mount{
 		{
 			Type:    "overlay",
 			Source:  "overlay",
@@ -402,7 +401,7 @@ type TestChange struct {
 }
 
 func collectAndCheckChanges(t *testing.T, base, upperdir string, expected []TestChange) error {
-	ctx := context.Background()
+	ctx := t.Context()
 	changes := []TestChange{}
 
 	emptyLower := t.TempDir() // empty directory used for the lower of diff view

--- a/util/progress/progress_test.go
+++ b/util/progress/progress_test.go
@@ -17,11 +17,11 @@ import (
 
 func TestProgress(t *testing.T) {
 	t.Parallel()
-	s, err := calc(context.TODO(), 4, "calc")
+	s, err := calc(t.Context(), 4, "calc")
 	require.NoError(t, err)
 	assert.Equal(t, 10, s)
 
-	eg, ctx := errgroup.WithContext(context.Background())
+	eg, ctx := errgroup.WithContext(t.Context())
 
 	pr, ctx, cancelProgress := NewContext(ctx)
 	var trace trace
@@ -50,7 +50,7 @@ func TestProgress(t *testing.T) {
 
 func TestProgressNested(t *testing.T) {
 	t.Parallel()
-	eg, ctx := errgroup.WithContext(context.Background())
+	eg, ctx := errgroup.WithContext(t.Context())
 	pr, ctx, cancelProgress := NewContext(ctx)
 	var trace trace
 	eg.Go(func() error {

--- a/util/staticfs/merge_test.go
+++ b/util/staticfs/merge_test.go
@@ -1,7 +1,6 @@
 package staticfs
 
 import (
-	"context"
 	"io"
 	iofs "io/fs"
 	"os"
@@ -38,7 +37,7 @@ func TestMerge(t *testing.T) {
 	require.Equal(t, []byte("barbarbar"), data)
 
 	var files []string
-	err = fs.Walk(context.TODO(), "", func(path string, entry iofs.DirEntry, err error) error {
+	err = fs.Walk(t.Context(), "", func(path string, entry iofs.DirEntry, err error) error {
 		require.NoError(t, err)
 		info, err := entry.Info()
 		require.NoError(t, err)
@@ -89,7 +88,7 @@ func TestMerge(t *testing.T) {
 	require.True(t, os.IsNotExist(err))
 
 	files = nil
-	err = fs.Walk(context.TODO(), "", func(path string, entry iofs.DirEntry, err error) error {
+	err = fs.Walk(t.Context(), "", func(path string, entry iofs.DirEntry, err error) error {
 		require.NoError(t, err)
 		files = append(files, path)
 		return nil

--- a/util/staticfs/static_test.go
+++ b/util/staticfs/static_test.go
@@ -1,7 +1,6 @@
 package staticfs
 
 import (
-	"context"
 	"io"
 	iofs "io/fs"
 	"os"
@@ -29,7 +28,7 @@ func TestStatic(t *testing.T) {
 	require.True(t, os.IsNotExist(err))
 
 	var files []string
-	err = fs.Walk(context.TODO(), "", func(path string, entry iofs.DirEntry, err error) error {
+	err = fs.Walk(t.Context(), "", func(path string, entry iofs.DirEntry, err error) error {
 		require.NoError(t, err)
 		info, err := entry.Info()
 		require.NoError(t, err)

--- a/util/testutil/containerd/containerd.go
+++ b/util/testutil/containerd/containerd.go
@@ -1,7 +1,6 @@
 package containerd
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -16,7 +15,7 @@ func GetVersion(t *testing.T, cdAddress string) string {
 		t.Fatal(err)
 	}
 	defer cdClient.Close()
-	ctx := context.TODO()
+	ctx := t.Context()
 	cdVersion, err := cdClient.Version(ctx)
 	if err != nil {
 		t.Fatal(err)

--- a/util/testutil/helpers/azurite.go
+++ b/util/testutil/helpers/azurite.go
@@ -41,7 +41,7 @@ func NewAzuriteServer(t *testing.T, sb integration.Sandbox, opts AzuriteOpts) (a
 	}()
 
 	listener := net.ListenConfig{}
-	l, err := listener.Listen(context.TODO(), "tcp", "localhost:0")
+	l, err := listener.Listen(t.Context(), "tcp", "localhost:0")
 	if err != nil {
 		return "", nil, err
 	}
@@ -57,7 +57,7 @@ func NewAzuriteServer(t *testing.T, sb integration.Sandbox, opts AzuriteOpts) (a
 	address = fmt.Sprintf("http://%s/%s", addr, opts.AccountName)
 
 	// start server
-	cmd := exec.CommandContext(context.TODO(), azuriteBin, "--disableProductStyleUrl", "--blobHost", host, "--blobPort", port, "--location", t.TempDir())
+	cmd := exec.CommandContext(t.Context(), azuriteBin, "--disableProductStyleUrl", "--blobHost", host, "--blobPort", port, "--location", t.TempDir())
 	cmd.Env = append(os.Environ(), []string{
 		"AZURITE_ACCOUNTS=" + opts.AccountName + ":" + opts.AccountKey,
 	}...)

--- a/util/testutil/helpers/minio.go
+++ b/util/testutil/helpers/minio.go
@@ -52,7 +52,7 @@ func NewMinioServer(t *testing.T, sb integration.Sandbox, opts MinioOpts) (addre
 	}()
 
 	listener := net.ListenConfig{}
-	l, err := listener.Listen(context.TODO(), "tcp", "localhost:0")
+	l, err := listener.Listen(t.Context(), "tcp", "localhost:0")
 	if err != nil {
 		return "", "", nil, err
 	}
@@ -64,7 +64,7 @@ func NewMinioServer(t *testing.T, sb integration.Sandbox, opts MinioOpts) (addre
 	address = "http://" + addr
 
 	// start server
-	cmd := exec.CommandContext(context.TODO(), minioBin, "server", "--json", "--address", addr, t.TempDir())
+	cmd := exec.CommandContext(t.Context(), minioBin, "server", "--json", "--address", addr, t.TempDir())
 	cmd.Env = append(os.Environ(), []string{
 		"MINIO_ROOT_USER=" + opts.AccessKeyID,
 		"MINIO_ROOT_PASSWORD=" + opts.SecretAccessKey,
@@ -81,22 +81,22 @@ func NewMinioServer(t *testing.T, sb integration.Sandbox, opts MinioOpts) (addre
 
 	// create alias config
 	alias := randomString(10)
-	cmd = exec.CommandContext(context.TODO(), mcBin, "alias", "set", alias, address, opts.AccessKeyID, opts.SecretAccessKey)
+	cmd = exec.CommandContext(t.Context(), mcBin, "alias", "set", alias, address, opts.AccessKeyID, opts.SecretAccessKey)
 	if err := integration.RunCmd(cmd, sb.Logs()); err != nil {
 		return "", "", nil, err
 	}
 	deferF.Append(func() error {
-		return exec.CommandContext(context.TODO(), mcBin, "alias", "rm", alias).Run()
+		return exec.CommandContext(t.Context(), mcBin, "alias", "rm", alias).Run()
 	})
 
 	// create bucket
-	cmd = exec.CommandContext(context.TODO(), mcBin, "mb", "--region", opts.Region, fmt.Sprintf("%s/%s", alias, bucket)) // #nosec G204
+	cmd = exec.CommandContext(t.Context(), mcBin, "mb", "--region", opts.Region, fmt.Sprintf("%s/%s", alias, bucket)) // #nosec G204
 	if err := integration.RunCmd(cmd, sb.Logs()); err != nil {
 		return "", "", nil, err
 	}
 
 	// trace
-	cmd = exec.CommandContext(context.TODO(), mcBin, "admin", "trace", "--json", alias)
+	cmd = exec.CommandContext(t.Context(), mcBin, "admin", "trace", "--json", alias)
 	traceStop, err := integration.StartCmd(cmd, sb.Logs())
 	if err != nil {
 		return "", "", nil, err

--- a/util/testutil/integration/run.go
+++ b/util/testutil/integration/run.go
@@ -230,7 +230,7 @@ func Run(t *testing.T, testCases []Test, opt ...TestOpt) {
 						if !strings.HasSuffix(fn, "NoParallel") && runtime.GOOS != "windows" {
 							t.Parallel()
 						}
-						require.NoError(t, sandboxLimiter.Acquire(context.TODO(), 1))
+						require.NoError(t, sandboxLimiter.Acquire(t.Context(), 1))
 						defer sandboxLimiter.Release(1)
 
 						ctx, cancel := context.WithCancelCause(ctx)
@@ -284,7 +284,7 @@ func copyImagesLocal(t *testing.T, host string, images map[string]string) error 
 		localImageCache[host][to] = struct{}{}
 
 		// already exists check
-		if _, _, err := docker.NewResolver(docker.ResolverOptions{}).Resolve(context.TODO(), host+"/"+to); err == nil {
+		if _, _, err := docker.NewResolver(docker.ResolverOptions{}).Resolve(t.Context(), host+"/"+to); err == nil {
 			continue
 		}
 
@@ -316,7 +316,7 @@ func copyImagesLocal(t *testing.T, host string, images map[string]string) error 
 			}
 		}
 
-		desc, err = resolveDefaultPlatform(context.TODO(), provider, desc)
+		desc, err = resolveDefaultPlatform(t.Context(), provider, desc)
 		if err != nil {
 			return err
 		}
@@ -325,7 +325,7 @@ func copyImagesLocal(t *testing.T, host string, images map[string]string) error 
 		if err != nil {
 			return err
 		}
-		if err := contentutil.CopyChain(context.TODO(), ingester, provider, desc); err != nil {
+		if err := contentutil.CopyChain(t.Context(), ingester, provider, desc); err != nil {
 			return err
 		}
 		t.Logf("copied %s to local mirror %s", from, host+"/"+to)

--- a/util/testutil/integration/util.go
+++ b/util/testutil/integration/util.go
@@ -39,7 +39,7 @@ func Tmpdir(t *testing.T, appliers ...fstest.Applier) *TmpDirWithName {
 	// appliers might contain fstest.CreateSocket. If the test name is too long,
 	// t.TempDir() could return a path that is longer than 108 characters. This
 	// would result in "bind: invalid argument" when we listen on the socket.
-	tmpdir, err := os.MkdirTemp("", "buildkit")
+	tmpdir, err := os.MkdirTemp("", "buildkit") //nolint:usetesting // see comment above
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/util/tracing/detect/detect_test.go
+++ b/util/tracing/detect/detect_test.go
@@ -1,7 +1,6 @@
 package detect
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -27,8 +26,8 @@ func TestDetectExporterIgnoreErrors(t *testing.T) {
 			t.Setenv("OTEL_METRICS_EXPORTER", "invalid")
 			t.Setenv("OTEL_IGNORE_ERROR", tc.ignoreErrors)
 
-			spanExp, spanErr := NewSpanExporter(context.Background())
-			metricExp, metricErr := NewMetricExporter(context.Background())
+			spanExp, spanErr := NewSpanExporter(t.Context())
+			metricExp, metricErr := NewMetricExporter(t.Context())
 			if tc.wantErr {
 				require.Error(t, spanErr)
 				require.Error(t, metricErr)

--- a/util/tracing/forwarder/forwarder_test.go
+++ b/util/tracing/forwarder/forwarder_test.go
@@ -41,7 +41,7 @@ func TestExportSpansDropsExpiredRequest(t *testing.T) {
 		},
 	})
 
-	e.exportSpans(context.Background(), exportRequest{
+	e.exportSpans(t.Context(), exportRequest{
 		deadline: time.Now().Add(-time.Millisecond),
 		spans:    testSpans,
 	})
@@ -55,7 +55,7 @@ func TestShutdownReturnsWhenExportBlocks(t *testing.T) {
 	exportDone := make(chan struct{})
 	var exportStartedOnce sync.Once
 
-	e, err := New(context.Background(), testExporter{
+	e, err := New(t.Context(), testExporter{
 		exportSpans: func(context.Context, []sdktrace.ReadOnlySpan) error {
 			exportStartedOnce.Do(func() {
 				close(exportStarted)
@@ -67,10 +67,10 @@ func TestShutdownReturnsWhenExportBlocks(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.NoError(t, e.ExportSpans(context.Background(), testSpans))
+	require.NoError(t, e.ExportSpans(t.Context(), testSpans))
 	requireCloses(t, exportStarted)
 
-	ctx, cancel := context.WithTimeoutCause(context.Background(), 50*time.Millisecond, context.DeadlineExceeded)
+	ctx, cancel := context.WithTimeoutCause(t.Context(), 50*time.Millisecond, context.DeadlineExceeded)
 	defer cancel()
 
 	start := time.Now()
@@ -86,7 +86,7 @@ func TestShutdownReturnsWhenExportBlocks(t *testing.T) {
 func TestShutdownPassesContextToExporterShutdown(t *testing.T) {
 	shutdownStarted := make(chan struct{})
 
-	e, err := New(context.Background(), testExporter{
+	e, err := New(t.Context(), testExporter{
 		shutdown: func(ctx context.Context) error {
 			close(shutdownStarted)
 			<-ctx.Done()
@@ -95,7 +95,7 @@ func TestShutdownPassesContextToExporterShutdown(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeoutCause(context.Background(), 50*time.Millisecond, context.DeadlineExceeded)
+	ctx, cancel := context.WithTimeoutCause(t.Context(), 50*time.Millisecond, context.DeadlineExceeded)
 	defer cancel()
 
 	errCh := make(chan error, 1)
@@ -116,7 +116,7 @@ func TestShutdownPassesContextToExporterShutdown(t *testing.T) {
 func TestShutdownDrainsPendingExports(t *testing.T) {
 	var exports atomic.Int64
 	var shutdowns atomic.Int64
-	e, err := New(context.Background(), testExporter{
+	e, err := New(t.Context(), testExporter{
 		exportSpans: func(context.Context, []sdktrace.ReadOnlySpan) error {
 			exports.Add(1)
 			return nil
@@ -128,10 +128,10 @@ func TestShutdownDrainsPendingExports(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.NoError(t, e.ExportSpans(context.Background(), testSpans))
-	require.NoError(t, e.ExportSpans(context.Background(), testSpans))
-	require.NoError(t, e.ExportSpans(context.Background(), testSpans))
-	require.NoError(t, e.Shutdown(context.Background()))
+	require.NoError(t, e.ExportSpans(t.Context(), testSpans))
+	require.NoError(t, e.ExportSpans(t.Context(), testSpans))
+	require.NoError(t, e.ExportSpans(t.Context(), testSpans))
+	require.NoError(t, e.Shutdown(t.Context()))
 
 	require.Equal(t, int64(3), exports.Load())
 	require.Equal(t, int64(1), shutdowns.Load())

--- a/worker/containerd/containerd_test.go
+++ b/worker/containerd/containerd_test.go
@@ -3,7 +3,6 @@
 package containerd
 
 import (
-	"context"
 	"testing"
 
 	"github.com/moby/buildkit/util/network/netproviders"
@@ -61,7 +60,7 @@ func testContainerdWorkerExec(t *testing.T, sb integration.Sandbox) {
 		t.Skip("requires root")
 	}
 	workerOpt := newWorkerOpt(t, sb.ContainerdAddress())
-	w, err := base.NewWorker(context.TODO(), workerOpt)
+	w, err := base.NewWorker(t.Context(), workerOpt)
 	require.NoError(t, err)
 
 	tests.TestWorkerExec(t, w)
@@ -72,7 +71,7 @@ func testContainerdWorkerExecFailures(t *testing.T, sb integration.Sandbox) {
 		t.Skip("requires root")
 	}
 	workerOpt := newWorkerOpt(t, sb.ContainerdAddress())
-	w, err := base.NewWorker(context.TODO(), workerOpt)
+	w, err := base.NewWorker(t.Context(), workerOpt)
 	require.NoError(t, err)
 
 	tests.TestWorkerExecFailures(t, w)
@@ -83,7 +82,7 @@ func testContainerdWorkerCancel(t *testing.T, sb integration.Sandbox) {
 		t.Skip("requires root")
 	}
 	workerOpt := newWorkerOpt(t, sb.ContainerdAddress())
-	w, err := base.NewWorker(context.TODO(), workerOpt)
+	w, err := base.NewWorker(t.Context(), workerOpt)
 	require.NoError(t, err)
 
 	tests.TestWorkerCancel(t, w)

--- a/worker/runc/runc_test.go
+++ b/worker/runc/runc_test.go
@@ -65,7 +65,7 @@ func TestRuncWorker(t *testing.T) {
 	checkRequirement(t)
 
 	workerOpt := newWorkerOpt(t, oci.ProcessSandbox)
-	w, err := base.NewWorker(context.TODO(), workerOpt)
+	w, err := base.NewWorker(t.Context(), workerOpt)
 	require.NoError(t, err)
 
 	ctx := tests.NewCtx("buildkit-test")
@@ -186,7 +186,7 @@ func TestRuncWorkerNoProcessSandbox(t *testing.T) {
 	checkRequirement(t)
 
 	workerOpt := newWorkerOpt(t, oci.NoProcessSandbox)
-	w, err := base.NewWorker(context.TODO(), workerOpt)
+	w, err := base.NewWorker(t.Context(), workerOpt)
 	require.NoError(t, err)
 
 	ctx := tests.NewCtx("buildkit-test")
@@ -216,7 +216,7 @@ func TestRuncWorkerExec(t *testing.T) {
 	checkRequirement(t)
 
 	workerOpt := newWorkerOpt(t, oci.ProcessSandbox)
-	w, err := base.NewWorker(context.TODO(), workerOpt)
+	w, err := base.NewWorker(t.Context(), workerOpt)
 	require.NoError(t, err)
 
 	tests.TestWorkerExec(t, w)
@@ -227,7 +227,7 @@ func TestRuncWorkerExecFailures(t *testing.T) {
 	checkRequirement(t)
 
 	workerOpt := newWorkerOpt(t, oci.ProcessSandbox)
-	w, err := base.NewWorker(context.TODO(), workerOpt)
+	w, err := base.NewWorker(t.Context(), workerOpt)
 	require.NoError(t, err)
 
 	tests.TestWorkerExecFailures(t, w)
@@ -238,7 +238,7 @@ func TestRuncWorkerCancel(t *testing.T) {
 	checkRequirement(t)
 
 	workerOpt := newWorkerOpt(t, oci.ProcessSandbox)
-	w, err := base.NewWorker(context.TODO(), workerOpt)
+	w, err := base.NewWorker(t.Context(), workerOpt)
 	require.NoError(t, err)
 
 	tests.TestWorkerCancel(t, w)


### PR DESCRIPTION
Enable the `usetesting` linter with context-background and context-todo checks, and update tests to use `t.Context()` and `t.TempDir()` instead of `context.Background()`, `context.TODO()`, and `os.MkdirTemp()`.

Some time ago, I was submitting a PR to BuildKit and there was a PR comment about using `t.Context()` instead of `context.Background()`, so I'm adding these rules to consistently use the "better" variants + obviously fixing the existing findings.