### PR TITLE
docs: document attestation size limit

### DIFF
--- a/docs/attestations/attestation-storage.md
+++ b/docs/attestations/attestation-storage.md
@@ -85,6 +85,10 @@ The contents of each layer will be a blob dependent on its `mediaType`.
   target manifest described in the [Attestation Manifest Descriptor](#attestation-manifest-descriptor),
   or some object within.
 
+BuildKit limits each attestation file read from a build result to 40 MiB
+before wrapping it as an in-toto statement. This protects exporters from
+unbounded reads of frontend-provided attestation files.
+
 ### Attestation Manifest Descriptor
 
 Attestation manifests are attached to the root [image index](https://github.com/opencontainers/image-spec/blob/main/image-index.md),

--- a/docs/attestations/sbom.md
+++ b/docs/attestations/sbom.md
@@ -198,3 +198,7 @@ The exact output will depend on the generator you use, however, generally:
 Entries in the `files` and `packages` will contain a `comment` field that
 contains the `sha256` digest of the layer which introduced it if that layer is
 present in the final image.
+
+Generated SBOM attestation files are limited to 40 MiB before they are
+attached to the exported image. Large SPDX JSON documents can approach this
+limit because SPDX includes detailed file, package, and relationship metadata.


### PR DESCRIPTION
relates to https://github.com/moby/buildkit/issues/7044

Document that BuildKit limits attestation files read from build results to 40 MiB before
wrapping them as in-toto statements.