### PR TITLE
Use maxRegistryConcurrency instead of DefaultMaxConcurrency

### DIFF
--- a/cache/remotecache/export.go
+++ b/cache/remotecache/export.go
@@ -222,7 +222,7 @@ func (ce *contentCacheExporter) Finalize(ctx context.Context) (map[string]string
 		layerDone(nil)
 		return nil, nil
 	})
-	if err := images.Dispatch(ctx, copyHandler, semaphore.NewWeighted(limited.DefaultMaxConcurrency), layerDescs...); err != nil {
+	if err := images.Dispatch(ctx, copyHandler, semaphore.NewWeighted(limited.Default.Size()), layerDescs...); err != nil {
 		return nil, err
 	}
 

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -326,7 +326,7 @@ func main() {
 				if *v <= 0 {
 					return errors.Errorf("maxRegistryConcurrency must be greater than zero; set to %d in the configuration file", *v)
 				}
-				limited.SetMaxConcurrency(*v)
+				limited.SetMaxConcurrency(int64(*v))
 			}
 		}
 

--- a/util/resolver/limited/group.go
+++ b/util/resolver/limited/group.go
@@ -23,11 +23,11 @@ var contextKey = contextKeyT("buildkit/util/resolver/limited")
 // DefaultMaxConcurrency is the default number of concurrent connections per registry.
 var DefaultMaxConcurrency int64 = 4
 
-var Default = New(int(DefaultMaxConcurrency))
+var Default = New(DefaultMaxConcurrency)
 
 type Group struct {
 	mu   sync.Mutex
-	size int
+	size int64
 	sem  map[string][2]*semaphore.Weighted
 }
 
@@ -66,11 +66,16 @@ func (r *req) acquire(ctx context.Context, desc ocispecs.Descriptor) (context.Co
 	}, nil
 }
 
-func New(size int) *Group {
+func New(size int64) *Group {
 	return &Group{
 		size: size,
 		sem:  make(map[string][2]*semaphore.Weighted),
 	}
+}
+
+// Size returns the maximum concurrency for the group.
+func (g *Group) Size() int64 {
+	return g.size
 }
 
 func (g *Group) req(ref string) *req {
@@ -84,8 +89,8 @@ func (g *Group) getOrInit(domain string) [2]*semaphore.Weighted {
 	s, ok := g.sem[domain]
 	if !ok {
 		s = [2]*semaphore.Weighted{
-			semaphore.NewWeighted(int64(g.size)),
-			semaphore.NewWeighted(int64(g.size + 1)),
+			semaphore.NewWeighted(g.size),
+			semaphore.NewWeighted(g.size + 1),
 		}
 		g.sem[domain] = s
 	}
@@ -93,7 +98,7 @@ func (g *Group) getOrInit(domain string) [2]*semaphore.Weighted {
 }
 
 // SetMaxConcurrency sets the default maximum concurrency for the default group.
-func SetMaxConcurrency(size int) {
+func SetMaxConcurrency(size int64) {
 	Default = New(size)
 }
 


### PR DESCRIPTION
We've been seeing some slow builds caused by contention in buildkitd. The traces show that  when they reach the concurrency limit for registry uploads other builds get blocked on this semaphore.

`cache/remotecache/export.go` used the `limited.DefaultMaxConcurrency` constant, where as everything else was using `limited.Default`.  `limited.Default` honors the `maxRegistryConcurrency` setting, but the constant does not.

This PR updates `cache/remotecache/export.go` to use the configurable value. We plan on increasing  that value to increase throughput on the buildkitd workers.

This PR also switches the `Group.size` field to `int64` since all uses of  the value were already converting from `int` to `int64`.