### PR TITLE
cmd/buildctl: fix usetesting linting

### DIFF
--- a/cmd/buildctl/build/opt_test.go
+++ b/cmd/buildctl/build/opt_test.go
@@ -86,7 +86,7 @@ func TestParseOpt(t *testing.T) {
 			for _, k := range []string{"SOURCE_DATE_EPOCH", "IMAGE"} {
 				if v, ok := os.LookupEnv(k); ok {
 					require.NoError(t, os.Unsetenv(k))
-					t.Cleanup(func() { os.Setenv(k, v) })
+					t.Cleanup(func() { os.Setenv(k, v) }) //nolint:usetesting // cannot use t.Setenv for unsetting env-vars.
 				}
 			}
 			for k, v := range tc.env {


### PR DESCRIPTION
- relates to https://github.com/moby/buildkit/pull/7056#issuecomment-5387023284


Linter incorectly suggests using t.SetEnv, but we need to unset the env-var;

    level=warning msg="[runner/exclusion_rules] Skipped 0 issues by rules: [Path: \".*\\\\.pb\\\\.go$\", Linters: \"gofmt, goimports\"]"
    cmd/buildctl/build/opt_test.go:89:25: os.Setenv() could be replaced by t.Setenv() in TestParseOpt (usetesting)
     					t.Cleanup(func() { os.Setenv(k, v) })
     					                   ^