### PR TITLE
source: redact credentials in diagnostics

### DIFF
--- a/source/git/bundle.go
+++ b/source/git/bundle.go
@@ -17,6 +17,7 @@ import (
 	srctypes "github.com/moby/buildkit/source/types"
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/gitutil"
+	"github.com/moby/buildkit/util/urlutil"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
@@ -336,7 +337,7 @@ func (gs *gitSourceHandler) checkoutAsBundle(ctx context.Context, repo *gitRepo,
 		commit = ref
 	}
 
-	checkoutRef, err := gs.cache.New(ctx, nil, g, cache.CachePolicyRetain, cache.WithDescription(fmt.Sprintf("git bundle checkout for %s#%s", gs.src.Remote, ref)))
+	checkoutRef, err := gs.cache.New(ctx, nil, g, cache.CachePolicyRetain, cache.WithDescription(fmt.Sprintf("git bundle checkout for %s#%s", urlutil.RedactCredentials(gs.src.Remote), ref)))
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create new mutable for bundle checkout")
 	}

--- a/source/http/source.go
+++ b/source/http/source.go
@@ -32,6 +32,7 @@ import (
 	"github.com/moby/buildkit/util/cachedigest"
 	"github.com/moby/buildkit/util/pgpsign"
 	"github.com/moby/buildkit/util/tracing"
+	"github.com/moby/buildkit/util/urlutil"
 	"github.com/moby/buildkit/version"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
@@ -347,7 +348,7 @@ func (hs *httpSourceHandler) resolveMetadataRef(ctx context.Context, jobCtx solv
 				return &hs.resolved.Metadata, nil
 			}
 			if hs.src.Checksum != "" && len(vals) > 0 {
-				return nil, errors.Errorf("digest mismatch for %s: %s (expected: %s)", hs.src.URL, vals[0], hs.src.Checksum)
+				return nil, errors.Errorf("digest mismatch for %s: %s (expected: %s)", urlutil.RedactCredentials(hs.src.URL), vals[0], hs.src.Checksum)
 			}
 		}
 	}
@@ -555,7 +556,7 @@ func (hs *httpSourceHandler) validatePinnedChecksum(got digest.Digest) error {
 	if hs.src.Checksum == "" || got == hs.src.Checksum {
 		return nil
 	}
-	return errors.Errorf("digest mismatch for %s: %s (expected: %s)", hs.src.URL, got, hs.src.Checksum)
+	return errors.Errorf("digest mismatch for %s: %s (expected: %s)", urlutil.RedactCredentials(hs.src.URL), got, hs.src.Checksum)
 }
 
 func validateChecksumRequest(req *MetadataChecksumRequest) error {
@@ -723,7 +724,7 @@ func checksumAlgo(algo MetadataChecksumAlgo) (digest.Algorithm, error) {
 }
 
 func (hs *httpSourceHandler) save(ctx context.Context, resp *http.Response, s session.Group) (ref cache.ImmutableRef, dgst digest.Digest, retErr error) {
-	newRef, err := hs.cache.New(ctx, nil, s, cache.CachePolicyRetain, cache.WithDescription(fmt.Sprintf("http url %s", hs.src.URL)))
+	newRef, err := hs.cache.New(ctx, nil, s, cache.CachePolicyRetain, cache.WithDescription(fmt.Sprintf("http url %s", urlutil.RedactCredentials(hs.src.URL))))
 	if err != nil {
 		return nil, "", err
 	}
@@ -870,7 +871,7 @@ func (hs *httpSourceHandler) Snapshot(ctx context.Context, jobCtx solver.JobCont
 	if refID != "" {
 		ref, err := hs.cache.Get(ctx, refID, nil)
 		if err != nil {
-			bklog.G(ctx).WithError(err).Warnf("failed to get HTTP snapshot for ref %s (%s)", refID, hs.src.URL)
+			bklog.G(ctx).WithError(err).Warnf("failed to get HTTP snapshot for ref %s (%s)", refID, urlutil.RedactCredentials(hs.src.URL))
 		} else {
 			return ref, nil
 		}
@@ -930,7 +931,7 @@ func (hs *httpSourceHandler) snapshotRefIDFromResolverCache(rc solver.ResolverCa
 		}
 	}
 	if hs.src.Checksum != "" && len(vals) > 0 && refID == "" {
-		return "", errors.Errorf("digest mismatch for %s: %s (expected: %s)", hs.src.URL, vals[0], hs.src.Checksum)
+		return "", errors.Errorf("digest mismatch for %s: %s (expected: %s)", urlutil.RedactCredentials(hs.src.URL), vals[0], hs.src.Checksum)
 	}
 	return refID, nil
 }

--- a/source/http/source_test.go
+++ b/source/http/source_test.go
@@ -218,6 +218,23 @@ func TestHTTPInvalidURL(t *testing.T) {
 	require.Contains(t, err.Error(), "invalid response")
 }
 
+func TestHTTPCredentialsRedactedInError(t *testing.T) {
+	t.Parallel()
+
+	hs := &httpSourceHandler{
+		src: HTTPIdentifier{
+			URL:      "https://user:s3cr3t@example.com/file",
+			Checksum: digest.FromBytes([]byte("expected")),
+		},
+	}
+
+	err := hs.validatePinnedChecksum(digest.FromBytes([]byte("actual")))
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "s3cr3t")
+	require.NotContains(t, err.Error(), "user:")
+	require.Contains(t, err.Error(), "xxxxx:xxxxx@example.com")
+}
+
 func TestHTTPChecksum(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()


### PR DESCRIPTION
Avoid leaking HTTP source credentials through checksum mismatch errors, cache descriptions, snapshot cache warnings and also Git bundle checkout description.