### PR TITLE
solver: fix metrics test context import

### DIFF
--- a/solver/llbsolver/metrics_test.go
+++ b/solver/llbsolver/metrics_test.go
@@ -1,6 +1,7 @@
 package llbsolver
 
 import (
+	"context"
 	"testing"
 	"time"
 


### PR DESCRIPTION
introduced by https://github.com/moby/buildkit/pull/7040

relates to https://github.com/moby/buildkit/actions/runs/32727515717/job/97432101867#step:3:825

```
> [golangci-lint 1/1] RUN --mount=target=/go/src/github.com/moby/buildkit     --mount=target=/root/.cache,type=cache,id=lint-cache-default-freebsd/amd64   xx-go --wrap &&   golangci-lint run --build-tags "" &&   touch /golangci-lint.done:
115.8 level=warning msg="[runner/exclusion_rules] Skipped 0 issues by rules: [Path: \".*\\\\.pb\\\\.go$\", Linters: \"gofmt, goimports\"]"
115.8 level=warning msg="[runner/exclusion_rules] Skipped 0 issues by rules: [Text: \"superfluous-else\", Linters: \"revive\"]"
115.8 level=warning msg="[runner/exclusion_rules] Skipped 0 issues by rules: [Text: \"unused-parameter\", Linters: \"revive\"]"
115.8 level=warning msg="[runner/exclusion_rules] Skipped 0 issues by rules: [Text: \"var-naming\", Linters: \"revive\"]"
115.8 solver/llbsolver/bridge.go:1: : # github.com/moby/buildkit/solver/llbsolver [github.com/moby/buildkit/solver/llbsolver.test]
115.8 solver/llbsolver/metrics_test.go:199:57: undefined: context (typecheck)
115.8 level=warning msg="[runner/exclusion_rules] Skipped 0 issues by rules: [Text: \"stutters\", Linters: \"revive\"]"
115.8 package llbsolver
115.8 1 issues:
115.8 * typecheck: 1
```