### PR TITLE
solver: fail ADD unpack when xz is missing

### DIFF
--- a/solver/llbsolver/file/backend_test.go
+++ b/solver/llbsolver/file/backend_test.go
@@ -1,7 +1,9 @@
 package file
 
 import (
+	stderrors "errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -77,4 +79,18 @@ func TestRmPathRemovesSymlinkItself(t *testing.T) {
 
 	_, err = os.Stat(target)
 	require.NoError(t, err)
+}
+
+func TestArchivePathNeedsXz(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("PATH", root)
+
+	src := filepath.Join(root, "archive.tar.xz")
+	require.NoError(t, os.WriteFile(src, []byte{0xfd, 0x37, 0x7a, 0x58, 0x5a, 0x00}, 0o600))
+
+	ok, err := isArchivePath(src)
+	require.Error(t, err)
+	_, isExecErr := stderrors.AsType[*exec.Error](err)
+	require.True(t, isExecErr)
+	require.False(t, ok)
 }

--- a/solver/llbsolver/file/unpack.go
+++ b/solver/llbsolver/file/unpack.go
@@ -2,7 +2,9 @@ package file
 
 import (
 	"archive/tar"
+	stderrors "errors"
 	"os"
+	"os/exec"
 	"time"
 
 	"github.com/containerd/continuity/fs"
@@ -18,7 +20,11 @@ func unpack(srcRoot string, src string, destRoot string, dest string, ch copy.Ch
 	if err != nil {
 		return false, err
 	}
-	if !isArchivePath(src) {
+	isArchive, err := isArchivePath(src)
+	if err != nil {
+		return false, err
+	}
+	if !isArchive {
 		return false, nil
 	}
 
@@ -51,25 +57,28 @@ func unpack(srcRoot string, src string, destRoot string, dest string, ch copy.Ch
 	return true, chrootarchive.Untar(file, dest, opts)
 }
 
-func isArchivePath(path string) bool {
+func isArchivePath(path string) (bool, error) {
 	fi, err := os.Lstat(path)
 	if err != nil {
-		return false
+		return false, nil
 	}
 	if fi.Mode()&os.ModeType != 0 {
-		return false
+		return false, nil
 	}
 	file, err := os.Open(path)
 	if err != nil {
-		return false
+		return false, nil
 	}
 	defer file.Close()
 	rdr, err := compression.DecompressStream(file)
 	if err != nil {
-		return false
+		if _, ok := stderrors.AsType[*exec.Error](err); ok {
+			return false, err
+		}
+		return false, nil
 	}
 	defer rdr.Close()
 	r := tar.NewReader(rdr)
 	_, err = r.Next()
-	return err == nil
+	return err == nil, nil
 }


### PR DESCRIPTION
fixes https://github.com/moby/buildkit/issues/7059

`ADD --unpack` now fails when it detects an xz-compressed archive but cannot start the xz decompressor. Previously, BuildKit treated that decompressor setup failure like a non-archive input, so the build silently copied the `.tar.xz` file instead of unpacking it.

This keeps the existing fallback behavior for ordinary non-archive files while making missing runtime support visible for archives that BuildKit has already recognized.