### PR TITLE
verifier: allow inferred Windows platform versions

### DIFF
--- a/exporter/verifier/platforms.go
+++ b/exporter/verifier/platforms.go
@@ -96,12 +96,19 @@ func CheckInvalidPlatforms[T comparable](ctx context.Context, res *result.Result
 	mismatch := len(reqMap) != len(ps.Platforms)
 
 	if !mismatch {
+	results:
 		for _, p := range ps.Platforms {
 			pp := platforms.Normalize(p.Platform)
-			if _, ok := reqMap[platforms.FormatAll(pp)]; !ok {
-				mismatch = true
-				break
+			if _, ok := reqMap[platforms.FormatAll(pp)]; ok {
+				continue
 			}
+			for _, reqP := range reqList {
+				if platforms.OnlyStrict(reqP.Platform).Match(pp) {
+					continue results
+				}
+			}
+			mismatch = true
+			break
 		}
 	}
 

--- a/exporter/verifier/platforms_test.go
+++ b/exporter/verifier/platforms_test.go
@@ -1,0 +1,101 @@
+package verifier
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/containerd/platforms"
+	"github.com/moby/buildkit/exporter/containerimage/exptypes"
+	"github.com/moby/buildkit/solver/result"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultiPlatformWindowsVersionInferred(t *testing.T) {
+	res := platformResult(t,
+		[]string{"linux/amd64", "windows/amd64"},
+		[]exptypes.Platform{
+			{
+				ID:       "linux/amd64",
+				Platform: platforms.MustParse("linux/amd64"),
+			},
+			{
+				ID: "windows/amd64",
+				Platform: ocispecs.Platform{
+					OS:           "windows",
+					Architecture: "amd64",
+					OSVersion:    "10.0.26100.33296",
+				},
+			},
+		},
+	)
+
+	warnings, err := CheckInvalidPlatforms(t.Context(), res)
+	require.NoError(t, err)
+	require.Empty(t, warnings)
+}
+
+func TestSinglePlatformWindowsVersionInferred(t *testing.T) {
+	res := platformResult(t,
+		[]string{"windows/amd64"},
+		[]exptypes.Platform{
+			{
+				ID: "windows/amd64",
+				Platform: ocispecs.Platform{
+					OS:           "windows",
+					Architecture: "amd64",
+					OSVersion:    "10.0.26100.33296",
+				},
+			},
+		},
+	)
+
+	warnings, err := CheckInvalidPlatforms(t.Context(), res)
+	require.NoError(t, err)
+	require.Empty(t, warnings)
+}
+
+func TestWindowsVersionMismatch(t *testing.T) {
+	res := platformResult(t,
+		[]string{"linux/amd64", "windows(10.0.20348.1006)/amd64"},
+		[]exptypes.Platform{
+			{
+				ID:       "linux/amd64",
+				Platform: platforms.MustParse("linux/amd64"),
+			},
+			{
+				ID: "windows(10.0.20348.1006)/amd64",
+				Platform: ocispecs.Platform{
+					OS:           "windows",
+					Architecture: "amd64",
+					OSVersion:    "10.0.26100.33296",
+				},
+			},
+		},
+	)
+
+	warnings, err := CheckInvalidPlatforms(t.Context(), res)
+	require.NoError(t, err)
+	require.Len(t, warnings, 1)
+	require.Contains(t, string(warnings[0].Short), "Requested platforms")
+}
+
+func platformResult(t *testing.T, requested []string, resultPlatforms []exptypes.Platform) *result.Result[string] {
+	t.Helper()
+	res := &result.Result[string]{}
+
+	attrs := map[string]string{"platform": requested[0]}
+	for _, platform := range requested[1:] {
+		attrs["platform"] += "," + platform
+	}
+	require.NoError(t, CaptureFrontendOpts(attrs, res))
+
+	dt, err := json.Marshal(exptypes.Platforms{Platforms: resultPlatforms})
+	require.NoError(t, err)
+	res.AddMeta(exptypes.ExporterPlatformsKey, dt)
+
+	for _, p := range resultPlatforms {
+		res.AddRef(p.ID, p.ID)
+	}
+	return res
+}


### PR DESCRIPTION
This relates to docker/buildx#4008. When testing that change with `docker buildx --builder builder bake https://github.com/docker/buildkit-syft-scanner.git image-all`, the verifier reports that the requested platforms include `windows/amd64` while the result platforms include `windows(10.0.26100.33296)/amd64`:

```
docker buildx --builder builder bake https://github.com/docker/buildkit-syft-scanner.git image-all
...
#34 Verifying build result
#34 WARN: Requested platforms linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le,linux/riscv64,linux/s390x,windows/amd64 do not match result platforms linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le,linux/riscv64,linux/s390x,windows(10.0.26100.33296)/amd64
#34 DONE 0.0s
WARNING: No output specified for image-all target(s) with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load

 1 warning found (use docker --debug to expand):
 - Requested platforms linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le,linux/riscv64,linux/s390x,windows/amd64 do not match result platforms linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le,linux/riscv64,linux/s390x,windows(10.0.26100.33296)/amd64

View build details: docker-desktop://dashboard/build/builder/builder0/9xvawy2lahqip1mjngno84byi
```

The Dockerfile frontend may infer a concrete Windows OS version from the base image even when the request used versionless `windows/amd64`. The verifier already tolerated this for single-platform builds, but multi-platform builds still compared the requested and result platform sets strictly and emitted a mismatch warning.

This updates the multi-platform verifier path to use strict platform matching for result platforms that don't match by exact `FormatAll` key. This keeps explicit Windows OS version requests strict, while allowing the existing inferred Windows OS version behavior to pass without warning.