### PR TITLE
test: fix dockerd integration coverage

### DIFF
--- a/frontend/dockerfile/dockerfile_rundevice_test.go
+++ b/frontend/dockerfile/dockerfile_rundevice_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/frontend/dockerui"
 	"github.com/moby/buildkit/util/testutil/integration"
+	"github.com/moby/buildkit/util/testutil/workers"
 	"github.com/stretchr/testify/require"
 	"github.com/tonistiigi/fsutil"
 )
@@ -20,6 +21,8 @@ func init() {
 }
 
 func testDeviceRunEnv(t *testing.T, sb integration.Sandbox) {
+	workers.CheckFeatureCompat(t, sb, workers.FeatureCDI)
+
 	if sb.Rootless() {
 		t.SkipNow()
 	}

--- a/util/testutil/dockerd/config.go
+++ b/util/testutil/dockerd/config.go
@@ -6,6 +6,10 @@ type Config struct {
 	Builder  BuilderConfig   `json:"builder"`
 }
 
+type BuilderHistoryConfig struct {
+	MaxEntries *int64 `json:"maxEntries,omitempty"`
+}
+
 type BuilderEntitlements struct {
 	NetworkHost      bool `json:"network-host,omitempty"`
 	SecurityInsecure bool `json:"security-insecure,omitempty"`
@@ -14,4 +18,5 @@ type BuilderEntitlements struct {
 
 type BuilderConfig struct {
 	Entitlements BuilderEntitlements
+	History      *BuilderHistoryConfig `json:"history,omitempty"`
 }

--- a/util/testutil/workers/dockerd.go
+++ b/util/testutil/workers/dockerd.go
@@ -133,6 +133,11 @@ func (c Moby) New(ctx context.Context, cfg *integration.BackendConfig) (b integr
 			}
 		}
 	}
+	if bkcfg.History != nil && bkcfg.History.MaxEntries != nil {
+		dcfg.Builder.History = &dockerd.BuilderHistoryConfig{
+			MaxEntries: bkcfg.History.MaxEntries,
+		}
+	}
 
 	dcfgdt, err := json.Marshal(dcfg)
 	if err != nil {


### PR DESCRIPTION
Forward an explicit zero history limit into daemon.json so dockerd can disable build history. Skip CDI device coverage on unsupported workers.