### PR TITLE
gateway: compare Windows environment names case-insensitively

### DIFF
--- a/frontend/gateway/container/container.go
+++ b/frontend/gateway/container/container.go
@@ -354,9 +354,9 @@ func (gwCtr *gatewayContainer) Start(ctx context.Context, req client.StartReques
 	if procInfo.Meta.Cwd == "" {
 		procInfo.Meta.Cwd = "/"
 	}
-	procInfo.Meta.Env = addDefaultEnvvar(procInfo.Meta.Env, "PATH", system.DefaultPathEnv(gwCtr.platform.OS))
+	procInfo.Meta.Env = addDefaultEnvvar(procInfo.Meta.Env, "PATH", system.DefaultPathEnv(gwCtr.platform.OS), gwCtr.platform.OS)
 	if req.Tty {
-		procInfo.Meta.Env = addDefaultEnvvar(procInfo.Meta.Env, "TERM", "xterm")
+		procInfo.Meta.Env = addDefaultEnvvar(procInfo.Meta.Env, "TERM", "xterm", gwCtr.platform.OS)
 	}
 
 	secretEnv, err := gwCtr.loadSecretEnv(ctx, req.SecretEnv)
@@ -644,9 +644,10 @@ func (gwProc *gatewayContainerProcess) Signal(ctx context.Context, sig syscall.S
 	return nil
 }
 
-func addDefaultEnvvar(env []string, k, v string) []string {
+func addDefaultEnvvar(env []string, k, v, targetOS string) []string {
 	for _, e := range env {
-		if strings.HasPrefix(e, k+"=") {
+		name, _, ok := strings.Cut(e, "=")
+		if ok && (name == k || targetOS == "windows" && strings.EqualFold(name, k)) {
 			return env
 		}
 	}

--- a/frontend/gateway/container/container_test.go
+++ b/frontend/gateway/container/container_test.go
@@ -1,0 +1,24 @@
+package container
+
+import (
+	"testing"
+
+	"github.com/moby/buildkit/util/system"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddDefaultEnvvarWindowsCaseInsensitive(t *testing.T) {
+	env := []string{"Path=C:\\custom"}
+
+	got := addDefaultEnvvar(env, "PATH", system.DefaultPathEnvWindows, "windows")
+
+	require.Equal(t, env, got)
+}
+
+func TestAddDefaultEnvvarLinuxCaseSensitive(t *testing.T) {
+	env := []string{"Path=/custom"}
+
+	got := addDefaultEnvvar(env, "PATH", system.DefaultPathEnvUnix, "linux")
+
+	require.Equal(t, []string{"Path=/custom", "PATH=" + system.DefaultPathEnvUnix}, got)
+}


### PR DESCRIPTION
Compare gateway container environment names case-insensitively for Windows targets, preventing duplicate defaults such as `PATH`.

Fixes #7079.