### PR TITLE
solver: preserve proxy network digest associations

### DIFF
--- a/solver/llbsolver/bridge.go
+++ b/solver/llbsolver/bridge.go
@@ -71,7 +71,7 @@ func (b *llbBridge) Warn(ctx context.Context, dgst digest.Digest, msg string, op
 	})
 }
 
-func (b *llbBridge) loadResult(ctx context.Context, def *pb.Definition, cacheImports []gw.CacheOptionsEntry, pol []*spb.Policy) (solver.CachedResultWithProvenance, error) {
+func (b *llbBridge) loadResult(ctx context.Context, def *pb.Definition, cacheImports []gw.CacheOptionsEntry, pol []*spb.Policy, digestMapping map[digest.Digest]digest.Digest) (solver.CachedResultWithProvenance, error) {
 	w, err := b.resolveWorker()
 	if err != nil {
 		return nil, err
@@ -142,7 +142,7 @@ func (b *llbBridge) loadResult(ctx context.Context, def *pb.Definition, cacheImp
 	}
 	dpc := &detectPrunedCacheID{}
 
-	edge, err := loadWithProxyNetwork(ctx, def, b.policy(polEngine), b.proxyNetwork, dpc.Load, ValidateEntitlements(ent, w.CDIManager()), WithCacheSources(cms), NormalizeRuntimePlatforms(), WithValidateCaps(), WithLinuxResourcesMetadata())
+	edge, err := loadWithProxyNetworkAndDigestMap(ctx, def, b.policy(polEngine), b.proxyNetwork, digestMapping, dpc.Load, ValidateEntitlements(ent, w.CDIManager()), WithCacheSources(cms), NormalizeRuntimePlatforms(), WithValidateCaps(), WithLinuxResourcesMetadata())
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load LLB")
 	}

--- a/solver/llbsolver/provenance/buildconfig.go
+++ b/solver/llbsolver/provenance/buildconfig.go
@@ -64,6 +64,11 @@ func AddBuildConfig(ctx context.Context, p *provenancetypes.ProvenancePredicateS
 		}
 	}
 
+	for original, runtime := range c.DigestMapping {
+		if idx, ok := indexes[original]; ok {
+			indexes[runtime] = idx
+		}
+	}
 	return indexes, nil
 }
 
@@ -142,6 +147,9 @@ func toBuildSteps(def *pb.Definition, c *Capture, withUsage bool) ([]provenancet
 		}
 		if withUsage {
 			s.ResourceUsage = c.Samples[dgst]
+			if s.ResourceUsage == nil {
+				s.ResourceUsage = c.Samples[c.DigestMapping[dgst]]
+			}
 		}
 		out = append(out, s)
 	}

--- a/solver/llbsolver/provenance/buildconfig_test.go
+++ b/solver/llbsolver/provenance/buildconfig_test.go
@@ -1,0 +1,104 @@
+package provenance
+
+import (
+	"testing"
+
+	resourcestypes "github.com/moby/buildkit/executor/resources/types"
+	"github.com/moby/buildkit/solver"
+	provenancetypes "github.com/moby/buildkit/solver/llbsolver/provenance/types"
+	"github.com/moby/buildkit/solver/pb"
+	digest "github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProxyNetworkResourceUsageKeepsBuildStepAssociation(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		proxy bool
+	}{
+		{name: "disabled", proxy: false},
+		{name: "enabled", proxy: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			def, definitionDigest, runtimeDigest := proxyNetworkBuildConfigDefinition(t, tc.proxy)
+			want := &resourcestypes.Samples{Samples: []*resourcestypes.Sample{{}}}
+			capture := &Capture{Samples: map[digest.Digest]*resourcestypes.Samples{runtimeDigest: want}}
+			if tc.proxy {
+				capture.DigestMapping = map[digest.Digest]digest.Digest{definitionDigest: runtimeDigest}
+			}
+
+			steps, _, err := toBuildSteps(def, capture, true)
+			require.NoError(t, err)
+			for _, step := range steps {
+				if step.Op.GetExec() != nil {
+					require.Same(t, want, step.ResourceUsage)
+					return
+				}
+			}
+			t.Fatal("exec build step not found")
+		})
+	}
+}
+
+func TestProxyNetworkLayerKeepsBuildStepAssociation(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		proxy bool
+	}{
+		{name: "disabled", proxy: false},
+		{name: "enabled", proxy: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			def, definitionDigest, runtimeDigest := proxyNetworkBuildConfigDefinition(t, tc.proxy)
+			capture := &Capture{}
+			if tc.proxy {
+				capture.DigestMapping = map[digest.Digest]digest.Digest{definitionDigest: runtimeDigest}
+			}
+			predicate := &provenancetypes.ProvenancePredicateSLSA1{}
+			indexes, err := AddBuildConfig(t.Context(), predicate, capture, &definitionResultProxy{definition: def}, false)
+			require.NoError(t, err)
+
+			definitionIndex, ok := indexes[definitionDigest]
+			require.True(t, ok)
+			runtimeIndex, ok := indexes[runtimeDigest]
+			require.True(t, ok)
+			require.Equal(t, definitionIndex, runtimeIndex)
+		})
+	}
+}
+
+type definitionResultProxy struct {
+	solver.ResultProxy
+	definition *pb.Definition
+}
+
+func (p *definitionResultProxy) Definition() *pb.Definition {
+	return p.definition
+}
+
+func proxyNetworkBuildConfigDefinition(t *testing.T, proxy bool) (*pb.Definition, digest.Digest, digest.Digest) {
+	t.Helper()
+	marshal := func(op *pb.Op) (digest.Digest, []byte) {
+		dt, err := op.Marshal()
+		require.NoError(t, err)
+		return digest.FromBytes(dt), dt
+	}
+
+	sourceDigest, sourceBytes := marshal(&pb.Op{Op: &pb.Op_Source{Source: &pb.SourceOp{Identifier: "local://context"}}})
+	execDigest, execBytes := marshal(&pb.Op{
+		Inputs: []*pb.Input{{Digest: sourceDigest.String()}},
+		Op: &pb.Op_Exec{Exec: &pb.ExecOp{
+			Meta:   &pb.Meta{Args: []string{"true"}},
+			Mounts: []*pb.Mount{{Input: 0, Dest: pb.RootMount}},
+		}},
+	})
+	_, rootBytes := marshal(&pb.Op{Inputs: []*pb.Input{{Digest: execDigest.String()}}})
+
+	runtimeDigest := execDigest
+	if proxy {
+		salted := append([]byte(nil), execBytes...)
+		salted = append(salted, []byte("\x00buildkit.proxy-network.v0")...)
+		runtimeDigest = digest.FromBytes(salted)
+	}
+	return &pb.Definition{Def: [][]byte{sourceBytes, execBytes, rootBytes}}, execDigest, runtimeDigest
+}

--- a/solver/llbsolver/provenance/capture.go
+++ b/solver/llbsolver/provenance/capture.go
@@ -23,6 +23,8 @@ type Capture struct {
 	IncompleteMaterials bool
 	ProxyIncomplete     []provenancetypes.ProxyCaptureIncomplete
 	Samples             map[digest.Digest]*resourcestypes.Samples
+	// DigestMapping maps frontend definition digests to runtime vertex digests.
+	DigestMapping map[digest.Digest]digest.Digest `json:"-"`
 }
 
 func (c *Capture) Clone() *Capture {
@@ -46,6 +48,9 @@ func (c *Capture) Clone() *Capture {
 	if len(c.Samples) > 0 {
 		out.Samples = make(map[digest.Digest]*resourcestypes.Samples, len(c.Samples))
 		maps.Copy(out.Samples, c.Samples)
+	}
+	if len(c.DigestMapping) > 0 {
+		out.DigestMapping = maps.Clone(c.DigestMapping)
 	}
 	return out
 }
@@ -90,6 +95,17 @@ func (c *Capture) Merge(c2 *Capture) error {
 	}
 	c.ProxyIncomplete = append(c.ProxyIncomplete, c2.ProxyIncomplete...)
 	return nil
+}
+
+// AddDigestMapping adds frontend-to-runtime digest mappings for this result.
+func (c *Capture) AddDigestMapping(mapping map[digest.Digest]digest.Digest) {
+	if len(mapping) == 0 {
+		return
+	}
+	if c.DigestMapping == nil {
+		c.DigestMapping = make(map[digest.Digest]digest.Digest, len(mapping))
+	}
+	maps.Copy(c.DigestMapping, mapping)
 }
 
 func (c *Capture) Sort() {

--- a/solver/llbsolver/provenance/capture_test.go
+++ b/solver/llbsolver/provenance/capture_test.go
@@ -187,6 +187,22 @@ func TestCaptureMergeNil(t *testing.T) {
 	require.NoError(t, c.Merge(nil))
 }
 
+func TestCaptureDigestMapping(t *testing.T) {
+	t.Parallel()
+
+	original := digest.FromString("original")
+	runtime := digest.FromString("runtime")
+	c := &Capture{}
+	c.AddDigestMapping(map[digest.Digest]digest.Digest{original: runtime})
+
+	clone := c.Clone()
+	require.Equal(t, runtime, clone.DigestMapping[original])
+
+	merged := &Capture{}
+	require.NoError(t, merged.Merge(c))
+	require.Empty(t, merged.DigestMapping)
+}
+
 func TestCaptureSort(t *testing.T) {
 	t.Parallel()
 	c := &Capture{}

--- a/solver/llbsolver/result.go
+++ b/solver/llbsolver/result.go
@@ -2,6 +2,7 @@ package llbsolver
 
 import (
 	"context"
+	"slices"
 	"sync"
 
 	cacheconfig "github.com/moby/buildkit/cache/config"
@@ -16,6 +17,7 @@ import (
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/flightcontrol"
 	"github.com/moby/buildkit/worker"
+	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
 
@@ -38,16 +40,17 @@ func workerRefResolver(refCfg cacheconfig.RefConfig, all bool, g session.Group) 
 }
 
 type resultProxy struct {
-	id         string
-	b          *provenanceBridge
-	req        frontend.SolveRequest
-	g          flightcontrol.Group[solver.CachedResult]
-	mu         sync.Mutex
-	released   bool
-	v          solver.CachedResult
-	err        error
-	errResults []solver.Result
-	provenance *provenance.Capture
+	id            string
+	b             *provenanceBridge
+	req           frontend.SolveRequest
+	g             flightcontrol.Group[solver.CachedResult]
+	mu            sync.Mutex
+	released      bool
+	v             solver.CachedResult
+	err           error
+	errResults    []solver.Result
+	provenance    *provenance.Capture
+	digestMapping map[digest.Digest]digest.Digest
 }
 
 func newResultProxy(b *provenanceBridge, req frontend.SolveRequest) *resultProxy {
@@ -98,8 +101,12 @@ func (rp *resultProxy) wrapError(err error) error {
 	var ve *errdefs.VertexError
 	if errors.As(err, &ve) {
 		if rp.req.Definition.Source != nil {
-			locs, ok := rp.req.Definition.Source.Locations[ve.Digest]
-			if ok {
+			digests := append([]digest.Digest{digest.Digest(ve.Digest)}, rp.definitionDigests(digest.Digest(ve.Digest))...)
+			for _, dgst := range digests {
+				locs, ok := rp.req.Definition.Source.Locations[string(dgst)]
+				if !ok {
+					continue
+				}
 				for _, loc := range locs.Locations {
 					err = errdefs.WithSource(err, &errdefs.Source{
 						Info:   rp.req.Definition.Source.Infos[loc.SourceIndex],
@@ -113,7 +120,9 @@ func (rp *resultProxy) wrapError(err error) error {
 }
 
 func (rp *resultProxy) loadResult(ctx context.Context) (solver.CachedResultWithProvenance, error) {
-	res, err := rp.b.loadResult(ctx, rp.req.Definition, rp.req.CacheImports, rp.req.SourcePolicies)
+	digestMapping := map[digest.Digest]digest.Digest{}
+	res, err := rp.b.loadResult(ctx, rp.req.Definition, rp.req.CacheImports, rp.req.SourcePolicies, digestMapping)
+	rp.setDigestMapping(digestMapping)
 	var ee *llberrdefs.ExecError
 	if errors.As(err, &ee) {
 		ee.EachRef(func(res solver.Result) error {
@@ -124,6 +133,25 @@ func (rp *resultProxy) loadResult(ctx context.Context) (solver.CachedResultWithP
 		ee.OwnerBorrowed = true
 	}
 	return res, err
+}
+
+func (rp *resultProxy) setDigestMapping(digestMapping map[digest.Digest]digest.Digest) {
+	rp.mu.Lock()
+	rp.digestMapping = digestMapping
+	rp.mu.Unlock()
+}
+
+func (rp *resultProxy) definitionDigests(runtime digest.Digest) []digest.Digest {
+	rp.mu.Lock()
+	defer rp.mu.Unlock()
+	var out []digest.Digest
+	for original, mapped := range rp.digestMapping {
+		if mapped == runtime {
+			out = append(out, original)
+		}
+	}
+	slices.Sort(out)
+	return out
 }
 
 func (rp *resultProxy) Result(ctx context.Context) (res solver.CachedResult, err error) {
@@ -166,6 +194,9 @@ func (rp *resultProxy) Result(ctx context.Context) (res solver.CachedResult, err
 				err = errors.Errorf("failed to capture provenance: %v", err)
 				v.Release(context.TODO())
 				v = nil
+			}
+			if capture != nil {
+				capture.AddDigestMapping(rp.digestMapping)
 			}
 			rp.provenance = capture
 		}

--- a/solver/llbsolver/result_test.go
+++ b/solver/llbsolver/result_test.go
@@ -1,0 +1,57 @@
+package llbsolver
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/moby/buildkit/frontend"
+	"github.com/moby/buildkit/solver/errdefs"
+	"github.com/moby/buildkit/solver/pb"
+	digest "github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProxyNetworkVertexErrorKeepsSourceLocation(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		proxy bool
+	}{
+		{name: "disabled", proxy: false},
+		{name: "enabled", proxy: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			def := proxyNetworkTestDefinition(t)
+			definitionDigest := digest.FromBytes(def.Def[1])
+			def.Source = &pb.Source{
+				Infos: []*pb.SourceInfo{{Filename: "Dockerfile"}},
+				Locations: map[string]*pb.Locations{
+					definitionDigest.String(): {
+						Locations: []*pb.Location{{SourceIndex: 0}},
+					},
+				},
+			}
+
+			digestMapping := map[digest.Digest]digest.Digest{}
+			edge, err := loadWithProxyNetworkAndDigestMap(t.Context(), def, nil, tc.proxy, digestMapping)
+			require.NoError(t, err)
+			runtimeDigest := edge.Vertex.Digest()
+
+			if tc.proxy {
+				require.NotEqual(t, definitionDigest, runtimeDigest)
+				require.Equal(t, runtimeDigest, digestMapping[definitionDigest])
+			} else {
+				require.Equal(t, definitionDigest, runtimeDigest)
+				require.Empty(t, digestMapping)
+			}
+
+			rp := &resultProxy{
+				req:           frontend.SolveRequest{Definition: def},
+				digestMapping: digestMapping,
+			}
+			wrapped := rp.wrapError(errdefs.WrapVertex(errors.New("boom"), runtimeDigest))
+			sources := errdefs.Sources(wrapped)
+			require.Len(t, sources, 1)
+			require.Equal(t, "Dockerfile", sources[0].Info.Filename)
+		})
+	}
+}

--- a/solver/llbsolver/vertex.go
+++ b/solver/llbsolver/vertex.go
@@ -246,7 +246,7 @@ func (dpc *detectPrunedCacheID) Load(op *pb.Op, md *pb.OpMetadata, opt *solver.V
 }
 
 func Load(ctx context.Context, def *pb.Definition, polEngine SourcePolicyEvaluator, opts ...LoadOpt) (solver.Edge, error) {
-	return loadLLB(ctx, def, polEngine, nil, func(dgst digest.Digest, op *op, load func(digest.Digest) (solver.Vertex, error)) (solver.Vertex, error) {
+	return loadLLB(ctx, def, polEngine, nil, nil, func(dgst digest.Digest, op *op, load func(digest.Digest) (solver.Vertex, error)) (solver.Vertex, error) {
 		vtx, err := newVertex(dgst, op, load, opts...)
 		if err != nil {
 			return nil, err
@@ -256,7 +256,11 @@ func Load(ctx context.Context, def *pb.Definition, polEngine SourcePolicyEvaluat
 }
 
 func loadWithProxyNetwork(ctx context.Context, def *pb.Definition, polEngine SourcePolicyEvaluator, proxyNetwork bool, opts ...LoadOpt) (solver.Edge, error) {
-	return loadLLB(ctx, def, polEngine, &proxyNetwork, func(dgst digest.Digest, op *op, load func(digest.Digest) (solver.Vertex, error)) (solver.Vertex, error) {
+	return loadWithProxyNetworkAndDigestMap(ctx, def, polEngine, proxyNetwork, nil, opts...)
+}
+
+func loadWithProxyNetworkAndDigestMap(ctx context.Context, def *pb.Definition, polEngine SourcePolicyEvaluator, proxyNetwork bool, digestMapping map[digest.Digest]digest.Digest, opts ...LoadOpt) (solver.Edge, error) {
+	return loadLLB(ctx, def, polEngine, &proxyNetwork, digestMapping, func(dgst digest.Digest, op *op, load func(digest.Digest) (solver.Vertex, error)) (solver.Vertex, error) {
 		vtx, err := newVertex(dgst, op, load, opts...)
 		if err != nil {
 			return nil, err
@@ -352,7 +356,7 @@ type op struct {
 
 // loadLLB loads LLB.
 // fn is executed sequentially.
-func loadLLB(ctx context.Context, def *pb.Definition, polEngine SourcePolicyEvaluator, proxyNetwork *bool, fn func(digest.Digest, *op, func(digest.Digest) (solver.Vertex, error)) (solver.Vertex, error)) (solver.Edge, error) {
+func loadLLB(ctx context.Context, def *pb.Definition, polEngine SourcePolicyEvaluator, proxyNetwork *bool, digestMapping map[digest.Digest]digest.Digest, fn func(digest.Digest, *op, func(digest.Digest) (solver.Vertex, error)) (solver.Vertex, error)) (solver.Edge, error) {
 	if len(def.Def) == 0 {
 		return solver.Edge{}, errors.New("invalid empty definition")
 	}
@@ -413,6 +417,11 @@ func loadLLB(ctx context.Context, def *pb.Definition, polEngine SourcePolicyEval
 	for dgst := range allOps {
 		if _, err := recomputeDigests(ctx, allOps, mutatedDigests, dgst); err != nil {
 			return solver.Edge{}, err
+		}
+	}
+	for original, runtime := range mutatedDigests {
+		if original != runtime && digestMapping != nil {
+			digestMapping[original] = runtime
 		}
 	}
 


### PR DESCRIPTION
Preserve frontend-to-runtime digest mappings so proxy-network builds retain source locations, resource usage, and provenance layer associations.

Fixes #7084.