### PR TITLE
kill process group when container hangs under NoProcessSandbox

### DIFF
--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -554,14 +554,15 @@ func (s *forwardIO) Stderr() io.ReadCloser {
 }
 
 // newRunProcKiller returns an abstraction for sending SIGKILL to the
-// process inside the container initiated from `runc run`.
-func newRunProcKiller(runC *runc.Runc, id string) procKiller {
-	return procKiller{runC: runC, id: id}
+// process inside the container initiated from `runc run`. A non-empty
+// pidfile enables KillProcessGroup.
+func newRunProcKiller(runC *runc.Runc, id, pidfile string) procKiller {
+	return procKiller{runC: runC, id: id, pidfile: pidfile, killGroup: pidfile != ""}
 }
 
 // newExecProcKiller returns an abstraction for sending SIGKILL to the
 // process inside the container initiated from `runc exec`.
-func newExecProcKiller(runC *runc.Runc, id string) (procKiller, error) {
+func newExecProcKiller(runC *runc.Runc, id string, killGroup bool) (procKiller, error) {
 	// for `runc exec` we need to create a pidfile and read it later to kill
 	// the process
 	tdir, err := os.MkdirTemp("", "runc")
@@ -570,9 +571,11 @@ func newExecProcKiller(runC *runc.Runc, id string) (procKiller, error) {
 	}
 
 	return procKiller{
-		runC:    runC,
-		id:      id,
-		pidfile: filepath.Join(tdir, "pidfile"),
+		runC:        runC,
+		id:          id,
+		pidfile:     filepath.Join(tdir, "pidfile"),
+		execProcess: true,
+		killGroup:   killGroup,
 		cleanup: func() {
 			os.RemoveAll(tdir)
 		},
@@ -580,10 +583,12 @@ func newExecProcKiller(runC *runc.Runc, id string) (procKiller, error) {
 }
 
 type procKiller struct {
-	runC    *runc.Runc
-	id      string
-	pidfile string
-	cleanup func()
+	runC        *runc.Runc
+	id          string
+	pidfile     string
+	execProcess bool
+	killGroup   bool
+	cleanup     func()
 }
 
 // Cleanup will delete any tmp files created for the pidfile allocation
@@ -612,7 +617,7 @@ func (k procKiller) Kill(ctx context.Context) (err error) {
 	ctx, _ = context.WithTimeoutCause(ctx, 10*time.Second, errors.WithStack(context.DeadlineExceeded)) //nolint:govet
 	defer func() { cancel(errors.WithStack(context.Canceled)) }()
 
-	if k.pidfile == "" {
+	if !k.execProcess {
 		// for `runc run` process we use `runc kill` to terminate the process
 		return k.runC.Kill(ctx, k.id, int(syscall.SIGKILL), nil)
 	}
@@ -648,6 +653,38 @@ func (k procKiller) Kill(ctx context.Context) (err error) {
 	}
 	defer process.Release()
 	return process.Signal(syscall.SIGKILL)
+}
+
+// KillProcessGroup sends SIGKILL to the process group of the in-container
+// process. Under host pidns, its subprocesses can survive the kill and keep
+// runc from exiting.
+func (k procKiller) KillProcessGroup(ctx context.Context) error {
+	if !k.killGroup || k.pidfile == "" {
+		return nil
+	}
+
+	pidData, err := os.ReadFile(k.pidfile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// the container never started, there is no process group yet
+			return nil
+		}
+		return errors.Wrap(err, "failed to read pidfile from runc")
+	}
+	pid, err := strconv.Atoi(string(pidData))
+	if err != nil {
+		return errors.Wrap(err, "read invalid pid from pidfile")
+	}
+	if pid <= 1 {
+		return errors.Errorf("refusing to kill process group of pid %d", pid)
+	}
+
+	bklog.G(ctx).Debugf("sending sigkill to process group %d in container %s", pid, k.id)
+	err = syscall.Kill(-pid, syscall.SIGKILL)
+	if err != nil && !errors.Is(err, syscall.ESRCH) {
+		return errors.Wrapf(err, "failed to kill process group %d", pid)
+	}
+	return nil
 }
 
 // procHandle is to track the process so we can send signals to it
@@ -828,6 +865,18 @@ func doKillProc(ctx context.Context, p *procHandle) error {
 
 	// Wait for the process to end. Track how long it takes.
 	start := time.Now()
+	select {
+	case <-p.ended:
+		return nil
+	case <-time.After(killWaitDelay):
+	}
+
+	// runc has not exited after the kill, kill the process group for
+	// surviving subprocesses
+	if err := p.killer.KillProcessGroup(context.WithoutCancel(ctx)); err != nil {
+		bklog.G(ctx).Errorf("failed to kill process group in container %s: %+v", p.killer.id, err)
+	}
+
 	select {
 	case <-p.ended:
 		return nil

--- a/executor/runcexecutor/executor_linux.go
+++ b/executor/runcexecutor/executor_linux.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containerd/console"
 	runc "github.com/containerd/go-runc"
 	"github.com/moby/buildkit/executor"
+	"github.com/moby/buildkit/executor/oci"
 	gatewayapi "github.com/moby/buildkit/frontend/gateway/pb"
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/sys/signal"
@@ -27,7 +28,13 @@ func updateRuncFieldsForHostOS(runtime *runc.Runc) {
 }
 
 func (w *runcExecutor) run(ctx context.Context, id, bundle string, process executor.ProcessInfo, started func(), keep bool) error {
-	killer := newRunProcKiller(w.runc, id)
+	killGroup := w.processMode == oci.NoProcessSandbox
+	var pidfile string
+	if killGroup {
+		// subprocesses survive the kill only under host pidns, we need a pidfile to kill them
+		pidfile = filepath.Join(bundle, "pid")
+	}
+	killer := newRunProcKiller(w.runc, id, pidfile)
 	return w.callWithIO(ctx, process, started, killer, func(ctx context.Context, started chan<- int, io runc.IO, pidfile string) error {
 		extraArgs := []string{}
 		if keep {
@@ -37,6 +44,7 @@ func (w *runcExecutor) run(ctx context.Context, id, bundle string, process execu
 			NoPivot:   w.noPivot,
 			Started:   started,
 			IO:        io,
+			PidFile:   pidfile,
 			ExtraArgs: extraArgs,
 		})
 		return err
@@ -44,7 +52,8 @@ func (w *runcExecutor) run(ctx context.Context, id, bundle string, process execu
 }
 
 func (w *runcExecutor) exec(ctx context.Context, id string, specsProcess *specs.Process, process executor.ProcessInfo, started func()) error {
-	killer, err := newExecProcKiller(w.runc, id)
+	killGroup := w.processMode == oci.NoProcessSandbox
+	killer, err := newExecProcKiller(w.runc, id, killGroup)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize process killer")
 	}

--- a/worker/runc/runc_test.go
+++ b/worker/runc/runc_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/executor"
 	"github.com/moby/buildkit/executor/oci"
+	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/snapshot"
 	"github.com/moby/buildkit/util/iohelper"
@@ -242,6 +243,97 @@ func TestRuncWorkerCancel(t *testing.T) {
 	require.NoError(t, err)
 
 	tests.TestWorkerCancel(t, w)
+}
+
+func TestRuncWorkerCancelNoProcessSandbox(t *testing.T) {
+	t.Parallel()
+	checkRequirement(t)
+
+	workerOpt := newWorkerOpt(t, oci.NoProcessSandbox)
+	w, err := base.NewWorker(t.Context(), workerOpt)
+	require.NoError(t, err)
+
+	ctx := tests.NewCtx("buildkit-test")
+	sm, err := session.NewManager()
+	require.NoError(t, err)
+
+	snap := tests.NewBusyboxSourceSnapshot(ctx, t, w, sm)
+	root, err := w.CacheMgr.New(ctx, snap, nil)
+	require.NoError(t, err)
+
+	id := identity.NewID()
+
+	// a subprocess survives the kill of the in-container process under host
+	// pidns and would keep runc from returning without the process group kill
+	meta := executor.Meta{
+		Args: []string{"/bin/sh", "-c", "(sleep 600 &); sleep 600"},
+		Cwd:  "/",
+	}
+
+	pid1Ctx, pid1Cancel := context.WithCancelCause(ctx)
+	defer pid1Cancel(context.Canceled)
+
+	var (
+		pid1Err, pid2Err error
+		pid1Done         = make(chan struct{})
+		pid2Done         = make(chan struct{})
+	)
+
+	started := make(chan struct{})
+
+	go func() {
+		defer close(pid1Done)
+		_, pid1Err = w.WorkerOpt.Executor.Run(pid1Ctx, id, execMount(root, false), nil, executor.ProcessInfo{Meta: meta}, started)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(10 * time.Second):
+		t.Error("Unexpected timeout waiting for pid1 to start")
+	}
+
+	select {
+	case <-pid1Done:
+		t.Fatalf("pid1 exited early: %v", pid1Err)
+	case <-time.After(time.Second):
+	}
+
+	pid2Ctx, pid2Cancel := context.WithCancelCause(ctx)
+	defer pid2Cancel(context.Canceled)
+
+	started = make(chan struct{})
+
+	go func() {
+		defer close(pid2Done)
+		// Exec has no started channel, fake it
+		go func() {
+			<-time.After(2 * time.Second)
+			close(started)
+		}()
+		pid2Err = w.WorkerOpt.Executor.Exec(pid2Ctx, id, executor.ProcessInfo{Meta: meta})
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(10 * time.Second):
+		t.Error("Unexpected timeout waiting for pid2 to start")
+	}
+
+	pid2Cancel(context.Canceled)
+	select {
+	case <-pid2Done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Unexpected timeout waiting for pid2 to return after cancel")
+	}
+	require.Contains(t, pid2Err.Error(), "exit code: 137", "pid2 exits with sigkill")
+
+	pid1Cancel(context.Canceled)
+	select {
+	case <-pid1Done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Unexpected timeout waiting for pid1 to return after cancel")
+	}
+	require.Contains(t, pid1Err.Error(), "exit code: 137", "pid1 exits with sigkill")
 }
 
 func execMount(m cache.Mountable, readonly bool) executor.Mount {


### PR DESCRIPTION
Under --oci-worker-no-process-sandbox, `runc kill` only SIGKILLs the in-container init: the container shares the host pid namespace, so subprocesses survive it, and rootless runc cannot enumerate them without cgroups (opencontainers/runc#4398). Survivors keep the container's IO open, `runc run` never returns, and the solve never completes. See #4483 and #2855.

The fix passes a pidfile to `runc run` under NoProcessSandbox and, when the process has not ended within the existing grace after Kill, SIGKILLs its process group.