### PR TITLE
solver: include proxy mode in BuildOp cache key

### DIFF
--- a/solver/llbsolver/ops/build.go
+++ b/solver/llbsolver/ops/build.go
@@ -18,34 +18,38 @@ import (
 	"github.com/pkg/errors"
 )
 
-const buildCacheType = "buildkit.build.v0"
+const buildCacheType = "buildkit.build.v1"
 
 type BuildOp struct {
-	op *pb.BuildOp
-	b  frontend.FrontendLLBBridge
-	v  solver.Vertex
+	op           *pb.BuildOp
+	b            frontend.FrontendLLBBridge
+	v            solver.Vertex
+	proxyNetwork bool
 }
 
 var _ solver.Op = &BuildOp{}
 
-func NewBuildOp(v solver.Vertex, op *pb.Op_Build, b frontend.FrontendLLBBridge, _ worker.Worker) (*BuildOp, error) {
+func NewBuildOp(v solver.Vertex, op *pb.Op_Build, b frontend.FrontendLLBBridge, _ worker.Worker, proxyNetwork bool) (*BuildOp, error) {
 	if err := opsutils.Validate(&pb.Op{Op: op}); err != nil {
 		return nil, err
 	}
 	return &BuildOp{
-		op: op.Build,
-		b:  b,
-		v:  v,
+		op:           op.Build,
+		b:            b,
+		v:            v,
+		proxyNetwork: proxyNetwork,
 	}, nil
 }
 
 func (b *BuildOp) CacheMap(ctx context.Context, job solver.JobContext, index int) (*solver.CacheMap, bool, error) {
 	dt, err := json.Marshal(struct {
-		Type string
-		Exec *pb.BuildOp
+		Type         string
+		Exec         *pb.BuildOp
+		ProxyNetwork bool `json:",omitempty"`
 	}{
-		Type: buildCacheType,
-		Exec: b.op,
+		Type:         buildCacheType,
+		Exec:         b.op,
+		ProxyNetwork: b.proxyNetwork,
 	})
 	if err != nil {
 		return nil, false, err

--- a/solver/llbsolver/ops/build_test.go
+++ b/solver/llbsolver/ops/build_test.go
@@ -1,0 +1,69 @@
+package ops
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/util/cachedigest"
+	digest "github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildOpCacheMapIncludesProxyNetwork(t *testing.T) {
+	vertex := &buildTestVertex{}
+	disabled := &BuildOp{op: &pb.BuildOp{}, v: vertex}
+	enabled := &BuildOp{op: &pb.BuildOp{}, v: vertex, proxyNetwork: true}
+
+	disabledMap, _, err := disabled.CacheMap(t.Context(), nil, 0)
+	require.NoError(t, err)
+	enabledMap, _, err := enabled.CacheMap(t.Context(), nil, 0)
+	require.NoError(t, err)
+	require.NotEqual(t, disabledMap.Digest, enabledMap.Digest)
+}
+
+func TestBuildOpCacheMapDoesNotMatchLegacy(t *testing.T) {
+	build := &pb.BuildOp{}
+	current := &BuildOp{op: build, v: &buildTestVertex{}}
+
+	currentMap, _, err := current.CacheMap(t.Context(), nil, 0)
+	require.NoError(t, err)
+
+	legacyPayload, err := json.Marshal(struct {
+		Type string
+		Exec *pb.BuildOp
+	}{
+		Type: "buildkit.build.v0",
+		Exec: build,
+	})
+	require.NoError(t, err)
+	legacyDigest, err := cachedigest.FromBytes(legacyPayload, cachedigest.TypeJSON)
+	require.NoError(t, err)
+
+	require.NotEqual(t, legacyDigest, currentMap.Digest)
+}
+
+type buildTestVertex struct{}
+
+func (*buildTestVertex) Digest() digest.Digest {
+	return ""
+}
+
+func (*buildTestVertex) Sys() any {
+	return nil
+}
+
+func (*buildTestVertex) Options() solver.VertexOptions {
+	return solver.VertexOptions{}
+}
+
+func (*buildTestVertex) Inputs() []solver.Edge {
+	return nil
+}
+
+func (*buildTestVertex) Name() string {
+	return "build test"
+}
+
+var _ solver.Vertex = (*buildTestVertex)(nil)

--- a/solver/llbsolver/vertex.go
+++ b/solver/llbsolver/vertex.go
@@ -385,6 +385,10 @@ func loadLLB(ctx context.Context, def *pb.Definition, polEngine SourcePolicyEval
 
 	if proxyNetwork != nil {
 		for _, op := range allOps {
+			if op.GetBuild() != nil {
+				op.ProxyNetwork = *proxyNetwork
+				continue
+			}
 			var err error
 			op.ProxyNetwork, err = proxyNetworkForOp(op.Op, *proxyNetwork)
 			if err != nil {

--- a/solver/llbsolver/vertex_test.go
+++ b/solver/llbsolver/vertex_test.go
@@ -131,6 +131,21 @@ func TestWithProxyNetworkAffectsVertexDigest(t *testing.T) {
 	require.NotEqual(t, defaultEdge.Vertex.Digest(), proxyEdge.Vertex.Digest())
 }
 
+func TestWithProxyNetworkAffectsBuildOpVertexDigest(t *testing.T) {
+	build := &pb.Op{Op: &pb.Op_Build{Build: &pb.BuildOp{}}}
+	buildDigest, buildBytes := marshalTestOp(t, build)
+	root := &pb.Op{Inputs: []*pb.Input{{Digest: string(buildDigest)}}}
+	_, rootBytes := marshalTestOp(t, root)
+	def := &pb.Definition{Def: [][]byte{buildBytes, rootBytes}}
+
+	defaultEdge, err := loadWithProxyNetwork(t.Context(), def, nil, false)
+	require.NoError(t, err)
+	proxyEdge, err := loadWithProxyNetwork(t.Context(), def, nil, true)
+	require.NoError(t, err)
+
+	require.NotEqual(t, defaultEdge.Vertex.Digest(), proxyEdge.Vertex.Digest())
+}
+
 func TestNormalizeRuntimePlatformsDoesNotAffectVertexDigest(t *testing.T) {
 	def := proxyNetworkTestDefinition(t)
 

--- a/worker/base/worker.go
+++ b/worker/base/worker.go
@@ -424,7 +424,7 @@ func (w *Worker) ResolveOp(v solver.Vertex, s frontend.FrontendLLBBridge, sm *se
 		case *pb.Op_File:
 			return ops.NewFileOp(v, op, w.CacheMgr, w.ParallelismSem, w)
 		case *pb.Op_Build:
-			return ops.NewBuildOp(v, op, s, w)
+			return ops.NewBuildOp(v, op, s, w, proxyOpt.Network)
 		case *pb.Op_Merge:
 			return ops.NewMergeOp(v, op, w)
 		case *pb.Op_Diff:


### PR DESCRIPTION
Include daemon-wide proxy-network mode in nested `BuildOp` cache identity to prevent cross-mode cache reuse. **Please note that this bumps the `BuildOp` cache-key version from `v0` to `v1`.**

Fixes #7094.