### PR TITLE
Fix typo in media type googeapis -> googleapis

### DIFF
--- a/frontend/dockerfile/dockerfile_history_test.go
+++ b/frontend/dockerfile/dockerfile_history_test.go
@@ -270,7 +270,7 @@ COPY notexist /foo
 		require.NotNil(t, extErr)
 
 		require.Greater(t, extErr.Size, int64(0))
-		require.Equal(t, "application/vnd.googeapis.google.rpc.status+proto", extErr.MediaType)
+		require.Equal(t, "application/vnd.googleapis.google.rpc.status+proto", extErr.MediaType)
 
 		bkstore := proxy.NewContentStore(c.ContentClient())
 

--- a/solver/llbsolver/history/buildhistory.go
+++ b/solver/llbsolver/history/buildhistory.go
@@ -711,7 +711,7 @@ func (h *Queue) ImportError(ctx context.Context, err error) (_ *spb.Status, _ *c
 		return nil, nil, nil, err
 	}
 
-	w, err := h.OpenBlobWriter(ctx, "application/vnd.googeapis.google.rpc.status+proto")
+	w, err := h.OpenBlobWriter(ctx, "application/vnd.googleapis.google.rpc.status+proto")
 	if err != nil {
 		return nil, nil, nil, err
 	}


### PR DESCRIPTION
I came across this typo when looking at the BuildKit BuildHistoryRecord. 