### PR TITLE
Fix typos in code comments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ ENV GOFLAGS=-mod=vendor
 FROM buildkit-base AS buildkit-version
 # TODO: PKG should be inferred from go modules
 RUN --mount=target=. <<'EOT'
-  # if git is worktree (file starting with gitdir:) then skip verions check
+  # if git is worktree (file starting with gitdir:) then skip version check
   if [ -f .git ] && head -1 .git | grep -q "^gitdir:"; then
     echo >&2 "Skipping version check for worktree"
     # set dev stubs

--- a/cache/manager.go
+++ b/cache/manager.go
@@ -322,7 +322,7 @@ func (cm *cacheManager) GetByBlob(ctx context.Context, desc ocispecs.Descriptor,
 }
 
 // init loads all snapshots from metadata state and tries to load the records
-// from the snapshotter. If snaphot can't be found, metadata is deleted as well.
+// from the snapshotter. If snapshot can't be found, metadata is deleted as well.
 func (cm *cacheManager) init(ctx context.Context) error {
 	items, err := cm.MetadataStore.All()
 	if err != nil {

--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -1465,7 +1465,7 @@ func testSharingCompressionVariant(ctx context.Context, t *testing.T, co *cmOut,
 			checkCompression(bDesc, c)
 		}
 
-		// check if compression variables are availalbe on B still after A is released
+		// check if compression variables are available on B still after A is released
 		if testCase.checkPrune && aRef.ID() != bRef.ID() {
 			require.NoError(t, aRef.Release(ctx))
 			ensurePrune(ctx, t, cm, 1, 10)

--- a/cmd/buildkitd/main_oci_worker.go
+++ b/cmd/buildkitd/main_oci_worker.go
@@ -483,13 +483,13 @@ const (
 	// the target image.
 	targetImageLayersLabel = "containerd.io/snapshot/remote/stargz.layers"
 
-	// targetSessionLabel is a labeld which contains session IDs usable for
+	// targetSessionLabel is a label which contains session IDs usable for
 	// authenticating the target snapshot.
 	targetSessionLabel = "containerd.io/snapshot/remote/stargz.session"
 )
 
 // sourceWithSession returns a callback which implements a converter from labels to the
-// typed snapshot source info. This callback is called everytime the snapshotter resolves a
+// typed snapshot source info. This callback is called every time the snapshotter resolves a
 // snapshot. This callback returns configuration that is based on buildkitd's registry config
 // and utilizes the session-based authorizer.
 func sourceWithSession(hosts docker.RegistryHosts, sm *session.Manager) sgzsource.GetSources {

--- a/snapshot/snapshotter_test.go
+++ b/snapshot/snapshotter_test.go
@@ -356,7 +356,7 @@ func TestHardlinks(t *testing.T) {
 			require.EqualValues(t, 1, stat2.Nlink)
 			require.NotEqual(t, stat2Ino, stat2.Ino)
 
-			// verify the original files and the files inthe merge are unchanged
+			// verify the original files and the files in the merge are unchanged
 			requireContents(ctx, t, sn, base1Snap.Name,
 				fstest.CreateFile("1", []byte("1"), 0600),
 			)


### PR DESCRIPTION
Six spelling fixes, all in comments:

- `Dockerfile`: "verions check" -> "version check"
- `cmd/buildkitd/main_oci_worker.go`: "a labeld which" -> "a label which", and "everytime" -> "every time"
- `cache/manager.go`: "snaphot" -> "snapshot"
- `cache/manager_test.go`: "availalbe" -> "available"
- `snapshot/snapshotter_test.go`: "inthe merge" -> "in the merge"

Every changed line is a comment, so there are no behaviour changes.