### PR TITLE
exporter: raise max attestation size to 80 MiB

### DIFF
--- a/docs/attestations/attestation-storage.md
+++ b/docs/attestations/attestation-storage.md
@@ -85,7 +85,7 @@ The contents of each layer will be a blob dependent on its `mediaType`.
   target manifest described in the [Attestation Manifest Descriptor](#attestation-manifest-descriptor),
   or some object within.
 
-BuildKit limits each attestation file read from a build result to 40 MiB
+BuildKit limits each attestation file read from a build result to 80 MiB
 before wrapping it as an in-toto statement. This protects exporters from
 unbounded reads of frontend-provided attestation files.
 

--- a/docs/attestations/sbom.md
+++ b/docs/attestations/sbom.md
@@ -199,6 +199,6 @@ Entries in the `files` and `packages` will contain a `comment` field that
 contains the `sha256` digest of the layer which introduced it if that layer is
 present in the final image.
 
-Generated SBOM attestation files are limited to 40 MiB before they are
+Generated SBOM attestation files are limited to 80 MiB before they are
 attached to the exported image. Large SPDX JSON documents can approach this
 limit because SPDX includes detailed file, package, and relationship metadata.

--- a/exporter/attestation/make.go
+++ b/exporter/attestation/make.go
@@ -17,7 +17,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const maxAttestationBytes int64 = 40 << 20
+const maxAttestationBytes int64 = 80 << 20
 
 // ReadAll reads the content of an attestation.
 func ReadAll(ctx context.Context, s session.Group, att exporter.Attestation) ([]byte, error) {


### PR DESCRIPTION
Increase the shared attestation read limit and update its documentation.