### PR TITLE
solver: resolve lazy blob cache opts per record during cache export

### DIFF
--- a/client/client_cache_test.go
+++ b/client/client_cache_test.go
@@ -1943,3 +1943,137 @@ func testStargzLazyRegistryCacheImportExport(t *testing.T, sb integration.Sandbo
 
 	ensurePruneAll(t, c, sb)
 }
+
+// testStargzCacheExportMaxCrossStageLazyBase covers
+// https://github.com/moby/buildkit/issues/6893: with a lazy (stargz)
+// snapshotter and a multi-stage build where a later stage consumes an
+// earlier, different-base stage via COPY --from, mode=max cache export used
+// to silently drop the earlier stage's cache records (their lazy base blobs
+// were not resolvable during export), so a later build re-ran steps that
+// should have been restored from cache.
+func testStargzCacheExportMaxCrossStageLazyBase(t *testing.T, sb integration.Sandbox) {
+	workers.CheckFeatureCompat(t, sb,
+		workers.FeatureCacheExport,
+		workers.FeatureCacheImport,
+		workers.FeatureCacheBackendRegistry,
+		workers.FeatureDirectPush,
+	)
+	requiresLinux(t)
+	cdAddress := sb.ContainerdAddress()
+	if cdAddress == "" || sb.Snapshotter() != "stargz" {
+		t.Skip("test requires containerd worker with stargz snapshotter")
+	}
+
+	c, err := New(sb.Context(), sb.Address())
+	require.NoError(t, err)
+	defer c.Close()
+
+	registry, err := sb.NewRegistry()
+	if errors.Is(err, integration.ErrRequirements) {
+		t.Skip(err.Error())
+	}
+	require.NoError(t, err)
+
+	// Prepare two different eStargz base images. The bug only triggers when
+	// the stages use different base images, so that the lazy base blobs of
+	// the earlier stage are not part of the final stage's ref chain.
+	pushEsgz := func(orgImage, name string) string {
+		ref := registry + "/stargz/" + name + ":" + identity.NewID()
+		def, err := llb.Image(orgImage).Run(llb.Args([]string{"/bin/touch", "/marker-" + name})).Marshal(sb.Context())
+		require.NoError(t, err)
+		_, err = c.Solve(sb.Context(), def, SolveOpt{
+			Exports: []ExportEntry{
+				{
+					Type: ExporterImage,
+					Attrs: map[string]string{
+						"name":              ref,
+						"push":              "true",
+						"compression":       "estargz",
+						"oci-mediatypes":    "true",
+						"force-compression": "true",
+					},
+				},
+			},
+		}, nil)
+		require.NoError(t, err)
+		return ref
+	}
+	baseA := pushEsgz("docker.io/library/alpine:latest", "alpine")
+	baseB := pushEsgz("docker.io/library/busybox:latest", "busybox")
+
+	// Remove the local copies of the pushed eStargz images (and any state the
+	// preparation builds left behind) so that the pulls in the actual build
+	// are lazy and need desc-handler resolution during cache export, which is
+	// the precondition for this bug.
+	client, err := newContainerd(cdAddress)
+	require.NoError(t, err)
+	defer client.Close()
+	imageService := client.ImageService()
+	ctx := namespaces.WithNamespace(sb.Context(), "buildkit")
+	for _, ref := range []string{baseA, baseB} {
+		err = imageService.Delete(ctx, ref, images.SynchronousDelete())
+		require.NoError(t, err)
+	}
+	checkAllReleasable(t, c, sb, true)
+
+	// Multi-stage graph mirroring the issue reproducer: an earlier stage on
+	// baseA writes a random marker plus a stable file, a later step in the
+	// same stage depends on the first RUN and is forced to re-run by the
+	// bust value; the final stage on the different baseB copies the results.
+	//
+	// The first RUN writes content that changes whenever it re-executes, so
+	// a cache miss (the dropped record) is observable on the second build.
+	buildDef := func(bust string) (*llb.Definition, error) {
+		build := llb.Image(baseA).
+			Run(llb.Shlex("sh -c 'echo stable > /stable && head -c 100 /dev/urandom | sha256sum > /stable-id'")).
+			Run(llb.Shlex("sh -c 'echo " + bust + " > /bust'"))
+		final := llb.Image(baseB).
+			File(llb.Copy(build.Root(), "/stable-id", "/stable-id")).
+			File(llb.Copy(build.Root(), "/bust", "/bust"))
+		return final.Marshal(sb.Context())
+	}
+
+	cacheRef := registry + "/buildkit/stargz-crossstagecache:" + identity.NewID()
+	cacheEntry := []CacheOptionsEntry{{
+		Type: "registry",
+		Attrs: map[string]string{
+			"ref":            cacheRef,
+			"mode":           "max",
+			"compression":    "estargz",
+			"oci-mediatypes": "true",
+		},
+	}}
+
+	def1, err := buildDef("1")
+	require.NoError(t, err)
+	firstOutput := t.TempDir()
+	_, err = c.Solve(sb.Context(), def1, SolveOpt{
+		Exports:      []ExportEntry{{Type: ExporterLocal, OutputDir: firstOutput}},
+		CacheExports: cacheEntry,
+	}, nil)
+	require.NoError(t, err)
+
+	stableID, err := os.ReadFile(filepath.Join(firstOutput, "stable-id"))
+	require.NoError(t, err)
+
+	// Drop all local state so the second build must be restored from the
+	// exported registry cache.
+	ensurePruneAll(t, c, sb)
+
+	// Rebuild with a different bust value so the second RUN of the build
+	// stage re-runs, which requires the first RUN's record (and its lazy
+	// base layers) to have been exported.
+	def2, err := buildDef("2")
+	require.NoError(t, err)
+	secondOutput := t.TempDir()
+	_, err = c.Solve(sb.Context(), def2, SolveOpt{
+		Exports:      []ExportEntry{{Type: ExporterLocal, OutputDir: secondOutput}},
+		CacheImports: cacheEntry,
+	}, nil)
+	require.NoError(t, err)
+
+	actualID, err := os.ReadFile(filepath.Join(secondOutput, "stable-id"))
+	require.NoError(t, err)
+	require.Equal(t, stableID, actualID,
+		"first RUN of the build stage was re-executed on cache import: its record was dropped from the mode=max cache export")
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -42,6 +42,7 @@ var allTests = []func(t *testing.T, sb integration.Sandbox){
 	testZstdRegistryCacheImportExport,
 	testStargzLazyInlineCacheImportExport,
 	testStargzLazyRegistryCacheImportExport,
+	testStargzCacheExportMaxCrossStageLazyBase,
 
 	// client_control_test.go
 	testCallInfo,

--- a/solver/exporter.go
+++ b/solver/exporter.go
@@ -145,8 +145,40 @@ func (e *exporter) ExportTo(ctx context.Context, t CacheExporterTarget, opt Cach
 	var i int
 
 	mainCtx := ctx
-	if CacheOptGetterOf(ctx) == nil && e.recordCtxOpts != nil {
-		ctx = e.recordCtxOpts(ctx)
+	if e.recordCtxOpts != nil {
+		if outer := CacheOptGetterOf(ctx); outer != nil {
+			// The context already carries a cache opt getter installed by the
+			// caller of the export (e.g. withDescHandlerCacheOpts for the
+			// exported result ref). Such a getter is rooted at a single
+			// state/ref chain, so it can only resolve cache opts (e.g. desc
+			// handlers for lazy blobs) that belong to that chain. Records that
+			// belong to other branches of the build graph (e.g. an earlier
+			// stage consumed through COPY --from) would fail to resolve their
+			// lazy blobs through it and get silently dropped from the export.
+			// Re-root the lookup at this record's own state (recordCtxOpts)
+			// and keep the inherited getter as a fallback for anything the
+			// record-specific lookup can not resolve.
+			recordOptGetter := CacheOptGetterOf(e.recordCtxOpts(ctx))
+			ctx = WithCacheOptGetter(ctx, func(includeAncestors bool, keys ...any) map[any]any {
+				vals := recordOptGetter(includeAncestors, keys...)
+				if len(vals) < len(keys) {
+					var missing []any
+					for _, k := range keys {
+						if _, ok := vals[k]; !ok {
+							missing = append(missing, k)
+						}
+					}
+					for k, v := range outer(includeAncestors, missing...) {
+						if _, ok := vals[k]; !ok {
+							vals[k] = v
+						}
+					}
+				}
+				return vals
+			})
+		} else {
+			ctx = e.recordCtxOpts(ctx)
+		}
 	}
 	v := e.record
 	for exportRecord && addRecord {

--- a/solver/exporter_test.go
+++ b/solver/exporter_test.go
@@ -1,9 +1,18 @@
 package solver
 
 import (
+	"context"
+	"fmt"
 	"slices"
 	"testing"
 	"time"
+
+	"github.com/moby/buildkit/identity"
+	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/util/compression"
+	digest "github.com/opencontainers/go-digest"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCompareCacheRecord(t *testing.T) {
@@ -31,4 +40,229 @@ func TestCompareCacheRecord(t *testing.T) {
 	if !slices.Equal(got, want) {
 		t.Fatalf("unexpected order: got %v, want %v", got, want)
 	}
+}
+
+// lazyOptKey is a stand-in for cache.DescHandlerKey: an opaque cache opt key
+// that identifies a lazy blob for which a descriptor handler (provider) must
+// be resolvable through the context cache-opt getter before the blob can be
+// loaded.
+type lazyOptKey digest.Digest
+
+// cacheOptsCtx wraps ctx with a cache-opt getter that resolves exactly the
+// given keys, mimicking the record-specific ancestor getter installed by
+// withAncestorCacheOpts for one vertex state.
+func cacheOptsCtx(known map[lazyOptKey]any) func(context.Context) context.Context {
+	return func(ctx context.Context) context.Context {
+		return WithCacheOptGetter(ctx, func(_ bool, keys ...any) map[any]any {
+			vals := make(map[any]any)
+			for _, k := range keys {
+				if key, ok := k.(lazyOptKey); ok {
+					if v, ok := known[key]; ok {
+						vals[key] = v
+					}
+				}
+			}
+			return vals
+		})
+	}
+}
+
+// outerGetter returns a cache-opt getter resolving exactly the given keys,
+// mimicking the caller-installed getter (withDescHandlerCacheOpts) that only
+// covers the final result ref chain.
+func outerGetter(known map[lazyOptKey]any) func(bool, ...any) map[any]any {
+	return func(_ bool, keys ...any) map[any]any {
+		vals := make(map[any]any)
+		for _, k := range keys {
+			if key, ok := k.(lazyOptKey); ok {
+				if v, ok := known[key]; ok {
+					vals[key] = v
+				}
+			}
+		}
+		return vals
+	}
+}
+
+// lazyResultStore simulates worker result storage backed by a lazy snapshotter:
+// results registered in the lazy map can only be loaded when the context
+// cache-opt getter resolves their lazyOptKey (mirroring how LoadRef recovers
+// DescHandlers via CacheOptGetterOf before retrying, and how LoadRemotes
+// swallows the failure best-effort and falls back to a local Load).
+type lazyResultStore struct {
+	CacheResultStorage
+	lazy map[string]lazyOptKey // result ID -> required cache opt key
+}
+
+func (s *lazyResultStore) resolvable(ctx context.Context, key lazyOptKey) bool {
+	if g := CacheOptGetterOf(ctx); g != nil {
+		_, ok := g(true, key)[key]
+		return ok
+	}
+	return false
+}
+
+func (s *lazyResultStore) Load(ctx context.Context, res CacheResult) (Result, error) {
+	if key, ok := s.lazy[res.ID]; ok && !s.resolvable(ctx, key) {
+		return nil, fmt.Errorf("lazy blob %s: no descriptor handler available", digest.Digest(key))
+	}
+	return s.CacheResultStorage.Load(ctx, res)
+}
+
+func (s *lazyResultStore) LoadRemotes(ctx context.Context, res CacheResult, compressionopt *compression.Config, g session.Group) ([]*Remote, error) {
+	if key, ok := s.lazy[res.ID]; ok {
+		if !s.resolvable(ctx, key) {
+			// mirror worker/cacheresult.go: loadRemote is best effort
+			return nil, nil
+		}
+		return []*Remote{{Descriptors: []ocispecs.Descriptor{{Digest: digest.Digest(key)}}}}, nil
+	}
+	return s.CacheResultStorage.LoadRemotes(ctx, res, compressionopt, g)
+}
+
+// testCacheTarget collects records added by the export.
+type testCacheTarget struct {
+	adds []testCacheTargetAdd
+}
+
+type testCacheTargetAdd struct {
+	dgst    digest.Digest
+	deps    [][]CacheLink
+	results []CacheExportResult
+}
+
+func (t *testCacheTarget) Add(dgst digest.Digest, deps [][]CacheLink, results []CacheExportResult) (CacheExporterRecord, bool, error) {
+	t.adds = append(t.adds, testCacheTargetAdd{dgst: dgst, deps: deps, results: results})
+	return &CacheExporterRecordBase{}, true, nil
+}
+
+// exportedBlobDigests returns the remote blob digests attached to records
+// added to the target.
+func (t *testCacheTarget) exportedBlobDigests() map[digest.Digest]struct{} {
+	out := map[digest.Digest]struct{}{}
+	for _, a := range t.adds {
+		for _, r := range a.results {
+			if r.Result == nil {
+				continue
+			}
+			for _, d := range r.Result.Descriptors {
+				out[d.Digest] = struct{}{}
+			}
+		}
+	}
+	return out
+}
+
+func testExportOpt() CacheExportOpt {
+	return CacheExportOpt{
+		Mode:            CacheExportModeMax,
+		IgnoreBacklinks: true,
+		ResolveRemotes: func(context.Context, Result) ([]*Remote, error) {
+			return nil, nil
+		},
+	}
+}
+
+// TestExportToLazyCrossStageRecordsUseTheirOwnCacheOpts covers the
+// cross-stage cache export regression from
+// https://github.com/moby/buildkit/issues/6893.
+//
+// The outer export context carries a cache-opt getter that only knows the
+// lazy blob of the final (root) record, like the withDescHandlerCacheOpts
+// getter the cache exporter installs for the final result ref. An
+// intermediate record from an earlier build stage (here: the dependency of
+// the root, itself depending on a base record) has a lazy blob that is only
+// resolvable through the record-specific ancestor getter (recordCtxOpts).
+//
+// ExportTo must re-root the getter at each record's own state so that the
+// intermediate record can resolve its lazy blob. Before the fix, the
+// pre-existing getter made ExportTo skip re-rooting, the intermediate record
+// failed to load and was silently dropped together with the root record.
+func TestExportToLazyCrossStageRecordsUseTheirOwnCacheOpts(t *testing.T) {
+	ctx := t.Context()
+
+	blobMid := lazyOptKey(digest.FromBytes([]byte("mid-blob")))
+	blobRoot := lazyOptKey(digest.FromBytes([]byte("root-blob")))
+
+	cm := NewCacheManager(ctx, identity.NewID(), NewInMemoryCacheStorage(), &lazyResultStore{
+		CacheResultStorage: NewInMemoryResultStorage(),
+		lazy:               map[string]lazyOptKey{},
+	})
+
+	baseRes := testResult("base")
+	cmSaveBase, err := cm.Save(NewCacheKey(dgst("base"), "", 0), baseRes, time.Now())
+	require.NoError(t, err)
+
+	midRes := testResult("mid")
+	cmSaveMid, err := cm.Save(testCacheKey(dgst("mid"), 0, *cmSaveBase), midRes, time.Now())
+	require.NoError(t, err)
+
+	rootRes := testResult("root")
+	cmSaveRoot, err := cm.Save(testCacheKey(dgst("root"), 0, *cmSaveMid), rootRes, time.Now())
+	require.NoError(t, err)
+
+	// The lazy blobs are only resolvable through the record-specific getters
+	// (recordCtxOpts), except the root blob which the outer export context
+	// (the caller-installed getter) knows too.
+	cm.(*cacheManager).results.(*lazyResultStore).lazy = map[string]lazyOptKey{
+		midRes.ID():  blobMid,
+		rootRes.ID(): blobRoot,
+	}
+
+	// base record has no lazy blob and needs no getter.
+	midExp := cmSaveMid.Exporter.(*exporter)
+	rootExp := cmSaveRoot.Exporter.(*exporter)
+	midExp.recordCtxOpts = cacheOptsCtx(map[lazyOptKey]any{blobMid: "mid-handler"})
+	rootExp.recordCtxOpts = cacheOptsCtx(map[lazyOptKey]any{blobRoot: "root-handler"})
+
+	// Caller-installed getter: knows the root (final result) chain only.
+	outer := WithCacheOptGetter(ctx, outerGetter(map[lazyOptKey]any{blobRoot: "root-handler"}))
+
+	target := &testCacheTarget{}
+	_, err = rootExp.ExportTo(outer, target, testExportOpt())
+	require.NoError(t, err)
+
+	got := target.exportedBlobDigests()
+	require.Contains(t, got, digest.Digest(blobMid),
+		"intermediate (cross-stage) record was dropped from the export: its lazy blob was not resolvable")
+	require.Contains(t, got, digest.Digest(blobRoot),
+		"root record was dropped from the export")
+}
+
+// TestExportToKeepsCallerCacheOptsFallback verifies that a cache-opt getter
+// installed by the caller of the export (e.g. withDescHandlerCacheOpts for
+// the already-loaded final result ref) keeps working for records whose own
+// record-specific getter cannot resolve the lazy blob (e.g. when the
+// exporting record has no live solver state to walk).
+func TestExportToKeepsCallerCacheOptsFallback(t *testing.T) {
+	ctx := t.Context()
+
+	blobRoot := lazyOptKey(digest.FromBytes([]byte("root-blob")))
+
+	cm := NewCacheManager(ctx, identity.NewID(), NewInMemoryCacheStorage(), &lazyResultStore{
+		CacheResultStorage: NewInMemoryResultStorage(),
+		lazy:               map[string]lazyOptKey{},
+	})
+	rootRes := testResult("root")
+	cmSaveRoot, err := cm.Save(NewCacheKey(dgst("root"), "", 0), rootRes, time.Now())
+	require.NoError(t, err)
+	cm.(*cacheManager).results.(*lazyResultStore).lazy = map[string]lazyOptKey{
+		rootRes.ID(): blobRoot,
+	}
+
+	rootExp := cmSaveRoot.Exporter.(*exporter)
+	// Record-specific getter that cannot resolve anything (no live state).
+	rootExp.recordCtxOpts = cacheOptsCtx(map[lazyOptKey]any{})
+
+	// Caller-installed getter knows the root blob.
+	outer := WithCacheOptGetter(ctx, outerGetter(map[lazyOptKey]any{blobRoot: "root-handler"}))
+
+	opt := testExportOpt()
+	opt.ExportRoots = true
+
+	target := &testCacheTarget{}
+	_, err = rootExp.ExportTo(outer, target, opt)
+	require.NoError(t, err)
+	require.Contains(t, target.exportedBlobDigests(), digest.Digest(blobRoot),
+		"caller-installed cache opts were not honored for the exported record")
 }


### PR DESCRIPTION
### Description

Fixes #6893 — `mode=max` cache export silently drops earlier-stage cache records when a lazy/remote snapshotter (stargz/eStargz, overlaybd, ...) is used with a multi-stage build where a later stage consumes an earlier, different-base stage via `COPY --from`. On later builds, steps that should be restored from cache re-run instead, with no error reported.

**Root cause.** The cache exporter callers install a cache-opt getter in the export context (`withDescHandlerCacheOpts`) that resolves descriptor handlers for the exported *final result ref chain* only. `ExportTo` used to re-root the getter at each record's own state (`recordCtxOpts`, an ancestor walk over the record's vertex graph) so every record could resolve the handlers for its own lazy blobs. Commit 051818cf3 added a `CacheOptGetterOf(ctx) == nil` guard ("remotecache: only load desc handlers if not set") so that the caller-installed getter is kept and per-record re-rooting is skipped. Since the caller getter is rooted at a single ref chain, records from other branches of the graph (an earlier build stage) can no longer resolve their lazy base blobs: `LoadRef` fails with `NeedsRemoteProviderError` and the deps loop drops the record silently, producing a degraded cache. Eager snapshotters are unaffected because their base blobs are materialized.

**Fix.** Re-root the cache-opt lookup at each record's own state while keeping the inherited (caller-installed) getter as a fallback for keys the record-specific lookup cannot resolve. This restores the pre-regression behavior for nested/cross-stage records and preserves the behavior that 051818cf3/2fcce87cf intentionally added for the root record (handler resolution through the already-loaded final ref, e.g. when the record has no live solver state to walk).

```diff
 mainCtx := ctx
-if CacheOptGetterOf(ctx) == nil && e.recordCtxOpts != nil {
-    ctx = e.recordCtxOpts(ctx)
-}
+if e.recordCtxOpts != nil {
+    if outer := CacheOptGetterOf(ctx); outer != nil {
+        // composed: record-specific getter first, inherited getter as fallback
+        ...
```

### Tests

- `solver/exporter_test.go` (new, run locally):
  - `TestExportToLazyCrossStageRecordsUseTheirOwnCacheOpts` — fails on `master` (intermediate record silently dropped from the export) and passes with the fix. Verified locally: red on master, green after the change.
  - `TestExportToKeepsCallerCacheOptsFallback` — guards the caller-installed-getter contract; verified it fails against the naive "remove the guard only" variant and passes with the composed fix.
  - `go test ./solver/ -skip TestJobsIntegration` — full solver unit suite passes (TestJobsIntegration requires worker spawn infra and fails identically on pristine master in this environment).
- `client/client_cache_test.go` (new) — `testStargzCacheExportMaxCrossStageLazyBase`, a containerd+stargz integration test mirroring the issue reproducer: two different eStargz bases, an earlier stage whose first RUN writes a random marker, a bust step forcing re-run, `mode=max` registry cache export, prune, then rebuild from cache import asserting the marker is unchanged (i.e., the RUN was restored from cache, not re-executed). Runs on the `containerd-snapshotter-stargz` CI worker (skips elsewhere, same as the existing stargz tests).

### Notes

- `go vet` clean on changed files (pre-existing `solver/jobs.go:719` vet warning untouched, present on master).
- Not a supersede of #6880 (unrelated WCOW work); no other open PR covers #6893.
