### PR TITLE
source/http: report errors before checksum mismatch

### DIFF
--- a/source/http/source.go
+++ b/source/http/source.go
@@ -896,6 +896,9 @@ func (hs *httpSourceHandler) Snapshot(ctx context.Context, jobCtx solver.JobCont
 	defer func() {
 		_ = resp.Body.Close()
 	}()
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		return nil, errors.Errorf("invalid response status %d", resp.StatusCode)
+	}
 
 	ref, dgst, err := hs.save(ctx, resp, g)
 	if err != nil {

--- a/source/http/source_test.go
+++ b/source/http/source_test.go
@@ -2,6 +2,8 @@ package http
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -313,6 +315,31 @@ func TestHTTPChecksum(t *testing.T) {
 
 	ref.Release(t.Context())
 	ref = nil
+}
+
+func TestHTTPChecksumReturnsResponseStatus(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("forbidden response body"))
+	}))
+	defer server.Close()
+
+	hs, err := newHTTPSource(t)
+	require.NoError(t, err)
+	id := &HTTPIdentifier{
+		URL:      server.URL + "/artifact",
+		Checksum: digest.FromString("expected"),
+	}
+	h, err := hs.Resolve(ctx, id, nil, nil)
+	require.NoError(t, err)
+	_, _, _, _, err = h.CacheKey(ctx, nil, 0)
+	require.NoError(t, err)
+
+	_, err = h.Snapshot(ctx, nil)
+	require.ErrorContains(t, err, "invalid response status 403")
 }
 
 func TestHTTPSignatureVerification(t *testing.T) {


### PR DESCRIPTION
Pinned HTTP sources download their payload during `Snapshot`. When the server returns an error response, the current path saves that response body and compares its digest first, producing a misleading checksum mismatch instead of the HTTP status reported by unpinned sources.

Check the response status before saving the snapshot. The regression test uses a local HTTP server returning 403 and verifies that `Snapshot` reports `invalid response status 403`.

Testing:

- `mise x go@1.26.3 -- go test ./source/http -run ^'TestHTTPChecksumReturnsResponseStatus$' -count=1`\n- `git diff --check`\n\nBoth pass. The full package suite was also run; the new test passes, while four existing snapshot-reading tests fail because this unprivileged environment cannot perform bind mounts (`operation not permitted`).\n\nFixes #6380