### PR TITLE
vendor: github.com/containerd/containerd/v2 v2.3.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/containerd/accelerated-container-image v1.3.0
 	github.com/containerd/console v1.0.5
 	github.com/containerd/containerd/api v1.11.1
-	github.com/containerd/containerd/v2 v2.3.4
+	github.com/containerd/containerd/v2 v2.3.5
 	github.com/containerd/continuity v0.5.0
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/fuse-overlayfs-snapshotter/v2 v2.1.7

--- a/go.sum
+++ b/go.sum
@@ -132,8 +132,8 @@ github.com/containerd/console v1.0.5 h1:R0ymNeydRqH2DmakFNdmjR2k0t7UPuiOV/N/27/q
 github.com/containerd/console v1.0.5/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
 github.com/containerd/containerd/api v1.11.1 h1:h8nfoDW9+fNsC/9TwiAHj8B1GzXKtR4eFtkhi/X5RLU=
 github.com/containerd/containerd/api v1.11.1/go.mod h1:CaQFRu+N1MtbgL6JDOJLUB1hCKESU1lD6MuTJhgtdlw=
-github.com/containerd/containerd/v2 v2.3.4 h1:c2PJo/9UGVdiiw8SwrxuLxWGY+9b3jQ6Xp9zntneIvI=
-github.com/containerd/containerd/v2 v2.3.4/go.mod h1:a30D8fWZJ1Uzx/2WpjLbLsxBkq9He41pe8ENW+QZ3LY=
+github.com/containerd/containerd/v2 v2.3.5 h1:9MYlI81gUcOZ0WsCkSMtvOU7rTR3hqAoa2eCzhoLlkA=
+github.com/containerd/containerd/v2 v2.3.5/go.mod h1:RXDyLPaI3zoO7dFdAW9/54W4cix+z3A6larieufC9mg=
 github.com/containerd/continuity v0.5.0 h1:7a85HZpCSs+1Zps0Ee3DPSuAWY+0SJM1JNM51nlEVDg=
 github.com/containerd/continuity v0.5.0/go.mod h1:/lNJvtJKUQStBzpVQ1+rasXO1LAWtUQssk28EZvJ3nE=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=

--- a/vendor/github.com/containerd/containerd/v2/core/remotes/docker/fetcher.go
+++ b/vendor/github.com/containerd/containerd/v2/core/remotes/docker/fetcher.go
@@ -218,6 +218,40 @@ type dockerFetcher struct {
 	*dockerBase
 }
 
+func stripSensitiveHeadersForExternalURLs(h http.Header) {
+	h.Del("Authorization")
+	h.Del("Proxy-Authorization")
+	h.Del("Cookie")
+	h.Del("Cookie2")
+}
+
+func effectivePort(u *url.URL) string {
+	if port := u.Port(); port != "" {
+		return port
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http":
+		return "80"
+	case "https":
+		return "443"
+	default:
+		return ""
+	}
+}
+
+func isRegistryOrigin(u *url.URL, hosts []RegistryHost) bool {
+	for _, host := range hosts {
+		if !strings.EqualFold(u.Scheme, host.Scheme) {
+			continue
+		}
+		hostURL := &url.URL{Scheme: host.Scheme, Host: host.Host}
+		if strings.EqualFold(u.Hostname(), hostURL.Hostname()) && effectivePort(u) == effectivePort(hostURL) {
+			return true
+		}
+	}
+	return false
+}
+
 func (r dockerFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.ReadCloser, error) {
 	ctx = log.WithLogger(ctx, log.G(ctx).WithField("digest", desc.Digest))
 
@@ -255,7 +289,9 @@ func (r dockerFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.R
 				Capabilities: HostCapabilityPull,
 			}
 			req := r.request(host, http.MethodGet)
-			// Strip namespace from base
+			if !isRegistryOrigin(u, hosts) {
+				stripSensitiveHeadersForExternalURLs(req.header)
+			}
 			req.path = u.Path
 			if u.RawQuery != "" {
 				req.path = req.path + "?" + u.RawQuery

--- a/vendor/github.com/containerd/containerd/v2/core/streaming/proxy/streaming.go
+++ b/vendor/github.com/containerd/containerd/v2/core/streaming/proxy/streaming.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 
 	streamingapi "github.com/containerd/containerd/api/services/streaming/v1"
 	"github.com/containerd/errdefs"
@@ -105,10 +106,13 @@ func (sc *streamCreator) Create(ctx context.Context, id string) (streaming.Strea
 }
 
 type clientStream struct {
-	s streamingapi.TTRPCStreaming_StreamClient
+	sendMu sync.Mutex
+	s      streamingapi.TTRPCStreaming_StreamClient
 }
 
 func (cs *clientStream) Send(a typeurl.Any) (err error) {
+	cs.sendMu.Lock()
+	defer cs.sendMu.Unlock()
 	err = cs.s.Send(typeurl.MarshalProto(a))
 	if !errors.Is(err, io.EOF) {
 		err = errgrpc.ToNative(err)
@@ -125,5 +129,7 @@ func (cs *clientStream) Recv() (a typeurl.Any, err error) {
 }
 
 func (cs *clientStream) Close() error {
+	cs.sendMu.Lock()
+	defer cs.sendMu.Unlock()
 	return cs.s.CloseSend()
 }

--- a/vendor/github.com/containerd/containerd/v2/core/transfer/streaming/reader.go
+++ b/vendor/github.com/containerd/containerd/v2/core/transfer/streaming/reader.go
@@ -18,9 +18,9 @@ package streaming
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
+	"sync/atomic"
 
 	transferapi "github.com/containerd/containerd/api/types/transfer"
 	"github.com/containerd/containerd/v2/core/streaming"
@@ -30,7 +30,7 @@ import (
 type readByteStream struct {
 	ctx       context.Context
 	stream    streaming.Stream
-	window    int32
+	window    atomic.Int32
 	updated   chan struct{}
 	errCh     chan error
 	remaining []byte
@@ -40,13 +40,12 @@ func ReadByteStream(ctx context.Context, stream streaming.Stream) io.ReadCloser 
 	rbs := &readByteStream{
 		ctx:     ctx,
 		stream:  stream,
-		window:  0,
-		errCh:   make(chan error),
+		errCh:   make(chan error, 1),
 		updated: make(chan struct{}, 1),
 	}
 	go func() {
 		for {
-			if rbs.window >= windowSize {
+			if rbs.window.Load() >= windowSize {
 				select {
 				case <-ctx.Done():
 					return
@@ -62,11 +61,11 @@ func ReadByteStream(ctx context.Context, stream streaming.Stream) io.ReadCloser 
 				rbs.errCh <- err
 				return
 			}
-			if err := stream.Send(anyType); err == nil {
-				rbs.window += windowSize
-			} else if !errors.Is(err, io.EOF) {
-				rbs.errCh <- err
+			if err := stream.Send(anyType); err != nil {
+				// Read reports stream errors.
+				return
 			}
+			rbs.window.Add(windowSize)
 		}
 
 	}()
@@ -105,9 +104,12 @@ func (r *readByteStream) Read(p []byte) (n int, err error) {
 		if len(v.Data) > plen {
 			r.remaining = v.Data[plen:]
 		}
-		r.window = r.window - int32(n)
-		if r.window < windowSize {
-			r.updated <- struct{}{}
+		if r.window.Add(-int32(len(v.Data))) < windowSize {
+			select {
+			case r.updated <- struct{}{}:
+			default:
+				// Don't block if the window goroutine has ended.
+			}
 		}
 		return n, nil
 	default:

--- a/vendor/github.com/containerd/containerd/v2/pkg/archive/tar.go
+++ b/vendor/github.com/containerd/containerd/v2/pkg/archive/tar.go
@@ -169,6 +169,9 @@ func applyNaive(ctx context.Context, root string, r io.Reader, options ApplyOpti
 		// Used for handling opaque directory markers which
 		// may occur out of order
 		unpackedPaths = make(map[string]struct{})
+		// Used for tracking directories that have already processed an
+		// opaque directory marker to avoid redundant directory walks
+		opaqueDirs = make(map[string]struct{})
 
 		convertWhiteout = options.ConvertWhiteout
 	)
@@ -179,6 +182,11 @@ func applyNaive(ctx context.Context, root string, r io.Reader, options ApplyOpti
 			base := filepath.Base(path)
 			dir := filepath.Dir(path)
 			if base == whiteoutOpaqueDir {
+				if _, ok := opaqueDirs[dir]; ok {
+					return false, nil
+				}
+				opaqueDirs[dir] = struct{}{}
+
 				_, err := os.Lstat(dir)
 				if err != nil {
 					return false, err
@@ -195,7 +203,12 @@ func applyNaive(ctx context.Context, root string, r io.Reader, options ApplyOpti
 					}
 					if _, exists := unpackedPaths[path]; !exists {
 						err := os.RemoveAll(path)
-						return err
+						if err != nil {
+							return err
+						}
+						if info.IsDir() {
+							return filepath.SkipDir
+						}
 					}
 					return nil
 				})

--- a/vendor/github.com/containerd/containerd/v2/pkg/oci/spec_opts.go
+++ b/vendor/github.com/containerd/containerd/v2/pkg/oci/spec_opts.go
@@ -1835,16 +1835,11 @@ func WithWindowsNetworkNamespace(ns string) SpecOpts {
 	}
 }
 
-// readLinker defines the ReadLink method locally.
-// We keep this shim to ensure compatibility with build environments where
-// the standard library's fs.ReadLinkFS interface is not yet available or recognized.
-type readLinker interface {
-	ReadLink(name string) (string, error)
-}
-
 // openUserFile attempts to open a file within the root fs.
-// It handles cases where the file is an absolute symlink (e.g., NixOS /etc/passwd -> /nix/store/...),
-// which triggers "path escapes from parent" errors in Go 1.24+ due to stricter os.DirFS validation.
+// It handles cases where the path contains symlinks (e.g., NixOS
+// /etc/passwd -> /nix/store/...). os.Root-backed filesystems reject
+// absolute symlinks, so when the direct open fails the path is resolved
+// within the root via resolveInRootFS and the open is retried.
 //
 // The returned file rejects non-regular sources and returns an error if more
 // than maxUserFileBytes are read from it.
@@ -1854,32 +1849,21 @@ func openUserFile(root fs.FS, name string) (fs.File, error) {
 		return wrapUserFile(f, name)
 	}
 
-	// Check if the FS implements our local ReadLink interface.
-	// We use a local interface instead of fs.ReadLinkFS to avoid strict dependency
-	// issues in some build environments.
-	if lfs, ok := root.(readLinker); ok {
-		if target, lerr := lfs.ReadLink(name); lerr == nil {
-			// Use filepath.IsAbs to handle platform-agnostic absolute path checks
-			if filepath.IsAbs(target) {
-				// Re-anchor the absolute path to the root.
-				// e.g. /nix/store/... becomes nix/store/... (relative to root fs)
-				// We use filepath.Rel to safely strip the leading separator.
-				rel, rerr := filepath.Rel(string(filepath.Separator), target)
-				if rerr == nil {
-					// filepath.Rel might return OS-specific separators (backslashes on Windows).
-					// fs.Open strictly expects forward slashes, so we convert it.
-					f, oerr := root.Open(filepath.ToSlash(rel))
-					if oerr != nil {
-						return nil, oerr
-					}
-					return wrapUserFile(f, name)
-				}
-			}
-		}
+	lfs, ok := root.(fs.ReadLinkFS)
+	if !ok {
+		return nil, err
 	}
 
-	// Return the original error if we couldn't resolve it
-	return nil, err
+	resolvedName, err := resolveInRootFS(lfs, name)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err = root.Open(resolvedName)
+	if err != nil {
+		return nil, err
+	}
+	return wrapUserFile(f, name)
 }
 
 // maxUserFileBytes caps how much data is read from any user-database file

--- a/vendor/github.com/containerd/containerd/v2/pkg/oci/utils_unix.go
+++ b/vendor/github.com/containerd/containerd/v2/pkg/oci/utils_unix.go
@@ -21,8 +21,11 @@ package oci
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
+	"syscall"
 
 	"github.com/moby/sys/userns"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -182,4 +185,121 @@ func DeviceFromPath(path string) (*specs.LinuxDevice, error) {
 		UID:      &stat.Uid,
 		GID:      &stat.Gid,
 	}, nil
+}
+
+// resolveInRootFS resolves name within rootFS, following symbolic links while
+// treating rootFS as the filesystem root. It returns the canonical path
+// relative to rootFS.
+//
+// ReadLink is expected to return a bounded target. Linux rejects symlink
+// targets of PATH_MAX (4096) bytes or more when creating them. Together with
+// the 40-link limit, this bounds the work during resolution. However, a
+// synthetic fs.ReadLinkFS can return an arbitrarily large target and make the
+// resolution expensive. See the "Length limit" section of path_resolution(7).
+func resolveInRootFS(rootFs fs.ReadLinkFS, name string) (string, error) {
+	if len(name) == 0 {
+		return "", &fs.PathError{
+			Op:   "resolve",
+			Path: name,
+			Err:  syscall.ENOENT,
+		}
+	}
+
+	// In Linux 4.2, the kernel's pathname-resolution code was reworked to
+	// eliminate the use of recursion, so that the only limit that remains
+	// is the maximum of 40 resolutions for the entire pathname.
+	//
+	// https://man7.org/linux/man-pages/man7/path_resolution.7.html
+	const symloopMax = 40
+	followed := 0
+
+	seq := "/"
+
+	pendings := splitPathComponents(name)
+	candidates := make([]string, 0, len(pendings))
+	for len(pendings) > 0 {
+		part := pendings[0]
+		pendings = pendings[1:]
+
+		if part == "." {
+			continue
+		}
+
+		if part == ".." {
+			if len(candidates) > 0 {
+				candidates = candidates[:len(candidates)-1]
+			}
+			continue
+		}
+
+		candidates = append(candidates, part)
+
+		resolved := strings.Join(candidates, seq)
+
+		info, err := rootFs.Lstat(resolved)
+		if err != nil {
+			return "", err
+		}
+
+		if info.Mode()&os.ModeSymlink != 0 {
+			followed++
+
+			if followed > symloopMax {
+				return "", &fs.PathError{
+					Op:   "resolve",
+					Path: resolved,
+					Err:  syscall.ELOOP,
+				}
+			}
+
+			// target can't be empty in real filesystem because
+			// linux kernel doesn't allow to create empty symbolic
+			// link. However, synthetic fs.FS can do that.
+			target, err := rootFs.ReadLink(resolved)
+			if err != nil {
+				return "", err
+			}
+
+			if filepath.IsAbs(target) {
+				candidates = candidates[:0]
+			} else {
+				candidates = candidates[:len(candidates)-1]
+			}
+
+			pendings = append(splitPathComponents(target), pendings...)
+			continue
+		}
+
+		if !info.IsDir() && len(pendings) > 0 {
+			return "", &fs.PathError{
+				Op:   "resolve",
+				Path: resolved,
+				Err:  syscall.ENOTDIR,
+			}
+		}
+	}
+
+	resolvedName := strings.Join(candidates, seq)
+	if resolvedName == "" {
+		resolvedName = "."
+	}
+	return resolvedName, nil
+}
+
+// splitPathComponents returns path components in string slice format and appends
+// "." as last one if origin name contains trailing slash. With trailing dot
+// component, the path resolution can verify if name is directory or not.
+func splitPathComponents(name string) []string {
+	res := make([]string, 0, 8)
+	for part := range strings.SplitSeq(name, "/") {
+		if part == "" {
+			continue
+		}
+		res = append(res, part)
+	}
+
+	if len(name) > 0 && name[len(name)-1] == '/' {
+		res = append(res, ".")
+	}
+	return res
 }

--- a/vendor/github.com/containerd/containerd/v2/pkg/oci/utils_windows.go
+++ b/vendor/github.com/containerd/containerd/v2/pkg/oci/utils_windows.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package oci
+
+import "io/fs"
+
+func resolveInRootFS(_ fs.ReadLinkFS, name string) (string, error) {
+	return name, nil
+}

--- a/vendor/github.com/containerd/containerd/v2/pkg/tracing/helpers.go
+++ b/vendor/github.com/containerd/containerd/v2/pkg/tracing/helpers.go
@@ -73,13 +73,15 @@ func keyValue(k string, v any) attribute.KeyValue {
 		return attribute.String(k, typed)
 	case []string:
 		return attribute.StringSlice(k, typed)
+	case error:
+		return attribute.String(k, fmt.Sprint(typed))
 	}
 
 	if stringer, ok := v.(fmt.Stringer); ok {
-		return attribute.String(k, stringer.String())
+		return attribute.String(k, fmt.Sprint(stringer))
 	}
 	if b, err := json.Marshal(v); b != nil && err == nil {
 		return attribute.String(k, string(b))
 	}
-	return attribute.String(k, fmt.Sprintf("%v", v))
+	return attribute.String(k, fmt.Sprint(v))
 }

--- a/vendor/github.com/containerd/containerd/v2/version/version.go
+++ b/vendor/github.com/containerd/containerd/v2/version/version.go
@@ -24,7 +24,7 @@ var (
 	Package = "github.com/containerd/containerd/v2"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "2.3.4+unknown"
+	Version = "2.3.5+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -357,7 +357,7 @@ github.com/containerd/containerd/api/types/runc/options
 github.com/containerd/containerd/api/types/runtimeoptions/v1
 github.com/containerd/containerd/api/types/task
 github.com/containerd/containerd/api/types/transfer
-# github.com/containerd/containerd/v2 v2.3.4
+# github.com/containerd/containerd/v2 v2.3.5
 ## explicit; go 1.26.3
 github.com/containerd/containerd/v2/client
 github.com/containerd/containerd/v2/core/containers


### PR DESCRIPTION
full diff: https://github.com/containerd/containerd/compare/v2.3.4...v2.3.5

Security Updates

- [**CVE-2026-53495**](https://github.com/containerd/containerd/security/advisories/GHSA-7jxh-36q5-gcqv)
- [**GHSA-rp3h-jf77-q9p4**](https://github.com/containerd/containerd/security/advisories/GHSA-rp3h-jf77-q9p4)

Image Distribution

- Apply hardening to strip sensitive authentication headers when fetching descriptor URLs

Runtime

- Avoid hangs and data races when streaming container standard I/O in CRI
- Fix missing error messages in OpenTelemetry trace attributes
- Fix user and group lookup failures in container rootfs containing symlinked /etc/passwd or /etc/group
- Fix configuration loading error when drop-in configuration files have a higher version than the root configuration
- Avoid containerd startup hangs when loading shims
- Add context to error when shim delete times out
- Fix Windows Server 2022 container compatibility on host builds newer than the latest LTSC

Snapshotters

- Fix unpack failure for EROFS images containing the erofs OS feature