### PR TITLE
solver: skip loading the result during cache export when the remote already matches

### DIFF
--- a/solver/exporter.go
+++ b/solver/exporter.go
@@ -22,14 +22,19 @@ type exporter struct {
 
 // remoteMatchesCompression reports whether every layer of remote is already in
 // the requested compression, in which case resolving the result again cannot
-// produce a better remote. A partial match is not enough; that case keeps the
-// existing behaviour.
+// produce a better remote.
+//
+// It uses IsExactMediaType rather than IsMediaType because it needs to know
+// what a blob is, not whether it is acceptable: an eStargz layer carries the
+// plain gzip media type, so a chain of gzip descriptors is no evidence that the
+// layers are eStargz, and asking for eStargz must still resolve. A partial
+// match is not enough either; that case keeps the existing behaviour.
 func remoteMatchesCompression(remote *Remote, comp compression.Config) bool {
 	if remote == nil || len(remote.Descriptors) == 0 {
 		return false
 	}
 	for _, desc := range remote.Descriptors {
-		if !compression.IsMediaType(comp.Type, desc.MediaType) {
+		if !compression.IsExactMediaType(comp.Type, desc.MediaType) {
 			return false
 		}
 	}

--- a/solver/exporter.go
+++ b/solver/exporter.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 
 	cerrdefs "github.com/containerd/errdefs"
+	"github.com/moby/buildkit/util/compression"
 	digest "github.com/opencontainers/go-digest"
 )
 
@@ -17,6 +18,22 @@ type exporter struct {
 
 	edge     *edge // for secondaryExporters
 	override *bool
+}
+
+// remoteMatchesCompression reports whether every layer of remote is already in
+// the requested compression, in which case resolving the result again cannot
+// produce a better remote. A partial match is not enough; that case keeps the
+// existing behaviour.
+func remoteMatchesCompression(remote *Remote, comp compression.Config) bool {
+	if remote == nil || len(remote.Descriptors) == 0 {
+		return false
+	}
+	for _, desc := range remote.Descriptors {
+		if !compression.IsMediaType(comp.Type, desc.MediaType) {
+			return false
+		}
+	}
+	return true
 }
 
 func addBacklinks(t CacheExporterTarget, cm *cacheManager, id string, bkm map[string][]CacheExporterRecord) ([]CacheExporterRecord, error) {
@@ -187,7 +204,19 @@ func (e *exporter) ExportTo(ctx context.Context, t CacheExporterTarget, opt Cach
 			}
 		}
 
-		if (remote == nil || opt.CompressionOpt != nil) && opt.Mode != CacheExportModeRemoteOnly {
+		// Loading the result is expensive: for a record that came from an
+		// imported cache it rebuilds the whole ref chain, one blob at a time,
+		// under the cache manager's global lock, only for the ref to be
+		// released a few lines later. It is needed to produce a remote when the
+		// storage did not return one, or to get one in the requested
+		// compression. Neither applies when the remote we already have is
+		// entirely in that compression, so skip it then.
+		needsResolve := remote == nil
+		if !needsResolve && opt.CompressionOpt != nil {
+			needsResolve = !remoteMatchesCompression(remote, *opt.CompressionOpt)
+		}
+
+		if needsResolve && opt.Mode != CacheExportModeRemoteOnly {
 			res, err := cm.results.Load(ctx, res)
 			if err != nil {
 				if !errors.Is(err, cerrdefs.ErrNotFound) {

--- a/solver/exporter_resolve_test.go
+++ b/solver/exporter_resolve_test.go
@@ -1,0 +1,380 @@
+package solver
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/util/compression"
+	digest "github.com/opencontainers/go-digest"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+)
+
+// A cache export walks every record in the graph. For each one it first asks the
+// result storage for a remote, which is cheap, and then may load the result and
+// resolve it again, which is not: loading a result that came from an imported
+// cache rebuilds its whole ref chain a blob at a time under a global lock.
+//
+// The tests below pin down when that second step happens.
+
+// countingResultStore hands out a remote for every result, the way a storage
+// backed by an imported cache manifest does, and counts what the exporter asks
+// of it.
+type countingResultStore struct {
+	CacheResultStorage
+
+	// mediaTypes is cycled through when building a remote's descriptors. One
+	// entry gives a uniform chain, several give a mixed one.
+	mediaTypes []string
+	noRemotes  bool
+
+	// perLayerLoad stands in for the work FromRemote does when it materializes
+	// a result: one GetByBlob per layer, each taking the cache manager's global
+	// lock. Cost therefore grows with the record's chain depth, which is what
+	// makes the total quadratic over a chain.
+	perLayerLoad time.Duration
+
+	mu      sync.Mutex
+	remotes []*Remote      // by step, so step i has i+1 layers
+	steps   map[string]int // result ID to step
+
+	loads        atomic.Int64
+	loadRemotes  atomic.Int64
+	loadedLayers atomic.Int64
+	resolves     atomic.Int64
+}
+
+func newCountingResultStore(mediaTypes ...string) *countingResultStore {
+	return &countingResultStore{
+		CacheResultStorage: NewInMemoryResultStorage(),
+		mediaTypes:         mediaTypes,
+		steps:              map[string]int{},
+	}
+}
+
+// addResult registers the result of the next step of the chain. Its remote has
+// one layer per step so far, the way a Dockerfile step's does; a fixed layer
+// count would hide the quadratic that the benchmarks measure.
+func (s *countingResultStore) addResult(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	step := len(s.remotes)
+	r := &Remote{}
+	for i := range step + 1 {
+		r.Descriptors = append(r.Descriptors, ocispecs.Descriptor{
+			Digest:    digest.FromString(fmt.Sprintf("%s-layer-%d", id, i)),
+			MediaType: s.mediaTypes[i%len(s.mediaTypes)],
+			Size:      int64(i + 1),
+		})
+	}
+	s.remotes = append(s.remotes, r)
+	s.steps[id] = step
+}
+
+func (s *countingResultStore) remote(id string) *Remote {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.remotes[s.steps[id]]
+}
+
+func (s *countingResultStore) remoteForStep(step int) *Remote {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.remotes[step]
+}
+
+func (s *countingResultStore) Load(ctx context.Context, res CacheResult) (Result, error) {
+	s.loads.Add(1)
+	n := len(s.remote(res.ID).Descriptors)
+	s.loadedLayers.Add(int64(n))
+	if s.perLayerLoad > 0 {
+		time.Sleep(time.Duration(n) * s.perLayerLoad)
+	}
+	return s.CacheResultStorage.Load(ctx, res)
+}
+
+func (s *countingResultStore) LoadRemotes(_ context.Context, res CacheResult, _ *compression.Config, _ session.Group) ([]*Remote, error) {
+	s.loadRemotes.Add(1)
+	if s.noRemotes {
+		return nil, nil
+	}
+	return []*Remote{s.remote(res.ID)}, nil
+}
+
+// resolveRemotes is the CacheExportOpt.ResolveRemotes counterpart: it returns
+// the same remote the store would, and counts the call.
+func (s *countingResultStore) resolveRemotes(_ context.Context, r Result) ([]*Remote, error) {
+	s.resolves.Add(1)
+	return []*Remote{s.remote(r.ID())}, nil
+}
+
+type testExportRecord struct {
+	CacheExporterRecordBase
+	results []CacheExportResult
+}
+
+type testExportTarget struct {
+	mu      sync.Mutex
+	records map[digest.Digest]*testExportRecord
+}
+
+func newTestExportTarget() *testExportTarget {
+	return &testExportTarget{records: map[digest.Digest]*testExportRecord{}}
+}
+
+func (t *testExportTarget) Add(dgst digest.Digest, _ [][]CacheLink, results []CacheExportResult) (CacheExporterRecord, bool, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	r, ok := t.records[dgst]
+	if !ok {
+		r = &testExportRecord{}
+		t.records[dgst] = r
+	}
+	r.results = append(r.results, results...)
+	return r, true, nil
+}
+
+// resultsFor returns what was recorded for the given step of a chain built by
+// buildChain.
+func (t *testExportTarget) resultsFor(step int) []CacheExportResult {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if r, ok := t.records[rootKey(stepDigest(step), 0)]; ok {
+		return r.results
+	}
+	return nil
+}
+
+func stepDigest(step int) digest.Digest {
+	return dgst(fmt.Sprintf("step-%d", step))
+}
+
+// buildChain saves a linear chain of depth records into a cache manager backed
+// by store and returns the topmost key. This is the shape a Dockerfile
+// produces: every step depends on the one before it.
+//
+// Step 0 has no dependencies, and none of the exports below set ExportRoots,
+// so an export of the chain visits depth-1 records.
+func buildChain(t testing.TB, store *countingResultStore, depth int) *ExportableCacheKey {
+	t.Helper()
+	cm := NewCacheManager(t.Context(), "test-cache-manager", NewInMemoryCacheStorage(), store)
+	now := time.Now()
+
+	var key *ExportableCacheKey
+	for step := range depth {
+		k := NewCacheKey(stepDigest(step), "", 0)
+		if key != nil {
+			k = testCacheKey(stepDigest(step), 0, *key)
+		}
+		r := testResult(fmt.Sprintf("res-%d", step))
+		store.addResult(r.ID())
+
+		var err error
+		key, err = cm.Save(k, r, now)
+		require.NoError(t, err)
+	}
+	return key
+}
+
+// exportChain runs a cache export over a chain of the given depth and returns
+// the target the records were added to.
+func exportChain(t testing.TB, store *countingResultStore, depth int, comp *compression.Config, mode CacheExportMode) *testExportTarget {
+	t.Helper()
+
+	key := buildChain(t, store, depth)
+	target := newTestExportTarget()
+
+	_, err := key.Exporter.ExportTo(t.Context(), target, CacheExportOpt{
+		ResolveRemotes: store.resolveRemotes,
+		Mode:           mode,
+		CompressionOpt: comp,
+	})
+	require.NoError(t, err)
+	return target
+}
+
+// requireLoads asserts how many results the export loaded and resolved, which
+// is the expensive step the tests are about.
+func requireLoads(t *testing.T, store *countingResultStore, want int) {
+	t.Helper()
+	require.EqualValues(t, want, store.loads.Load(), "results loaded")
+	require.EqualValues(t, want, store.resolves.Load(), "results resolved")
+}
+
+// TestExportSkipsResolveWhenCompressionAlreadyMatches is the point of the
+// change. When the remote we already have is entirely in the requested
+// compression, loading and resolving the result cannot produce anything better,
+// so it must not happen, and the remote we had is what gets recorded.
+func TestExportSkipsResolveWhenCompressionAlreadyMatches(t *testing.T) {
+	const depth = 20
+	gzip := compression.New(compression.Gzip)
+	store := newCountingResultStore(ocispecs.MediaTypeImageLayerGzip)
+
+	target := exportChain(t, store, depth, &gzip, CacheExportModeMax)
+
+	require.EqualValues(t, depth-1, store.loadRemotes.Load(), "remotes must still be read for every record")
+	requireLoads(t, store, 0)
+
+	for step := 1; step < depth; step++ {
+		results := target.resultsFor(step)
+		require.Len(t, results, 1, "step %d", step)
+		require.Equal(t, store.remoteForStep(step).Descriptors, results[0].Result.Descriptors, "step %d", step)
+	}
+}
+
+// TestExportResolvesWhenCompressionDiffers checks the case the skip must not
+// swallow. A remote in the wrong compression is exactly when resolving is worth
+// its cost, because it can produce one in the right compression.
+func TestExportResolvesWhenCompressionDiffers(t *testing.T) {
+	const depth = 20
+	zstd := compression.New(compression.Zstd)
+	store := newCountingResultStore(ocispecs.MediaTypeImageLayerGzip)
+
+	exportChain(t, store, depth, &zstd, CacheExportModeMax)
+
+	requireLoads(t, store, depth-1)
+}
+
+// TestExportResolvesWhenNoRemote checks the other reason the load exists: with
+// no remote at all, the result has to be loaded to produce one.
+func TestExportResolvesWhenNoRemote(t *testing.T) {
+	const depth = 20
+	gzip := compression.New(compression.Gzip)
+	store := newCountingResultStore(ocispecs.MediaTypeImageLayerGzip)
+	store.noRemotes = true
+
+	target := exportChain(t, store, depth, &gzip, CacheExportModeMax)
+
+	requireLoads(t, store, depth-1)
+	for step := 1; step < depth; step++ {
+		require.Len(t, target.resultsFor(step), 1, "the resolved remote must be recorded for step %d", step)
+	}
+}
+
+// TestExportPartialCompressionMatchStillResolves checks that the match is all
+// or nothing. A chain where only some layers are in the requested compression
+// keeps the existing behaviour and resolves.
+func TestExportPartialCompressionMatchStillResolves(t *testing.T) {
+	const depth = 20
+	gzip := compression.New(compression.Gzip)
+	store := newCountingResultStore(ocispecs.MediaTypeImageLayerGzip, ocispecs.MediaTypeImageLayerZstd)
+
+	exportChain(t, store, depth, &gzip, CacheExportModeMax)
+
+	requireLoads(t, store, depth-1)
+}
+
+// TestExportWithoutCompressionOptResolvesOnlyWithoutRemote guards the path that
+// does not ask for a compression at all. There the remote decides on its own,
+// exactly as before.
+func TestExportWithoutCompressionOptResolvesOnlyWithoutRemote(t *testing.T) {
+	const depth = 20
+
+	store := newCountingResultStore(ocispecs.MediaTypeImageLayerGzip)
+	exportChain(t, store, depth, nil, CacheExportModeMax)
+	requireLoads(t, store, 0)
+
+	store = newCountingResultStore(ocispecs.MediaTypeImageLayerGzip)
+	store.noRemotes = true
+	exportChain(t, store, depth, nil, CacheExportModeMax)
+	requireLoads(t, store, depth-1)
+}
+
+// TestExportMinModeResolvesOnlyTheFrontier guards the mode that was already
+// fast. Once min mode has a remote it walks the rest of the chain remote-only,
+// so at most the first record can pay for a resolve: none when its remote
+// already matches, one when it does not.
+func TestExportMinModeResolvesOnlyTheFrontier(t *testing.T) {
+	const depth = 20
+	gzip := compression.New(compression.Gzip)
+	zstd := compression.New(compression.Zstd)
+
+	store := newCountingResultStore(ocispecs.MediaTypeImageLayerGzip)
+	target := exportChain(t, store, depth, &gzip, CacheExportModeMin)
+	require.EqualValues(t, depth-1, store.loadRemotes.Load())
+	requireLoads(t, store, 0)
+	for step := 1; step < depth; step++ {
+		require.Len(t, target.resultsFor(step), 1, "step %d", step)
+	}
+
+	store = newCountingResultStore(ocispecs.MediaTypeImageLayerGzip)
+	exportChain(t, store, depth, &zstd, CacheExportModeMin)
+	require.EqualValues(t, depth-1, store.loadRemotes.Load())
+	requireLoads(t, store, 1)
+}
+
+// TestRemoteMatchesCompression covers the helper on its own.
+func TestRemoteMatchesCompression(t *testing.T) {
+	remoteOf := func(mediaTypes ...string) *Remote {
+		r := &Remote{}
+		for i, mt := range mediaTypes {
+			r.Descriptors = append(r.Descriptors, ocispecs.Descriptor{
+				Digest:    dgst(fmt.Sprintf("layer-%d", i)),
+				MediaType: mt,
+			})
+		}
+		return r
+	}
+	gzip := compression.New(compression.Gzip)
+
+	for _, tc := range []struct {
+		name   string
+		remote *Remote
+		comp   compression.Config
+		want   bool
+	}{
+		{name: "nil remote", remote: nil, comp: gzip, want: false},
+		{name: "empty remote", remote: &Remote{}, comp: gzip, want: false},
+		{name: "all layers match", remote: remoteOf(ocispecs.MediaTypeImageLayerGzip, ocispecs.MediaTypeImageLayerGzip), comp: gzip, want: true},
+		{name: "some layers match", remote: remoteOf(ocispecs.MediaTypeImageLayerGzip, ocispecs.MediaTypeImageLayerZstd), comp: gzip, want: false},
+		{name: "no layer matches", remote: remoteOf(ocispecs.MediaTypeImageLayerZstd), comp: gzip, want: false},
+		{name: "uncompressed", remote: remoteOf(ocispecs.MediaTypeImageLayer), comp: compression.New(compression.Uncompressed), want: true},
+		{name: "unknown media type", remote: remoteOf("application/octet-stream"), comp: gzip, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, remoteMatchesCompression(tc.remote, tc.comp))
+		})
+	}
+}
+
+func benchmarkExportChain(b *testing.B, comp compression.Config) {
+	for _, depth := range []int{50, 100, 200} {
+		b.Run(fmt.Sprintf("depth=%d", depth), func(b *testing.B) {
+			// The export does not mutate the chain, so build it once and only
+			// time the walk.
+			store := newCountingResultStore(ocispecs.MediaTypeImageLayerGzip)
+			store.perLayerLoad = 20 * time.Microsecond
+			key := buildChain(b, store, depth)
+
+			for b.Loop() {
+				_, err := key.Exporter.ExportTo(b.Context(), newTestExportTarget(), CacheExportOpt{
+					ResolveRemotes: store.resolveRemotes,
+					Mode:           CacheExportModeMax,
+					CompressionOpt: &comp,
+				})
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkExportChainWarmRemotes measures the export walk over a chain whose
+// remotes are already in the requested compression, which is the common shape
+// for a mode=max build against a warm cache.
+func BenchmarkExportChainWarmRemotes(b *testing.B) {
+	benchmarkExportChain(b, compression.New(compression.Gzip))
+}
+
+// BenchmarkExportChainMismatchedRemotes is the control. Here the remotes are in
+// the wrong compression, so every record still has to be resolved and the
+// change must not move it.
+func BenchmarkExportChainMismatchedRemotes(b *testing.B) {
+	benchmarkExportChain(b, compression.New(compression.Zstd))
+}

--- a/solver/exporter_resolve_test.go
+++ b/solver/exporter_resolve_test.go
@@ -269,6 +269,21 @@ func TestExportPartialCompressionMatchStillResolves(t *testing.T) {
 	requireLoads(t, store, depth-1)
 }
 
+// TestExportEStargzStillResolves is the case that makes the resolve genuinely
+// necessary rather than merely defensive. An eStargz layer reports the plain
+// gzip media type, because it is a gzip layer with a table of contents appended.
+// So a chain of gzip descriptors is not evidence that the layers are eStargz,
+// and asking for eStargz has to resolve even though every media type "matches".
+func TestExportEStargzStillResolves(t *testing.T) {
+	const depth = 20
+	estargz := compression.New(compression.EStargz)
+	store := newCountingResultStore(ocispecs.MediaTypeImageLayerGzip)
+
+	exportChain(t, store, depth, &estargz, CacheExportModeMax)
+
+	requireLoads(t, store, depth-1)
+}
+
 // TestExportWithoutCompressionOptResolvesOnlyWithoutRemote guards the path that
 // does not ask for a compression at all. There the remote decides on its own,
 // exactly as before.
@@ -335,6 +350,9 @@ func TestRemoteMatchesCompression(t *testing.T) {
 		{name: "no layer matches", remote: remoteOf(ocispecs.MediaTypeImageLayerZstd), comp: gzip, want: false},
 		{name: "uncompressed", remote: remoteOf(ocispecs.MediaTypeImageLayer), comp: compression.New(compression.Uncompressed), want: true},
 		{name: "unknown media type", remote: remoteOf("application/octet-stream"), comp: gzip, want: false},
+		// eStargz shares the gzip media type, so a gzip descriptor proves nothing.
+		{name: "estargz never matches", remote: remoteOf(ocispecs.MediaTypeImageLayerGzip), comp: compression.New(compression.EStargz), want: false},
+		{name: "unset type", remote: remoteOf(ocispecs.MediaTypeImageLayerGzip), comp: compression.Config{}, want: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.want, remoteMatchesCompression(tc.remote, tc.comp))

--- a/util/compression/compression.go
+++ b/util/compression/compression.go
@@ -105,6 +105,21 @@ func fromMediaType(mediaType string) (Type, error) {
 	}
 }
 
+// IsExactMediaType reports whether mediaType identifies ct and nothing else.
+//
+// It is stricter than IsMediaType, which compares against Type.MediaType() and
+// therefore cannot tell eStargz from plain gzip: both report the gzip media
+// type, because an eStargz layer is a valid gzip layer with a table of contents
+// appended. A caller that needs to know what a blob actually is, rather than
+// whether it is acceptable, must use this.
+func IsExactMediaType(ct Type, mediaType string) bool {
+	t, err := fromMediaType(mediaType)
+	if err != nil {
+		return false
+	}
+	return t == ct
+}
+
 func IsMediaType(ct Type, mt string) bool {
 	mt, ok := toOCILayerType[mt]
 	if !ok {

--- a/util/compression/compression_test.go
+++ b/util/compression/compression_test.go
@@ -1,0 +1,52 @@
+package compression
+
+import (
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/images"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsExactMediaType(t *testing.T) {
+	for _, tc := range []struct {
+		mediaType string
+		exact     Type // the one type the media type identifies, or nil
+	}{
+		{ocispecs.MediaTypeImageLayer, Uncompressed},
+		{images.MediaTypeDockerSchema2Layer, Uncompressed},
+		{ocispecs.MediaTypeImageLayerNonDistributable, Uncompressed}, //nolint:staticcheck // ignore SA1019: Non-distributable layers are deprecated, and not recommended for future use.
+		{images.MediaTypeDockerSchema2LayerForeign, Uncompressed},
+		{ocispecs.MediaTypeImageLayerGzip, Gzip},
+		{images.MediaTypeDockerSchema2LayerGzip, Gzip},
+		{ocispecs.MediaTypeImageLayerNonDistributableGzip, Gzip}, //nolint:staticcheck // ignore SA1019: Non-distributable layers are deprecated, and not recommended for future use.
+		{images.MediaTypeDockerSchema2LayerForeignGzip, Gzip},
+		{ocispecs.MediaTypeImageLayerZstd, Zstd},
+		{images.MediaTypeDockerSchema2LayerZstd, Zstd},
+		{ocispecs.MediaTypeImageLayerNonDistributableZstd, Zstd}, //nolint:staticcheck // ignore SA1019: Non-distributable layers are deprecated, and not recommended for future use.
+		{"application/octet-stream", nil},
+		{"", nil},
+	} {
+		t.Run(tc.mediaType, func(t *testing.T) {
+			// EStargz is never identified by a media type: it shares gzip's.
+			for _, ct := range []Type{Uncompressed, Gzip, EStargz, Zstd} {
+				require.Equal(t, ct == tc.exact, IsExactMediaType(ct, tc.mediaType), "IsExactMediaType(%s, %q)", ct, tc.mediaType)
+			}
+		})
+	}
+}
+
+// TestIsMediaType pins the overlap that makes IsExactMediaType necessary:
+// IsMediaType compares against what a type would emit, and eStargz emits the
+// gzip media type, so it cannot tell the two apart.
+func TestIsMediaType(t *testing.T) {
+	require.True(t, IsMediaType(Gzip, ocispecs.MediaTypeImageLayerGzip))
+	require.True(t, IsMediaType(Gzip, images.MediaTypeDockerSchema2LayerGzip))
+	require.True(t, IsMediaType(EStargz, ocispecs.MediaTypeImageLayerGzip))
+	require.True(t, IsMediaType(Zstd, ocispecs.MediaTypeImageLayerZstd))
+	require.True(t, IsMediaType(Uncompressed, ocispecs.MediaTypeImageLayer))
+
+	require.False(t, IsMediaType(Zstd, ocispecs.MediaTypeImageLayerGzip))
+	require.False(t, IsMediaType(Gzip, "application/octet-stream"))
+	require.False(t, IsMediaType(Gzip, ""))
+}


### PR DESCRIPTION
# Skip loading the result during cache export when the remote already matches

## What is happening

Cache export walks every record in the build graph. For each record it asks the
result storage for a remote. For a record that came from an imported cache that
call is cheap: it hands back the remote from the cache manifest.

It then loads the result and resolves it again. That call is not cheap. Loading
a record from an imported cache rebuilds the entire ref chain one blob at a
time. Each of those blobs takes the cache manager's global lock. The ref is
released four lines later.

A record ten steps deep does ten locked round trips. Across a graph where depth
grows with position, that adds up quickly.

## Why it runs when it does not need to

The condition is this:

```go
if (remote == nil || opt.CompressionOpt != nil) && opt.Mode != CacheExportModeRemoteOnly {
```

`runCacheExporters` always passes a compression config. So `opt.CompressionOpt`
is never nil on this path, and the `remote == nil` half never decides anything.
The expensive branch runs for every record whether or not we already have a
perfectly good remote.

In `mode=min` nobody notices. The walk downgrades to remote-only once it has a
remote, so only the first record pays. In `mode=max` there is no downgrade, so
the whole graph pays.

## What this changes

The load is worth doing for two reasons. It produces a remote when the storage
did not give us one. And it can produce a remote in the compression that was
asked for.

Neither reason applies when the remote we already have is already entirely in
the requested compression. So we skip it in that case.

Everything else behaves as before. If there is no remote, we still load. If the
remote is in the wrong compression, we still load. If only some layers match, we
still load: that keeps the existing behaviour for the mixed case rather than
reasoning about it. `mode=min` saves the one load its first record used to pay.

## Where the resolve is not redundant

Worth being precise about this, because the first version of the check got it
wrong.

An eStargz layer reports the plain gzip media type. It is a gzip layer with a
table of contents appended, so the media type cannot tell the two apart.
`IsMediaType` compares against what a type would emit, so it answers true when
asked whether a gzip descriptor matches eStargz. Skipping on that basis would
mean an export asking for eStargz quietly kept plain gzip layers.

So the skip needs to know what a blob is, not whether it is acceptable. This
adds `IsExactMediaType`, which maps the media type back to a type rather than
comparing against what a type would emit, and uses that. Asking for eStargz now
always resolves.

Nydus was already safe, since it has a media type of its own.

## Numbers

Benchmarks over a chain of the given depth, where a record at depth k has k
layers, which is the shape a Dockerfile produces. The stand-in cost per load is
20 microseconds per layer, because a real load does one locked `GetByBlob` per
layer. The store hands out prebuilt remotes, as the imported storage does, so
the walk itself is what is measured. `go test ./solver/ -bench ExportChain
-count=6`, medians.

Warm remotes, already in the requested compression:

| Depth | Before | After |
|---|---|---|
| 50 | 37.5 ms | 0.20 ms |
| 100 | 138.4 ms | 0.41 ms |
| 200 | 528.9 ms | 0.97 ms |

The before column roughly quadruples when depth doubles. That is the quadratic
this removes: every record reloads its whole ancestor chain.

Mismatched remotes, which still have to resolve. This is the control, and it
should not move. It costs the same as the warm case did before, because both
resolve every record:

| Depth | Before | After |
|---|---|---|
| 50 | 35.8 ms | 36.1 ms |
| 100 | 137.0 ms | 140.2 ms |
| 200 | 530.6 ms | 540.1 ms |

A real `GetByBlob` is a boltdb transaction taken under a global lock, so the
absolute numbers on a busy daemon are considerably larger; on large builds this
is tens of seconds. Treat the shape and the ratio as the result, not the
absolute times.

## Tests

`TestExportSkipsResolveWhenCompressionAlreadyMatches` is the one that pins the
change down. It fails on the current code with 19 loads for a 20 step chain and
passes with 0, and it checks that what gets recorded for every record is the
remote the storage handed out.

The rest guard the cases the skip must not swallow, each asserting the exact
number of loads:

- `TestExportResolvesWhenCompressionDiffers`
- `TestExportResolvesWhenNoRemote`
- `TestExportPartialCompressionMatchStillResolves`, through `ExportTo` with a
  mixed chain
- `TestExportEStargzStillResolves`
- `TestExportWithoutCompressionOptResolvesOnlyWithoutRemote`, the path the
  change leaves alone
- `TestExportMinModeResolvesOnlyTheFrontier`, no load when the first remote
  matches and exactly one when it does not
- `TestRemoteMatchesCompression` for the helper on its own

`util/compression` had no tests. `TestIsExactMediaType` and `TestIsMediaType`
pin down which type each layer media type identifies, including the Docker and
non-distributable variants, and the gzip/eStargz overlap that makes the exact
check necessary.

## What changes in the written manifest

When the skip applies, the extra `CacheExportResult` the resolve used to append
is gone. It is worth spelling out what that means, because it is not quite
"nothing".

`CacheChains.item.addResult` treats two results with the same `CreatedAt` and
the same number of layers as duplicates and keeps the first one. (The digest
comparison in that loop is dead: its `continue` applies to the inner loop, so
it never rejects anything. That is pre-existing and not touched here.) The
resolve result was appended before the remote from the storage, so in
`mode=max` an imported record used to be written from the re-resolved local
ref. Now it is written from the imported remote itself.

The digests, sizes and media types are identical, so the layers in the manifest
do not change. What differs is the provider (the imported registry rather than
a local lazy ref, so the layer is streamed rather than pulled into the content
store first) and the descriptor annotations (the imported ones carry what the
manifest recorded plus `containerd.io/distribution.source.ref`; the re-resolved
ones additionally carried `containerd.io/distribution.source.<host>` for the
cache repo, which the pusher can use for a cross-repo mount). Records below the
frontier in `mode=min`, and everything in remote-only mode, were already
exported from the imported remote this way.

One narrow case where the old resolve did real work: `force-compression=true`
with gzip against an imported cache whose layers are eStargz and happen to be
in the local content store already. `gzipType.NeedsConversion` would have
converted those to plain gzip; the skip keeps them as they are. The descriptors
say gzip either way, and eStargz layers are valid gzip, so the outcome is
benign, but it is a difference.
