### PR TITLE
cache/s3: fix io.ReaderAt contract violations in the import read path

### DIFF
--- a/cache/remotecache/s3/readerat.go
+++ b/cache/remotecache/s3/readerat.go
@@ -14,7 +14,6 @@ type readerAtCloser struct {
 	mu     sync.Mutex
 	offset int64
 	rc     io.ReadCloser
-	ra     io.ReaderAt
 	open   func(offset int64) (io.ReadCloser, error)
 	closed bool
 }
@@ -33,10 +32,12 @@ func (hrs *readerAtCloser) ReadAt(p []byte, off int64) (n int, err error) {
 		return 0, io.EOF
 	}
 
-	if hrs.ra != nil {
-		return hrs.ra.ReadAt(p, off)
+	if len(p) == 0 {
+		return 0, nil
 	}
 
+	// The underlying object is served as a stream, so a read at an offset other
+	// than where the current stream sits requires reopening it with a new range.
 	if hrs.rc == nil || off != hrs.offset {
 		if hrs.rc != nil {
 			hrs.rc.Close()
@@ -47,24 +48,14 @@ func (hrs *readerAtCloser) ReadAt(p []byte, off int64) (n int, err error) {
 			return 0, err
 		}
 		hrs.rc = rc
-	}
-	if ra, ok := hrs.rc.(io.ReaderAt); ok {
-		hrs.ra = ra
-		n, err = ra.ReadAt(p, off)
-	} else {
-		for {
-			var nn int
-			nn, err = hrs.rc.Read(p)
-			n += nn
-			p = p[nn:]
-			if nn == len(p) || err != nil {
-				break
-			}
-		}
+		hrs.offset = off
 	}
 
-	hrs.offset += int64(n)
-	return
+	// io.ReadFull matches the io.ReaderAt contract: a read that returns fewer
+	// bytes than requested must report a non-nil error.
+	n, err = io.ReadFull(hrs.rc, p)
+	hrs.offset = off + int64(n)
+	return n, err
 }
 
 func (hrs *readerAtCloser) Close() error {

--- a/cache/remotecache/s3/readerat_test.go
+++ b/cache/remotecache/s3/readerat_test.go
@@ -1,0 +1,241 @@
+package s3
+
+import (
+	"io"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// chunkedReader serves data from an offset, returning at most chunk bytes per
+// Read so that short reads can be exercised. An HTTP response body behaves this
+// way, which is what the s3 reader is built on.
+type chunkedReader struct {
+	data   []byte
+	pos    int
+	chunk  int
+	closed bool
+}
+
+func (r *chunkedReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, io.EOF
+	}
+	n := len(p)
+	if r.chunk > 0 && n > r.chunk {
+		n = r.chunk
+	}
+	if n > len(r.data)-r.pos {
+		n = len(r.data) - r.pos
+	}
+	copy(p, r.data[r.pos:r.pos+n])
+	r.pos += n
+	return n, nil
+}
+
+func (r *chunkedReader) Close() error {
+	r.closed = true
+	return nil
+}
+
+// opener records the offsets it was asked to open at, standing in for the
+// ranged GetObject calls the real backend makes.
+type opener struct {
+	data    []byte
+	chunk   int
+	mu      sync.Mutex
+	offsets []int64
+	opened  []*chunkedReader
+}
+
+func (o *opener) open(offset int64) (io.ReadCloser, error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.offsets = append(o.offsets, offset)
+	rc := &chunkedReader{data: o.data[offset:], chunk: o.chunk}
+	o.opened = append(o.opened, rc)
+	return rc, nil
+}
+
+func (o *opener) openCount() int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return len(o.offsets)
+}
+
+func testData(n int) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte(i % 251)
+	}
+	return b
+}
+
+// TestReaderAtShortReads checks that a read is filled completely even when the
+// underlying stream returns fewer bytes per Read than requested. Returning a
+// short count with a nil error would violate the io.ReaderAt contract, and
+// callers such as content.Copy rely on that contract.
+//
+// The chunk sizes matter. A stream handing back exactly half of what was asked
+// for is the case that used to return 50 bytes and no error.
+func TestReaderAtShortReads(t *testing.T) {
+	for _, chunk := range []int{1, 7, 50, 99} {
+		t.Run(strconv.Itoa(chunk), func(t *testing.T) {
+			data := testData(1000)
+			o := &opener{data: data, chunk: chunk}
+			ra := toReaderAtCloser(o.open)
+			defer ra.Close()
+
+			p := make([]byte, 100)
+			n, err := ra.ReadAt(p, 0)
+			require.NoError(t, err)
+			require.Equal(t, 100, n)
+			require.Equal(t, data[:100], p)
+		})
+	}
+}
+
+// TestReaderAtSequentialReadsReuseStream checks that reads which continue where
+// the previous one stopped do not reopen the object.
+func TestReaderAtSequentialReadsReuseStream(t *testing.T) {
+	data := testData(1000)
+	o := &opener{data: data, chunk: 13}
+	ra := toReaderAtCloser(o.open)
+	defer ra.Close()
+
+	var off int64
+	for range 10 {
+		p := make([]byte, 100)
+		n, err := ra.ReadAt(p, off)
+		require.NoError(t, err)
+		require.Equal(t, 100, n)
+		require.Equal(t, data[off:off+100], p)
+		off += int64(n)
+	}
+
+	require.Equal(t, 1, o.openCount(), "sequential reads should reuse a single stream")
+}
+
+// TestReaderAtOffsetAccounting checks that the reader tracks its position from
+// the offset it was asked for, not from wherever it happened to be. Getting
+// this wrong caused redundant reopens and, when a later offset collided with
+// the stale position, reads served from the wrong place in the object.
+func TestReaderAtOffsetAccounting(t *testing.T) {
+	data := testData(1000)
+	o := &opener{data: data, chunk: 0}
+	ra := toReaderAtCloser(o.open)
+	defer ra.Close()
+
+	// Start with a non-sequential read, which must reopen at that offset.
+	p := make([]byte, 10)
+	n, err := ra.ReadAt(p, 500)
+	require.NoError(t, err)
+	require.Equal(t, 10, n)
+	require.Equal(t, data[500:510], p)
+	require.Equal(t, []int64{500}, o.offsets)
+
+	// Continuing from where that read ended must reuse the stream and return
+	// the bytes that actually follow.
+	p2 := make([]byte, 10)
+	n, err = ra.ReadAt(p2, 510)
+	require.NoError(t, err)
+	require.Equal(t, 10, n)
+	require.Equal(t, data[510:520], p2)
+	require.Equal(t, 1, o.openCount(), "continuation read should not reopen")
+
+	// A jump elsewhere must reopen at exactly that offset.
+	p3 := make([]byte, 10)
+	n, err = ra.ReadAt(p3, 100)
+	require.NoError(t, err)
+	require.Equal(t, 10, n)
+	require.Equal(t, data[100:110], p3)
+	require.Equal(t, []int64{500, 100}, o.offsets)
+}
+
+// TestReaderAtTruncatedObject checks that a read which cannot be satisfied
+// reports an error rather than silently returning fewer bytes.
+func TestReaderAtTruncatedObject(t *testing.T) {
+	data := testData(50)
+	o := &opener{data: data, chunk: 8}
+	ra := toReaderAtCloser(o.open)
+	defer ra.Close()
+
+	p := make([]byte, 100)
+	n, err := ra.ReadAt(p, 0)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	require.Equal(t, 50, n)
+}
+
+// TestReaderAtEmptyRead checks that a zero length read is a no-op and does not
+// open the object.
+func TestReaderAtEmptyRead(t *testing.T) {
+	o := &opener{data: testData(10)}
+	ra := toReaderAtCloser(o.open)
+	defer ra.Close()
+
+	n, err := ra.ReadAt(nil, 0)
+	require.NoError(t, err)
+	require.Zero(t, n)
+	require.Zero(t, o.openCount())
+}
+
+// TestReaderAtCloseReleasesStream checks that Close closes the open stream and
+// that reads afterwards report EOF.
+func TestReaderAtCloseReleasesStream(t *testing.T) {
+	o := &opener{data: testData(100)}
+	ra := toReaderAtCloser(o.open)
+
+	p := make([]byte, 10)
+	_, err := ra.ReadAt(p, 0)
+	require.NoError(t, err)
+	require.Len(t, o.opened, 1)
+	require.False(t, o.opened[0].closed)
+
+	require.NoError(t, ra.Close())
+	require.True(t, o.opened[0].closed)
+
+	n, err := ra.ReadAt(p, 0)
+	require.ErrorIs(t, err, io.EOF)
+	require.Zero(t, n)
+
+	// Close is idempotent.
+	require.NoError(t, ra.Close())
+}
+
+// TestReaderAtConcurrentReads checks that concurrent readers see correct data.
+// Run with -race to catch unsynchronised access to the shared stream.
+func TestReaderAtConcurrentReads(t *testing.T) {
+	data := testData(4096)
+	o := &opener{data: data, chunk: 11}
+	ra := toReaderAtCloser(o.open)
+	defer ra.Close()
+
+	type read struct {
+		off int64
+		buf []byte
+		n   int
+		err error
+	}
+	reads := make([]read, 16)
+
+	var wg sync.WaitGroup
+	for i := range reads {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			off := int64(i * 64)
+			p := make([]byte, 64)
+			n, err := ra.ReadAt(p, off)
+			reads[i] = read{off: off, buf: p, n: n, err: err}
+		}()
+	}
+	wg.Wait()
+
+	for _, r := range reads {
+		require.NoError(t, r.err)
+		require.Equal(t, 64, r.n)
+		require.Equal(t, data[r.off:r.off+64], r.buf)
+	}
+}


### PR DESCRIPTION
The s3 cache backend reads blobs back through a `ReaderAt` built on ranged `GetObject` calls. There are three bugs in it.

## A short read comes back with no error

This is the loop that fills the buffer:

```go
nn, err = hrs.rc.Read(p)
n += nn
p = p[nn:]
if nn == len(p) || err != nil {
	break
}
```

`nn` is what was just read. `len(p)` after the reslice is what is still wanted. Those are different things, and when they happen to be equal the loop stops early and returns a short count with a nil error.

Ask for 100 bytes from a stream that gives back 50 at a time and you get 50 bytes and no error. One byte at a time gives you 99. `io.ReaderAt` says a read shorter than the buffer must report an error, and the content package relies on that, so it does not read again. The layer is quietly truncated.

The body of an S3 response is an HTTP stream, so short reads are normal, not an edge case.

## The offset is tracked from the wrong place

`hrs.offset += int64(n)` adds to wherever the reader thought it was, not to the offset it was actually asked for.

After a read at a new offset the tracked position no longer matches the stream. The next read that continues from there looks like a seek, so the object is reopened for nothing. Worse, a later read whose offset happens to equal the stale value looks like a continuation, and gets served from the wrong part of the object.

## The io.ReaderAt fast path could not have worked

The stream is opened with a `bytes=off-` range, so byte 0 of the stream is byte `off` of the object. The cached reader would then apply the same offset again and read from twice as far in.

It never ran, because an HTTP response body is not an `io.ReaderAt`. But it was cached in a field and reused for every later call, so if it ever became one the reads would be wrong from then on.

## The fix

Use `io.ReadFull`, which returns `io.ErrUnexpectedEOF` when it cannot fill the buffer. Track the offset from the one that was requested. Drop the fast path. A zero length read now returns without opening the object at all.

## Tests

There were no tests for this file. This adds seven, against a fake stream that hands back a fixed number of bytes per read and records the offsets it was opened at.

Five of them fail on the current code:

- `TestReaderAtShortReads` at chunk sizes 1 and 50
- `TestReaderAtSequentialReadsReuseStream`
- `TestReaderAtOffsetAccounting`
- `TestReaderAtTruncatedObject`
- `TestReaderAtEmptyRead`

The other two cover Close and concurrent reads and pass either way. They are there to keep the mutex added in b0e7d805e honest.

## Notes

This is a standalone fix. It does not depend on anything else and nothing else in the s3 backend changes.
