### PR TITLE
cache/s3: fix a panic, an off-by-one and a discarded abort in the touch path

### DIFF
--- a/cache/remotecache/s3/s3.go
+++ b/cache/remotecache/s3/s3.go
@@ -25,6 +25,7 @@ import (
 	cacheimporttypes "github.com/moby/buildkit/cache/remotecache/v1/types"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/compression"
 	"github.com/moby/buildkit/util/progress"
 	"github.com/moby/buildkit/worker"
@@ -52,6 +53,10 @@ const (
 	attrRetryMode             = "retry_mode"
 	attrRetryMaxAttempts      = "retry_max_attempts"
 	maxCopyObjectSize         = 5 * 1024 * 1024 * 1024
+	// abortMultipartTimeout bounds the best-effort cleanup of a failed
+	// multipart upload, which runs on a context detached from the failed
+	// operation.
+	abortMultipartTimeout = 30 * time.Second
 )
 
 type Config struct {
@@ -283,7 +288,13 @@ func (e *exporter) Finalize(ctx context.Context) (map[string]string, error) {
 				}
 				if exists != nil {
 					if time.Since(*exists) > e.config.TouchRefresh {
-						err = e.s3Client.touch(groupCtx, key, size)
+						// Some S3-compatible endpoints omit Content-Length from
+						// HeadObject responses, and dereferencing it
+						// unconditionally took the daemon down.
+						if size == nil {
+							return errors.Errorf("failed to touch %s: object has no content length", key)
+						}
+						err = e.s3Client.touch(groupCtx, key, *size)
 						if err != nil {
 							return errors.Wrapf(err, "failed to touch file")
 						}
@@ -562,7 +573,8 @@ func (s3Client *s3Client) exists(ctx context.Context, key string) (*time.Time, *
 
 func buildCopySourceRange(start int64, objectSize int64) string {
 	end := start + maxCopyObjectSize - 1
-	if end > objectSize {
+	// The range is inclusive, so the last addressable byte is objectSize-1.
+	if end >= objectSize {
 		end = objectSize - 1
 	}
 	startRange := strconv.FormatInt(start, 10)
@@ -570,11 +582,11 @@ func buildCopySourceRange(start int64, objectSize int64) string {
 	return "bytes=" + startRange + "-" + stopRange
 }
 
-func (s3Client *s3Client) touch(ctx context.Context, key string, size *int64) (err error) {
+func (s3Client *s3Client) touch(ctx context.Context, key string, size int64) (err error) {
 	copySource := fmt.Sprintf("%s/%s", s3Client.bucket, key)
 
 	// CopyObject does not support files > 5GB
-	if *size < maxCopyObjectSize {
+	if size < maxCopyObjectSize {
 		cp := &s3.CopyObjectInput{
 			Bucket:            &s3Client.bucket,
 			CopySource:        &copySource,
@@ -598,13 +610,22 @@ func (s3Client *s3Client) touch(ctx context.Context, key string, size *int64) (e
 	}
 
 	defer func() {
+		if err == nil {
+			return
+		}
 		abortIn := s3.AbortMultipartUploadInput{
 			Bucket:   &s3Client.bucket,
 			Key:      &key,
 			UploadId: output.UploadId,
 		}
-		if err != nil {
-			s3Client.AbortMultipartUpload(ctx, &abortIn)
+		// By the time we get here the operation context is usually already
+		// cancelled, which would fail the abort and leave the upload to accrue
+		// storage charges. Abort on a detached context, and report a failure
+		// rather than discarding it.
+		abortCtx, cancel := context.WithTimeoutCause(context.WithoutCancel(ctx), abortMultipartTimeout, errors.WithStack(context.DeadlineExceeded))
+		defer cancel()
+		if _, abortErr := s3Client.AbortMultipartUpload(abortCtx, &abortIn); abortErr != nil {
+			bklog.G(ctx).Errorf("failed to abort multipart upload for %s, it may keep incurring storage costs until a bucket lifecycle rule removes it: %v", key, abortErr)
 		}
 	}()
 
@@ -612,8 +633,8 @@ func (s3Client *s3Client) touch(ctx context.Context, key string, size *int64) (e
 	var currentPosition int64
 	var completedParts []s3types.CompletedPart
 
-	for currentPosition < *size {
-		copyRange := buildCopySourceRange(currentPosition, *size)
+	for currentPosition < size {
+		copyRange := buildCopySourceRange(currentPosition, size)
 		partInput := s3.UploadPartCopyInput{
 			Bucket:          &s3Client.bucket,
 			CopySource:      &copySource,

--- a/cache/remotecache/s3/touch_test.go
+++ b/cache/remotecache/s3/touch_test.go
@@ -1,0 +1,59 @@
+package s3
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildCopySourceRange checks the ranges used to refresh an object larger
+// than the CopyObject limit. A copy source range is inclusive, so the last
+// byte it may name is objectSize-1.
+func TestBuildCopySourceRange(t *testing.T) {
+	tests := []struct {
+		name       string
+		start      int64
+		objectSize int64
+		want       string
+	}{
+		{
+			name:       "first part of a larger object",
+			start:      0,
+			objectSize: 3 * maxCopyObjectSize,
+			want:       "bytes=0-5368709119",
+		},
+		{
+			name:       "final short part",
+			start:      maxCopyObjectSize,
+			objectSize: maxCopyObjectSize + 100,
+			want:       "bytes=5368709120-5368709219",
+		},
+		{
+			name:       "remainder ends exactly on the part size",
+			start:      0,
+			objectSize: maxCopyObjectSize,
+			want:       "bytes=0-5368709119",
+		},
+		{
+			name:       "remainder one byte short of the part size",
+			start:      0,
+			objectSize: maxCopyObjectSize - 1,
+			want:       "bytes=0-5368709118",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildCopySourceRange(tt.start, tt.objectSize)
+			require.Equal(t, tt.want, got)
+
+			// The range must never address a byte past the end of the object.
+			var start, end int64
+			_, err := fmt.Sscanf(got, "bytes=%d-%d", &start, &end)
+			require.NoError(t, err)
+			require.Less(t, end, tt.objectSize)
+			require.LessOrEqual(t, start, end)
+		})
+	}
+}


### PR DESCRIPTION
When a blob is already in the bucket the exporter refreshes its timestamp instead of uploading it again. There are three separate problems on that path.

## A nil dereference takes the daemon down

`exists` returns `head.ContentLength`, which is a `*int64`. The SDK leaves it nil when the response has no `Content-Length` header. `touch` then does:

```go
if *size < maxCopyObjectSize {
```

The SDK models the field as optional, so nothing guarantees it is set. When it is not, this is a nil dereference, and an export that should have failed with an error panics the daemon instead.

I have not reproduced a nil from a specific endpoint. The argument here is only that the code dereferences a pointer the SDK says may be absent, and that the cost of being wrong is the whole daemon.

Check it at the call site and pass the size by value, so `touch` cannot be handed a nil in the first place.

## The copy range can name a byte past the end of the object

`buildCopySourceRange` clamps like this:

```go
end := start + maxCopyObjectSize - 1
if end > objectSize {
	end = objectSize - 1
}
```

A copy source range is inclusive. For an object of `objectSize` bytes the last byte you may name is `objectSize-1`. So an `end` equal to `objectSize` is already one too far, and `>` lets it through.

You need the remaining bytes to be exactly one part short of the part size to hit it, which is why nobody has. The bound should be `>=`.

## A failed multipart upload is never actually aborted

The cleanup runs on the context that just failed:

```go
if err != nil {
	s3Client.AbortMultipartUpload(ctx, &abortIn)
}
```

If the export was cancelled, or the context timed out, that context is already dead and the abort fails immediately. The result is discarded, so there is no log line and no error either.

An incomplete multipart upload keeps the parts that were uploaded. They do not show up in a bucket listing, but they are billed until something removes them. If you do not have a lifecycle rule for `AbortIncompleteMultipartUpload`, they stay forever.

Abort on a context detached from the failed one, with its own 30 second timeout, and log it if that fails too.

## Tests

Adds a table test for `buildCopySourceRange`. Every case also asserts that the range never names a byte at or past `objectSize`, which is the property that was broken.

The "remainder one byte short of the part size" case fails on the current bound.

The other two fixes are on paths that need a real bucket, so they are not covered here.

## Notes

This is independent of #7123 and #7121. It only touches the touch path.
