### PR TITLE
dockerfile: scope CopyIgnoredFile suppression to relevant negations

### DIFF
--- a/frontend/dockerfile/dockerfile2llb/validations.go
+++ b/frontend/dockerfile/dockerfile2llb/validations.go
@@ -32,13 +32,8 @@ var reservedStageNames = map[string]struct{}{
 }
 
 func validateCopySourcePath(src string, cfg *copyConfig) error {
-	// Do not validate copy source paths if there is no dockerignore file
-	// or if the dockerignore file contains exclusions.
-	//
-	// Exclusions are too difficult to statically determine if they're proper
-	// because it's ok for a directory to be excluded and a file inside the directory
-	// to be negated.
-	if cfg.ignoreMatcher == nil || cfg.ignoreMatcher.Exclusions() {
+	// Do not validate copy source paths if there is no dockerignore file.
+	if cfg.ignoreMatcher == nil {
 		return nil
 	}
 	cmd := "Copy"
@@ -54,6 +49,17 @@ func validateCopySourcePath(src string, cfg *copyConfig) error {
 			return nil
 		}
 	}
+
+	// A negated pattern that re-includes a path at or below the source path
+	// makes the exclusion impossible to statically determine, because it's ok
+	// for a directory to be excluded and a file inside the directory to be
+	// negated. Skip the check for those source paths only. Negations that
+	// cannot affect anything at or below the source path are resolved
+	// correctly by MatchesOrParentMatches and must not disable the check.
+	if copySourceNegated(cfg.ignoreMatcher, src) {
+		return nil
+	}
+
 	ok, err := cfg.ignoreMatcher.MatchesOrParentMatches(src)
 	if err != nil {
 		return err
@@ -77,6 +83,56 @@ func copySourceRootIgnored(matcher *patternmatcher.PatternMatcher) bool {
 		}
 	}
 	return false
+}
+
+// copySourceNegated reports whether the dockerignore patterns contain a
+// negation that could re-include a path at or below src. Patterns with
+// wildcards cannot be statically resolved, so they are assumed to match
+// anything at or below the longest path prefix that precedes the first
+// wildcard.
+func copySourceNegated(matcher *patternmatcher.PatternMatcher, src string) bool {
+	src = strings.TrimPrefix(src, "/")
+	if src == "." {
+		src = ""
+	}
+	for _, pattern := range matcher.Patterns() {
+		if !pattern.Exclusion() {
+			continue
+		}
+		p := filepath.ToSlash(pattern.String())
+		prefix, wildcard := patternLiteralPrefix(p)
+		if pathAtOrBelow(prefix, src) {
+			return true
+		}
+		// A pattern with a wildcard may still match a path below src even if
+		// its literal prefix is above src, e.g. "*/keep.txt" and "sub".
+		if wildcard && pathAtOrBelow(src, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// patternLiteralPrefix returns the path prefix of the pattern that precedes
+// the first path element containing a wildcard, and whether the pattern
+// contains a wildcard at all.
+func patternLiteralPrefix(pattern string) (string, bool) {
+	elems := strings.Split(pattern, "/")
+	for i, elem := range elems {
+		if strings.ContainsAny(elem, "*?[") {
+			return strings.Join(elems[:i], "/"), true
+		}
+	}
+	return pattern, false
+}
+
+// pathAtOrBelow reports whether path is base or is contained in base. An
+// empty base is the context root and contains every path.
+func pathAtOrBelow(path, base string) bool {
+	if base == "" {
+		return true
+	}
+	return path == base || strings.HasPrefix(path, base+"/")
 }
 
 func validateCircularDependency(states []*dispatchState) error {

--- a/frontend/dockerfile/dockerfile2llb/validations_test.go
+++ b/frontend/dockerfile/dockerfile2llb/validations_test.go
@@ -1,0 +1,163 @@
+package dockerfile2llb
+
+import (
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/linter"
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+	"github.com/moby/patternmatcher"
+	"github.com/stretchr/testify/require"
+)
+
+func copySourceLintWarnings(t *testing.T, patterns []string, src string, isAdd bool) []string {
+	t.Helper()
+
+	pm, err := patternmatcher.New(patterns)
+	require.NoError(t, err)
+
+	var warnings []string
+	lint := linter.New(&linter.Config{
+		Warn: func(rulename, description, url, fmtmsg string, location []parser.Range) {
+			warnings = append(warnings, fmtmsg)
+		},
+	})
+
+	cfg := &copyConfig{
+		isAddCommand:  isAdd,
+		ignoreMatcher: pm,
+		opt:           dispatchOpt{lint: lint},
+	}
+	require.NoError(t, validateCopySourcePath(src, cfg))
+	return warnings
+}
+
+func TestValidateCopySourcePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		patterns []string
+		src      string
+		isAdd    bool
+		expected []string
+	}{
+		{
+			name:     "no dockerignore patterns",
+			patterns: []string{},
+			src:      "sub/a.txt",
+		},
+		{
+			name:     "excluded file",
+			patterns: []string{"sub"},
+			src:      "sub/a.txt",
+			expected: []string{`Attempting to Copy file "sub/a.txt" that is excluded by .dockerignore`},
+		},
+		{
+			name:     "excluded file with add",
+			patterns: []string{"sub"},
+			src:      "sub/a.txt",
+			isAdd:    true,
+			expected: []string{`Attempting to Add file "sub/a.txt" that is excluded by .dockerignore`},
+		},
+		{
+			name:     "file that is not excluded",
+			patterns: []string{"sub"},
+			src:      "other.txt",
+		},
+
+		// Negations that cannot re-include anything at or below the source
+		// path must not disable the check for that source path.
+		{
+			name:     "negation for sibling file in the excluded directory",
+			patterns: []string{"sub", "!sub/b.txt"},
+			src:      "sub/a.txt",
+			expected: []string{`Attempting to Copy file "sub/a.txt" that is excluded by .dockerignore`},
+		},
+		{
+			name:     "negation for an unrelated directory",
+			patterns: []string{"sub", "!other.txt"},
+			src:      "sub/a.txt",
+			expected: []string{`Attempting to Copy file "sub/a.txt" that is excluded by .dockerignore`},
+		},
+		{
+			name:     "negation for a path that does not exist",
+			patterns: []string{"sub", "!nope/missing.txt"},
+			src:      "sub/a.txt",
+			expected: []string{`Attempting to Copy file "sub/a.txt" that is excluded by .dockerignore`},
+		},
+		{
+			name:     "negation before the exclusion",
+			patterns: []string{"!sub/b.txt", "sub"},
+			src:      "sub/a.txt",
+			expected: []string{`Attempting to Copy file "sub/a.txt" that is excluded by .dockerignore`},
+		},
+		{
+			name:     "negation for an unrelated directory with wildcard",
+			patterns: []string{"sub", "!other/*.txt"},
+			src:      "sub/a.txt",
+			expected: []string{`Attempting to Copy file "sub/a.txt" that is excluded by .dockerignore`},
+		},
+
+		// Negations that re-include a path at or below the source path make
+		// the exclusion impossible to determine statically, so the check has
+		// to stay silent for that source path.
+		{
+			name:     "directory excluded and file inside it negated",
+			patterns: []string{"sub", "!sub/keep.txt"},
+			src:      "sub",
+		},
+		{
+			name:     "directory excluded and nested file negated",
+			patterns: []string{"sub", "!sub/nested/keep.txt"},
+			src:      "sub",
+		},
+		{
+			name:     "directory excluded and file inside it negated before the exclusion",
+			patterns: []string{"!sub/keep.txt", "sub"},
+			src:      "sub",
+		},
+		{
+			name:     "directory excluded and wildcard negation inside it",
+			patterns: []string{"sub", "!sub/*.txt"},
+			src:      "sub",
+		},
+		{
+			name:     "negation with a wildcard that may match the source path",
+			patterns: []string{"sub", "!*/keep.txt"},
+			src:      "sub",
+		},
+		{
+			name:     "negated file is the source path",
+			patterns: []string{"sub", "!sub/keep.txt"},
+			src:      "sub/keep.txt",
+		},
+		{
+			name:     "parent directory of the source path is negated",
+			patterns: []string{"**", "!sub"},
+			src:      "sub/a.txt",
+		},
+
+		// Context root handling.
+		{
+			name:     "context root with everything excluded",
+			patterns: []string{"*"},
+			src:      ".",
+			expected: []string{`Attempting to Copy file "." that is excluded by .dockerignore`},
+		},
+		{
+			name:     "context root with everything excluded and a negation",
+			patterns: []string{"**", "!Dockerfile"},
+			src:      ".",
+		},
+		{
+			name:     "context root with only dotfiles excluded",
+			patterns: []string{".*"},
+			src:      ".",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warnings := copySourceLintWarnings(t, tt.patterns, tt.src, tt.isAdd)
+			require.Equal(t, tt.expected, warnings)
+		})
+	}
+}

--- a/frontend/dockerfile/dockerfile_check_test.go
+++ b/frontend/dockerfile/dockerfile_check_test.go
@@ -49,6 +49,7 @@ var lintTests = integration.TestFuncs(
 	testFromPlatformFlagConstDisallowed,
 	testCopyIgnoredFiles,
 	testCopyIgnoredFileContextRoot,
+	testCopyIgnoredFileNegation,
 	testDefinitionDescription,
 	testExposeProtoCasing,
 	testExposeInvalidFormat,
@@ -275,6 +276,111 @@ COPY . .
 				},
 			},
 		})
+	})
+}
+
+func testCopyIgnoredFileNegation(t *testing.T, sb integration.Sandbox) {
+	contextFiles := []fstest.Applier{
+		fstest.CreateDir("sub", 0o755),
+		fstest.CreateFile("sub/a.txt", []byte("one"), 0o600),
+		fstest.CreateFile("sub/b.txt", []byte("two"), 0o600),
+		fstest.CreateFile("other.txt", []byte("three"), 0o600),
+	}
+
+	// A negation that cannot re-include the copied path must not disable the
+	// rule for that path.
+	t.Run("unrelated", func(t *testing.T) {
+		dockerfile := []byte(`
+FROM scratch
+COPY sub/a.txt /
+`)
+		for _, tc := range []struct {
+			name         string
+			dockerignore []byte
+		}{
+			{
+				name:         "sibling file in the excluded directory",
+				dockerignore: []byte("sub\n!sub/b.txt\n"),
+			},
+			{
+				name:         "different directory",
+				dockerignore: []byte("sub\n!other.txt\n"),
+			},
+			{
+				name:         "nonexistent path",
+				dockerignore: []byte("sub\n!nope/missing.txt\n"),
+			},
+			{
+				name:         "negation before the exclusion",
+				dockerignore: []byte("!sub/b.txt\nsub\n"),
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				files := append([]fstest.Applier{
+					fstest.CreateFile("Dockerfile", dockerfile, 0o600),
+					fstest.CreateFile(".dockerignore", tc.dockerignore, 0o600),
+				}, contextFiles...)
+				checkLinterWarnings(t, sb, &lintTestParams{
+					TmpDir:               integration.Tmpdir(t, files...),
+					Dockerfile:           dockerfile,
+					BuildErrLocation:     3,
+					StreamBuildErrRegexp: regexp.MustCompile(`failed to solve: failed to compute cache key: failed to calculate checksum of ref [^\s]+ "/sub/a.txt": not found`),
+					Warnings: []expectedLintWarning{
+						{
+							RuleName:    "CopyIgnoredFile",
+							Description: "Attempting to Copy file that is excluded by .dockerignore",
+							Detail:      `Attempting to Copy file "sub/a.txt" that is excluded by .dockerignore`,
+							URL:         "https://docs.docker.com/go/dockerfile/rule/copy-ignored-file/",
+							Level:       1,
+							Line:        3,
+						},
+					},
+				})
+			})
+		}
+	})
+
+	// A negation that re-includes a path below the copied path means the copy
+	// still has content, so the rule must stay silent.
+	t.Run("reincluded", func(t *testing.T) {
+		dockerignore := []byte("sub\n!sub/a.txt\n")
+		for _, tc := range []struct {
+			name       string
+			dockerfile []byte
+		}{
+			{
+				name: "copy of the excluded directory",
+				dockerfile: []byte(`
+FROM scratch
+COPY sub /sub
+`),
+			},
+			{
+				name: "copy of the context root",
+				dockerfile: []byte(`
+FROM scratch
+COPY . /ctx
+`),
+			},
+			{
+				name: "copy of the negated file",
+				dockerfile: []byte(`
+FROM scratch
+COPY sub/a.txt /
+`),
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				files := append([]fstest.Applier{
+					fstest.CreateFile("Dockerfile", tc.dockerfile, 0o600),
+					fstest.CreateFile(".dockerignore", dockerignore, 0o600),
+				}, contextFiles...)
+				checkLinterWarnings(t, sb, &lintTestParams{
+					TmpDir:     integration.Tmpdir(t, files...),
+					Dockerfile: tc.dockerfile,
+				})
+			})
+		}
 	})
 }
 


### PR DESCRIPTION
Fixes #7125

`CopyIgnoredFile` stops firing for the entire build as soon as `.dockerignore` contains any `!` line — including a negation for an unrelated directory, or one naming a path that does not exist.

The cause is in `validateCopySourcePath`:

```go
	// Do not validate copy source paths if there is no dockerignore file
	// or if the dockerignore file contains exclusions.
	//
	// Exclusions are too difficult to statically determine if they're proper
	// because it's ok for a directory to be excluded and a file inside the directory
	// to be negated.
	if cfg.ignoreMatcher == nil || cfg.ignoreMatcher.Exclusions() {
		return nil
	}
```

`PatternMatcher.Exclusions()` is a single global boolean — true when the pattern list contains a negation anywhere, with no relation to the path being copied. One `!` line therefore disables the rule for every `COPY` and `ADD` in the Dockerfile. The failure mode is quiet in an unpleasant way: the documented way to silence a genuine `CopyIgnoredFile` warning is to add a `!` line, and doing so switches the check off for everything after it while `docker build --check` keeps reporting no warnings.

## Keeping the original concern

The comment describes a real false positive and this change preserves it. With `sub` and `!sub/keep.txt`, `COPY sub /dst` still copies `sub/keep.txt`, so warning that `sub` is excluded would be wrong — and `MatchesOrParentMatches("sub")` does return true.

But that ambiguity only arises when a negation re-includes something *at or below* the path being copied. Everywhere else `MatchesOrParentMatches` already resolves negations correctly: with that same `.dockerignore`, `COPY sub/a.txt` correctly reports excluded and `COPY sub/keep.txt` correctly reports not excluded.

So rather than the global flag, the source path is now compared against the individual negated patterns, and the check is skipped only when some negation could re-include a path at or below that source path. Patterns containing `*`, `?` or `[` cannot be resolved statically, so they are treated as matching anything at or below the longest path prefix preceding the first wildcard, in both directions. That deliberately errs toward suppression — a noisy linter is worse than a quiet one. `.` and `/` context roots keep their existing handling.

## Known imprecision

A wildcard negation whose literal prefix is empty (`!*.txt`, `!**/x`) still suppresses the rule for all source paths, even though patternmatcher's `*` does not cross `/` and such a pattern can only re-include top-level entries. That is no worse than current behaviour and can be tightened separately if you'd like.

## Tests

`TestValidateCopySourcePath` is a table covering every row of the issue's reproduction — unrelated negation, negation for a nonexistent path, negation placed before the exclude, and a wildcard negation with a disjoint prefix — plus the cases that must stay silent: `sub` + `!sub/keep.txt` with `COPY sub`, nested and wildcard negations inside the copied directory, a wildcard negation that could reach into it (`!*/keep.txt`), parent-directory re-inclusion (`**` + `!sub` with `COPY sub/a.txt`), and the three context-root cases.

Reverting `validations.go` alone fails 5 of these subtests and passes the rest; with the change all 19 pass.

`testCopyIgnoredFileNegation` adds the same two groups to the lint integration suite against a real build context. I could not run the integration suite locally — it needs a buildkitd worker — so those are compile-checked only; the unit table above is what I actually ran.
