### PR TITLE
compression: add compression-threads option

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ Keys supported by image output:
 * `name-canonical=true`: add additional canonical name `name@<digest>`
 * `compression=<uncompressed|gzip|estargz|zstd>`: choose compression type for layers newly created and cached, gzip is default value. estargz should be used with `oci-mediatypes=true`.
 * `compression-level=<value>`: compression level for gzip, estargz (0-9) and zstd (0-22)
+* `compression-threads=<value>`: number of threads used to compress each layer (zstd only). `0` uses all available CPUs; by default layers are not compressed in parallel
 * `rewrite-timestamp=true`: rewrite the file timestamps to the `SOURCE_DATE_EPOCH` value.
    See [`docs/build-repro.md`](docs/build-repro.md) for how to specify the `SOURCE_DATE_EPOCH` value.
 * `force-compression=true`: forcefully apply `compression` option to all layers (including already existing layers)
@@ -477,6 +478,7 @@ buildctl build ... \
 * `oci-mediatypes=<true|false>`: whether to use OCI mediatypes in exported manifests (default: `true`, since BuildKit `v0.8`)
 * `compression=<uncompressed|gzip|estargz|zstd>`: choose compression type for layers newly created and cached, gzip is default value. estargz and zstd should be used with `oci-mediatypes=true`
 * `compression-level=<value>`: choose compression level for gzip, estargz (0-9) and zstd (0-22)
+* `compression-threads=<value>`: number of threads used to compress each layer (zstd only). `0` uses all available CPUs; by default layers are not compressed in parallel
 * `force-compression=true`: forcibly apply `compression` option to all layers
 * `ignore-error=<false|true>`: specify if error is ignored in case cache export fails (default: `false`)
 
@@ -504,6 +506,7 @@ The directory layout conforms to OCI Image Spec v1.0.
 * `oci-mediatypes=<true|false>`: whether to use OCI mediatypes in exported manifests (default `true`, since BuildKit `v0.8`)
 * `compression=<uncompressed|gzip|estargz|zstd>`: choose compression type for layers newly created and cached, gzip is default value. estargz and zstd should be used with `oci-mediatypes=true`.
 * `compression-level=<value>`: compression level for gzip, estargz (0-9) and zstd (0-22)
+* `compression-threads=<value>`: number of threads used to compress each layer (zstd only). `0` uses all available CPUs; by default layers are not compressed in parallel
 * `force-compression=true`: forcibly apply `compression` option to all layers
 * `ignore-error=<false|true>`: specify if error is ignored in case cache export fails (default: `false`)
 * `reset=<true|false>`: remove any blobs in the cache directory that are not referenced by the current manifests in `index.json` (default: `false`). This is useful for keeping the local cache directory from growing indefinitely.

--- a/exporter/containerimage/exptypes/keys.go
+++ b/exporter/containerimage/exptypes/keys.go
@@ -83,6 +83,11 @@ var (
 	// Value: int (0-22) for zstd
 	OptKeyCompressionLevel ImageExporterOptKey = "compression-level"
 
+	// Number of threads used to compress each layer. Only applies to zstd.
+	// 0 uses all available CPUs.
+	// Value: int (>= 0)
+	OptKeyCompressionThreads ImageExporterOptKey = "compression-threads"
+
 	// Rewrite timestamps in layers to match SOURCE_DATE_EPOCH
 	// Value: bool <true|false>
 	OptKeyRewriteTimestamp ImageExporterOptKey = "rewrite-timestamp"

--- a/exporter/containerimage/writer.go
+++ b/exporter/containerimage/writer.go
@@ -386,6 +386,9 @@ func (ic *ImageWriter) exportLayers(ctx context.Context, refCfg cacheconfig.RefC
 	if refCfg.Compression.Level != nil {
 		attr = append(attr, attribute.Int("exportLayers.compressionLevel", *refCfg.Compression.Level))
 	}
+	if refCfg.Compression.Threads != nil {
+		attr = append(attr, attribute.Int("exportLayers.compressionThreads", *refCfg.Compression.Threads))
+	}
 	span, ctx := tracing.StartSpan(ctx, "export layers", trace.WithAttributes(attr...))
 
 	eg, ctx := errgroup.WithContext(ctx)

--- a/util/compression/attrs.go
+++ b/util/compression/attrs.go
@@ -7,9 +7,10 @@ import (
 )
 
 const (
-	attrLayerCompression = "compression"
-	attrForceCompression = "force-compression"
-	attrCompressionLevel = "compression-level"
+	attrLayerCompression   = "compression"
+	attrForceCompression   = "force-compression"
+	attrCompressionLevel   = "compression-level"
+	attrCompressionThreads = "compression-threads"
 )
 
 func ParseAttributes(attrs map[string]string) (Config, error) {
@@ -43,6 +44,16 @@ func ParseAttributes(attrs map[string]string) (Config, error) {
 			return Config{}, errors.Wrapf(err, "non-integer value %s specified for %s", v, attrCompressionLevel)
 		}
 		compressionConfig = compressionConfig.SetLevel(int(ii))
+	}
+	if v, ok := attrs[attrCompressionThreads]; ok {
+		ii, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return Config{}, errors.Wrapf(err, "non-integer value %s specified for %s", v, attrCompressionThreads)
+		}
+		if ii < 0 {
+			return Config{}, errors.Errorf("negative value %s specified for %s", v, attrCompressionThreads)
+		}
+		compressionConfig = compressionConfig.SetThreads(int(ii))
 	}
 	return compressionConfig, nil
 }

--- a/util/compression/attrs_test.go
+++ b/util/compression/attrs_test.go
@@ -1,0 +1,82 @@
+package compression
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAttributes(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		attrs    map[string]string
+		expected Config
+		err      string
+	}{
+		{
+			name:     "default",
+			attrs:    map[string]string{},
+			expected: New(Default),
+		},
+		{
+			name: "all",
+			attrs: map[string]string{
+				"compression":         "zstd",
+				"force-compression":   "true",
+				"compression-level":   "3",
+				"compression-threads": "4",
+			},
+			expected: New(Zstd).SetForce(true).SetLevel(3).SetThreads(4),
+		},
+		{
+			name:     "force without value",
+			attrs:    map[string]string{"force-compression": ""},
+			expected: New(Default).SetForce(true),
+		},
+		{
+			name:     "threads all cpus",
+			attrs:    map[string]string{"compression": "zstd", "compression-threads": "0"},
+			expected: New(Zstd).SetThreads(0),
+		},
+		{
+			name:     "threads single",
+			attrs:    map[string]string{"compression": "zstd", "compression-threads": "1"},
+			expected: New(Zstd).SetThreads(1),
+		},
+		{
+			name:  "unsupported type",
+			attrs: map[string]string{"compression": "lz4"},
+			err:   "unsupported compression type lz4",
+		},
+		{
+			name:  "non-bool force",
+			attrs: map[string]string{"force-compression": "yes"},
+			err:   "non-bool value yes specified for force-compression",
+		},
+		{
+			name:  "non-integer level",
+			attrs: map[string]string{"compression-level": "high"},
+			err:   "non-integer value high specified for compression-level",
+		},
+		{
+			name:  "non-integer threads",
+			attrs: map[string]string{"compression-threads": "many"},
+			err:   "non-integer value many specified for compression-threads",
+		},
+		{
+			name:  "negative threads",
+			attrs: map[string]string{"compression-threads": "-1"},
+			err:   "negative value -1 specified for compression-threads",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := ParseAttributes(tc.attrs)
+			if tc.err != "" {
+				require.ErrorContains(t, err, tc.err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, cfg)
+		})
+	}
+}

--- a/util/compression/compression.go
+++ b/util/compression/compression.go
@@ -54,9 +54,10 @@ var (
 )
 
 type Config struct {
-	Type  Type
-	Force bool
-	Level *int
+	Type    Type
+	Force   bool
+	Level   *int
+	Threads *int // number of threads used for parallel compression, 0 for all CPUs
 }
 
 func New(t Type) Config {
@@ -72,6 +73,11 @@ func (c Config) SetForce(v bool) Config {
 
 func (c Config) SetLevel(l int) Config {
 	c.Level = &l
+	return c
+}
+
+func (c Config) SetThreads(n int) Config {
+	c.Threads = &n
 	return c
 }
 

--- a/util/compression/zstd.go
+++ b/util/compression/zstd.go
@@ -16,6 +16,15 @@ func (c zstdType) Compress(ctx context.Context, comp Config) (compressorFunc Com
 		if comp.Level != nil {
 			opts = append(opts, zstd.WithEncoderLevel(zstd.EncoderLevelFromZstd(*comp.Level)))
 		}
+		if comp.Threads != nil {
+			// Split the stream into independently compressed jobs that are
+			// encoded in parallel, like `zstd -T<n>`. The encoder falls back
+			// to sequential encoding when the concurrency resolves to 1.
+			opts = append(opts,
+				zstd.WithEncoderConcurrency(*comp.Threads),
+				zstd.WithConcurrentBlocks(true),
+			)
+		}
 		return zstd.NewWriter(dest, opts...)
 	}, nil
 }

--- a/util/compression/zstd_test.go
+++ b/util/compression/zstd_test.go
@@ -1,0 +1,151 @@
+package compression
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"runtime"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestZstdCompressThreads(t *testing.T) {
+	// larger than the 16-32MB job size of the parallel encoder so that the
+	// input is split into multiple jobs
+	src := zstdTestData(40 << 20)
+
+	for _, tc := range []struct {
+		name string
+		comp Config
+	}{
+		{name: "default level", comp: New(Zstd)},
+		{name: "fastest", comp: New(Zstd).SetLevel(1)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sequential := zstdCompress(t, tc.comp, src, 0)
+			require.True(t, bytes.Equal(src, zstdDecompress(t, sequential)), "sequential output does not roundtrip")
+
+			// a single thread is the sequential encoder
+			require.True(t, bytes.Equal(sequential, zstdCompress(t, tc.comp.SetThreads(1), src, 0)), "single-threaded output differs from default")
+
+			parallel := zstdCompress(t, tc.comp.SetThreads(2), src, 0)
+			require.True(t, bytes.Equal(src, zstdDecompress(t, parallel)), "parallel output does not roundtrip")
+			// jobs are compressed with a limited history, so a different output
+			// is the only observable proof that the parallel encoder was used
+			require.False(t, bytes.Equal(parallel, sequential), "parallel output is identical to the sequential output")
+
+			// the output must not depend on the number of threads or on how
+			// the input is chunked, otherwise layer digests would not be
+			// reproducible across machines
+			require.True(t, bytes.Equal(parallel, zstdCompress(t, tc.comp.SetThreads(4), src, 0)), "output depends on the number of threads")
+			require.True(t, bytes.Equal(parallel, zstdCompress(t, tc.comp.SetThreads(4), src, 4096)), "output depends on the write chunk size")
+			if runtime.GOMAXPROCS(0) > 1 {
+				require.True(t, bytes.Equal(parallel, zstdCompress(t, tc.comp.SetThreads(0), src, 0)), "output with all CPUs differs")
+			}
+		})
+	}
+}
+
+func TestZstdCompressThreadsSmall(t *testing.T) {
+	// inputs that fit in a single job or a single block
+	for _, size := range []int{0, 1, 1000, 1 << 20} {
+		src := zstdTestData(size)
+		for _, threads := range []int{0, 1, 4} {
+			out := zstdCompress(t, New(Zstd).SetThreads(threads), src, 0)
+			require.Equal(t, src, zstdDecompress(t, out), "size=%d threads=%d", size, threads)
+		}
+	}
+}
+
+func BenchmarkZstdCompressThreads(b *testing.B) {
+	// several 32MB jobs, otherwise the parallel encoder cannot scale
+	src := zstdTestData(256 << 20)
+	for _, level := range []int{3, 12} {
+		for _, threads := range []*int{nil, new(1), new(2), new(4), new(0)} {
+			comp := New(Zstd).SetLevel(level)
+			name := fmt.Sprintf("level=%d/threads=default", level)
+			if threads != nil {
+				comp = comp.SetThreads(*threads)
+				name = fmt.Sprintf("level=%d/threads=%d", level, *threads)
+			}
+			b.Run(name, func(b *testing.B) {
+				compress, _ := Zstd.Compress(b.Context(), comp)
+				var cw countingWriter
+				b.SetBytes(int64(len(src)))
+				for b.Loop() {
+					cw.n = 0
+					w, err := compress(&cw, ocispecs.MediaTypeImageLayerZstd)
+					if err != nil {
+						b.Fatal(err)
+					}
+					if _, err := w.Write(src); err != nil {
+						b.Fatal(err)
+					}
+					if err := w.Close(); err != nil {
+						b.Fatal(err)
+					}
+				}
+				b.ReportMetric(float64(cw.n)*100/float64(len(src)), "ratio%")
+			})
+		}
+	}
+}
+
+type countingWriter struct {
+	n int64
+}
+
+func (w *countingWriter) Write(p []byte) (int, error) {
+	w.n += int64(len(p))
+	return len(p), nil
+}
+
+// zstdCompress compresses src with the zstd compressor for comp, writing the
+// input in chunks of chunkSize bytes (all at once when chunkSize is 0).
+func zstdCompress(t *testing.T, comp Config, src []byte, chunkSize int) []byte {
+	t.Helper()
+	compress, _ := Zstd.Compress(t.Context(), comp)
+	var buf bytes.Buffer
+	w, err := compress(&buf, ocispecs.MediaTypeImageLayerZstd)
+	require.NoError(t, err)
+	if chunkSize <= 0 || chunkSize > len(src) {
+		chunkSize = len(src)
+	}
+	for len(src) > 0 {
+		n := min(chunkSize, len(src))
+		_, err := w.Write(src[:n])
+		require.NoError(t, err)
+		src = src[n:]
+	}
+	require.NoError(t, w.Close())
+	return buf.Bytes()
+}
+
+func zstdDecompress(t *testing.T, data []byte) []byte {
+	t.Helper()
+	r, err := zstd.NewReader(bytes.NewReader(data))
+	require.NoError(t, err)
+	defer r.Close()
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	if out == nil {
+		out = []byte{}
+	}
+	return out
+}
+
+// zstdTestData returns n bytes of compressible but non-repetitive data.
+func zstdTestData(n int) []byte {
+	words := []string{"buildkit ", "layer ", "zstd ", "compression ", "threads ", "content ", "store ", "digest ", "\n"}
+	buf := make([]byte, 0, n+16)
+	x := uint32(1)
+	for len(buf) < n {
+		x = x*1664525 + 1013904223 // LCG
+		buf = append(buf, words[(x>>28)%uint32(len(words))]...)
+		buf = append(buf, byte('0'+x%10))
+	}
+	return buf[:n]
+}


### PR DESCRIPTION
Layers exported as zstd are not compressed in parallel today. `zstd.NewWriter` is created with klauspost's default concurrency (GOMAXPROCS), but in streaming mode that only pipelines match finding with entropy coding and writing; the blocks themselves are encoded sequentially because they share the match history. A large layer at a high compression level takes minutes while the other cores sit idle.

klauspost/compress (already vendored at v1.19.2) supports real parallel stream compression with `WithConcurrentBlocks(true)`: the input is split into large jobs (4× window size, 16–32MB) that are compressed simultaneously, each non-first job receives an overlap prefix from the previous job, and the output is flushed in order as a valid single-frame stream — the same design as `zstd -T<n>`.

This PR exposes that as a `compression-threads=<n>` attribute next to `compression-level`. It is parsed by the shared `compression.ParseAttributes`, so the image, OCI, registry cache and local cache exporters all accept it:

- `0`: use all CPUs (GOMAXPROCS), like `zstd -T0`
- `1`: the sequential encoder
- `n ≥ 2`: `n` parallel jobs
- unset: unchanged behaviour

Only zstd honours it for now; like `compression-level` with `compression=uncompressed`, other types ignore it. Negative or non-integer values are rejected when the attributes are parsed.

### Determinism

Job boundaries are fixed by size and each job depends only on its own input and its overlap prefix, so the output does not depend on the number of threads or on how the tar stream is chunked into writes — only on whether parallel mode is used at all. `TestZstdCompressThreads` asserts this on a 40MB input spanning several jobs: `threads=2` ≡ `threads=4` ≡ `threads=0`, one write ≡ 4KB writes, and `threads=1` ≡ unset.

The option is opt-in and the default output is byte-for-byte unchanged, because enabling parallel jobs changes the produced blob digests.

### Numbers

256MB of synthetic text-like data, Apple M1 Pro (10 cores), `BenchmarkZstdCompressThreads`:

| level | default | `threads=1` | `threads=2` | `threads=4` | `threads=8` | ratio default → parallel |
|---|---|---|---|---|---|---|
| 3 | 493 MB/s | 309 MB/s | 593 MB/s | 1057 MB/s | 1652 MB/s | 20.112% → 20.111% |
| 12 | 83 MB/s | 76 MB/s | 147 MB/s | 282 MB/s | 384 MB/s | 17.106% → 17.105% |

Memory grows with the thread count: each in-flight job buffers 16–32MB of input and up to ~2n jobs can be in flight per layer writer, on top of buildkit already compressing the layers of a chain concurrently. That is why this is opt-in rather than the new default.

### Not in this PR

- gzip/estargz stay as they are; the option is deliberately generic so a parallel gzip implementation could honour it later.
- Switching the default to parallel. That changes digests and memory use, so it deserves its own discussion.
