### PR TITLE
cache: load parent chain only once in remote cache LoadWithParents

### DIFF
--- a/cache/remotecache/v1/cachestorage.go
+++ b/cache/remotecache/v1/cachestorage.go
@@ -249,6 +249,11 @@ func (cs *cacheResultStorage) Save(res solver.Result, createdAt time.Time) (solv
 
 func (cs *cacheResultStorage) LoadWithParents(ctx context.Context, res solver.CacheResult) (map[string]solver.Result, error) {
 	m := map[string]solver.Result{}
+	releaseAll := func() {
+		for _, v := range m {
+			v.Release(context.TODO())
+		}
+	}
 
 	visited := make(map[*item]struct{})
 
@@ -259,36 +264,77 @@ func (cs *cacheResultStorage) LoadWithParents(ctx context.Context, res solver.Ca
 
 	for id := range ids {
 		v, ok := cs.byID[id]
-		if ok {
-			if _, ok := visited[v.item]; ok {
+		if !ok {
+			continue
+		}
+		if _, ok := visited[v.item]; ok {
+			continue
+		}
+		for _, result := range v.results {
+			resultID := remoteID(result.Result)
+			if resultID != res.ID {
 				continue
 			}
-			for _, result := range v.results {
-				resultID := remoteID(result.Result)
-				if resultID == res.ID {
-					if err := v.walkAllResults(func(i *item) error {
-						for _, subRes := range i.results {
-							id, ok := cs.byItem[i]
-							if !ok {
-								return nil
-							}
-							if isSubRemote(*subRes.Result, *result.Result) {
-								ref, err := cs.w.FromRemote(ctx, subRes.Result)
-								if err != nil {
-									return err
-								}
-								m[id] = worker.NewWorkerRefResult(ref, cs.w)
-							}
-						}
-						return nil
-					}, visited); err != nil {
-						for _, v := range m {
-							v.Release(context.TODO())
-						}
-						return nil, err
+			// Every record in the parent chain has a remote that is a prefix
+			// of the matched result's remote, so instead of loading each of
+			// them separately (which would verify the same parent layers over
+			// and over again), collect the records with the depth of their
+			// remote and load the full chain only once.
+			type entry struct {
+				id     string
+				remote *solver.Remote
+			}
+			var entries []entry
+			if err := v.walkAllResults(func(i *item) error {
+				id, ok := cs.byItem[i]
+				if !ok {
+					return nil
+				}
+				for _, subRes := range i.results {
+					if isSubRemote(*subRes.Result, *result.Result) {
+						entries = append(entries, entry{id: id, remote: subRes.Result})
 					}
 				}
+				return nil
+			}, visited); err != nil {
+				releaseAll()
+				return nil, err
 			}
+			if len(entries) == 0 {
+				continue
+			}
+
+			ref, err := cs.w.FromRemote(ctx, result.Result)
+			if err != nil {
+				releaseAll()
+				return nil, err
+			}
+			chain := ref.LayerChain()
+			ref.Release(context.TODO())
+
+			for _, e := range entries {
+				depth := len(e.remote.Descriptors)
+				var res solver.Result
+				if depth > 0 && depth <= len(chain) && len(chain) == len(result.Result.Descriptors) {
+					res = worker.NewWorkerRefResult(chain[depth-1].Clone(), cs.w)
+				} else {
+					// the worker returned a ref with a layer chain that does
+					// not map 1:1 to the remote descriptors; load this record
+					// directly
+					ref, err := cs.w.FromRemote(ctx, e.remote)
+					if err != nil {
+						chain.Release(context.TODO())
+						releaseAll()
+						return nil, err
+					}
+					res = worker.NewWorkerRefResult(ref, cs.w)
+				}
+				if prev, ok := m[e.id]; ok {
+					prev.Release(context.TODO())
+				}
+				m[e.id] = res
+			}
+			chain.Release(context.TODO())
 		}
 	}
 


### PR DESCRIPTION
cache: load parent chain only once in remote cache LoadWithParents

Fixes #2184

Problem

When a remote cache match is found, cacheManager.LoadWithParents loads not only the matched record but every 
parent record as well, so that cache metadata is saved for all parent layers and a later build with only loca
cache can still get a partial match.                                                                         
                                                                                                             
In cacheResultStorage.LoadWithParents (cache/remotecache/v1/cachestorage.go), each of those records was loaded with its own worker.FromRemote call. Every parent record's solver.Remote contains the full descriptor chain 
from the root up to that record, so each call verified (Provider.Info) and loaded (GetByBlob) all the layers   below it again. For a chain of n layers this is n + (n-1) + ... + 1 = O(n²) layer verifications. The checks 
are cheap in the common case, but noticeable for large images, and expensive in the moby integration where     verification of existing layers goes through the download manager and touches the local disk.               

Approach

The key observation is that every record collected by the walk passes isSubRemote(subRes.Result, result.Result), i.e. its remote is a strict prefix of the matched result's remote. So there is no need to load each prefix independently:

1. During walkAllResults, only collect the (record id, remote) pairs instead of loading them.
2. Call worker.FromRemote once for the matched result's full remote.
3. Take each record's ref from the returned ref's LayerChain() (ordered root→top): a record whose remote has k descriptors gets chain[k-1].Clone().

Each layer is now verified and loaded exactly once — O(n) — while the results map handed back to the solver is unchanged, so cache metadata is still recorded for every parent record.

No function signatures change, and no state needs to be threaded through the solver: the "parent already loaded" state the issue mentions is exactly what the loaded ref's layer chain already represents.

Safety fallback

If a worker ever returns a ref whose layer chain does not map 1:1 onto the remote's descriptors, the affected records fall back to the previous per-record FromRemote call, so behavior is preserved for non-standard workers.

Also fixed

The old code did m[id] = worker.NewWorkerRefResult(...) for every matching result of an item, overwriting earlier entries for the same id without releasing them — a ref leak. Overwritten entries are now released.

Testing

- go build ./cache/... ./solver/... ./worker/... — clean
- go vet ./cache/remotecache/v1/ — clean
- go test ./cache/remotecache/... — v1 and registry pass (TestGhaCacheIntegration fails without an integration environment, both before and after this change)
- go test -short ./solver/ — pass