### PR TITLE
ci: distribute compatibility release tests

### DIFF
--- a/.github/workflows/compatibility-releases.yml
+++ b/.github/workflows/compatibility-releases.yml
@@ -22,8 +22,27 @@ env:
   CACHE_SCOPE: "build-integration-tests"
 
 jobs:
-  compatibility:
+  prepare:
     runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      -
+        name: Generate matrix
+        id: matrix
+        run: |
+          echo "matrix=$(./hack/test-compatibility-releases --matrix)" >> "$GITHUB_OUTPUT"
+
+  compatibility:
+    needs:
+      - prepare
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     steps:
       -
         name: Checkout
@@ -56,6 +75,7 @@ jobs:
       -
         name: Test compatibility releases
         env:
+          COMPATIBILITY_RELEASES: ${{ matrix.compatibility_release }}
           TEST_IMAGE_BUILD: "0"
           TEST_IMAGE_NAME: ${{ env.TEST_IMAGE_NAME }}
         run: |

--- a/hack/test-compatibility-releases
+++ b/hack/test-compatibility-releases
@@ -31,9 +31,26 @@ v0.29.0:20
 "
 fi
 
-failures=0
+if [ "${1:-}" = "--matrix" ]; then
+  sep=""
+  printf '{"compatibility_release":['
+  for entry in $COMPATIBILITY_RELEASES; do
+    printf '%s"%s"' "$sep" "$entry"
+    sep=","
+  done
+  printf ']}\n'
+  exit 0
+fi
 
-for entry in $COMPATIBILITY_RELEASES; do
+failures=0
+set -- $COMPATIBILITY_RELEASES
+group_logs=
+
+if [ "$#" -gt 1 ]; then
+  group_logs=1
+fi
+
+for entry; do
   release=${entry%:*}
   expected=${entry#*:}
   suffix=$(printf '%s' "$release" | tr -cd '[:alnum:]-')
@@ -41,7 +58,9 @@ for entry in $COMPATIBILITY_RELEASES; do
 
   mkdir -p "$bindir"
 
-  echo "::group::compatibility $release"
+  if [ -n "$group_logs" ]; then
+    echo "::group::compatibility $release"
+  fi
   docker pull "moby/buildkit:$release"
   cid=$(docker create "moby/buildkit:$release")
   trap 'docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
@@ -56,7 +75,9 @@ for entry in $COMPATIBILITY_RELEASES; do
     ./hack/test integration; then
     failures=1
   fi
-  echo "::endgroup::"
+  if [ -n "$group_logs" ]; then
+    echo "::endgroup::"
+  fi
 done
 
 exit "$failures"


### PR DESCRIPTION
relates to:

```
System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/2.337.0/_diag/Worker_20260908-072835-utc.log'
   at System.IO.RandomAccess.WriteAtOffset(SafeFileHandle handle, ReadOnlySpan`1 buffer, Int64 fileOffset)
   at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder)
   at System.Diagnostics.TextWriterTraceListener.Flush()
   at GitHub.Runner.Common.HostTraceListener.WriteHeader(String source, TraceEventType eventType, Int32 id)
   at System.Diagnostics.TraceSource.TraceEvent(TraceEventType eventType, Int32 id, String message)
   at GitHub.Runner.Worker.Worker.RunAsync(String pipeIn, String pipeOut)
   at GitHub.Runner.Worker.Worker.RunAsync(String pipeIn, String pipeOut)
   at GitHub.Runner.Worker.Program.MainAsync(IHostContext context, String[] args)
```

<img width="2190" height="469" alt="image" src="https://github.com/user-attachments/assets/5ec11672-ba87-4898-a3ad-32095ee04546" />


The compatibility releases workflow currently runs every historical BuildKit release test on a single GitHub-hosted runner. This can exhaust the runner disk while the job is still writing runner diagnostics, which showed up as `System.IO.IOException: No space left on device`.

This change distributes the release list across a workflow matrix and passes one `release:compatibility-version` entry to each job through the existing `COMPATIBILITY_RELEASES` input. Each compatibility release now runs on its own runner, reducing per-runner disk pressure while preserving the same test coverage.