### PR TITLE
cache/metadata: remove obsolete indexes when replacing values

### DIFF
--- a/cache/metadata/metadata.go
+++ b/cache/metadata/metadata.go
@@ -395,35 +395,64 @@ func (s *StorageItem) clearIndex(tx *bolt.Tx, index string) error {
 }
 
 func (s *StorageItem) setValue(b *bolt.Bucket, key string, v *Value) error {
-	if v == nil {
-		if old, ok := s.values[key]; ok {
-			if old.Index != "" {
-				s.clearIndex(b.Tx(), old.Index) // ignore error
-			}
+	// Read the previous index from the transaction: another StorageItem handle
+	// or a caller modifying a Value returned by Get may have changed the cache.
+	var old Value
+	if dt := b.Get([]byte(key)); len(dt) > 0 {
+		if err := json.Unmarshal(dt, &old); err != nil {
+			return errors.WithStack(err)
 		}
-		if err := b.Put([]byte(key), nil); err != nil {
-			return err
-		}
-		delete(s.values, key)
-		return nil
 	}
-	dt, err := json.Marshal(v)
-	if err != nil {
-		return errors.WithStack(err)
+	var dt []byte
+	var index string
+	if v != nil {
+		var err error
+		dt, err = json.Marshal(v)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		index = v.Index
 	}
 	if err := b.Put([]byte(key), dt); err != nil {
 		return errors.WithStack(err)
 	}
-	if v.Index != "" {
+	if old.Index != "" && old.Index != index {
+		// Index entries are shared by all values on this record. Remove an old
+		// entry only after its last value stops referencing it.
+		inUse := false
+		if err := b.ForEach(func(_, dt []byte) error {
+			if len(dt) == 0 {
+				return nil
+			}
+			var current Value
+			if err := json.Unmarshal(dt, &current); err != nil {
+				return errors.WithStack(err)
+			}
+			inUse = inUse || current.Index == old.Index
+			return nil
+		}); err != nil {
+			return err
+		}
+		if !inUse {
+			if err := s.clearIndex(b.Tx(), old.Index); err != nil {
+				return err
+			}
+		}
+	}
+	if index != "" {
 		b, err := b.Tx().CreateBucketIfNotExists([]byte(indexBucket))
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		if err := b.Put([]byte(indexKey(v.Index, s.ID())), []byte{}); err != nil {
+		if err := b.Put([]byte(indexKey(index, s.ID())), []byte{}); err != nil {
 			return errors.WithStack(err)
 		}
 	}
-	s.values[key] = v
+	if v == nil {
+		delete(s.values, key)
+	} else {
+		s.values[key] = v
+	}
 	return nil
 }
 

--- a/cache/metadata/metadata_test.go
+++ b/cache/metadata/metadata_test.go
@@ -1,9 +1,11 @@
 package metadata
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	bolt "go.etcd.io/bbolt"
 )
@@ -202,4 +204,180 @@ func TestExternalData(t *testing.T) {
 	si, _ = s.Get("foo")
 	_, err = si.GetExternal("ext1")
 	require.Error(t, err)
+}
+
+func TestIndexReplacement(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		newIndex string
+		remove   bool
+	}{
+		{name: "change index", newIndex: "tag:new"},
+		{name: "remove index"},
+		{name: "keep same index", newIndex: "tag:old"},
+		{name: "delete value", remove: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, err := NewStore(filepath.Join(t.TempDir(), "storage.db"))
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, s.Close()) })
+			si, _ := s.Get("record")
+			old, err := NewValue("old")
+			require.NoError(t, err)
+			old.Index = "tag:old"
+			require.NoError(t, si.Update(func(b *bolt.Bucket) error { return si.SetValue(b, "key", old) }))
+			var replacement *Value
+			if !tc.remove {
+				replacement, err = NewValue("new")
+				require.NoError(t, err)
+				replacement.Index = tc.newIndex
+			}
+			require.NoError(t, si.Update(func(b *bolt.Bucket) error { return si.SetValue(b, "key", replacement) }))
+			exists, err := s.Probe("tag:old")
+			require.NoError(t, err)
+			assert.Equal(t, tc.newIndex == "tag:old", exists, "obsolete index must disappear when the indexed value changes")
+			results, err := s.Search(t.Context(), "tag:old", false)
+			require.NoError(t, err)
+			if tc.newIndex == "tag:old" {
+				assert.Len(t, results, 1)
+			} else {
+				assert.Empty(t, results)
+			}
+			if tc.newIndex != "" {
+				results, err := s.Search(t.Context(), tc.newIndex, false)
+				require.NoError(t, err)
+				assert.Len(t, results, 1)
+			}
+			require.NoError(t, s.Clear("record"))
+			for _, index := range []string{"tag:old", "tag:new"} {
+				exists, err := s.Probe(index)
+				require.NoError(t, err)
+				assert.False(t, exists, "Clear must not leave a live index key pointing at deleted metadata")
+			}
+		})
+	}
+}
+
+func TestIndexSharedByMultipleValues(t *testing.T) {
+	s, err := NewStore(filepath.Join(t.TempDir(), "storage.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	si, _ := s.Get("record")
+	for _, key := range []string{"first", "second"} {
+		v, err := NewValue(key)
+		require.NoError(t, err)
+		v.Index = "shared"
+		require.NoError(t, si.Update(func(b *bolt.Bucket) error { return si.SetValue(b, key, v) }))
+	}
+	v, err := NewValue("replacement")
+	require.NoError(t, err)
+	v.Index = "replacement"
+	require.NoError(t, si.Update(func(b *bolt.Bucket) error { return si.SetValue(b, "first", v) }))
+	results, err := s.Search(t.Context(), "shared", false)
+	require.NoError(t, err)
+	require.Len(t, results, 1, "another value still owns the shared index")
+	require.NoError(t, si.Update(func(b *bolt.Bucket) error { return si.SetValue(b, "second", nil) }))
+	exists, err := s.Probe("shared")
+	require.NoError(t, err)
+	require.False(t, exists, "last reference to the shared index was deleted")
+	results, err = s.Search(t.Context(), "replacement", false)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+}
+
+func TestIndexReplacementUsesStoredValue(t *testing.T) {
+	for _, mode := range []string{"stale handle", "mutated value", "queued replacements"} {
+		t.Run(mode, func(t *testing.T) {
+			filename := filepath.Join(t.TempDir(), "storage.db")
+			s, err := NewStore(filename)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, s.Close()) })
+			si, _ := s.Get("record")
+			stale, _ := s.Get("record")
+			v, err := NewValue("value")
+			require.NoError(t, err)
+			v.Index = "old"
+			require.NoError(t, si.Update(func(b *bolt.Bucket) error { return si.SetValue(b, "key", v) }))
+			if mode == "mutated value" {
+				require.NoError(t, si.GetAndSetValue("key", func(v *Value) (*Value, error) { v.Index = "new"; return v, nil }))
+			} else {
+				v, err = NewValue("replacement")
+				require.NoError(t, err)
+				v.Index = "new"
+				if mode == "stale handle" {
+					require.NoError(t, stale.Update(func(b *bolt.Bucket) error { return stale.SetValue(b, "key", v) }))
+				} else {
+					for _, index := range []string{"intermediate", "new"} {
+						replacement, err := NewValue(index)
+						require.NoError(t, err)
+						replacement.Index = index
+						si.Queue(func(b *bolt.Bucket) error { return si.SetValue(b, "key", replacement) })
+					}
+					require.NoError(t, si.Commit())
+				}
+			}
+			require.NoError(t, s.Close())
+			s, err = NewStore(filename)
+			require.NoError(t, err)
+			for _, index := range []string{"old", "intermediate"} {
+				exists, err := s.Probe(index)
+				require.NoError(t, err)
+				require.False(t, exists, "obsolete index survived reopening the database")
+			}
+			results, err := s.Search(t.Context(), "new", false)
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+			require.NoError(t, s.Clear("record"))
+			require.NoError(t, s.db.View(func(tx *bolt.Tx) error {
+				k, _ := tx.Bucket([]byte(indexBucket)).Cursor().First()
+				require.Nil(t, k, "all live index keys should have been removed")
+				return nil
+			}))
+		})
+	}
+}
+
+func TestIndexReplacementRollback(t *testing.T) {
+	s, err := NewStore(filepath.Join(t.TempDir(), "storage.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	si, _ := s.Get("record")
+	v, err := NewValue("old value")
+	require.NoError(t, err)
+	v.Index = "old"
+	require.NoError(t, si.Update(func(b *bolt.Bucket) error { return si.SetValue(b, "key", v) }))
+	replacement, err := NewValue("new value")
+	require.NoError(t, err)
+	replacement.Index = "new"
+	rollback := errors.New("rollback transaction")
+	err = si.Update(func(b *bolt.Bucket) error {
+		if err := si.SetValue(b, "key", replacement); err != nil {
+			return err
+		}
+		return rollback
+	})
+	require.ErrorIs(t, err, rollback)
+	// Check durable state through a fresh handle. StorageItem's in-memory value
+	// cache is not transaction-aware, so the original handle can be stale here.
+	fresh, ok := s.Get("record")
+	require.True(t, ok)
+	var got string
+	require.NoError(t, fresh.Get("key").Unmarshal(&got))
+	require.Equal(t, "old value", got)
+	for index, want := range map[string]bool{"old": true, "new": false} {
+		exists, err := s.Probe(index)
+		require.NoError(t, err)
+		require.Equal(t, want, exists)
+	}
+	// The next update through that stale handle still clears the actual stored
+	// index rather than the index from the rolled-back cached value.
+	replacement, err = NewValue("final value")
+	require.NoError(t, err)
+	replacement.Index = "final"
+	require.NoError(t, si.Update(func(b *bolt.Bucket) error { return si.SetValue(b, "key", replacement) }))
+	for index, want := range map[string]bool{"old": false, "new": false, "final": true} {
+		exists, err := s.Probe(index)
+		require.NoError(t, err)
+		require.Equal(t, want, exists)
+	}
 }


### PR DESCRIPTION
Replacing a `cache/metadata` value indexed as `A` with one indexed as `B` leaves `A::record` in `_index`. Searching for `A` still returns the record, and clearing the record removes only its current indexes, leaving the obsolete entry behind. Replacing an indexed value with an unindexed value has the same problem.

Read the previous value from the active transaction and remove its old index when the replacement no longer references it. Preserve the index if another field on the same record still uses it. Reading persisted state also handles stale `StorageItem` objects and callers that mutate a value returned by `Get`.

Regression tests cover indexed and unindexed replacements, shared indexes, stale handles, mutated values, queued writes, reopening, record deletion, and transaction rollback followed by another update.

This prevents obsolete entries from being retained by these updates. It doesn't sweep historical orphan entries or compact database files. The reproduction exercises the metadata API; the frequency of this sequence in normal build workloads hasn't been established.

Validation:

- The replacement regression fails against the base implementation and passes with this change.
- `go test -race ./cache/metadata -count=1 -v` passes.
- `go vet ./cache/metadata` and `git diff --check` pass.
- GitHub CI on the current head has 196 successful checks and 3 skipped as of 17 September, with none failing or pending.

## Standalone reproducer

[Run instructions, source and verified comparison](https://github.com/benharris-docker/buildkit/tree/4bd997315bd2e5d61f76d87e7103a65ddb15ea6e/reproducers/obsolete-index) exercise the exported metadata storage API without a Docker daemon. The [Go program](https://github.com/benharris-docker/buildkit/blob/4bd997315bd2e5d61f76d87e7103a65ddb15ea6e/reproducers/obsolete-index/main.go) covers indexed-to-indexed and indexed-to-unindexed replacement, including the obsolete index remaining after record deletion and reopening.

The comparison pins base `3ed6f95b290c23fec77b5b08635751ad99257a13` and fixed `bce34f2971ce296fbfbedeb9a5f8237e2920df10`. Both produce their expected results; deliberately asking the fixed revision to exhibit the bug exits nonzero. This demonstrates the storage defect, not its frequency or contribution to production database growth.
