### PR TITLE
buildkitd: fail when an explicit --config file does not exist

### DIFF
--- a/cmd/buildkitd/config/load.go
+++ b/cmd/buildkitd/config/load.go
@@ -21,9 +21,6 @@ func Load(r io.Reader) (Config, error) {
 func LoadFile(fp string) (Config, error) {
 	f, err := os.Open(fp)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return Config{}, nil
-		}
 		return Config{}, errors.Wrapf(err, "failed to load config from %s", fp)
 	}
 	defer f.Close()

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -267,7 +267,7 @@ func main() {
 		ctx, cancel := context.WithCancelCause(appcontext.Context())
 		defer func() { cancel(errors.WithStack(context.Canceled)) }()
 
-		cfg, err := config.LoadFile(c.String("config"))
+		cfg, err := loadConfigFile(c)
 		if err != nil {
 			return err
 		}
@@ -551,9 +551,17 @@ func defaultConfigPath() string {
 	return filepath.Join(appdefaults.ConfigDir, "buildkitd.toml")
 }
 
+func loadConfigFile(c *cli.Command) (config.Config, error) {
+	cfg, err := config.LoadFile(c.String("config"))
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return config.Config{}, err
+	}
+	return cfg, nil
+}
+
 func defaultConf() (config.Config, error) {
 	cfg, err := config.LoadFile(defaultConfigPath())
-	if err != nil {
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		var pe *os.PathError
 		if !errors.As(err, &pe) {
 			return config.Config{}, err

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -553,8 +553,12 @@ func defaultConfigPath() string {
 
 func loadConfigFile(c *cli.Command) (config.Config, error) {
 	cfg, err := config.LoadFile(c.String("config"))
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return config.Config{}, err
+	if err != nil {
+		// If a user explicitly passes a config file, we want to fail loudly.
+		// On the other hand, an absent default config path should not fail.
+		if c.IsSet("config") || !errors.Is(err, os.ErrNotExist) {
+			return config.Config{}, err
+		}
 	}
 	return cfg, nil
 }

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -267,7 +267,7 @@ func main() {
 		ctx, cancel := context.WithCancelCause(appcontext.Context())
 		defer func() { cancel(errors.WithStack(context.Canceled)) }()
 
-		cfg, err := loadConfigFile(c)
+		cfg, configFound, err := loadConfigFile(c)
 		if err != nil {
 			return err
 		}
@@ -310,6 +310,12 @@ func main() {
 				return errors.Wrap(err, "unsupported log level")
 			}
 			logrus.SetLevel(level)
+		}
+
+		if configFound {
+			bklog.G(ctx).Infof("using config file %q", c.String("config"))
+		} else {
+			bklog.G(ctx).Infof("no config file found at %q, using defaults", c.String("config"))
 		}
 
 		if logrus.IsLevelEnabled(logrus.WarnLevel) {
@@ -551,16 +557,17 @@ func defaultConfigPath() string {
 	return filepath.Join(appdefaults.ConfigDir, "buildkitd.toml")
 }
 
-func loadConfigFile(c *cli.Command) (config.Config, error) {
+func loadConfigFile(c *cli.Command) (config.Config, bool, error) {
 	cfg, err := config.LoadFile(c.String("config"))
 	if err != nil {
 		// If a user explicitly passes a config file, we want to fail loudly.
 		// On the other hand, an absent default config path should not fail.
 		if c.IsSet("config") || !errors.Is(err, os.ErrNotExist) {
-			return config.Config{}, err
+			return config.Config{}, false, err
 		}
+		return cfg, false, nil
 	}
-	return cfg, nil
+	return cfg, true, nil
 }
 
 func defaultConf() (config.Config, error) {

--- a/cmd/buildkitd/main_test.go
+++ b/cmd/buildkitd/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/moby/buildkit/cmd/buildkitd/config"
@@ -38,4 +39,35 @@ func runApplyMainFlags(t *testing.T, args []string, cfg *config.Config) error {
 		},
 	}
 	return cmd.Run(t.Context(), append([]string{"buildkitd"}, args...))
+}
+
+func TestLoadConfigFile(t *testing.T) {
+	fp := filepath.Join(t.TempDir(), "buildkitd.toml")
+
+	_, err := runLoadConfigFile(t, fp, []string{"--config", fp})
+	require.ErrorContains(t, err, fp)
+
+	_, err = runLoadConfigFile(t, fp, nil)
+	require.NoError(t, err)
+}
+
+func runLoadConfigFile(t *testing.T, defaultPath string, args []string) (config.Config, error) {
+	t.Helper()
+
+	var cfg config.Config
+	cmd := &cli.Command{
+		Name: "buildkitd",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "config",
+				Value: defaultPath,
+			},
+		},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			var err error
+			cfg, err = loadConfigFile(cmd)
+			return err
+		},
+	}
+	return cfg, cmd.Run(t.Context(), append([]string{"buildkitd"}, args...))
 }

--- a/cmd/buildkitd/main_test.go
+++ b/cmd/buildkitd/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -44,17 +45,25 @@ func runApplyMainFlags(t *testing.T, args []string, cfg *config.Config) error {
 func TestLoadConfigFile(t *testing.T) {
 	fp := filepath.Join(t.TempDir(), "buildkitd.toml")
 
-	_, err := runLoadConfigFile(t, fp, []string{"--config", fp})
+	_, _, err := runLoadConfigFile(t, fp, []string{"--config", fp})
 	require.ErrorContains(t, err, fp)
 
-	_, err = runLoadConfigFile(t, fp, nil)
+	_, found, err := runLoadConfigFile(t, fp, nil)
 	require.NoError(t, err)
+	require.False(t, found)
+
+	require.NoError(t, os.WriteFile(fp, nil, 0644))
+
+	_, found, err = runLoadConfigFile(t, fp, nil)
+	require.NoError(t, err)
+	require.True(t, found)
 }
 
-func runLoadConfigFile(t *testing.T, defaultPath string, args []string) (config.Config, error) {
+func runLoadConfigFile(t *testing.T, defaultPath string, args []string) (config.Config, bool, error) {
 	t.Helper()
 
 	var cfg config.Config
+	var found bool
 	cmd := &cli.Command{
 		Name: "buildkitd",
 		Flags: []cli.Flag{
@@ -65,9 +74,9 @@ func runLoadConfigFile(t *testing.T, defaultPath string, args []string) (config.
 		},
 		Action: func(_ context.Context, cmd *cli.Command) error {
 			var err error
-			cfg, err = loadConfigFile(cmd)
+			cfg, found, err = loadConfigFile(cmd)
 			return err
 		},
 	}
-	return cfg, cmd.Run(t.Context(), append([]string{"buildkitd"}, args...))
+	return cfg, found, cmd.Run(t.Context(), append([]string{"buildkitd"}, args...))
 }


### PR DESCRIPTION
Currently, when a user passes an explicit `--config /foo/bar` path and it doesn't exist, it is silently ignored.

This makes it quite confusing why a config file isn't being respected. For me, this caused a small typo to lead to a multi-hour wild goose chase ^^'

This PR turns `--config /not/a/real/path` fail loudly. If none is passed and the default path does not exist, this still passes silently as before.
Additionally, this PR logs the used config path, to make it easier to debug if you e.g. expected `/etc/...` but got `~/.config/...` or vice versa.
